### PR TITLE
stdenvs: Distinguish between `extraBuildInputs` and `extraNativeBuildInputs`

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -59,11 +59,12 @@ in rec {
   stageFun = step: last: {shell             ? "${bootstrapTools}/bin/bash",
                           overrides         ? (self: super: {}),
                           extraPreHook      ? "",
+                          extraNativeBuildInputs,
                           extraBuildInputs,
                           allowedRequisites ? null}:
     let
       thisStdenv = import ../generic {
-        inherit config shell extraBuildInputs;
+        inherit config shell extraNativeBuildInputs extraBuildInputs;
         allowedRequisites = if allowedRequisites == null then null else allowedRequisites ++ [
           thisStdenv.cc.expand-response-params
         ];
@@ -162,6 +163,7 @@ in rec {
 
     };
 
+    extraNativeBuildInputs = [];
     extraBuildInputs = [];
   };
 
@@ -169,6 +171,7 @@ in rec {
 
   stage1 = prevStage: with prevStage; stageFun 1 prevStage {
     extraPreHook = "export NIX_CFLAGS_COMPILE+=\" -F${bootstrapTools}/Library/Frameworks\"";
+    extraNativeBuildInputs = [];
     extraBuildInputs = [ pkgs.libcxx ];
 
     allowedRequisites =
@@ -195,7 +198,8 @@ in rec {
       export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
     '';
 
-    extraBuildInputs = with pkgs; [ xz darwin.CF libcxx ];
+    extraNativeBuildInputs = [ pkgs.xz ];
+    extraBuildInputs = with pkgs; [ darwin.CF libcxx ];
 
     allowedRequisites =
       [ bootstrapTools ] ++
@@ -226,7 +230,8 @@ in rec {
     # enables patchShebangs above. Unfortunately, patchShebangs ignores our $SHELL setting
     # and instead goes by $PATH, which happens to contain bootstrapTools. So it goes and
     # patches our shebangs back to point at bootstrapTools. This makes sure bash comes first.
-    extraBuildInputs = with pkgs; [ xz darwin.CF libcxx pkgs.bash ];
+    extraNativeBuildInputs = with pkgs; [ xz pkgs.bash ];
+    extraBuildInputs = with pkgs; [ darwin.CF libcxx ];
 
     extraPreHook = ''
       export PATH=${pkgs.bash}/bin:$PATH
@@ -260,7 +265,8 @@ in rec {
 
   stage4 = prevStage: with prevStage; stageFun 4 prevStage {
     shell = "${pkgs.bash}/bin/bash";
-    extraBuildInputs = with pkgs; [ xz darwin.CF libcxx pkgs.bash ];
+    extraNativeBuildInputs = with pkgs; [ xz pkgs.bash ];
+    extraBuildInputs = with pkgs; [ darwin.CF libcxx ];
     extraPreHook = ''
       export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
     '';
@@ -321,6 +327,7 @@ in rec {
       libc = pkgs.darwin.Libsystem;
     };
 
+    extraNativeBuildInputs = [];
     extraBuildInputs = with pkgs; [ darwin.CF libcxx ];
 
     extraAttrs = {

--- a/pkgs/stdenv/generic/builder.sh
+++ b/pkgs/stdenv/generic/builder.sh
@@ -9,6 +9,7 @@ mkdir $out
 echo "export SHELL=$shell" > $out/setup
 echo "initialPath=\"$initialPath\"" >> $out/setup
 echo "defaultNativeBuildInputs=\"$defaultNativeBuildInputs\"" >> $out/setup
+echo "defaultBuildInputs=\"$defaultBuildInputs\"" >> $out/setup
 echo "$preHook" >> $out/setup
 cat "$setup" >> $out/setup
 

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -9,6 +9,7 @@ let lib = import ../../../lib; in lib.makeOverridable (
 
 , setupScript ? ./setup.sh
 
+, extraNativeBuildInputs ? []
 , extraBuildInputs ? []
 , __stdenvImpureHostDeps ? []
 , __extraImpureHostDeps ? []
@@ -41,7 +42,7 @@ let lib = import ../../../lib; in lib.makeOverridable (
 }:
 
 let
-  defaultNativeBuildInputs = extraBuildInputs ++
+  defaultNativeBuildInputs = extraNativeBuildInputs ++
     [ ../../build-support/setup-hooks/move-docs.sh
       ../../build-support/setup-hooks/compress-man-pages.sh
       ../../build-support/setup-hooks/strip.sh
@@ -58,11 +59,16 @@ let
       cc
     ];
 
+  defaultBuildInputs = extraBuildInputs;
+
   # The stdenv that we are producing.
   stdenv =
     derivation (
-    (if isNull allowedRequisites then {} else { allowedRequisites = allowedRequisites ++ defaultNativeBuildInputs; }) //
-    {
+    lib.optionalAttrs (allowedRequisites != null) {
+      allowedRequisites = allowedRequisites
+        ++ defaultNativeBuildInputs ++ defaultBuildInputs;
+    }
+    // {
       inherit name;
 
       # Nix itself uses the `system` field of a derivation to decide where to
@@ -75,7 +81,8 @@ let
 
       setup = setupScript;
 
-      inherit preHook initialPath shell defaultNativeBuildInputs;
+      inherit preHook initialPath shell
+        defaultNativeBuildInputs defaultBuildInputs;
     }
     // lib.optionalAttrs buildPlatform.isDarwin {
       __sandboxProfile = stdenvSandboxProfile;
@@ -91,7 +98,8 @@ let
 
       inherit buildPlatform hostPlatform targetPlatform;
 
-      inherit extraBuildInputs __extraImpureHostDeps extraSandboxProfile;
+      inherit extraNativeBuildInputs extraBuildInputs
+        __extraImpureHostDeps extraSandboxProfile;
 
       # Utility flags to test the type of platform.
       inherit (hostPlatform)

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -65,13 +65,21 @@ rec {
            "sandboxProfile" "propagatedSandboxProfile"])
         // (let
           computedSandboxProfile =
-            lib.concatMap (input: input.__propagatedSandboxProfile or []) (stdenv.extraBuildInputs ++ lib.concatLists dependencies);
+            lib.concatMap (input: input.__propagatedSandboxProfile or [])
+              (stdenv.extraNativeBuildInputs
+               ++ stdenv.extraBuildInputs
+               ++ lib.concatLists dependencies);
           computedPropagatedSandboxProfile =
-            lib.concatMap (input: input.__propagatedSandboxProfile or []) (lib.concatLists propagatedDependencies);
+            lib.concatMap (input: input.__propagatedSandboxProfile or [])
+              (lib.concatLists propagatedDependencies);
           computedImpureHostDeps =
-            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (stdenv.extraBuildInputs ++ lib.concatLists dependencies));
+            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or [])
+              (stdenv.extraNativeBuildInputs
+               ++ stdenv.extraBuildInputs
+               ++ lib.concatLists dependencies));
           computedPropagatedImpureHostDeps =
-            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (lib.concatLists propagatedDependencies));
+            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or [])
+              (lib.concatLists propagatedDependencies));
         in
         {
           name = name + lib.optionalString

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -47,7 +47,7 @@ let
   # the bootstrap.  In all stages, we build an stdenv and the package
   # set that can be built with that stdenv.
   stageFun = prevStage:
-    { name, overrides ? (self: super: {}), extraBuildInputs ? [] }:
+    { name, overrides ? (self: super: {}), extraNativeBuildInputs ? [] }:
 
     let
 
@@ -56,7 +56,7 @@ let
         buildPlatform = localSystem;
         hostPlatform = localSystem;
         targetPlatform = localSystem;
-        inherit config extraBuildInputs;
+        inherit config extraNativeBuildInputs;
         preHook =
           ''
             # Don't patch #!/interpreter because it leads to retained
@@ -219,7 +219,7 @@ in
         isl = isl_0_14;
       };
     };
-    extraBuildInputs = [ prevStage.patchelf prevStage.paxctl ] ++
+    extraNativeBuildInputs = [ prevStage.patchelf prevStage.paxctl ] ++
       # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
       lib.optional (system == "aarch64-linux") prevStage.updateAutotoolsGnuConfigScriptsHook;
   })
