### PR TITLE
KDE Frameworks: 5.36 -> 5.37 and KDE Applications 17.04.3 -> 17.08.0

### DIFF
--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/applications/17.04.3/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/applications/17.08.0/ -A '*.tar.xz' )

--- a/pkgs/applications/kde/khelpcenter.nix
+++ b/pkgs/applications/kde/khelpcenter.nix
@@ -12,4 +12,5 @@ mkDerivation {
     grantlee kcmutils kconfig kcoreaddons kdbusaddons kdelibs4support khtml
     ki18n kinit kservice xapian
   ];
+  patches = [ ./khelpcenter_kcoreaddons.patch ];
 }

--- a/pkgs/applications/kde/khelpcenter_kcoreaddons.patch
+++ b/pkgs/applications/kde/khelpcenter_kcoreaddons.patch
@@ -1,0 +1,13 @@
+diff --git a/searchhandlers/CMakeLists.txt b/searchhandlers/CMakeLists.txt
+index 298a32e..b9e06c6 100644
+--- a/searchhandlers/CMakeLists.txt
++++ b/searchhandlers/CMakeLists.txt
+@@ -16,7 +16,7 @@ set(khc_xapianindexer_SOURCES
+ add_executable(khc_xapianindexer ${khc_xapianindexer_SOURCES})
+ kde_target_enable_exceptions(khc_xapianindexer PRIVATE)
+ ecm_mark_nongui_executable(khc_xapianindexer)
+-target_link_libraries(khc_xapianindexer Qt5::Core KF5::Archive ${XAPIAN_LIBRARIES} ${LIBXML2_LIBRARIES})
++target_link_libraries(khc_xapianindexer Qt5::Core KF5::Archive KF5::CoreAddons ${XAPIAN_LIBRARIES} ${LIBXML2_LIBRARIES})
+ if (${KF5_VERSION} VERSION_GREATER 5.35.0)
+     # practically means >=5.36
+     target_link_libraries(khc_xapianindexer KF5::DocTools)

--- a/pkgs/applications/kde/okteta.nix
+++ b/pkgs/applications/kde/okteta.nix
@@ -1,7 +1,9 @@
 {
   mkDerivation, lib,
-  extra-cmake-modules, kdoctools, shared_mime_info,
-  kconfig, kinit, kcmutils, kconfigwidgets, knewstuff, kparts, qca-qt5, qtscript
+  extra-cmake-modules, kdoctools,
+  qtscript, kconfig, kinit, karchive, kcrash,
+  kcmutils, kconfigwidgets, knewstuff, kparts, qca-qt5,
+  shared_mime_info
 }:
 
 mkDerivation {
@@ -10,8 +12,10 @@ mkDerivation {
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ peterhoeg ];
   };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools shared_mime_info ];
-  buildInputs = [
-    kconfig kinit kcmutils kconfigwidgets knewstuff kparts qca-qt5 qtscript
+  nativeBuildInputs = [ qtscript extra-cmake-modules kdoctools ];
+  buildInputs = [ shared_mime_info ];
+  propagatedBuildInputs = [
+    kconfig kinit kcmutils kconfigwidgets knewstuff kparts qca-qt5
+    karchive kcrash
   ];
 }

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -3,2235 +3,2235 @@
 
 {
   akonadi = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/akonadi-17.04.3.tar.xz";
-      sha256 = "0cddlz5v25ak9x1f682rjm3vlaqfm9n9y1bfd3h3md59j9l4gq49";
-      name = "akonadi-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/akonadi-17.08.0.tar.xz";
+      sha256 = "00mj3gvlv1cgb7dxzjym87404laxsk7insykbb12zj4wlhzakznp";
+      name = "akonadi-17.08.0.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/akonadi-calendar-17.04.3.tar.xz";
-      sha256 = "0543wixfwy80sx0lsy8jwlbyr3cxl3jyf04n644zyrkl461lv637";
-      name = "akonadi-calendar-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/akonadi-calendar-17.08.0.tar.xz";
+      sha256 = "0mv41pkn24rdbg5xyz7vxaihma02qry3sladgpffg27yw56xp5x4";
+      name = "akonadi-calendar-17.08.0.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/akonadi-calendar-tools-17.04.3.tar.xz";
-      sha256 = "1yzfv80lyair5nkyql17ijnbcp9iyidhwrff6if9kn87sv5i9b4v";
-      name = "akonadi-calendar-tools-17.04.3.tar.xz";
-    };
-  };
-  akonadiconsole = {
-    version = "17.04.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/akonadiconsole-17.04.3.tar.xz";
-      sha256 = "1v449q0d1ld84jjy0bshnf99ss5qq9mg2vp9c2wl2i8f640k7f0v";
-      name = "akonadiconsole-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/akonadi-calendar-tools-17.08.0.tar.xz";
+      sha256 = "1vzmdgbn6hjjv74837s18kfif7s2gak5jbag2l1kqdj9lgwi4lv0";
+      name = "akonadi-calendar-tools-17.08.0.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/akonadi-contacts-17.04.3.tar.xz";
-      sha256 = "03sffvybravzmg8qjqylgvfrn7ajvahkm7qnr8k44b9i9cy676ak";
-      name = "akonadi-contacts-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/akonadi-contacts-17.08.0.tar.xz";
+      sha256 = "0j49zf83bfzrxygdg98cijjjva96niv24312ng7f8hckm369zc91";
+      name = "akonadi-contacts-17.08.0.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/akonadi-import-wizard-17.04.3.tar.xz";
-      sha256 = "0gb2vzvznmyc3qvrzaka5q43qp982izm4yf7i340yi780qaixz18";
-      name = "akonadi-import-wizard-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/akonadi-import-wizard-17.08.0.tar.xz";
+      sha256 = "0hhi8l94fariz6q2zazxsqnm08scfqsc3sm8azklj24gbz59qzzf";
+      name = "akonadi-import-wizard-17.08.0.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/akonadi-mime-17.04.3.tar.xz";
-      sha256 = "050kn3shqnzk22bx2h83b6qymn3npscnjqd2vrrwvbwh1b2ww2si";
-      name = "akonadi-mime-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/akonadi-mime-17.08.0.tar.xz";
+      sha256 = "0lg0rqikgdbdvh44p52m7acw6ni5wi1rsgx93wn1nki4rhnsgndp";
+      name = "akonadi-mime-17.08.0.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/akonadi-notes-17.04.3.tar.xz";
-      sha256 = "1l8rhfvl8fh04igldggcq1fz1f6s595c89hzzza75qqbcs2azfps";
-      name = "akonadi-notes-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/akonadi-notes-17.08.0.tar.xz";
+      sha256 = "1d17403bhbh7nk73vcq86dilfancb31fdz2al6pr7xrkxm5nql0v";
+      name = "akonadi-notes-17.08.0.tar.xz";
     };
   };
   akonadi-search = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/akonadi-search-17.04.3.tar.xz";
-      sha256 = "0b4magnl3lrlnfsnsw46vkbhkp1bbxf2fgjfm84vndmwyglj1605";
-      name = "akonadi-search-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/akonadi-search-17.08.0.tar.xz";
+      sha256 = "1i6v4mvm2g0v4kzbs6rla9gf16lswg4xghsam9k1cpqpakkaqf84";
+      name = "akonadi-search-17.08.0.tar.xz";
+    };
+  };
+  akonadiconsole = {
+    version = "17.08.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.08.0/src/akonadiconsole-17.08.0.tar.xz";
+      sha256 = "0a0gvw6xn4wcl5hzxnv4170n1yq0ycmfs6nyff4x8fcj0ffl6rqv";
+      name = "akonadiconsole-17.08.0.tar.xz";
     };
   };
   akregator = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/akregator-17.04.3.tar.xz";
-      sha256 = "12wajdwn3pp2prl9b2wlx1326b9w75j04yhg6q3082nrhlgmcnm2";
-      name = "akregator-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/akregator-17.08.0.tar.xz";
+      sha256 = "16ss44md7vnz6nclhza7ygvfaqr8dpd2lq1cz4szm0qwwiciwxkc";
+      name = "akregator-17.08.0.tar.xz";
     };
   };
   analitza = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/analitza-17.04.3.tar.xz";
-      sha256 = "0scz8qi25gk1p8n6134wbcrknvxihyjkwvs6x22606nnrghlfc1b";
-      name = "analitza-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/analitza-17.08.0.tar.xz";
+      sha256 = "1qmh4xc912bw5m07pnqdp6pmjiba6mirlwhgbl6wqvzi97cjrsxq";
+      name = "analitza-17.08.0.tar.xz";
     };
   };
   ark = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ark-17.04.3.tar.xz";
-      sha256 = "1b9kadiz91d86q3hrailzd56pbaxzh7jmvy317nfiqrflw541sin";
-      name = "ark-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ark-17.08.0.tar.xz";
+      sha256 = "1d3p4y1bchnqza2xxmd7z3ys66373mgvdr8xa5z2n2pq55qnvrx1";
+      name = "ark-17.08.0.tar.xz";
     };
   };
   artikulate = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/artikulate-17.04.3.tar.xz";
-      sha256 = "0axc54cqyhmb28rzxlflmms4cfv2539wwb4lmgm99z8kgg7634g6";
-      name = "artikulate-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/artikulate-17.08.0.tar.xz";
+      sha256 = "0gybg5aw8gbrmfg46985p2xmdz624vjc6rkkh2f2dvrijx9z82sf";
+      name = "artikulate-17.08.0.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/audiocd-kio-17.04.3.tar.xz";
-      sha256 = "1q1zlp2p94044p0gb6vwzybvj3g2c1lwnyj4x2kim6wkj2x9pqrf";
-      name = "audiocd-kio-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/audiocd-kio-17.08.0.tar.xz";
+      sha256 = "05h1rp7f3jqx9jzn3x48sdd0ycb0ksflyy8ncy9bb72ky3j3f986";
+      name = "audiocd-kio-17.08.0.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/baloo-widgets-17.04.3.tar.xz";
-      sha256 = "1awhqv8gqjkdcblsq9sn6wd2f2693niyk59x0vhf3ml87sqmhki4";
-      name = "baloo-widgets-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/baloo-widgets-17.08.0.tar.xz";
+      sha256 = "0z5lpmca6w691ckyhhr99ky0fjli7sk8riarhrr65hk6zyf3djmx";
+      name = "baloo-widgets-17.08.0.tar.xz";
     };
   };
   blinken = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/blinken-17.04.3.tar.xz";
-      sha256 = "13m0854d4bahhcpfq7v04ydhvxs79x9h0rhhvp9zapzq8kvhc6s0";
-      name = "blinken-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/blinken-17.08.0.tar.xz";
+      sha256 = "0p2yx91sggn908i24lqjkd5lw5djidwdfybf6dvdz916bv2ypf90";
+      name = "blinken-17.08.0.tar.xz";
     };
   };
   blogilo = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/blogilo-17.04.3.tar.xz";
-      sha256 = "1ziipi55hwmkmf7pr9j64qhc0px3v4pzd3b4b2gqz4fjg2sggp12";
-      name = "blogilo-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/blogilo-17.08.0.tar.xz";
+      sha256 = "1dabq57krzjkrs5xpgarisik66n0cvk097y9szxbmw1ghmw871cf";
+      name = "blogilo-17.08.0.tar.xz";
     };
   };
   bomber = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/bomber-17.04.3.tar.xz";
-      sha256 = "13z4zs9mvcwlidxx17nx6qzbdcc7r15adh5awxnjxnqv0akmqj7p";
-      name = "bomber-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/bomber-17.08.0.tar.xz";
+      sha256 = "0ydg1is0ayscj275177ivkzqdhc1mkqwbjfq5wdwiqdmh4p2dgzh";
+      name = "bomber-17.08.0.tar.xz";
     };
   };
   bovo = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/bovo-17.04.3.tar.xz";
-      sha256 = "0a27n64krkj6nmkzyi5vww6nsc2bzjlfzh8k32r8fjix500263i1";
-      name = "bovo-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/bovo-17.08.0.tar.xz";
+      sha256 = "1fl7cq27y3n0nzabh7xxwdipczww7pcck8nk2vrxzpnnwyzc4hjn";
+      name = "bovo-17.08.0.tar.xz";
     };
   };
   calendarsupport = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/calendarsupport-17.04.3.tar.xz";
-      sha256 = "1xv8n8hc5kp0cvbj7fpd065sb329ps3sazfmrf4h4gkh1zj5i8wi";
-      name = "calendarsupport-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/calendarsupport-17.08.0.tar.xz";
+      sha256 = "01fw1ddd6xhv84557214ilj088cdczv26whl6q4wm7c4wyicrrxs";
+      name = "calendarsupport-17.08.0.tar.xz";
     };
   };
   cantor = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/cantor-17.04.3.tar.xz";
-      sha256 = "0lcvhc2pyhyzlj9px6cni99l0zddyv32gk32s3wg7pz71msaw91w";
-      name = "cantor-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/cantor-17.08.0.tar.xz";
+      sha256 = "0mv7qx5zam6mcri3j3jqci70bxxzrf3f7vdpmsmwcm2w0isv02x0";
+      name = "cantor-17.08.0.tar.xz";
     };
   };
   cervisia = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/cervisia-17.04.3.tar.xz";
-      sha256 = "1hrik6r87sx2d99fnn89k48mf76xnrq4wgh2zg03hmf327ydviq2";
-      name = "cervisia-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/cervisia-17.08.0.tar.xz";
+      sha256 = "0pz6qqq5nayw68z30gf0bxjm8lz0hn2cswvdyc0b505p2gkq1ika";
+      name = "cervisia-17.08.0.tar.xz";
     };
   };
   dolphin = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/dolphin-17.04.3.tar.xz";
-      sha256 = "1q8pj2wh186l76cg5ir3l9f6xma1kjgbrk9kfd9br400dx2pz62a";
-      name = "dolphin-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/dolphin-17.08.0.tar.xz";
+      sha256 = "1fxga83magv47jpmrbcyyxblxyws0n6mp8vjv8pa5jzwywsxg09r";
+      name = "dolphin-17.08.0.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/dolphin-plugins-17.04.3.tar.xz";
-      sha256 = "1is11ja2lzqxnsmj6kkr1q9l9csjy4ymv869yrgsbid0xjc2krj3";
-      name = "dolphin-plugins-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/dolphin-plugins-17.08.0.tar.xz";
+      sha256 = "1vb0flj4151d1h4x7rgfn79hcqk1pal9hxdi5wmkzjy3aj702gcc";
+      name = "dolphin-plugins-17.08.0.tar.xz";
     };
   };
   dragon = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/dragon-17.04.3.tar.xz";
-      sha256 = "1raki9yp51s73ca6fv093pbhwjfw3hbiazbhfwf6f3dqag24w11w";
-      name = "dragon-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/dragon-17.08.0.tar.xz";
+      sha256 = "0h9ysyjpcj8hlsbp622dzpzjvilad1qrjflhmx71gaan2dyq0jd0";
+      name = "dragon-17.08.0.tar.xz";
     };
   };
   eventviews = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/eventviews-17.04.3.tar.xz";
-      sha256 = "18j8xikfxn2mpx61d4ynahai9s6gwi0x5xsfvnyrc2v43a69w7ks";
-      name = "eventviews-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/eventviews-17.08.0.tar.xz";
+      sha256 = "166jsnyv3xwhli931xwh18cy6alkj7w2lc3bqzkch0bc4gd2w8ba";
+      name = "eventviews-17.08.0.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ffmpegthumbs-17.04.3.tar.xz";
-      sha256 = "1f8xrga8v045g5drcls87m9w5d00887sglk274gi1jmf60sy55jk";
-      name = "ffmpegthumbs-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ffmpegthumbs-17.08.0.tar.xz";
+      sha256 = "1771abzrfifvw2c34vl1j0xl5j9lv9q2cwfyan3bzviwyyca0gka";
+      name = "ffmpegthumbs-17.08.0.tar.xz";
     };
   };
   filelight = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/filelight-17.04.3.tar.xz";
-      sha256 = "0srwhi3zi3gv8iid21f9gk709w59r4l7z560piywfgdmpp9spmgg";
-      name = "filelight-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/filelight-17.08.0.tar.xz";
+      sha256 = "1y6b705q04hjzdyy3k3dps9rgvaqlvy232f3m0qg1j9kjy0hs7kb";
+      name = "filelight-17.08.0.tar.xz";
     };
   };
   granatier = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/granatier-17.04.3.tar.xz";
-      sha256 = "1gv4xikxkqfw54pcgrkj5l2m84fc39pckyg495aid3fbh73pgi7i";
-      name = "granatier-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/granatier-17.08.0.tar.xz";
+      sha256 = "1i55hqgn69c1y03wwnm360bmw3v0nsn5wi1nd4p5na4vxcr7ly03";
+      name = "granatier-17.08.0.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/grantlee-editor-17.04.3.tar.xz";
-      sha256 = "0lm97icf22gbrq9pgj8cmwcgpqb5nsgwv78ldz8hp1s9x05qck2v";
-      name = "grantlee-editor-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/grantlee-editor-17.08.0.tar.xz";
+      sha256 = "1kvkbjicfnl8r13gzlb85d4c4allz6257285rmm3anhp12k84z31";
+      name = "grantlee-editor-17.08.0.tar.xz";
     };
   };
   grantleetheme = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/grantleetheme-17.04.3.tar.xz";
-      sha256 = "0jbgxjlsih2alc5ylbkrwwc2ij11ywsynlz1vsm0qzrfb7j534si";
-      name = "grantleetheme-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/grantleetheme-17.08.0.tar.xz";
+      sha256 = "04q29qvibxzxi9s9jldjvnx8x7x76ybcy7964im303zhcf3djmm5";
+      name = "grantleetheme-17.08.0.tar.xz";
     };
   };
   gwenview = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/gwenview-17.04.3.tar.xz";
-      sha256 = "12dy8hicrbns40gjnz2j60cqyjmrz5ci8sq2npblq5gr3avhdgla";
-      name = "gwenview-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/gwenview-17.08.0.tar.xz";
+      sha256 = "1xqma79v0sd48fsslblqaw5rbz80p2qi9rmwgv4adr1cd4n69f5i";
+      name = "gwenview-17.08.0.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/incidenceeditor-17.04.3.tar.xz";
-      sha256 = "1xjgmz23q45s5m3kzfdr3k94l711i672m8cp5lfv9sczv4lgi45y";
-      name = "incidenceeditor-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/incidenceeditor-17.08.0.tar.xz";
+      sha256 = "0pl9qza8bmbr6f29iaq9afhr89nkap8yzf36qn0i0fvc2x1940wk";
+      name = "incidenceeditor-17.08.0.tar.xz";
     };
   };
   jovie = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/jovie-17.04.3.tar.xz";
-      sha256 = "0v9ndwp7phd62vnp3qv3ax9khrzbqwhs0mv2glf8r8w4qqv39gsq";
-      name = "jovie-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/jovie-17.08.0.tar.xz";
+      sha256 = "1q8l5xm93x2kacz8ay2ra6jg0q24r22y8lxfpqzb8l8sz7gy81qa";
+      name = "jovie-17.08.0.tar.xz";
     };
   };
   juk = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/juk-17.04.3.tar.xz";
-      sha256 = "1kff1rcipw1m19w7dij3fjzqm4xkgzzy3qanhwhbicy77pkmcwjp";
-      name = "juk-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/juk-17.08.0.tar.xz";
+      sha256 = "0dzhn7x4r32smfil8v5afrl4d3xlx0c23f21rbj8gnnbiz3033iw";
+      name = "juk-17.08.0.tar.xz";
     };
   };
   k3b = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/k3b-17.04.3.tar.xz";
-      sha256 = "0a1hk0is5iswbvrq1zlj8fgr02dg94nm1393s3j1ashgvxsfzmfk";
-      name = "k3b-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/k3b-17.08.0.tar.xz";
+      sha256 = "1n0jvvd414mmfpljj1ja2ik7hcf3ih6i5ghcsq6irq6ijxibrkdd";
+      name = "k3b-17.08.0.tar.xz";
     };
   };
   kaccessible = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kaccessible-17.04.3.tar.xz";
-      sha256 = "1iik3dbdxqr9702mcrvij56j3w5wr4vmylnpkr9lm46pf0kpxyby";
-      name = "kaccessible-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kaccessible-17.08.0.tar.xz";
+      sha256 = "0xnlirxm5bp7wbvalml4z9l7yrnkxi7966dxb2a6n140xbnzy3f5";
+      name = "kaccessible-17.08.0.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kaccounts-integration-17.04.3.tar.xz";
-      sha256 = "0s67vgk2sh11gf2icg5syk3zy66ilkdnjspahhfsmvqkgpgcr3w7";
-      name = "kaccounts-integration-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kaccounts-integration-17.08.0.tar.xz";
+      sha256 = "181324pacp8nvnzyivwr657qi4jsbi5c1hv7yi5m9z0lw0b0h515";
+      name = "kaccounts-integration-17.08.0.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kaccounts-providers-17.04.3.tar.xz";
-      sha256 = "0j3w66gvvaa1fsncr2h15lw3fk4m1qzkhzaxp13yg5cig3mkg3bb";
-      name = "kaccounts-providers-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kaccounts-providers-17.08.0.tar.xz";
+      sha256 = "1428vak366hkx54shpymsg6xk1f92hkz2hgbipim5rddgjqpa9w4";
+      name = "kaccounts-providers-17.08.0.tar.xz";
     };
   };
   kaddressbook = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kaddressbook-17.04.3.tar.xz";
-      sha256 = "0gr3g0vi2h9qy4fw82g997wq2snam71qivqg5fk7bdgvzi3qm2d0";
-      name = "kaddressbook-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kaddressbook-17.08.0.tar.xz";
+      sha256 = "1m6k5gadrq5l6grw9y677360lxxcvz4axhr0rkpamvf0vy92iy8w";
+      name = "kaddressbook-17.08.0.tar.xz";
     };
   };
   kajongg = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kajongg-17.04.3.tar.xz";
