### PR TITLE
Make UEFI installer test release critical

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -70,6 +70,7 @@ in rec {
         (all nixos.tests.installer.simple)
         (all nixos.tests.installer.simpleLabels)
         (all nixos.tests.installer.simpleProvided)
+        (all nixos.tests.installer.simpleUefiSystemdBoot)
         (all nixos.tests.installer.swraid)
         (all nixos.tests.installer.btrfsSimple)
         (all nixos.tests.installer.btrfsSubvols)

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -270,7 +270,7 @@ in {
     };
 
   # Simple GPT/UEFI configuration using systemd-boot with 3 partitions: ESP, swap & root filesystem
-  simpleUefiGummiboot = makeInstallerTest "simpleUefiGummiboot"
+  simpleUefiSystemdBoot = makeInstallerTest "simpleUefiSystemdBoot"
     { createPartitions =
         ''
           $machine->succeed(


### PR DESCRIPTION
Seems to be (mostly) working fine, based on the history:

https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.installer.simpleUefiGummiboot.i686-linux/all
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.installer.simpleUefiGummiboot.x86_64-linux/all

I do see one failure due to a race condition during partitioning in https://hydra.nixos.org/build/54464614 but as far as I can tell that isn't specific to EFI partitions.

Fixes https://github.com/NixOS/nixpkgs/issues/14956