### PR TITLE
cc-wrapper: Empy array workaround for native stdenv

### DIFF
--- a/pkgs/build-support/cc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-wrapper.sh
@@ -121,7 +121,7 @@ if [ "$NIX_@infixSalt@_DONT_SET_RPATH" != 1 ]; then
     # It's important to add the rpath in the order of -L..., so
     # the link time chosen objects will be those of runtime linking.
     declare -A rpaths
-    for dir in "${libDirs[@]}"; do
+    for dir in ${libDirs+"${libDirs[@]}"}; do
         if [[ "$dir" =~ [/.][/.] ]] && dir2=$(readlink -f "$dir"); then
             dir="$dir2"
         fi


### PR DESCRIPTION
libDirs can be empty, which in combination with "set -u" of
9f1e009975dc2d58541de435c74a26afe011542a will cause a variable unbound
error on old bash versions. Fix in the same way by adding a temporary
set +u as in other places in this file


###### Motivation for this change

Found that the ld-wrapper script was failing when using native environment on Linux, e.g., ld -v fails so libtool autoconf does not reckognise the linker as GNU linker. Traced error to this problem. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

