### PR TITLE
vscode-with-extension: improvements

### DIFF
--- a/pkgs/applications/editors/vscode-with-extensions/default.nix
+++ b/pkgs/applications/editors/vscode-with-extensions/default.nix
@@ -2,7 +2,7 @@
 , vscodeExtensions ? [] }:
 
 /*
-  `vsixExtensions`
+  `vscodeExtensions`
    :  A set of vscode extensions to be installed alongside the editor. Here's a an
       example:
 
@@ -10,12 +10,12 @@
       vscode-with-extensions.override {
 
         # When the extension is already available in the default extensions set.
-        vscodeExtensions = with vscodeExtensions; [
-          nix
+        vscodeExtensions = with vscode-extensions; [
+          bbenoist.Nix
         ]   
 
         # Concise version from the vscode market place when not available in the default set.
-        ++ vscodeUtils.extensionsFromVscodeMarketplace [
+        ++ vscode-utils.extensionsFromVscodeMarketplace [
           {
             name = "code-runner";
             publisher = "formulahendry";

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -3,16 +3,23 @@
 let
   inherit (vscode-utils) buildVscodeExtension buildVscodeMarketplaceExtension;
 in
-
+#
+# Unless there is a good reason not to, we attemp to use the same name as the 
+# extension's unique identifier (the name the extension gets when installed
+# from vscode under `~/.vscode`) and found on the marketplace extension page.
+# So an extension's attribute name should be of the form: 
+# "${mktplcRef.publisher}.${mktplcRef.name}".
+#
 rec {
-  nix = buildVscodeMarketplaceExtension {
+  bbenoist.Nix = buildVscodeMarketplaceExtension {
     mktplcRef = {
-        name = "nix";
+        name = "Nix";
         publisher = "bbenoist";
         version = "1.0.1";
         sha256 = "0zd0n9f5z1f0ckzfjr38xw2zzmcxg1gjrava7yahg5cvdcw6l35b";
     };
-
-    # TODO: Fill meta with appropriate information.
+    meta = with stdenv.lib; {
+      license = licenses.mit;
+    };
   };
 }


### PR DESCRIPTION
 -  Now simply let the default `unpackPhase` unzip the vsix file. This
    should allow users to retrieve the extension directly from github.
 -  Extensions now installed using their unique id as install folder.
 -  Extensions under `vscode-extensions` now use the unique id
    as extension name.

###### Motivation for this change

Iterates on the `vscode-with-extensions` set of tools so that we gets something better.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

