### PR TITLE
mate: caja-extensions: init at 1.18.1, engrampa: init at 1.18.2

### DIFF
--- a/pkgs/desktops/mate/caja-extensions/default.nix
+++ b/pkgs/desktops/mate/caja-extensions/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, pkgconfig, intltool, gtk3, dbus_glib, gupnp, mate, imagemagick }:
+
+stdenv.mkDerivation rec {
+  name = "caja-extensions-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "1";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "0hgala7zkfsa60jflq3s4n9yd11dhfdcla40l83cmgc3r1az7cmw";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+  ];
+
+  buildInputs = [
+    gtk3
+    dbus_glib
+    gupnp
+    mate.caja
+    mate.mate-desktop
+    imagemagick
+  ];
+
+  postPatch = ''
+    for f in image-converter/caja-image-{resizer,rotator}.c; do
+      substituteInPlace $f --replace "/usr/bin/convert" "${imagemagick}/bin/convert"
+    done
+  '';
+  
+  configureFlags = [ "--with-cajadir=$$out/lib/caja/extensions-2.0" ];
+
+  meta = with stdenv.lib; {
+    description = "Set of extensions for Caja file manager";
+    homepage = http://mate-desktop.org;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/desktops/mate/caja/caja-extension-dirs.patch
+++ b/pkgs/desktops/mate/caja/caja-extension-dirs.patch
@@ -1,0 +1,30 @@
+diff --git a/libcaja-private/caja-module.c b/libcaja-private/caja-module.c
+index 023c22e..414913b 100644
+--- a/libcaja-private/caja-module.c
++++ b/libcaja-private/caja-module.c
+@@ -258,11 +258,25 @@ caja_module_setup (void)
+ {
+     static gboolean initialized = FALSE;
+     GList *res;
++    gchar *caja_extension_dirs;
++    gchar **dir_vector;
+ 
+     if (!initialized)
+     {
+         initialized = TRUE;
+ 
++        caja_extension_dirs = (gchar *) g_getenv ("CAJA_EXTENSION_DIRS");
++
++        if (caja_extension_dirs)
++        {
++            dir_vector = g_strsplit (caja_extension_dirs, G_SEARCHPATH_SEPARATOR_S, 0);
++
++            for (gchar **dir = dir_vector; *dir != NULL; ++ dir)
++                load_module_dir (*dir);
++
++            g_strfreev(dir_vector);
++        }
++
+         load_module_dir (CAJA_EXTENSIONDIR);
+ 
+         eel_debug_call_at_shutdown (free_module_objects);

--- a/pkgs/desktops/mate/caja/cajaWithExtensions.nix
+++ b/pkgs/desktops/mate/caja/cajaWithExtensions.nix
@@ -1,0 +1,11 @@
+{ buildEnv, makeWrapper, caja, extensions ? [] }:
+
+buildEnv {
+  name = "cajaWithExtensions-${caja.version}";
+  meta = caja.meta // { description = "File manager (including extensions) for the MATE desktop"; };
+  paths = [ caja ] ++ extensions;
+  buildInputs = [ makeWrapper ];
+  postBuild = ''
+    wrapProgram "$out/bin/caja" --set CAJA_EXTENSION_DIRS "$out/lib/caja/extensions-2.0"
+  '';
+}

--- a/pkgs/desktops/mate/caja/default.nix
+++ b/pkgs/desktops/mate/caja/default.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation rec {
     mate.mate-desktop
   ];
 
+  patches = [
+    ./caja-extension-dirs.patch
+  ];
+  
   configureFlags = [ "--disable-update-mimedb" ];
   
   meta = {

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -2,6 +2,7 @@
 rec {
   atril = callPackage ./atril { };
   caja = callPackage ./caja { };
+  caja-extensions = callPackage ./caja-extensions { };
   eom = callPackage ./eom { };
   pluma = callPackage ./pluma { };
   mate-common = callPackage ./mate-common { };

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -3,6 +3,9 @@ rec {
   atril = callPackage ./atril { };
   caja = callPackage ./caja { };
   caja-extensions = callPackage ./caja-extensions { };
+  cajaWithExtensions = callPackage ./caja/cajaWithExtensions.nix {
+    extensions = [ caja-extensions ];
+  };
   eom = callPackage ./eom { };
   pluma = callPackage ./pluma { };
   mate-common = callPackage ./mate-common { };

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -6,6 +6,7 @@ rec {
   cajaWithExtensions = callPackage ./caja/cajaWithExtensions.nix {
     extensions = [ caja-extensions ];
   };
+  engrampa = callPackage ./engrampa { };
   eom = callPackage ./eom { };
   pluma = callPackage ./pluma { };
   mate-common = callPackage ./mate-common { };

--- a/pkgs/desktops/mate/engrampa/default.nix
+++ b/pkgs/desktops/mate/engrampa/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, gnome3, mate, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "engrampa-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "2";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "0d98zhqqc7qdnxcf0195kd04xmhijc0w2qrn6q61zd0daiswnv98";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    itstool
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    libxml2
+    gnome3.gtk
+    mate.caja
+    mate.mate-desktop
+  ];
+
+  configureFlags = [ "--with-cajadir=$$out/lib/caja/extensions-2.0" ];
+
+  meta = {
+    description = "Archive Manager for MATE";
+    homepage = http://mate-desktop.org;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Add [Caja Extensions](https://github.com/mate-desktop/caja-extensions), which is a set of extensions for [Caja](https://github.com/mate-desktop/caja), the [MATE](http://www.mate-desktop.org) file manager.

Add `cajWithExtensions`, a wrapper to `caja` to give access to a list of extensions.

Add [Engrampa](https://github.com/mate-desktop/engrampa), a file archiver for [MATE](http://www.mate-desktop.org).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).