### PR TITLE
[staging] perl: 5.24.x -> 5.26.x

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -185,7 +185,7 @@ let
     setupHook = ./setup-hook-cross.sh;
   });
 in rec {
-  perl = perl524;
+  perl = perl526;
 
   perl522 = common {
     version = "5.22.4";
@@ -194,7 +194,7 @@ in rec {
 
   perl524 = common {
     version = "5.24.4";
-    sha256 = "0w0r6v5k5hw5q1k3p4c7krcxidkj2qzsj5dlrlrxhm01n7fksbxz"; 
+    sha256 = "0w0r6v5k5hw5q1k3p4c7krcxidkj2qzsj5dlrlrxhm01n7fksbxz";
   };
 
   perl526 = common {

--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -1,6 +1,6 @@
 source $stdenv/setup
 
-PERL5LIB="$PERL5LIB${PERL5LIB:+:}$out/lib/perl5/site_perl"
+PERL5LIB="$PERL5LIB${PERL5LIB:+:}$out/lib/perl5/site_perl:."
 
 perlFlags=
 for i in $(IFS=:; echo $PERL5LIB); do


### PR DESCRIPTION
###### Motivation for this change

Changing default perl from ```5.24.x``` to ```5.26.x```

Once this was part of [```17.09```  milestone ](https://github.com/NixOS/nixpkgs/milestone/11) but then cancelled because some of the perl libs were not adapted quickly to the breaking changes introduced in ```5.26```

An year has been passed,
- [x] ```perl-5.26.x``` matured from ```5.26.0``` to ```5.26.2```
- [x]  the libraries (except the abandoned ones) have been adapted to ```perl-5.26.x```
- [x] ```cpan2nix``` ensures the perl libraries in nixpkgs are up to date
- [x]  ```perl-5.28.0``` has been released recently and that means ```5.24.x``` is going to be deprecated by upstream soon.

This is another try to build NixOS defaulting ```perl``` to ```perl526``` instead of ```perl524```