-      sha256 = "0clq9gvxn8lma5s1qxl2j56nylbs1vijqlw1xplxi4pfwzv2d09g";
-      name = "kajongg-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kajongg-17.08.0.tar.xz";
+      sha256 = "0nf1p3gm9mq4szq49wmc39hjk52v4x5x7fn35sgmfi0dprz9i8y1";
+      name = "kajongg-17.08.0.tar.xz";
     };
   };
   kalarm = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kalarm-17.04.3.tar.xz";
-      sha256 = "00h90n9r05ffgca34fz1f5vr4c95xgq6ay6a0y7p7bda2kvl2rwg";
-      name = "kalarm-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kalarm-17.08.0.tar.xz";
+      sha256 = "1680i011p15pra6cb95icz788v7qivc3l8d9fngw9hg03i33y118";
+      name = "kalarm-17.08.0.tar.xz";
     };
   };
   kalarmcal = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kalarmcal-17.04.3.tar.xz";
-      sha256 = "1qn9idrjql02fzbvjdk70jqp1c4npjmbjgfbnjg2m4jnd98xd7yr";
-      name = "kalarmcal-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kalarmcal-17.08.0.tar.xz";
+      sha256 = "0wwb2xx6avjaqkfsf2jnxbk31i4dss3j1gp1rjb608slq8kpwyy0";
+      name = "kalarmcal-17.08.0.tar.xz";
     };
   };
   kalgebra = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kalgebra-17.04.3.tar.xz";
-      sha256 = "0hcybpy7bjmxym09xlv4mi4fidl8l130c0ghbigw8774f11k6vp5";
-      name = "kalgebra-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kalgebra-17.08.0.tar.xz";
+      sha256 = "1i8b9cv1qv8vhfbx0qa3ka08qgyyp6h474v9x504ypsx8124f8g4";
+      name = "kalgebra-17.08.0.tar.xz";
     };
   };
   kalzium = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kalzium-17.04.3.tar.xz";
-      sha256 = "0pwxbb1qgkbx9y3320hwx96ymy91p6ycarvx731cyinp6v9lizld";
-      name = "kalzium-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kalzium-17.08.0.tar.xz";
+      sha256 = "01xvnczj6dhjx37f2i1dil31zc5bff25p3i0mk01dgnvzcq7cflf";
+      name = "kalzium-17.08.0.tar.xz";
     };
   };
   kamera = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kamera-17.04.3.tar.xz";
-      sha256 = "0gjxv55lzdfwxk7cm8s9yzk5z6lqb64irx57682l76an3azkjwsf";
-      name = "kamera-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kamera-17.08.0.tar.xz";
+      sha256 = "14krfdwraffbhsqhmi0h91mmpxx4952vbmilbp6955psz7cn8xyi";
+      name = "kamera-17.08.0.tar.xz";
     };
   };
   kanagram = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kanagram-17.04.3.tar.xz";
-      sha256 = "01479ryshlaf9kqd3nlhdrx02i8xp7sn7n1ir4cdxpnm8jg28x0c";
-      name = "kanagram-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kanagram-17.08.0.tar.xz";
+      sha256 = "1szksc9w22dzkwhsgpbd5xrrg1iwn13wdcdhhc5g2mcx1xgwksr0";
+      name = "kanagram-17.08.0.tar.xz";
     };
   };
   kapman = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kapman-17.04.3.tar.xz";
-      sha256 = "0llrh5g52gzvyxa5l3ardjv17msy2zj83in2g4cy094g1zciyk40";
-      name = "kapman-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kapman-17.08.0.tar.xz";
+      sha256 = "042lczwbcb7nrbw2wx486mg9qmlx1kcxjdwab10gmy0hvx83p0m3";
+      name = "kapman-17.08.0.tar.xz";
     };
   };
   kapptemplate = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kapptemplate-17.04.3.tar.xz";
-      sha256 = "0r4s5lfggv3nbqgi2y5y9zbyqp3fc7hlhlbdfr24cyljagmi8hgw";
-      name = "kapptemplate-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kapptemplate-17.08.0.tar.xz";
+      sha256 = "1i2w06fb6i0b5yhawms9a0qmis1kz8hyyg8hhnfwcsb0frp4sp7s";
+      name = "kapptemplate-17.08.0.tar.xz";
     };
   };
   kate = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kate-17.04.3.tar.xz";
-      sha256 = "1p6sfn80f8hvkgrg6z2yk7h23v403695sp39fb7s3q4cn5a0sch8";
-      name = "kate-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kate-17.08.0.tar.xz";
+      sha256 = "0zb6w346y5lz4bfvgvnkr9x1vkv6nblc2lrdx103jwbjwb3kjnpj";
+      name = "kate-17.08.0.tar.xz";
     };
   };
   katomic = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/katomic-17.04.3.tar.xz";
-      sha256 = "0rm2alxjmr74m2nxf5vwg3j5ynajz4c5z57cnpmzwvxgdh2c49p0";
-      name = "katomic-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/katomic-17.08.0.tar.xz";
+      sha256 = "0csnag857syf1966b8r1z8xhrcddy1r4qnk0lxgf326w1z33lyl3";
+      name = "katomic-17.08.0.tar.xz";
     };
   };
   kblackbox = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kblackbox-17.04.3.tar.xz";
-      sha256 = "183yvajbg8h48h4zwzm55zdajjan84dsnndg1db4n8gyibkv3f9d";
-      name = "kblackbox-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kblackbox-17.08.0.tar.xz";
+      sha256 = "10n6an0m5q11i8jlg1v3fz5ib8mhwifalhkj3syda4wjnc6i98g0";
+      name = "kblackbox-17.08.0.tar.xz";
     };
   };
   kblocks = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kblocks-17.04.3.tar.xz";
-      sha256 = "0j66756d66ravgiq4ybfyhm4hacmys9snjyadr035103j26z89pw";
-      name = "kblocks-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kblocks-17.08.0.tar.xz";
+      sha256 = "0ahc5pyrhfx49pyyj5i7kp7jj5y9dkxd12xbrmv3hyqips1q83ds";
+      name = "kblocks-17.08.0.tar.xz";
     };
   };
   kblog = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kblog-17.04.3.tar.xz";
-      sha256 = "10ngg2b83mczd937ikwzbwdqlrvlxsqzgrz95454x3s3j649hcy9";
-      name = "kblog-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kblog-17.08.0.tar.xz";
+      sha256 = "0hspjg73yjqsxykc2spsva4bc33bn0rxbdjn33fhzyz31n2cv6km";
+      name = "kblog-17.08.0.tar.xz";
     };
   };
   kbounce = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kbounce-17.04.3.tar.xz";
-      sha256 = "1f9np47ddhybnmm0m98fwpy51d9c8zgl7qrlj8g3diia45hy1s39";
-      name = "kbounce-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kbounce-17.08.0.tar.xz";
+      sha256 = "0269mfnzkvf25j60hj1mpg1wsjd2a90llcqxfzc9bi3kfvg9k11f";
+      name = "kbounce-17.08.0.tar.xz";
     };
   };
   kbreakout = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kbreakout-17.04.3.tar.xz";
-      sha256 = "0s7khwg6sl709gjzf5ymq5l79iilnfx14jp5bnck0ir568vhybkf";
-      name = "kbreakout-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kbreakout-17.08.0.tar.xz";
+      sha256 = "1vcknsahyaya6mk81mzbv56924k55yzhkfiv389bwj8gfg0983a0";
+      name = "kbreakout-17.08.0.tar.xz";
     };
   };
   kbruch = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kbruch-17.04.3.tar.xz";
-      sha256 = "11r50x5yp7s749prqwkxf3k5pm93pmk0h3b0i9c5507nbh2b2x9b";
-      name = "kbruch-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kbruch-17.08.0.tar.xz";
+      sha256 = "0gdz4ayk7bpc3w0pw8a4k742hxp7qh6a0j5b21qfhjzlhbpb4y4r";
+      name = "kbruch-17.08.0.tar.xz";
     };
   };
   kcachegrind = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kcachegrind-17.04.3.tar.xz";
-      sha256 = "0wcjvmdsqg27b2d4rzvrl98nqj5k7hp02d1w136fklfsh5mzxbxn";
-      name = "kcachegrind-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kcachegrind-17.08.0.tar.xz";
+      sha256 = "0n0sj9vpawjanj92jkbkvb4njr6qy3v5j2npglg2skv1brqhn55h";
+      name = "kcachegrind-17.08.0.tar.xz";
     };
   };
   kcalc = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kcalc-17.04.3.tar.xz";
-      sha256 = "1zshisq51vwsd04fxc5pw7lywrimpz04v2c9ad6lxwppmxcjr177";
-      name = "kcalc-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kcalc-17.08.0.tar.xz";
+      sha256 = "03xiwv8c86p3s640a35021z5varqkfrgpkrlc5gyxd2nnjldy9ky";
+      name = "kcalc-17.08.0.tar.xz";
     };
   };
   kcalcore = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kcalcore-17.04.3.tar.xz";
-      sha256 = "17i7d29yq06his3qjn5jblbdzf04500q9sdh7cr7xffdr3rpahdc";
-      name = "kcalcore-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kcalcore-17.08.0.tar.xz";
+      sha256 = "1vpyzbv6lv29ihzwrwd0nsb9vmy6iswka244fixa278218g2lfix";
+      name = "kcalcore-17.08.0.tar.xz";
     };
   };
   kcalutils = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kcalutils-17.04.3.tar.xz";
-      sha256 = "07k0vx3rdn1dvg16b3ipwng87aibr9g1jv9wg0hnk0fydsrpf99n";
-      name = "kcalutils-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kcalutils-17.08.0.tar.xz";
+      sha256 = "1s90arpxjnbzikpy1j1rcbvljcjgq5pgvmsr852r8qgw7s9dkpmh";
+      name = "kcalutils-17.08.0.tar.xz";
     };
   };
   kcharselect = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kcharselect-17.04.3.tar.xz";
-      sha256 = "1cy3ljdmip0zqqmyqjj2d5jd5q0hyxiqkl8pcgl2hb7ypx5c06sx";
-      name = "kcharselect-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kcharselect-17.08.0.tar.xz";
+      sha256 = "16hgzm3v84xkq4s68cpz73b4vgw1sarlgab0f2qkacvggpa0gkb6";
+      name = "kcharselect-17.08.0.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kcolorchooser-17.04.3.tar.xz";
-      sha256 = "0jc7cynzbvc1r743fzqlfl5ck0cdd7m63lh27i033c4fpvvi4f6k";
-      name = "kcolorchooser-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kcolorchooser-17.08.0.tar.xz";
+      sha256 = "177v2wi0dwzydbi1xwqq34s38rlgqifirm6r4frbxzbxzi1bpvw0";
+      name = "kcolorchooser-17.08.0.tar.xz";
     };
   };
   kcontacts = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kcontacts-17.04.3.tar.xz";
-      sha256 = "0y0vnpk09bk8w5dx8a2zpng2phdzlrs2s380saf06h01n0ni9g01";
-      name = "kcontacts-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kcontacts-17.08.0.tar.xz";
+      sha256 = "0852x0nindb8daczdhyiqahyqq0r60gmpyhsymccpz8jzirxlbfv";
+      name = "kcontacts-17.08.0.tar.xz";
     };
   };
   kcron = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kcron-17.04.3.tar.xz";
-      sha256 = "11sbb1wvl1v6z0059hkmg3p29p8b77ij51kvkv3dicyvh7xzc4f8";
-      name = "kcron-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kcron-17.08.0.tar.xz";
+      sha256 = "0fmzikk0zyhf41k7mxwyzlxr67jg3ffjj0jilskzdq6ffsnc7m08";
+      name = "kcron-17.08.0.tar.xz";
     };
   };
   kdav = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdav-17.04.3.tar.xz";
-      sha256 = "1yv8jhfak671k1s0fsy3j4bj7y64shhipp9k67v34q5cgg0q4hwl";
-      name = "kdav-17.04.3.tar.xz";
-    };
-  };
-  kdebugsettings = {
-    version = "17.04.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdebugsettings-17.04.3.tar.xz";
-      sha256 = "1l2jg75jfvbf9ixs2spg4b284vimsf0hz04yhfcqicljykrwlwq4";
-      name = "kdebugsettings-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kdav-17.08.0.tar.xz";
+      sha256 = "066hhcf8n6wnm4f76f24xq9hy0x9771kvbmappaicwnlza71v0i1";
+      name = "kdav-17.08.0.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-dev-scripts-17.04.3.tar.xz";
-      sha256 = "0cshxm7s2ivvj1baciy3il8vbk9qby9ybdclrhkq6n7a7li5w1lm";
-      name = "kde-dev-scripts-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-dev-scripts-17.08.0.tar.xz";
+      sha256 = "1skvgaj54a9apvwbjwpzvqyk1cqg3mf8p0h2fyp0k1i1f3ig8qrb";
+      name = "kde-dev-scripts-17.08.0.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-dev-utils-17.04.3.tar.xz";
-      sha256 = "02d0fm4dv5vl5zi3xp608m9c8rnv00x7wk3hkv4mdvi7li5h62j4";
-      name = "kde-dev-utils-17.04.3.tar.xz";
-    };
-  };
-  kdeedu-data = {
-    version = "17.04.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdeedu-data-17.04.3.tar.xz";
-      sha256 = "01vv6x600hpqpvg25aa07mbsjsnv83jqghna1bwqxgwrx1p3z8nd";
-      name = "kdeedu-data-17.04.3.tar.xz";
-    };
-  };
-  kdegraphics-mobipocket = {
-    version = "17.04.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdegraphics-mobipocket-17.04.3.tar.xz";
-      sha256 = "1nir7k3sf8q0k8ancs5mhp4qs5v405mjdiwnqf92mpmpfv6gw7ba";
-      name = "kdegraphics-mobipocket-17.04.3.tar.xz";
-    };
-  };
-  kdegraphics-thumbnailers = {
-    version = "17.04.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdegraphics-thumbnailers-17.04.3.tar.xz";
-      sha256 = "041bd8in0kwma5xkdwv9304r49rim4sxc977l7dnpyf306dx48rr";
-      name = "kdegraphics-thumbnailers-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-dev-utils-17.08.0.tar.xz";
+      sha256 = "00xz7n5bjss2im106n7r8zncan9v1mxmlfl27if1wff0nflbnfcm";
+      name = "kde-dev-utils-17.08.0.tar.xz";
     };
   };
   kde-l10n-ar = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-ar-17.04.3.tar.xz";
-      sha256 = "1z72mz94c95m2fq4k1aaqga8j9pnf4735radlny9ybfvv3wyliyb";
-      name = "kde-l10n-ar-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-ar-17.08.0.tar.xz";
+      sha256 = "0jp0zcc8m0zmi342y8656z6gw93drnripfj0qbkblqj7fmqbgjf4";
+      name = "kde-l10n-ar-17.08.0.tar.xz";
     };
   };
   kde-l10n-ast = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-ast-17.04.3.tar.xz";
-      sha256 = "0r4srnzb30c0616zl15qbadb9rpkskvdhrqhxmy5pj0vaq349y8p";
-      name = "kde-l10n-ast-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-ast-17.08.0.tar.xz";
+      sha256 = "03pzn3pa39350njjww36mk6l809bnx332v1y0hic0rrpbnscmbfk";
+      name = "kde-l10n-ast-17.08.0.tar.xz";
     };
   };
   kde-l10n-bg = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-bg-17.04.3.tar.xz";
-      sha256 = "15ffbpsynzqinjvirn4aa7ij87awq4b2kv8bx6bbnpv727b34cm8";
-      name = "kde-l10n-bg-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-bg-17.08.0.tar.xz";
+      sha256 = "15a14mwyi29pc66mx02axsham6mgqw7bmd54rinhafhwcdsdyhia";
+      name = "kde-l10n-bg-17.08.0.tar.xz";
     };
   };
   kde-l10n-bs = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-bs-17.04.3.tar.xz";
-      sha256 = "0hc9gsw7i1wmvxd5lg3xd14njsdnfpf82km3hny46lyiqki1riyd";
-      name = "kde-l10n-bs-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-bs-17.08.0.tar.xz";
+      sha256 = "17irsp0zdk66k66rg2an3bdx38y8d64zijh4fm7kr0nx3vm1gzxp";
+      name = "kde-l10n-bs-17.08.0.tar.xz";
     };
   };
   kde-l10n-ca = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-ca-17.04.3.tar.xz";
-      sha256 = "0h6aj2hi1gyjq7prza9v207ipcis32hr2a76i5rrbnf5c8hpih1r";
-      name = "kde-l10n-ca-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-ca-17.08.0.tar.xz";
+      sha256 = "0yhr0yrxxbzkp2aby7kfkscf4rrk12myhqqvcy4v1acqywqn3zrs";
+      name = "kde-l10n-ca-17.08.0.tar.xz";
     };
   };
   kde-l10n-ca_valencia = {
-    version = "ca_valencia-17.04.3";
+    version = "ca_valencia-17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-ca@valencia-17.04.3.tar.xz";
-      sha256 = "1bvl1v9niqb9h2ilji70qfcybx7lraszkimbi6zawvimj5y68jfg";
-      name = "kde-l10n-ca_valencia-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-ca@valencia-17.08.0.tar.xz";
+      sha256 = "0khslngsws4z0frc93w0yj3lgi9164j94pknwzhiq6h39bdy5jha";
+      name = "kde-l10n-ca_valencia-17.08.0.tar.xz";
     };
   };
   kde-l10n-cs = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-cs-17.04.3.tar.xz";
-      sha256 = "0miqxwhbcqzds8lgq5g7zb2w0gkx3y7g45vq989641jaqqlfca1c";
-      name = "kde-l10n-cs-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-cs-17.08.0.tar.xz";
+      sha256 = "0ia1lysymd87z1a7hcg95v30q8gwlx1f2m5brkh1s1fdkl4hf7zc";
+      name = "kde-l10n-cs-17.08.0.tar.xz";
     };
   };
   kde-l10n-da = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-da-17.04.3.tar.xz";
-      sha256 = "0j7j9b9i81984fyh7g5yv9j0gasws9hz648ycqi96k43zs80cahb";
-      name = "kde-l10n-da-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-da-17.08.0.tar.xz";
+      sha256 = "1fzmzhnsp6jfiahga685dnn8li24lhyq0pdvpbmx2fsq8izg449s";
+      name = "kde-l10n-da-17.08.0.tar.xz";
     };
   };
   kde-l10n-de = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-de-17.04.3.tar.xz";
-      sha256 = "0ra0idakfiggiw8x67iw4jbv9g2g0ypcskgcjzvwm61q9dqnr6hy";
-      name = "kde-l10n-de-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-de-17.08.0.tar.xz";
+      sha256 = "1zaypk1y6bmpbrymds5iiq0gcc1fcja61fpm9iqc76s3x22walw3";
+      name = "kde-l10n-de-17.08.0.tar.xz";
     };
   };
   kde-l10n-el = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-el-17.04.3.tar.xz";
-      sha256 = "1lmxrx7vkdpa9m730his0z9ry6nvycp4428waz0r4wxqqfz1acwr";
-      name = "kde-l10n-el-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-el-17.08.0.tar.xz";
+      sha256 = "0440flgz1sfs8b8qrvzn2gh14z25pivvxgcv2kgsgb6lq9b98bhg";
+      name = "kde-l10n-el-17.08.0.tar.xz";
     };
   };
   kde-l10n-en_GB = {
-    version = "en_GB-17.04.3";
+    version = "en_GB-17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-en_GB-17.04.3.tar.xz";
-      sha256 = "1mr9rgxklfnmhd7yb5h3hddjjn1qxxbqw16sn5d1d077p3wz6896";
-      name = "kde-l10n-en_GB-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-en_GB-17.08.0.tar.xz";
+      sha256 = "1w11hbr3sdrr724qvfh15ppyg0r4003110v876xqy2f2d5z2v9mq";
+      name = "kde-l10n-en_GB-17.08.0.tar.xz";
     };
   };
   kde-l10n-eo = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-eo-17.04.3.tar.xz";
-      sha256 = "1aq501z6mnpp8h354p45wwxs4fbfawm0dj67xh74xcr6sh0nj3ap";
-      name = "kde-l10n-eo-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-eo-17.08.0.tar.xz";
+      sha256 = "0w034zx2qmwimq5p8gr0dgh1d51bhwnqc1db9jszr0hv891fji8v";
+      name = "kde-l10n-eo-17.08.0.tar.xz";
     };
   };
   kde-l10n-es = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-es-17.04.3.tar.xz";
-      sha256 = "1hk8731avlmirzhv2sckrqaf4ykgvy2brnq0a86dr4n95138hhmw";
-      name = "kde-l10n-es-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-es-17.08.0.tar.xz";
+      sha256 = "1428jqjqmxh1fql39af52f0g8ha7jlnmkpkb45x9k95cfbm0hccn";
+      name = "kde-l10n-es-17.08.0.tar.xz";
     };
   };
   kde-l10n-et = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-et-17.04.3.tar.xz";
-      sha256 = "0cdy7mmjg8q5s19lqjsbhn64h3fk6f8y0j3ldvnmc4wj24gfnc5n";
-      name = "kde-l10n-et-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-et-17.08.0.tar.xz";
+      sha256 = "0iqs6636jfxyhdiifx9nzxg1z7z4rb9parj93njhb6x34kpa6b4v";
+      name = "kde-l10n-et-17.08.0.tar.xz";
     };
   };
   kde-l10n-eu = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-eu-17.04.3.tar.xz";
-      sha256 = "06c2940qsqf03acly35jpcnsljzq20mljmlzx9234i7gqr88g74r";
-      name = "kde-l10n-eu-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-eu-17.08.0.tar.xz";
+      sha256 = "1x3r1m0yivvasv7832v2my2nn8kgdfp8326dmjz1fcgs7cnnv4ab";
+      name = "kde-l10n-eu-17.08.0.tar.xz";
     };
   };
   kde-l10n-fa = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-fa-17.04.3.tar.xz";
