### PR TITLE
python linode-api: 4.1.1b2 -> 4.1.2b0

### DIFF
--- a/pkgs/development/python-modules/linode-api/default.nix
+++ b/pkgs/development/python-modules/linode-api/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "linode-api";
-  version = "4.1.1b2"; # NOTE: this is a beta, and the API may change in future versions.
+  version = "4.1.2b0"; # NOTE: this is a beta, and the API may change in future versions.
   name = "${pname}-${version}";
 
   disabled = (pythonOlder "2.7");
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1lfqsll3wv1wzn98ymmcbw0yawj8ab3mxniws6kaxf99jd4a0xp4";
+    sha256 = "19yzyb4sbxib8yxmrqm6d8i0fm8cims56q7kiq2ana26nbcm0gr4";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Without this update, the library will not work, as the web API which it
depends on has changed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

