### PR TITLE
pythonPackages.docker: 2.3.0 -> 2.4.2

### DIFF
--- a/pkgs/development/python-modules/docker.nix
+++ b/pkgs/development/python-modules/docker.nix
@@ -3,13 +3,13 @@
 , ipaddress, backports_ssl_match_hostname, docker_pycreds
 }:
 buildPythonPackage rec {
-  version = "2.3.0";
+  version = "2.4.2";
   pname = "docker";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://pypi/d/docker/${name}.tar.gz";
-    sha256 = "b0e3f353a3df3eedfbbcaf48235117263479b893edfa0cf6d8d056cca5edde1c";
+    sha256 = "11kl6kl82056bzcycvc2jpz59ra89vwbyzi0yaamixgcm9nzlvr1";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Required for docker-compose: 1.13.0 -> 1.15.0 (#28351)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

