### PR TITLE
phantomjs2: fix references to qt plugins

### DIFF
--- a/pkgs/development/tools/phantomjs2/default.nix
+++ b/pkgs/development/tools/phantomjs2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch
+{ stdenv, fetchFromGitHub, fetchpatch, makeWrapper
 , bison2, flex, fontconfig, freetype, gperf, icu, openssl, libjpeg
 , libpng, perl, python, ruby, sqlite, qtwebkit, qmake, qtbase
 , darwin, writeScriptBin, cups
@@ -46,7 +46,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ qmake ];
   buildInputs = [
     bison2 flex fontconfig freetype gperf icu openssl
-    libjpeg libpng perl python ruby sqlite qtwebkit qtbase
+    libjpeg libpng perl python ruby sqlite qtwebkit qtbase makeWrapper
   ] ++ stdenv.lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     AGL ApplicationServices AppKit Cocoa OpenGL
     darwin.libobjc fakeClang cups
@@ -102,6 +102,10 @@ in stdenv.mkDerivation rec {
 
   preFixup = ''
     rm -r ../__nix_qt5__
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/phantomjs --set QT_QPA_PLATFORM_PLUGIN_PATH "${qtbase.bin}/lib/qt-5.9/plugins/platforms/"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Without this change, `phantomjs` fails with the following error when I try to run it inside of `nix-shell -p phantomjs2`:
```
This application failed to start because it could not find or load the Qt platform plugin "xcb" in ""
```

###### Things done

Adjust `QT_QPA_PLATFORM_PLUGIN_PATH` to point to `qtbase.bin`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

