### PR TITLE
programs.zsh: move evlauation of `${zshAliases}` after `cfg.interactiveShellInit`

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -164,11 +164,11 @@ in
           "source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
         }
 
-        ${zshAliases}
-
         ${cfge.interactiveShellInit}
 
         ${cfg.interactiveShellInit}
+
+        ${zshAliases}
 
         ${cfg.promptInit}
 


### PR DESCRIPTION
###### Motivation for this change

:warning: __Caution: (possible) BC Break:__ This changes the order of operations in `/etc/zshrc` which might break several people's setups.

`cfg.interactiveShellInit` is used by modules like
`programs.zsh.oh-my-zsh`. This means that all aliases defined in
`programs.zsh.shellAliases` might be overriden which is highly
unpredictable in some cases.

__Example:__

`oh-my-zsh` overrides `ll` and `l` aliases in the core (no plugin which might be disabled), but I decided to use `exa` as `ls` replacement.
Now I tried to alias `ls` and `ll` to `exa` in `programs.zsh.shellAliases`, but it was overriden by `oh-my-zsh` as `interactiveShellInit` is evaluated after `shellAliases`.

A quickfix was to use `mkAfter`:

 ```nix
{
  programs.zsh.interactiveShellInit = pkgs.lib.mkAfter ''
    alias ls="${pkgs.exa}/bin/exa";
  '';
}
```

As you can see I create `alias` statements manually in a custom `interactiveShellInit` block, however I don't think that such hacks should be necessary to prevent such unexpectable behavior.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

