### PR TITLE
naev: add freetype dependency

### DIFF
--- a/pkgs/games/naev/default.nix
+++ b/pkgs/games/naev/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, SDL, openal, SDL_mixer, libxml2, pkgconfig, libvorbis
-, libpng, mesa, makeWrapper, zlib }:
+, libpng, mesa, makeWrapper, zlib, freetype }:
 
 let
   pname = "naev";
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
     sha256 = "0gahi91lmpra0wvxsz49zwwb28q9w2v1s3y7r70252hq6v80kanb";
   };
 
-  buildInputs = [ SDL SDL_mixer openal libxml2 libvorbis libpng mesa zlib ];
+  buildInputs = [ SDL SDL_mixer openal libxml2 libvorbis libpng mesa zlib freetype ];
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];
 


### PR DESCRIPTION
###### Motivation for this change
`naev` breaks without that change.

###### Things done

added `freetype` as a buildInput.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

