### PR TITLE
mercurial: remove hardcoded linux-only cacert

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -44,12 +44,6 @@ in python2Packages.buildPythonApplication {
           $WRAP_TK
       done
 
-      mkdir -p $out/etc/mercurial
-      cat >> $out/etc/mercurial/hgrc << EOF
-      [web]
-      cacerts = /etc/ssl/certs/ca-certificates.crt
-      EOF
-
       # copy hgweb.cgi to allow use in apache
       mkdir -p $out/share/cgi-bin
       cp -v hgweb.cgi contrib/hgweb.wsgi $out/share/cgi-bin


### PR DESCRIPTION
This is no more needed since the introduction of NIX_SSL_CERT_PATH.
Furthermore, it breaks on darwin because the path does not exist.

Fixes #27928.