### PR TITLE
idris: Fix build-idris-packages

### DIFF
--- a/pkgs/development/idris-modules/build-idris-package.nix
+++ b/pkgs/development/idris-modules/build-idris-package.nix
@@ -16,10 +16,6 @@
     envHooks+=(addIdrisLibs)
   '';
 
-  configurePhase = ''
-    export TARGET=$out/lib/${idris.name}
-  '';
-
   buildPhase = ''
     ${idris}/bin/idris --build *.ipkg
   '';
@@ -33,7 +29,7 @@
   '';
 
   installPhase = ''
-    ${idris}/bin/idris --install *.ipkg
+    ${idris}/bin/idris --ibcsubdir $out/lib/${idris.name} --install *.ipkg
   '';
 
   buildInputs = [ gmp ];


### PR DESCRIPTION
###### Motivation for this change
idrisPackages.with-packages [] was broken. No output was ever produced for any package, and even Prelude failed to import.

This minor change makes it possible to at least run a basic "Hello, World!" in the interpreter again, and module imports *seem* to work, eg:

    nix-shell -p 'idrisPackages.with-packages [ idrisPackages.lightyear ]'
    idris -p lightyear
    :module Lightyear

... does not simply error out. All in all I think it's strictly an improvement, though there may still be pitfalls that I havent't immediately identified.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---