### PR TITLE
abiword: 3.0.1 -> 3.0.2

### DIFF
--- a/pkgs/applications/office/abiword/default.nix
+++ b/pkgs/applications/office/abiword/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchurl, pkgconfig, gtk3, libglade, libgnomecanvas, fribidi
+{ stdenv, fetchurl, fetchpatch, pkgconfig, gtk3, libglade, libgnomecanvas, fribidi
 , libpng, popt, libgsf, enchant, wv, librsvg, bzip2, libjpeg, perl
 , boost, libxslt, goffice, makeWrapper, iconTheme
 }:
 
 stdenv.mkDerivation rec {
   name = "abiword-${version}";
-  version = "3.0.1";
+  version = "3.0.2";
 
   src = fetchurl {
     url = "http://www.abisource.org/downloads/abiword/${version}/source/${name}.tar.gz";
-    sha256 = "1ik591rx15nn3n1297cwykl8wvrlgj78i528id9wbidgy3xzd570";
+    sha256 = "08imry821g81apdwym3gcs4nss0l9j5blqk31j5rv602zmcd9gxg";
   };
 
   enableParallelBuilding = true;
@@ -18,6 +18,14 @@ stdenv.mkDerivation rec {
     [ pkgconfig gtk3 libglade librsvg bzip2 libgnomecanvas fribidi libpng popt
       libgsf enchant wv libjpeg perl boost libxslt goffice makeWrapper iconTheme
     ];
+
+  patches = [
+    (fetchpatch {
+      name = "fix_gcc6_build";
+      url = "https://raw.githubusercontent.com/AbiWord/abiword-flatpak/33a7307aeca303509ed09d09ecc5330401ca4e88/patches/nullptr.patch";
+      sha256 = "05njg60966hyq34xi82kqbzsl5xhmiay38m5hkd1rlwh1nyvx2wx";
+    })
+  ];
 
   postFixup = ''
     wrapProgram "$out/bin/abiword" \


### PR DESCRIPTION
###### Motivation for this change
Update

Abiword did not build with GCC6, so I grabbed a patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Somebody needs to test this, it works fine for me but the document background flickers, which I blame on my setup.