### PR TITLE
libquvi-scripts: init at 0.9.2

### DIFF
--- a/pkgs/development/libraries/libquvi-scripts/default.nix
+++ b/pkgs/development/libraries/libquvi-scripts/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchurl, fetchgit, pkgconfig, lua5_1, libproxy, curl, glib, libgcrypt }:
+
+let
+    version = "0.9.2";
+in
+stdenv.mkDerivation rec {
+  name = "libquvi-${version}";
+  src = fetchgit {
+      url = "https://github.com/mogaal/libquvi-scripts";
+      rev = "c23ed0406f54831f9d6e242cc80948d173da0eea";
+      sha256 = "0cki6cl5vaspcx51jx55fmy40rsrkdk308fifqix3rszv2x67bpx";
+  };
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ lua5_1 libproxy curl libgcrypt glib];
+
+  meta = {
+    homepage = http://quvi.sourceforge.net/;
+    description = "A selection of Lua scripts that libquvi calls upon to parse the properties for a media URL.";
+    license = stdenv.lib.licenses.agpl3Plus;
+    maintainers = [ stdenv.lib.maintainers.kiloreux ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9998,6 +9998,8 @@ with pkgs;
       libva = libva-full; # also wants libva-x11
     };
 
+    libquvi-scripts = callPackage ../development/libraries/libquvi-scripts { };
+
     kpmcore = callPackage ../development/libraries/kpmcore { };
 
     mlt = callPackage ../development/libraries/mlt/qt-5.nix {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

