### PR TITLE
openfst: init at 1.6.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -144,6 +144,7 @@
   desiderius = "Didier J. Devroye <didier@devroye.name>";
   devhell = "devhell <\"^\"@regexmail.net>";
   dezgeg = "Tuomas Tynkkynen <tuomas.tynkkynen@iki.fi>";
+  dfordivam = "Divam <dfordivam+nixpkgs@gmail.com>";
   dfoxfranke = "Daniel Fox Franke <dfoxfranke@gmail.com>";
   dgonyeo = "Derek Gonyeo <derek@gonyeo.com>";
   dipinhora = "Dipin Hora <dipinhora+github@gmail.com>";

--- a/pkgs/development/libraries/openfst/default.nix
+++ b/pkgs/development/libraries/openfst/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   pname = "openfst";
   version = "1.6.3";
 
-  src =fetchurl {
+  src = fetchurl {
     url = "http://www.openfst.org/twiki/pub/FST/FstDownload/${name}.tar.gz";
     sha256 = "5c28b6ccd017fc6ff94ebd0c73ed8ab37d48f563dab1c603856fb05bc9333d99";
   };
@@ -22,3 +22,4 @@ stdenv.mkDerivation rec {
     platforms = stdenv.lib.platforms.linux;
   };
 }
+

--- a/pkgs/development/libraries/openfst/default.nix
+++ b/pkgs/development/libraries/openfst/default.nix
@@ -22,3 +22,4 @@ stdenv.mkDerivation rec {
     platforms = stdenv.lib.platforms.linux;
   };
 }
+

--- a/pkgs/development/libraries/openfst/default.nix
+++ b/pkgs/development/libraries/openfst/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "openfst";
+  version = "1.6.3";
+
+  src =fetchurl {
+    url = "http://www.openfst.org/twiki/pub/FST/FstDownload/${name}.tar.gz";
+    sha256 = "5c28b6ccd017fc6ff94ebd0c73ed8ab37d48f563dab1c603856fb05bc9333d99";
+  };
+  meta = {
+    description = "Library for working with finite-state transducers";
+    longDescription = ''
+      Library for constructing, combining, optimizing, and searching weighted finite-state transducers (FSTs).
+      FSTs have key applications in speech recognition and synthesis, machine translation, optical character recognition,
+      pattern matching, string processing, machine learning, information extraction and retrieval among others
+    '';
+    homepage = http://www.openfst.org/twiki/bin/view/FST/WebHome;
+    license = stdenv.lib.licenses.asl20;
+    maintainers = [ stdenv.lib.maintainers.dfordivam ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/openfst/default.nix
+++ b/pkgs/development/libraries/openfst/default.nix
@@ -22,4 +22,3 @@ stdenv.mkDerivation rec {
     platforms = stdenv.lib.platforms.linux;
   };
 }
-

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19225,6 +19225,8 @@ with pkgs;
 
   xtermcontrol = callPackage ../applications/misc/xtermcontrol {};
 
+  openfst = callPackage ../development/libraries/openfst {};
+
   # `recurseIntoAttrs` for sake of hydra, not nix-env
   tests = recurseIntoAttrs {
     macOSSierraShared = callPackage ../test/macos-sierra-shared {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

