### PR TITLE
awsebcli: init at 3.10.5

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -185,6 +185,7 @@
   ellis = "Ellis Whitehead <nixos@ellisw.net>";
   eperuffo = "Emanuele Peruffo <info@emanueleperuffo.com>";
   epitrochoid = "Mabry Cervin <mpcervin@uncg.edu>";
+  eqyiel = "Ruben Maher <r@rkm.id.au>";
   ericbmerritt = "Eric Merritt <eric@afiniate.com>";
   ericsagnes = "Eric Sagnes <eric.sagnes@gmail.com>";
   erikryb = "Erik Rybakken <erik.rybakken@math.ntnu.no>";

--- a/pkgs/development/python-modules/blessed/default.nix
+++ b/pkgs/development/python-modules/blessed/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi, six, wcwidth }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "blessed";
+  version = "1.14.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fv9f0074kxy1849h0kwwxw12sifpq3bv63pcz900zzjsigi4hi3";
+  };
+
+  propagatedBuildInputs = [ wcwidth six ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/jquast/blessed;
+    description = "A thin, practical wrapper around terminal capabilities in Python.";
+    maintainers = with maintainers; [ eqyiel ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/cement/default.nix
+++ b/pkgs/development/python-modules/cement/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "cement";
+  name = "${pname}-${version}";
+  version = "2.8.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1li2whjzfhbpg6fjb6r1r92fb3967p1xv6hqs3j787865h2ysrc7";
+  };
+
+  # Disable test tests since they depend on a memcached server running on
+  # 127.0.0.1:11211.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = http://builtoncement.com/;
+    description = "A CLI Application Framework for Python.";
+    maintainers = with maintainers; [ eqyiel ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -1,0 +1,99 @@
+ { stdenv, python }:
+let
+  inherit (localPythonPackageSet) pkgs;
+  inherit (pkgs) fetchPypi buildPythonApplication;
+
+  localPythonPackageSet = python.override {
+    packageOverrides = self: super: rec {
+      colorama = super.colorama.overridePythonAttrs (oldAttrs: rec {
+        version = "0.3.7";
+
+        src = fetchPypi {
+          inherit (oldAttrs) pname;
+          inherit version;
+          sha256 = "0avqkn6362v7k2kg3afb35g4sfdvixjgy890clip4q174p9whhz0";
+        };
+      });
+
+      docker = super.docker.overridePythonAttrs (oldAttrs: rec {
+          pname = "docker-py";
+          version = "1.7.2";
+          name = "${pname}-${version}";
+
+          src = fetchPypi {
+            inherit pname version;
+            sha256 = "0k6hm3vmqh1d3wr9rryyif5n4rzvcffdlb1k4jvzp7g4996d3ccm";
+          };
+        });
+
+      pathspec = super.pathspec.overridePythonAttrs (oldAttrs: rec {
+        version = "0.5.0";
+
+        src = fetchPypi {
+          inherit (oldAttrs) pname;
+          inherit version;
+          sha256 = "07yx1gxj9v1iyyiy5fhq2wsmh4qfbrx158wi7jb0nx6lah80ffma";
+        };
+      });
+
+      requests = super.requests.overridePythonAttrs (oldAttrs: rec {
+        version = "2.9.1";
+
+        src = fetchPypi {
+          inherit (oldAttrs) pname;
+          inherit version;
+          sha256 = "0zsqrzlybf25xscgi7ja4s48y2abf9wvjkn47wh984qgs1fq2xy5";
+        };
+      });
+
+      semantic-version = super.semantic-version.overridePythonAttrs (oldAttrs: rec {
+        version = "2.5.0";
+
+        src = fetchPypi {
+          inherit (oldAttrs) pname; inherit version;
+          sha256 = "0p5n3d6blgkncxdz00yxqav0cis87fisdkirjm0ljjh7rdfx7aiv";
+        };
+      });
+
+      tabulate = super.tabulate.overridePythonAttrs (oldAttrs: rec {
+        version = "0.7.5";
+
+        src = fetchPypi {
+          inherit (oldAttrs) pname;
+          inherit version;
+          sha256 = "03l1r7ddd1a0j2snv1yd0hlnghjad3fg1an1jr8936ksv75slwch";
+        };
+      });
+    };
+  };
+in buildPythonApplication rec {
+  name = "${pname}-${version}";
+  pname = "awsebcli";
+  version = "3.10.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1g53z2flhp3navdf8lw6rgh99akf3k0ng1zkkqswvh66zswkxnwn";
+  };
+
+  checkInputs = with localPythonPackageSet.pkgs; [
+    pytest mock nose pathspec colorama requests docutils
+  ];
+
+  propagatedBuildInputs = with localPythonPackageSet.pkgs; [
+    blessed botocore cement colorama docker dockerpty docopt pathspec pyyaml
+    requests semantic-version setuptools tabulate termcolor websocket_client
+  ];
+
+  postInstall = ''
+    mkdir -p $out/etc/bash_completion.d
+    mv $out/bin/eb_completion.bash $out/etc/bash_completion.d
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://aws.amazon.com/elasticbeanstalk/;
+    description = "A command line interface for Elastic Beanstalk.";
+    maintainers = with maintainers; [ eqyiel ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -509,6 +509,8 @@ with pkgs;
 
   awscli = pythonPackages.awscli; # Should be moved out of python-packages.nix
 
+  awsebcli = callPackage ../tools/virtualization/awsebcli {};
+
   awslogs = callPackage ../tools/admin/awslogs { };
 
   aws_shell = python2Packages.aws_shell; # Should be moved out of python-packages.nix

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20797,9 +20797,12 @@ in {
   };
 
   semantic-version = buildPythonPackage rec {
-    name = "semantic_version-2.4.2";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/s/semantic_version/${name}.tar.gz";
+    pname = "semantic_version";
+    version = "2.4.2";
+    name = "${pname}${version}";
+
+    src = self.fetchPypi {
+      inherit pname version;
       sha256 = "7e8b7fa74a3bc9b6e90b15b83b9bc2377c78eaeae3447516425f475d5d6932d2";
     };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1513,6 +1513,8 @@ in {
     };
   };
 
+  blessed = callPackage ../development/python-modules/blessed {};
+
   # Build boost for this specific Python version
   # TODO: use separate output for libboost_python.so
   boost = pkgs.boost.override {inherit python;};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1603,6 +1603,8 @@ in {
     };
   };
 
+  cement = callPackage ../development/python-modules/cement {};
+
   cgroup-utils = callPackage ../development/python-modules/cgroup-utils {};
     postPatch = ''
       substituteInPlace setup.py --replace "argparse" ""

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21586,10 +21586,11 @@ in {
 
   tabulate = buildPythonPackage rec {
     version = "0.7.7";
-    name = "tabulate-${version}";
+    pname = "tabulate";
+    name = "${pname}-${version}";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/t/tabulate/${name}.tar.gz";
+    src = fetchPypi {
+      inherit pname version;
       sha256 = "83a0b8e17c09f012090a50e1e97ae897300a72b35e0c86c0b53d3bd2ae86d8c6";
     };
 


### PR DESCRIPTION
###### Motivation for this change

I wanted to use `awsebcli` at work and it wasn't in `nixpkgs` yet.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Also:

- moved `colorama_3_7` from the awscli derivation into `python-packages` since both `awscli` and `awsebcli` depend on it.
- refactored some of the parent derivations that I needed to override in order to use `fetchPypi`, which AFAICT is preferred for python packages (https://github.com/NixOS/nixpkgs/pull/25202#discussion_r113117919, https://github.com/NixOS/nixpkgs/pull/26078).
- I tried to find what is the current best practice regarding versioning derivation names but it appears that although there is [a section in the manual](https://nixos.org/nixpkgs/manual/#sec-package-naming) about it there is a lot of bikeshedding still (https://github.com/NixOS/nixpkgs/issues/17625), so I just went with what I think is sensible based on the names of other derivations in `pythonPackages` (`package_V_V`).