### PR TITLE
radare2: 1.4.0 -> 1.6.0

### DIFF
--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, libusb, readline, libewf, perl, zlib, openssl,
+{stdenv, fetchFromGitHub, fetchurl, pkgconfig, libusb, readline, libewf, perl, zlib, openssl,
 gtk2 ? null, vte ? null, gtkdialog ? null,
 python ? null,
 ruby ? null,
@@ -10,23 +10,48 @@ assert rubyBindings -> ruby != null;
 assert pythonBindings -> python != null;
 
 let
-  optional = stdenv.lib.optional;
+  inherit (stdenv.lib) optional;
 in
 stdenv.mkDerivation rec {
-  version = "1.4.0";
+  version = "1.6.0";
   name = "radare2-${version}";
 
-  src = fetchurl {
-    url = "http://cloud.radare.org/get/${version}/${name}.tar.gz";
-    sha256 = "bf6e9ad94fd5828d3936563b8b13218433fbf44231cacfdf37a7312ae2b3e93e";
+  src = fetchFromGitHub {
+    owner = "radare";
+    repo = "radare2";
+    rev = version;
+    sha256 = "0kb7y0b5kw2p1kxpzjgc8pnwdkqyzkijzp5d2a9zs2ira96668zd";
   };
 
+  postPatch = let
+    cs_ver = "3.0.4"; # version from $sourceRoot/shlr/Makefile
+    capstone = fetchurl {
+      url = "https://github.com/aquynh/capstone/archive/${cs_ver}.tar.gz";
+      sha256 = "1whl5c8j6vqvz2j6ay2pyszx0jg8d3x8hq66cvgghmjchvsssvax";
+    };
+  in ''
+    if ! grep -F "CS_VER=${cs_ver}" shlr/Makefile; then echo "CS_VER mismatch"; exit 1; fi
+    substituteInPlace shlr/Makefile --replace CS_RELEASE=0 CS_RELEASE=1
+    cp ${capstone} shlr/capstone-${cs_ver}.tar.gz
+
+    # make compiler happy (fixed in upstream 2017-08-11)
+    substituteInPlace libr/asm/arch/hexagon/gnu/hexagon-dis.c --replace \
+      '(*info->fprintf_func) (info->stream, errmsg);' \
+      '(*info->fprintf_func) (info->stream, "%s", errmsg);'
+  '';
 
   buildInputs = [pkgconfig readline libusb libewf perl zlib openssl]
     ++ optional useX11 [gtkdialog vte gtk2]
     ++ optional rubyBindings [ruby]
     ++ optional pythonBindings [python]
     ++ optional luaBindings [lua];
+
+  postInstall = ''
+    # replace symlinks pointing into the build directory with the files they point to
+    rm $out/bin/{r2-docker,r2-indent}
+    cp sys/r2-docker.sh $out/bin/r2-docker
+    cp sys/indent.sh    $out/bin/r2-indent
+  '';
 
   meta = {
     description = "unix-like reverse engineering framework and commandline tools";


### PR DESCRIPTION
###### Motivation for this change

- [x] radare2: 1.4.0 -> 1.6.0
- [x] build from github instead of tarball, because:
   1. it is the [upstream recommended way](http://rada.re/r/down.html)
   2. http://cloud.radare.org (the tarball host) is currently down
   3. there was [an incident](https://github.com/NixOS/nixpkgs/commit/938df03ed1ae250fd21a7615763b1ecabb041b66) with tarball rewrite 
   4. ease to override the derivation to build the bleeding edge version from the github head.
- [x] Fixes https://github.com/NixOS/nixpkgs/pull/26322 (dangling symlinks in ```bin/```)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

