### PR TITLE
grammalecte: 0.5.17 -> 0.5.18

### DIFF
--- a/pkgs/development/python-modules/grammalecte/default.nix
+++ b/pkgs/development/python-modules/grammalecte/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "grammalecte";
-  version = "0.5.17";
+  version = "0.5.18";
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "http://www.dicollecte.org/grammalecte/oxt/Grammalecte-fr-v${version}.zip";
-    sha256 = "0ccvj8p8bwvrj8bp370dzjs16pwm755a7364lvk8bp4505n7g0b6";
+    url = "http://www.dicollecte.org/grammalecte/zip/Grammalecte-fr-v${version}.zip";
+    sha256 = "0izfsqsj8w4awhmwmn4x8wwpqsmqbnfvfafzk93i6yj0l3fn3i97";
   };
 
   propagatedBuildInputs = [ bottle ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6181,12 +6181,12 @@ in {
 
   dropbox = buildPythonPackage rec {
     name = "dropbox-${version}";
-    version = "3.37";
-    #doCheck = false; # python 2.7.9 does verify ssl certificates
+    version = "8.0.0";
+    doCheck = false; # Set DROPBOX_TOKEN environment variable to a valid token.
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/d/dropbox/${name}.tar.gz";
-      sha256 = "f65c12bd97f09e29a951bc7cb30a74e005fc4b2f8bb48778796be3f73866b173";
+      sha256 = "0bixx80zjq0286dwm4zhg8bdhc8pqlrqy4n2jg7i6m6a4gv4gak5";
     };
 
     propagatedBuildInputs = with self; [ requests urllib3 mock setuptools ];


### PR DESCRIPTION
###### Motivation for this change

grammalecte: 0.5.17 -> 0.5.18

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

