### PR TITLE
qt5.qtcharts: enable qml

### DIFF
--- a/pkgs/development/libraries/qt-5/5.9/qtcharts.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtcharts.nix
@@ -1,8 +1,8 @@
-{ qtSubmodule, qtbase }:
+{ qtSubmodule, qtbase, qtdeclarative }:
 
 qtSubmodule {
   name = "qtcharts";
-  qtInputs = [ qtbase ];
+  qtInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
   postInstall = ''
     moveToOutput "$qtQmlPrefix" "$bin"


### PR DESCRIPTION
Dependency qtdeclarative was missing so QML plugin was not built.

###### Motivation for this change

Fix for https://github.com/NixOS/nixpkgs/issues/28343.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

