### PR TITLE
androidsdk: put license hashes to nix store

### DIFF
--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -246,6 +246,11 @@ stdenv.mkDerivation rec {
             ln -sf $i $out/bin/$(basename $i)
         fi
     done
+
+    mkdir -p $out/libexec/licenses
+    echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$out/libexec/licenses/android-sdk-license"
+    echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$out/libexec/licenses/android-sdk-preview-license"
+    echo -e "\nd975f751698a77b662f1254ddbeed3901e976f5a" > "$out/libexec/licenses/intel-android-extra-license"
   '';
   
   buildInputs = [ unzip makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Put license hashes to nix store as there is no way to install them into the read-only store later
Fixes https://github.com/NixOS/nixpkgs/issues/23910