-      sha256 = "1q3a2dyvrk22azj0rngb8h0dh88aczsxys7aaf4yvvwsdm7zbj8k";
-      name = "kde-l10n-fa-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-fa-17.08.0.tar.xz";
+      sha256 = "1kaibymfrpa5c6pmq3rkxnnl532s19bg60nzq0iirn3n0kgplwy2";
+      name = "kde-l10n-fa-17.08.0.tar.xz";
     };
   };
   kde-l10n-fi = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-fi-17.04.3.tar.xz";
-      sha256 = "0hfzs1g5ikz6cgjss7kibxx2vd0zxn9rny7br4ysp1x89nz5qb34";
-      name = "kde-l10n-fi-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-fi-17.08.0.tar.xz";
+      sha256 = "0yml2hpg0b48rknik9kfhdgn6znwjqxg43gaglglm79d68a7xdng";
+      name = "kde-l10n-fi-17.08.0.tar.xz";
     };
   };
   kde-l10n-fr = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-fr-17.04.3.tar.xz";
-      sha256 = "14i752qqdzdgbxh8r9rmjmjjsmhhh6vpcna3gp8g577r7y8rqpwk";
-      name = "kde-l10n-fr-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-fr-17.08.0.tar.xz";
+      sha256 = "1r97zi8p1jha99r5k2qljrypmyzdrmpz0r60bv1b7nhx7m6ix503";
+      name = "kde-l10n-fr-17.08.0.tar.xz";
     };
   };
   kde-l10n-ga = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-ga-17.04.3.tar.xz";
-      sha256 = "164jc111sgj8mqcvvqx8yccjjinvk5h7g5z4a964dwhh587xir1h";
-      name = "kde-l10n-ga-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-ga-17.08.0.tar.xz";
+      sha256 = "1y43njj4k79mzcvhg8ycr7641js698kda762jffdzfl2navx2f7r";
+      name = "kde-l10n-ga-17.08.0.tar.xz";
     };
   };
   kde-l10n-gl = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-gl-17.04.3.tar.xz";
-      sha256 = "1c5vz652fd91pxx8p5savcfjg40ks96qay8djjvjznhs8rpkmxf9";
-      name = "kde-l10n-gl-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-gl-17.08.0.tar.xz";
+      sha256 = "053x6v84bpa8cnl6v95kfks7b914b9jy1wd41lyxd9a8z5nh04yp";
+      name = "kde-l10n-gl-17.08.0.tar.xz";
     };
   };
   kde-l10n-he = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-he-17.04.3.tar.xz";
-      sha256 = "142np920w44jwrkkrbplnfdyxpf72c0r86zwfdps7cc2giycj793";
-      name = "kde-l10n-he-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-he-17.08.0.tar.xz";
+      sha256 = "08fq8v7af2j2iqnwja3pznklizxib7v4zs22i359iql05iayd0wy";
+      name = "kde-l10n-he-17.08.0.tar.xz";
     };
   };
   kde-l10n-hi = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-hi-17.04.3.tar.xz";
-      sha256 = "17r2rfzk7773zxj454zm33fysd0jfc0kaji2pcpi27skypxcrsl7";
-      name = "kde-l10n-hi-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-hi-17.08.0.tar.xz";
+      sha256 = "0zizfvwiwix937iczh186w42ydsvyp3h4pyk2r05ds4hbz6jw4yd";
+      name = "kde-l10n-hi-17.08.0.tar.xz";
     };
   };
   kde-l10n-hr = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-hr-17.04.3.tar.xz";
-      sha256 = "08fak1f5f5228djl28l8xx026mxq5khklvklss8fi42l57091azv";
-      name = "kde-l10n-hr-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-hr-17.08.0.tar.xz";
+      sha256 = "18fdby0dpgymrya63cks23k5nq4ni9n7nymvx65z7bn8h7r8cbmc";
+      name = "kde-l10n-hr-17.08.0.tar.xz";
     };
   };
   kde-l10n-hu = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-hu-17.04.3.tar.xz";
-      sha256 = "0i5lgkdxs81kjhjrhzjdk0ayp28vdigrsfv1n6k0aqj3jzfpbhbz";
-      name = "kde-l10n-hu-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-hu-17.08.0.tar.xz";
+      sha256 = "1gcqmf4vbmwah8yi78inb9miirs13r80wjfif5c8vblhvdmlbrc1";
+      name = "kde-l10n-hu-17.08.0.tar.xz";
     };
   };
   kde-l10n-ia = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-ia-17.04.3.tar.xz";
-      sha256 = "18bgdyazgqcslyajz97g0s96linx89ngr916zqknz64xqhxdhvdy";
-      name = "kde-l10n-ia-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-ia-17.08.0.tar.xz";
+      sha256 = "11ljcxwsq09885rdd3kszfchjdi4g3359b88rfsq4dn11bnmm50s";
+      name = "kde-l10n-ia-17.08.0.tar.xz";
     };
   };
   kde-l10n-id = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-id-17.04.3.tar.xz";
-      sha256 = "0dncq9p12bgn4d6zra4skk6mb1ivnswn0z51llqrma90271ibflr";
-      name = "kde-l10n-id-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-id-17.08.0.tar.xz";
+      sha256 = "005563k8bdqzyhm3l231vlc96iwc4sg9f0932y9w1nmlxkh0n02f";
+      name = "kde-l10n-id-17.08.0.tar.xz";
     };
   };
   kde-l10n-is = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-is-17.04.3.tar.xz";
-      sha256 = "1pkp87di1da6f2f9jjsj7li19d8pcn5ljhk1fhbrqc9b3whaansm";
-      name = "kde-l10n-is-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-is-17.08.0.tar.xz";
+      sha256 = "143zja0j77lgmkb34lycrdzkpsffzljmlmmiaisjpb1bj664sk9d";
+      name = "kde-l10n-is-17.08.0.tar.xz";
     };
   };
   kde-l10n-it = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-it-17.04.3.tar.xz";
-      sha256 = "0n468q4z29mfl9b4a4clmv643p6fhlhf5mhsfl6dsi4l0v9a15mk";
-      name = "kde-l10n-it-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-it-17.08.0.tar.xz";
+      sha256 = "0ppd16w8zdpslz8p6yrhw4dl7pm0i3a6wpin3kvqxaxd87vxzzvb";
+      name = "kde-l10n-it-17.08.0.tar.xz";
     };
   };
   kde-l10n-ja = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-ja-17.04.3.tar.xz";
-      sha256 = "00q937jdq6c2q2x75ky2xyfij0654xfzjm904j6kimvmpkyc33xk";
-      name = "kde-l10n-ja-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-ja-17.08.0.tar.xz";
+      sha256 = "0qq88f5gm3ifw1l5m2xq8x6ajqj6ngfpydbrz5ry62nz8mi0w1i0";
+      name = "kde-l10n-ja-17.08.0.tar.xz";
     };
   };
   kde-l10n-kk = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-kk-17.04.3.tar.xz";
-      sha256 = "1srjbxg969rhzqw81vy8kab9pkasp061i4r5ark8rg8k7agjdcml";
-      name = "kde-l10n-kk-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-kk-17.08.0.tar.xz";
+      sha256 = "0w953g4hvhisawb3423c9dd1vin8zxk3643ilkrf3mlkx972ib5m";
+      name = "kde-l10n-kk-17.08.0.tar.xz";
     };
   };
   kde-l10n-km = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-km-17.04.3.tar.xz";
-      sha256 = "1szigmhybhfa70lg2wzpkzja73c20szzr8wawjzy869ql8fcip3w";
-      name = "kde-l10n-km-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-km-17.08.0.tar.xz";
+      sha256 = "1xhmmnxsd0lcr68zz5x68cs4gxxlxm71p30zj3cm188dq756c9a9";
+      name = "kde-l10n-km-17.08.0.tar.xz";
     };
   };
   kde-l10n-ko = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-ko-17.04.3.tar.xz";
-      sha256 = "1j9zgf9pl3nns5a8jdd2ggragq2ln3x11h7y2apkffihyd0kz40v";
-      name = "kde-l10n-ko-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-ko-17.08.0.tar.xz";
+      sha256 = "1c6arfbp06kmapxp8ass37sb250pbsvfhwjqn57yaya0hvf3my82";
+      name = "kde-l10n-ko-17.08.0.tar.xz";
     };
   };
   kde-l10n-lt = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-lt-17.04.3.tar.xz";
-      sha256 = "1rpia72cz2a3knxzzanhhpqp3r89mj5dn4yh9ym81xw6s4acz5fg";
-      name = "kde-l10n-lt-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-lt-17.08.0.tar.xz";
+      sha256 = "09cidww52igwav358a1f1gm7djcrpnl7d3wc11w2v7hn76cabjmx";
+      name = "kde-l10n-lt-17.08.0.tar.xz";
     };
   };
   kde-l10n-lv = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-lv-17.04.3.tar.xz";
-      sha256 = "1vpdgq90ph7c6yjvn0ijdq7ry699m03i7857sxq9vsgy4hi7xi14";
-      name = "kde-l10n-lv-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-lv-17.08.0.tar.xz";
+      sha256 = "148sfbalalp3calzgl4kga1bcj1sqgkwdgx07bsqza9q142z5xjs";
+      name = "kde-l10n-lv-17.08.0.tar.xz";
     };
   };
   kde-l10n-mr = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-mr-17.04.3.tar.xz";
-      sha256 = "1rfp5bi6xpdc503id328h8jl6z8alzjvg24dspaj209390hvldqv";
-      name = "kde-l10n-mr-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-mr-17.08.0.tar.xz";
+      sha256 = "1m8la1a1fyfm5k732hnm3ybxqmah7mdf6f3nhxisr3c2h3gxqysk";
+      name = "kde-l10n-mr-17.08.0.tar.xz";
     };
   };
   kde-l10n-nb = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-nb-17.04.3.tar.xz";
-      sha256 = "1d25ffix6pakdcpcr2qz1h6729550l9ba93z545n0psjgqpwvmmr";
-      name = "kde-l10n-nb-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-nb-17.08.0.tar.xz";
+      sha256 = "13r7dzwbr1qggwbh4lbb45xy7qck04waxjsaj66d5zv7gw9hc2gp";
+      name = "kde-l10n-nb-17.08.0.tar.xz";
     };
   };
   kde-l10n-nds = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-nds-17.04.3.tar.xz";
-      sha256 = "0pvx1rm6bx9xwyl4zfcw52mwif06350i9wmwz0kxxg3zs7lqb7h3";
-      name = "kde-l10n-nds-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-nds-17.08.0.tar.xz";
+      sha256 = "19mrs2l6z6ypr1h4ppw0v588hj46nngzanlq5rcznimf9v1b4jwr";
+      name = "kde-l10n-nds-17.08.0.tar.xz";
     };
   };
   kde-l10n-nl = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-nl-17.04.3.tar.xz";
-      sha256 = "1ivm2qsl0dmkrgmddnp3cjmcjc6jag0wawhklacp1c9iscfcrppm";
-      name = "kde-l10n-nl-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-nl-17.08.0.tar.xz";
+      sha256 = "1lvqjgjk2qfbvlkjyp0pkdp015dcxmc4db0zy077fy1vbrcclj54";
+      name = "kde-l10n-nl-17.08.0.tar.xz";
     };
   };
   kde-l10n-nn = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-nn-17.04.3.tar.xz";
-      sha256 = "0jsx980g7zn8m9xd7ljiqz1w9cvlgy84bl6hjhi0a89mfwkd27lg";
-      name = "kde-l10n-nn-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-nn-17.08.0.tar.xz";
+      sha256 = "1vk504hjrai30rbr7v9fkyf8yj4ms33ck7c32xk5jxq0avd3yyj7";
+      name = "kde-l10n-nn-17.08.0.tar.xz";
     };
   };
   kde-l10n-pa = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-pa-17.04.3.tar.xz";
-      sha256 = "149d7pdxb0543c36gyxidd7z4j2jw5nbilv7c561j3zazbbcg4nm";
-      name = "kde-l10n-pa-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-pa-17.08.0.tar.xz";
+      sha256 = "0vh52aqbd66mrb492d2h8gihbs6wql6q0yjvk0ixhhi2b9cykzi0";
+      name = "kde-l10n-pa-17.08.0.tar.xz";
     };
   };
   kde-l10n-pl = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-pl-17.04.3.tar.xz";
-      sha256 = "04zxzx8586328v9dw6w5igxa95i7raqzpvdxshphv3wfnjgbzad5";
-      name = "kde-l10n-pl-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-pl-17.08.0.tar.xz";
+      sha256 = "1mfjjvm41cd4z1bvnrhpjbwcp2czw70mp3p3snyb7397d2c786f1";
+      name = "kde-l10n-pl-17.08.0.tar.xz";
     };
   };
   kde-l10n-pt = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-pt-17.04.3.tar.xz";
-      sha256 = "009dnijcznzaf6p85mg3j7s4zhjfmk4smk8bkns6pjn1r2wdpfbi";
-      name = "kde-l10n-pt-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-pt-17.08.0.tar.xz";
+      sha256 = "1z44l4qa8ks9r7bwa7dgp43nlcymkdkz31jl7qvgy8c8lil8a6vy";
+      name = "kde-l10n-pt-17.08.0.tar.xz";
     };
   };
   kde-l10n-pt_BR = {
-    version = "pt_BR-17.04.3";
+    version = "pt_BR-17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-pt_BR-17.04.3.tar.xz";
-      sha256 = "07ird1j382m8c9459nvhmw0jy8i8ri5wmh6h7m36b8m4i7cbfdcx";
-      name = "kde-l10n-pt_BR-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-pt_BR-17.08.0.tar.xz";
+      sha256 = "1hgbw89f7slscc7cgfsxdk0l3y5szsqsidq9grj0j4v2v1qfy320";
+      name = "kde-l10n-pt_BR-17.08.0.tar.xz";
     };
   };
   kde-l10n-ro = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-ro-17.04.3.tar.xz";
-      sha256 = "1zs9yxv7566yi7rz9z9zk7mzq2rkh50y6s92sp52wyzsr3q4pl9j";
-      name = "kde-l10n-ro-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-ro-17.08.0.tar.xz";
+      sha256 = "0y3mpa1jckzl76yz3fal05dprpmch0m7y03q83yzgb6xdr021bds";
+      name = "kde-l10n-ro-17.08.0.tar.xz";
     };
   };
   kde-l10n-ru = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-ru-17.04.3.tar.xz";
-      sha256 = "12a5s73rwnx25vvwdgqis24q26x8kg6zrin3gili4kdmfxr0x27i";
-      name = "kde-l10n-ru-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-ru-17.08.0.tar.xz";
+      sha256 = "0ixs6n9jz2i570i5qfd36pjg8jldlgsrwbdb8n82h9c9mjyc7if9";
+      name = "kde-l10n-ru-17.08.0.tar.xz";
     };
   };
   kde-l10n-sk = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-sk-17.04.3.tar.xz";
-      sha256 = "0s3s94nb7dl7pdfm5pa7cw66q4vvjqqmv6rrzriia3z1dgg0n9y4";
-      name = "kde-l10n-sk-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-sk-17.08.0.tar.xz";
+      sha256 = "0g60hxlbck1rjjmwx0wvxzzgqjmi6wc1n5s6i2230150apas9dh1";
+      name = "kde-l10n-sk-17.08.0.tar.xz";
     };
   };
   kde-l10n-sl = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-sl-17.04.3.tar.xz";
-      sha256 = "1n0bj63inj5j9zxqfimza7frqikzyxjr7cyfaqa46ck2wcawhmwm";
-      name = "kde-l10n-sl-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-sl-17.08.0.tar.xz";
+      sha256 = "0vs0kvyxb5yc0qwsdf9rg49gvzd5mwd9bag5mvwp4hcrcn3i7db0";
+      name = "kde-l10n-sl-17.08.0.tar.xz";
     };
   };
   kde-l10n-sr = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-sr-17.04.3.tar.xz";
-      sha256 = "0cs5rab87yydwpg6pql67x05802yzdj28y6rfzc0z0kr4diay34h";
-      name = "kde-l10n-sr-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-sr-17.08.0.tar.xz";
+      sha256 = "0wq1n8ygcz1jpxi3qf0q9qj07vb1p4agn1hjfyy4bjzm3kdy2jkw";
+      name = "kde-l10n-sr-17.08.0.tar.xz";
     };
   };
   kde-l10n-sv = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-sv-17.04.3.tar.xz";
-      sha256 = "01f8zr3rf8zvsd0v69vyy45nn7bq9zlxf6f5lgr0i1yd4xjz6fvn";
-      name = "kde-l10n-sv-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-sv-17.08.0.tar.xz";
+      sha256 = "09h9d65idax2d10gzwrff96a2si1anc827j2b9r1d559gx9imy0w";
+      name = "kde-l10n-sv-17.08.0.tar.xz";
     };
   };
   kde-l10n-tr = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-tr-17.04.3.tar.xz";
-      sha256 = "082xrk31hajdq9hhnxh7z6ngn56q2adn8xjwkfizjyl3frf8ksya";
-      name = "kde-l10n-tr-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-tr-17.08.0.tar.xz";
+      sha256 = "1dg4l6cy2qn9zvspwf7hfn2p0aad3x3zq0jhipdh4n00gykwh3sm";
+      name = "kde-l10n-tr-17.08.0.tar.xz";
     };
   };
   kde-l10n-ug = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-ug-17.04.3.tar.xz";
-      sha256 = "01k9mchkkwyka0sgwg1mx0j1sax227s4mnm74vmpshj651nxqm3r";
-      name = "kde-l10n-ug-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-ug-17.08.0.tar.xz";
+      sha256 = "00732l2qisn2kaal3k19f6bnf8ynxalfvmazapbcn3hbcig8cyi5";
+      name = "kde-l10n-ug-17.08.0.tar.xz";
     };
   };
   kde-l10n-uk = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-uk-17.04.3.tar.xz";
-      sha256 = "1nwlqbr8cxcs2ny85bmzn549j66b1d7fiswlwgrvjlqj4mav3cwz";
-      name = "kde-l10n-uk-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-uk-17.08.0.tar.xz";
+      sha256 = "10jrvzy4kfbcn0vcbyir967vhbmk05kzjc7sydx3mg98b0j6qicz";
+      name = "kde-l10n-uk-17.08.0.tar.xz";
     };
   };
   kde-l10n-wa = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-wa-17.04.3.tar.xz";
-      sha256 = "13flih2ca2r8l3favp0xw1hcvwd07dsj64rmg6s2ysk3pcizy3i8";
-      name = "kde-l10n-wa-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-wa-17.08.0.tar.xz";
+      sha256 = "0p595ra21jn72r46haiwi4h8a3gia96qv0lsdfsi8s6lyqqca0i1";
+      name = "kde-l10n-wa-17.08.0.tar.xz";
     };
   };
   kde-l10n-zh_CN = {
-    version = "zh_CN-17.04.3";
+    version = "zh_CN-17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-zh_CN-17.04.3.tar.xz";
-      sha256 = "02gzlwbq1zqaa1kqk7pd55yv7agg7igbb2147yvdj9462igpzjyi";
-      name = "kde-l10n-zh_CN-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-zh_CN-17.08.0.tar.xz";
+      sha256 = "08fxsafnmzizfhr2i63p41jgkjgnkrb07s6mpdrxklkhafl8bmg8";
+      name = "kde-l10n-zh_CN-17.08.0.tar.xz";
     };
   };
   kde-l10n-zh_TW = {
-    version = "zh_TW-17.04.3";
+    version = "zh_TW-17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-l10n/kde-l10n-zh_TW-17.04.3.tar.xz";
-      sha256 = "0x1nwahmh6142g21a949hibmx2slgbvrp5iwq137zmzmxffp7y9h";
-      name = "kde-l10n-zh_TW-17.04.3.tar.xz";
-    };
-  };
-  kdelibs = {
-    version = "4.14.34";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdelibs-4.14.34.tar.xz";
-      sha256 = "1yxwz6dln7km22cwxsns2rxxmw5p1c126xqnczz5fcjvalrk8zbp";
-      name = "kdelibs-4.14.34.tar.xz";
-    };
-  };
-  kdenetwork-filesharing = {
-    version = "17.04.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdenetwork-filesharing-17.04.3.tar.xz";
-      sha256 = "0r16jgsp45cf7gyjii04gq12wm68j86mrz4502szq0c02hfnmrsd";
-      name = "kdenetwork-filesharing-17.04.3.tar.xz";
-    };
-  };
-  kdenlive = {
-    version = "17.04.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdenlive-17.04.3.tar.xz";
-      sha256 = "1n4x12pri0kw0lk3376l2059rnabi4c54ax8bdmx39hhn7lqxv45";
-      name = "kdenlive-17.04.3.tar.xz";
-    };
-  };
-  kdepim-addons = {
-    version = "17.04.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdepim-addons-17.04.3.tar.xz";
-      sha256 = "118n8jdpjr50wgf45y2gzbqljbyichg4a6df014cdi0qcc55mcdl";
-      name = "kdepim-addons-17.04.3.tar.xz";
-    };
-  };
-  kdepim-apps-libs = {
-    version = "17.04.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdepim-apps-libs-17.04.3.tar.xz";
-      sha256 = "154057mxhkhm4lwlm49lx2m02qkddv0w96ikani7prb5p0kdw09i";
-      name = "kdepim-apps-libs-17.04.3.tar.xz";
-    };
-  };
-  kdepim-runtime = {
-    version = "17.04.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdepim-runtime-17.04.3.tar.xz";
-      sha256 = "07fcrvs9aqjxn7big60hh9hcd6mg211cmk69wdhhi455arjsfpzq";
-      name = "kdepim-runtime-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-l10n/kde-l10n-zh_TW-17.08.0.tar.xz";
+      sha256 = "04qq28sf2pjb4rc32j5j9cnhw0h4hpw69gikb5s06324mmmvap0f";
+      name = "kde-l10n-zh_TW-17.08.0.tar.xz";
     };
   };
   kde-runtime = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kde-runtime-17.04.3.tar.xz";
