### PR TITLE
cc-wrapper: Newstyle setup vars

### DIFF
--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -139,7 +139,7 @@ export ${role}CC=@named_cc@
 export ${role}CXX=@named_cxx@
 
 for cmd in \
-    ar as nm objcopy ranlib strip strings size ld windres
+    ar as ld nm objcopy objdump readelf ranlib strip strings size windres
 do
     if
         PATH=$_PATH type -p "@targetPrefix@${cmd}" > /dev/null

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -97,10 +97,12 @@ ccWrapper_addCVars () {
 # setup-hook, which `role` tracks.
 if [ -n "${crossConfig:-}" ]; then
     export NIX_CC_WRAPPER_@infixSalt@_TARGET_BUILD=1
-    role="BUILD_"
+    role_pre='BUILD_'
+    role_post='_FOR_BUILD'
 else
     export NIX_CC_WRAPPER_@infixSalt@_TARGET_HOST=1
-    role=""
+    role_pre=''
+    role_post=''
 fi
 
 # Eventually the exact sort of env-hook we create will depend on the role. This
@@ -133,10 +135,12 @@ fi
 
 # Export tool environment variables so various build systems use the right ones.
 
-export NIX_${role}CC=@out@
+export NIX_${role_pre}CC=@out@
 
-export ${role}CC=@named_cc@
-export ${role}CXX=@named_cxx@
+export ${role_pre}CC=@named_cc@
+export ${role_pre}CXX=@named_cxx@
+export CC${role_post}=@named_cc@
+export CXX${role_post}=@named_cxx@
 
 for cmd in \
     ar as ld nm objcopy objdump readelf ranlib strip strings size windres
@@ -144,9 +148,11 @@ do
     if
         PATH=$_PATH type -p "@targetPrefix@${cmd}" > /dev/null
     then
-        export "${role}$(echo "$cmd" | tr "[:lower:]" "[:upper:]")=@targetPrefix@${cmd}";
+        upper_case="$(echo "$cmd" | tr "[:lower:]" "[:upper:]")"
+        export "${role_pre}${upper_case}=@targetPrefix@${cmd}";
+        export "${upper_case}${role_post}=@targetPrefix@${cmd}";
     fi
 done
 
 # No local scope in sourced file
-unset -v role cmd
+unset -v role_pre role_post cmd upper_case

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -138,15 +138,15 @@ export NIX_${role}CC=@out@
 export ${role}CC=@named_cc@
 export ${role}CXX=@named_cxx@
 
-for CMD in \
+for cmd in \
     ar as nm objcopy ranlib strip strings size ld windres
 do
     if
-        PATH=$_PATH type -p "@targetPrefix@$CMD" > /dev/null
+        PATH=$_PATH type -p "@targetPrefix@${cmd}" > /dev/null
     then
-        export "${role}$(echo "$CMD" | tr "[:lower:]" "[:upper:]")=@targetPrefix@${CMD}";
+        export "${role}$(echo "$cmd" | tr "[:lower:]" "[:upper:]")=@targetPrefix@${cmd}";
     fi
 done
 
 # No local scope in sourced file
-unset role
+unset -v role cmd


### PR DESCRIPTION
###### Motivation for this change

I suspect this change might be needed for building GCC. I incorporated this into https://github.com/NixOS/nixpkgs/pull/26805, tested https://hydra.nixos.org/jobset/nixpkgs/ericson2314-cross-trunk per https://github.com/NixOS/nixpkgs/pull/30882 this is needed, and in https://github.com/NixOS/nixpkgs/pull/30882#issuecomment-346022433 @dezgeg agrees we should be doing this across the board for cross.

Also threw in cleaning up the `CMD` env var, which @edolstra mentioned once, and two missing env vars for more binutils tools.

###### Things done

It's all these changes have been tested tested as part of various PRs. I started a stdenv build of this PR in particular as quick smoke check.

-  [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

