### PR TITLE
hdfview: init at 2.14

### DIFF
--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -55,6 +55,7 @@ stdenv.mkDerivation rec {
       applications to evolve in their use of HDF5. The HDF5 Technology suite includes tools and 
       applications for managing, manipulating, viewing, and analyzing data in the HDF5 format.
     '';
+    license = stdenv.lib.licenses.free; # BSD-like
     homepage = https://www.hdfgroup.org/HDF5/;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/tools/misc/hdfjava/default.nix
+++ b/pkgs/tools/misc/hdfjava/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, cmake, javac }:
+
+stdenv.mkDerivation rec {
+  name = "hdf-java-${version}";
+  version = "3.3.2";
+
+  src = fetchurl {
+    url = "http://www.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/hdfjni-${version}/src/CMake-hdfjava-${version}.tar.gz";
+    sha256 = "0m1gp2aspcblqzmpqbdpfp6giskws85ds6p5gz8sx7asyp7wznpr";
+  };
+
+  nativeBuildInputs = [ cmake javac ];
+
+  configurePhase = "true";
+  buildPhase = "./build-hdfjava-unix.sh";
+  installPhase = ''
+    mkdir -p $out
+    cp -r build/_CPack_Packages/Linux/TGZ/HDFJava-3.3.2-Linux/HDF_Group/HDFJava/${version}/* $out/
+  '';
+
+  meta = {
+    description = "A Java package that implements HDF4 and HDF5 data objects in an object-oriented form";
+    license = stdenv.lib.licenses.free; # BSD-like
+    homepage = https://support.hdfgroup.org/products/java/index.html;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/misc/hdfview/default.nix
+++ b/pkgs/tools/misc/hdfview/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, cmake, ant, javac, hdf_java }:
+
+stdenv.mkDerivation rec {
+  name = "hdfview-${version}";
+  version = "2.14";
+
+  src = fetchurl {
+    url = "http://support.hdfgroup.org/ftp/HDF5/hdf-java/current/src/${name}-${version}.tar.gz";
+    sha256 = "0lv9djfm7hnp14mcyzbiax3xjb8vkbzhh7bdl6cvgy53pc08784p";
+  };
+
+  nativeBuildInputs = [ ant javac ];
+
+  HDFLIBS = hdf_java;
+
+  buildPhase = ''
+    ant run
+    ant package
+  '';
+
+  installPhase = ''
+    mkdir $out
+    # exclude jre
+    cp -r build/HDF_Group/HDFView/*/{lib,share} $out/
+    mkdir $out/bin
+    cp -r build/HDF_Group/HDFView/*/hdfview.sh $out/bin/hdfview
+    chmod +x $out/bin/hdfview
+    substituteInPlace $out/bin/hdfview \
+      --replace "@JAVABIN@" "${javac}/bin/" \
+      --replace "@INSTALLDIR@" "$out"
+  '';
+
+  meta = {
+    description = "A visual tool for browsing and editing HDF4 and HDF5 files";
+    license = stdenv.lib.licenses.free; # BSD-like
+    homepage = https://support.hdfgroup.org/products/java/index.html;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/misc/hdfview/default.nix
+++ b/pkgs/tools/misc/hdfview/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2.14";
 
   src = fetchurl {
-    url = "http://support.hdfgroup.org/ftp/HDF5/hdf-java/current/src/${name}-${version}.tar.gz";
+    url = "http://support.hdfgroup.org/ftp/HDF5/hdf-java/current/src/${name}.tar.gz";
     sha256 = "0lv9djfm7hnp14mcyzbiax3xjb8vkbzhh7bdl6cvgy53pc08784p";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2464,6 +2464,14 @@ with pkgs;
     inherit gfortran;
   });
 
+  hdfview = callPackage ../tools/misc/hdfview {
+    javac = jdk;
+  };
+
+  hdf_java = callPackage ../tools/misc/hdfjava {
+    javac = jdk;
+  };
+
   hecate = callPackage ../applications/editors/hecate { };
 
   heaptrack = libsForQt5.callPackage ../development/tools/profiling/heaptrack {};


### PR DESCRIPTION
hdf_java: init at 3.3.2

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

