### PR TITLE
boot.kernelParams: dedup and sort

### DIFF
--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -57,6 +57,7 @@ in
       type = types.listOf types.str;
       default = [ ];
       description = "Parameters added to the kernel command line.";
+      apply = list: attrNames (genAttrs list (_: true)); # dedup and sort to avoid restarting services on eval order change
     };
 
     boot.consoleLogLevel = mkOption {


### PR DESCRIPTION
###### Motivation for this change

dedup and sort boot.kernelParams  to avoid restarting services on eval order change
Fixes https://github.com/NixOS/nixpkgs/issues/28277
