### PR TITLE
eigen: fix configuration file for pkg-config

### DIFF
--- a/pkgs/development/libraries/eigen/3.3.nix
+++ b/pkgs/development/libraries/eigen/3.3.nix
@@ -13,7 +13,11 @@ stdenv.mkDerivation {
   };
   
   nativeBuildInputs = [ cmake ];
-  
+
+  postInstall = ''
+    sed -e '/Cflags:/s@''${prefix}/@@' -i "$out"/share/pkgconfig/eigen3.pc
+  '';
+   
   meta = with stdenv.lib; {
     description = "C++ template library for linear algebra: vectors, matrices, and related algorithms";
     license = licenses.lgpl3Plus;


### PR DESCRIPTION
###### Motivation for this change
Fix pkg-config file for eigen3_3 (same as eigen) -> the command:
```
$ nix-shell -p eigen3_3 pkgconfig --pure --run "pkg-config --cflags eigen3"
```
returns something like:
```
-I/nix/store/2f366hh65bb46jpzk5m9wvmbfm8d7fia-eigen-3.3.3//nix/store/2f366hh65bb46jpzk5m9wvmbfm8d7fia-eigen-3.3.3/include/eigen3
```
but it should return  something like:
```
-I/nix/store/8c33w272zvxwaacyharsrmzp2m7827f1-eigen-3.3.3/include/eigen3
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

