### PR TITLE
ncurses: 6.0 -> 6.0-20170729

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -9,19 +9,18 @@
 , buildPlatform, hostPlatform
 , buildPackages
 }:
-let
-  version = if abiVersion == "5" then "5.9" else "6.0";
-  sha256 = if abiVersion == "5"
-    then "0fsn7xis81za62afan0vvm38bvgzg5wfmv1m86flqcj0nj7jjilh"
-    else "0q3jck7lna77z5r42f13c4xglc7azd19pxfrjrpgp2yf615w4lgm";
-in
+
 stdenv.mkDerivation rec {
+  version = if abiVersion == "5" then "5.9" else "6.0-20170729";
   name = "ncurses-${version}";
 
-  src = fetchurl {
+  src = fetchurl (if abiVersion == "5" then {
     url = "mirror://gnu/ncurses/${name}.tar.gz";
-    inherit sha256;
-  };
+    sha256 = "0fsn7xis81za62afan0vvm38bvgzg5wfmv1m86flqcj0nj7jjilh";
+  } else {
+    url = "ftp://ftp.invisible-island.net/ncurses/current/${name}.tgz";
+    sha256 = "1cfdpl2gnj8szw28jmzrw47va0yqn16g03ywyzz3bjmaqxxmmwga";
+  });
 
   patches = [ ./clang.patch ] ++ lib.optional (abiVersion == "5" && stdenv.cc.isGNU) ./gcc-5.patch;
 


### PR DESCRIPTION
Ncurses has no stable release since v6.0 which was released two years ago.
Given that even debian started using unstable weekly updates, I see no issue in doing the same.

This has been tested on my package set, but not the whole nixpkgs.
:warning: this is a small mass-rebuild.

Fixes #19785.