### PR TITLE
nixos/caddy: improve documentation

### DIFF
--- a/nixos/modules/services/web-servers/caddy.nix
+++ b/nixos/modules/services/web-servers/caddy.nix
@@ -5,12 +5,22 @@ with lib;
 let
   cfg = config.services.caddy;
   configFile = pkgs.writeText "Caddyfile" cfg.config;
-in
-{
+in {
   options.services.caddy = {
     enable = mkEnableOption "Caddy web server";
 
     config = mkOption {
+      default = "";
+      example = ''
+        example.com {
+        gzip
+        minify
+        log syslog
+
+        root /srv/http
+        }
+      '';
+      type = types.lines;
       description = "Verbatim Caddyfile to use";
     };
 


### PR DESCRIPTION
###### Motivation for this change
There was no documentation for the "config" option, and it wasn't quite clear whether it was supposed to be a file, a string, or what. This commit removes that ambiguity.

###### Things done
(I haven't done any testing because I've only changed documentation)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Also, the diff is a bit messy because the indentation was off, and my editor fixed it.