### PR TITLE
petsc: init at 3.7.6

### DIFF
--- a/pkgs/development/libraries/science/math/petsc/default.nix
+++ b/pkgs/development/libraries/science/math/petsc/default.nix
@@ -5,9 +5,9 @@
 , liblapack
 , python }:
 
-let version = "3.7.6";
-in stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "petsc-${version}";
+  version = "3.7.6";
 
   src = fetchurl {
     url = "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-${version}.tar.gz";
@@ -16,15 +16,18 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [ blas gfortran.cc.lib liblapack python ];
 
-  configurePhase = ''
-    ./configure --prefix=$out \
-      --CC=$CC \
-      --with-cxx=0 \
-      --with-fc=0 \
-      --with-mpi=0 \
-      --with-blas-lib=[${blas}/lib/libblas.a,${gfortran.cc.lib}/lib/libgfortran.a] \
-      --with-lapack-lib=[${liblapack}/lib/liblapack.a,${gfortran.cc.lib}/lib/libgfortran.a]
-    '';
+  preConfigure = ''
+    patchShebangs .
+    configureFlagsArray=(
+      $configureFlagsArray
+      "--CC=$CC"
+      "--with-cxx=0"
+      "--with-fc=0"
+      "--with-mpi=0"
+      "--with-blas-lib=[${blas}/lib/libblas.a,${gfortran.cc.lib}/lib/libgfortran.a]"
+      "--with-lapack-lib=[${liblapack}/lib/liblapack.a,${gfortran.cc.lib}/lib/libgfortran.a]"
+    )
+  '';
 
   meta = {
     description = "Library of linear algebra algorithms for solving partial differential equations";

--- a/pkgs/development/libraries/science/math/petsc/default.nix
+++ b/pkgs/development/libraries/science/math/petsc/default.nix
@@ -29,6 +29,13 @@ stdenv.mkDerivation rec {
     )
   '';
 
+  postInstall = ''
+    rm $out/bin/petscmpiexec
+    rm $out/bin/popup
+    rm $out/bin/uncrustify.cfg
+    rm -rf $out/bin/win32fe
+  '';
+
   meta = {
     description = "Library of linear algebra algorithms for solving partial differential equations";
     homepage = https://www.mcs.anl.gov/petsc/index.html;

--- a/pkgs/development/libraries/science/math/petsc/default.nix
+++ b/pkgs/development/libraries/science/math/petsc/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, fetchurl
+, blas
+, gfortran
+, liblapack
+, python }:
+
+let version = "3.7.6";
+in stdenv.mkDerivation {
+  name = "petsc-${version}";
+
+  src = fetchurl {
+    url = "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-${version}.tar.gz";
+    sha256 = "0jfl35lrhzvv982z6h1v5rcp39g0x16ca43rm9dx91wm6i8y13iw";
+  };
+
+  nativeBuildInputs = [ blas gfortran.cc.lib liblapack python ];
+
+  configurePhase = ''
+    ./configure --prefix=$out \
+      --CC=$CC \
+      --with-cxx=0 \
+      --with-fc=0 \
+      --with-mpi=0 \
+      --with-blas-lib=[${blas}/lib/libblas.a,${gfortran.cc.lib}/lib/libgfortran.a] \
+      --with-lapack-lib=[${liblapack}/lib/liblapack.a,${gfortran.cc.lib}/lib/libgfortran.a]
+    '';
+
+  meta = {
+    description = "Library of linear algebra algorithms for solving partial differential equations";
+    homepage = https://www.mcs.anl.gov/petsc/index.html;
+    platforms = stdenv.lib.platforms.all;
+    license = stdenv.lib.licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17922,6 +17922,8 @@ with pkgs;
 
   nauty = callPackage ../applications/science/math/nauty {};
 
+  petsc = callPackage ../development/libraries/science/math/petsc { };
+
   sage = callPackage ../applications/science/math/sage { };
 
   suitesparse_4_2 = callPackage ../development/libraries/science/math/suitesparse/4.2.nix { };


### PR DESCRIPTION
###### Motivation for this change
Add the PETSc library, so that it may later be used by, e.g., the FEniCS computing platform (https://fenicsproject.org) for solving partial differential equations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
