### PR TITLE
browserpass: 1.0.5 -> 1.0.6

### DIFF
--- a/pkgs/tools/security/browserpass/default.nix
+++ b/pkgs/tools/security/browserpass/default.nix
@@ -3,7 +3,7 @@
 
 buildGoPackage rec {
   name = "browserpass-${version}";
-  version = "1.0.5";
+  version = "1.0.6";
 
   goPackagePath = "github.com/dannyvankooten/browserpass";
 
@@ -11,7 +11,7 @@ buildGoPackage rec {
     repo = "browserpass";
     owner = "dannyvankooten";
     rev = version;
-    sha256 = "1r9x1asgblay7pry2jpgfisfgb3423x3cqd3g68q8b98zvc9l9lz";
+    sha256 = "07wkvwb9klzxnlrm9a07kxzj3skpy0lymc9ijr8ykfbz6l0bpbqy";
   };
 
   postInstall = ''
@@ -31,5 +31,6 @@ buildGoPackage rec {
     homepage = https://github.com/dannyvankooten/browserpass;
     license = licenses.mit;
     platforms = with platforms; linux ++ darwin ++ openbsd;
+    maintainers = with maintainers; [ rvolosatovs ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Upstream update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

