### PR TITLE
LXQT-config: Adds patch for Cmake >3.8

### DIFF
--- a/pkgs/desktops/lxqt/core/lxqt-config/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-config/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools, standardPatch, qtbase, qtx11extras, qttools, qtsvg, kwindowsystem, libkscreen, liblxqt, libqtxdg, libpthreadstubs, xorg }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, pkgconfig, lxqt-build-tools, standardPatch, qtbase, qtx11extras, qttools, qtsvg, kwindowsystem, libkscreen, liblxqt, libqtxdg, libpthreadstubs, xorg }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -45,4 +45,13 @@ stdenv.mkDerivation rec {
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];
   };
+
+  patches = [
+    # Fixes a FTBFS with CMake v3.8
+    (fetchpatch {
+       url = https://github.com/lxde/lxqt-config/commit/bca652a75f8a497a69b1fbc1c7eaa353f6b4eef8.patch;
+       sha256 = "17k26xj97ks9gvcjhiwc5y39fciria4xyxrzcz67zj0flqm3cmrf";
+     })
+  ];
+
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

