### PR TITLE
et: init at 2017-03-04

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -212,6 +212,7 @@
   garrison = "Jim Garrison <jim@garrison.cc>";
   gavin = "Gavin Rogers <gavin@praxeology.co.uk>";
   gebner = "Gabriel Ebner <gebner@gebner.org>";
+  geistesk = "Alvar Penning <post@0x21.biz>";
   georgewhewell = "George Whewell <georgerw@gmail.com>";
   gilligan = "Tobias Pflug <tobias.pflug@gmail.com>";
   giogadi = "Luis G. Torres <lgtorres42@gmail.com>";

--- a/pkgs/applications/misc/et/default.nix
+++ b/pkgs/applications/misc/et/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, pkgconfig, libnotify, gdk_pixbuf }:
+
+stdenv.mkDerivation rec {
+  name = "et-${version}";
+  version = "2017-03-04";
+
+  src = fetchFromGitHub {
+    owner = "geistesk";
+    repo = "et";
+    rev = "151e9b6bc0d2d4f45bda8ced740ee99d0f2012f6";
+    sha256 = "1a1jdnzmal05k506bbvzlwsj2f3kql6l5xc1gdabm79y6vaf4r7s";
+  };
+
+  buildInputs = [ libnotify gdk_pixbuf ];
+  nativeBuildInputs = [ pkgconfig ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp et $out/bin
+    cp et-status.sh $out/bin/et-status
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Minimal libnotify-based (egg) timer for GNU/Linux";
+    homepage = https://github.com/geistesk/et;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ geistesk ];
+  };
+}

--- a/pkgs/applications/misc/et/default.nix
+++ b/pkgs/applications/misc/et/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, pkgconfig, libnotify, gdk_pixbuf }:
+
+stdenv.mkDerivation rec {
+  name = "et-${version}";
+  version = "2017-03-04";
+
+  src = fetchFromGitHub {
+    owner = "geistesk";
+    repo = "et";
+    rev = "151e9b6bc0d2d4f45bda8ced740ee99d0f2012f6";
+    sha256 = "1a1jdnzmal05k506bbvzlwsj2f3kql6l5xc1gdabm79y6vaf4r7s";
+  };
+
+  buildInputs = [ pkgconfig libnotify gdk_pixbuf ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp et $out/bin
+    cp et-status.sh $out/bin/et-status
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Minimal libnotify-based (egg) timer for GNU/Linux";
+    homepage = https://github.com/geistesk/et;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ geistesk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -999,6 +999,8 @@ with pkgs;
 
   ephemeralpg = callPackage ../applications/misc/ephemeralpg {};
 
+  et = callPackage ../applications/misc/et {};
+
   f3 = callPackage ../tools/filesystems/f3 { };
 
   facedetect = callPackage ../tools/graphics/facedetect { };


### PR DESCRIPTION
###### Motivation for this change
Adds the [et](https://github.com/geistesk/et)-software, which is a minimal libnotify-based (egg) timer for GNU/Linux.

###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

