### PR TITLE
zcash: 1.0.8 -> 1.0.11

### DIFF
--- a/pkgs/applications/altcoins/zcash/default.nix
+++ b/pkgs/applications/altcoins/zcash/default.nix
@@ -1,27 +1,27 @@
 { stdenv, libsodium, fetchFromGitHub, wget, pkgconfig, autoreconfHook, openssl, db62, boost
-, zlib, gtest, gmock, miniupnpc, callPackage, gmp, qt4, utillinux, protobuf, qrencode, libevent
+, zlib, gtest, gmock, callPackage, gmp, qt4, utillinux, protobuf, qrencode, libevent
 , withGui }:
 
 let libsnark     = callPackage ./libsnark { inherit boost openssl; };
     librustzcash = callPackage ./librustzcash {};
 in
 with stdenv.lib;
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
 
   name = "zcash" + (toString (optional (!withGui) "d")) + "-" + version;
-  version = "1.0.8";
+  version = "1.0.11";
 
   src = fetchFromGitHub {
     owner = "zcash";
     repo  = "zcash";
-    rev = "f630519d865ce22a6cf72a29785f2a876902f8e1";
-    sha256 = "1zjxg3dp0amjfs67469yp9b223v9hx29lkxid9wz2ivxj3paq7bv";
+    rev = "v${version}";
+    sha256 = "09474jdhsg30maqrwfxigbw3llqi8axhh82lz3a23ii2gj68ni55";
   };
 
   enableParallelBuilding = true;
 
   buildInputs = [ pkgconfig gtest gmock gmp libsnark autoreconfHook openssl wget db62 boost zlib
-                  miniupnpc protobuf libevent libsodium librustzcash ]
+                  protobuf libevent libsodium librustzcash ]
                   ++ optionals stdenv.isLinux [ utillinux ]
                   ++ optionals withGui [ qt4 qrencode ];
 


### PR DESCRIPTION
###### Motivation for this change

Updated to latest version. Note that upnp support has been removed upstream, so I've removed the miniupnpc dependency.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

