### PR TITLE
Version bumps: tcpdump, valgrind, qjson, rmlint, rawdog

### DIFF
--- a/pkgs/applications/networking/feedreaders/rawdog/default.nix
+++ b/pkgs/applications/networking/feedreaders/rawdog/default.nix
@@ -2,11 +2,11 @@
 
 python2Packages.buildPythonApplication rec {
   name = "rawdog-${version}";
-  version = "2.21";
+  version = "2.22";
 
   src = fetchurl {
-    url = "http://offog.org/files/${name}.tar.gz";
-    sha256 = "0f5z7b70pyhjl6s28hgxninsr86s4dj5ycd50sv6bfz4hm1c2030";
+    url = "https://offog.org/files/${name}.tar.gz";
+    sha256 = "01ircwl80xi5lamamsb22i7vmsh2ysq3chn9mbsdhqic2i32hcz0";
   };
 
   propagatedBuildInputs = with python2Packages; [ feedparser ];
@@ -14,7 +14,7 @@ python2Packages.buildPythonApplication rec {
   namePrefix = "";
 
   meta = with stdenv.lib; {
-    homepage = http://offog.org/code/rawdog/;
+    homepage = https://offog.org/code/rawdog/;
     description = "RSS Aggregator Without Delusions Of Grandeur";
     license = licenses.gpl2;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/qjson/default.nix
+++ b/pkgs/development/libraries/qjson/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, qt4 }:
 
 stdenv.mkDerivation rec {
-  version = "0.8.1";
+  version = "0.9.0";
   name = "qjson-${version}";
 
   src = fetchFromGitHub {
     owner = "flavio";
     repo = "qjson";
     rev = "${version}";
-    sha256 = "1rb3ydrhyd4bczqzfv0kqpi2mx4hlpq1k8jvnwpcmvyaypqpqg59";
+    sha256 = "1f4wnxzx0qdmxzc7hqk28m0sva7z9p9xmxm6aifvjlp0ha6pmfxs";
   };
 
   buildInputs = [ cmake qt4 ];

--- a/pkgs/development/tools/analysis/valgrind/default.nix
+++ b/pkgs/development/tools/analysis/valgrind/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, fetchpatch, perl, gdb, llvm, cctools, xnu, bootstrap_cmds }:
 
 stdenv.mkDerivation rec {
-  name = "valgrind-3.12.0";
+  name = "valgrind-3.13.0";
 
   src = fetchurl {
-    url = "http://valgrind.org/downloads/${name}.tar.bz2";
-    sha256 = "18bnrw9b1d55wi1wnl68n25achsp9w48n51n1xw4fwjjnaal7jk7";
+    url = "https://sourceware.org/pub/valgrind/${name}.tar.bz2";
+    sha256 = "0fqc3684grrbxwsic1rc5ryxzxmigzjx9p5vf3lxa37h0gpq0rnp";
   };
 
   outputs = [ "out" "dev" "man" "doc" ];

--- a/pkgs/tools/misc/rmlint/default.nix
+++ b/pkgs/tools/misc/rmlint/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, fetchurl
-, gettext, glib, json_glib, libelf, pkgconfig, scons, sphinx, utillinux }:
+{ stdenv, fetchFromGitHub,
+  gettext, glib, json_glib, libelf, pkgconfig, scons, sphinx, utillinux }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "rmlint-${version}";
-  version = "2.4.4";
+  version = "2.6.1";
 
-  src = fetchurl {
-    url = "https://github.com/sahib/rmlint/archive/v${version}.tar.gz";
-    sha256 = "1g38wmf58m9lbdngfsbz3dbkd44yqxppzvgi5mwag0w7r7khhir9";
+  src = fetchFromGitHub {
+    owner = "sahib";
+    repo = "rmlint";
+    rev = "v${version}";
+    sha256 = "1j09qk3zypw4my713q9g36kq37ggqd5v9vrs3h821p6p3qmmkdn8";
   };
 
   configurePhase = "scons config";
@@ -21,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Extremely fast tool to remove duplicates and other lint from your filesystem";
-    homepage = http://rmlint.readthedocs.org;
+    homepage = https://rmlint.readthedocs.org;
     platforms = platforms.linux;
     license = licenses.gpl3;
     maintainers = [ maintainers.koral ];

--- a/pkgs/tools/networking/tcpdump/default.nix
+++ b/pkgs/tools/networking/tcpdump/default.nix
@@ -1,15 +1,16 @@
-{ stdenv, fetchurl, libpcap, enableStatic ? false
+{ stdenv, fetchFromGitHub, libpcap, enableStatic ? false
 , hostPlatform
 }:
 
 stdenv.mkDerivation rec {
   name = "tcpdump-${version}";
-  version = "4.9.0";
+  version = "4.9.1";
 
-  src = fetchurl {
-    #url = "http://www.tcpdump.org/release/${name}.tar.gz";
-    url = "mirror://debian/pool/main/t/tcpdump/tcpdump_${version}.orig.tar.gz";
-    sha256 = "0pjsxsy8l71i813sa934cwf1ryp9xbr7nxwsvnzavjdirchq3sga";
+  src = fetchFromGitHub rec {
+    owner = "the-tcpdump-group";
+    repo = "tcpdump";
+    rev = "${repo}-${version}";
+    sha256 = "1vzrvn1q7x28h18yskqc390y357pzpg5xd3pzzj4xz3llnvsr64p";
   };
 
   buildInputs = [ libpcap ];


### PR DESCRIPTION
###### Things done
tcpdump: 4.9.0 -> 4.9.1
valgrind: 3.12.0 -> 3.13.0
qjson: 0.8.1 -> 0.9.0
rmlint: 2.4.4 -> 2.6.1
rawdog: 2.21 -> 2.22

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

