### PR TITLE
androidndk: wrap scripts in $out/libexec

### DIFF
--- a/pkgs/development/mobile/androidenv/androidndk.nix
+++ b/pkgs/development/mobile/androidenv/androidndk.nix
@@ -64,17 +64,17 @@ stdenv.mkDerivation rec {
     sed -i -e ${sed_script_2} ndk-which
     # a bash script
     patchShebangs ndk-which
+    # wrap
+    for i in ndk-build ndk-gdb ndk-gdb-py ndk-which
+    do
+        wrapProgram "$(pwd)/$i" --prefix PATH : "${runtime_paths}"
+    done
     # make some executables available in PATH
     mkdir -pv ${bin_path}
     for i in \
         ndk-build ndk-depends ndk-gdb ndk-gdb-py ndk-gdb.py ndk-stack ndk-which
     do
         ln -sf ${pkg_path}/$i ${bin_path}/$i
-    done
-    # wrap
-    for i in ndk-build ndk-gdb ndk-gdb-py ndk-which
-    do
-        wrapProgram "${bin_path}/$i" --prefix PATH : "${runtime_paths}"
     done
   '';
 

--- a/pkgs/development/mobile/androidenv/androidndk_r8e.nix
+++ b/pkgs/development/mobile/androidenv/androidndk_r8e.nix
@@ -64,17 +64,17 @@ stdenv.mkDerivation rec {
     sed -i -e ${sed_script_2} ndk-which
     # a bash script
     patchShebangs ndk-which
+    # wrap
+    for i in ndk-build ndk-gdb ndk-gdb-py ndk-which
+    do
+        wrapProgram "$(pwd)/$i" --prefix PATH : "${runtime_paths}"
+    done
     # make some executables available in PATH
     mkdir -pv ${bin_path}
     for i in \
         ndk-build ndk-depends ndk-gdb ndk-gdb-py ndk-gdb.py ndk-stack ndk-which
     do
         ln -sf ${pkg_path}/$i ${bin_path}/$i
-    done
-    # wrap
-    for i in ndk-build ndk-gdb ndk-gdb-py ndk-which
-    do
-        wrapProgram "${bin_path}/$i" --prefix PATH : "${runtime_paths}"
     done
   '';
 }


### PR DESCRIPTION
###### Motivation for this change

Build scripts of some Android programs run ```$ANDROID_NDK/libexec/*/ndk-build``` where scripts are not wrapped
This PR puts wrapping of scripts before making symlinks in ```$out/bin```, so both ```$ANDROID_NDK/bin/ndk-build``` and ```$ANDROID_NDK/libexec/*/ndk-build``` are wrapped.