### PR TITLE
(rustc, cargo): (1.17.0, 0.18.0) -> (1.19.0, 0.20.0)

### DIFF
--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -13,16 +13,16 @@ let
     else throw "missing bootstrap url for platform ${stdenv.system}";
 
   # fetch hashes by patching print-hashes.sh to not use the "$DATE" variable
-  # then running `print-hashes.sh 1.16.0`
+  # then running `print-hashes.sh 1.18.0`
   bootstrapHash =
     if stdenv.system == "i686-linux"
-    then "b5859161ebb182d3b75fa14a5741e5de87b088146fb0ef4a30f3b2439c6179c5"
+    then "821ced1bd5a8e89322f20c3565ef50a3708faca047d21686d4a2139f6dc0b1d6"
     else if stdenv.system == "x86_64-linux"
-    then "48621912c242753ba37cad5145df375eeba41c81079df46f93ffb4896542e8fd"
+    then "abdc9f37870c979dd241ba8c7c06d8bb99696292c462ed852c0af7f988bb5887"
     else if stdenv.system == "i686-darwin"
-    then "26356b14164354725bd0351e8084f9b164abab134fb05cddb7758af35aad2065"
+    then "977aaad697a995e28c6d9511fd8301d236da48978f8f3b938d8f22f105e4bf2f"
     else if stdenv.system == "x86_64-darwin"
-    then "2d08259ee038d3a2c77a93f1a31fc59e7a1d6d1bbfcba3dba3c8213b2e5d1926"
+    then "30f210e3133121812d74995a2831cfb3fe79c271b3cb1721815943bd4f7eb297"
     else throw "missing bootstrap hash for platform ${stdenv.system}";
 
   src = fetchurl {
@@ -32,7 +32,7 @@ let
 
   # Note: the version  MUST be one version prior to the version we're
   # building
-  version = "1.16.0";
+  version = "1.18.0";
 in import ./binaryBuild.nix
   { inherit stdenv fetchurl makeWrapper cacert zlib curl;
     buildRustPackage = null;

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -6,7 +6,7 @@
 
 let
   rustPlatform = recurseIntoAttrs (makeRustPlatform (callPackage ./bootstrap.nix {}));
-  version = "1.17.0";
+  version = "1.19.0";
 in
 rec {
   rustc = callPackage ./rustc.nix {
@@ -16,7 +16,7 @@ rec {
 
     src = fetchurl {
       url = "https://static.rust-lang.org/dist/rustc-${version}-src.tar.gz";
-      sha256 = "4baba3895b75f2492df6ce5a28a916307ecd1c088dc1fd02dbfa8a8e86174f87";
+      sha256 = "15231f5053fb72ad82be91f5abfd6aa60cb7898c5089e4f1ac5910a731090c51";
     };
 
     patches = [
@@ -26,10 +26,10 @@ rec {
   };
 
   cargo = callPackage ./cargo.nix rec {
-    version = "0.18.0";
-    srcRev = "fe7b0cdcf5ca7aab81630706ce40b70f6aa2e666";
-    srcSha = "164iywv1l3v87b0pznf5kkzxigd6w19myv9d7ka4c65zgrk9n9px";
-    depsSha256 = "1mrgd8ib48vxxbhkvsqqq4p19sc6b74x3cd8p6lhhlm6plrajrvm";
+    version = "0.20.0";
+    srcRev = "a60d185c878c470876e123b0e40b0ba9f3271163";
+    srcSha = "0j6i2ak1zlwfhz0d1hsrzislgvajdqc8kdfdn242lim9dar81swp";
+    depsSha256 = "1n42mcgwx5pxzgy2xzimrap3gjy90a8q7bb65k5pw8z3jrss91ck";
 
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -54,6 +54,8 @@ stdenv.mkDerivation {
                 ++ optional (targets != []) "--target=${target}"
                 ++ optional (!forceBundledLLVM) "--llvm-root=${llvmShared}";
 
+  dontFixLibtool = true;
+
   patches = patches ++ targetPatches;
 
   passthru.target = target;


### PR DESCRIPTION
###### Motivation for this change
Update Rust and Cargo to up-to-date versions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

