### PR TITLE
tectonic: init at 0.1.6

### DIFF
--- a/pkgs/tools/typesetting/tectonic/default.nix
+++ b/pkgs/tools/typesetting/tectonic/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, rustPlatform, makeWrapper
+, fontconfig, harfbuzz-icu, openssl, pkgconfig }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "tectonic-${version}";
+  version = "0.1.6";
+
+  src = fetchFromGitHub {
+    owner = "tectonic-typesetting";
+    repo = "tectonic";
+    rev = "v${version}";
+    sha256 = "0k5vkn112bjwh4wnxryzqz79dlja64k7s105mf3yaik136hqnmqv";
+  };
+
+  depsSha256 = "1vxvkh1v9x6j4ggbh6sysi5i3089hrs0mjbp910a1jljiav7l8nj";
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ fontconfig harfbuzz-icu openssl ];
+
+  # tests fail due to read-only nix store
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Modernized, complete, self-contained TeX/LaTeX engine, powered by XeTeX and TeXLive";
+    homepage = https://tectonic-typesetting.github.io/;
+    license = with licenses; [ mit ];
+    maintainers = [ maintainers.lluchs ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10393,6 +10393,8 @@ with pkgs;
 
   tecla = callPackage ../development/libraries/tecla { };
 
+  tectonic = callPackage ../tools/typesetting/tectonic { };
+
   telepathy_glib = callPackage ../development/libraries/telepathy/glib { };
 
   telepathy_farstream = callPackage ../development/libraries/telepathy/farstream {};


### PR DESCRIPTION
###### Motivation for this change
New package!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

