### PR TITLE
enlightenment fixes and updates

### DIFF
--- a/pkgs/desktops/enlightenment/default.nix
+++ b/pkgs/desktops/enlightenment/default.nix
@@ -11,5 +11,5 @@ rec {
   econnman = callPackage ./econnman.nix { };
   terminology = callPackage ./terminology.nix { };
   rage = callPackage ./rage.nix { };
-  ephoto = callPackage ./ephoto.nix { efl = efl_1_19; };
+  ephoto = callPackage ./ephoto.nix { };
 }

--- a/pkgs/desktops/enlightenment/default.nix
+++ b/pkgs/desktops/enlightenment/default.nix
@@ -2,7 +2,6 @@
 rec {
   #### CORE EFL
   efl = callPackage ./efl.nix { openjpeg = pkgs.openjpeg_1; };
-  efl_1_19 = callPackage ./efl.nix { eflVersion = "1.19.1"; openjpeg = pkgs.openjpeg_1; };
 
   #### WINDOW MANAGER
   enlightenment = callPackage ./enlightenment.nix { };

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -4,20 +4,15 @@
 , python27Packages, openjpeg, doxygen, expat, harfbuzz, jbig2dec, librsvg
 , dbus_libs, alsaLib, poppler, ghostscript, libraw, libspectre, xineLib, libwebp
 , curl, libinput, systemd, writeText
-# Support more than one version because for now ephoto does not work with efl-1.20.x
-, eflVersion ? "1.20.2"
 }:
 
 stdenv.mkDerivation rec {
   name = "efl-${version}";
-  version = eflVersion;
+  version = "1.20.2";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/libs/efl/${name}.tar.xz";
-    sha256 = {
-      "1.19.1" = "0fndwraca9rg0bz3al4isdprvyw56szr88qiyvglb4j8ygsylscc";
-      "1.20.2" = "0zll6k4xbbdsxqg53g8jddgv889g5m1xh20i03iz5a52y2bcnh55";
-    }.${version};
+    sha256 = "0zll6k4xbbdsxqg53g8jddgv889g5m1xh20i03iz5a52y2bcnh55";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -22,17 +22,17 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ openssl zlib lz4 freetype fontconfig fribidi SDL2 SDL mesa
+  buildInputs = [ openssl zlib lz4 freetype fontconfig SDL mesa
     giflib libpng libtiff glib gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
     gst_all_1.gst-libav libpulseaudio libsndfile xorg.libXcursor xorg.printproto
-    xorg.libX11 udev utillinux systemd ];
+    xorg.libX11 udev systemd ];
 
   propagatedBuildInputs = [ libxkbcommon python27Packages.dbus-python dbus libjpeg xorg.libXcomposite
     xorg.libXdamage xorg.libXinerama xorg.libXp xorg.libXtst xorg.libXi xorg.libXext
     bullet xorg.libXScrnSaver xorg.libXrender xorg.libXfixes xorg.libXrandr
     xorg.libxkbfile xorg.libxcb xorg.xcbutilkeysyms openjpeg doxygen expat luajit
     harfbuzz jbig2dec librsvg dbus_libs alsaLib poppler ghostscript libraw libspectre xineLib libwebp curl libdrm
-    libinput ];
+    libinput utillinux fribidi SDL2 ];
 
   # ac_ct_CXX must be set to random value, because then it skips some magic which does alternative searching for g++
   configureFlags = [

--- a/pkgs/desktops/enlightenment/enlightenment.nix
+++ b/pkgs/desktops/enlightenment/enlightenment.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, efl, xcbutilkeysyms, libXrandr, libXdmcp,
 libxcb, libffi, pam, alsaLib, luajit, bzip2, libpthreadstubs, gdbm, libcap,
-mesa_glu, xkeyboard_config }:
+mesa_glu, xkeyboard_config, pcre }:
 
 stdenv.mkDerivation rec {
   name = "enlightenment-${version}";
@@ -11,21 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "0w5f3707hyfc20i6xqh4jlr5p2yhy1z794061mjsz2rp4w00qmpb";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ (pkgconfig.override { vanilla = true; }) ];
 
   buildInputs = [
     efl libXdmcp libxcb xcbutilkeysyms libXrandr libffi pam alsaLib
-    luajit bzip2 libpthreadstubs gdbm
+    luajit bzip2 libpthreadstubs gdbm pcre
   ] ++
     stdenv.lib.optionals stdenv.isLinux [ libcap ];
-
-  NIX_CFLAGS_COMPILE = [
-    "-I${efl}/include/ecore-imf-1"
-    "-I${efl}/include/emile-1"
-    "-I${efl}/include/eo-1"
-    "-I${efl}/include/ethumb-1"
-    "-I${efl}/include/ethumb-client-1"
-  ];
 
   preConfigure = ''
     export USER_SESSION_DIR=$prefix/lib/systemd/user

--- a/pkgs/desktops/enlightenment/ephoto.nix
+++ b/pkgs/desktops/enlightenment/ephoto.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, efl, curl, makeWrapper }:
+{ stdenv, fetchurl, pkgconfig, efl, pcre, curl, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "ephoto-${version}";
@@ -9,21 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "09kraa5zz45728h2dw1ssh23b87j01bkfzf977m48y1r507sy3vb";
   };
 
