### PR TITLE
containers: automatically use user namespaces on supporting systems

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -123,7 +123,7 @@ let
       EXIT_ON_REBOOT=1 \
       exec ${config.systemd.package}/bin/systemd-nspawn \
         --keep-unit \
-        -M "$INSTANCE" -D "$root" $extraFlags \
+        -M "$INSTANCE" -D "$root" -U $extraFlags \
         $EXTRA_NSPAWN_FLAGS \
         --notify-ready=yes \
         --bind-ro=/nix/store \


### PR DESCRIPTION
On kernels that support user namespaces, `-U` enables their use. This is the default if `systemd-nspawn@.service` is used (which it isn't (yet) in `containers.nix`).

Basically, a 16-bit subset (that is not 0-65535) of the 32-bit UID and GID spaces is chosen and used as the hosts' UID and GID segments the container's UID and GID ranges map to. The container's directory will be `chown`ed recursively to ensure that this works.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

