### PR TITLE
canto-{daemon,curses}: 0.9.6,0.9.7 -> 0.9.7,0.9.9

### DIFF
--- a/pkgs/applications/networking/feedreaders/canto-curses/default.nix
+++ b/pkgs/applications/networking/feedreaders/canto-curses/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, python34Packages, readline, ncurses, canto-daemon }:
 
 python34Packages.buildPythonApplication rec {
-  version = "0.9.7";
+  version = "0.9.9";
   name = "canto-curses-${version}";
 
   src = fetchFromGitHub {
     owner = "themoken";
     repo = "canto-curses";
     rev = "v${version}";
-    sha256 = "0ap1b4m5gbzi0l7vj6pwvvg77i2aarbynbdc147z2b1lzvr985zq";
+    sha256 = "1vzb9n1j4gxigzll6654ln79lzbrrm6yy0lyazd9kldyl349b8sr";
   };
 
   buildInputs = [ readline ncurses canto-daemon ];

--- a/pkgs/applications/networking/feedreaders/canto-daemon/default.nix
+++ b/pkgs/applications/networking/feedreaders/canto-daemon/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python34Packages, }:
 
 python34Packages.buildPythonApplication rec {
-  version = "0.9.6";
+  version = "0.9.7";
   name = "canto-daemon-${version}";
   namePrefix = "";
 
@@ -9,7 +9,7 @@ python34Packages.buildPythonApplication rec {
     owner = "themoken";
     repo = "canto-next";
     rev = "v${version}";
-    sha256 = "0ibakwmsbpk10bvxsr5vvka0pks89arric428y5cmfgcpr72sqzw";
+    sha256 = "1si53r8cd4avfc56r315zyrghkppnjd6n125z1agfv59i7hdmk3n";
   };
 
   propagatedBuildInputs = with python34Packages; [ feedparser ];


### PR DESCRIPTION
Upstream changelog available at:
https://codezen.org/canto-ng/news/

###### Motivation for this change
Update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