-      sha256 = "05dshxx8bx872c4vp42i9n0dv19zq79p5m1lpd9kvmfpk3cvpxin";
-      name = "kde-runtime-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kde-runtime-17.08.0.tar.xz";
+      sha256 = "14j61bsrrpajw5djk7aa49xid2lg51a886y3q1xdv3dnflmldm70";
+      name = "kde-runtime-17.08.0.tar.xz";
+    };
+  };
+  kdebugsettings = {
+    version = "17.08.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.08.0/src/kdebugsettings-17.08.0.tar.xz";
+      sha256 = "057z4bi9mlpdyb8giq5zsgm1fzfq7sz05a0p4is8cawlyjji8qd3";
+      name = "kdebugsettings-17.08.0.tar.xz";
+    };
+  };
+  kdeedu-data = {
+    version = "17.08.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.08.0/src/kdeedu-data-17.08.0.tar.xz";
+      sha256 = "1w5zvzgqa8jzvqkgc16sffj6fygrizqmy5lzmxhisnph8im5rxyp";
+      name = "kdeedu-data-17.08.0.tar.xz";
+    };
+  };
+  kdegraphics-mobipocket = {
+    version = "17.08.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.08.0/src/kdegraphics-mobipocket-17.08.0.tar.xz";
+      sha256 = "1r66s3yay2pvy77pfa8g1s07iq4v2fiz9nl4lxhd8lvdg7jxa88i";
+      name = "kdegraphics-mobipocket-17.08.0.tar.xz";
+    };
+  };
+  kdegraphics-thumbnailers = {
+    version = "17.08.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.08.0/src/kdegraphics-thumbnailers-17.08.0.tar.xz";
+      sha256 = "0cp2p5nmxxg09wfrhg7qzz781rbxyml42y6l42njqfphgxsyqs5h";
+      name = "kdegraphics-thumbnailers-17.08.0.tar.xz";
+    };
+  };
+  kdelibs = {
+    version = "4.14.35";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.08.0/src/kdelibs-4.14.35.tar.xz";
+      sha256 = "00zkbamzqw1jmxc344dlwvprhdd59bblkj2yalxhc7fy11sbsclp";
+      name = "kdelibs-4.14.35.tar.xz";
+    };
+  };
+  kdenetwork-filesharing = {
+    version = "17.08.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.08.0/src/kdenetwork-filesharing-17.08.0.tar.xz";
+      sha256 = "0m4z3mf40sp874ml128489isqjihn5a92gpcn1wbx6j9d37g0aah";
+      name = "kdenetwork-filesharing-17.08.0.tar.xz";
+    };
+  };
+  kdenlive = {
+    version = "17.08.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.08.0/src/kdenlive-17.08.0.tar.xz";
+      sha256 = "0dnapnr7fdqf0ng99q7wvzyipvkpzb75xm379jynwv15x5isc7di";
+      name = "kdenlive-17.08.0.tar.xz";
+    };
+  };
+  kdepim-addons = {
+    version = "17.08.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.08.0/src/kdepim-addons-17.08.0.tar.xz";
+      sha256 = "0ksa8k1hssclq4q6q14gc9jjg7k8iy6fq2wsxv6i3yjvbslkiyzd";
+      name = "kdepim-addons-17.08.0.tar.xz";
+    };
+  };
+  kdepim-apps-libs = {
+    version = "17.08.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.08.0/src/kdepim-apps-libs-17.08.0.tar.xz";
+      sha256 = "0zlg5d4arf0qqdys5p30965868hwb24cj39h2xfbb4jqi7gh3nvv";
+      name = "kdepim-apps-libs-17.08.0.tar.xz";
+    };
+  };
+  kdepim-runtime = {
+    version = "17.08.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.08.0/src/kdepim-runtime-17.08.0.tar.xz";
+      sha256 = "0mdw7m16pl3z32ri0hng08apg045f0dhr3q68alq6cs743b74dy3";
+      name = "kdepim-runtime-17.08.0.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdesdk-kioslaves-17.04.3.tar.xz";
-      sha256 = "1j9m08r8jpdq5fqp9irvbqyb37maah1wz2xg4byinrn9qqp76dfl";
-      name = "kdesdk-kioslaves-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kdesdk-kioslaves-17.08.0.tar.xz";
+      sha256 = "0jpbv0rjc5pw1ym74khdkg0jm5qhszamb5ahj0l7da9bphshdj3v";
+      name = "kdesdk-kioslaves-17.08.0.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdesdk-thumbnailers-17.04.3.tar.xz";
-      sha256 = "0jjaajz3yxghm7phzhw3cgc0y4kgsc1vs0yc1w4cn8kmipal0x1q";
-      name = "kdesdk-thumbnailers-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kdesdk-thumbnailers-17.08.0.tar.xz";
+      sha256 = "09hh2m6mbblsj7a9wy9xpsl9irdw4agadwgrgpzi75ixdfwl998y";
+      name = "kdesdk-thumbnailers-17.08.0.tar.xz";
     };
   };
   kdf = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdf-17.04.3.tar.xz";
-      sha256 = "1d5nrp3x7r5fvghj7acrjhbz6n2cvd2qr60s6i0za7703b5iflyr";
-      name = "kdf-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kdf-17.08.0.tar.xz";
+      sha256 = "1qqr4a65p9bxkmv6rnyy0qlg21nqi59zxaxg6p2qb35vy19n1izd";
+      name = "kdf-17.08.0.tar.xz";
     };
   };
   kdialog = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdialog-17.04.3.tar.xz";
-      sha256 = "15b5qhxy387wpv2hx6hw31r3lyh7j30vwzn9q474vsmp6jj2zq5m";
-      name = "kdialog-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kdialog-17.08.0.tar.xz";
+      sha256 = "166q8nhxcnw4g727nq89vva7sidrg6jxi6v54rhdnlgqdvf1y5kb";
+      name = "kdialog-17.08.0.tar.xz";
     };
   };
   kdiamond = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kdiamond-17.04.3.tar.xz";
-      sha256 = "0ri611bmqa81qlsfqmza4n5m14hlcrljhi4xlq2h5pcmg3j8ihyj";
-      name = "kdiamond-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kdiamond-17.08.0.tar.xz";
+      sha256 = "0hz34w1anpihcb0wdx2kyp7ypi7ama48vjhax2520h5gaxfpy8lj";
+      name = "kdiamond-17.08.0.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/keditbookmarks-17.04.3.tar.xz";
-      sha256 = "0pxrf18rml40lh2z3l8kk1nlzpdbwf3jdlzjy745fdc9x9q3phhm";
-      name = "keditbookmarks-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/keditbookmarks-17.08.0.tar.xz";
+      sha256 = "0l26chf97ak4vqil8v5ya62376j7hh0xgabbav5ay8i1d0sk6p6z";
+      name = "keditbookmarks-17.08.0.tar.xz";
     };
   };
   kfilereplace = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kfilereplace-17.04.3.tar.xz";
-      sha256 = "115p6kjax7rhz646pvfi1av7pbllh42fmykzk4ld4mblgs56nj1j";
-      name = "kfilereplace-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kfilereplace-17.08.0.tar.xz";
+      sha256 = "1a1hfjzv9vgfyf1n1ihr5rqzc5javpn4y7h70babl37s54i9k3xj";
+      name = "kfilereplace-17.08.0.tar.xz";
     };
   };
   kfind = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kfind-17.04.3.tar.xz";
-      sha256 = "12iaj6f1b1w3b8jnhdh0gg9k57qxmicsxw68bi0ha4i8lw6dmfc5";
-      name = "kfind-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kfind-17.08.0.tar.xz";
+      sha256 = "1ryl0xwpyww8sipignr8j3dfq79cf1apm47vc4r8dk1704qzm4v9";
+      name = "kfind-17.08.0.tar.xz";
     };
   };
   kfloppy = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kfloppy-17.04.3.tar.xz";
-      sha256 = "0ayaslvnfhf3v082dfv62ml5ss185jkm1cx7jlqqvpn84l6vykmk";
-      name = "kfloppy-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kfloppy-17.08.0.tar.xz";
+      sha256 = "1gyrgii897r4habi9kmls258pv40zs6hrgyfhcyqibl3vk4ndgfb";
+      name = "kfloppy-17.08.0.tar.xz";
     };
   };
   kfourinline = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kfourinline-17.04.3.tar.xz";
-      sha256 = "00ci1vbnqvr84ihdh6dcp7dw5pjqx3s40j5fafym0q2mji1q0cwj";
-      name = "kfourinline-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kfourinline-17.08.0.tar.xz";
+      sha256 = "02zbriz434n9xk5rrb3y0y76hrizbf0mq3pl679fa89jcqaml1fj";
+      name = "kfourinline-17.08.0.tar.xz";
     };
   };
   kgeography = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kgeography-17.04.3.tar.xz";
-      sha256 = "0l9923fzpq5dxjvhsbxb03fh717yrys1najqdfyw1f9vs3fmkws9";
-      name = "kgeography-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kgeography-17.08.0.tar.xz";
+      sha256 = "03xwpdngikjiml4kxbp0n893xzvb21h6cyj4xp09j19db9gj0jd7";
+      name = "kgeography-17.08.0.tar.xz";
     };
   };
   kget = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kget-17.04.3.tar.xz";
-      sha256 = "1fffkpnzhi9gl9xib398l8az16wyysjlphqga0a9a0bfkk6h884k";
-      name = "kget-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kget-17.08.0.tar.xz";
+      sha256 = "1h1svqyj2d8qpw65zidzk90smh0d4dbxzzsi8ar0hvgr8d0lq157";
+      name = "kget-17.08.0.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kgoldrunner-17.04.3.tar.xz";
-      sha256 = "15sjikgk1qr36r5z6fbx535i6dj1l08klihrzyymmnr1vl5s02pr";
-      name = "kgoldrunner-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kgoldrunner-17.08.0.tar.xz";
+      sha256 = "0iw7f8760fgy08g9pncnvfv8ynj673glfb8bf6hmwylpa3nddz54";
+      name = "kgoldrunner-17.08.0.tar.xz";
     };
   };
   kgpg = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kgpg-17.04.3.tar.xz";
-      sha256 = "1xdnpmrb6kd48ppvim2bs9c2abhr55f5ha25xr3r89blawmw16w0";
-      name = "kgpg-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kgpg-17.08.0.tar.xz";
+      sha256 = "1kbndyswhx5l5s566gg22n8yqk372gpk53iiksizr6mrjx3wjvf8";
+      name = "kgpg-17.08.0.tar.xz";
     };
   };
   khangman = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/khangman-17.04.3.tar.xz";
-      sha256 = "0n49zhwcsb8mgn416kzvq0x97b3x8mnln480wf8nd58f63hd4hdn";
-      name = "khangman-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/khangman-17.08.0.tar.xz";
+      sha256 = "1wvz8p05lsmip65wcwsxzii6sgk48vqw8plghafd7x2dlbzwv3bi";
+      name = "khangman-17.08.0.tar.xz";
     };
   };
   khelpcenter = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/khelpcenter-17.04.3.tar.xz";
-      sha256 = "1sri5vb730k5n03kiykds024kl2hyw4bhzclxy5v0x36sjdqyz1z";
-      name = "khelpcenter-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/khelpcenter-17.08.0.tar.xz";
+      sha256 = "00i9nq837z6khvz06bvfndv37vhpl72dg0mx9s8wnifni5nixshm";
+      name = "khelpcenter-17.08.0.tar.xz";
     };
   };
   kholidays = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kholidays-17.04.3.tar.xz";
-      sha256 = "1hljhvlk6z3a4injfafwazai25qicmbdazj12pxb0wn5s538m9nw";
-      name = "kholidays-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kholidays-17.08.0.tar.xz";
+      sha256 = "1dyy03dcm6j0wrn71pxmdfhxph7hgvdnkcsrl0q6g2br01yjy7fl";
+      name = "kholidays-17.08.0.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kidentitymanagement-17.04.3.tar.xz";
-      sha256 = "17n7shm642jxnbzz11k9xrb7c3lmhzi3dabrl4qwxam1vf4zli6a";
-      name = "kidentitymanagement-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kidentitymanagement-17.08.0.tar.xz";
+      sha256 = "0xwnydrsw4g8ym415qi93hkhmghspwrdyzl5kw6vhl8xwm67h7i5";
+      name = "kidentitymanagement-17.08.0.tar.xz";
     };
   };
   kig = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kig-17.04.3.tar.xz";
-      sha256 = "1r8w0b99fi0jj8ah2sxgzpz93b1324d4vrrjvgz1wjcwskwqmbld";
-      name = "kig-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kig-17.08.0.tar.xz";
+      sha256 = "1f7w40glwbpqv33alpssg8vapx7sw6q3wbdw22r3ivlrqfy3lfmb";
+      name = "kig-17.08.0.tar.xz";
     };
   };
   kigo = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kigo-17.04.3.tar.xz";
-      sha256 = "0qx4bccniavbsy4icy98r4i3rgqcq3vw4fim9ad1ibmwsakzwrb9";
-      name = "kigo-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kigo-17.08.0.tar.xz";
+      sha256 = "04d4dg9w57cl6hfhwxc7l6hfas19q02l4wszvqbnagci333nqbsm";
+      name = "kigo-17.08.0.tar.xz";
     };
   };
   killbots = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/killbots-17.04.3.tar.xz";
-      sha256 = "0hjpzkdc0rgqiawy8vqh54bb693lhps9h2x9gxjsdhmk225l44b1";
-      name = "killbots-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/killbots-17.08.0.tar.xz";
+      sha256 = "1h5z310nvkn8dsamzifr4njwasyv9w32dy1i0qwkc6x8672n4xhi";
+      name = "killbots-17.08.0.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kimagemapeditor-17.04.3.tar.xz";
-      sha256 = "1c1gv3bac40a4ix45ydxbn5rys1z33c3ycxvii17cgv591yqrana";
-      name = "kimagemapeditor-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kimagemapeditor-17.08.0.tar.xz";
+      sha256 = "0klal67dzrr8l9x3xw4z54llwgf2r19xc2jfi4a8qmn3kqm2inmm";
+      name = "kimagemapeditor-17.08.0.tar.xz";
     };
   };
   kimap = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kimap-17.04.3.tar.xz";
-      sha256 = "0bdcxlwlr8k2ydmaimm4ja2kgg93qp0bjfl2cpsrzsfrp7fky5q2";
-      name = "kimap-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kimap-17.08.0.tar.xz";
+      sha256 = "0s2sfdlzaz6bj5rz077hnli500ddx53j6lvka1pyz7pc2qfj5lpp";
+      name = "kimap-17.08.0.tar.xz";
     };
   };
   kio-extras = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kio-extras-17.04.3.tar.xz";
-      sha256 = "10zr3gafwswnk9qzb2f0ysllzbxfzq3l482f75sfzn8i2ripd3z1";
-      name = "kio-extras-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kio-extras-17.08.0.tar.xz";
+      sha256 = "0yfg3jjzblrpsi0mc08sfg5lyzr4q4bqg23vha1b4wk323kx758f";
+      name = "kio-extras-17.08.0.tar.xz";
     };
   };
   kiriki = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kiriki-17.04.3.tar.xz";
-      sha256 = "1a4bnxv7y55fgkb0p0x7i09sqajsxg599zxqdfhsrm4ak6cqgkrg";
-      name = "kiriki-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kiriki-17.08.0.tar.xz";
+      sha256 = "10f7qydq97l65wrcxfvjvd0amal5achp6zdl33k04sx3dv62wb63";
+      name = "kiriki-17.08.0.tar.xz";
     };
   };
   kiten = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kiten-17.04.3.tar.xz";
-      sha256 = "1bxj013cb9jbahjghrdiq544zm7z4l4m1yd0zm0g9in9kp7rimzz";
-      name = "kiten-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kiten-17.08.0.tar.xz";
+      sha256 = "1j1qqz1vxgc8746qn9ss8p2qy8c099pfwscfsmd6fj3p04hm0xp7";
+      name = "kiten-17.08.0.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kjumpingcube-17.04.3.tar.xz";
-      sha256 = "0n1lpp6mvhj65zdw19hqsi21fwmfrxng570w1sbc4nr2xq5axibn";
-      name = "kjumpingcube-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kjumpingcube-17.08.0.tar.xz";
+      sha256 = "1a3lyyx7gx3brwyz3dzzf193088v510vjjr6vvlp7p1af0y5rxjp";
+      name = "kjumpingcube-17.08.0.tar.xz";
     };
   };
   kldap = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kldap-17.04.3.tar.xz";
-      sha256 = "03ynbrf5slmkdigp4wpwys1gn6iyd9n6b2ki3adcff9vb6k636kc";
-      name = "kldap-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kldap-17.08.0.tar.xz";
+      sha256 = "1dn37m64sqp816c2mnjcd7vb58bl9zy3zpmf4zghyhnln4hljnjq";
+      name = "kldap-17.08.0.tar.xz";
     };
   };
   kleopatra = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kleopatra-17.04.3.tar.xz";
-      sha256 = "08v1gldjk0f6d3card84ml4654irxswmvcizg5zbd8cbqb3mxzpw";
-      name = "kleopatra-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kleopatra-17.08.0.tar.xz";
+      sha256 = "0bx4bs2ssjhasbfhvjkhwf4p22wiyfrdkkazp79vs2i1z2anjsqm";
+      name = "kleopatra-17.08.0.tar.xz";
     };
   };
   klettres = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/klettres-17.04.3.tar.xz";
-      sha256 = "1gc1haxgx380q5chzm6l7hwf9laimjff3j2dvlfcqjq6hjjdasfw";
-      name = "klettres-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/klettres-17.08.0.tar.xz";
+      sha256 = "12vsp99x2j7xndgm31lhjxcvzp9v4plxmzjr9yn7l72ayvgf5s61";
+      name = "klettres-17.08.0.tar.xz";
     };
   };
   klickety = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/klickety-17.04.3.tar.xz";
-      sha256 = "1622y0ijw9y28i7fqbxlxj7hi1g1p5ff8dgn9f7bz02a67pdpxxz";
-      name = "klickety-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/klickety-17.08.0.tar.xz";
+      sha256 = "1nsf7yiqp1i0hzh053qr6b3pb6p25nr6w0z5kv6jnjpcvis1w3dj";
+      name = "klickety-17.08.0.tar.xz";
     };
   };
   klines = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/klines-17.04.3.tar.xz";
-      sha256 = "1rzp34309ay7hrrjh6ya0ghr167dkxpkizvhz7l7dzrqv9r216wg";
-      name = "klines-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/klines-17.08.0.tar.xz";
+      sha256 = "1w9hyxy4fdf9cj7c97lx8553phdp2gcx3z0c2y6gb3ic6nign4x7";
+      name = "klines-17.08.0.tar.xz";
     };
   };
   klinkstatus = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/klinkstatus-17.04.3.tar.xz";
-      sha256 = "0lx9f382nsl008r796bpck5f6q8iw6kh46kzkbxn6ygcc6fxz4nk";
-      name = "klinkstatus-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/klinkstatus-17.08.0.tar.xz";
+      sha256 = "07zzi44x2s3sfnp373san27dbbcpcph2l6l7z5b31vmqbcr2fia1";
+      name = "klinkstatus-17.08.0.tar.xz";
     };
   };
   kmag = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kmag-17.04.3.tar.xz";
-      sha256 = "0frj2nzmkc0k8vmhhan0qb5qq519msjyz8g16yxip2wgw98n7z8w";
-      name = "kmag-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kmag-17.08.0.tar.xz";
+      sha256 = "0fr4p707qhwnqz7nb52rh0xzrxwj5vxq64zpxcdxplapbhqczqkv";
+      name = "kmag-17.08.0.tar.xz";
     };
   };
   kmahjongg = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kmahjongg-17.04.3.tar.xz";
-      sha256 = "14afsfnnkdwhwqlyxvi16aldwanvn6s5nip6dy6k6aprap03y600";
-      name = "kmahjongg-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kmahjongg-17.08.0.tar.xz";
+      sha256 = "0z6k2nc11h1y8qby9knwwzppnbsl6rw0x52a571ikidakm5jg2j8";
+      name = "kmahjongg-17.08.0.tar.xz";
     };
   };
   kmail = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kmail-17.04.3.tar.xz";
-      sha256 = "0ml3vkk8d8hhhl3ir09dfn17vnkc94m8vr7fln3246w8rajzcnxb";
-      name = "kmail-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kmail-17.08.0.tar.xz";
+      sha256 = "1vdypb5a9fswnw4z6bj1mjmcp1kdrb0sc9yxigrj572w4hg31hjp";
+      name = "kmail-17.08.0.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kmail-account-wizard-17.04.3.tar.xz";
-      sha256 = "1d03kvjx92bqqh7b57kpfcy5viwkxwv4f113hw57bm6myfbv430z";
-      name = "kmail-account-wizard-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kmail-account-wizard-17.08.0.tar.xz";
+      sha256 = "06f0fa727fxzjbxch18lhnch9krcly0crk7waciajg4jnmg1v77b";
+      name = "kmail-account-wizard-17.08.0.tar.xz";
     };
   };
   kmailtransport = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kmailtransport-17.04.3.tar.xz";
-      sha256 = "0d8w2xq0zjmk3h0hawsbacfvwb3s5qkzqns5hsdrf1dv7mx4w76r";
-      name = "kmailtransport-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kmailtransport-17.08.0.tar.xz";
+      sha256 = "1liqqrk5xpzaim8kj87acavry33m5pidx7ajmbmk2hb01dhiq20z";
+      name = "kmailtransport-17.08.0.tar.xz";
     };
   };
   kmbox = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kmbox-17.04.3.tar.xz";
-      sha256 = "1r457xa9s30hpm92cd5lga89g1y256macfmi9kj4l0vjvjphligh";
-      name = "kmbox-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kmbox-17.08.0.tar.xz";
+      sha256 = "1cg9cl6a4z09adyyim7yahlg95slsw4zw4r9lqhqznmjr5nyf9bq";
+      name = "kmbox-17.08.0.tar.xz";
     };
   };
   kmime = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kmime-17.04.3.tar.xz";
