### PR TITLE
openshift: 1.5.0 -> 3.6.0

### DIFF
--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, which, buildGoPackage }:
 
 let
-  version = "1.5.0";
+  version = "3.6.0";
   ver = stdenv.lib.elemAt (stdenv.lib.splitString "." version);
   versionMajor = ver 0;
   versionMinor = ver 1;
@@ -14,7 +14,7 @@ in buildGoPackage rec {
     owner = "openshift";
     repo = "origin";
     rev = "v${version}";
-    sha256 = "0qvyxcyca3888nkgvyvqcmybm95ncwxb3zvrzbg2gz8kx6g6350v";
+    sha256 = "08bdqvsjl6c7dmllyz8n4akb7gyn91znvbph5cgmmk1bhskycy1r";
   };
 
   buildInputs = [ which ];
@@ -28,7 +28,7 @@ in buildGoPackage rec {
     cd go/src/origin-v${version}-src
     # Openshift build require this variables to be set
     # unless there is a .git folder which is not the case with fetchFromGitHub
-    export OS_GIT_VERSION=${version}
+    export OS_GIT_VERSION=v${version}
     export OS_GIT_MAJOR=${versionMajor}
     export OS_GIT_MINOR=${versionMinor}
     make build
@@ -43,7 +43,7 @@ in buildGoPackage rec {
     description = "Build, deploy, and manage your applications with Docker and Kubernetes";
     license = licenses.asl20;
     homepage = http://www.openshift.org;
-    maintainers = with maintainers; [offline bachp];
+    maintainers = with maintainers; [offline bachp moretea];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -32,7 +32,7 @@ in buildGoPackage rec {
 
     substituteInPlace pkg/bootstrap/docker/host/host.go  \
       --replace 'nsenter --mount=/rootfs/proc/1/ns/mnt mkdir' \
-      'nsenter --mount=/rootfs/proc/1/ns/mnt ${coreutils}/bin/mount'
+      'nsenter --mount=/rootfs/proc/1/ns/mnt ${utillinux}/bin/mount'
   '';
 
   buildPhase = ''

--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, which, buildGoPackage }:
+{ stdenv, fetchFromGitHub, which, buildGoPackage, utillinux, coreutils }:
 
 let
   version = "3.6.0";
@@ -22,6 +22,17 @@ in buildGoPackage rec {
   goPackagePath = null;
   patchPhase = ''
     patchShebangs ./hack
+    substituteInPlace pkg/bootstrap/docker/host/host.go  \
+      --replace 'nsenter --mount=/rootfs/proc/1/ns/mnt findmnt' \
+      'nsenter --mount=/rootfs/proc/1/ns/mnt ${utillinux}/bin/findmnt'
+
+    substituteInPlace pkg/bootstrap/docker/host/host.go  \
+      --replace 'nsenter --mount=/rootfs/proc/1/ns/mnt mount' \
+      'nsenter --mount=/rootfs/proc/1/ns/mnt ${utillinux}/bin/mount'
+
+    substituteInPlace pkg/bootstrap/docker/host/host.go  \
+      --replace 'nsenter --mount=/rootfs/proc/1/ns/mnt mkdir' \
+      'nsenter --mount=/rootfs/proc/1/ns/mnt ${coreutils}/bin/mount'
   '';
 
   buildPhase = ''


### PR DESCRIPTION
<s>Unfortunately, `oc cluster up` still does not work after this update (but neither did it work on 1.5.0)</s>

- Updated from 1.5.0 to 3.6.0 (this is just the next version, but Red Hat did quite the version bump there)
- Added 'v' to the version; it is used by `oc cluster up` to determine  which image should be downloaded.
- Added myself as a maintainer.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

