### PR TITLE
quickder: 1.0-RC2 -> 1.2.2

### DIFF
--- a/pkgs/development/libraries/quickder/default.nix
+++ b/pkgs/development/libraries/quickder/default.nix
@@ -1,36 +1,29 @@
-{ stdenv, fetchFromGitHub, fetchurl, hexio, python, which, asn2quickder, bash }:
+{ stdenv, fetchFromGitHub, fetchurl, pythonPackages, which, bash, cmake, git }:
 
 stdenv.mkDerivation rec {
   pname = "quickder";
   name = "${pname}-${version}";
-  version = "1.0-RC2";
+  version = "1.2-2";
 
   src = fetchFromGitHub {
-    sha256 = "1nzk8x6qzpvli8bf74dc2qya63nlppqjrnkaxvjxr2dbqb8qcrqd";
+    sha256 = "0bd8x4acfswpq3hrqmp22mfqq2l60swmybmki69jayzxb5m96p3w";
     rev = "version-${version}";
     owner = "vanrein";
     repo = "quick-der";
   };
 
-  buildInputs = [ which asn2quickder bash ];
+  buildInputs = [ which bash cmake git ];
+  propagatedBuildInputs = with pythonPackages; [ pyparsing asn1ate ];
 
-  patchPhase = ''
-    substituteInPlace Makefile \
-      --replace 'lib tool test rfc' 'lib test rfc'
-    substituteInPlace ./rfc/Makefile \
-      --replace 'ASN2QUICKDER_CMD = ' 'ASN2QUICKDER_CMD = ${asn2quickder}/bin/asn2quickder #'
-    '';
-
-  installFlags = "ASN2QUICKDER_DIR=${asn2quickder}/bin ASN2QUICKDER_CMD=${asn2quickder}/bin/asn2quickder";
-  installPhase = ''
-    mkdir -p $out/lib $out/man
-    make DESTDIR=$out PREFIX=/ all
-    make DESTDIR=$out PREFIX=/ install
+    buildPhase = with pythonPackages; ''
+      mkdir -p "$out/lib/${python.libPrefix}/site-packages"
+      export PYTHONPATH="${asn1ate}/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
+      cmake .
     '';
 
   meta = with stdenv.lib; {
     description = "Quick (and Easy) DER, a Library for parsing ASN.1";
-    homepage = https://github.com/vanrein/quick-der;
+    homepage = "https://github.com/vanrein/quick-der";
     license = licenses.bsd2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ leenaars ];


### PR DESCRIPTION
###### Motivation for this change

Version bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

