### PR TITLE
Update tilix

### DIFF
--- a/pkgs/applications/misc/tilix/default.nix
+++ b/pkgs/applications/misc/tilix/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
   preFixup = ''
     substituteInPlace $out/share/applications/com.gexperts.Tilix.desktop \
       --replace "Exec=tilix" "Exec=$out/bin/tilix"
+    sed -i '/^DBusActivatable=/d' $out/share/applications/com.gexperts.Tilix.desktop
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/tilix/default.nix
+++ b/pkgs/applications/misc/tilix/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "tilix-${version}";
-  version = "1.6.1";
+  version = "1.6.4";
 
   src = fetchFromGitHub {
     owner = "gnunn1";
     repo = "tilix";
     rev = "${version}";
-    sha256 = "10nw3q6s941dm44bkfryl1xclr1xy1vjr2n8w7g6kfahpcazf8f8";
+    sha256 = "1vqi68jlbbaky1569kd4lr6p02zsiv7v2rfb8j1pzwj7gydblaac";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Update tilix from 1.6.1 to 1.6.4.
I also removed `DBusActivatable=true` from the desktop entry, since this seemed to block tilix from starting in gnome-shell.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