-      sha256 = "107ylqgnc63l4a554c4rxp4ckyq33bgy6rwmgihysyy8ff4gfa9a";
-      name = "kmime-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kmime-17.08.0.tar.xz";
+      sha256 = "1k4xicq14i35f2x3xkkhqrs2darql5rw2i2j3zd73gkmd37gdrai";
+      name = "kmime-17.08.0.tar.xz";
     };
   };
   kmines = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kmines-17.04.3.tar.xz";
-      sha256 = "0m42zmfy51qricg9k1rf3b0bcl4cg982iazrh85qcgvpjlgba70n";
-      name = "kmines-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kmines-17.08.0.tar.xz";
+      sha256 = "1wci2wrkj96ywwvvdpbjf4270qq8x7gdbppy9la860x5nvp34xvx";
+      name = "kmines-17.08.0.tar.xz";
     };
   };
   kmix = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kmix-17.04.3.tar.xz";
-      sha256 = "1q5pk99hn4shfrbcfab8d1bh79i77v16q3ss2cfa6y8xkrny05rd";
-      name = "kmix-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kmix-17.08.0.tar.xz";
+      sha256 = "1s3hmg2wdav2mn9ddcp2lp147xz1k5y52jql0q2w65i5dzcpav3a";
+      name = "kmix-17.08.0.tar.xz";
     };
   };
   kmousetool = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kmousetool-17.04.3.tar.xz";
-      sha256 = "08f7lvvqks75g0bcjd0cylixa93fr85rnc5jni0ygvi02b9fiy5a";
-      name = "kmousetool-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kmousetool-17.08.0.tar.xz";
+      sha256 = "0287rgx7rgwa95zfhwl6754ia58scq86qd18max8yg6l5mwjny8v";
+      name = "kmousetool-17.08.0.tar.xz";
     };
   };
   kmouth = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kmouth-17.04.3.tar.xz";
-      sha256 = "1x1g29ipq8v6zshhybwsm9ib8f0ks8rxyc0wjn0ncyirvrwr1ka3";
-      name = "kmouth-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kmouth-17.08.0.tar.xz";
+      sha256 = "1gfh2akqxq4w9k8y4xpmafrn9q17c5xyc3f7vgl9r0h9jfrnndx8";
+      name = "kmouth-17.08.0.tar.xz";
     };
   };
   kmplot = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kmplot-17.04.3.tar.xz";
-      sha256 = "0v8v2bqarn34xahnprpyi66szaq0kjp16cqz90kk8d4ch4xnvhjv";
-      name = "kmplot-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kmplot-17.08.0.tar.xz";
+      sha256 = "1bvx0298n3aa39qsnlzxv431w2ayhkinin1sj1indpjzs3qia8li";
+      name = "kmplot-17.08.0.tar.xz";
     };
   };
   knavalbattle = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/knavalbattle-17.04.3.tar.xz";
-      sha256 = "1qkpzd0fdnz6cdd308xsrk2g6s5lfpq8v5nl6rd6h6ksv599017n";
-      name = "knavalbattle-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/knavalbattle-17.08.0.tar.xz";
+      sha256 = "1v52g5jr201cyvjdhd70vsjrxa75j95d8ssy5pqfvzdb0251pxdi";
+      name = "knavalbattle-17.08.0.tar.xz";
     };
   };
   knetwalk = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/knetwalk-17.04.3.tar.xz";
-      sha256 = "16p7lxc4qzs4r2yjgshc8pcgpdi714rll6x0mzgsb0fdpdk3wrjg";
-      name = "knetwalk-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/knetwalk-17.08.0.tar.xz";
+      sha256 = "0aiasbf6ww9ccqsamvn2kljyjh4bzxccp5clysglhmliv1g6qx44";
+      name = "knetwalk-17.08.0.tar.xz";
     };
   };
   knotes = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/knotes-17.04.3.tar.xz";
-      sha256 = "0x6ymg6x3yiaz3gz9kaj88clw7ra0bbmyh230hi0s9v0x085slp3";
-      name = "knotes-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/knotes-17.08.0.tar.xz";
+      sha256 = "07cbhgxsf1qdayzxvwv6ihlz1jfq3nn0csf1qscx7qj1a2jypcv6";
+      name = "knotes-17.08.0.tar.xz";
     };
   };
   kolf = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kolf-17.04.3.tar.xz";
-      sha256 = "15l4pgidr6r4hh6q6c7gslh7027j1f5xxzwh5w76vlx3j0spzm7l";
-      name = "kolf-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kolf-17.08.0.tar.xz";
+      sha256 = "1y2dk5rfssnnl93wilmz3bkvk6jllyq3isy4aj6dp8v1qrisna0m";
+      name = "kolf-17.08.0.tar.xz";
     };
   };
   kollision = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kollision-17.04.3.tar.xz";
-      sha256 = "0wlwyayrcjrlgzvci3ih2as6dw38jm0j4s15c13ssr545r7mdd4m";
-      name = "kollision-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kollision-17.08.0.tar.xz";
+      sha256 = "1fqlxj4792g4k10pzfk53svvfp8kkaz126z7509qrwjngq8y4bji";
+      name = "kollision-17.08.0.tar.xz";
     };
   };
   kolourpaint = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kolourpaint-17.04.3.tar.xz";
-      sha256 = "1xy95vmwajlzvmaqg02ywd8ar8j0ncv0qr5gm49qc57kxnylixhj";
-      name = "kolourpaint-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kolourpaint-17.08.0.tar.xz";
+      sha256 = "15xm9hf9b2bq4s66pbiqpjhshjfx7xf3gvk3cfc01xibly442xc9";
+      name = "kolourpaint-17.08.0.tar.xz";
     };
   };
   kompare = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kompare-17.04.3.tar.xz";
-      sha256 = "16wvfb337prnd9ncq1076hg3fz83lykpmaxmhznrjbiw8plc11n2";
-      name = "kompare-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kompare-17.08.0.tar.xz";
+      sha256 = "1rh71a152vnlhx7f5046ndlk4gb15p4jy7sqfrmnx1ssmi2vhs8g";
+      name = "kompare-17.08.0.tar.xz";
     };
   };
   konqueror = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/konqueror-17.04.3.tar.xz";
-      sha256 = "08dv4w507zm1qhzis543jamggpsl2rardcvkqanlrh24v83q9zl8";
-      name = "konqueror-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/konqueror-17.08.0.tar.xz";
+      sha256 = "1ir47i0g48rabjh86xy426imw682wr6kff9cwvbf7lgl6gqkpafw";
+      name = "konqueror-17.08.0.tar.xz";
     };
   };
   konquest = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/konquest-17.04.3.tar.xz";
-      sha256 = "0slnjkzlp0sk3sc5mjg27n918g4l4dsmz4ikz0cwbp46dbfz5y4c";
-      name = "konquest-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/konquest-17.08.0.tar.xz";
+      sha256 = "1b6bw8ga4wjaa7zw344y8cb3hiylpcq5m3mj96hasri6jyd1lwp8";
+      name = "konquest-17.08.0.tar.xz";
     };
   };
   konsole = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/konsole-17.04.3.tar.xz";
-      sha256 = "1dhjadpcfh4d7h3ll2sr387c3hgskx8as9p6rksjwkp05mkbgh79";
-      name = "konsole-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/konsole-17.08.0.tar.xz";
+      sha256 = "0il0hffq62plq7jdbq2a1y1djdb406639h2zz6jsmn6fbbrwxwh4";
+      name = "konsole-17.08.0.tar.xz";
     };
   };
   kontact = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kontact-17.04.3.tar.xz";
-      sha256 = "148b86fd192nfc8yp9x5h4wwv7cnlyci1y3fb0wfl85h96d8sa5n";
-      name = "kontact-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kontact-17.08.0.tar.xz";
+      sha256 = "0cs8sjq0dlhggly1kjcqsdsjxfg717mgjzg84ac64m2gdkk213sz";
+      name = "kontact-17.08.0.tar.xz";
     };
   };
   kontactinterface = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kontactinterface-17.04.3.tar.xz";
-      sha256 = "0qlm7mfbhzbhfab0l9rfn5krnxlgbj9yny9bbn4isiyj8csjxmjy";
-      name = "kontactinterface-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kontactinterface-17.08.0.tar.xz";
+      sha256 = "01zz7zah35wfpqkmz46jxjljys4ngkh5m94ldirjg95pfrcxlsnc";
+      name = "kontactinterface-17.08.0.tar.xz";
     };
   };
   kopete = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kopete-17.04.3.tar.xz";
-      sha256 = "0gz47c9i9ziamh8295r407yamlwx3lqi6f2h9xrapsac8qm4cj7c";
-      name = "kopete-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kopete-17.08.0.tar.xz";
+      sha256 = "0f26ln78pxdj69rvsxpbzf8554hdwcij3z488pgv8j2h9j6pwgfd";
+      name = "kopete-17.08.0.tar.xz";
     };
   };
   korganizer = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/korganizer-17.04.3.tar.xz";
-      sha256 = "1z3vqlj1jhzvn9kq08hfpnw760yy8j4y82r151rb04c3k3x33mr7";
-      name = "korganizer-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/korganizer-17.08.0.tar.xz";
+      sha256 = "0mqzbjyxb8625m2m2js8pqj8m9k8q1ali46wj96prfk1y9abnp5i";
+      name = "korganizer-17.08.0.tar.xz";
     };
   };
   kpat = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kpat-17.04.3.tar.xz";
-      sha256 = "0j39nvb9nvgmg9lxw70q11vj1v08zy3dpbdrzx73v2grp7mvlc14";
-      name = "kpat-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kpat-17.08.0.tar.xz";
+      sha256 = "04phaqbbyys0zz7rqivifz620xmw32pvv2kkax3n37spsdiyaq5j";
+      name = "kpat-17.08.0.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kpimtextedit-17.04.3.tar.xz";
-      sha256 = "011y7f5aarznqs9ngbvi75h1z10avz1sp0286zmsi00g9733ap7h";
-      name = "kpimtextedit-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kpimtextedit-17.08.0.tar.xz";
+      sha256 = "01klpd4cqxq8cd0s32k9m44nly6w7ym41h385hw888xf356xsjpb";
+      name = "kpimtextedit-17.08.0.tar.xz";
     };
   };
   kppp = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kppp-17.04.3.tar.xz";
-      sha256 = "158zgjjlmnk2lh048c271ac9a1h70x0ihm77xr5bgnjg1yyp8lwj";
-      name = "kppp-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kppp-17.08.0.tar.xz";
+      sha256 = "1bzwsjw46vj36fwir0r6l26l1fr3mpj37g87wrg8zb3g9vz6ixnp";
+      name = "kppp-17.08.0.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kqtquickcharts-17.04.3.tar.xz";
-      sha256 = "1v7cllvz4bhkqnqfib723psvd053wvazvvniw1w6g69lv9a6kn88";
-      name = "kqtquickcharts-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kqtquickcharts-17.08.0.tar.xz";
+      sha256 = "1g487xniyv6yic2wyvd3rxn0rn95anrr4djf10nglvlxzcx3fnrc";
+      name = "kqtquickcharts-17.08.0.tar.xz";
     };
   };
   krdc = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/krdc-17.04.3.tar.xz";
-      sha256 = "0xi4s5w9wyrgcyqs4xixs8mcprnn3dp4p22fbgi8z8i25znd20d0";
-      name = "krdc-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/krdc-17.08.0.tar.xz";
+      sha256 = "0hsp05nns2ddvg4md6lwywh8c58vxzrb8r4d512mlcvprm8w6qb4";
+      name = "krdc-17.08.0.tar.xz";
     };
   };
   kremotecontrol = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kremotecontrol-17.04.3.tar.xz";
-      sha256 = "1m1yh4knmj5llrgv043j50azq5s7clfmlg8b86nasz78svbdhxwg";
-      name = "kremotecontrol-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kremotecontrol-17.08.0.tar.xz";
+      sha256 = "1vxb73zycw1d2spnkhv93ml1b1m8hw1g3lac77l1vq17g873ibg5";
+      name = "kremotecontrol-17.08.0.tar.xz";
     };
   };
   kreversi = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kreversi-17.04.3.tar.xz";
-      sha256 = "0splganr60x9nz59jj4ysl8dk867c54k68d3pc8ac2yxhgb7qg0i";
-      name = "kreversi-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kreversi-17.08.0.tar.xz";
+      sha256 = "1wi6s3rjqbc6269x856ri2a6iirnx1p9pizkqpq8yma7lpzl59ss";
+      name = "kreversi-17.08.0.tar.xz";
     };
   };
   krfb = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/krfb-17.04.3.tar.xz";
-      sha256 = "0yx19gf8mh6l5k4apfim48jw61hcllwb2nbk9d7k08nl635lxd7i";
-      name = "krfb-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/krfb-17.08.0.tar.xz";
+      sha256 = "0kyyl4zrrx4naj5nlczmc3fn0gbc7nrb42hm43hf4c0l5djsw4vj";
+      name = "krfb-17.08.0.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kross-interpreters-17.04.3.tar.xz";
-      sha256 = "1z7xnd4l1ksi0m4281pg9p0l2qv46acr1yijhrkg82va67y13r81";
-      name = "kross-interpreters-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kross-interpreters-17.08.0.tar.xz";
+      sha256 = "0k7p1c2lpknw0q45ahgld9pcxi5f3nsbl4hima10s6n3jf91d4v9";
+      name = "kross-interpreters-17.08.0.tar.xz";
     };
   };
   kruler = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kruler-17.04.3.tar.xz";
-      sha256 = "01pab2j5jpkqxmymhkkwlaw63idmbi9pdv0974ypg209lp51nw9i";
-      name = "kruler-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kruler-17.08.0.tar.xz";
+      sha256 = "0rfmn3wh1k8xigpk07mcj2xd0jq85jm81ymaka0pjm8ka98njbr6";
+      name = "kruler-17.08.0.tar.xz";
     };
   };
   ksaneplugin = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ksaneplugin-17.04.3.tar.xz";
-      sha256 = "0iyxzgxfvw8wk18bbhif5is8nj421rnf6hrm6jz8s1gzlamnmfkm";
-      name = "ksaneplugin-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ksaneplugin-17.08.0.tar.xz";
+      sha256 = "1dyifhfyzg7p8j8h45k8m4vkvrq7nbj07810j5r8hqcmbpbjw2m1";
+      name = "ksaneplugin-17.08.0.tar.xz";
     };
   };
   kscd = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kscd-17.04.3.tar.xz";
-      sha256 = "1c2w5kjm020930460iyq3q9jb1m3lz8cld4zmd2q7vr68ga31756";
-      name = "kscd-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kscd-17.08.0.tar.xz";
+      sha256 = "0bc6npz4s4fn2vzm3xpm0si06ql9k6a9gx9b1ghxn5y2dy3hjshy";
+      name = "kscd-17.08.0.tar.xz";
     };
   };
   kshisen = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kshisen-17.04.3.tar.xz";
-      sha256 = "14dswml5cgjr0q27gv7wgkl3mn3z2dvwa847k59s3mzpy7q45zyy";
-      name = "kshisen-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kshisen-17.08.0.tar.xz";
+      sha256 = "1b3q8fcm6pialqwljm2hwmk1k9fcwa77m55zxyb2wcyvgz9gpkjq";
+      name = "kshisen-17.08.0.tar.xz";
     };
   };
   ksirk = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ksirk-17.04.3.tar.xz";
-      sha256 = "16hibmv3697wzy62p51s5nkps942dav2wk7hllaykx3qzcr3dflf";
-      name = "ksirk-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ksirk-17.08.0.tar.xz";
+      sha256 = "1qcbr7lrj1zdbyb7agf2afnc39lvinam48yrzxbv0ry62l965c82";
+      name = "ksirk-17.08.0.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ksnakeduel-17.04.3.tar.xz";
-      sha256 = "08v2yr8n9px55c467wyji2lmiyl1d7m7qm5ll7vynxsdzz6g02wq";
-      name = "ksnakeduel-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ksnakeduel-17.08.0.tar.xz";
+      sha256 = "1vd9cspaxwxbs1lqbla292zwfyjj4giajx2n19m26x857xb6va0k";
+      name = "ksnakeduel-17.08.0.tar.xz";
     };
   };
   kspaceduel = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kspaceduel-17.04.3.tar.xz";
-      sha256 = "0y5c4hbxyl7pi4fp2zkkjmzqy27mazyh4capjnyjckqy91n3cfwa";
-      name = "kspaceduel-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kspaceduel-17.08.0.tar.xz";
+      sha256 = "1y6nyyvig6y5s99bym21xyazxly0v7pdqygkwb3rq5152bf4xi78";
+      name = "kspaceduel-17.08.0.tar.xz";
     };
   };
   ksquares = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ksquares-17.04.3.tar.xz";
-      sha256 = "04531lg5xz9rk81l0xqvy8wlh1jmpgfc74i0drv4s712v0bvjixb";
-      name = "ksquares-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ksquares-17.08.0.tar.xz";
+      sha256 = "0fmx2zj5qrqyxg1yf2pbl2a4fq96rm088m7hmiq85ha7i1dd0wbw";
+      name = "ksquares-17.08.0.tar.xz";
     };
   };
   kstars = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kstars-17.04.3.tar.xz";
-      sha256 = "011ncpkly5x6js9vx5d8pnrd3z9iz3zqxivx7cibjbgmwrl80dn8";
-      name = "kstars-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kstars-17.08.0.tar.xz";
+      sha256 = "1k2rln20qw7rm7dxxyd3yrxbmpjhkpbqd0v82xfnqal6i3cx8xdb";
+      name = "kstars-17.08.0.tar.xz";
     };
   };
   ksudoku = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ksudoku-17.04.3.tar.xz";
-      sha256 = "0x54jmzjz01nlsxrn1hr6my54rb58v1qdibz03a8nl7pfndq6qhi";
-      name = "ksudoku-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ksudoku-17.08.0.tar.xz";
+      sha256 = "1lysfddiy12fxnwampy3djbkrabfqch4vsvxn6hclpii8a6sx5nr";
+      name = "ksudoku-17.08.0.tar.xz";
     };
   };
   ksystemlog = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ksystemlog-17.04.3.tar.xz";
-      sha256 = "00g7cw2g2450x2m8wip62aajs2r6knw359s5lr5cl2llzasp297i";
-      name = "ksystemlog-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ksystemlog-17.08.0.tar.xz";
+      sha256 = "0n4387si8q8183rysmbdbyqs9d5x09qdrkd47g66bxn0w4qbwmkq";
+      name = "ksystemlog-17.08.0.tar.xz";
     };
   };
   kteatime = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kteatime-17.04.3.tar.xz";
-      sha256 = "1cm5bmb0n8b6pxq0zbdl01mhrzh50ccrywzn2zjscbsnasnbynxk";
-      name = "kteatime-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kteatime-17.08.0.tar.xz";
+      sha256 = "17jxrivkmrwnwrw641slm756lpqk5vg8chadn797b1w3ddr7vwl7";
+      name = "kteatime-17.08.0.tar.xz";
     };
   };
   ktimer = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktimer-17.04.3.tar.xz";
-      sha256 = "0s5xvm2fk0i5lyj2420c561xbf536508l1basv3dn12l9xixmbm4";
-      name = "ktimer-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktimer-17.08.0.tar.xz";
+      sha256 = "12aj0v1z3y797xs3bxqa3pd4z5k9bhjbpgp1v3kf87arpvrdb9q7";
+      name = "ktimer-17.08.0.tar.xz";
     };
   };
   ktnef = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktnef-17.04.3.tar.xz";
-      sha256 = "06gyfz2xil0p9y1442dcwj3ymi1py3wrdbgkccc9vy4zpmaqmk68";
-      name = "ktnef-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktnef-17.08.0.tar.xz";
+      sha256 = "1j4yaxmz8kcar2hmsd39l7l757ca16fdzlvhljhjpii4br2lp17s";
+      name = "ktnef-17.08.0.tar.xz";
     };
   };
   ktouch = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktouch-17.04.3.tar.xz";
-      sha256 = "0ms1cbmf21w0ypwkxi3flazkkx790kciblk1izwn3p6ywqdig0ih";
-      name = "ktouch-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktouch-17.08.0.tar.xz";
+      sha256 = "1g2kxdp0734yqz8044z7z1sgwyf0n7spql1r8vwzr6zisx6gy7pb";
+      name = "ktouch-17.08.0.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktp-accounts-kcm-17.04.3.tar.xz";
-      sha256 = "065gx0k28qialw41iqx3m25l1qppp77qssmhywb158pryy1v2clz";
-      name = "ktp-accounts-kcm-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktp-accounts-kcm-17.08.0.tar.xz";
+      sha256 = "11z8g0pcv04lh70qx4gb5226h7wm7g7bm7n14mpw8xbcnlh2sax8";
+      name = "ktp-accounts-kcm-17.08.0.tar.xz";
     };
   };
   ktp-approver = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktp-approver-17.04.3.tar.xz";
