### PR TITLE
geogebra: 5-0-377-0 -> 5-0-382-0

### DIFF
--- a/pkgs/applications/science/math/geogebra/default.nix
+++ b/pkgs/applications/science/math/geogebra/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "geogebra-${version}";
-  version = "5-0-377-0";
+  version = "5-0-382-0";
 
   preferLocalBuild = true;
 
   src = fetchurl {
     url = "http://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2";
-    sha256 = "0rvsjpf7pyz8z5yrqmc5ixzq7mnf1pyp00i914qd6wn5bx0apkxv";
+    sha256 = "0xqln1ssm35q8ry4a0ly8rkgw41brmrhn26l6q6r0qqrnw85cnyv";
   };
 
   srcIcon = fetchurl {

--- a/pkgs/applications/science/math/geogebra/default.nix
+++ b/pkgs/applications/science/math/geogebra/default.nix
@@ -7,7 +7,14 @@ stdenv.mkDerivation rec {
   preferLocalBuild = true;
 
   src = fetchurl {
-    url = "http://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2";
+    urls = [
+      "http://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2"
+
+      # Fallback for 5-0-382-0
+      # To avoid breaks when latest geogebra version is
+      # removed from `download.geogebra.org`
+      "http://web.archive.org/web/20170818191250/http://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-5-0-382-0.tar.bz2"
+    ];
     sha256 = "0xqln1ssm35q8ry4a0ly8rkgw41brmrhn26l6q6r0qqrnw85cnyv";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Updates `geogebra` to latest version to prevent breaks.
Furthermore it adds a fallback to `web.archive.org`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

