### PR TITLE
qt5: Add qtnetworkauth submodule

### DIFF
--- a/pkgs/development/libraries/qt-5/5.9/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/default.nix
@@ -110,6 +110,7 @@ let
       qtmultimedia = callPackage ./qtmultimedia.nix {
         inherit gstreamer gst-plugins-base;
       };
+      qtnetworkauth = callPackage ./qtnetworkauth.nix {};
       qtquick1 = null;
       qtquickcontrols = callPackage ./qtquickcontrols.nix {};
       qtquickcontrols2 = callPackage ./qtquickcontrols2.nix {};
@@ -130,9 +131,9 @@ let
       env = callPackage ../qt-env.nix {};
       full = env "qt-${qtbase.version}" ([
         qtcharts qtconnectivity qtdeclarative qtdoc qtgraphicaleffects
-        qtimageformats qtlocation qtmultimedia qtquickcontrols qtscript
-        qtsensors qtserialport qtsvg qttools qttranslations qtwebsockets
-        qtx11extras qtxmlpatterns
+        qtimageformats qtlocation qtmultimedia qtnetworkauth qtquickcontrols
+        qtscript qtsensors qtserialport qtsvg qttools qttranslations
+        qtwebsockets qtx11extras qtxmlpatterns
       ] ++ optional (!stdenv.isDarwin) qtwayland
         ++ optional (stdenv.isDarwin) qtmacextras);
 

--- a/pkgs/development/libraries/qt-5/5.9/qtnetworkauth.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtnetworkauth.nix
@@ -1,0 +1,7 @@
+{ qtSubmodule, qtbase }:
+
+qtSubmodule {
+  name = "qtnetworkauth";
+  qtInputs = [ qtbase ];
+  outputs = [ "out" "dev" ];
+}


### PR DESCRIPTION
###### Motivation for this change
Add QtNetworkAuth module available since Qt 5.8.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

