### PR TITLE
remove collection-json from dont-distribute-packages

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2594,6 +2594,8 @@ package-maintainers:
   abbradar:
     - Agda
     - lambdabot
+  alunduil:
+    - collection-json
 
 dont-distribute-packages:
   # hard restrictions that really belong into meta.platforms
@@ -3433,7 +3435,6 @@ dont-distribute-packages:
   collada-output:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   collada-types:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   collapse-util:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  collection-json:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   collections-api:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   collections-base-instances:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   collections:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]


### PR DESCRIPTION
###### Motivation for this change

I believe I've fixed the build issues for collection-json and would like
to see it make it into the next stable release of NixOS.  I'm also
adding myself as maintainer.

Let me know if there is anything I did incorrectly or missed.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

