### PR TITLE
scaleway-cli: init at v1.14

### DIFF
--- a/pkgs/tools/admin/scaleway-cli/default.nix
+++ b/pkgs/tools/admin/scaleway-cli/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, buildGoPackage }:
+
+buildGoPackage rec{
+  name = "scaleway-cli-${version}";
+  version = "1.14";
+
+  goPackagePath = "github.com/scaleway/scaleway-cli";
+
+  src = fetchFromGitHub {
+    owner = "scaleway";
+    repo = "scaleway-cli";
+    rev = "v${version}";
+    sha256 = "09rqw82clfdiixa9m3hphxh5v7w1gks3wicz1dvpay2sx28bpddr";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Interact with Scaleway API from the command line";
+    homepage = https://github.com/scaleway/scaleway-cli;
+    license = licenses.mit;
+    maintainers = with maintainers; [ nickhu ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17461,6 +17461,8 @@ with pkgs;
 
   sauerbraten = callPackage ../games/sauerbraten {};
 
+  scaleway-cli = callPackage ../tools/admin/scaleway-cli { };
+
   scid = callPackage ../games/scid {
     tcl = tcl-8_5;
     tk = tk-8_5;


### PR DESCRIPTION
Utility to manage scaleway servers


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---