### PR TITLE
gnonlin: use httpS to fetch archive

### DIFF
--- a/pkgs/development/libraries/gstreamer/legacy/gnonlin/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gnonlin/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     urls = [
-      "http://gstreamer.freedesktop.org/src/gnonlin/${name}.tar.bz2"
+      "https://gstreamer.freedesktop.org/src/gnonlin/${name}.tar.bz2"
       "mirror://gentoo/distfiles/${name}.tar.bz2"
       ];
     sha256 = "0dc9kvr6i7sh91cyhzlbx2bchwg84rfa4679ccppzjf0y65dv8p4";


### PR DESCRIPTION
###### Motivation for this change

Fetch archive with https instead of http.

###### Things done

- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

---