-  nativeBuildInputs = [ pkgconfig makeWrapper ];
+  nativeBuildInputs = [ (pkgconfig.override { vanilla = true; }) makeWrapper ];
 
-  buildInputs = [ efl curl ];
-
-  NIX_CFLAGS_COMPILE = [
-    "-I${efl}/include/ecore-con-1"
-    "-I${efl}/include/ecore-evas-1"
-    "-I${efl}/include/ecore-imf-1"
-    "-I${efl}/include/ecore-input-1"
-    "-I${efl}/include/eet-1"
-    "-I${efl}/include/eldbus-1"
-    "-I${efl}/include/emile-1"
-    "-I${efl}/include/ethumb-1"
-    "-I${efl}/include/ethumb-client-1"
-  ];
+  buildInputs = [ efl pcre curl ];
 
   postInstall = ''
     wrapProgram $out/bin/ephoto --prefix LD_LIBRARY_PATH : ${curl.out}/lib

--- a/pkgs/desktops/enlightenment/ephoto.nix
+++ b/pkgs/desktops/enlightenment/ephoto.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "ephoto-${version}";
-  version = "1.0";
+  version = "1.5";
   
   src = fetchurl {
     url = "http://www.smhouston.us/stuff/${name}.tar.gz";
-    sha256 = "0l6zrk22fap6pylmzxwp6nycy8l5wdc7jza890h4zrwmpfag8w31";
+    sha256 = "09kraa5zz45728h2dw1ssh23b87j01bkfzf977m48y1r507sy3vb";
   };
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];

--- a/pkgs/desktops/enlightenment/rage.nix
+++ b/pkgs/desktops/enlightenment/rage.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, efl, gst_all_1, curl, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, efl, gst_all_1, pcre, curl, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "rage-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pkgconfig
+    (pkgconfig.override { vanilla = true; })
     wrapGAppsHook
   ];
 
@@ -21,23 +21,9 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-good
     gst_all_1.gst-plugins-bad
     gst_all_1.gst-libav
+    pcre
     curl
  ];
-
-  NIX_CFLAGS_COMPILE = [
-    "-I${efl}/include/ecore-con-1"
-    "-I${efl}/include/ecore-evas-1"
-    "-I${efl}/include/ecore-file-1"
-    "-I${efl}/include/ecore-imf-1"
-    "-I${efl}/include/ecore-input-1"
-    "-I${efl}/include/eet-1"
-    "-I${efl}/include/efreet-1"
-    "-I${efl}/include/eldbus-1"
-    "-I${efl}/include/emile-1"
-    "-I${efl}/include/eo-1"
-    "-I${efl}/include/ethumb-1"
-    "-I${efl}/include/ethumb-client-1"
-  ];
 
   postInstall = ''
     wrapProgram $out/bin/rage --prefix LD_LIBRARY_PATH : ${curl.out}/lib

--- a/pkgs/desktops/enlightenment/terminology.nix
+++ b/pkgs/desktops/enlightenment/terminology.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, efl, curl, makeWrapper }:
+{ stdenv, fetchurl, pkgconfig, efl, pcre, curl, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "terminology-${version}";
@@ -9,18 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "13rl1k22yf8qrpzdm5nh6ij641fibadr2ww1r7rnz7mbhzj3d4gb";
   };
 
-  nativeBuildInputs = [ pkgconfig makeWrapper ];
+  nativeBuildInputs = [ (pkgconfig.override { vanilla = true; }) makeWrapper ];
 
-  buildInputs = [ efl curl ];
-
-  NIX_CFLAGS_COMPILE = [
-    "-I${efl}/include/ecore-con-1"
-    "-I${efl}/include/eldbus-1"
-    "-I${efl}/include/elocation-1"
-    "-I${efl}/include/emile-1"
-    "-I${efl}/include/eo-1"
-    "-I${efl}/include/ethumb-1"
-  ];
+  buildInputs = [ efl pcre curl ];
 
   postInstall = ''
     for f in $out/bin/*; do

--- a/pkgs/desktops/enlightenment/terminology.nix
+++ b/pkgs/desktops/enlightenment/terminology.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "terminology-${version}";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/apps/terminology/${name}.tar.xz";
-    sha256 = "1x4j2q4qqj10ckbka0zaq2r2zm66ff1x791kp8slv1ff7fw45vdz";
+    sha256 = "13rl1k22yf8qrpzdm5nh6ij641fibadr2ww1r7rnz7mbhzj3d4gb";
   };
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

- `efl`: propagate `utillinux`, `fribidi` and `SDL2`, which are runtime dependencies
- `ephoto`: 1.0 -> 1.5
- `efl`: remove old version 1.19.1
- `terminology`: 1.0.0 -> 1.1.0
-  efl applications: use vanilla `pkg-config`
   
   Use vanilla pkg-config to build EFL applications.

   The EFL library has a set of pkg-config files (*.pc) which uses private requirements. The default pkg-config setup on nixpkgs is patched to disable resolving those requirements. See http://bugs.freedesktop.org/show_bug.cgi?id=4738 for reference.

   As a consequence each package depending on efl has to explicitly set the search path in order to be able to find the corresponding header files.

   By using vanilla pkg-config this is not necessary (and this is the expected behaviour for pkg-config), allowing simpler nix expressions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).