-      sha256 = "11694778gg47fjq76rwxjibrcga7fqmnv88pmqvrb6hhskbnriav";
-      name = "ktp-approver-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktp-approver-17.08.0.tar.xz";
+      sha256 = "03v2mz29r3lzwwa5bis8sn8zjjr7vdpq2f39fzkyvb3vjnkb0kh8";
+      name = "ktp-approver-17.08.0.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktp-auth-handler-17.04.3.tar.xz";
-      sha256 = "0m3s8piyhi9r11pq202ky14drhm45gxvvvy30w2x57qz9k013c67";
-      name = "ktp-auth-handler-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktp-auth-handler-17.08.0.tar.xz";
+      sha256 = "1yj8cn4s0p1fdlcd1zn8ai2l1rfhzg2n3qny9s2q1jz1wnbhxj1z";
+      name = "ktp-auth-handler-17.08.0.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktp-call-ui-17.04.3.tar.xz";
-      sha256 = "16zz91kiyz1mnipl6sqxqrak6cfhcp195in45cvlpcm5pn7gn0x6";
-      name = "ktp-call-ui-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktp-call-ui-17.08.0.tar.xz";
+      sha256 = "1vddjzcq0qy25f8qqwhck2icl9v6arihlg63fdr4bz05cifhmip4";
+      name = "ktp-call-ui-17.08.0.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktp-common-internals-17.04.3.tar.xz";
-      sha256 = "12mwfd60f7iyb0f0y3yzscw38dygakhv9xlidwy4yxj6n7xylr0k";
-      name = "ktp-common-internals-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktp-common-internals-17.08.0.tar.xz";
+      sha256 = "1qw92sh1lhm3zmyj3jr4r1rhcnfbaipfnrr78bsfixdb784is7dk";
+      name = "ktp-common-internals-17.08.0.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktp-contact-list-17.04.3.tar.xz";
-      sha256 = "068m2nd969qrzsip4ks1zgcdardl4gzsdxm6jic04gxfhygrkllk";
-      name = "ktp-contact-list-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktp-contact-list-17.08.0.tar.xz";
+      sha256 = "162fzvs8x63091arc7c4njwzz1xn5bgzai0bh57va4fzqhzxs012";
+      name = "ktp-contact-list-17.08.0.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktp-contact-runner-17.04.3.tar.xz";
-      sha256 = "0qq1x1ip7vrjapq6aq8a7lbfcd6gn9cmal8g8247hilcjbmzlab2";
-      name = "ktp-contact-runner-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktp-contact-runner-17.08.0.tar.xz";
+      sha256 = "16j9ljcab4xmsjdbllr36a02s07w3xgpz0i4p0wzpwlfg42kb0nj";
+      name = "ktp-contact-runner-17.08.0.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktp-desktop-applets-17.04.3.tar.xz";
-      sha256 = "0jsza9vaz7vn108j9c49fyqwyy2v7yjrmn3kpxn9kd4jmz81z74s";
-      name = "ktp-desktop-applets-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktp-desktop-applets-17.08.0.tar.xz";
+      sha256 = "1n0f5a5lfb3zn8h9dvqm4c6gs39pvlnglr7lvcgqmabhvncwdxbp";
+      name = "ktp-desktop-applets-17.08.0.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktp-filetransfer-handler-17.04.3.tar.xz";
-      sha256 = "15bp0lrdingxz0sm9cxrjb3zhc1a56van2jl809v7703r3q6fliv";
-      name = "ktp-filetransfer-handler-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktp-filetransfer-handler-17.08.0.tar.xz";
+      sha256 = "1jprbcc3cnz1h9491bbmfxs6rbq6plpl7mrkfha7p3f1qn72w0h0";
+      name = "ktp-filetransfer-handler-17.08.0.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktp-kded-module-17.04.3.tar.xz";
-      sha256 = "14jksyvl41179fm53834finmmh7pg5lyhgalvaa88dch62f3s6r7";
-      name = "ktp-kded-module-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktp-kded-module-17.08.0.tar.xz";
+      sha256 = "1676s6w8wcwvbzgmg5vfw6i88smrzicgjbbg6q5k5hzp5xaxr8yk";
+      name = "ktp-kded-module-17.08.0.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktp-send-file-17.04.3.tar.xz";
-      sha256 = "10h7y12z4l05yblh4drngqzb77yijik28iilj619491w865kia90";
-      name = "ktp-send-file-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktp-send-file-17.08.0.tar.xz";
+      sha256 = "153v1yzhjxh1afkq5r7spp45f7lzj07x61ziv74ignpshm28a69l";
+      name = "ktp-send-file-17.08.0.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktp-text-ui-17.04.3.tar.xz";
-      sha256 = "1ggac4v9wiqdqihnp9ddfh20p7kli2yhikdkiv8wb2ia3836j6y1";
-      name = "ktp-text-ui-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktp-text-ui-17.08.0.tar.xz";
+      sha256 = "169lb6d07xra6v25wsdzmhbpj2lhbkjxdhvgyprwv3wlh7fyd6z2";
+      name = "ktp-text-ui-17.08.0.tar.xz";
     };
   };
   ktuberling = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/ktuberling-17.04.3.tar.xz";
-      sha256 = "0h66d6jhp9p47pb177hrjjkp0agwa4vzgjl53rib8lgv3ifyxq1d";
-      name = "ktuberling-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/ktuberling-17.08.0.tar.xz";
+      sha256 = "06iqdi5j7yywv4xfv6lciw8s80a1z41w0cw029l26r97yrm5qc3c";
+      name = "ktuberling-17.08.0.tar.xz";
     };
   };
   kturtle = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kturtle-17.04.3.tar.xz";
-      sha256 = "04sykc7bsvc20i0nq8h1w89gafz6cli9x1iphf0l6v8whvb7avmn";
-      name = "kturtle-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kturtle-17.08.0.tar.xz";
+      sha256 = "0ds7n7bpg4m5av48k9nqjaka94jddrxqxn61dn54c8yxx8zwka1j";
+      name = "kturtle-17.08.0.tar.xz";
     };
   };
   kubrick = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kubrick-17.04.3.tar.xz";
-      sha256 = "1zkjwsl7bsb170qac59psjkvdbqypfkp0s4snqvqw07jicbq75ss";
-      name = "kubrick-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kubrick-17.08.0.tar.xz";
+      sha256 = "1azzy536xwcpcf37hvkrvqg63l9jn67vsw1nxa68a7vh7pw104hi";
+      name = "kubrick-17.08.0.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kwalletmanager-17.04.3.tar.xz";
-      sha256 = "1wz27vg9h2g7q26ii1m358b3qdnra96zp3kwlz5yn5jkgv6500cr";
-      name = "kwalletmanager-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kwalletmanager-17.08.0.tar.xz";
+      sha256 = "03dam64smpw9fqpq4kqisn5kcwvwf2rl0x5jq1ws6pxdk72cn5wj";
+      name = "kwalletmanager-17.08.0.tar.xz";
     };
   };
   kwave = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kwave-17.04.3.tar.xz";
-      sha256 = "1mps4fq351fxqpsrv74hchn64qm5407jr9vlh169khvrcjbj72xn";
-      name = "kwave-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kwave-17.08.0.tar.xz";
+      sha256 = "0zqv5iqn3nzijvhlwx303dhjj0f9ha9fvg0infn9170vhcx2v2mn";
+      name = "kwave-17.08.0.tar.xz";
     };
   };
   kwordquiz = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/kwordquiz-17.04.3.tar.xz";
-      sha256 = "0kacbsr56a063586vs4if4mcqp9fwics4344ha12zh2j2clr20h3";
-      name = "kwordquiz-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/kwordquiz-17.08.0.tar.xz";
+      sha256 = "0mxvx4br53grsp48mx1z5vf9awlrbj6s7yipz75mj1cskzq103pb";
+      name = "kwordquiz-17.08.0.tar.xz";
     };
   };
   libgravatar = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libgravatar-17.04.3.tar.xz";
-      sha256 = "0mdnvr7k67v2j9x5zwfsy2d3hw6j83npcv7546yqxfv6myb0ffvc";
-      name = "libgravatar-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libgravatar-17.08.0.tar.xz";
+      sha256 = "1wijd89xpg82p36f4c5y3lphdpgisj66408idar7x4wfsz6x9ypj";
+      name = "libgravatar-17.08.0.tar.xz";
     };
   };
   libkcddb = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libkcddb-17.04.3.tar.xz";
-      sha256 = "01mmll75l2lv0djahfaikq5nc52z3k7zlc2hx3djw9xrhhvmd63k";
-      name = "libkcddb-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libkcddb-17.08.0.tar.xz";
+      sha256 = "0cxhjf80kncmwl8gflf8mawghqz0bdwqb3sjipwy241p1irisyb4";
+      name = "libkcddb-17.08.0.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libkcompactdisc-17.04.3.tar.xz";
-      sha256 = "0zr581qyf81v9sfh3qvhkjh0krzs35y0gpi4wp07df071hiddmvj";
-      name = "libkcompactdisc-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libkcompactdisc-17.08.0.tar.xz";
+      sha256 = "16qa7mn9pxrghka56y4n3kg7i1wm9fp3njnpaczc5f8brl7fm8wk";
+      name = "libkcompactdisc-17.08.0.tar.xz";
     };
   };
   libkdcraw = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libkdcraw-17.04.3.tar.xz";
-      sha256 = "1w0zhz20vf2i55wywzf7ar5sp2paflbxjg3r35p6wpfrlafzvnjw";
-      name = "libkdcraw-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libkdcraw-17.08.0.tar.xz";
+      sha256 = "0c76c055i2h4hwxp7xpnkpyn86mg8rs5z8wxzamc9yjynsym29k6";
+      name = "libkdcraw-17.08.0.tar.xz";
     };
   };
   libkdegames = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libkdegames-17.04.3.tar.xz";
-      sha256 = "02j5kmbnxnmgf0vnmz6hzmkz5jc4aw2vm8gnjvs4l2hzcf7f82p8";
-      name = "libkdegames-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libkdegames-17.08.0.tar.xz";
+      sha256 = "0zhfr0pq4vb7ax2wlspkczrfnqfs9w78r2l77777yhgha0mvs5hl";
+      name = "libkdegames-17.08.0.tar.xz";
     };
   };
   libkdepim = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libkdepim-17.04.3.tar.xz";
-      sha256 = "0a0kxx99swyw31bf9npbfa5smavpar2qg593dvg1basdy102lpcv";
-      name = "libkdepim-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libkdepim-17.08.0.tar.xz";
+      sha256 = "0xf1r07hzqwnjjwkbi0a61dpmpsa33a33ac41rlaknclpvmgakxl";
+      name = "libkdepim-17.08.0.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libkeduvocdocument-17.04.3.tar.xz";
-      sha256 = "1z138s14cd7cfgv442i848m4w71f6442rjm8cghbd8m4kbd3m8yg";
-      name = "libkeduvocdocument-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libkeduvocdocument-17.08.0.tar.xz";
+      sha256 = "1x779zxawd3zg341a5lph669afg8qnnbvrbblv9rd775bpygwkhj";
+      name = "libkeduvocdocument-17.08.0.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libkexiv2-17.04.3.tar.xz";
-      sha256 = "035akzr9f7f9k86j1ihx9ql574vjfm3ai792k8h46xh9d7xn385q";
-      name = "libkexiv2-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libkexiv2-17.08.0.tar.xz";
+      sha256 = "02i1nm4ggj72kgk8j0qkgqrc5kh4dg4qa62bp8q5lgi27fxijhxy";
+      name = "libkexiv2-17.08.0.tar.xz";
     };
   };
   libkface = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libkface-17.04.3.tar.xz";
-      sha256 = "081ghj31f39xxq692ad5a32w8kaks7xyl3xmcmgl0sp7yac102ar";
-      name = "libkface-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libkface-17.08.0.tar.xz";
+      sha256 = "08k7ci77lry0z5178w5fm0rf0rvsvfcdlhs70xg3iwzbhha3crz7";
+      name = "libkface-17.08.0.tar.xz";
     };
   };
   libkgapi = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libkgapi-17.04.3.tar.xz";
-      sha256 = "1j6lg6mdd7bhapdkfpicksbd9y9b4qh0f9m3k3yddx318n49nl8r";
-      name = "libkgapi-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libkgapi-17.08.0.tar.xz";
+      sha256 = "1i0z16x77wmxk11w75kp1j6w6v00kr9knpryg7n3gpp4kbpnkj8c";
+      name = "libkgapi-17.08.0.tar.xz";
     };
   };
   libkgeomap = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libkgeomap-17.04.3.tar.xz";
-      sha256 = "1zc4ja631f54xk1mycda1h4c3wdhq9ggn67xn68jrlv4wrsm3ly1";
-      name = "libkgeomap-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libkgeomap-17.08.0.tar.xz";
+      sha256 = "02njkvk9qvd6zycfa1s85mlc66jal5icg23dbh5vliiwq3xqlyix";
+      name = "libkgeomap-17.08.0.tar.xz";
     };
   };
   libkipi = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libkipi-17.04.3.tar.xz";
-      sha256 = "1qf1qpq1q65fk96c6rvq4avlbqnfa7cr58fkcv8c620j7fkhh3iv";
-      name = "libkipi-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libkipi-17.08.0.tar.xz";
+      sha256 = "0z1vllhfimwp7dgf2hfxwhpvfg0j6kg6n7m166ji7nalb8p5avd4";
+      name = "libkipi-17.08.0.tar.xz";
     };
   };
   libkleo = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libkleo-17.04.3.tar.xz";
-      sha256 = "1jk0qlsx6k77vg85xp1fjvz3b2h6f08zmwgjfh24gz9jacdps2bq";
-      name = "libkleo-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libkleo-17.08.0.tar.xz";
+      sha256 = "0i747aq06yzl8rzznyrgwyypff4g5fdmdc1k5v63z99yf8rb0zqg";
+      name = "libkleo-17.08.0.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libkmahjongg-17.04.3.tar.xz";
-      sha256 = "1bwgrvzzwqd1zp9qskss8l20ihxd8z7mn4ap7xr2snr7m6bzandx";
-      name = "libkmahjongg-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libkmahjongg-17.08.0.tar.xz";
+      sha256 = "0cya2gnqr8cjgw2abpnwvyqa243zjdr89h1dwvjyag8s0aw595af";
+      name = "libkmahjongg-17.08.0.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libkomparediff2-17.04.3.tar.xz";
-      sha256 = "0jfhvp1dxbrblaqizflbs2c2r5ar1nd41rzhnrm4iwgafnpsa9av";
-      name = "libkomparediff2-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libkomparediff2-17.08.0.tar.xz";
+      sha256 = "0nrd6a5agvgmqcx5bvx11s4zal9ln6q6awavbyr5m1hvccch2k1r";
+      name = "libkomparediff2-17.08.0.tar.xz";
     };
   };
   libksane = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libksane-17.04.3.tar.xz";
-      sha256 = "0wvqdbi7a2ji2fhvxqn5iyab8qwq9ycb5lngj1wlyzp96c3lyz40";
-      name = "libksane-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libksane-17.08.0.tar.xz";
+      sha256 = "18s3d3m0ylbrrbf4vivc29lms9yz6ppkdb247kbmxxnwvzk867bl";
+      name = "libksane-17.08.0.tar.xz";
     };
   };
   libksieve = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/libksieve-17.04.3.tar.xz";
-      sha256 = "107bcfb3nvlwxhcwqdy90yki69xz2r7ipisb0dasxc70yvlkax83";
-      name = "libksieve-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/libksieve-17.08.0.tar.xz";
+      sha256 = "10864y6d473y93ikkw0kiz7rl85x2whb5c4ifl24w5njri3szl89";
+      name = "libksieve-17.08.0.tar.xz";
     };
   };
   lokalize = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/lokalize-17.04.3.tar.xz";
-      sha256 = "0v9q0xs6vgwxk6cpirpv41y49r7c74fwlqvrr23m70252781gx7a";
-      name = "lokalize-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/lokalize-17.08.0.tar.xz";
+      sha256 = "0aps3s5gbja1fngndfwbi21wg7kr8pr3l48hx5n4hgcpa4rxbf0n";
+      name = "lokalize-17.08.0.tar.xz";
     };
   };
   lskat = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/lskat-17.04.3.tar.xz";
-      sha256 = "1bzrfb51aq0ir0kjsmzfvdfvjsj81xrn3sv6vsp0wmq1510dz0qq";
-      name = "lskat-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/lskat-17.08.0.tar.xz";
+      sha256 = "0xwbyfjlkfxccnmi4kmvrar1jds7976j1m2s8sd69knfccj43n6a";
+      name = "lskat-17.08.0.tar.xz";
     };
   };
   mailcommon = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/mailcommon-17.04.3.tar.xz";
-      sha256 = "1zyjcdn2x70304l2gyijwyv5p1p3wqvvlx9b6aj2xmhm0yvsfibk";
-      name = "mailcommon-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/mailcommon-17.08.0.tar.xz";
+      sha256 = "1laqipa3mqyxzbx3xkg5jm6ah74a68fgyb37hjw52mkbf6jzqpsx";
+      name = "mailcommon-17.08.0.tar.xz";
     };
   };
   mailimporter = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/mailimporter-17.04.3.tar.xz";
-      sha256 = "0f5nipzfz505c3bibsw6v4qnqd7bkv4fy61dyapka0dy0sxlmgdk";
-      name = "mailimporter-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/mailimporter-17.08.0.tar.xz";
+      sha256 = "11677y558xy0rdn5g63cpjl3nz1w5x38dfr0ky0nsylary9diwwn";
+      name = "mailimporter-17.08.0.tar.xz";
     };
   };
   marble = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/marble-17.04.3.tar.xz";
-      sha256 = "0mlhngwscikcayi71kdsd6wbz2nj6gpzcib2gax32lnjdhx3zml3";
-      name = "marble-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/marble-17.08.0.tar.xz";
+      sha256 = "1qi4fiagxp2734myd2grg38sf9bdbfys46rhmn0jp8p39dqic4di";
+      name = "marble-17.08.0.tar.xz";
     };
   };
   mbox-importer = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/mbox-importer-17.04.3.tar.xz";
-      sha256 = "03mah1djrmks8zvqhzds9r6gx4z6z9ngqc0ki4524pf1yshg4bic";
-      name = "mbox-importer-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/mbox-importer-17.08.0.tar.xz";
+      sha256 = "15iipvs5szfjnl1r0gfx30wr4rq1l5a74wywy8lm73ma9hgb0fpc";
+      name = "mbox-importer-17.08.0.tar.xz";
     };
   };
   messagelib = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/messagelib-17.04.3.tar.xz";
-      sha256 = "15jvx0f4dmkl7sp8qpijisamqvvz70x3xfk3q7n0cr81pdbc5s2k";
-      name = "messagelib-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/messagelib-17.08.0.tar.xz";
+      sha256 = "0qik1a4rka6qj28jdmdh5rk7m3p3gh27i0jcg9nxijrg7wz1hx98";
+      name = "messagelib-17.08.0.tar.xz";
     };
   };
   minuet = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/minuet-17.04.3.tar.xz";
-      sha256 = "16x4rbckwbiv77wvqyd60p34lds9pm5zhllzhzhlllz21m041z2p";
-      name = "minuet-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/minuet-17.08.0.tar.xz";
+      sha256 = "1f9pd9wzai2sqs87m70ywgqsn9azr2xnpaj2msii7cl2mn6km6wb";
+      name = "minuet-17.08.0.tar.xz";
     };
   };
   okteta = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/okteta-17.04.3.tar.xz";
-      sha256 = "01x9rp2h5ca85rriw8hz5qcmv4xm9isxvm8yc8b806kd08kwmhrv";
-      name = "okteta-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/okteta-17.08.0.tar.xz";
+      sha256 = "1f3041vn9p24avkj7svz9mb9sr5s5p16jvh9m7417svy307g1hii";
+      name = "okteta-17.08.0.tar.xz";
     };
   };
   okular = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/okular-17.04.3.tar.xz";
-      sha256 = "0c05ma4yi6yhibxqfl26y32792cv21kvxdxs2yxbhm1xy3b397iv";
-      name = "okular-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/okular-17.08.0.tar.xz";
+      sha256 = "0fghjj149ji6p1hi7zlzfmgsp7zrwyhz3989ff2an9yx5qvmwayg";
+      name = "okular-17.08.0.tar.xz";
     };
   };
   palapeli = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/palapeli-17.04.3.tar.xz";
-      sha256 = "1ixp23cp5qsil4dhvkq9q0d6cl3qyh6jard1zrd6qv3cz3586jsc";
-      name = "palapeli-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/palapeli-17.08.0.tar.xz";
+      sha256 = "1gv4hfjj9b7bgfsvpmdydvb8pmbqwvm2s0f0ip8mjxnfcayig4xn";
+      name = "palapeli-17.08.0.tar.xz";
     };
   };
   parley = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/parley-17.04.3.tar.xz";
-      sha256 = "1i4l18c5vndx6i3f4l6yyhgr4bmnvfwiqgjj01bicxzawnknv75m";
-      name = "parley-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/parley-17.08.0.tar.xz";
+      sha256 = "1qx10l0h4099w6xl5jnlp259glq0whqjsxl4b4a6kj4ddz55ysyr";
+      name = "parley-17.08.0.tar.xz";
     };
   };
   picmi = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/picmi-17.04.3.tar.xz";
-      sha256 = "0n1wrbscjdqs4cks9igxdhqh583ksdqsi339cnlqdnazcpjrb96n";
-      name = "picmi-17.04.3.tar.xz";
-    };
-  };
-  pimcommon = {
-    version = "17.04.3";
-    src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/pimcommon-17.04.3.tar.xz";
-      sha256 = "02wzindfacgj3f7a71h7wqa0jk0096xidw9bwdb5nvjnaigxxnx3";
-      name = "pimcommon-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/picmi-17.08.0.tar.xz";
+      sha256 = "03cl8hbxa5kfb9ji24x2svp2ids0jwyam847zncrdkg72gjmnjlb";
+      name = "picmi-17.08.0.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/pim-data-exporter-17.04.3.tar.xz";
-      sha256 = "1q4vjynfbwrdn9j7ggxfsrilzb3g5s1yqr51siiw17jr11xca3cb";
-      name = "pim-data-exporter-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/pim-data-exporter-17.08.0.tar.xz";
+      sha256 = "01n9m8ssyla5rz9cg61fv0rhl4gz02488cghak7idb18an36lfak";
+      name = "pim-data-exporter-17.08.0.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/pim-sieve-editor-17.04.3.tar.xz";
-      sha256 = "1dfksp7ric5na75i6hyj4q2sgzz7zdc9a0izpzhwzqbx86m56zd8";
-      name = "pim-sieve-editor-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/pim-sieve-editor-17.08.0.tar.xz";
+      sha256 = "0i3ry6hrdiz3wdjqw1b6mqrya3jxphrv9lx1px8grp0gs8ci0gc4";
+      name = "pim-sieve-editor-17.08.0.tar.xz";
+    };
+  };
+  pimcommon = {
+    version = "17.08.0";
+    src = fetchurl {
+      url = "${mirror}/stable/applications/17.08.0/src/pimcommon-17.08.0.tar.xz";
+      sha256 = "0vv3fxf6d9vx75gxn2lwmv43ifman5av9xxy17yzxsmvjpvf2mmv";
+      name = "pimcommon-17.08.0.tar.xz";
     };
   };
   poxml = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/poxml-17.04.3.tar.xz";