@@ -253,7 +253,7 @@ in
         shell = self.bash + "/bin/bash";
       };
     };
-    extraBuildInputs = [ prevStage.patchelf prevStage.xz ] ++
+    extraNativeBuildInputs = [ prevStage.patchelf prevStage.xz ] ++
       # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
       lib.optional (system == "aarch64-linux") prevStage.updateAutotoolsGnuConfigScriptsHook;
   })
@@ -283,7 +283,7 @@ in
       initialPath =
         ((import ../common-path.nix) {pkgs = prevStage;});
 
-      extraBuildInputs = [ prevStage.patchelf prevStage.paxctl ] ++
+      extraNativeBuildInputs = [ prevStage.patchelf prevStage.paxctl ] ++
         # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
         lib.optional (system == "aarch64-linux") prevStage.updateAutotoolsGnuConfigScriptsHook;
 

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -66,7 +66,7 @@ let
     export lt_cv_deplibs_check_method=pass_all
   '';
 
-  extraBuildInputsCygwin = [
+  extraNativeBuildInputsCygwin = [
     ../cygwin/all-buildinputs-as-runtimedep.sh
     ../cygwin/wrap-exes-to-find-dlls.sh
   ] ++ (if system == "i686-cygwin" then [
@@ -94,9 +94,9 @@ let
         if system == "x86_64-cygwin" then prehookCygwin else
         prehookBase;
 
-      extraBuildInputs =
-        if system == "i686-cygwin" then extraBuildInputsCygwin else
-        if system == "x86_64-cygwin" then extraBuildInputsCygwin else
+      extraNativeBuildInputs =
+        if system == "i686-cygwin" then extraNativeBuildInputsCygwin else
+        if system == "x86_64-cygwin" then extraNativeBuildInputsCygwin else
         [];
 
       initialPath = extraPath ++ path;


### PR DESCRIPTION
This version continues to use `stdenv/setup` for the default inputs.

###### Motivation for this change

Restore uncontroversial bits of https://github.com/NixOS/nixpkgs/pull/28304

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

