### PR TITLE
zanshin: 0.3.1 -> 0.4.1

### DIFF
--- a/pkgs/applications/office/zanshin/default.nix
+++ b/pkgs/applications/office/zanshin/default.nix
@@ -1,21 +1,45 @@
-{ stdenv, fetchurl, automoc4, cmake, perl, pkgconfig
-, kdelibs4, kdepimlibs, boost, baloo }:
+{
+  stdenv,
+  fetchurl, fetchpatch,
+  extra-cmake-modules,
+  qtbase, boost,
+  akonadi-calendar, akonadi-notes, akonadi-search, kidentitymanagement, kontactinterface, kldap,
+  krunner, kwallet
+}:
 
 stdenv.mkDerivation rec {
-  name = "zanshin-0.3.1";
+  pname = "zanshin";
+  version = "0.4.1";
+  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "http://files.kde.org/zanshin/${name}.tar.bz2";
-    sha256 = "1ck2ncz8i816d6d1gcsdrh6agd2zri24swgz3bhn8vzbk4215yzl";
+    url = "https://files.kde.org/${pname}/${name}.tar.bz2";
+    sha256 = "1llqm4w4mhmdirgrmbgwrpqyn47phwggjdghf164k3qw0bi806as";
   };
 
-  nativeBuildInputs = [ automoc4 cmake perl pkgconfig ];
+  patches = [
+    (fetchpatch {
+      name = "zanshin-fix-qt59-build.patch";
+      url = "https://phabricator.kde.org/R4:77ad64872f69ad9f7abe3aa8e103a12b95e100a4?diff=1";
+      sha256 = "0p497gqd3jmhbmqzh46zp6zwf6j1q77a9jp0in49xhgc2kj5ar7x";
+    })
+  ];
 
-  buildInputs = [ kdelibs4 kdepimlibs boost baloo ];
+  nativeBuildInputs = [
+    extra-cmake-modules
+  ];
 
-  meta = {
-    description = "GTD for KDE";
-    maintainers = [ ];
-    inherit (kdelibs4.meta) platforms;
+  buildInputs = [
+    qtbase boost
+    akonadi-calendar akonadi-notes akonadi-search kidentitymanagement kontactinterface kldap
+    krunner kwallet
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A powerful yet simple application to manage your day to day actions, getting your mind like water";
+    homepage = https://zanshin.kde.org/;
+    maintainers = with maintainers; [ zraexy ];
+    platforms = platforms.linux;
+    license = licenses.gpl2Plus;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17000,7 +17000,10 @@ with pkgs;
 
   zam-plugins = callPackage ../applications/audio/zam-plugins { };
 
-  zanshin = kde4.callPackage ../applications/office/zanshin { };
+  zanshin = libsForQt5.callPackage ../applications/office/zanshin {
+    inherit (kdeApplications) akonadi-calendar akonadi-notes akonadi-search kidentitymanagement kontactinterface kldap;
+    inherit (kdeFrameworks) krunner kwallet;
+  };
 
   zathura = callPackage ../applications/misc/zathura {
     useMupdf = config.zathura.useMupdf or true;


### PR DESCRIPTION
###### Motivation for this change

Update zanshin to 0.4.1 which uses QT5/KF5
Resolves #22964

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

