### PR TITLE
airsonic: init at 10.0.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -268,6 +268,7 @@
   ./services/mail/rspamd.nix
   ./services/mail/rmilter.nix
   ./services/mail/nullmailer.nix
+  ./services/misc/airsonic.nix
   ./services/misc/apache-kafka.nix
   ./services/misc/autofs.nix
   ./services/misc/autorandr.nix

--- a/nixos/modules/services/misc/airsonic.nix
+++ b/nixos/modules/services/misc/airsonic.nix
@@ -1,0 +1,117 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.airsonic;
+in {
+  options = {
+
+    services.airsonic = {
+      enable = mkEnableOption "Airsonic, the Free and Open Source media streaming server (fork of Subsonic and Libresonic)";
+
+      user = mkOption {
+        type = types.str;
+        default = "airsonic";
+        description = "User account under which airsonic runs.";
+      };
+
+      home = mkOption {
+        type = types.path;
+        default = "/var/lib/airsonic";
+        description = ''
+          The directory where Airsonic will create files.
+          Make sure it is writable.
+        '';
+      };
+
+      listenAddress = mkOption {
+        type = types.string;
+        default = "127.0.0.1";
+        description = ''
+          The host name or IP address on which to bind Airsonic.
+          Only relevant if you have multiple network interfaces and want
+          to make Airsonic available on only one of them. The default value
+          will bind Airsonic to all available network interfaces.
+        '';
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = 4040;
+        description = ''
+          The port on which Airsonic will listen for
+          incoming HTTP traffic. Set to 0 to disable.
+        '';
+      };
+
+      contextPath = mkOption {
+        type = types.path;
+        default = "/";
+        description = ''
+          The context path, i.e., the last part of the Airsonic
+          URL. Typically '/' or '/airsonic'. Default '/'
+        '';
+      };
+
+      maxMemory = mkOption {
+        type = types.int;
+        default = 100;
+        description = ''
+          The memory limit (max Java heap size) in megabytes.
+          Default: 100
+        '';
+      };
+
+      transcoders = mkOption {
+        type = types.listOf types.path;
+        default = [ "${pkgs.ffmpeg.bin}/bin/ffmpeg" ];
+        defaultText= [ "\${pkgs.ffmpeg.bin}/bin/ffmpeg" ];
+        description = ''
+          List of paths to transcoder executables that should be accessible
+          from Airsonic. Symlinks will be created to each executable inside
+          ${cfg.home}/transcoders.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.airsonic = {
+      description = "Airsonic Media Server";
+      after = [ "local-fs.target" "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      script = ''
+        ${pkgs.jre}/bin/java -Xmx${toString cfg.maxMemory}m \
+          -Dairsonic.home=${cfg.home} \
+          -Dserver.address=${cfg.listenAddress} \
+          -Dserver.port=${toString cfg.port} \
+          -Dairsonic.contextPath=${cfg.contextPath} \
+          -Djava.awt.headless=true \
+          -verbose:gc \
+          -jar ${pkgs.airsonic}/webapps/airsonic.war
+      '';
+
+      preStart = ''
+        # Install transcoders.
+        ${pkgs.coreutils}/bin/rm -rf ${cfg.home}/transcode
+        ${pkgs.coreutils}/bin/mkdir -p ${cfg.home}/transcode
+        for exe in ${toString cfg.transcoders}; do
+            ${pkgs.coreutils}/bin/ln -sf "$exe" ${cfg.home}/transcode
+        done
+      '';
+      serviceConfig = {
+        Restart = "always";
+        User = "airsonic";
+        UMask = "0022";
+      };
+    };
+
+    users.extraUsers.airsonic = {
+      description = "Airsonic service user";
+      name = cfg.user;
+      home = cfg.home;
+      createHome = true;
+    };
+  };
+}

--- a/nixos/modules/services/misc/airsonic.nix
+++ b/nixos/modules/services/misc/airsonic.nix
@@ -84,10 +84,10 @@ in {
 
       preStart = ''
         # Install transcoders.
-        ${pkgs.coreutils}/bin/rm -rf ${cfg.home}/transcode
-        ${pkgs.coreutils}/bin/mkdir -p ${cfg.home}/transcode
+        rm -rf ${cfg.home}/transcode
+        mkdir -p ${cfg.home}/transcode
         for exe in ${toString cfg.transcoders}; do
-            ${pkgs.coreutils}/bin/ln -sf "$exe" ${cfg.home}/transcode
+          ln -sf "$exe" ${cfg.home}/transcode
         done
       '';
       serviceConfig = {

--- a/nixos/modules/services/misc/airsonic.nix
+++ b/nixos/modules/services/misc/airsonic.nix
@@ -81,16 +81,6 @@ in {
       description = "Airsonic Media Server";
       after = [ "local-fs.target" "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      script = ''
-        ${pkgs.jre}/bin/java -Xmx${toString cfg.maxMemory}m \
-          -Dairsonic.home=${cfg.home} \
-          -Dserver.address=${cfg.listenAddress} \
-          -Dserver.port=${toString cfg.port} \
-          -Dairsonic.contextPath=${cfg.contextPath} \
-          -Djava.awt.headless=true \
-          -verbose:gc \
-          -jar ${pkgs.airsonic}/webapps/airsonic.war
-      '';
 
       preStart = ''
         # Install transcoders.
@@ -101,6 +91,16 @@ in {
         done
       '';
       serviceConfig = {
+        ExecStart = ''
+          ${pkgs.jre}/bin/java -Xmx${toString cfg.maxMemory}m \
+          -Dairsonic.home=${cfg.home} \
+          -Dserver.address=${cfg.listenAddress} \
+          -Dserver.port=${toString cfg.port} \
+          -Dairsonic.contextPath=${cfg.contextPath} \
+          -Djava.awt.headless=true \
+          -verbose:gc \
+          -jar ${pkgs.airsonic}/webapps/airsonic.war
+        '';
         Restart = "always";
         User = "airsonic";
         UMask = "0022";

--- a/pkgs/servers/misc/airsonic/default.nix
+++ b/pkgs/servers/misc/airsonic/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "airsonic-${version}";
-  version = "10.0.0";
+  version = "10.0.1";
 
   src = fetchurl {
     url = "https://github.com/airsonic/airsonic/releases/download/v${version}/airsonic.war";
-    sha256 = "0ldqccdm7z25my0wmispbshnn26l50a61q2ig2yl0krx4lmhfams";
+    sha256 = "1qky8dz49200f6100ivkn5g7i0hzkv3gpq2r0cj6z53s8d1ayblc";
   };
 
   buildCommand = ''

--- a/pkgs/servers/misc/airsonic/default.nix
+++ b/pkgs/servers/misc/airsonic/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "airsonic-${version}";
+  version = "10.0.0";
+
+  src = fetchurl {
+    url = "https://github.com/airsonic/airsonic/releases/download/v${version}/airsonic.war";
+    sha256 = "0ldqccdm7z25my0wmispbshnn26l50a61q2ig2yl0krx4lmhfams";
+  };
+
+  buildCommand = ''
+    mkdir -p "$out/webapps"
+    cp "$src" "$out/webapps/airsonic.war"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Personal media streamer";
+    homepage = https://airsonic.github.io;
+    license = stdenv.lib.licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ disassembler ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -412,6 +412,8 @@ with pkgs;
 
   airfield = callPackage ../tools/networking/airfield { };
 
+  airsonic = callPackage ../servers/misc/airsonic { };
+
   aj-snapshot  = callPackage ../applications/audio/aj-snapshot { };
 
   albert = libsForQt5.callPackage ../applications/misc/albert {};


### PR DESCRIPTION
###### Motivation for this change
addresses issue #28014

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

