### PR TITLE
phpPackages.pcs: init at 1.3.3

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -72,6 +72,12 @@ let
     buildInputs = with pkgs; [ pkgconfig cyrus_sasl zlib ];
   };
 
+  pcs = buildPecl rec {
+    name = "pcs-1.3.3";
+
+    sha256 = "0d4p1gpl8gkzdiv860qzxfz250ryf0wmjgyc8qcaaqgkdyh5jy5p";
+  };
+
   # No support for PHP 7 yet (and probably never will be)
   spidermonkey = assert !isPhp7; buildPecl rec {
     name = "spidermonkey-1.0.0";


### PR DESCRIPTION
###### Motivation for this change

Adds php pcs extension. Needed for a following PR when adding php couchbase extension to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
