### PR TITLE
pythonPackages.zc_buildout_nix: 2.5.3 -> 2.9.4

### DIFF
--- a/pkgs/development/python-modules/buildout-nix/default.nix
+++ b/pkgs/development/python-modules/buildout-nix/default.nix
@@ -1,11 +1,13 @@
 { fetchurl, stdenv, buildPythonPackage }:
 
-buildPythonPackage {
-  name = "zc.buildout-nix-2.5.3";
+buildPythonPackage rec {
+  pname = "zc.buildout";
+  version = "2.9.4";
+  name = "${pname}-nix-${version}";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/e4/7b/63863f09bec5f5d7b9474209a6d4d3fc1e0bca02ecfb4c17f0cdd7b554b6/zc.buildout-2.5.3.tar.gz";
-    sha256 = "3e5f3afcc64416604c5efc554c2fa0901b60657e012a710c320e2eb510efcfb9";
+    url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "df56cc55735e984510986c633090ad0d64f59d7e42d1aac57ecf04ab183d1053";
   };
 
   patches = [ ./nix.patch ];

--- a/pkgs/development/python-modules/buildout-nix/nix.patch
+++ b/pkgs/development/python-modules/buildout-nix/nix.patch
@@ -1,6 +1,19 @@
---- a/src/zc/buildout/easy_install.py	2013-08-27 22:28:40.233718116 +0200
-+++ b/src/zc/buildout/easy_install.py   2013-10-07 00:29:31.077413935 +0200
-@@ -227,6 +227,12 @@
+--- a/src/zc/buildout/buildout.py       2017-08-18 10:06:24.946428977 +0300
++++ b/src/zc/buildout/buildout.py       2017-08-18 10:08:49.115613364 +0300
+@@ -382,6 +382,10 @@
+                  if k not in versions
+                  ))
+ 
++        # Override versions with available (nix) system packages
++        for dist in pkg_resources.working_set:
++             versions[dist.project_name] = SectionKey(dist.version, dist.location)
++
+         # Absolutize some particular directory, handling also the ~/foo form,
+         # and considering the location of the configuration file that generated
+         # the setting as the base path, falling back to the main configuration
+--- a/src/zc/buildout/easy_install.py   2017-08-18 10:06:24.948428980 +0300
++++ b/src/zc/buildout/easy_install.py   2017-08-18 10:07:37.462521740 +0300
+@@ -321,6 +321,12 @@
  
      def _satisfied(self, req, source=None):
          dists = [dist for dist in self._env[req.project_name] if dist in req]


### PR DESCRIPTION
###### Motivation for this change

@cillianderoiste In addition to updating, this overrides possibly pinned versions from those available in the current environment.

If you remember, buildout-nix differs from the original buildout in that it prefers "system packages" over buildout packages: this allows to use hard-to-build python packages from nixpkgs with buildout and also running buildout with only nix-dependencies. My only issue has been the need of manually unpinning the conflicting versions.

With these changes, I can simply

    $ nix-shell -p pythonPackages.ldap pythonPackages.lxml pythonPackages.pillow pythonPackages.pyyaml pythonPackages.python_magic pythonPackages.zc_buildout_nix --run buildout-nix

to get a complex Plone buildout run without needing to think about the pinned versions (in this case still installing most of the packages directly from PyPI using buildout).

Nix-pinned packages can be seen using buildout annote

    $ buildout-nix annotate|grep -i pillow
    Pillow= 3.4.2
         /nix/store/g4p8gi7ygwkcyfj0iqvm4kzq12dvi8af-python2.7-Pillow-3.4.2/lib/python2.7/site-packages

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

