### PR TITLE
sha1collisiondetection: 1.0.1 -> 1.0.3

### DIFF
--- a/pkgs/tools/security/sha1collisiondetection/default.nix
+++ b/pkgs/tools/security/sha1collisiondetection/default.nix
@@ -1,15 +1,14 @@
 { stdenv, fetchFromGitHub, libtool, which }:
 
 stdenv.mkDerivation  rec {
-  pname = "sha1collisiondetection";
-  version = "1.0.1";
-  name = "${pname}-${version}";
+  name = "sha1collisiondetection-${version}";
+  version = "1.0.3";
 
   src = fetchFromGitHub {
     owner = "cr-marcstevens";
-    repo = pname;
-    rev = "development-v${version}";
-    sha256 = "09vd5mgclcdx7yq3kwzxy1z7pbxcp0xljfly7hy4ixahmnn290h6";
+    repo = "sha1collisiondetection";
+    rev = "stable-v${version}";
+    sha256 = "0xn31hkkqs0kj9203rzx6w4nr0lq8fnrlm5i76g0px3q4v2dzw1s";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

