### PR TITLE
nixos/tor: default of IsolateClientAddr in SocksPort was inverted

### DIFF
--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -21,8 +21,8 @@ let
   ''
   # Client connection config
   + optionalString cfg.client.enable  ''
-    SOCKSPort ${cfg.client.socksListenAddress} IsolateDestAddr
-    SOCKSPort ${cfg.client.socksListenAddressFaster}
+    SOCKSPort ${cfg.client.socksListenAddress}
+    SOCKSPort ${cfg.client.socksListenAddressFaster} NoIsolateClientAddr
     ${opt "SocksPolicy" cfg.client.socksPolicy}
   ''
   # Relay config


### PR DESCRIPTION
###### Motivation for this change

The current documentation is misleading, since both ports `9050` and `9063` will have `IsolateClientAddr` enabled. The tor project does not recommend to disable it: https://www.torproject.org/docs/tor-manual.html.en
An alternative would be to completely remove the option `services.tor.client.enable` and `services.tor.socksListenAddressFaster`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

