### PR TITLE
llvm: 4.0.1 -> 5.0.0rc2

### DIFF
--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -1,0 +1,67 @@
+{ stdenv, fetch, cmake, libxml2, libedit, llvm, version, release_version, clang-tools-extra_src, python }:
+
+let
+  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
+  self = stdenv.mkDerivation {
+    name = "clang-${version}";
+
+    unpackPhase = ''
+      unpackFile ${fetch "cfe" "1ajfb302fbxasfsbwybvfqnl7r271isc2nq0b13ag3z15gc4i5c7"}
+      mv cfe-${version}* clang
+      sourceRoot=$PWD/clang
+      unpackFile ${clang-tools-extra_src}
+      mv clang-tools-extra-* $sourceRoot/tools/extra
+    '';
+
+    buildInputs = [ cmake libedit libxml2 llvm python ];
+
+    cmakeFlags = [
+      "-DCMAKE_CXX_FLAGS=-std=c++11"
+    ] ++
+    # Maybe with compiler-rt this won't be needed?
+    (stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}") ++
+    (stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include");
+
+    patches = [ ./purity.patch ];
+
+    postPatch = ''
+      sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/ToolChains/Gnu.cpp
+    '';
+
+    outputs = [ "out" "python" ];
+
+    # Clang expects to find LLVMgold in its own prefix
+    # Clang expects to find sanitizer libraries in its own prefix
+    postInstall = ''
+      ln -sv ${llvm}/lib/LLVMgold.so $out/lib
+      ln -sv ${llvm}/lib/clang/${release_version}/lib $out/lib/clang/${release_version}/
+      ln -sv $out/bin/clang $out/bin/cpp
+
+      mkdir -p $python/bin $python/share/clang/
+      mv $out/bin/{git-clang-format,scan-view} $python/bin
+      if [ -e $out/bin/set-xcode-analyzer ]; then
+        mv $out/bin/set-xcode-analyzer $python/bin
+      fi
+      mv $out/share/clang/*.py $python/share/clang
+
+      rm $out/bin/c-index-test
+    '';
+
+    enableParallelBuilding = true;
+
+    passthru = {
+      lib = self; # compatibility with gcc, so that `stdenv.cc.cc.lib` works on both
+      isClang = true;
+      inherit llvm;
+    } // stdenv.lib.optionalAttrs stdenv.isLinux {
+      inherit gcc;
+    };
+
+    meta = {
+      description = "A c, c++, objective-c, and objective-c++ frontend for the llvm compiler";
+      homepage    = http://llvm.org/;
+      license     = stdenv.lib.licenses.ncsa;
+      platforms   = stdenv.lib.platforms.all;
+    };
+  };
+in self

--- a/pkgs/development/compilers/llvm/5/clang/purity.patch
+++ b/pkgs/development/compilers/llvm/5/clang/purity.patch
@@ -1,0 +1,16 @@
+--- a/lib/Driver/ToolChains/Gnu.cpp
++++ b/lib/Driver/ToolChains/Gnu.cpp
+@@ -491,13 +491,6 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+   if (!Args.hasArg(options::OPT_static)) {
+     if (Args.hasArg(options::OPT_rdynamic))
+       CmdArgs.push_back("-export-dynamic");
+-
+-    if (!Args.hasArg(options::OPT_shared)) {
+-      const std::string Loader =
+-          D.DyldPrefix + ToolChain.getDynamicLinker(Args);
+-      CmdArgs.push_back("-dynamic-linker");
+-      CmdArgs.push_back(Args.MakeArgString(Loader));
+-    }
+   }
+ 
+   CmdArgs.push_back("-o");

--- a/pkgs/development/compilers/llvm/5/default.nix
+++ b/pkgs/development/compilers/llvm/5/default.nix
@@ -1,0 +1,48 @@
+{ newScope, stdenv, cmake, libxml2, python2, isl, fetchurl, overrideCC, wrapCC, darwin, ccWrapperFun }:
+let
+  callPackage = newScope (self // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
+
+  release_version = "5.0.0";
+  version = "5.0.0rc2"; # differentiating these is important for rc's
+
+  fetch = name: sha256: fetchurl {
+    url = "http://prereleases.llvm.org/${release_version}/rc2/${name}-${version}.src.tar.xz";
+    inherit sha256;
+  };
+
+  compiler-rt_src = fetch "compiler-rt" "07ip30f6scx59zy2jch7gqjp0amb9gy1wci87x6fxdf55i4l8rb4";
+  clang-tools-extra_src = fetch "clang-tools-extra" "1298jk0nn5pizac2d775164y3yklc2hm0rgzxmg771rk0fcfnggr";
+
+  self = {
+    llvm = callPackage ./llvm.nix {
+      inherit compiler-rt_src stdenv;
+    };
+
+    clang-unwrapped = callPackage ./clang {
+      inherit clang-tools-extra_src stdenv;
+    };
+
+    clang = wrapCC self.clang-unwrapped;
+
+    libcxxClang = ccWrapperFun {
+      cc = self.clang-unwrapped;
+      isClang = true;
+      inherit (self) stdenv;
+      /* FIXME is this right? */
+      inherit (stdenv.cc) libc nativeTools nativeLibc;
+      extraPackages = [ self.libcxx self.libcxxabi ];
+    };
+
+    stdenv = overrideCC stdenv self.clang;
+
+    libcxxStdenv = overrideCC stdenv self.libcxxClang;
+
+    lld = callPackage ./lld.nix {};
+
+    lldb = callPackage ./lldb.nix {};
+
+    libcxx = callPackage ./libc++ {};
+
+    libcxxabi = callPackage ./libc++abi.nix {};
+  };
+in self

