### PR TITLE
pythonpackages.thrift: 0.9.3 -> 0.10.0

### DIFF
--- a/pkgs/development/python-modules/thrift/default.nix
+++ b/pkgs/development/python-modules/thrift/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, six }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "thrift";
+  version = "0.10.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "029jcdjdiw7pm1dllcvw3r4cg8542pf21yzr0fpnj49jan8w1xmp";
+  };
+
+  # No tests. Breaks when not disabling.
+  doCheck = false;
+
+  propagatedBuildInputs = [ six ];
+
+  meta = with stdenv.lib; {
+    description = "Python bindings for the Apache Thrift RPC system";
+    homepage = http://thrift.apache.org/;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hbunke ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26836,15 +26836,17 @@ EOF
 
   thrift = buildPythonPackage rec {
     name = "thrift-${version}";
-    version = "0.9.3";
+    version = "0.10.0";
 
     src = pkgs.fetchurl {
-      url = "mirror://pypi/t/thrift/${name}.tar.gz";
-      sha256 = "dfbc3d3bd19d396718dab05abaf46d93ae8005e2df798ef02e32793cd963877e";
+      url = "mirror://pypi/t/thrift/${name}.zip";
+      sha256 = "029jcdjdiw7pm1dllcvw3r4cg8542pf21yzr0fpnj49jan8w1xmp";
     };
 
     # No tests. Breaks when not disabling.
     doCheck = false;
+
+    propagatedBuildInputs = [ self.six ];
 
     meta = {
       description = "Python bindings for the Apache Thrift RPC system";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5460,7 +5460,7 @@ in {
   };
 
   easydict = callPackage ../development/python-modules/easydict { };
-  
+
   EasyProcess = buildPythonPackage rec {
     name = "EasyProcess-0.2.3";
 
@@ -7289,17 +7289,17 @@ in {
   logfury = buildPythonPackage rec {
     name = "logfury-${version}";
     version = "0.1.2";
-  
+
     src = pkgs.fetchurl {
       url = "mirror://pypi/l/logfury/${name}.tar.gz";
       sha256 = "1lywirv3d1lw691mc4mfpz7ak6r49klri43bbfgdnvsfppxminj2";
     };
-  
+
     buildInputs =
       [ self.funcsigs
         self.six
       ];
-  
+
     meta = with pkgs.stdenv.lib; {
       description = "Logfury is for python library maintainers. It allows for responsible, low-boilerplate logging of method calls.";
       homepage = "https://github.com/ppolewicz/logfury";
@@ -26834,28 +26834,7 @@ EOF
     };
   };
 
-  thrift = buildPythonPackage rec {
-    name = "thrift-${version}";
-    version = "0.10.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/t/thrift/${name}.zip";
-      sha256 = "029jcdjdiw7pm1dllcvw3r4cg8542pf21yzr0fpnj49jan8w1xmp";
-    };
-
-    # No tests. Breaks when not disabling.
-    doCheck = false;
-
-    propagatedBuildInputs = [ self.six ];
-
-    meta = {
-      description = "Python bindings for the Apache Thrift RPC system";
-      homepage = http://thrift.apache.org/;
-      license = licenses.asl20;
-      maintainers = with maintainers; [ hbunke ];
-
-    };
-  };
+  thrift = callPackage ../development/python-modules/thrift { };
 
   geeknote = buildPythonPackage rec {
     version = "2015-05-11";
@@ -28755,17 +28734,17 @@ EOF
 
   cymem = callPackage ../development/python-modules/cymem { };
 
-  ftfy = callPackage ../development/python-modules/ftfy { };    
+  ftfy = callPackage ../development/python-modules/ftfy { };
 
-  murmurhash = callPackage ../development/python-modules/murmurhash { };      
+  murmurhash = callPackage ../development/python-modules/murmurhash { };
 
-  plac = callPackage ../development/python-modules/plac { };        
-  
+  plac = callPackage ../development/python-modules/plac { };
+
   preshed = callPackage ../development/python-modules/preshed { };
 
-  thinc = callPackage ../development/python-modules/thinc { };  
+  thinc = callPackage ../development/python-modules/thinc { };
 
-  spacy = callPackage ../development/python-modules/spacy { };  
+  spacy = callPackage ../development/python-modules/spacy { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

thrift-0.10.0 was released some time ago.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

