### PR TITLE
Reloadable containers

### DIFF
--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -147,10 +147,15 @@ my $activePrev = getActiveUnits;
 while (my ($unit, $state) = each %{$activePrev}) {
     my $baseUnit = $unit;
 
-    # Recognise template instances.
-    $baseUnit = "$1\@.$2" if $unit =~ /^(.*)@[^\.]*\.(.*)$/;
     my $prevUnitFile = "/etc/systemd/system/$baseUnit";
     my $newUnitFile = "$out/etc/systemd/system/$baseUnit";
+
+    # Detect template instances.
+    if (!-e $prevUnitFile && !-e $newUnitFile && $unit =~ /^(.*)@[^\.]*\.(.*)$/) {
+      $baseUnit = "$1\@.$2";
+      $prevUnitFile = "/etc/systemd/system/$baseUnit";
+      $newUnitFile = "$out/etc/systemd/system/$baseUnit";
+    }
 
     my $baseName = $baseUnit;
     $baseName =~ s/\.[a-z]*$//;

--- a/nixos/tests/containers-reloadable.nix
+++ b/nixos/tests/containers-reloadable.nix
@@ -1,0 +1,66 @@
+import ./make-test.nix ({ pkgs, lib, ...} :
+let
+  client_base = rec {
+    
+    containers.test1 = {
+      autoStart = true;
+      config = {
+        environment.etc."check".text = "client_base";
+      };
+    };
+
+    # prevent make-test.nix to change IP
+    networking.interfaces = {
+      eth1.ip4 = lib.mkOverride 0 [ ];
+    };
+  };
+in {
+  name = "cotnainers-reloadable";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ danbst ];
+  };
+
+  nodes = {
+    client = { lib, pkgs, ... }: {
+      imports = [ client_base ];
+    };
+
+    client_c1 = { lib, pkgs, ... }: {
+      imports = [ client_base ];
+
+      containers.test1.config = {
+        environment.etc."check".text = lib.mkForce "client_c1";
+        services.httpd.enable = true;
+        services.httpd.adminAddr = "nixos@example.com";
+      };
+    };
+    client_c2 = { lib, pkgs, ... }: {
+      imports = [ client_base ];
+
+      containers.test1.config = {
+        environment.etc."check".text = lib.mkForce "client_c2";
+        services.nginx.enable = true;
+      };
+    };
+  };
+
+  testScript = {nodes, ...}: let
+    originalSystem = nodes.client.config.system.build.toplevel;
+    c1System = nodes.client_c1.config.system.build.toplevel;
+    c2System = nodes.client_c2.config.system.build.toplevel;
+  in ''
+    $client->start();
+    $client->waitForUnit("default.target");
+    $client->succeed("[[ \$(nixos-container run test1 cat /etc/check) == client_base ]] >&2");
+
+    $client->succeed("${c1System}/bin/switch-to-configuration test >&2");
+    $client->succeed("[[ \$(nixos-container run test1 cat /etc/check) == client_c1 ]] >&2");
+    $client->succeed("systemctl status httpd -M test1 >&2");
+
+    $client->succeed("${c2System}/bin/switch-to-configuration test >&2");
+    $client->succeed("[[ \$(nixos-container run test1 cat /etc/check) == client_c2 ]] >&2");
+    $client->fail("systemctl status httpd -M test1 >&2");
+    $client->succeed("systemctl status nginx -M test1 >&2");
+  '';
+
+})


### PR DESCRIPTION
###### Motivation for this change

This makes declarative containers truly reloadable (container config changes are applied on `nixos-rebuild switch`). Current code already declares it:

https://github.com/NixOS/nixpkgs/blob/56904d7c423f2b13b37fbd29f39bbb4b52bc7824/nixos/modules/virtualisation/containers.nix#L488

https://github.com/NixOS/nixpkgs/blob/56904d7c423f2b13b37fbd29f39bbb4b52bc7824/nixos/modules/virtualisation/containers.nix#L540

Original author: @chrisfarms in https://github.com/NixOS/nixpkgs/pull/3021/commits/6e36619b277f78ece1bb81b79b5651897e46a2bf
Most of stuff from that commit has already been ported.

### Details
There is indeed a bug in how `switch-to-configuraiton.pl` detects template instances. That's why systemd units for containers were never considered as changed and so never where reloaded.

This obviously doesn't do anything to imperative containers.

### Pitfalls

In current state containers suffer from the long-running problem - when to restart and when to reload. Because this change makes containers "reloadable-only" (was "never restart, never reload"), it imposes several problems:
- when you change bind-mounts container won't be restarted to reflect that
- network can go down in containers (https://github.com/NixOS/nixpkgs/issues/26342), so restart required
- `journalctl` won't show container reload logs without `-M $container_name_here`
- it makes activation phase slower when there are a lot of containers

###### Things done

[x] Test in production
[x] Nixos test for this stuff
[ ] Release notes update
