### PR TITLE
mpfshell: init at 0.8.1

### DIFF
--- a/pkgs/development/tools/mpfshell/default.nix
+++ b/pkgs/development/tools/mpfshell/default.nix
@@ -1,0 +1,23 @@
+{ lib, python3Packages, fetchFromGitHub }:
+
+python3Packages.buildPythonPackage rec {
+  name = "mpfshell";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "wendlers";
+    repo = "mpfshell";
+    rev = version;
+    sha256 = "1n4ap4yfii54y125f9n9krc0lc0drwg3hsq4z6g89xbswdx9sygr";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    pyserial colorama websocket_client
+  ];
+
+  meta = with lib; {
+    homepage = https://github.com/wendlers/mpfshell;
+    description = "A simple shell based file explorer for ESP8266 Micropython based devices";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/tools/mpfshell/default.nix
+++ b/pkgs/development/tools/mpfshell/default.nix
@@ -1,7 +1,7 @@
 { lib, python3Packages, fetchFromGitHub }:
 
 python3Packages.buildPythonPackage rec {
-  name = "mpfshell";
+  name = "mpfshell-${version}";
   version = "0.8.1";
 
   src = fetchFromGitHub {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8048,6 +8048,8 @@ with pkgs;
 
   mpfi = callPackage ../development/libraries/mpfi { };
 
+  mpfshell = callPackage ../development/tools/mpfshell { };
+
   # A GMP fork
   mpir = callPackage ../development/libraries/mpir {};
 


### PR DESCRIPTION
###### Motivation for this change
This pull requests adds the [mpfshell](https://github.com/wendlers/mpfshell)-software.

###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).