### PR TITLE
rstudio: fix build

### DIFF
--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -11,7 +11,6 @@ stdenv.mkDerivation rec {
   name = "RStudio-${version}";
 
   buildInputs = [ cmake boost163 zlib openssl R qt5.full qt5.qtwebkit libuuid unzip ant jdk makeWrapper pandoc ];
-  nativeBuildInputs = [ qt5.qmake ];
 
   src = fetchurl {
     url = "https://github.com/rstudio/rstudio/archive/v${version}.tar.gz";
@@ -91,7 +90,7 @@ stdenv.mkDerivation rec {
       cp ${pandoc}/bin/pandoc dependencies/common/pandoc/
     '';
 
-  cmakeFlags = [ "-DRSTUDIO_TARGET=Desktop" "-DQT_QMAKE_EXECUTABLE=${qt5.qmake}/bin/qmake" ];
+  cmakeFlags = [ "-DRSTUDIO_TARGET=Desktop" "-DQT_QMAKE_EXECUTABLE=$NIX_QT5_TMP/bin/qmake" ];
 
   desktopItem = makeDesktopItem {
     name = name;


### PR DESCRIPTION
###### Motivation for this change
Fixes #27600

This commit do the following:
1. removes `nativeBuildInputs = [ qt5.qmake ];`, which was added by @ttuegel . This change makes `rstudio` built again. Although I have no idea why removing `qt5.qmake` from `nativeBuildInputs` will fix the problem and I am not very sure if this is the correct fix (maybe this breaks cross compiling or something?).
2. change `${qt5.qmake}/bin/qmake"` to `$NIX_QT5_TMP/bin/qmake"`, since this is the correct path to find `qmake` binary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

