### PR TITLE
(legacy) gstreamer: fetch archive with httpS instead of http

### DIFF
--- a/pkgs/development/libraries/gstreamer/legacy/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gstreamer/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   setupHook = ./setup-hook.sh;
 
   meta = {
-    homepage = http://gstreamer.freedesktop.org;
+    homepage = https://gstreamer.freedesktop.org;
 
     description = "Library for constructing graphs of media-handling components";
 


### PR DESCRIPTION
###### Things done
- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

---

