### PR TITLE
tasksh: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/applications/misc/tasksh/default.nix
+++ b/pkgs/applications/misc/tasksh/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "tasksh-${version}";
-  version = "1.1.0";
+  version = "1.2.0";
 
   enableParallelBuilding = true;
 
   src = fetchurl {
     url = "http://taskwarrior.org/download/${name}.tar.gz";
-    sha256 = "0900nzfgvhcc106pl68d0v0qszvdc34yi59mw70b34b2gmkwdxzf";
+    sha256 = "1z8zw8lld62fjafjvy248dncjk0i4fwygw0ahzjdvyyppx4zjhkf";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