-      sha256 = "18rpy9l1blmgzjhl0pw3gjfngzjylwkqiwzilb2pdijs1121sjhv";
-      name = "poxml-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/poxml-17.08.0.tar.xz";
+      sha256 = "1a68lddadm3iar64q4zfi4f0mp97zagfnfs3i1czdyq83hqp1c3x";
+      name = "poxml-17.08.0.tar.xz";
     };
   };
   print-manager = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/print-manager-17.04.3.tar.xz";
-      sha256 = "0w51wkh2rlbwsna4amfiav0pi89si5cx8g0krfr12hiji05w4van";
-      name = "print-manager-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/print-manager-17.08.0.tar.xz";
+      sha256 = "0cj8ijzl3xsxyrkcpigscqj84mza5lzwsaal586zqf1z2p8pabcx";
+      name = "print-manager-17.08.0.tar.xz";
     };
   };
   rocs = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/rocs-17.04.3.tar.xz";
-      sha256 = "078451k2vx4pryxs93hry41jd6w6i8nd9lifwivgs8nrrbk4pf5b";
-      name = "rocs-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/rocs-17.08.0.tar.xz";
+      sha256 = "0cjz0n4bk21c6csqhr937dfyzhn8i8viy7h94pr3813vfwffd0mn";
+      name = "rocs-17.08.0.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/signon-kwallet-extension-17.04.3.tar.xz";
-      sha256 = "0ahfzsr7xpnps14fwajc2fvgxd6jh18w9da40hc47pm5n8wwwbb0";
-      name = "signon-kwallet-extension-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/signon-kwallet-extension-17.08.0.tar.xz";
+      sha256 = "0nzgjrr8hgc2pmiwx3cdp9pcgw25hvr0y7mkjllyh2cigcnbw6dg";
+      name = "signon-kwallet-extension-17.08.0.tar.xz";
     };
   };
   spectacle = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/spectacle-17.04.3.tar.xz";
-      sha256 = "0xjclcvi5fq3aq0dz34cf4w6yvi9bjr3mwc0ywqfliw0j35r4iqv";
-      name = "spectacle-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/spectacle-17.08.0.tar.xz";
+      sha256 = "1lmh53rhgbkg81xxk1dhcsxwh7shzlxvfqfs3zflq88ghm53fnzf";
+      name = "spectacle-17.08.0.tar.xz";
     };
   };
   step = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/step-17.04.3.tar.xz";
-      sha256 = "111pqn908khirr66d9l4va2blcm2zcksb3w11lvwz7dfidag0bks";
-      name = "step-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/step-17.08.0.tar.xz";
+      sha256 = "0rqj6idzdlkljvfx6jwjlwc6ibpqmmb9w7fi4cax2h89s9fc4fqy";
+      name = "step-17.08.0.tar.xz";
     };
   };
   svgpart = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/svgpart-17.04.3.tar.xz";
-      sha256 = "101kll7q53qwhgjll4vrqdapag9bc5nwqnq14gxbmmyknpjpgxqh";
-      name = "svgpart-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/svgpart-17.08.0.tar.xz";
+      sha256 = "0gqzhm6shsirkb2h933n5slhm5kwhvjrszqbdlpm7a28643r0jgq";
+      name = "svgpart-17.08.0.tar.xz";
     };
   };
   sweeper = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/sweeper-17.04.3.tar.xz";
-      sha256 = "1ai6bhfq7g80y7w3jaqzhlq8z3krmpjjg9ap1p358485d6ja9i0k";
-      name = "sweeper-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/sweeper-17.08.0.tar.xz";
+      sha256 = "0hxkf65jdy5qirrycr55v3v0d63x4bh3hd49wjvbh0qx4sbkazhs";
+      name = "sweeper-17.08.0.tar.xz";
     };
   };
   syndication = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/syndication-17.04.3.tar.xz";
-      sha256 = "1d3nfzz2f0n31ivzrhld5gi1bk486i5dpp0v0b1wlnacm8z0ddy5";
-      name = "syndication-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/syndication-17.08.0.tar.xz";
+      sha256 = "0z5jpygkphmq2xvmnnj8nyagcx320ngnjjqphwfymp14y8yp8cla";
+      name = "syndication-17.08.0.tar.xz";
     };
   };
   umbrello = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/umbrello-17.04.3.tar.xz";
-      sha256 = "1v1694j5crffmy12qij1hrikrsn2irasjra11jcc4rx2klfhv2bs";
-      name = "umbrello-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/umbrello-17.08.0.tar.xz";
+      sha256 = "09dnmafzqbhjymqpb8lcspaqwkprma11r4l0dhlqfmlzwbdhp9vg";
+      name = "umbrello-17.08.0.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "17.04.3";
+    version = "17.08.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.04.3/src/zeroconf-ioslave-17.04.3.tar.xz";
-      sha256 = "04k2mc2kl3raiirpfq150zdxb4w86cg5m70xcw711qddw1fv0g3y";
-      name = "zeroconf-ioslave-17.04.3.tar.xz";
+      url = "${mirror}/stable/applications/17.08.0/src/zeroconf-ioslave-17.08.0.tar.xz";
+      sha256 = "16zw9gsd89qaadhlii5c5wjfd75c1jf9ivg55fmmfsqc5nqzjf4b";
+      name = "zeroconf-ioslave-17.08.0.tar.xz";
     };
   };
 }

--- a/pkgs/applications/misc/latte-dock/default.nix
+++ b/pkgs/applications/misc/latte-dock/default.nix
@@ -1,4 +1,5 @@
-{ mkDerivation, lib, cmake, xorg, plasma-framework, fetchFromGitHub }:
+{ mkDerivation, lib, cmake, xorg, plasma-framework, fetchFromGitHub
+, extra-cmake-modules, karchive, kwindowsystem, qtx11extras }:
 
 let version = "0.6.0"; in
 
@@ -14,7 +15,8 @@ mkDerivation {
 
   buildInputs = [ plasma-framework xorg.libpthreadstubs xorg.libXdmcp ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ extra-cmake-modules cmake karchive kwindowsystem
+    qtx11extras ];
 
   meta = with lib; {
     description = "Dock-style app launcher based on Plasma frameworks";

--- a/pkgs/desktops/lxqt/core/lxqt-notificationd/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-notificationd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools, qtbase, qttools, qtsvg, kwindowsystem, liblxqt, libqtxdg, lxqt-common }:
+{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools, qtbase, qttools, qtsvg, kwindowsystem, liblxqt, libqtxdg, lxqt-common, qtx11extras }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
     liblxqt
     libqtxdg
     lxqt-common
+    qtx11extras
   ];
 
   cmakeFlags = [ "-DPULL_TRANSLATIONS=NO" ];

--- a/pkgs/desktops/lxqt/core/lxqt-runner/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-runner/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools, qtbase, qttools, qtsvg, kwindowsystem, liblxqt, libqtxdg, lxqt-common, lxqt-globalkeys,
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools, qtbase, qttools, qtsvg, kwindowsystem, liblxqt, libqtxdg, lxqt-common, lxqt-globalkeys, qtx11extras,
 menu-cache, muparser }:
 
 stdenv.mkDerivation rec {
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
     qtbase
     qttools
     qtsvg
+    qtx11extras
     kwindowsystem
     liblxqt
     libqtxdg

--- a/pkgs/desktops/plasma-5/milou.nix
+++ b/pkgs/desktops/plasma-5/milou.nix
@@ -2,7 +2,7 @@
   mkDerivation,
   extra-cmake-modules,
   kcoreaddons, kdeclarative, ki18n, krunner, kservice, plasma-framework,
-  qtscript, qtdeclarative,
+  qtscript, qtdeclarative
 }:
 
 mkDerivation {

--- a/pkgs/desktops/plasma-5/plasma-pa.nix
+++ b/pkgs/desktops/plasma-5/plasma-pa.nix
@@ -2,7 +2,7 @@
   mkDerivation,
   extra-cmake-modules, kdoctools,
   gconf, glib, kconfigwidgets, kcoreaddons, kdeclarative, kglobalaccel, ki18n,
-  libcanberra_gtk3, libpulseaudio, plasma-framework, qtdeclarative
+  libcanberra_gtk3, libpulseaudio, plasma-framework, qtdeclarative, kwindowsystem
 }:
 
 mkDerivation {
@@ -10,6 +10,6 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     gconf glib kconfigwidgets kcoreaddons kdeclarative kglobalaccel ki18n
-    libcanberra_gtk3 libpulseaudio plasma-framework qtdeclarative
+    libcanberra_gtk3 libpulseaudio plasma-framework qtdeclarative kwindowsystem
   ];
 }

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.36/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.37/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/krunner.nix
+++ b/pkgs/development/libraries/kde-frameworks/krunner.nix
@@ -2,7 +2,7 @@
   mkDerivation, lib,
   extra-cmake-modules,
   kconfig, kcoreaddons, ki18n, kio, kservice, plasma-framework, qtbase,
-  qtdeclarative, solid, threadweaver
+  qtdeclarative, solid, threadweaver, kwindowsystem
 }:
 
 mkDerivation {
@@ -13,5 +13,5 @@ mkDerivation {
     kconfig kcoreaddons ki18n kio kservice qtdeclarative solid
     threadweaver
   ];
-  propagatedBuildInputs = [ plasma-framework qtbase ];
+  propagatedBuildInputs = [ plasma-framework qtbase kwindowsystem ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kwallet-dbus.patch
+++ b/pkgs/development/libraries/kde-frameworks/kwallet-dbus.patch
@@ -1,9 +1,0 @@
-diff --git a/src/runtime/kwalletd/org.kde.kwalletd5.service.in b/src/runtime/kwalletd/org.kde.kwalletd5.service.in
-index 76eb90e..7a78e83 100644
---- a/src/runtime/kwalletd/org.kde.kwalletd5.service.in
-+++ b/src/runtime/kwalletd/org.kde.kwalletd5.service.in
-@@ -1,3 +1,3 @@
- [D-BUS Service]
- Name=org.kde.kwalletd5
--Exec=@CMAKE_INSTALL_PREFIX@/bin/kwalletd5
-+Exec=@CMAKE_INSTALL_BINDIR@/kwalletd5

--- a/pkgs/development/libraries/kde-frameworks/kwallet.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwallet.nix
@@ -15,8 +15,4 @@ mkDerivation {
     knotifications kservice kwidgetsaddons kwindowsystem libgcrypt qgpgme
   ];
   propagatedBuildInputs = [ qtbase ];
-  patches = [ ./kwallet-dbus.patch ];
-  postFixup = ''
-    rm "''${!outputBin}/share/dbus-1/services/org.kde.kwalletd.service"
-  '';
 }

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,595 +3,603 @@
 
 {
   attica = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/attica-5.36.0.tar.xz";
-      sha256 = "12i5ky68aaxfxb0x6ixcjjqcdw87b435yf06qiz74pwvbj7rklld";
-      name = "attica-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/attica-5.37.0.tar.xz";
+      sha256 = "13jqk4w9crh8pca6n9334l1gb8bmwf86pa36k0mfh5j19dq72g2p";
+      name = "attica-5.37.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/baloo-5.36.0.tar.xz";
-      sha256 = "1zrikrzg4v8mh3w1wln6dqx4jazjqkx0k3482gxf71g7gi9xj8gi";
-      name = "baloo-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/baloo-5.37.0.tar.xz";
+      sha256 = "19sl07lhjrri40vfi8wl6azgmg08lgfb98xx110j6spjbbbnww79";
+      name = "baloo-5.37.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/bluez-qt-5.36.0.tar.xz";
-      sha256 = "1r3g5f2ll4flav9vjrxzh35y0w38h5fkg89h3s88pldshvgg208w";
-      name = "bluez-qt-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/bluez-qt-5.37.0.tar.xz";
+      sha256 = "1x6nj7vsn0sp9rckzkcbl6fwm7qzj5w98w2qys1fndb1spl7av8s";
+      name = "bluez-qt-5.37.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/breeze-icons-5.36.0.tar.xz";
-      sha256 = "19b6jpy3zaawll53fg4cm50p93128bw483y1bjn82ghs7yqmp7f3";
-      name = "breeze-icons-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/breeze-icons-5.37.0.tar.xz";
+      sha256 = "17nr2phd0nxyx49igvl170ksikapgc4365z26pw0dmmw41llcbxw";
+      name = "breeze-icons-5.37.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/extra-cmake-modules-5.36.0.tar.xz";
-      sha256 = "1bsxdlk08zn98isbycm982xz67d40c63qsgghfambvqi0js0n4kf";
-      name = "extra-cmake-modules-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/extra-cmake-modules-5.37.0.tar.xz";
+      sha256 = "1jr7nmhh4kyz1g454qkldfhimfjvvylqa19zna5iak08bkq8q696";
+      name = "extra-cmake-modules-5.37.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/frameworkintegration-5.36.0.tar.xz";
-      sha256 = "1qa325fsdqk30v310qmira6j9cr5ij4bbj7yxyp4m1jzbp16sprl";
-      name = "frameworkintegration-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/frameworkintegration-5.37.0.tar.xz";
+      sha256 = "0pcy3hjqbahbx65yxz5bl0h2ah4y3fb7mq3pj1rrp2cpp92s135a";
+      name = "frameworkintegration-5.37.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kactivities-5.36.0.tar.xz";
-      sha256 = "0h13jl5f35g24flwx19sxpknc7f5mx25nnwy0xdrhkbd6dknkss7";
-      name = "kactivities-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kactivities-5.37.0.tar.xz";
+      sha256 = "005xvzp10kvwcsl2w6ghcqgqnr2rdvv9w61i4y44y25vcb85g26v";
+      name = "kactivities-5.37.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kactivities-stats-5.36.0.tar.xz";
-      sha256 = "1hgpvga64244kh70ad0iwfl60bqpdly78db57hdh3b4as3mc7z8h";
-      name = "kactivities-stats-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kactivities-stats-5.37.0.tar.xz";
+      sha256 = "09zsdzf77palmww7x3dzinl0hxrm4z0q0yc2fmf0d7z6cfl695y2";
+      name = "kactivities-stats-5.37.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kapidox-5.36.0.tar.xz";
-      sha256 = "181zgybsavvn2pdg9acyg7d2wspy8myf79qxbc8mb9zp5vnhb9br";
-      name = "kapidox-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kapidox-5.37.0.tar.xz";
+      sha256 = "1xwkaamifxjghv158rwslndfd9z70rm9ixnp1mmkgw8radwsqg5v";
+      name = "kapidox-5.37.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/karchive-5.36.0.tar.xz";
-      sha256 = "0l93ws6c09hm2qrhbc2r71qjgf27mv36ahnisygamfwh754n4700";
-      name = "karchive-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/karchive-5.37.0.tar.xz";
+      sha256 = "1599lql0kcx705313bfvbazr7rayr6vsiwrpiq6iwljzc7lli1im";
+      name = "karchive-5.37.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kauth-5.36.0.tar.xz";
-      sha256 = "0a3xcl1wqb2ggw5lcll4i95jpi68zvmyyd7jb57qk1ags49l3yfk";
-      name = "kauth-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kauth-5.37.0.tar.xz";
+      sha256 = "0ciz28bvbvxlv0iz0cgs31x2m1czkki21ypzqj8rg2ix8jw2p65w";
+      name = "kauth-5.37.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kbookmarks-5.36.0.tar.xz";
-      sha256 = "1176bily8w0q9l2k070rcgvki5mcjz8kh9nlvrgnch17bzqrwcsr";
-      name = "kbookmarks-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kbookmarks-5.37.0.tar.xz";
+      sha256 = "0l6rkj0b7hk2wg6dypj1dkl8pcd1vx89gaiixbhkd3vf7jp46n41";
+      name = "kbookmarks-5.37.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kcmutils-5.36.0.tar.xz";
-      sha256 = "0rifncrndad2fr4b2imrshlhmzapw7zq05z52dyp0i5fdmznc8fz";
-      name = "kcmutils-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kcmutils-5.37.0.tar.xz";
+      sha256 = "1ik1505f16swsmvrv62dacis33f1ccnmkw3zbhb84vbrbqyskvzx";
+      name = "kcmutils-5.37.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kcodecs-5.36.0.tar.xz";
-      sha256 = "0v5yv988ixdwbz0bbybia3f9y64k17ic935dr84kaqndz643xzvc";
-      name = "kcodecs-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kcodecs-5.37.0.tar.xz";
+      sha256 = "0kmk97b5vbnyb3xjxwmg3l47aka8mkf50g4p7wvr096qwplffbva";
+      name = "kcodecs-5.37.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kcompletion-5.36.0.tar.xz";
-      sha256 = "1wi0fcrzxk27a1r0arrylxqyx4jpz1scj8pwf6whnpl56vmh6w9p";
-      name = "kcompletion-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kcompletion-5.37.0.tar.xz";
+      sha256 = "0qhjkqmd1jjy50hlzsdxwgnjwpfdrz3njl5n88h3nzp83yjv1ljz";
+      name = "kcompletion-5.37.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kconfig-5.36.0.tar.xz";
-      sha256 = "0m6n6dw4sgc1mr84dlg3lsbm080jqwrqd0mil15c33gsjn2kl7mk";
-      name = "kconfig-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kconfig-5.37.0.tar.xz";
+      sha256 = "1f0y2gmwy05b17clr7vg1zp18l1z0fd757v02ha7cwd64yznyr5d";
+      name = "kconfig-5.37.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kconfigwidgets-5.36.0.tar.xz";
-      sha256 = "0siw3rhl8pjm6hnxis22rfdji28svp8q27991wsdmm7d5m284hx5";
-      name = "kconfigwidgets-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kconfigwidgets-5.37.0.tar.xz";
+      sha256 = "001d1nj8q6xpl71rwm15rnvy5ajyxpvknvf4ic7p5pbik3021bs6";
+      name = "kconfigwidgets-5.37.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kcoreaddons-5.36.0.tar.xz";
-      sha256 = "152mkf75bvn95viz3cz54cmssp1j89wp591sycvnqcni4azjcjwx";
-      name = "kcoreaddons-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kcoreaddons-5.37.0.tar.xz";
+      sha256 = "0a45sz11d7b2d8sbr9z57mv337nbhd94fiqk3issw470n0y46g3y";
+      name = "kcoreaddons-5.37.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kcrash-5.36.0.tar.xz";
-      sha256 = "0f6sbs91qykh0c4fs1lvdz89jn8rhnfg0v6dd3pkqm5q2fcdv3id";
-      name = "kcrash-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kcrash-5.37.0.tar.xz";
+      sha256 = "16k2pwf3s3adgayd9vq7kk8c5gnq9g6wra4psrvs3a3c5k5am5y0";
+      name = "kcrash-5.37.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kdbusaddons-5.36.0.tar.xz";
-      sha256 = "012fbzdpzamc2nvbfhzv2270p4jsxiwa552mmmj16yxnrjrwycw4";
-      name = "kdbusaddons-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kdbusaddons-5.37.0.tar.xz";
+      sha256 = "0745arkp4wnpwyhjq02h7lfac049cmlg5qwhf96i7ss0w54vch4i";
+      name = "kdbusaddons-5.37.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kdeclarative-5.36.0.tar.xz";
-      sha256 = "0ljx1841490sl1qsi8304whczxgj4q4irm8z720bkjqh0c8i5pid";
-      name = "kdeclarative-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kdeclarative-5.37.0.tar.xz";
+      sha256 = "1ish46m2dpnpqjnf8g660clcg7ky65w11cbk2m79pwyhqvhxgggj";
+      name = "kdeclarative-5.37.0.tar.xz";
     };
   };
   kded = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kded-5.36.0.tar.xz";
