### PR TITLE
Update Idris

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -697,6 +697,11 @@ self: super: {
   # test suite cannot find its own "idris" binary
   idris = doJailbreak (dontCheck super.idris);
 
+  idris_1_1_1 = overrideCabal (doJailbreak (dontCheck super.idris_1_1_1)) (drv: {
+    # The standard libraries are compiled separately
+    configureFlags = (drv.configureFlags or []) ++ [ "-fexeconly" ];
+  });
+
   # https://github.com/bos/math-functions/issues/25
   math-functions = dontCheck super.math-functions;
 

--- a/pkgs/development/idris-modules/build-builtin-package.nix
+++ b/pkgs/development/idris-modules/build-builtin-package.nix
@@ -13,8 +13,11 @@ build-idris-package {
   inherit (idris) src;
 
   postUnpack = ''
-    mv $sourceRoot/libs/${name} $IDRIS_LIBRARY_PATH
-    sourceRoot=$IDRIS_LIBRARY_PATH/${name}
+    sourceRoot=$sourceRoot/libs/${name}
+  '';
+
+  postPatch = ''
+    sed -i ${name}.ipkg -e "/^opts/ s|-i \\.\\./|-i $IDRIS_LIBRARY_PATH/|g"
   '';
 
   meta = idris.meta // {

--- a/pkgs/development/idris-modules/build-builtin-package.nix
+++ b/pkgs/development/idris-modules/build-builtin-package.nix
@@ -1,8 +1,12 @@
 # Build one of the packages that come with idris
 # name: The name of the package
 # deps: The dependencies of the package
-{ idris, build-idris-package, lib }: name: deps: build-idris-package {
-  inherit name;
+{ idris, build-idris-package, lib }: name: deps:
+let
+  inherit (builtins.parseDrvName idris.name) version;
+in
+build-idris-package {
+  name = "${name}-${version}";
 
   propagatedBuildInputs = deps;
 

--- a/pkgs/development/idris-modules/build-idris-package.nix
+++ b/pkgs/development/idris-modules/build-idris-package.nix
@@ -4,8 +4,13 @@
 #       name and src.
 { stdenv, idris, gmp }: args: stdenv.mkDerivation ({
   preHook = ''
-    mkdir idris-libs
+    # Library import path
     export IDRIS_LIBRARY_PATH=$PWD/idris-libs
+    mkdir -p $IDRIS_LIBRARY_PATH
+
+    # Library install path
+    export IBCSUBDIR=$out/lib/${idris.name}
+    mkdir -p $IBCSUBDIR
 
     addIdrisLibs () {
       if [ -d $1/lib/${idris.name} ]; then
@@ -14,10 +19,6 @@
     }
 
     envHooks+=(addIdrisLibs)
-  '';
-
-  configurePhase = ''
-    export TARGET=$out/lib/${idris.name}
   '';
 
   buildPhase = ''
@@ -33,7 +34,7 @@
   '';
 
   installPhase = ''
-    ${idris}/bin/idris --install *.ipkg
+    ${idris}/bin/idris --install *.ipkg --ibcsubdir $IBCSUBDIR
   '';
 
   buildInputs = [ gmp ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5646,7 +5646,21 @@ with pkgs;
   icedtea_web = icedtea8_web;
 
   idrisPackages = callPackage ../development/idris-modules {
-    inherit (haskellPackages) idris;
+    idris =
+      let
+        inherit (self.haskell) lib;
+        haskellPackages = self.haskellPackages.override {
+          overrides = self: super: {
+            binary = lib.dontCheck self.binary_0_8_5_1;
+            cheapskate = self.cheapskate_0_1_1;
+            idris = self.idris_1_1_1;
+            parsers = lib.dontCheck super.parsers;
+            semigroupoids = lib.dontCheck super.semigroupoids;
+            trifecta = lib.dontCheck super.trifecta;
+          };
+        };
+      in
+        haskellPackages.idris;
   };
 
   intercal = callPackage ../development/compilers/intercal { };


### PR DESCRIPTION
### Motivation for this change

This fixes the build failure of idris-1.1.1 and updates `idrisPackages` to use that version.
The build system has changed slightly, so `build-idris-package` changes.
`build-builtin-package` is mainly affected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

