### PR TITLE
cups service: Automatically detect Gutenprint in drivers

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 
 with lib;
 
@@ -14,6 +14,10 @@ with lib;
     (mkRenamedOptionModule [ "networking" "enableRT73Firmware" ] [ "networking" "enableRalinkFirmware" ])
 
     (mkRenamedOptionModule [ "services" "cadvisor" "host" ] [ "services" "cadvisor" "listenAddress" ])
+    (mkChangedOptionModule [ "services" "printing" "gutenprint" ] [ "services" "printing" "drivers" ]
+      (config:
+        let enabled = getAttrFromPath [ "services" "printing" "gutenprint" ] config;
+        in if enabled then [ pkgs.gutenprint ] else [ ]))
     (mkRenamedOptionModule [ "services" "elasticsearch" "host" ] [ "services" "elasticsearch" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "graphite" "api" "host" ] [ "services" "graphite" "api" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "graphite" "web" "host" ] [ "services" "graphite" "web" "listenAddress" ])

--- a/pkgs/misc/drivers/gutenprint/default.nix
+++ b/pkgs/misc/drivers/gutenprint/default.nix
@@ -47,5 +47,6 @@ stdenv.mkDerivation rec {
     homepage = https://sourceforge.net/projects/gimp-print/;
     license = licenses.gpl2;
     platforms = platforms.linux;
+    isGutenprint = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

See #28273 or the commit message.

TODO:
- [x] Should we remove the old option or leave it there?
- [x] Mention this in the changelog?
  - Probably unnecessary since this change is backwards compatible and prints a warning

Advantages:
- Using a customized `gutenprint` derivation in `drivers` should be possible.
- Consistency (Gutenprint isn't an exception anymore).

Disadvantages:
- Adding a `gutenprint` derivation to `drivers` will cause automatic PPD updates (which isn't obvious from the description - This shouldn't be a problem though)
- Some people will have to change their config or they will get an annoying warning.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

