### PR TITLE
 firefox: 55.0 -> 55.0.2 

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,955 +1,955 @@
 {
-  version = "55.0.1";
+  version = "55.0.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ach/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/ach/firefox-55.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "c991a8c53d1f415253a66fdf337e082a3cb75f30b9b340ed29b059e2a6f50d67c320bcfa9584206f1e23c1af5d3e8b825e30ee009f7d8130318cc356d8550316";
+      sha512 = "3824d633f5aec2bf1f9c6809ddde44a85081dcceee05898275b8c4c6dc26113e453ad701d4c05b5a81c81fe2ac42baf37fa2fa9c22129451435eb78791df51b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/af/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/af/firefox-55.0.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "8112c343179b1bd61f03cb67a0712ef5584848bd2dfb28dc46ccabfc66eb803ef9f23d023c6f22c6cadf715ba459f36e99bae5be8f6c62af772a7f67f724767e";
+      sha512 = "e3ad3df3469ced1f12fad5a6cc16c7be6754867bbd2871aaa07a9f49a26c3d8c07363892cfae0e8245d9020c5448e82d01d4d2b6c7fd93a7083b2d6480aec689";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/an/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/an/firefox-55.0.2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "41899ad93e627e851423ec8b5acd6bd940a10dbe80e98377e7d4080b31e9a8f5ceb51eec46931429688a4b56065af2a3595f51c3ef2c51561dd5a06d0c0cb347";
+      sha512 = "1ace2fbf01cc30f70ba7dba7803f4052ec8c05f93e174225e9aff14a67e8b7214dfba43080b4c50c761b80801a9e16a92c0f753734cdc34dd7b482cf023ff0b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ar/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/ar/firefox-55.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "ba4bf0c1ede64f3c11d00b5ef3b193d4e36bfc49687572050b22cbd0bc30be050a7df3401eb20e869b1f33ab16988701392b845f89d4693a589be589eda54ecd";
+      sha512 = "a1dd8e128bec748c37b849c8c480c9f106c614440bc4f8d3b17b28cbf0558b8e6524a0b459d2ed5f6031133056f0f73826691b9ccc1a9efd216ffbc3f64a6eb2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/as/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/as/firefox-55.0.2.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "b3ae2fad8940ddaa16102f9d43bc5113a5f4f38a4527c43e1a4b88a63015d128a201b68b72377c23274023b7486829181bb44ecec43ba50fe1bc438d30da8349";
+      sha512 = "995993ac28d2ef309e025d15f75ce29c3cd028f79bcbc4aab65d1e10efda2887faaabc6beb8277baf81ef256d8365c062e6362f2dfa91b37a65930ba5cb59c0f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ast/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/ast/firefox-55.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "80688f5eb65f4fe09a840d5f3ba2516bbe45dbb2f2b96cb4f8af38900880dea22f3b8e040491d81c96abb4fa1d50815e86b5806dc8e31148c0235b0a72bafb12";
+      sha512 = "8bd9c1dbc549b7b8024c28f026e2b9b5a099b80904938955372e157016b4ddc729a378502fb7973a9352bbdd09646942241eb23d8a7528874ff500b0aaade77b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/az/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/az/firefox-55.0.2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "0e8d42394d79c3a8f8f9f7a7ddf5894adbd89627832908e2f82b4712bd3260e8b10e04eb0166ee8c2a1010cd9dc4836ccbf99d3af794187ee90f06142286bed1";
+      sha512 = "38ba0acf054195274043470d4c71c8f2800ea543806ab0d6f39b0545fe634c742072900075c319593e5a75b8403dc2228c049cd9c359497a71627d74bb750bbb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/be/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/be/firefox-55.0.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "c13a53874775cf3e2da703dc7ca5c1f9d69e3af9050b7f58cf903f87a2ee7643e7db361d3d3628e470d808ce1b412d355653cf2d67691e1e89c584a9709cfe41";
+      sha512 = "dde5852d9d000b81ef460e49c540fdf2731ba836d5df50771c551b96f857263552389dbe97289b6d95019630774c1e8b8a85a90ca94ac275410c1ea18bcde833";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/bg/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/bg/firefox-55.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "8a6a34f0a31793e70edfd44edb54d3709a3960c3625f5856626c28f0df0e93d18d0190d3161c18315df678328918fd4029de9be9db7a6ee426a9054dc5d9c50e";
+      sha512 = "e0e642f9a7e6c1968f77cd34722acc77de84994b92745048093abb123d79ce9206945c9eea519b10a293ea349c7922937c27e6d9e7b6709b6aef388058f6e6ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/bn-BD/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/bn-BD/firefox-55.0.2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "17e2b8046b6dfe2bef7c8dd7027fa2fe2c008672b7d5a9676a9b6ece12b7b3bf7fe61a5d5378f1974f530199739982a83b421b7cf4643c9bd654a4b2235f3bc2";
+      sha512 = "49834af50d8f8e547f504a504d6161c07675cdcd98bb8d964d5f6c72c76d22925865677e64a90175ddb3312c8a9efc1d113e76aaa914e9d6315f635dc3095bac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/bn-IN/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/bn-IN/firefox-55.0.2.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "39a5c15019881507552a583053fe601dbc04e0de410dad3ce7727ddcdb128b28c5becfc748a1c5b89bb272db66f2bcb4eb6ea1b8a3cd37c1d10156ba29b3165d";
+      sha512 = "664692ced004e94e61ff9c44618931f62b316ddf0b56eb83dab7d4fe69a5016b3b5efd5a02c49e3ba41cb51b2298096c74ff2fa8131731bf79708a23203ce350";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/br/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/br/firefox-55.0.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "7ee7d1fcffbaa0791c88338a8b471bc20747abed505ece15f74f58b747eb56b300b71ff15e72e56d5deaf75d98ccbe93bf8c1e0ad3038238913f72f9156f8790";
+      sha512 = "e9ba0f8bfff1929820ca0cca3de5c377c8c483e4ba46b3064cb210f971aebbf2f5cc67d13a05e1c19e988006ff37dfee607d00317162f5146dd8a1b7e167ee83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/bs/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/bs/firefox-55.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "038c185cd6fd2efb1dc51c9e2275d98fa0040e68de306d5cc3d799893a69f937353c94c00bfb9fcfef2a2c6099149926ce30ecfbd972170cea501f9c44c836c4";
+      sha512 = "41fc17c916c3c23cbbcccdad686ebbbee3ff9d68b0b72f8e8e8819e438df2fda7aa954be3a0076d91fb5c05b507873a2bca90e2b661542b86ffb0bee3cf6bb77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ca/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/ca/firefox-55.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "be717242a9c93705234d87d0b091925f1b07e60130aa06ef19b72283f0594abafed577b6d98eaa9fab6941d1f8c2f43292de20b9476312aebe0fc51d368ac50d";
+      sha512 = "d0880ef0357a3e8d9f3d419390b8bbd95c75d6f50469a63e7c1e0182cf98e85c942d75dd1c3736c856deace3f49c6751f9e8e1b320fb0aa73a78129340e5467e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/cak/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/cak/firefox-55.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "1b9ea57bd4164862c9c29e3fa16200aa7ca15c277f00b838439edba4256e323aff97d27264bbd20a5e08ed70e4f897611505570eb01a2ce0f9cb30c2c611d065";
+      sha512 = "62a6e53dd82ef2bc2881c1aa912bdcd9628123b13a769f43d640c05c1a02dde9ad5d69f486c2858c68ddac7dcd2275fd3970e56d48f4e842a3757f453e6843fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/cs/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/cs/firefox-55.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "ee32ed99d5d4b05d6a9ca4d6d274e16ada833dfc9f5735898eebcffa7925d1ac1229ab671af9f8eaad7d4fd6d2135e58c8f6266e1173a8797a513b977235ec0b";
+      sha512 = "719e052b32b1e080b4627f286bacd9b3bc2b8f40cf8b79ba2643f08220a05201e649fa98f679c4fb926a23355a12ef744ff7b5ef819d9b825d5a5ae790f7a6ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/cy/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/cy/firefox-55.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "29302ad22573fc52e0764b89848ea43ebff98ffe94d3d91d1aafa05e063cf9c5580c9e79e0b987f18a87a648a6076f98c48d20d5621ebd46be02fcf41ce19779";
+      sha512 = "ffbb24e8720f354c2a20d5d13d6b3f003a0b3d1606da231cc9c4750d837efeedb4a789fc4b787463d0e6f0fd9492583fc24b791de6ab4eeff6f2258dc2206f93";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/da/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/da/firefox-55.0.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "25f8252bac8b1b4e353dc8be0945820bb9e013dfb30866b14d6109026c122cd9038e0e70d54f959a59dbf99fbbee48d0e3254f7e1091b2e2e2811b83498e36d1";
+      sha512 = "62a53b150f4dce8d09e63c44bc4ec5d3657b8db624a71415b666101b5a4ff2c98da3ab4e0587bef824ad0303da78060c6ac5409747291dd021d2d62437417928";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/de/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/de/firefox-55.0.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "2d013bd921ea9758807e64588f887fd841c6b8b32a18b9eab3b2ac1f598c4d7acb27b2defd4a836bedac238c96cc7bf700ef87f973a39d21e87ddbb7e27be1ff";
+      sha512 = "feddf89febf177d83e816900cdfcfc03c119c4aebb026586cee127d541db7d7c37c6d47e989402a657e51d66d7564e13016926f16cd3510ae0cbf6b4f767aeba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/dsb/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/dsb/firefox-55.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "f640fd20c2beb5cf6aaf402fa220a01176e0eb74d4429cc10f76bfca9a8579e17e490bb2f045ca6e61de4ab49703c68571c4dd7ee82c438b2f8ab94ecf53ec0c";
+      sha512 = "ceb9fe65ef661d721c43879082c1d99c90f293ff38137c7ff2994f0a7b53086452f139f3ccd2c15fdba1b09a16abe560d4a81499926830f06b5311eb05746157";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/el/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/el/firefox-55.0.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "6d1f68305ef9faf6c0d304b8ed4b4c093375c03b95b01ea7c61fd421cefbc84b8fb878cf49fdc5f3ec8552b277dc351f201470c5c4f45a249b3e010a863dd65b";
+      sha512 = "13c7ffaa22e1b9968b643d4cd6e4b46310476592ec894293be1f0179e9c16c02944c34e2b25fb5a0dcea5d374c8bd5258a370df1539b967b96b6781fdfbde753";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/en-GB/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/en-GB/firefox-55.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "e4bb9746e00490bac82750130284847d845ee8c85d48d84b799d725a3dd82ce68046bb2c9bcfa4c92070383a4f439766abe58dbfc9346cb51aabdc730b3e8ea8";
+      sha512 = "566ff317b62ad2158866ca7f50509eed0272e00029686719c1843ea742d252c45137f9d6f867b0ca88e63e84a7f46444b9f6d669bca31f6bb2566edffa167f75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/en-US/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/en-US/firefox-55.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "13598109ae60682bfa122925874173749114a093f7989bf0a4cac4def59db5ad53db61546d28ce09482cab1225924c7d35bf4efa8b3051e78ad760f892050a35";
+      sha512 = "93092a136943c8901a1d62d34582dc3d6c5a71629a274e54650901eddde89287d489572605a0d937f16d3ff9cf2b0e95ec8dd90acaf7da979f599623d1b9ff99";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/en-ZA/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/en-ZA/firefox-55.0.2.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "5d7dd0d6b2e06dc2c3ab94cdeefd168c005703cc3c632aafd7896bc631002ebe26c1c0103307f3165b720cfe79e63fdc9b37429885a2eefdba492b714ab308ef";
+      sha512 = "5898f88d188daed37bd8b5bf523d94bc3ae8064a3a020b463658f333140c4cbdecc24f053bc898dd2e81f3e945a2d0ae63a05bbeaf27f8ac94a7477f697e354a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/eo/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/eo/firefox-55.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "1f67bfb98891effb2ecfb127b9ab9ffda714187a34265277fb7841f41d5a4ddfb81ead7f4cc1d38af290feaeb36c315b2050a889b6e9b9bd7b9cdd51ba0cbb6f";
+      sha512 = "ca234eba852ce9ed736490e3db9185baba4d190fc631133747219dce7b24fdcb4fc3bf348de21bc81cc02cd818660158a94f0d2129a6869e9dc88f0b7a426c95";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/es-AR/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/es-AR/firefox-55.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "011b4f49e90ad091be5e8d932ee9a76b1653f307db328ee6770b99ef37f57e62477ca7529d182f328203523f9d0160f337748166691921d5720640c634522515";
+      sha512 = "c86897d532114b6e9039e4eff546e724177b9de1049af2634580e8ed8f2de54484fc9573fca1640ad544b8db092a477f3d855227ae1ddf2766fb5c453cfea876";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/es-CL/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/es-CL/firefox-55.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "ef29baee74951692720c32522bec81330911ac0366e9bbd816a5bdf0738e064268af2f63ea5b3542e51eed21775cde8b4d60f6cb47bb18b94315afcd078a1c84";
+      sha512 = "868ab44893d60c66da1389dd36c8b84bb44a52f0daae20a7de247bd22aa4fe3b9c5d22dd75fcfaf3b36933fdfd91f694d9758ec9ea6cd40f1882a3a721889742";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/es-ES/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/es-ES/firefox-55.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "8f21e0632e2b4d86883b139f5992becd89a8c243afd131e2f9dd863e2fb21279bd858f618789a73d46218de3bd59a5c4b017dcdda5b1db9a3400e0e0ace3c9c0";
+      sha512 = "39c9841c7a1f6e1bd9028410b49f83d57193a6995053e7056d2f1884ac6706bc54972a531031b8e14a2aabeb0c8cc1f297bb580676b4c6e0b33edd5dbd6e43eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/es-MX/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/es-MX/firefox-55.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "9d59bfffc685aee31004894e81dda5efa3c512bfe61dbf5d224b31cdff6a859598287a8a80e7d96645718689df2dfee3b4a79c064e789d246cf32138b9346f5b";
+      sha512 = "d20bf48f886f739215fe2e46c30b355fb6113859ddc6c917c6936c119e3aa105161174f74d77e63f7bd59619b85f21353dba19be4f98d114551d585eccb70004";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/et/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/et/firefox-55.0.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "a833839e8243760942337161192fdcddcdd7ccffd3b5ce3c7dc939492366e8579e0deabc933a607885f20059e40dabffd389a52db05ea6bdbc794d9e15a1c9e7";
+      sha512 = "a794a793a7e430c643007d20898ff21f25a364d0629c022073747d15882f1470ee6b50c1bc6ba2d4830d09598044086d81f6f81555e23c7f3492eb8ee7b29835";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/eu/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/eu/firefox-55.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "0415c1f00f612d080dccfc3829c3f89de4fc5921ad8603c7eda0aaf9ca57b055c66a4a0f44782a8b381e4e166964f5cc805b65b84525a073a1fa3e605bd07aaa";
+      sha512 = "ae8b65527a12e8db514dcdea7d533edb52a39426e96f50707374395cc88f427e6370e864c9d55da93b02e2c92443c2f06dcda4aacb882be0a4982408678a05c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/fa/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/fa/firefox-55.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "699be76441b245de502cf0b9ac44fe3c454fd11fa00d6ad590b2a393a31f4f291c3b5b7075741c82c28a721eb38a11a3627e71b42e910fbc2f474f2284820f86";
+      sha512 = "ce8df8ad73cb30195a444dc9ca9f1514081315fa4a927af79eda41ea1b2fe22c67825157cae641f80b3dd8760bf8d3d26a538a211c5828b41458ff60337c6166";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ff/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/ff/firefox-55.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "910928159d16269784d3a41b8a423138060bdedc7e190c80e5bc95bb9358b6e8fd08c519106d68326eea4bc8f5c54157cda151fcb72d5bb1d19f82696297760b";
+      sha512 = "d896277ff916832466ae58f567cac018d259b08df13b59433707bcf60f5e75975678a25fb8bc138d3e705310e10d0cce06118f6581760fc9c1e8e076e4a5c355";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/fi/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/fi/firefox-55.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "1085f674e3fd557d62d29c81d52dbabbf09229a03d38d8eba1886a98937c560e91b8a5cd5fac1d313946eba6622eb21462bb1227cd35dfef523b34e8928b7f3a";
+      sha512 = "adc3dce086ea0113b8daf96e1ebc5d292d35007ef59b0febdf72868350e98696c4efc25ad9dc9cbee908a0721829a106ca4d72690f5e9295077e7971bc9950d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/fr/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/fr/firefox-55.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "038f8198004d38ad9e2814bd55b2ef1d6e3af3f8f3369a90b41e44421b94ae960380ab65367375e15eeb1d0af72343874314c1005aee18dc86cf079fdc19fb80";
+      sha512 = "2446635b7fc3b76e3fdd15634c7563483fe6bdb3c26e98cbcfb0f025567a5a003bddeca68fb87a6119e46da7325b50bb429444a30b92137f7e7aac8a57ed382b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/fy-NL/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/fy-NL/firefox-55.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "83eb5df7022ad9adce4ab7966fc4979aad7f6d1bf2b47001105d67d7933feb8c264708938b87fac3908a65adcebf72f6af9d5623fa6026458dad76a360f0608d";
+      sha512 = "fb02a7d115c00f36680d9b33a65b8ce459a2607e8c9bfc9ecb70b6712a59185e990415b4998583da70996331fe3ac7230b5f2c540d27e0d04c193940b398585a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ga-IE/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/ga-IE/firefox-55.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "34f3bf3ecfc264bcbde3bbca80bf138d1f7f925ce6606d6c588f0df25f22eb912dd3d0388a6798091cb88b51a22380e01fe984bc80edf95c76e301e7cac2b2cb";
+      sha512 = "02f16ddfede728b0a1b103266805263414b2ffa959ee5e5b41d4d542c747ec2b819e4e4b1b6d30173f76d91eba388572ff4a84433b05ec7d02b7ea3d351232c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/gd/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/gd/firefox-55.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "4d2f04c7cf06c6f8efed7abe74f8ab27794c01aba57ae2f45bbd1a749295ed7b6db4389b1c93148330695c6d213642dd9046068f0bd23ed3920bfcc7fb9dd4f6";
+      sha512 = "e1e25afce2d91f582a2cd93cab594f08f47ea5bebf273db47b79950a674e39b580e8efc477611e5f0e288593508e9cc583c6a9509f08357e9c717c84fa54acb5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/gl/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/gl/firefox-55.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "d70c3cd99be7dd1d80c070d5301a1d84f33f1b626e0471861980512c81672066a7869a5d289cf862ff4d0ff6f488b0a7cc298675aa9afb0a62a191ac476b71b1";
+      sha512 = "f077016885b4780b91e9be185fce08398be4b34e496afba3b41c9dadea4d191d4c93a36f31ec094b0e57fe0636bcf1b38c67ad5180bd63086fc07800e90f076a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/gn/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/gn/firefox-55.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "f183e3c3ef451367362aad3bc96cf1500fce451d3c0f467822e756266bc48d7d9d7952e82f171db2d8bf23d41bf58cef34f67da7211d31335f86574abaee567f";
+      sha512 = "c935d587a2d5d5ef9278d265fe6d7225c4568e2f9058bddef99c677e9b89ab286bece8b066a44bc4ca6d155d83ccc14382e80f2fba4a44aaaf272cfce178f5f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/gu-IN/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/gu-IN/firefox-55.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "31afdd21bc2d9af1a52cd24f74c76480658fb0506f38e6fd5f5f85bd66eedae49cef89aed9060f1255c515d24b2998cbf9eb449b5083bc6f2bf1805d152197ea";
+      sha512 = "9afa840dcf0de2386923186f6f3b2da1c78d3a31eb794b3aa1caa0092e90a8f7594b729970de8bb410457ec88b681abd99bb9be7eaabd8496bcfcd521ed0f14e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/he/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/he/firefox-55.0.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "c68c416515336a6c2c8ae69151c1b8c972f24671d354929eaf3eb647944d6e99085b5768a8156e59015401a33174fac774f0bdacc6005c3ad23a008009653fb2";
+      sha512 = "41eefbde51929a1642310b62fc61881a16643372a94b9109dec6668e28ee71d3acfc154ff26052cf4702504523ea39e5e14679b14956dfaa21628717f66a5f10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/hi-IN/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/hi-IN/firefox-55.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "2e62b66e9d34c9a7d9472726dc322746ef399b24400b9315dcd15f010d0bdf80d8f0c1ca912ce3275770ad925f47d576b59484b3acd861d1f3fae9e2ffe5277f";
+      sha512 = "4ab94bfa479c1dc703206fd5529ba9821afe9f388cc18a80512c5beb9411c3476ba4db7b859df4556e8382c1fa5a521e6f6682021daa46510c3497deeaad1ec4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/hr/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/hr/firefox-55.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "a5caa5839d7ba556314c513a9599ebdae05de41f5b3289987a1f1d1dee030b53da07773fd6517f42899ef443770ec3549f4160c77e26f68a1e1bb3ca598bd866";
+      sha512 = "7a0048bef5a50588220be7145a2449e2f2f16a2542e5e2af17bdf5fab10a7ca9f9441ee52bf8c274fa462d4590be6269129db5dbf3f55574b8e3257f80d2604c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/hsb/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/hsb/firefox-55.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "df83ae1a93cbed29c85d75add44b70fde9c187953fa169cbdc106ecb722ec845b129fb762325f08d0ecca188ac6bac43c6662059a6694d43ed90472ee8eb23de";
+      sha512 = "d21ba3b5344ab0f105cc6f6c426dffb553f4b98d1b6c125266d8f53209ebb58011e41d72b431945656a2c619347e309ab57252c4ed7189f6160d61379017e062";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/hu/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/hu/firefox-55.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "c5787634d4fcff538423fdd9761989ef341058fb129f33bb729686cbe5319aad7d67c8d19d9e42b7d81ac08381cd0d07504fe413a9c38c310ba3d7440ceb6934";
+      sha512 = "5bb2e9c79cc08ca3b9e4c47e85daf351e411899318abd6f97bc715a1c4134ff271f7c1830eab1da9465c975d2c1abaaac0c490b7c2504f175b3b468b7824b622";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/hy-AM/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/hy-AM/firefox-55.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "6318a512fee633ce49a2ac6cf3b3295e74624bd935e9979193796956c11239f1da3ebeb99b5547e3aaaf339c4f87d0e4501edacc13fd11435abf000a9e119ed2";
+      sha512 = "25191d401eabab8adf1d603b4838ef5fd42630e5109cdc7fbdd638cb9537f91c16fc559dead9084ebc703f3ea0b3282c9ba72bc579466ac501b2d9446e398e21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/id/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/id/firefox-55.0.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "2c7d0de71a675a0d6abe14037db11087ad9a2825bc2d9bbd863f209b86d9875da08eb2005590418262b63bdb12a9b122e54230824d5916059f3855b628eec8de";
+      sha512 = "0c681e3f08b80e94b8b3c3c8fc2408e6161c3c8a665c6eaa29d5c33eaf508bcb8426dfdb0a3218d15c88b6a414e55d27468aaed43c2b87f8ccfb1ccd26f07817";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/is/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/is/firefox-55.0.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "a1dc23e047cb7bc21f3c1a888cd8f9168161296a47148c2296e4f033d7038fed83566a429610fb35b514aa8a902839a00201901d46361205e5e292eca7418813";
+      sha512 = "6bd3b4233ed6efa88b32047705ae9f5250cbf58f93e134924a0adb0ae7f569123b5d085011c35c0f022f37096fb812811f0fec0bf781e355a5342650820b269c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/it/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/it/firefox-55.0.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "cb2bd028873e28aa197e3f599b2d1aed913273f888cc2eb69775b1936763011baec1f03bc57e3da6b2088a8ff37d08ab014bdce8161bf6929c57f658772af8fe";
+      sha512 = "cf8bfaeef210cc2f94fc9405a9dcb8dda331fedb82e4743cbe6b75eb0eeca13b77a30fec648806057e0e8ec95bd957a4003e4210e38e9d122df50ee6c0c31b79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ja/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/ja/firefox-55.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "dda54f19f4a5a493b7ae6167955c9ff4c503d8cf239fe6b993a87d3f73171162e29270366bb3f2f1f1afea80e3332928417bb3e26fc414d6543e9ab2e1a2008a";
+      sha512 = "ed12eef067d9505266b27bbf856be093bd3f6bd2b82c355a3c75db0d964ba3a86838cfc976cd142c142dd77b90d5a878615577c57e7861b41a4ae6ba69bb9933";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ka/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/ka/firefox-55.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "9e0a7042225361addf1fe41c13e0e3df869e41c1a88b4adfa64cd4912c4cc113804dac23ef5ac7a8a196ebb8552a2baf988aa9da618ab1a64e307d02c15177c6";
+      sha512 = "594f2a455ec525956e92e77e5de1f54f8cd7bc615567ebb4bb9b938d1978df1bd87f9865e6311cb4280d0b1d435cc8a522b7d7b5fe6279aa3f387a288df81d60";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/kab/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/kab/firefox-55.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "27f319c418dc54296f616b9fc2b6069f1f0da92b2eb95d872b4fa582f494f0339cbe40fe0427ae1cf8a1ddb1ee436ae56773c7413591f4bd76f027916bcef187";
+      sha512 = "b7d3d54e7bff659074bfbab859acc3bb6c2141e9111fd0b207ec3ae81179356942f48ecae75a8f87af0514a79179e77f088be810cafe23eb234e85bebfffc798";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/kk/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/kk/firefox-55.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "7d5664fb243b214846fbf2a1772be96df94345bbc6cb076b9e75ea0dc126e3113faab67ee935792df48a915aa7274acc1d4ce48bf09f17f662341b2235ef6d1b";
+      sha512 = "0cabe96911784264c984e23831b8e8170fa27af03b15c85706c20059f5e935910deab728e2e8b68e00b62d4f073f4d8e156e302bccaef6794de07fce48f99255";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/km/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/km/firefox-55.0.2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "7df87f956678f7f90df95f5bbe1309eba7f89ec2e1030746f56df0e14cdce200a1204bb73f8db68b02655db36d13941cd0887116e974df2e11d8d222f5dfb6b6";
+      sha512 = "e62980ea8f48280dfa8123e4ba8bfbf7627bcab855e2869ffc947c9538377721fa6ab52b9bb209f7e2db859a5f606232e39248d7da3020693f4d7de1125b8a2a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/kn/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/kn/firefox-55.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "532c5d7a67d6508188628b9728fb6a1339ed9c789fd8cc58c33a9b9495e8ba8b979c631bfae66096b164c277dc0eeca167911aa4b856a1d6d437bd5a60103a3f";
+      sha512 = "b5bd9a15cb1526dc39bfe15c9bf5c8624eb919f85c0f61f83da0477afed65aaa3a2af71a0118fd48fdcc7a73da778b9781d56f41d70971e52799ac04f3a8ee78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ko/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/ko/firefox-55.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "c1170288dfe6d2ea418d93e3d401a2746c88df77cd8ededd70b17dac4652488b20966aa472f7e929662a8305fc03f7153b534d79d6e8dc62dfb0b468a417317c";
+      sha512 = "59462a1891d08c109827b1e92a267c28427222e62b945194d4c5610f823489e645714bc6a1975b42b3aed3b809c46f01670484ba8043538465a20c21b6519263";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/lij/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/lij/firefox-55.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "3f2b8227f04064ea5507774848296fb12d4e17b806cea7a356c36995648a4db740d68382ab6d6417d745dc278b6cddc6f18cfc6fbbeb60480106d726715c0d1d";
+      sha512 = "b0c1dfacb6a1333306dca3b16bc815d707ede40b96511c6e130ec76572e0ebef264537b458c4040d45790868114f8f652c84b525e1cf92b05785631a67de2196";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/lt/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/lt/firefox-55.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "24d0621a76f53b2a4fc7f3b4d97a1a066ff6fb7c7e1dba9028ef719a38042271412068a7a874862ccbbaf010a7491088e231036271c54e51c624bb82937b139f";
+      sha512 = "ea0f17e1b5f28e5ed0033ea5bdf8ef8461cb861123688dacc908e37670b22be9d115c3dbe8e92543a7b5234c3a45d159aa0c486eddb3348acd21f7430e5b3cdd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/lv/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/lv/firefox-55.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "c36c40e21e305373e7d4ddb67702055cdef28f880739c2339c5e75a0f1d30c2e73316f65badd69dc93552ae33a1f493658002d73caac5a97b8d03e3e4365e6fc";
+      sha512 = "2a6a5ede69b3280b43de68ad3c1082a4f46d606cd0e78a1968ab984b8b3aa8a455b809b3a6ecd9f8ffb2c296206e68446b2139a1739fdbc4f3fe8e6a736091a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/mai/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/mai/firefox-55.0.2.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "f033e7d1cf52486775ec614bf6272cdde3cbb17a00aad49c8c7739d72488c03d9803c860aed581640689e336bc55799521da4bb0b3a6c9cedd3af38f94c944f2";
+      sha512 = "178d8d1446287d0f163166851f7ec2d404d4328fe6b901c6227cf4d195de7e97e5097477d0f2a9cd4c2c492ac27fb15d3dbc90b798d3ea05c3e2d2a017ab3ae5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/mk/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/mk/firefox-55.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "d01f9acf588e5067681422daff9be1f2e033b91ab2dba9a979dfd9bd918b1a20e5ace64739ebccffe025e03b80a2f3a955cbf5940ee9341e2f62053ffcbdc408";
+      sha512 = "52673259ddf45b072037c28f872a03b75a3a948517a27514b6623bc5a975c0d745340638b04a5c9d16503bb0ab62e08795d1e387ea37a69e796fe0842c3957d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ml/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/ml/firefox-55.0.2.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "95a6cabe1b0fa984de1df148207d22b570a09a5c1fe95e898a33e0e0c905b9f868586294032712339562d8f5cc78961a7fed5aa3c1a5c1a77ea5a5f3197b520d";
+      sha512 = "a58262f6788002550220861c1a501fd9d15b7967bb538da738b831be91787e04c2f42ce5dcb045910ee022556af9330df4d0b985702995ec40f3368a3a52eb7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/mr/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/mr/firefox-55.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "59053496d9d37cec07ed1dde98ae07db593726d49fe97399e97e4a6ac667835cb34db4864c5e67bffd1a9c1727c1af2feb19fea0685fdd2f6b5226ad24022656";
+      sha512 = "c927b197ed833cb3beece57d247107865d6c1d9ddcf01292f28927ec4ad8cb325c8b75cc50e1bf9b31eaffef31a3d472c55338667c64425f80934534bd6b6f3d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ms/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/ms/firefox-55.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "c3a23a7165b0f233fa606e622868690f696b262f33a2c1f2b23ab37f392e71bac7cfd04f9e240660ed5f6075cd3192d9ce1be46a649d5abfb7beb9a16ff91e7d";
+      sha512 = "1b0227782120185c60cfc18f60fa592340fe5ff875d130d0d786b055c475dea9210e98867b8ac2c9c63273f138763cd73c2fc5e5085000af06aacfdcc9d69179";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/my/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/my/firefox-55.0.2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "493e5d971b55696121edcd72712120caf638aa13d2654e8f4db4e814a7b8c4cc2c7b89622b385029ed1a9ca14294cc39d8522784000708f418205c36b1f2fa64";
+      sha512 = "a18326b32fd45e968dfdb4800209ad76265e8c72237fe3e0d799c7a66456d3020722a1ef702a349a0d19411c5645e7d286a2c523cdd826d474d40f02faffb129";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/nb-NO/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/nb-NO/firefox-55.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "c7c3e85d2749bbdc75a359ff5285ef3cee14b710aaa6e0f39415cd72693f219589b64d26cbf15020c380b51ac0d4a6d41e730af9991cca1b4d5f1ddae4c63dee";
+      sha512 = "6652b0cc7aef35e81e0bf1a4aa3ee26516a874338d23a9d216e4c8003bf86f4f73b1872d39969f77e878e9894f66c23f930cc133b666a4b1cb5490668153d653";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/nl/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/nl/firefox-55.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "1d77c158ebfdb65004f5c999e6da15ba2cef2dc998c69bbf5477bdb8b41131e968187017783c65103f2040db2154833857790ab9c6aa705b866b60683f0c4ac5";
+      sha512 = "d6bb770bf841f7882ea61a2e780247d94333a8df7e72e99ce3574d9216b149fbf2d1c87cd385436492680c5c0e4d1cf897ce0987c43a15bb2776c4a80799229f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/nn-NO/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/nn-NO/firefox-55.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "37630d6abf1db435bbff8ea2821966ea58fcc3326199dcfc0e95833732c9ad767610781046ba4b031b516f5dc301e7a7d699699ad7b39efd2e9cf3df05bc3637";
+      sha512 = "117ae9c5939cd7f4eaf6b353b2e14b2680114be27066782b2348f56f8ab7b72bc37f48043e382adc40f6315167035afb33a40437b86560100563f1e5e752abef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/or/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/or/firefox-55.0.2.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "bec28704aff4671d2ee5413a29335f84bb04b4d5dfbd108988e1772c68486e1f5bdb2b7b799792343b1191b768cee7cda59aad0efbc0dbc45def3149e7eb41a5";
+      sha512 = "c58300fe25da662c6227c89189a6e17666a8d0482d56fabf5a3bc1a3001a1d9b62e0c7ad55c8eac7b8294153ef12adcf1a61067a697011b7ea74e23060449ccb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/pa-IN/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/pa-IN/firefox-55.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "eeb9a7a8400e14241296ea75c55fbc17461d298bf7d4a4b57e26cec434e398d070b9207d6d19a3038b65fec4792f9eff47b758f5e5b0ff373b349f67f44ee1c3";
+      sha512 = "b2c5f59305be66f6c3bb4bc2bd67e787e56461ae1be29efebf4880bee2378f567cb719f6cbce90502cb0df6645239d2abaf101bf4c171efb226c28821544bd16";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/pl/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/pl/firefox-55.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "560a7fe08b460f99e6d166caa8fd442ea343a1eff9c5643b96ce9085fbd76cc27eb3b2ccda59172c5e7542bfecdc3cad39257506531c51350f655744bfe166f0";
+      sha512 = "c7e062eac501d08bda55d0e2f642dcae3a3fff8e228521719999386e6b910ac9a0f101e36845a0cda326970aa7c6ada16d56a44ea27d5ce7deac773328272710";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/pt-BR/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/pt-BR/firefox-55.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "452bdb25f38b31af0ed6cb1f2636ce238ab898065b8f61f505206e1dde12555a18d491b5895b549e1d5efef94144b99988a69e19f9ccc068c76474bc0898aca2";
+      sha512 = "854054e7a77ae695f0344fa19d2c16afd112dd965f511c4d3d0a22d3e52e790e8adc1f86fe951f1daba7c390c851607af87a1886b6ca2970f4b4d921d7ee3998";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/pt-PT/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/pt-PT/firefox-55.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "54c6b9bae229fbdbe366fac25e9a3b89f48d85f41f715f9db1f3f1b4fd210056f642549a982eff9ac4e2b68640ab01517ff9756cd63b72045f11c07619b59761";
+      sha512 = "e490aaac75a1d7022ed79ec888963730cbe995a31755c62d431eed9cd7573cf607d361d190452fb1bbbcdf0e246fc52c0132637a2b58b6934e3564e221692efe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/rm/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/rm/firefox-55.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "075a161ab0cbc6417dbfb4873c8ade404a2fc911f2da9e0149d90b04b32f6c9ccbf42b22f2abaf13ef4f9cb4d8330a90054517a651d0c0f1f940431ece8b2518";
+      sha512 = "010c815bc7ff3b779f1d393e593eab21cb4740cf1ffa2eef670b508fa0915ad65bec15cdd916f6c4a6c1823fc800aa6f70c0c004e6c6910645e5dc9c109705f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ro/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/ro/firefox-55.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "5c1eea33100fe2bd020f9d1ac2bb781ec04b25a12d271d3dbc311319f7a688f245e2d7357055bd8321ead58923857f689e417827ac3125ec206975134e4203cd";
+      sha512 = "970a35a149c512d30efc1842748a26febe4c323c8682791396354c80d5b9e71a1e6a1d2c918a4552229dffdd26982665f8c339f483a179002edcce05d6ef3fe1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ru/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/ru/firefox-55.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "c9d99eaa7ad17a29cfd860c343581654da5daf15db5bf653a3d0b13b03d1914fafe7f6801810b3ee06abcf687c71cc1f9d20cd727b10cbe91e7bb6c977aa279b";
+      sha512 = "02ece7c9664416da2be2042676d60e6dbfcc27568d74bf23f64517255675e19fd52f031c6579a9ef08f7ebf3d94b92426f3f8dc74fdb3843634e958597bb30c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/si/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/si/firefox-55.0.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "e36e3e4767f9afd211dd4333bee2ca4ad3d9ccc7081b1cd008098263570aad4272eab91032527c3f6f0a70e54953dc806cfc00a08627ebd81943195add184603";
+      sha512 = "0f2f273b7912f73e8b022e5101ca40603a272914deb49159529fd96ac627fc106f039454941b902e5d9fdbf6aede57f38f263c93ea561fa9bd933acc21c329c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/sk/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/sk/firefox-55.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "148b8ebbaba7d111234108758fb48ddc883c6d9094e8f22680d65cb9ef05fb34eeec4e09c141e7523ff511fbbc2db84b0eef31efa92730ab30a4830192875c51";
+      sha512 = "fa95f13fc3cc513fa22012598a6bbd82b23b8e0d19d19aff100dddc1b0f123098db8306582b8ff27bc2e6188b579a2fa22d7205aa04e718f622c723df0ae78dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/sl/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/sl/firefox-55.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "fd0f058fb2a7fd304d08fc4966c7235c557d869b0a02955a3459b354793a1c2245e45ecffe9d0b251357062cd81db10b5d3f982ab15abcdf275af31d91038f9b";
+      sha512 = "eddc485ee09e45685a99715ed62921453f3d647e4f2c10b152d6e3faf626c4e1e12cc5ca76403c10cc94ebdee7dd999faf35b3e4e6d544628fabc760c07e7fd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/son/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/son/firefox-55.0.2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "4e6bc840e788b0a3a9cbeca86969d3a37afcf600b583777de84cd77d21010360afa39dc2ab4809b12cd798307cb84c6f10e7760395b2fd2aedabfc6419b02d18";
+      sha512 = "0a6b22284b2f65ce7cf8911b05a00df7675b042f7db31f8cbd9440929f4bd32a05b463a8c26399495847dd14881fa3fa1fd00309fa404b0cd12ffd24eb97131f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/sq/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/sq/firefox-55.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "e852af7925a2a5a0c59cc54137d1a574d5cadd831929ddbf375b726b1241dcf901b18f97f030a5ca08283453ee86ddfa113488adeac6fb974524911e354cb763";
+      sha512 = "fce71fb0cefa5d975d0eb22a0a32cf99e3a6448b206170b260b68f6bc08957ee5fe7fc83fe3bd29a3ccefebb5faf731e9fbef2b642a99adb48deb9c0fa934374";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/sr/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/sr/firefox-55.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "99b3f089f8c17701ddedb41add217ff5395b3f942e7f455c19f63e49a499282a2432d9f198eb4ca219cf25656ac90c803c4cb7be01975be307b7835b2ad0561b";
+      sha512 = "21667d882d2065d7106077fe280dd07afbbfffef1cd5625f830fc76ba8798ff45c4af9bab382af3eb390f63cb94de108aa113caeb3cb07bbea3ccd6c51333aa8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/sv-SE/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/sv-SE/firefox-55.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "f5f91a85e7ed10c2734779586e69856903051074ac76dd186d1816253e4d7441d60cad5172c1dc2496e0cb660dbc40fef4bc586e8e7bd19f7145f3b53f2c2736";
+      sha512 = "691cb5961830be2a7813a3e5c67af793e1f716f916fdebadd4031f288d8439403b3f49abedb4410a30317fa4fc51446638e7f18d4b33bbe0f94a93ee9c4dcb21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ta/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/ta/firefox-55.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "291bd760b10656f5cf7df91e5c978e3caf8748180aa98507e378ee90033df8b971a020b253d5ea691067eb7d08a3ac3f998b64860b49bdf7b2b8eeb29d18b737";
+      sha512 = "bed2f31f934f5feca3189e6064490c7e90401fc0373b8a46f9e3f19fc5245830fbec1bf84de63a5cda2c71577fc8e0cd834e60c722b2e6a4634f9cec3bb3912a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/te/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/te/firefox-55.0.2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "4b24c2f7a8e9b660285a9a8e14789bf18fe42bdd484dabf68a99b502a52eacce81df5d5375321cdc5c1b69988e35f0e9e3d2d2cfacaee72033a2c68af0b25a6d";
+      sha512 = "6a43c634e534daf172ad8847e442c577172eae5478896bb01e34ef941156664ec55c633195e1fe82677fc0cf481ddaf847229f7029d279bb0a0bab256fb3b239";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/th/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/th/firefox-55.0.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "a479f709c4c512dd3906e9694ffc454ae315855b4a37740619b8536d1dd98764ad191944617351243eba474ec44c95d3153efb69d4dc13aa8047bbc477feabec";
+      sha512 = "9c91a5c6d2304b92111c392fd3d7b017b38c1c686df5f55073237a6655c4780d6c90100ddd13d6a7569f1b82797be8452aa6df0a4a22ceb3320d69bc902641c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/tr/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/tr/firefox-55.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "1e12a004cd63cd547cd925736a2cec78ffb98d5f395474c9e8fc96752cf621a2311d638d96444afb593f113c6ec46a892fe96fba882ed7b7c49aa05d4685e70c";
+      sha512 = "d38f8e7097164075bc5e6866968403acd5dd91d67782eee968065ee5f2eb0a6204d207b8249d97efcf955f52d510410b6b868712a3796796c0eeefebb0f6e5d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/uk/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/uk/firefox-55.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "0634489527974d7c7afbe2c55d054f9dd50ebfeb2777944dcb8d4a14ba5171230540c17172c5b0d5df64d99fd23d7b9ce384657e1e1b25b73118b9b66b748613";
+      sha512 = "bf10105b97b89bb8ddd4769ec0428d938843b9d2ceab2d63851fa0a6698c6d10241b65a3f2068503a4a41bf9d50811a7aaf01105918b8afa92879be96f043dfb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/ur/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/ur/firefox-55.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "8a519683ea1d611f6932e651dd0e400596529ae428700ddf8929924910614598f8d8c660e317357520d31bf1347d1f90c1e89b91eb74b339eedb981da032af4c";
+      sha512 = "b241c882c867a5ee808e9ac37cd14dffd17d8eabd241e4e01ef4573f7d4641007d58fbaa8875284ac640d1ec8f013b7a7278f19768b07d388b5f30c4d943955d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/uz/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/uz/firefox-55.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "964afe349e8b7f908f520d039fd1da6c8ee245b68dc8957a04222ff281a077f86e7b8185850ef7a4b741a697832bc36bbfda39051409a9c3adb74f2def64b621";
+      sha512 = "357ef3d85e8174e765682b9bd99b5865994119c73d41eafe3c6ce17e3430a1eabe358a1ae8c4af6d2d9562673a6ee65e469ca423ef7e0b135b8f79df4643112f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/vi/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/vi/firefox-55.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "ae9dc4d2be8d82cd82dbcfe638d021713e8559fae2d14847aec687fa90d90afbbb206bfbabaa15ed00ba8c4ac058f4c950bfd320c307b968246968fdd30748de";
+      sha512 = "606c28e1777af2364c4a85557f6b173baa2f07ae198da154655d949b4999289e1a9de3ccf8086c771167abf70d74c576a4440a73cd1a34c3d1bb5e13f91da307";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/xh/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/xh/firefox-55.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "f9f0c35d0446da3bcc57b0b2dd9cd622de5a3fbb0a6daa987d2de6fcb2804be9020ca190c8b318375fb255d7ff86b265a65e7d0fd819f9004fbeab1546cb62c0";
+      sha512 = "2dd2317e3cf7a487730cba41d24db990844fac4b5f5c2b93e70fa5cf635478e26a60aa2ec60a98f670419c72564dde487050c1bf1d662cf7bc8440654cab2ca7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/zh-CN/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/zh-CN/firefox-55.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "f67ba436854973c9a809b78c3a2511aed27b6c4532304464220841a2159f851e84bdf0fe394527aeea48238802fc5c7336b2399078a8891d4c76554e8067038e";
+      sha512 = "714ef62fb08db12559e20d1bb6c7e253c4a12b275ad1db8279982ef5df9854e647241d9cfa15085620f12e894cc84a8d60da9b150cac222ca4b454e048e6ee68";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-x86_64/zh-TW/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-x86_64/zh-TW/firefox-55.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "ef0e3fc59630c9ab9072142651420151b897b048af3eac878c8222bdba76d47e2e45160227a2a58862a55ccce954451b892b4f5b5c6062d769dbd940edfefdfe";
+      sha512 = "ca5852892d7ab49bb1473425bc5b1e158b045f647ed33fda1b22d0e25267f45a87cd4ea296c58a4f1b502e6e0ca8c82ecca25720e61596e49508a550ba43f9bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ach/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/ach/firefox-55.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "cfd977fb5aea5c5b707df817993d547aae8b8c04293c3f57dfb630fcb2a0e85b5deb79253da544b7c3a92ec5319989fa148ad3b1ce950d6bafc7d4fe8f1bd2d0";
+      sha512 = "3819fa366f4f5ca40276a30cc5a7e90325d40ddd281160948c06e9db8eba05b51b5e0f230a3c5113eb21e9638374d383b318df3905877d14b654874c83db0934";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/af/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/af/firefox-55.0.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "b6c671a746691cea4d4cf6d5b9932b0f1c025f04e11e7ecd38a53c0c2759d3a3ca82e6d00febd1f644fc18730b2f6538734adc02c9e18094f7533f81a955088d";
+      sha512 = "eb7b48ee9ce0b7c08f96f5d09b51e1819d38fccf7c71cfcfae72e3189ebc928ec4692a7a10964d6dbb42fc2ff04da13d5f058084e6376b67b0a1f4818922ab45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/an/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/an/firefox-55.0.2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "51f824b2208b18939ac12a6d63507186d20e8e66e0fd9ff030c1bc637a14d987ba85ad5b2425883d90f88952fde84f43e291e68da004e8114d854965421ba9b2";
+      sha512 = "956bf6e053fb566f4a6506f672e7102c37548af41807797078b2cd7560fa4dc17cefde0b21939a5fad75005a98adcc58893ef01d170c312065c2fb1904102bb3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ar/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/ar/firefox-55.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "411b0f01d5f6a4f8915f51960b0d7d62a1b9cd9c3de665674a019d356677e9ea82720df4b715523ddc87458dc3edabd8945b7d1e41574a22dc4df5c0b62ed869";
+      sha512 = "a05cfaf18d92d8b0a43587cb685e192c69cae3603c94bb60f9b7d5c3380d498dd050559fc1d041860893fa52651fd30f7a734cb98699348587f3211625e880df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/as/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/as/firefox-55.0.2.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "18d6094a2780759e97b4556fad1d504ee1c1cb41a5ceb8481599f2a41458b5c0100b1fd2a0911f1e125b4089b093f1a306bf838e1c00bbd1bd5c482e0f894881";
+      sha512 = "b855da6d338d80a58aa9dc6f4a39ee9a5d21c92b25f5a4b349f83070fca7e27cda8c7d070b2c543723f6cd061949e6c91f79979edc45c0dba9dab3dbc81fe4bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ast/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/ast/firefox-55.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "ec88a6ae8ef64aa01b2c03feed80ece24ddbe19f2c1abe38f5e2b21554b782ee52331175ccada48f47d60c56d4c9a36b28b6d62b332dfe64f033ff9a90581449";
+      sha512 = "57f498045089ee3e96b5f3f80caf3919d39c3a40ebf68b1b578e1bfb14555635fc216956387ee417cc1bd05cfee7bba3260890d161fc1ea8471bd73399a0ad41";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/az/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/az/firefox-55.0.2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "e58a646b68a068de0c5b96f088770383345fe46661d667e6d9cc1b7fb0384351dbb10caca6eec618303ab8dfaa82708a71d9376e16017173710f41e0b7d55357";
+      sha512 = "38399cf0c73942f96df9a4a599092fcac64956353d14e6395a1c0507fd0c7cadd566f571c12bfe06275446a5412e69c29bae95dd86aec42b97acf960026b16f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/be/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/be/firefox-55.0.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "e4d8d905eab7b69c78864cbf268ff8e8246f5792e3e55d28e8a44c12027ae8269738a0ddd0fddd4282dd7536e1266e58461553334f1287f7416c9fd5dd29e2d0";
+      sha512 = "047c06fb4ec91013521b237592af85715140ae17a10f095f5b8d54516f6b62a4dd90c262294702258161bf781a6babdf7ead4b2c5f7211cb5e87a332c552ed0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/bg/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/bg/firefox-55.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "62ae8fab0c91d585234f7eda98a4a7075956b00bbcee5ba06d1dacc2262b32eae37ef3cd1b66da34b02bc309b1b704a2b97c297e3c189de6eb2c969dc1100626";
+      sha512 = "9a823d322edb570bc53c07eb63414b65baf82df2f37c7d2a6d52221b6b23d0804c890af9c3ecf66032035505ec246e096864754930426aef4be008f5969fee67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/bn-BD/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/bn-BD/firefox-55.0.2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "0cce61b9d0f88911abe306140de86964808d8e94880287e1d3ca6dec6b3c36b79143d03d46bc366809e69b70492ae648aa80bc57897d38c92bd76ab56b36a24e";
+      sha512 = "a5f8b004170993b4317044df0c65711597b5eb8f046cc1115cd047835b90045bd16740c47901b8e261a037be9592493c11cd527f80465d46d19c06b692139103";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/bn-IN/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/bn-IN/firefox-55.0.2.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "53f25ae4f49e125b7757740a5f5ec9d08687871d4ab56ae3f4f4506bee2d1453c24c99022a4be0e07f6376bce3b0c0063b7155ec7decff8e2ad61ca456def7e7";
+      sha512 = "2f161b15a10577a48386cf3277c027d2c0103c881ec33b57e87824b4e40f000348356ca0a6caaf20d50263c5d203ce02a6a734059ae477b72dd8b55e17bcbbbc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/br/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/br/firefox-55.0.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "98d83c45d5599bbc62db2204f177b2ff4b710a75ccbbe6d67c8d16829504b8f4a2dbfd2940e583514e41147811c4b3cc4f74637b3212e018eacad85f6f56e892";
+      sha512 = "1a99b157661a90607af89117321f1fbda167bc6804ac95434c6a17859c8c66d86bc957cc95d46e47c69f42b5f513dd39a876881ca69221adba9f7790da7e965f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/bs/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/bs/firefox-55.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "7691546b4cb9cc4de8f0544e42528704f5c204b382b195da7ef2764faf5e2b6cc58285da890e800ed83e82be01924db0e219d1523959c04faa24a11e3e16b04b";
+      sha512 = "f850f28cfb54798e0305dfc2525ae59f1568ae93133fef2fcaa5e30063d980263e47324a3bb038ba3a9512aa621d2232475d5c0098d4d5914d661d5f36e9b51a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ca/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/ca/firefox-55.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "21d664d5a589ef1f0f41a936d8e46a3b220d7b1c6e996f639556986e36097144b82dce5dcec1807b3191e5dc3835df6007e845c847bafcffb0e456777cfcbb67";
+      sha512 = "5b67953d4fd2ef7235fab59b83a17814d9edf106183983dde21746ae1330c9a9169cffaba21b7cb9623d93a82b67c9c249800892601db58b4e42efb8323cb7e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/cak/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/cak/firefox-55.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "a2a289569ed8ce5fd9916d11bab43a0f4166c2878095f2a30fc8ed587eabad7ddcd5fa7a43070eb54daf8549e5f19a3c12d103d1cee493eac2e1adc3b536a952";
+      sha512 = "05ac251aae543a91755b927db98ae44aa07b06ba824d784e72c91c8aed741eb54d0e4b27167dc11a96bbdb765c6daffefe6ad16982812664070d07b5b6a8dfc8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/cs/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/cs/firefox-55.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "a24dcacc4f5de63f335e44087f40c203de5ffd482232e691f1f1cd576bd4d41ab949c3d07ad8c1aeeba38863b1a9ce69380079a3cfa0ae7ea3dffebe7d964972";
+      sha512 = "c0789840e6a3bcc626ce99bc94db727c09d9b6e3b750dbe3c7e2310d00f3d3ef06d2dd3c755daf7e7081f7fa6d059a4e5b0982b513ce5cd4f4dcb2a63630743d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/cy/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/cy/firefox-55.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "7e961c9366d3c0fb2668d6f8d9d874bd7d52e28ed53a461afc234375a5d06239fdb866c12d53f41027672afb889e257075bb59ad869c56a54b409bcb3a4e0ab0";
+      sha512 = "8b8c1d7f561649f37b589cb11f4117a762e704a7374ff4f6aac1594d95482f13c7dc00924ffef76b41ad9c00780592c16f38fdecb60975de6d45f6d1b5e6a97f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/da/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/da/firefox-55.0.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "a058ea5cde4277a26d6f3592b281212087511e8efd79dbd05a59696c81e762949709e12f94f794b252abbfb810a410f95c103b52cfcba34d2397a0b0ca51ad96";
+      sha512 = "42312ed0a97b2bc03a37cbbefb8027d373c0e1894a3b37e78a6bb8ee5f72a846d4e14835507ad771fbf4be60ef34768d5e866a4f691a0af827d3667f7b1c01e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/de/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/de/firefox-55.0.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "22788aa3f8bf59a1366ef4bcf3250f2d6155d7ee3de8b2b019dda6a294e6fef58ce1ec6bd0d54b41e8618491de872249f4fe1618779edc418a43d2a5189f4b99";
+      sha512 = "9a228c3e177b11539666b9c5f0a4ec19ff86da023f5a302c81266d85ade1c8e39be861e43e143bc0247f09af85863aed224011bfdb4c64bc2dac267fa1e548f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/dsb/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/dsb/firefox-55.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "bbafd69ddb7f73c4b3fa272fdf91352a9db8b9ab57d56d2d5e743738026e6e5f811c0bda9a69b1db4d533ca8c6de1b5bece1f0f4784092b3b3e8672bb30c3876";
+      sha512 = "d8c791da0654bd46fb52c866ca89399a65186d63e0262536ede7263ca3fb7af852281e50faff750e2d3020f16d4f85caef8e5d33629ff0019e249bfdd87bf439";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/el/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/el/firefox-55.0.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "650b3add1753bbad904bb2c1577ee28598f0a0588e38a219b29ca1cb333e9e561c17e560e4e00ba6c861d89ddb70bd7352289b5711c0e24f6f78d37e53e02683";
+      sha512 = "9e466913d7d84dae64d0e537093cfcd46128f3ef9fef10f8ba675195e83e2fd0a32a4602231206cde599ee8be7e246e64e0858dba36c6e283649c59ac990db5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/en-GB/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/en-GB/firefox-55.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "e82dc2a34212a8346bee261ecfb07e82aca6b09582a652f1f9ff90df6f5a5fb9f44c284eb27db4aeba743239262a87faa0e4f6ee3fec66fa97788e66c4e83bfb";
+      sha512 = "5f4199493fc4c55c1b247cb729c65b83ed668c65704284dbe2206178e4264df852a73925a1adf1d079f77560c9538427544826af8ec311bfb604bc7a5c691073";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/en-US/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/en-US/firefox-55.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "763f0b2294085215282852ce482f2be625efe355138ae709c84ed65ef4ba28908115fe3027eece41e3b5fd1fc164c050d150fefb4fb142eb6652229c021bfe7c";
+      sha512 = "51cbedf391e4b2b33c4bf4882a6183084291136064d2125e14da6cd86cbed8f979e20adbe386848d1a22c2a4c567b99cb68bff51668e53b6dcb85e92c73e47f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/en-ZA/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/en-ZA/firefox-55.0.2.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "9ca62fc6eac9050a7141ad4025e6fd6e3a703e18c3a184ecd1620fa8cf098867ce4886774673e0c10833ca1312b555f02d436b5d8088b78963b682a5de1537bc";
+      sha512 = "33b6fcefc6d4867a670531e3de4d4a926c934a297b890fc60b3c4e6acb6237d2c2fc1d0655b8da42406ee4ed62fa98bac0a94fa7cdd3f70a918232e95df3a317";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/eo/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/eo/firefox-55.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "3dd8d02a132d96913e017aa4194ab496c21a7b708c5ee1e02bec3c7bcc769a7f53c8908bd56a71918e55b49201f645f68ece3e0eb522fe0719a152bd6067245b";
+      sha512 = "64d93eff3cb4f19185975b830e4f956d2d76e8bb600176a322a57f873e7bf8856582149b9c86d7af7652e2e0ee2a355f821607810713bd95e5738ef1b436a7d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/es-AR/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/es-AR/firefox-55.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "aa8ab141a092b481cfb9fa72f2226913ab7672260b2fd0dbee894215ce373d7cbc1ed7451cd1c1010ff079d14cf9f2e992cc32e981b44360b82d867fb4709d85";
+      sha512 = "6ac236b635ecdafd0864711c56bb3a4d339cb9540d5cfb4836c437f8df9c9fe9d6b65c4c8b1bcd68e2e04ae86f3e70edb5e704042c2ba00611b7f60fe0b3d071";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/es-CL/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/es-CL/firefox-55.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "73d2ae9ad8442a49700341127e7ba31ecba568e558d27b607c5a6bf8e89a9e515c3bf6b9946f094ba4640cf5bea970e5f8473a5ce953a09c1fdcabd2a68d7a7c";
+      sha512 = "0ba857c7d7f1ed986110ec356cb4db75f7ac6291ba0684add7cc56f4505fb946ddac3c603f3bda2a9fe91b2a3031a7cf4dac59bd781dc148c09dfce4d4837e3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/es-ES/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/es-ES/firefox-55.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "213f71697b99bb7dcc978bca57fe119940f8197b75b5aed3964db89859fdbaaa0968829269c5a8d6f01bf21f670f85bcbdc9f7d4f6b111971636e44580b67003";
+      sha512 = "0440a2e9eea08a43431c377bb4e8f4e747dcc8b608b68a2289ada27bd4b3950feb4ed2946845d725be15fb6fb910f984e791229631100d3cdfb39f9ab398780f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/es-MX/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/es-MX/firefox-55.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "d12e8f13fd94c3c6f93f5e20ef5cfeb5c3f82a479baa5bca5a5517dd55bd048db59454a56730e69f6bf051a81b5d2bad239ce0fe8975aa00c863667b464503cc";
+      sha512 = "7c9ef5df8bf96ac277e7488c2ac0743afb72165ffdc5723b4bc4c64e1c4f7d338f453fb50a7d938bec39cf04217b903a56b86ffe3856f8437ddb17f53a48f32d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/et/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/et/firefox-55.0.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "8f6a6393f009b19743debdaf1bf3cbe12e566a4288f8fdacbb0119961542fcbf082aff03ebe79f54311ba00017851ca4ec4efab9553ea2e1178b6dba9677e31e";
+      sha512 = "297fa442fbdc2042b3b7756de00f2573da9c5544a4d83a6409808ee929d441bbb7fafefa023f4d858f0fe55f08e6cf6397ad2732ee197d01d4a03ac504e62087";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/eu/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/eu/firefox-55.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "7b1f3af68205e3688bfc0e519f9cc6f796477d2f8b11f0c7e035fab1ce917e713b6b18dd498c5d04da3c51a50dda01132268a24180ebcdc15f452bb25d0dab0e";
+      sha512 = "fc79272cb8d9c22607fdf0075681abfa34ccc78bcba8801e1181dc46ac9ce420dc3b789a4964fac37bd89fc9e8b03af8b09bf5353f7b3784014c8327deca28f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/fa/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/fa/firefox-55.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "1379243d07c5216b31ae2689b11d8729d0905ace42e4bc8ba40289bd39509020ae551e2fd0f5a16b883486ae0bc20c33ee2902650304cf628a239ce3071ed683";
+      sha512 = "ec6429c1d78e9b5e1e174c7e13d8d99a8358289f67c76d2ba3c3bf096d9fef7558969df37693b86d7ff077206d35934187906f82edefa0634a3b2b111f42cc1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ff/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/ff/firefox-55.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "3bf4eec5d5a3c4da765db6997a57dca3f67d52ef302cd38db759592b9904e7b357870d39920bd75b805700ec4b9f4a94400111a321518c5d4f31690ece946289";
+      sha512 = "fc7287c16143ce71075b2f0bd5724cc6568e4c7ccd08ef81d1f46f945b6af18615c0b465bdbd358919af03ee956437cdb912e41c94741ad916d5e0ed993fb37c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/fi/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/fi/firefox-55.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "1a33cd82fbda2554fa76684afbf3a843babd5872459026f1f32fe496e99ed631252ec63933a291214535476f8858d03aea26b7cf2108a029ab5f99ea8c229650";
+      sha512 = "2a73b783ac0c9728385d7a47e94a430bb04c3d8d50f7d35fc8256551788f2b23156e0d8cd73595c2d11af26060a4f5caf9c711a2542d9d68197e5773fcd03cae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/fr/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/fr/firefox-55.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "c92bf5cfce5b5114342d98d526e287ded4d82516f008e705ded1ddbf11c1cccd8ba3d3ba777f6be0727f7aca776ac7312fc7e5ce3c2f77ae69420541471d0289";
+      sha512 = "c8c0fd587e0947793c734e8b8a71f50f8d9321e8ea5214290bfe721a95e7ddb5904a7254a39d1ce395cd674c47ee34e613e09174528fb5c5a94323018d03faed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/fy-NL/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/fy-NL/firefox-55.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "16973677379fa16283956fd31a73da2697c4f38b41618e14bcaef4fd3e68430c15ca5327f6752d8123c137b3e026ff682d534e7819f87d8cc3ebe7a7ca865b87";
+      sha512 = "965e29af8153a239da08de82ce52acf78a76a02634daafdb8919c2c8c82c553ad989c7d893c6e9c0f9c10b9540762997c2ecb4d41f0411593588edef34eeae22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ga-IE/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/ga-IE/firefox-55.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "a26c96dccb61b5e7685a9914f68e40e3ca468438438bbb07f9b524a9a2f3b26959b7a359b332eeb7da47f7a8ffee5f8811115e857406e99abd7f170b64fa26b9";
+      sha512 = "7abe283e1898c11bfe5df5a5ef629a0d08887e12606648c39a21eac4c96235c2ea5e2493ac1515d4ed8aaba638cd14f85c929fd08d8f79d933428823e7096266";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/gd/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/gd/firefox-55.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "d2e4578150f8ad0166c48f6fcad2f735ddc982af2cca30aa694e44e593f4033c259e7f7aee1fd1941fded86d2937464bf11e8a906fb732ca2084632ffc7d642a";
+      sha512 = "f980334b4576c3ffabcc41431a90379ac8d13e1bc493d39928f30faaf343bfeff9cdf897551b21548b4556df43eb27103f2836b9797331304be2dea536b63a57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/gl/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/gl/firefox-55.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "999546c43bb56cf95509a8e9b122e649e4ca608fc4e0a3b8e82e9f58c334460420c58650a8837e4247b63eee6f840def3bb80e6c517badd50449e0dfc471d661";
+      sha512 = "5fb1d134a6ad89556880d3df3208c796a14773e1c7a62f4191726d6eb24c13c2e76c9a4aba3927032da4865786b936667dd6f96b8ca49224494ceb0f08ee759e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/gn/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/gn/firefox-55.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "caeec1355d3bd3331241fec97b0c6008b8f3c42c1d56b1796a7be4c2ae994569a5d2011fd5b723ca3e560bf07fb1de50523ad2736345aee753f37d6cf5ae7f09";
+      sha512 = "508a04bef58c1042cf04f47134e615cafe26497ebe1ec0401f9d12c3fb21f87386a01859ba26226c9d0267c40cf6e5843349035c1a3e2f49c7c9f9d1439abd25";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/gu-IN/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/gu-IN/firefox-55.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "1e3feebb32c4240d5c15b0c915b92eff9f63b266ed74b32e1df9fe824b27a3c4d2d06492c9b9d47ba22460e0c2cc854322250edcc1a54e4b6346ac9ee0048b51";
+      sha512 = "5d44ee3027a37c8251a8c612a08d8f6916f809cc0d86f8906295a82efc6d98f475bb80c0f961bf95871e7b2dfed8faf151ecf43136a022a2f7796070625ac71d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/he/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/he/firefox-55.0.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "5d83b761b3f8653e1701e75a66c3741a9dc7e377fdb2d7b66a23bcf314f3993e45293d8682e65fb58f2d6a720ecffb0b2568aedcc89804da1efad0590629c3a3";
+      sha512 = "62d08c2ee0b7015808883e66e5c54ed09a5ecf3a0b730efd5a89bc8d4cd35aea9ad6dd9fbfe394f12c2846923f47fb66e393c41cf4c273590a890ef1701fb7a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/hi-IN/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/hi-IN/firefox-55.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "9c59cba32c02786bed46c01797e7bbf3d745f90da98cd07ce6ccb578c402bdc8cf3d8887a57b5523a072ddc6d98dcd9761862f32c59570160c732b8408f182c2";
+      sha512 = "b6b21ed97830233ce22658e4bd7637a6449f53e095cc92b7381afa30f4d74c8df5b1082bcf1704aa75b53c0dcd75ad509774e818ee4073bfe6986ae4e93538a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/hr/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/hr/firefox-55.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "20684ed388fffc81fd7b8d88f4d57f4bb130ea4671a60d4dd70d1bd5250b491a36cb0eff0b7820a26f24695d30afd5c909709b6e8ab27f9e24ae1381a8b4dbc8";
+      sha512 = "124965251c04b4db521b79102be73b88d747d0ab47898b2929ab867b24cce50768f62b61afcd3e03d338c958065c429524ef61ccaa0ae80fa1ad7c3def20e1d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/hsb/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/hsb/firefox-55.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "996ee7693cdb808ede4df1c6d8533a964f0bd98a4026067bfcdad8d1c78b232cdd83f1fa7fceb532deb9197ccde437d42d13449c8ad0fe9cde3dec1f3006a775";
+      sha512 = "aa08c3616051ff566576776977af5a5827c5dcb68472ca48af5adcf0a107325395f9fae8a51f824e126b74fc9f6816401acedc0bc61783a8416e6ea3431fdf85";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/hu/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/hu/firefox-55.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "faaf14a3f2aaefdada31761bca2056d2592bdb6ec5a053d7c8efe871b0b2ff191b152fc240782b24f3954b4913501efd303bdb301b4a69140e6c47a3fa6856a3";
+      sha512 = "5b7e3c318657e20bc012f1324928c43b950cb1fc860ecad40fe6a64e4cf8ce30e4a32bf617b02e397dda7a1f8bfc40c8709ba09144ae1bf5676104fad1763798";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/hy-AM/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/hy-AM/firefox-55.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "9190ade1a9885ebbfd0090ee926e0d5e31da61a7c98f874916c423a60328c5f936f29fb60949c1ebf9d726f07f097312c64a67dc193d71537d4adf4a9b7729c4";
+      sha512 = "31e5389d610ccc05d387ae23676bead9176d87ada142fc545e571ddf296a4bfe396725982f011a2c0b35dec8f8d06e97aad8b42235cb98aa9db5f0352356b3fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/id/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/id/firefox-55.0.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "88fe78ccc643a704e068a32d2fc60624a23c269b85bf0c96c8538fb5243c1db93578f1a91993537bd7dc672acb9dc6f4cc75ed444774ff74c7abaf621226b43e";
+      sha512 = "b037671a6d63e0a55564987dfcd1b3bee1347c180e29a6e6df80db0d6cda284e08a6eb5b31a37a1eff208030aea3cd3d4ef0ed711ec1c936c746efa870e5bd46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/is/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/is/firefox-55.0.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "969e28b5d8696fe735063161b4848fb3a8cc400ca2f2e3db246dbe68d301c7da3adad7bfda61eed10c85ac028582b2568f57d0c727abd184be2850d44bea427e";
+      sha512 = "6a681a05885574a163d7603edf61a0d075728c7eb50d8e78690c0828d5189ee757cc225913f060b27a254f2a19d03eb63525fd5f305377e45ee4ce5c729ba397";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/it/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/it/firefox-55.0.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "59b389ae6710bfe3d8c62b9b482bf44af419446db0ff5278b1c18bb45eaf122f5b3b47d32b19eb3686cd965bf1e51643221bb01fd6be6990f8ef14159ae6477a";
+      sha512 = "5e37dde84cd5b7a162438d2d418fa80f8529cc3ff3b28bd37b0826d8f5981ffec6fcfbe7b41cbba92d7c921bdb1249e6b0f5188ef983187e7b60bde08e80bb24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ja/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/ja/firefox-55.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "f79c322f4d2d23efc682ca4e02d114583008f2797e5672022d412b27356a1bd34f4c216545ef8c8f00fef17be0fb405384d98f4e44679372b9cf7953e2e8af78";
+      sha512 = "f59fe7957981b362d01f33483bb43ade19894c0f80fc2a1b889e3348b27876f54b7de20e9a67915bf8a4e0c4d89cefc87911841637c63f987b0aea183bba4ed4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ka/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/ka/firefox-55.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "a5f440758bc4607955911d0fb2320036b4d9a06dea07c7cbfe9fd67b767a544cc0df582af329e4c99f3eeb065627e90a989368d26a14530fc94a28d6fe65c7c1";
+      sha512 = "381f250da469df0245bf6a41165955b0dbac3a14268b9a9bd59836d3094695ac6ae434eaafd41138b24fec3507a6d020ec2bcde740865ec3605a554a1c7ca0e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/kab/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/kab/firefox-55.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "1f9d2fd390226d06f0165d9a5f53c5b9d67a424969b7881b91374867179ed09efd05cf404de086734165312cfe09131692874632359c9a9fd323a6a9b7dec101";
+      sha512 = "5f33d95c60567e02fd4f721a5a0084a255a16bb130737c7dc8e4ee3334f2eab33d4a415ef306bedf55f7f0aaca7e615bd5cc175a08edcbfd770c035ce928bca1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/kk/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/kk/firefox-55.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "faa9e21a95a41d8c846a5cec6f7cd0d2cdb0a382593e91e824e1d8013af146378c965b28cd44953702167e2e355436a2f5042ae727cf6c95ca75d0eb57f92119";
+      sha512 = "ba2006d6b797fb63bdeb285d7eb5f91374f2b8df7593f712a6b5fd185bfbf8af082f7e2db1f7a79a15cc34a95458ed114b78daf89b362dffc7238a253421ddd5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/km/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/km/firefox-55.0.2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "514bccf7cf2c433d846c7307c75b512f20c6ca4deef5f8f59f744656a81e514a9e62fd4336e223fdb59698b6dc00db0aeec51da4518f0d3467b5a3f06598ef42";
+      sha512 = "ff67a4724bd50795aa8161b74382f9b53caab3b98f6950b4d3285c0f8ea636c4b6626a4d3e8ed03c633f756ed9738b4ce69e6cffdd034aece4515ab7bb9ece07";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/kn/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/kn/firefox-55.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "814b1fcdd19fa4044ab760818ffc6e246ea2cea36b89785069af857763b23623f4e9cc50a6aa19a77a00a61b501c26182d7296706b7d01bc9a25006c03580058";
+      sha512 = "42eae0cb137fecfadc72dcbb0e7ff62e7b6701d1ebbf4190e1d20a1211d200b54989f15889f260566002a83d672b105453cdf23c2094af0f55cf4300381e9c81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ko/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/ko/firefox-55.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "462747db276da856fffb562036367b947822f18513c2eb7cf70d6d3ac31438b59896ebf9c12e9e61abd5adb0b761774ad90cb41eb59789beb994c8dba11fe8bb";
+      sha512 = "8fcb7965e550c9fd510bf782f54a60bdc38f3707874c6f24d1a24de7ddd5eec2736490c6cdc2ed1206e99a75b3d7267a216bd6003652375841789c0d0e0ed71d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/lij/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/lij/firefox-55.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "04802af2002399a7540f7ea5e5dbb23cb02d30f567a0afb64fdbc45645251d8bdd6e9563f4b5f5c324c267828115c719b161b074b80f7b9ba8ad4a1a0b24f371";
+      sha512 = "0dc0d54b31816be522fda4572347f6c4f1c244b0a919650500cc66beb39da1e46637db089cb595228213cd4e99262bfe4689f6315f25f6e359ad299bd9d202db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/lt/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/lt/firefox-55.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "968e19afc7f0613fc184632529b379334d2409d5d0da5b24117748cbdfac714e8465267b65d2674f8721b47e969279c054add60f2a060331617ac2a02e97d032";
+      sha512 = "9b498e3adc4d069e219af0034a69fddff2d70e7a28dee522448a2c4586e26b6b905ba8f501f5c9b83b9ff8a2888d7025171aefa002a815fb6d352889cad95016";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/lv/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/lv/firefox-55.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "b6ec789c77040508706702d1fff20f0a277c8a5a1f28a375eedef91e0d7cf29a58b3f2027ce1ad2bf8a25ea5043751ee52b8468c4cfc516e1859570a1dad02d9";
+      sha512 = "2246366ee92a315330a4e8d1e77e21cbf875d599c169bffdcf32eace63b5794ca106d5801523bcf547dbb26ed24aab3ad108e461a8cfce0254b6389f6b1df077";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/mai/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/mai/firefox-55.0.2.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "1ca567163688b14cfd4deb5cd2f0739807807060dde26508d87c8590cb8ebc9010edd7dc92869de6af2928eab32d42fad5da94a74ebb3bf96cdb7883cf2f9225";
+      sha512 = "ca5bc8eee4fe7643c98a3c93381a7156373b1ec94c86d8601d1529daf8cb225ee12d813fa2d310384d99cfd130dc3480ff243017a15739533d7cf7552052f12c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/mk/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/mk/firefox-55.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "87ad815c0aa9e45507ef044248fb961b7bb98b4d4b10426aa448f41d129a162bc1d3f6106016c7cd92cf03b63c1682224aedfea9093030561b13dca79c6d11f4";
+      sha512 = "ca81a90c97feedc7bda3ce61f5dccc0e3c2563d284a8e10c4ddd16a3d93042e3fa38f10dfbb0218df9fa83051b778ffa629d5f57735de85e44b74b820d180018";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ml/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/ml/firefox-55.0.2.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "85fe206ba0b20d8eb6c3846685c851ec579d8f188a5d6626ec56c9840bf8a76a0616457ee687cb4d395ac0e71978f9403832207a4675c560546c7ea813014aca";
+      sha512 = "7668eff72251028c9392774cb84742ed5027d4e0b617b4864b0e3d079061c95ab81c0a2471466a1b69a8e0e5d331b6b75c6a63be2411ff90bab48b3acab28ca6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/mr/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/mr/firefox-55.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "c41938fdc8a19a49a6100ebf2d452750069e3038d8dbaeab4397f2289622963fa6d74a3c96419eb6cfe7e14bafcbf4b3b4a1f85638f1a402c2cb69daf720b740";
+      sha512 = "27f6410bd1da1e7360cd86c493aaf7ec406a30957fa41b35c5ac8b7a5c32eae2da0b5197a018379215bfed60032c8291446d9e3a10f5b371675154cb54b8d0bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ms/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/ms/firefox-55.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "f37a606f1713e2f680b32ebcd5bb90f68cf324f26512bfeb628a4d9e71d138004bf08082fad8fa961b2ff28ae3d34c453d890c37b9f775fe27944bb7a5c013f5";
+      sha512 = "cb1718ed34f2e1a48a2ac2f69a00d477cd3aacab7a6b0d149f240ddaacf04993c44403f68c9d5cbac95e03db893c8b713208466784f867d4b00b0122b9de5c39";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/my/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/my/firefox-55.0.2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "fa730b3568f06a8350372ac88d3ed7738cd254406a65c36570efbb502a61a60a1a4ab14bf587b4ffe365d3133eb76c841540248402dc87db0d3607235f2878c3";
+      sha512 = "9fa2f51c3666a7536dcfb8fa769645117c98eff0af9969bd0e54853c42345ad407b102db952ae2a9cbf286c221b0a821f56f3f67caf114fb62990b0564aacba8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/nb-NO/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/nb-NO/firefox-55.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "5e1fb7632da3755454deca4169802694051c769b0da75978b1762694e0516b202198b74b306d2670c9d05f7237faead7ba15cb55272cc8b3c7cdf14c0a44ce8f";
+      sha512 = "230afe8420be9daeb270fbc836de70ae2eb197c2b1b9f8d7606d16c73c718190ebde135bdb8a78ef29b1b271a30bca3f5438434c54e76dd3f86076dc77fc5b6c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/nl/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/nl/firefox-55.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "5e6dc41cb51190786724b34a566ffa8b16314f54200b7bc2130a6178f0d3693df0fefc7a3935db13e9cd27ff5ade21927900680e9cd6c964ac7a23961d72214d";
+      sha512 = "8d8ba124d9efd39a2faee19d2e37fa11506a135aaf70fa780471a7ff763c943e943ff970a70023d4431da50f5e7f842382bef66eea6ddd07f3deac05850761ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/nn-NO/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/nn-NO/firefox-55.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "2d95d711b99a9e94bcb0e2cb923fa584d7a1e7ca2d2b3d289b20f78a8f8c0bf909a26d45a1feb540bcc4c9e983e40d0eecd24b16d0227d5155f7ad684705215c";
+      sha512 = "ee7125a2cbb47d1ad7b541ccd4480eae05ce5b94d8a280f8f99cc45a29e23480f3ba5610d5f97e2b5ad677a2d6b79b72162707fda851f5930b8f38ba030abdc4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/or/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/or/firefox-55.0.2.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "d9bb706c45c5e7a822f106888f47615c1948ee74d8bb5a179ba838634262862a561fcf8d0b79a86089b08f0213cf1ee21387bd4e7de1b47719fd76ef607234ff";
+      sha512 = "f7dee58fa33c741aeb0a85e5d9a2787e6af7a74e48cf41f76fb381f8761ce5883b639e023246ad94efa42c51da88dbc1bf5c1af25832c01e71915a9156e07a42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/pa-IN/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/pa-IN/firefox-55.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "ca8121c9ab978cd044bf8efd5c0ad07d7e790cfd1cd6121413d2508d6ddf8fa75e510cf866b5e8506312b1b22fdbc95e3af9008440fdfb8c392dbefeb81ad3a1";
+      sha512 = "28f22dacd509e904a61c915f40abfe315f724f919a1ef31d338173ba92df4e7977f77b48f7aac999a89b170f845d0bd1e21e07090189193a10568ed14749213a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/pl/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/pl/firefox-55.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "d83d65bf5f0ed37a7f5a2b66e075aaf4caea91240763e537d0198369e93d0c64b1526f14023d7daa697ac6678728f6d7520aa66bcec7ea282760116642b00c05";
+      sha512 = "712433bd8d4cc1d1a29adfd2c3de423f355dfe92ea9c341b1315272f22ae4c1a1b7cb34a9320e8ba2479652e99401b0d449824fca23b4a61bd2763265ccf401a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/pt-BR/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/pt-BR/firefox-55.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "2184c06f9f205b624f2fa7e9437311c9dd3100135061cb0eb94dabafa27e9b5c5da5aa31e97a70e6f8b773b1c1704472a4cd87d30d6dd463eaad3d8eda009254";
+      sha512 = "50701c3deac2821de87dde0858804bfe2e5ed25eaff5ab599a5a6fd03fc94ccbcae781f4b127bf4eee2cd068415d78535dc6f029ba472ab6060b803b815c33af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/pt-PT/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/pt-PT/firefox-55.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "c40aea22fe64588eae5510b0c047c2d42673b7f22ef17a126bd642a2cfa9fa6ee27e7480089b381d4ceaedec2508ca6685f8301631948624f85b024403456d6d";
+      sha512 = "4a03a6ee97a7576475c47c1eb9f4148fc242dab79f80013cc720f3e4f31a176d59ebbba9aa53e0ef72a3b890ac3c8d3905e22eabbac61b0c95bb50e8fd4aa2c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/rm/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/rm/firefox-55.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "235cf224fa8f78561ce0f1178dbaf3ac0798cbfd3c3da97069e74aadfb38c6fdc90c3e01d45a5346588bc001f5f82e5fbed73672e7bae6fd2ce721d99416c1ff";
+      sha512 = "868cf77f91cfba14156e5e053891407a831aa6e24c8050d20e7772a0e7d8f06b831d83134f177fa7fa1fe2fafa815036e7b9a6a5c3b1814d191aec9ffeede3a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ro/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/ro/firefox-55.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "f6f3ba58b8241678c4a82d03433e2f58ead36037068809c404e930afb335fcd4057f3db6a5266785fd573271e66dd98d4987d6524c2b0fa2d01fb05b5671432f";
+      sha512 = "a30d9ee09a94830d1196ea2ce0e92e304a28c696a8b8ccc9066ab67b03452fec4f93bd3c5975f9db22a8dba0cffd115000efad815fd9ae1a1a892cd5a3d87bc2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ru/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/ru/firefox-55.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "c7f9833724b30b81a58c6efb00ae57a69b32c2e7590d6ca0ccdc65d8960336068daf7b8f4e305a466c054f8f4897464cadb3fea48ac05aecef14e18c121a64ef";
+      sha512 = "de5678325845a719fdadc26928a6691887711e08a3067f2ad2c658db19e68a019b567e6916673ba6b869b8174cf9729015400feb7aae5cd9f7ea55e85d085348";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/si/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/si/firefox-55.0.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "669762fb074a3d7da7ae00c753863519e1d8afe68a183e7f6bd83d8e4305f2db7e1bb8b9a8e64aec20d3b735196bd55874573cca257d4a2de5f59b3d6d7aaee2";
+      sha512 = "0942c285a4e4a5dee08bca7709337f01d03624287a0ff8030309d1f503da4ac13c0df8314c2eac4be3a13a9842ba8e9fc2b3ebaf6a7d405e733afb8ff1bc3d8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/sk/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/sk/firefox-55.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "beb2861f5127b121fce3ef6811de7d801c5ec3cd05c832c16b2839c08a925d2e34a8106270ec956e5f45d6062e9d5cbf72ae4d7d9ed894d9cb44d5914f0a41dc";
+      sha512 = "881bf74e210e0b3430060644429bb77447014381e6aacee6901dfc35dfcd260e719e39dcd158fb7624261ca62c68587c12fc178ee62548f4a1f0844c8a9c1eea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/sl/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/sl/firefox-55.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "687b20e50fae586cfff1426e189f28d54aecdeacef80b3f68caacf002f52cb7141fe34803dd1e1d8664efc8500987c752e616e26aaa15b3f051afe878e3a82af";
+      sha512 = "f813a8dbef0506e281c3e347d8a240da65940c7fcb0609a9510ab3c83f2fd13462d1ad749bbe768ca65b92ae1d9dab72880f5592b430d796fd377748291ba41e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/son/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/son/firefox-55.0.2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "92b0b4353fb0e858e3998903c5d2ef82e38259ce1d9560abf06ec6b55174d17db871d967cdb62b4ad23bfbcbb10a2541d14f0b2886f73d6b2d670c93fc48220d";
+      sha512 = "61c75236138087ba7b56eaa5fcf4360fb869dcee60dd1f431b92a613ca00a64172bb48e9ff3a649e5e616566967ea0f254517ac1c98875efe2972bc9d2075b96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/sq/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/sq/firefox-55.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "d9ec031149f9a845e6f11c34a96aa54cc14566e569b1395a83158fe32f433c51a95b1e16e99706f92973661c48856372b134c43b2ebbdc8d358108dc0998033c";
+      sha512 = "072fc33249af1ffe150ef5ab2ccf79322227844e1adc4928947b43b7956b98812ed80b1995e06d5e731f107e58cd1bb1d26eba1b9695fff7a69e00010c364e0e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/sr/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/sr/firefox-55.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "cbb81a562427e4773a4c971d24bfc5f9ac689f8f85b6edc2a2b32572f10b202e8b16de562cae85cfe1a9e86eafa3bd60c8bcbfc2b3675128c96c73c223894f08";
+      sha512 = "bac3cfc1adf91712b58777b26fc506e1db025a58f94aef8016904d957cd8dbb2f91950ae652e076b27d4e6624458c1f10d60ca0e2906440663bfb9e239916e04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/sv-SE/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/sv-SE/firefox-55.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "f46223ace271fcd4ca96ac6724bf60d99da5e80dcf00d6f2889cfdb41d1ca8c03ea3ca5ba61f6cc855c9cc2b62e4602628847d641f85d8bf2c6dd33cdd208b0a";
+      sha512 = "57499d98d877bbe491737ebf1b799ffef61ea41f7c903b3fc298c7006fb3a1d791cb716487f4b4fcd32d230f0fe8466ee1f36cdfd3832d920928bcdc62586ef5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ta/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/ta/firefox-55.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "cd3297d41e6524eb7ce5d398b8a95ee0ab008a626b1846e50096343aa5f469149a2a5c0f3d452d0f10ebe6f397e68d76dda4eaa9f3c10b0fa2b6a0d5d60bfa2e";
+      sha512 = "dfc1348f2239d917c19aee05f2b0d181b8028ab14b5b60fef2d8eba955fe1cb50a1400f8b5639f86c2aa8b82cc3a248224dd126d3313a5dc2f2f16014db1d0dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/te/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/te/firefox-55.0.2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "ac7a7ffe87187610a861e32a1a314ab0dc3141eb0910a1987946adccc686cbd1b58ccd996009fef49d642f3ae0568cf429811e652f4fa23b1f5381f3511fb65c";
+      sha512 = "50e89852e7799661c506f313440c7ef10ce96fa7562452cf9f6685a93d8d2f8ec15b8984d6fe971e9fe16b4ab916b665c1e4343e37a5cd4b75f0227dd2530915";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/th/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/th/firefox-55.0.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "2dc3ed9875d863b27151ae75dc83b5f2f738f0fac24f5fd1b3ba9f7a4aed1c2e77aaaf588bdca534b2a4078a086558ed820cbfd6e852244897dda7601bd5091f";
+      sha512 = "d1538447ed93bc652131e6d608a784294cf5f6b828e88109ff452d8f8e537dd76f9fca95b29c7eb3874c1e0b284b8ff45680783282945820fce1609c2c1cd116";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/tr/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/tr/firefox-55.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "869d654afeb246281be5b287ae76749e25da2e15d7d456cb5848281153307ca50f35a2c62dba0014b90ecf322a85ae8b7daa12ca156e8f5ac33854f6a890f19e";
+      sha512 = "7e6984a3364c1da09ada8f4aff6c2e1c371b5a4a6ee64b13afd3144d8e221081248aad6baf0d5399c3dc8a9891b184ac9fb74c9572b66007b1f1fc29642c16d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/uk/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/uk/firefox-55.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "709a5b8889c4a871dfa15c46bc7eee38986f4b76eef4bade78daf88f46e0ee50a815c54c0bf1e77924d1ae04d464de3a4d1c03494bb2781df11ab32d9e4766ec";
+      sha512 = "98ffd7e12a77387cb503d8c91cad07385d6d151319afd6c109712638e83ff2391555906c762c4127455487d5d9dc0ee68a20a0865791b4ebad3deb1bf9bae04a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/ur/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/ur/firefox-55.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "d7a0481116d791eebc511ef35a79dad263bcbcde54838a03b86fd5864746c4353cea4e8ee7998b18b266509e2ce584da0cfed39c324c79b847b44ecb043ccf8e";
+      sha512 = "2e1de51b606d155bb05c6e6f51dbfa0932ec0d9d521e3904859e0c3a98ecdcd174efe865ccf44f54814530c8a979d00508d7edd25fd3d8b2e2824dc2576898fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/uz/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/uz/firefox-55.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "5102829f08869d90f362c8da8a6947c23b23c616b6c3cca58e4a8fc9ba68573e8d74238029ad51ca2439f7946359903bbf03c2468c86bfa7f7679580f9a60649";
+      sha512 = "850fed3fbca540e717bfc6941f1d41067e596b338173924cfd2bb4109f6c52d0eb83d0f5c405f3aa3074e853dc1f1cce205f1e599ea5a2dd1422ee37fc40b691";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/vi/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/vi/firefox-55.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "a4a936439a729142af19aa2db02a6e769bfe6c653e6d54381b7d80756968b6ebe6dbad51a267936e173b49d3f92b94e89012fd35c54aa790f17217b001b7dc3d";
+      sha512 = "aa512af12c17bf2703798b3e4bd846fcaaac2230be4062f1804b73461b78f9ea8fadec137783c8f7c6ecdb11d1a1f324c57884dd3e3deb7591c4203603887d73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/xh/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/xh/firefox-55.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "9ac4a54cb66cdbc720e263277dbeee14d243c025ee63f6a1ee4990575fbbb333a0979a19615c226fe1486d9896d6754b5485dedcffb576511754d6781c572dc8";
+      sha512 = "72273bedebc546a1fcb1869154cefe7cd542348e20d01a23a3cefa8eb8bd0766159d46d69759a7d444b8d28f9769d1ef693b9f16e4fded27eca2b1a93ace6ffd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/zh-CN/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/zh-CN/firefox-55.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "e007854739c12502665418c3e0470940cb9df0314537275dac5d3c80923a756dda14b7161196b7289187d6706d58f887f59f47e07f764714298e5da1a41a0979";
+      sha512 = "ef38cb84527c941be98315db0f9f6dd6c30a7eaf2ab8830429d79341e6af3ed919ae046b6e42d08e07990d2255b2600cb7dd3b3f24c36cb985d57e7828ab7f53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.1/linux-i686/zh-TW/firefox-55.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/55.0.2/linux-i686/zh-TW/firefox-55.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "f414e7c6da2b2b5a1871f25def1ee055f7cdb66a6e76ee66848c26e2eb2d999e65070a816067990cb9d855420392e4b84b52b957e6dca063f8a011f2ddb4bbe6";
+      sha512 = "b7aa08e3e983c0453ae2d4482ab3d15c7a0a814cef78cb2103539a2771555e0c2c8675e3f8bebcbfb7c801bb2b1399e321b805d99aa28dcb3aee104d887cd6ac";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -6,10 +6,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "55.0.1";
+    version = "55.0.2";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "2c15cb3e1a9f464f63ff7ac8ccf0625ed845a5cb9b186d7acf121c439cec38bcdeee93630e99dbfd336f1b7e60a7c09822a1eba59f308bba8866f155b2ed1c47";
+      sha512 = "a27722cb5840aac89752fea0880a7e093e84b50dc78a36dc8c4bd493ffda10fa61446007f680bfe65db7a0debe4c21e6f0bf9f0de9876bba067abdda6fed7be4";
     };
 
     patches = lib.optional stdenv.isi686 (fetchpatch {


### PR DESCRIPTION
###### Motivation for this change

- Bug fixes.

https://www.mozilla.org/en-US/firefox/55.0.2/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested only `firefox-bin`.

---

