### PR TITLE
Additional Nginx features

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, fetchFromGitHub, openssl, zlib, pcre, libxml2, libxslt, expat
 , gd, geoip
 , withStream ? false
+, withMail ? false
 , modules ? []
 , hardening ? true
 , version, sha256, ...
@@ -49,6 +50,10 @@ stdenv.mkDerivation {
     "--with-stream_realip_module"
     "--with-stream_ssl_module"
     "--with-stream_ssl_preread_module"
+  ] ++ optional withMail [
+    "--with-mail"
+    "--with-mail_ssl_module"
+  ]
     ++ optional (gd != null) "--with-http_image_filter_module"
     ++ optional (elem stdenv.system (with platforms; linux ++ freebsd)) "--with-file-aio"
     ++ map (mod: "--add-module=${mod.src}") modules;

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchFromGitHub, openssl, zlib, pcre, libxml2, libxslt, expat
 , gd, geoip
-, withStream ? false
+, withStream ? true
 , withMail ? false
 , modules ? []
 , hardening ? true

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation {
     "--with-http_secure_link_module"
     "--with-http_degradation_module"
     "--with-http_stub_status_module"
+    "--with-threads"
+    "--with-pcre-jit"
     # Install destination problems
     # "--with-http_perl_module"
   ] ++ optional withStream "--with-stream"

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation {
     "--with-http_secure_link_module"
     "--with-http_degradation_module"
     "--with-http_stub_status_module"
-    "--with-ipv6"
     # Install destination problems
     # "--with-http_perl_module"
   ] ++ optional withStream "--with-stream"

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -43,7 +43,12 @@ stdenv.mkDerivation {
     "--with-pcre-jit"
     # Install destination problems
     # "--with-http_perl_module"
-  ] ++ optional withStream "--with-stream"
+  ] ++ optional withStream [
+    "--with-stream"
+    "--with-stream_geoip_module"
+    "--with-stream_realip_module"
+    "--with-stream_ssl_module"
+    "--with-stream_ssl_preread_module"
     ++ optional (gd != null) "--with-http_image_filter_module"
     ++ optional (elem stdenv.system (with platforms; linux ++ freebsd)) "--with-file-aio"
     ++ map (mod: "--add-module=${mod.src}") modules;


### PR DESCRIPTION
###### Motivation for this change

Nginx can work as TCP and Mail reverser proxy too.

So far the package only supported activating streams (optional) and now way to enable mail functionality.

This PR does the following things:
- Add way to enable mail support (disabled by default)
- Enable additional functionality (TLS support, geoip, ...) when stream is enabled
- Enable TCP (stream) support by default
- Remove deprecated compile flags and add some new ones


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