--- a/pkgs/development/compilers/llvm/5/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/5/libc++/default.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, fetch, cmake, llvm, libcxxabi, fixDarwinDylibNames, version }:
+
+stdenv.mkDerivation rec {
+  name = "libc++-${version}";
+
+  src = fetch "libcxx" "0mdnq6wa61v2pnnj734agj9qxmkrpzif4vpwmrmjfzb32w5r2f4n";
+
+  postUnpack = ''
+    unpackFile ${libcxxabi.src}
+    export LIBCXXABI_INCLUDE_DIR="$PWD/$(ls -d libcxxabi-${version}*)/include"
+  '';
+
+  prePatch = ''
+    substituteInPlace lib/CMakeLists.txt --replace "/usr/lib/libc++" "\''${LIBCXX_LIBCXXABI_LIB_PATH}/libc++"
+  '';
+
+  preConfigure = ''
+    # Get headers from the cxxabi source so we can see private headers not installed by the cxxabi package
+    cmakeFlagsArray=($cmakeFlagsArray -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$LIBCXXABI_INCLUDE_DIR")
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
+
+  cmakeFlags = [
+    "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
+    "-DLIBCXX_LIBCPPABI_VERSION=2"
+    "-DLIBCXX_CXX_ABI=libcxxabi"
+  ];
+
+  enableParallelBuilding = true;
+
+  linkCxxAbi = stdenv.isLinux;
+
+  setupHook = ./setup-hook.sh;
+
+  meta = {
+    homepage = http://libcxx.llvm.org/;
+    description = "A new implementation of the C++ standard library, targeting C++11";
+    license = with stdenv.lib.licenses; [ ncsa mit ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/llvm/5/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/5/libc++/setup-hook.sh
@@ -1,0 +1,3 @@
+linkCxxAbi="@linkCxxAbi@"
+export NIX_CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/5/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/5/libc++abi.nix
@@ -1,0 +1,46 @@
+{ stdenv, cmake, fetch, libcxx, libunwind, llvm, version }:
+
+stdenv.mkDerivation {
+  name = "libc++abi-${version}";
+
+  src = fetch "libcxxabi" "035lhsdvblz9vg8hp2jl80zrwh6j5js4ymx712298c7an2bsxq21";
+
+  buildInputs = [ cmake ] ++ stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;
+
+  postUnpack = ''
+    unpackFile ${libcxx.src}
+    unpackFile ${llvm.src}
+    export cmakeFlags="-DLLVM_PATH=$PWD/$(ls -d llvm-*) -DLIBCXXABI_LIBCXX_PATH=$PWD/$(ls -d libcxx-*)"
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    export TRIPLE=x86_64-apple-darwin
+  '';
+
+  installPhase = if stdenv.isDarwin
+    then ''
+      for file in lib/*.dylib; do
+        # this should be done in CMake, but having trouble figuring out
+        # the magic combination of necessary CMake variables
+        # if you fancy a try, take a look at
+        # http://www.cmake.org/Wiki/CMake_RPATH_handling
+        install_name_tool -id $out/$file $file
+      done
+      make install
+      install -d 755 $out/include
+      install -m 644 ../include/*.h $out/include
+    ''
+    else ''
+      install -d -m 755 $out/include $out/lib
+      install -m 644 lib/libc++abi.so.1.0 $out/lib
+      install -m 644 ../include/cxxabi.h $out/include
+      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
+      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
+    '';
+
+  meta = {
+    homepage = http://libcxxabi.llvm.org/;
+    description = "A new implementation of low level support for a standard C++ library";
+    license = with stdenv.lib.licenses; [ ncsa mit ];
+    maintainers = with stdenv.lib.maintainers; [ vlstill ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/llvm/5/lld.nix
+++ b/pkgs/development/compilers/llvm/5/lld.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetch
+, cmake
+, zlib
+, llvm
+, python
+, version
+}:
+
+stdenv.mkDerivation {
+  name = "lld-${version}";
+
+  src = fetch "lld" "09w5zpsj0prx753hbz7r8wc027vbq0iad1gxz5a9scsih9pd04p1";
+
+  buildInputs = [ cmake llvm ];
+
+  outputs = [ "out" "dev" ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    moveToOutput include "$dev"
+    moveToOutput lib "$dev"
+  '';
+
+  meta = {
+    description = "The LLVM Linker";
+    homepage    = http://lld.llvm.org/;
+    license     = stdenv.lib.licenses.ncsa;
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/compilers/llvm/5/lldb.nix
+++ b/pkgs/development/compilers/llvm/5/lldb.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, fetch
+, cmake
+, zlib
+, ncurses
+, swig
+, which
+, libedit
+, libxml2
+, llvm
+, clang-unwrapped
+, python
+, version
+, darwin
+}:
+
+stdenv.mkDerivation {
+  name = "lldb-${version}";
+
+  src = fetch "lldb" "14l0lsp78fyhc74bicj7y8f55p3iwbxgrmkya939d2fjcg928yrn";
+
+  patchPhase = ''
+    # Fix up various paths that assume llvm and clang are installed in the same place
+    sed -i 's,".*ClangConfig.cmake","${clang-unwrapped}/lib/cmake/clang/ClangConfig.cmake",' \
+      cmake/modules/LLDBStandalone.cmake
+    sed -i 's,".*tools/clang/include","${clang-unwrapped}/include",' \
+      cmake/modules/LLDBStandalone.cmake
+    sed -i 's,"$.LLVM_LIBRARY_DIR.",${llvm}/lib ${clang-unwrapped}/lib,' \
+      cmake/modules/LLDBStandalone.cmake
+  '';
+
+  buildInputs = [ cmake python which swig ncurses zlib libedit libxml2 llvm ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.libobjc darwin.apple_sdk.libs.xpc ];
+
+  CXXFLAGS = "-fno-rtti";
+  hardeningDisable = [ "format" ];
+
+  cmakeFlags = [
+    "-DLLDB_DISABLE_LIBEDIT=ON"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A next-generation high-performance debugger";
+    homepage    = http://llvm.org/;
+    license     = licenses.ncsa;
+    platforms   = platforms.allBut platforms.darwin;
+  };
+}

--- a/pkgs/development/compilers/llvm/5/llvm-outputs.patch
+++ b/pkgs/development/compilers/llvm/5/llvm-outputs.patch
@@ -1,0 +1,26 @@
+diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.cpp
+index 94d426b..37f7794 100644
+--- a/tools/llvm-config/llvm-config.cpp
++++ b/tools/llvm-config/llvm-config.cpp
+@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+     ActiveIncludeOption = "-I" + ActiveIncludeDir;
+   }
+ 
++  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  if (!IsInDevelopmentTree) {
++    bool WantShared = true;
++    for (int i = 1; i < argc; ++i) {
++      StringRef Arg = argv[i];
++      if (Arg == "--link-shared")
++        WantShared = true;
++      else if (Arg == "--link-static")
++        WantShared = false; // the last one wins
++    }
++
++    if (WantShared)
++      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++  }
++
+   /// We only use `shared library` mode in cases where the static library form
+   /// of the components provided are not available; note however that this is
+   /// skipped if we're run from within the build dir. However, once installed,

--- a/pkgs/development/compilers/llvm/5/llvm.nix
+++ b/pkgs/development/compilers/llvm/5/llvm.nix
@@ -1,0 +1,130 @@
+{ stdenv
+, fetch
+, fetchpatch
+, perl
+, groff
+, cmake
+, python
+, libffi
+, binutils
+, libxml2
+, valgrind
+, ncurses
+, version
+, release_version
+, zlib
+, compiler-rt_src
+, libcxxabi
+, debugVersion ? false
+, enableSharedLibraries ? true
+, darwin
+}:
+
+let
+  src = fetch "llvm" "0s4ls5a2jskhpnl006qrnbggwmxyz4l9i03krxfsmh43an7jqi0l";
+  shlib = if stdenv.isDarwin then "dylib" else "so";
+
+  # Used when creating a version-suffixed symlink of libLLVM.dylib
+  shortVersion = with stdenv.lib;
+    concatStringsSep "." (take 2 (splitString "." release_version));
+in stdenv.mkDerivation rec {
+  name = "llvm-${version}";
+
+  unpackPhase = ''
+    unpackFile ${src}
+    mv llvm-${version}* llvm
+    sourceRoot=$PWD/llvm
+    unpackFile ${compiler-rt_src}
+    mv compiler-rt-* $sourceRoot/projects/compiler-rt
+  '';
+
+  outputs = [ "out" ] ++ stdenv.lib.optional enableSharedLibraries "lib";
+
+  buildInputs = [ perl groff cmake libxml2 python libffi ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ libcxxabi ];
+
+  propagatedBuildInputs = [ ncurses zlib ];
+
+  # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
+  # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra
+  # can build this. If we didn't do it, basically the entire nixpkgs on Darwin would have an unfree dependency and we'd
+  # get no binary cache for the entire platform. If you really find yourself wanting the TSAN, make this controllable by
+  # a flag and turn the flag off during the stdenv build.
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace ./projects/compiler-rt/cmake/config-ix.cmake \
+      --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
+  ''
+  # Patch llvm-config to return correct library path based on --link-{shared,static}.
+  + stdenv.lib.optionalString (enableSharedLibraries) ''
+    substitute '${./llvm-outputs.patch}' ./llvm-outputs.patch --subst-var lib
+    patch -p1 < ./llvm-outputs.patch
+  '';
+
+  # hacky fix: created binaries need to be run before installation
+  preBuild = ''
+    mkdir -p $out/
+    ln -sv $PWD/lib $out
+  '';
+
+  cmakeFlags = with stdenv; [
+    "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"
+    "-DLLVM_INSTALL_UTILS=ON"  # Needed by rustc
+    "-DLLVM_BUILD_TESTS=ON"
+    "-DLLVM_ENABLE_FFI=ON"
+    "-DLLVM_ENABLE_RTTI=ON"
+    "-DCOMPILER_RT_INCLUDE_TESTS=OFF" # FIXME: requires clang source code
+  ] ++ stdenv.lib.optional enableSharedLibraries [
+    "-DLLVM_LINK_LLVM_DYLIB=ON"
+  ] ++ stdenv.lib.optional (!isDarwin)
+    "-DLLVM_BINUTILS_INCDIR=${binutils.dev}/include"
+    ++ stdenv.lib.optionals (isDarwin) [
+    "-DLLVM_ENABLE_LIBCXX=ON"
+    "-DCAN_TARGET_i386=false"
+  ];
+
+  postBuild = ''
+    rm -fR $out
+
+    paxmark m bin/{lli,llvm-rtdyld}
+    paxmark m unittests/ExecutionEngine/MCJIT/MCJITTests
+    paxmark m unittests/ExecutionEngine/Orc/OrcJITTests
+    paxmark m unittests/Support/SupportTests
+    paxmark m bin/lli-child-target
+  '';
+
+  preCheck = ''
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
+  '';
+
+  postInstall = ""
+  + stdenv.lib.optionalString (enableSharedLibraries) ''
+    moveToOutput "lib/libLLVM-*" "$lib"
+    moveToOutput "lib/libLLVM.${shlib}" "$lib"
+    substituteInPlace "$out/lib/cmake/llvm/LLVMExports-release.cmake" \
+      --replace "\''${_IMPORT_PREFIX}/lib/libLLVM-" "$lib/lib/libLLVM-"
+  ''
+  + stdenv.lib.optionalString (stdenv.isDarwin && enableSharedLibraries) ''
+    substituteInPlace "$out/lib/cmake/llvm/LLVMExports-release.cmake" \
+      --replace "\''${_IMPORT_PREFIX}/lib/libLLVM.dylib" "$lib/lib/libLLVM.dylib"
+    install_name_tool -id $lib/lib/libLLVM.dylib $lib/lib/libLLVM.dylib
+    install_name_tool -change @rpath/libLLVM.dylib $lib/lib/libLLVM.dylib $out/bin/llvm-config
+    ln -s $lib/lib/libLLVM.dylib $lib/lib/libLLVM-${shortVersion}.dylib
+    ln -s $lib/lib/libLLVM.dylib $lib/lib/libLLVM-${release_version}.dylib
+  '';
+
+  doCheck = stdenv.isLinux;
+
+  checkTarget = "check-all";
+
+  enableParallelBuilding = true;
+
+  passthru.src = src;
+
+  meta = {
+    description = "Collection of modular and reusable compiler and toolchain technologies";
+    homepage    = http://llvm.org/;
+    license     = stdenv.lib.licenses.ncsa;
+    maintainers = with stdenv.lib.maintainers; [ lovek323 raskin viric dtzWill ];
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5192,6 +5192,7 @@ with pkgs;
     useMacosReexportHack = true;
   };
 
+  clang_5  = llvmPackages_5.clang;
   clang_4  = llvmPackages_4.clang;
   clang_39 = llvmPackages_39.clang;
   clang_38 = llvmPackages_38.clang;
@@ -5767,13 +5768,15 @@ with pkgs;
 
   lizardfs = callPackage ../tools/filesystems/lizardfs { };
 
-  lld = llvmPackages_4.lld;
+  lld = llvmPackages_5.lld;
 
   lldb = llvmPackages.lldb;
+  lldb_5 = llvmPackages_5.lldb;
   lldb_4 = llvmPackages_4.lldb;
 
   llvm = llvmPackages.llvm;
 
+  llvm_5  = llvmPackages_5.llvm;
   llvm_4  = llvmPackages_4.llvm;
   llvm_39 = llvmPackages_39.llvm;
   llvm_38 = llvmPackages_38.llvm;
@@ -5781,7 +5784,7 @@ with pkgs;
   llvm_35 = llvmPackages_35.llvm;
   llvm_34 = llvmPackages_34.llvm;
 
-  llvmPackages = recurseIntoAttrs llvmPackages_4;
+  llvmPackages = recurseIntoAttrs llvmPackages_5;
 
   llvmPackagesSelf = llvmPackages_34.override {
     stdenv = libcxxStdenv;
@@ -5811,6 +5814,14 @@ with pkgs;
     inherit (stdenvAdapters) overrideCC;
   } // stdenv.lib.optionalAttrs stdenv.isDarwin {
     cmake = cmake.override { isBootstrap = true; };
+    libxml2 = libxml2.override { pythonSupport = false; };
+    python2 = callPackage ../development/interpreters/python/cpython/2.7/boot.nix { inherit (darwin) CF configd; };
+  });
+
+  llvmPackages_5 = callPackage ../development/compilers/llvm/5 ({
+    inherit (stdenvAdapters) overrideCC;
+  } // stdenv.lib.optionalAttrs stdenv.isDarwin {
+    cmake = cmake.override { isBootstrap = true; useSharedLibraries = false; };
     libxml2 = libxml2.override { pythonSupport = false; };
     python2 = callPackage ../development/interpreters/python/cpython/2.7/boot.nix { inherit (darwin) CF configd; };
   });


### PR DESCRIPTION
###### Motivation for this change

LLVM 5.0 is coming out soon. From llvm.org, final release is August 23. This is rc2, we can test and see if everything works. I think we should be able to drop it in place instead of llvm 4, nothing really big changed.

I'm still waiting for it to build, will update this PR when status changes.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

