### PR TITLE
Add Meson/ninja setup hooks

### DIFF
--- a/pkgs/applications/audio/i-score/default.nix
+++ b/pkgs/applications/audio/i-score/default.nix
@@ -67,10 +67,6 @@ stdenv.mkDerivation rec {
     export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH:$(echo "${jamomacore}/jamoma/share/cmake/Jamoma")"
   '';
 
-  preBuild = ''
-    ninja
-  '';
-
   installPhase = ''
     cmake --build . --target install
   '';

--- a/pkgs/applications/graphics/ao/default.nix
+++ b/pkgs/applications/graphics/ao/default.nix
@@ -18,7 +18,6 @@ stdenv.mkDerivation rec {
   };
 
   cmakeFlags = "-G Ninja";
-  buildPhase = "ninja";
   installPhase = ''
     ninja install
     cd ..

--- a/pkgs/applications/science/logic/lean2/default.nix
+++ b/pkgs/applications/science/logic/lean2/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     cd src
   '';
 
+  cmakeFlags = [ "-GNinja" ];
+
   postInstall = ''
     wrapProgram $out/bin/linja --prefix PATH : $out/bin:${ninja}/bin
   '';

--- a/pkgs/development/libraries/audio/jamomacore/default.nix
+++ b/pkgs/development/libraries/audio/jamomacore/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, alsaLib, portaudio, portmidi, libsndfile, cmake, libxml2,  ninja }:
+{ stdenv, fetchFromGitHub, pkgconfig, alsaLib, portaudio, portmidi, libsndfile, cmake, libxml2 }:
 
 stdenv.mkDerivation rec {
   version = "1.0-beta.1";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1hb9b6qc18rsvzvixgllknn756m6zwcn22c79rdibbyz1bhrcnln";
   };
 
-  buildInputs = [ pkgconfig alsaLib portaudio portmidi libsndfile cmake libxml2  ninja ];
+  buildInputs = [ pkgconfig alsaLib portaudio portmidi libsndfile cmake libxml2 ];
 
   meta = {
     description = "A C++ platform for building dynamic and reflexive systems with an emphasis on audio and media";

--- a/pkgs/development/libraries/libhttpseverywhere/default.nix
+++ b/pkgs/development/libraries/libhttpseverywhere/default.nix
@@ -15,18 +15,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ gnome3.vala valadoc  gobjectIntrospection meson ninja pkgconfig ];
   buildInputs = [ glib gnome3.libgee libxml2 json_glib libsoup libarchive ];
 
-  configurePhase = ''
-    mkdir build
-    cd build
-    meson --prefix "$out" ..
-  '';
-
-  buildPhase = ''
-    ninja
-   '';
-
-  installPhase = "ninja install";
-
   doCheck = true;
 
   checkPhase = "./httpseverywhere_test";

--- a/pkgs/development/libraries/qt-5/5.9/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtwebengine/default.nix
@@ -100,6 +100,10 @@ qtSubmodule {
     xlibs.libXcomposite
   ];
   patches = optional stdenv.needsPax ./qtwebengine-paxmark-mksnapshot.patch;
+
+  dontUseNinjaBuild = true;
+  dontUseNinjaInstall = true;
+
   postInstall = ''
     cat > $out/libexec/qt.conf <<EOF
     [Paths]

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -18,6 +18,8 @@ python3Packages.buildPythonApplication rec {
     popd
   '';
 
+  setupHook = ./setup-hook.sh;
+
   meta = with lib; {
     homepage = http://mesonbuild.com;
     description = "SCons-like build system that use python as a front-end language and Ninja as a building backend";

--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -1,0 +1,22 @@
+mesonConfigurePhase() {
+    runHook preConfigure
+
+    if [ -z "$dontAddPrefix" ]; then
+        mesonFlags="--prefix=$prefix $mesonFlags"
+    fi
+
+    # Build release by default.
+    mesonFlags="--buildtype=${mesonBuildType:-release} $mesonFlags"
+
+    echo "meson flags: $mesonFlags ${mesonFlagsArray[@]}"
+
+    meson build $mesonFlags "${mesonFlagsArray[@]}"
+    cd build
+
+    runHook postConfigure
+}
+
+if [ -z "$dontUseMesonConfigure" -a -z "$configurePhase" ]; then
+    setOutputFlags=
+    configurePhase=mesonConfigurePhase
+fi

--- a/pkgs/development/tools/build-managers/ninja/default.nix
+++ b/pkgs/development/tools/build-managers/ninja/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     cp doc/manual.html $out/share/doc/ninja/
   '';
 
+  setupHook = ./setup-hook.sh;
+
   meta = with stdenv.lib; {
     description = "Small build system with a focus on speed";
     longDescription = ''

--- a/pkgs/development/tools/build-managers/ninja/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/ninja/setup-hook.sh
@@ -1,0 +1,43 @@
+ninjaBuildPhase() {
+    runHook preBuild
+
+    if [[ -z "$ninjaFlags" && ! ( -e build.ninja ) ]]; then
+        echo "no build.ninja, doing nothing"
+    else
+        # shellcheck disable=SC2086
+        local flagsArray=( \
+            ${enableParallelBuilding:+-j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES}} \
+            $ninjaFlags "${ninjaFlagsArray[@]}" \
+            $buildFlags "${buildFlagsArray[@]}")
+
+        echoCmd 'build flags' "${flagsArray[@]}"
+        ninja "${flagsArray[@]}"
+        unset flagsArray
+    fi
+
+    runHook postBuild
+}
+
+if [ -z "$dontUseNinjaBuild" -a -z "$buildPhase" ]; then
+    buildPhase=ninjaBuildPhase
+fi
+
+ninjaInstallPhase() {
+    runHook preInstall
+
+    installTargets="${installTargets:-install}"
+
+    # shellcheck disable=SC2086
+    local flagsArray=( $installTargets \
+        $ninjaFlags "${ninjaFlagsArray[@]}")
+
+    echoCmd 'install flags' "${flagsArray[@]}"
+    ninja "${flagsArray[@]}"
+    unset flagsArray
+
+    runHook postInstall
+}
+
+if [ -z "$dontUseNinjaInstall" -a -z "$installPhase" ]; then
+    installPhase=ninjaInstallPhase
+fi

--- a/pkgs/development/tools/xcbuild/default.nix
+++ b/pkgs/development/tools/xcbuild/default.nix
@@ -50,6 +50,8 @@ in stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-Wno-error=strict-aliasing";
 
+  cmakeFlags = [ "-GNinja" ];
+
   buildInputs = [ cmake zlib libxml2 libpng ninja ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices CoreGraphics ImageIO ];
 

--- a/pkgs/tools/system/illum/default.nix
+++ b/pkgs/tools/system/illum/default.nix
@@ -17,10 +17,6 @@ stdenv.mkDerivation rec {
     bash ./configure
   '';
 
-  buildPhase = ''
-    ninja
-  '';
-
   installPhase = ''
     mkdir -p $out/bin
     mv illum-d $out/bin


### PR DESCRIPTION
###### Motivation for this change

Lots of packages have been switching to Meson recently. The setup hooks should make updating these packages easier and prevent duplication in configure/build/install scripts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

