### PR TITLE
Nix minimal version: 1.10 -> 1.11

### DIFF
--- a/lib/minver.nix
+++ b/lib/minver.nix
@@ -1,2 +1,2 @@
 # Expose the minimum required version for evaluating Nixpkgs
-"1.10"
+"1.11"


### PR DESCRIPTION
`ruby` attribute requires features from 1.11
```
$ nix-build -A ruby
error: cannot coerce a set to a string, at pkgs/development/interpreters/ruby/default.nix:57:17
```

Closes https://github.com/NixOS/nixpkgs/pull/28083
Also should be backported to 17.03.