-      sha256 = "0y44rgrxh47bj4ljpxs6gdib4fhzyz6pvi5l2hnacwr2l1vnfcs4";
-      name = "kded-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kded-5.37.0.tar.xz";
+      sha256 = "162s5qx2qb0bi889f8jjvd3ci31azd8iwp25i04vwi0lzglwb8gy";
+      name = "kded-5.37.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/portingAids/kdelibs4support-5.36.0.tar.xz";
-      sha256 = "041ygn0yd5r91j9ppv63xwj21c4ny56qlmkv2hmpanl05y94bpnq";
-      name = "kdelibs4support-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/portingAids/kdelibs4support-5.37.0.tar.xz";
+      sha256 = "1zz100m1sqfmg3ni7023b99qn79jhdd2ryw6534axl5zgn0sglh9";
+      name = "kdelibs4support-5.37.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kdesignerplugin-5.36.0.tar.xz";
-      sha256 = "1ksa8f6ivjlmm6rlm20vmrlqw58rf1k4ry3mk60b073fni2779hv";
-      name = "kdesignerplugin-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kdesignerplugin-5.37.0.tar.xz";
+      sha256 = "1197003bqcdpsyn6faasr2nhaadh7ryg92vjpqim78af3vwinsdw";
+      name = "kdesignerplugin-5.37.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kdesu-5.36.0.tar.xz";
-      sha256 = "01lg36m19qsa8ipwyx85jr38jh9ddcl6cvs4z3jmhg2nl467pwwa";
-      name = "kdesu-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kdesu-5.37.0.tar.xz";
+      sha256 = "1qfhkzk6l9rfdyiad8y6k30zlhziz3q2dxvxkmnghxmkg98yhdza";
+      name = "kdesu-5.37.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kdewebkit-5.36.0.tar.xz";
-      sha256 = "1x53gzn1qyyvlx36qfjl6297v4862qqr8cmld32qaqxsgqc11b9s";
-      name = "kdewebkit-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kdewebkit-5.37.0.tar.xz";
+      sha256 = "1ph3a50wix42hmsbc9jbfxla172aihjx9yzp9rza09j1a7va3hg1";
+      name = "kdewebkit-5.37.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kdnssd-5.36.0.tar.xz";
-      sha256 = "07lfwbw546qsx2rss0ajblaqi9db2dz07s0vki1w9q17nf4lnl2p";
-      name = "kdnssd-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kdnssd-5.37.0.tar.xz";
+      sha256 = "03rd6znn2qwndn4m3bb03slwyic06ry535rawgyh06lfps0fcc5z";
+      name = "kdnssd-5.37.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kdoctools-5.36.0.tar.xz";
-      sha256 = "0sgvxp90141y11lz2vm8y78ymny8krq493w4xxaj9blzgfyr0yrj";
-      name = "kdoctools-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kdoctools-5.37.0.tar.xz";
+      sha256 = "0gbc5qqim6262hvkl9pf6rynnblxb3hsw3c4ars03ip7n761y0zl";
+      name = "kdoctools-5.37.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kemoticons-5.36.0.tar.xz";
-      sha256 = "0bwag8x27dfshhd42340zr591l4nxhj58qlzdz64q4h3rhvibk5f";
-      name = "kemoticons-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kemoticons-5.37.0.tar.xz";
+      sha256 = "1cx978s1dm3v1jh4aymncxs44iizdqp174dqg9m5mf043fcvvinq";
+      name = "kemoticons-5.37.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kfilemetadata-5.36.0.tar.xz";
-      sha256 = "17967dl9r2fipagdb3xknfv8p3cqi2mhxmpw1ghmw9mdid01y33m";
-      name = "kfilemetadata-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kfilemetadata-5.37.0.tar.xz";
+      sha256 = "17mbm6pdi6ac61kj2qzxf7y3rbxhxg9rwqr7qy766gh3img2vq8p";
+      name = "kfilemetadata-5.37.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kglobalaccel-5.36.0.tar.xz";
-      sha256 = "1nkm2w38n8f5wq446g9kng8xy7vd4y0acfbsnlc9zshzmbf655bj";
-      name = "kglobalaccel-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kglobalaccel-5.37.0.tar.xz";
+      sha256 = "1d84q3r6q5n2lclym9a9m1brfqnq3p3dykfpzvhcba3bjxh3cdsb";
+      name = "kglobalaccel-5.37.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kguiaddons-5.36.0.tar.xz";
-      sha256 = "1xliia9zfg9kcgi78pkrlvb1nqj3h1cms7pccrnqgfgszm3j2y4c";
-      name = "kguiaddons-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kguiaddons-5.37.0.tar.xz";
+      sha256 = "13g6nlw8fk135i6z3f8ichy8whxd6v4rycg80dlvm25h66rg6vn5";
+      name = "kguiaddons-5.37.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/portingAids/khtml-5.36.0.tar.xz";
-      sha256 = "15akih9pn3yzx4vskvq5vqrgq64vxfprvbfh00ir7bgl8rzrrngs";
-      name = "khtml-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/portingAids/khtml-5.37.0.tar.xz";
+      sha256 = "1n0mx2xy9n5ffhvh58z3kn61aa7dhppsrwgxk697pybqy1h45ah2";
+      name = "khtml-5.37.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/ki18n-5.36.0.tar.xz";
-      sha256 = "12sm340y2qvxlw7cac9mwq5ps4px4z607a9lx4q0ckaggix8gjf0";
-      name = "ki18n-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/ki18n-5.37.0.tar.xz";
+      sha256 = "1c1sy4pbhlwsajs2972brdmma5val72gkil6k0a0f58nfvvg952d";
+      name = "ki18n-5.37.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kiconthemes-5.36.0.tar.xz";
-      sha256 = "0a9dkn20siymgwy1fsnf98qbg14v0rfyrf96vrz1378vkyh37j2l";
-      name = "kiconthemes-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kiconthemes-5.37.0.tar.xz";
+      sha256 = "1j7mgfsvxa24nf1d9xyn2jv9y9j523vghsvsm73x8d3ijibchfxq";
+      name = "kiconthemes-5.37.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kidletime-5.36.0.tar.xz";
-      sha256 = "1dhszas2fai5pv0lhk26w93ankp1x56nq8zlqdqs77z6fihmnc9l";
-      name = "kidletime-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kidletime-5.37.0.tar.xz";
+      sha256 = "01m4q3l2yq83f2dpbv6jry7cjkj6bqdgfpy5b8byaf1gf9w2firs";
+      name = "kidletime-5.37.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kimageformats-5.36.0.tar.xz";
-      sha256 = "1j106d9m2z3dgz7ibff4cfzndann1yaf57c449s5l7gsdg229p89";
-      name = "kimageformats-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kimageformats-5.37.0.tar.xz";
+      sha256 = "1knha6wjzjs0vnkljwpfinzg3hg2jyh9c07ifqvd47cprl96ickg";
+      name = "kimageformats-5.37.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kinit-5.36.0.tar.xz";
-      sha256 = "0499wjpjpba3kgprs2pvvrply1mbnvm7pppncv4jh7ynhqkjvm94";
-      name = "kinit-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kinit-5.37.0.tar.xz";
+      sha256 = "0b7dyy4hqyf6wk7gg2l23ldnji2zl8vzyj5wd5qh4yi7rdl6js5r";
+      name = "kinit-5.37.0.tar.xz";
     };
   };
   kio = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kio-5.36.0.tar.xz";
-      sha256 = "1j23nxmsdivia5hrfdq42p4bdz5r0r739rr1px9dwmjiv3am33zi";
-      name = "kio-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kio-5.37.0.tar.xz";
+      sha256 = "0nxchbhs8p2d4243dyp7qa65g1p6r3ic2h6dz7w0aa0qzsy8wi29";
+      name = "kio-5.37.0.tar.xz";
+    };
+  };
+  kirigami2 = {
+    version = "5.37.0";
+    src = fetchurl {
+      url = "${mirror}/stable/frameworks/5.37/kirigami2-5.37.0.tar.xz";
+      sha256 = "1z42rsi8nzshrbv8m8vxkay4dq46kggglhgxbbgg2q00y8gjq9dd";
+      name = "kirigami2-5.37.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kitemmodels-5.36.0.tar.xz";
-      sha256 = "08vbjardjnj7bz8ah089gpljc05h67q15g2xa7h5swkvh0pvq19a";
-      name = "kitemmodels-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kitemmodels-5.37.0.tar.xz";
+      sha256 = "1nlpzzp4m0ghfz1p2hrwn4lbhjhxc8b8q8kbzqbh9hmwmimbzzrr";
+      name = "kitemmodels-5.37.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kitemviews-5.36.0.tar.xz";
-      sha256 = "01iayb6r8w4cnq3qpcs6c8cxmnjzp7mznk7s9d0djijplrcdgskl";
-      name = "kitemviews-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kitemviews-5.37.0.tar.xz";
+      sha256 = "17r7vnlyiiifhrz4gb4fifshn1jb4c67lhadczi8d301rzk7wwsm";
+      name = "kitemviews-5.37.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kjobwidgets-5.36.0.tar.xz";
-      sha256 = "1m4wsvpw4k7x7v32hxkk7dvs9gsnnwwzvgk81d86kvzdipkrbbcp";
-      name = "kjobwidgets-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kjobwidgets-5.37.0.tar.xz";
+      sha256 = "1162dxhpspd7p1735npp0amrxr5b0j467f5651k2rv6mvqfmqr4b";
+      name = "kjobwidgets-5.37.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/portingAids/kjs-5.36.0.tar.xz";
-      sha256 = "06pzx7jajhk3yd01hxkia4lh85mdc9a5m2jd0bl1sk1q42hrm4n6";
-      name = "kjs-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/portingAids/kjs-5.37.0.tar.xz";
+      sha256 = "046hy8ji4i6p2xp5gnqa8dk82sv6sbh4xg67y79i82bbi97dvq9b";
+      name = "kjs-5.37.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/portingAids/kjsembed-5.36.0.tar.xz";
-      sha256 = "1045jfxky4hnld24lg3qy7j4v0aa0n9fgwa13fm7sz923ylh3gs9";
-      name = "kjsembed-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/portingAids/kjsembed-5.37.0.tar.xz";
+      sha256 = "0w2wk5azf1b45db58qj0cdc1l056x9s1xcd09ibavx5xmdvq6br0";
+      name = "kjsembed-5.37.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/portingAids/kmediaplayer-5.36.0.tar.xz";
-      sha256 = "1pqg8ycsasn3sxh1r1wmrrz9431whylr77z8bvikj9x0w28fwnkm";
-      name = "kmediaplayer-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/portingAids/kmediaplayer-5.37.0.tar.xz";
+      sha256 = "0fqxrkcwwzg11zsax9q169lisnfp9jsqg4ccd6xvv8kpkz3g04jp";
+      name = "kmediaplayer-5.37.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/knewstuff-5.36.0.tar.xz";
-      sha256 = "0pfshizab7xkj71hjm69kqd63wvsmn4fpyhz7r1s9hsj136cjyzi";
-      name = "knewstuff-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/knewstuff-5.37.0.tar.xz";
+      sha256 = "1scnxhxx4g8j4wml6x8i5v00rpaxyzzcm7vqbra2axbql5d8g8ny";
+      name = "knewstuff-5.37.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/knotifications-5.36.0.tar.xz";
-      sha256 = "1hlyllhfdd4pgj7q9k76wsf58h6m9vls1iz6ah20qivbkkwls074";
-      name = "knotifications-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/knotifications-5.37.0.tar.xz";
+      sha256 = "0gvv6jal7n4m3y30ragjlyhghq3y2782d422im9klxqzlgdgvkb6";
+      name = "knotifications-5.37.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/knotifyconfig-5.36.0.tar.xz";
-      sha256 = "04cqyhbz6vfcwgd82jniwcc23sw7hzhrcfh5a3nlbx4yl0bifb3w";
-      name = "knotifyconfig-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/knotifyconfig-5.37.0.tar.xz";
+      sha256 = "14kjckynszv8015p17j578l3knmkmw25d8r8ks4wavgj3db9bik5";
+      name = "knotifyconfig-5.37.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kpackage-5.36.0.tar.xz";
-      sha256 = "0bwa588wj0nwvbnblzfqx0qz1cc7a43p4dk1pc95rvzf00h8i1q8";
-      name = "kpackage-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kpackage-5.37.0.tar.xz";
+      sha256 = "1ikf55q2pk8vm70pqm7rmakja309zjh9z1lg0xqslq1pqd6xki7s";
+      name = "kpackage-5.37.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kparts-5.36.0.tar.xz";
-      sha256 = "0ph5g1chbzlwb1x4iwvdcq56ya8pp7j0n56r9h2n2g0ybg4mmrzk";
-      name = "kparts-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kparts-5.37.0.tar.xz";
+      sha256 = "0jrd8idkz8nhkda2rwgf8rysqngiv4r5ajmrzp2kfz1pr91a6l5h";
+      name = "kparts-5.37.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kpeople-5.36.0.tar.xz";
-      sha256 = "0wifh4xp43h5q0iyb281pa50p6ww3ymnayq206675l07c84h021a";
-      name = "kpeople-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kpeople-5.37.0.tar.xz";
+      sha256 = "1qgp4wqp985ac1m9wakpsvk3c2driwkwrjkc3aic7dyr1p456qsf";
+      name = "kpeople-5.37.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kplotting-5.36.0.tar.xz";
-      sha256 = "0gabk9x7mqql2cdafigcrp5ciyd8839arrrnxjq9gb02087v1rx7";
-      name = "kplotting-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kplotting-5.37.0.tar.xz";
+      sha256 = "0k4s0qvhjm9h1bmg16l32g4bsdrp2jrcila4dgzvrb56447px0zw";
+      name = "kplotting-5.37.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kpty-5.36.0.tar.xz";
-      sha256 = "1z5adph6i7wpwk1rlbrmmwczmfp41h8lj1ifzpnp082wj5a5khk4";
-      name = "kpty-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kpty-5.37.0.tar.xz";
+      sha256 = "0wb873r1ycgi11s0qx3lhvz54703yz5sax6fb6wdmri5c05gzd5a";
+      name = "kpty-5.37.0.tar.xz";
     };
   };
   kross = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/portingAids/kross-5.36.0.tar.xz";
-      sha256 = "0yhjzzkpwd406h265fczvlrnwddn2b24mw21gy6x8kcjmdl0ssjq";
-      name = "kross-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/portingAids/kross-5.37.0.tar.xz";
+      sha256 = "06pk6f6v82pd7x9rsmkhkp5r9sgcbrc503lqckl8d7argbb7j4k1";
+      name = "kross-5.37.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/krunner-5.36.0.tar.xz";
-      sha256 = "0r91wd8dc9798j2ghiyxa2b46xvk9ns2rzk3yjaavmnq5xxf2mhq";
-      name = "krunner-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/krunner-5.37.0.tar.xz";
+      sha256 = "171qbhr1yszl2gcffm47p5wiwj71w9yhvk6srhvfpiwfyh61a4ld";
+      name = "krunner-5.37.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kservice-5.36.0.tar.xz";
-      sha256 = "19hhvbs0f7494xhmk7nx72lmff1hpnhin0y1my1xbw03l3f0l4wh";
-      name = "kservice-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kservice-5.37.0.tar.xz";
+      sha256 = "1zxs5yzd3rmy33vsip4c4igk9g38kzaggw8c29sxmgr8vgdrnvhr";
+      name = "kservice-5.37.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/ktexteditor-5.36.0.tar.xz";
-      sha256 = "02c6l6sl9ps1aly46p23wzfpgfc112fhjvhq53smw5qqzyd1187r";
-      name = "ktexteditor-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/ktexteditor-5.37.0.tar.xz";
+      sha256 = "0y04s1nwkf0np6iymjxf0jssin28qw2901kpb3iw8gd52ni5rrks";
+      name = "ktexteditor-5.37.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/ktextwidgets-5.36.0.tar.xz";
-      sha256 = "0b8w0gym1mmbsy1xic6nc76yqa5rwk8nmcjln2z5ri7cg20nxywa";
-      name = "ktextwidgets-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/ktextwidgets-5.37.0.tar.xz";
+      sha256 = "1p8ns75sbnapm6ds16hx36q9vlnz9phgy28rx0gm1ckxqvm4yzr5";
+      name = "ktextwidgets-5.37.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kunitconversion-5.36.0.tar.xz";
-      sha256 = "1xa2n3h13i6lrlxmhvvvgpmcdmr01gskim8wcy5gf0nl23v8bcmh";
-      name = "kunitconversion-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kunitconversion-5.37.0.tar.xz";
+      sha256 = "1qvq61sbv9naj5ndi5xjwx7ami0xa6bqiajr912kbbbp2257cjsi";
+      name = "kunitconversion-5.37.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kwallet-5.36.0.tar.xz";
-      sha256 = "1fyaki8j43i4q0spmgqbzhgv17ziib9g3pcf9jl6gnkmipmwm0l7";
-      name = "kwallet-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kwallet-5.37.0.tar.xz";
+      sha256 = "1l7jl3y0rzx2whnbp6w5p6kg71vwyccp2nwxxgcxr6541m0nihsz";
+      name = "kwallet-5.37.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kwayland-5.36.0.tar.xz";
-      sha256 = "0h9k8m9vb1y1w5gvhgs2fj1iqg64fc9zl4rqnssqgz6fyp3p7i52";
-      name = "kwayland-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kwayland-5.37.0.tar.xz";
+      sha256 = "0d4c8l8k38pgj73kzlf1hsq52w31wy9wgpwph1bv0cq5yn2rjiyr";
+      name = "kwayland-5.37.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kwidgetsaddons-5.36.0.tar.xz";
-      sha256 = "02x232rfagd7xv5m9jwyr5h0cr6g8ibr27s86240xpbb9z9656mw";
-      name = "kwidgetsaddons-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kwidgetsaddons-5.37.0.tar.xz";
+      sha256 = "1jmk377r1h4is2il7chh6bq8wbj21psf4b1yiw84iivg38vlpid4";
+      name = "kwidgetsaddons-5.37.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kwindowsystem-5.36.0.tar.xz";
-      sha256 = "0whih8hhlrqsfadqmh6msw8xv7pmmlk6v4zahlhalkfpdvir26ca";
-      name = "kwindowsystem-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kwindowsystem-5.37.0.tar.xz";
+      sha256 = "0pd2n0j5pdv1x7wf4mwcpimnah73g6l0xidhqbpg37p829jix2k2";
+      name = "kwindowsystem-5.37.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kxmlgui-5.36.0.tar.xz";
-      sha256 = "0c8fvawbcz4v2dcnb77vk7c49l9bd7v8jgg8r8763lwksdckyyz7";
-      name = "kxmlgui-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kxmlgui-5.37.0.tar.xz";
+      sha256 = "0jrvjlxkg9knj61b2gj2w6l96jlmww9kn4ij808ir35365x3cdg2";
+      name = "kxmlgui-5.37.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/kxmlrpcclient-5.36.0.tar.xz";
-      sha256 = "14x7xi2h1208wzj5jnxawz7frjvvkqargiv0v44p699s157bb0d1";
-      name = "kxmlrpcclient-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kxmlrpcclient-5.37.0.tar.xz";
+      sha256 = "1jn9v86dpfx43qcdcsp6lpnga9q6aa5vxjkkg4wg0wbxmw4w9gvq";
+      name = "kxmlrpcclient-5.37.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/modemmanager-qt-5.36.0.tar.xz";
-      sha256 = "0l9g374xwfhfjdniyrjyy8f3xkzdiiqzzpzwx2929h6jml0nr00f";
-      name = "modemmanager-qt-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/modemmanager-qt-5.37.0.tar.xz";
+      sha256 = "1fqf43kvj1v1mcdlbfxbh6sh3ycvg35aml2ywh2a684iz4qzq1aq";
+      name = "modemmanager-qt-5.37.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/networkmanager-qt-5.36.0.tar.xz";
-      sha256 = "1mii9qai7vkwj7x6g3yiqiqk5kzc7im27fg2dhzwgq95dgm4aa2x";
-      name = "networkmanager-qt-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/networkmanager-qt-5.37.0.tar.xz";
+      sha256 = "01px9n97gyvyyfg3dp1k7dik9fprgx9i28hg8wjr2rb5dlr99jd1";
+      name = "networkmanager-qt-5.37.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/oxygen-icons5-5.36.0.tar.xz";
-      sha256 = "042ry8g1v71ifb4yhdi3k6x64sbc0lfyzinyjz78l2zf154l3d9g";
-      name = "oxygen-icons5-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/oxygen-icons5-5.37.0.tar.xz";
+      sha256 = "1rns7n93f83qp5q11a7r5y87y0hvc0q95ar57cqy0fxsqrg4614h";
+      name = "oxygen-icons5-5.37.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/plasma-framework-5.36.0.tar.xz";
-      sha256 = "05wzhnn78f5fi8wwpdrcvjfdv3p14868wlk714shmc5q3svfaq3h";
-      name = "plasma-framework-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/plasma-framework-5.37.0.tar.xz";
+      sha256 = "0kamvxfzrbx3msn0cp3k20clqchz9jg5wlazz3h6p6zmrk5v16bh";
+      name = "plasma-framework-5.37.0.tar.xz";
     };
   };
   prison = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/prison-5.36.0.tar.xz";
-      sha256 = "0f52gmmvga0rd7d7m357dgbwxlwk7sq5mxakhjhwdgjgj1vjx0z3";
-      name = "prison-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/prison-5.37.0.tar.xz";
+      sha256 = "1icsirwfh7zscm8x9g2gp7aqzhs81ahhjflwjcwpz9bh0r9f1wb7";
+      name = "prison-5.37.0.tar.xz";
     };
   };
   solid = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/solid-5.36.0.tar.xz";
-      sha256 = "1b7g0gph6x353amnjskv40a037r7likanx9m52gdsc0z3dg3s3di";
-      name = "solid-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/solid-5.37.0.tar.xz";
+      sha256 = "1gb9gnp1a11q5abl97b7sq1if2rqcrcs0f33sakpxf1z9y0ppg8l";
+      name = "solid-5.37.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/sonnet-5.36.0.tar.xz";
-      sha256 = "1vb6jccfh5pxjb3r43qrqig3h0z8cr0pw27sb116igssc4j0gkxc";
-      name = "sonnet-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/sonnet-5.37.0.tar.xz";
+      sha256 = "0sb6i464riadgb2q73nj0vy6xavr2m1sszrvghr20nj7i64f3kk0";
+      name = "sonnet-5.37.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/syntax-highlighting-5.36.0.tar.xz";
-      sha256 = "1igxjkx8sphxaf4y07d78lnn2nad6q7siarsflh1f79srm2qhnlj";
-      name = "syntax-highlighting-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/syntax-highlighting-5.37.0.tar.xz";
+      sha256 = "1l56pb84z7sy0qq8xkd5w5v5418bm9n4qds0vd39ch655d47bl72";
+      name = "syntax-highlighting-5.37.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.36.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.36/threadweaver-5.36.0.tar.xz";
-      sha256 = "19z97ddba9pkv4j5p2iyr02khqmlgizky306irhhlwdw3y0m4pm1";
-      name = "threadweaver-5.36.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/threadweaver-5.37.0.tar.xz";
+      sha256 = "1hb3721r1zbbyj211886sfkcxk18k0rsdhcg9ssagx10f29rpxx4";
+      name = "threadweaver-5.37.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

New version of KDE Applications and KDE frameworks. Only small changes were needed to make it work.


###### Things done

I've tested konsole, dolphin, konversation, kate, k3b, kdenlive, spectacle, kmix, kcachegrind, filelight by opening them and using them a bit.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

