### PR TITLE
 phpPackages.memcache: fix php startup warning

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -37,6 +37,8 @@ let
     sha256 = "04c35rj0cvq5ygn2jgmyvqcb0k8d03v4k642b6i37zgv7x15pbic";
 
     configureFlags = "--with-zlib-dir=${pkgs.zlib.dev}";
+
+    makeFlags = [ "CFLAGS=-fgnu89-inline" ];
   };
 
   memcached = if isPhp7 then memcachedPhp7 else memcached22;


### PR DESCRIPTION
###### Motivation for this change

Adds make flag for compiling to prevent "unable to load dynamic library"
warning.

Example output:
`PHP Warning:  PHP Startup: Unable to load dynamic library '/nix/store/b32xqnj7f1y6b8x558js7bsm6i2i1cnx-php-memcache-3.0.8/lib/php/extensions/memcache.so' - /nix/store/b32xqnj7f1y6b8x558js7bsm6i2i1cnx-php-memcache-3.0.8/lib/php/extensions/memcache.so: undefined symbol: mmc_queue_remove in Unknown on line 0`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

