### PR TITLE
strongswan: 5.5.3 -> 5.6.0

### DIFF
--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "strongswan-${version}";
-  version = "5.5.3";
+  version = "5.6.0";
 
   src = fetchurl {
     url = "http://download.strongswan.org/${name}.tar.bz2";
-    sha256 = "1m7qq0l5pwj1wy0f7h2b7msb1d98rx78z6xg27g0hiqpk6qm9sn5";
+    sha256 = "04vvha2zgsg1cq05cnn6sf7a4hq9ndnsfxpw1drm5v9l4vcw0kd1";
   };
 
   dontPatchELF = true;


### PR DESCRIPTION
See: https://wiki.strongswan.org/versions/66

The new version works correctly on our company VPN.

This contains a fix for a DoS vulnerability so we should probably cherry-pick this on `release-17.03`.