### PR TITLE
mitmproxy: fix dependency requirement

### DIFF
--- a/pkgs/tools/networking/mitmproxy/default.nix
+++ b/pkgs/tools/networking/mitmproxy/default.nix
@@ -19,6 +19,8 @@ python3Packages.buildPythonPackage rec {
       url = "https://patch-diff.githubusercontent.com/raw/mitmproxy/mitmproxy/pull/2252.patch";
       sha256 = "1smld21df79249qbh412w8gi2agcf4zjhxnlawy19yjl1fk2h67c";
     })
+    # Bump tornado dependency
+    ./tornado.patch
   ];
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/tools/networking/mitmproxy/tornado.patch
+++ b/pkgs/tools/networking/mitmproxy/tornado.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index b95d6829..4411c7f9 100644
+--- a/setup.py
++++ b/setup.py
+@@ -78,7 +78,7 @@ setup(
+         "pyperclip>=1.5.22, <1.6",
+         "requests>=2.9.1, <3",
+         "ruamel.yaml>=0.13.2, <0.14",
+-        "tornado>=4.3, <4.5",
++        "tornado>=4.3, <4.6",
+         "urwid>=1.3.1, <1.4",
+         "watchdog>=0.8.3, <0.9",
+         "brotlipy>=0.5.1, <0.7",


### PR DESCRIPTION
###### Motivation for this change
The build is failing due to the usual dependency pinning thing.

###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

