### PR TITLE
Kde-Frameworks: Increases the minimum qt version to 5.7

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/attica.nix
+++ b/pkgs/development/libraries/kde-frameworks/attica.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "attica";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/bluez-qt.nix
+++ b/pkgs/development/libraries/kde-frameworks/bluez-qt.nix
@@ -7,7 +7,7 @@ mkDerivation {
   name = "bluez-qt";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtdeclarative ];

--- a/pkgs/development/libraries/kde-frameworks/karchive.nix
+++ b/pkgs/development/libraries/kde-frameworks/karchive.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "karchive";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ bzip2 lzma zlib ];

--- a/pkgs/development/libraries/kde-frameworks/kcodecs.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcodecs.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kcodecs";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qttools gperf ];

--- a/pkgs/development/libraries/kde-frameworks/kconfig.nix
+++ b/pkgs/development/libraries/kde-frameworks/kconfig.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kconfig";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qttools ];

--- a/pkgs/development/libraries/kde-frameworks/kcoreaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcoreaddons.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "kcoreaddons";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qttools shared_mime_info ];

--- a/pkgs/development/libraries/kde-frameworks/kdbusaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdbusaddons.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "kdbusaddons";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qttools qtx11extras ];

--- a/pkgs/development/libraries/kde-frameworks/kdnssd.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdnssd.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "kdnssd";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ avahi qttools ];

--- a/pkgs/development/libraries/kde-frameworks/kguiaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kguiaddons.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "kguiaddons";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtx11extras ];

--- a/pkgs/development/libraries/kde-frameworks/ki18n.nix
+++ b/pkgs/development/libraries/kde-frameworks/ki18n.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "ki18n";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedNativeBuildInputs = [ gettext python ];

--- a/pkgs/development/libraries/kde-frameworks/kidletime.nix
+++ b/pkgs/development/libraries/kde-frameworks/kidletime.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "kidletime";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtx11extras ];

--- a/pkgs/development/libraries/kde-frameworks/kitemmodels.nix
+++ b/pkgs/development/libraries/kde-frameworks/kitemmodels.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "kitemmodels";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kitemviews.nix
+++ b/pkgs/development/libraries/kde-frameworks/kitemviews.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "kitemviews";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qttools ];

--- a/pkgs/development/libraries/kde-frameworks/kplotting.nix
+++ b/pkgs/development/libraries/kde-frameworks/kplotting.nix
@@ -6,7 +6,7 @@ mkDerivation {
   name = "kplotting";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kwayland.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwayland.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "kwayland";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ wayland ];

--- a/pkgs/development/libraries/kde-frameworks/kwidgetsaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwidgetsaddons.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "kwidgetsaddons";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qttools ];

--- a/pkgs/development/libraries/kde-frameworks/kwindowsystem/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwindowsystem/default.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "kwindowsystem";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qttools qtx11extras ];

--- a/pkgs/development/libraries/kde-frameworks/modemmanager-qt.nix
+++ b/pkgs/development/libraries/kde-frameworks/modemmanager-qt.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "modemmanager-qt";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ modemmanager qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/networkmanager-qt.nix
+++ b/pkgs/development/libraries/kde-frameworks/networkmanager-qt.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "networkmanager-qt";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ networkmanager qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/solid.nix
+++ b/pkgs/development/libraries/kde-frameworks/solid.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "solid";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ bison extra-cmake-modules flex media-player-info ];
   buildInputs = [ qtdeclarative qttools ];

--- a/pkgs/development/libraries/kde-frameworks/sonnet.nix
+++ b/pkgs/development/libraries/kde-frameworks/sonnet.nix
@@ -7,7 +7,7 @@ mkDerivation {
   name = "sonnet";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ hunspell qttools ];

--- a/pkgs/development/libraries/kde-frameworks/syntax-highlighting.nix
+++ b/pkgs/development/libraries/kde-frameworks/syntax-highlighting.nix
@@ -6,7 +6,7 @@ mkDerivation {
   name = "syntax-highlighting";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules perl ];
   buildInputs = [ qttools ];

--- a/pkgs/development/libraries/kde-frameworks/threadweaver.nix
+++ b/pkgs/development/libraries/kde-frameworks/threadweaver.nix
@@ -8,7 +8,7 @@ mkDerivation {
   name = "threadweaver";
   meta = {
     maintainers = [ lib.maintainers.ttuegel ];
-    broken = builtins.compareVersions qtbase.version "5.6.0" < 0;
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ qtbase ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

