### PR TITLE
dgraph: init at 0.8.1

### DIFF
--- a/pkgs/servers/dgraph/default.nix
+++ b/pkgs/servers/dgraph/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "dgraph-${version}";
+  version = "0.8.1";
+
+  goPackagePath = "github.com/dgraph-io/dgraph";
+
+  src = fetchFromGitHub {
+    owner = "dgraph-io";
+    repo = "dgraph";
+    rev = "v${version}";
+    sha256 = "1gls2pvgcmd364x84gz5fafs7pwkll4k352rg1lmv70wvzyydsdr";
+  };
+
+  extraOutputsToInstall = [ "dashboard" ];
+
+  goDeps = ./deps.nix;
+  subPackages = [ "cmd/dgraph" "cmd/dgraphloader" ];
+
+  # let's move the dashboard to a different output, to prevent $bin from
+  # depending on $out
+  # TODO: provide a proper npm application for the dashboard.
+  postPatch = ''
+    mv dashboard/* $dashboard
+  '';
+
+  preBuild = ''
+    export buildFlagsArray="-ldflags=\
+      -X github.com/dgraph-io/dgraph/x.dgraphVersion=${version} \
+      -X github.com/dgraph-io/dgraph/cmd/dgraph/main.uiDir=$dashboard/src/assets/"
+  '';
+
+  preFixup = stdenv.lib.optionalString stdenv.isDarwin ''
+    # Somehow on Darwin, $out/lib (which doesn't exist) ends up in RPATH.
+    # Removing it fixes cycle between $out and $bin
+    install_name_tool -delete_rpath $out/lib $bin/bin/dgraph
+    install_name_tool -delete_rpath $out/lib $bin/bin/dgraphloader
+  '';
+ 
+  meta = {
+    homepage = "https://dgraph.io/";
+    description = "Fast, Distributed Graph DB";
+    maintainers = with stdenv.lib.maintainers; [ sigma ];
+    license = stdenv.lib.licenses.agpl3;
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/servers/dgraph/deps.nix
+++ b/pkgs/servers/dgraph/deps.nix
@@ -1,0 +1,326 @@
+[
+  {
+    goPackagePath = "github.com/AndreasBriese/bbloom";
+    fetch = {
+      type = "git";
+      url = "https://github.com/AndreasBriese/bbloom";
+      rev = "28f7e881ca57bc00e028f9ede9f0d9104cfeef5e";
+      sha256 = "03cqhqvdz8c9by5w5ls4kwnnwlm6b2kkslc6m120fanw1lgamfzp";
+    };
+  }
+  {
+    goPackagePath = "github.com/MakeNowJust/heredoc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/MakeNowJust/heredoc";
+      rev = "1d91351acdc1cb2f2c995864674b754134b86ca7";
+      sha256 = "0ia1r8ibqmx6zv3wmsvgkpqlhwk79z9l38nzp4gd4f1kcb46856x";
+    };
+  }
+  {
+    goPackagePath = "github.com/beorn7/perks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/beorn7/perks";
+      rev = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9";
+      sha256 = "1hrybsql68xw57brzj805xx2mghydpdiysv3gbhr7f5wlxj2514y";
+    };
+  }
+  {
+    goPackagePath = "github.com/bkaradzic/go-lz4";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bkaradzic/go-lz4";
+      rev = "7224d8d8f27ef618c0a95f1ae69dbb0488abc33a";
+      sha256 = "10lmya17vdqg2pvqni0p73iahni48s1v11ya9a0hcz4jh5vw4dkb";
+    };
+  }
+  {
+    goPackagePath = "github.com/blevesearch/bleve";
+    fetch = {
+      type = "git";
+      url = "https://github.com/blevesearch/bleve";
+      rev = "a7ebb8480579777c6cd1c4750d2e6b5ff2b49bdd";
+      sha256 = "121jhd158slf4050kmghz25jrvv7gbsan31wr0nxyw9z32lyf6yx";
+    };
+  }
+  {
+    goPackagePath = "github.com/blevesearch/blevex";
+    fetch = {
+      type = "git";
+      url = "https://github.com/blevesearch/blevex";
+      rev = "507dcd576550f9f3260f11495ba2de4e96773a3e";
+      sha256 = "0i9azysvia99fjpx525qnc5rcgv45hfvl3zcs58gvgqyxpzpc78z";
+    };
+  }
+  {
+    goPackagePath = "github.com/blevesearch/go-porterstemmer";
+    fetch = {
+      type = "git";
+      url = "https://github.com/blevesearch/go-porterstemmer";
+      rev = "23a2c8e5cf1f380f27722c6d2ae8896431dc7d0e";
+      sha256 = "0rcfbrad79xd114h3dhy5d3zs3b5bcgqwm3h5ih1lk69zr9wi91d";
+    };
+  }
+  {
+    goPackagePath = "github.com/blevesearch/segment";
+    fetch = {
+      type = "git";
+      url = "https://github.com/blevesearch/segment";
+      rev = "762005e7a34fd909a84586299f1dd457371d36ee";
+      sha256 = "1nrm145sm0xlhqy3d12yipnb16ikjz9ykjcskmkgm7vjm47xkmfl";
+    };
+  }
+  {
+    goPackagePath = "github.com/cockroachdb/cmux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cockroachdb/cmux";
+      rev = "30d10be492927e2dcae0089c374c455d42414fcb";
+      sha256 = "0ixif6hwcm2dpi1si5ah49dmdyy5chillz1048jpvjzwzxyfv1nx";
+    };
+  }
+  {
+    goPackagePath = "github.com/codahale/hdrhistogram";
+    fetch = {
+      type = "git";
+      url = "https://github.com/codahale/hdrhistogram";
+      rev = "3a0bb77429bd3a61596f5e8a3172445844342120";
+      sha256 = "1zampgfjbxy192cbwdi7g86l1idxaam96d834wncnpfdwgh5kl57";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/etcd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/etcd";
+      rev = "1ebeef5cbfe69c0dab2bc701ee5307eed7a7d8d2";
+      sha256 = "12lidn1a8nwsk6nlwyfirrxkxhs4lhj53f4cd19xm8w070q0mg19";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "6d212800a42e8ab5c146b8ace3490ee17e5225f9";
+      sha256 = "01i0n1s4j7khb7n6mz2wymniz37q0vbzkgfv7rbi6p9hpg227q93";
+    };
+  }
+  {
+    goPackagePath = "github.com/dgraph-io/badger";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgraph-io/badger";
+      rev = "ad23a425b3c87b8223780cb882bed568ca14b9f0";
+      sha256 = "1xjd05vska1kanmgdhp5cvkn2i6236rqphrc9i4kfjndgwkmas57";
+    };
+  }
+  {
+    goPackagePath = "github.com/dgryski/go-farm";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgryski/go-farm";
+      rev = "d1e51a4af19092715f4ce7d8257fe5bc8f8be727";
+      sha256 = "00iijjzdg8g6jbzhdbfw8s2rf0k25gxw4x7h7r6mkxcq18n69182";
+    };
+  }
+  {
+    goPackagePath = "github.com/gogo/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogo/protobuf";
+      rev = "e57a569e1882958f6b188cb42231d6db87701f2a";
+      sha256 = "0r3jpmp6wp4xyrh1ikr8iqld3rg4r1yhv99zxw5zd7d2zprw9yfc";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/geo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/geo";
+      rev = "3a42ea109208469f16baf9e090135dd0e82ece5c";
+      sha256 = "1fzlakjj94gv516q7gd9qycn91lij7wmjbdv0vsrh6qnxvgqr8hw";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "2bba0603135d7d7f5cb73b2125beeda19c09f4ef";
+      sha256 = "1xy0bj66qks2xlzxzlfma16w7m8g6rrwawmlhlv68bcw2k5hvvib";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/codesearch";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/codesearch";
+      rev = "a45d81b686e85d01f2838439deaf72126ccd5a96";
+      sha256 = "12bv3yz0l3bmsxbasfgv7scm9j719ch6pmlspv4bd4ix7wjpyhny";
+    };
+  }
+  {
+    goPackagePath = "github.com/matttproud/golang_protobuf_extensions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/matttproud/golang_protobuf_extensions";
+      rev = "c12348ce28de40eed0136aa2b644d0ee0650e56c";
+      sha256 = "1d0c1isd2lk9pnfq2nk0aih356j30k3h1gi2w0ixsivi5csl7jya";
+    };
+  }
+  {
+    goPackagePath = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev = "17b591df37844cde689f4d5813e5cea0927d8dd2";
+      sha256 = "1f400f1682h1wdjknlh1ad95rbss09g0ia36a8w102bf2f1qfq8l";
+    };
+  }
+  {
+    goPackagePath = "github.com/pkg/profile";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/profile";
+      rev = "5b67d428864e92711fcbd2f8629456121a56d91f";
+      sha256 = "0blqmvgqvdbqmh3fp9pfdxc9w1qfshrr0zy9whj0sn372bw64qnr";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "792786c7400a136282c1664665ae0a8db921c6c2";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/client_golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_golang";
+      rev = "310ce84375bb84c5cbbf0d05069c92daa5673740";
+      sha256 = "11awb5bjkwqj7va3v7fgniwqkjqhmhjkp01rdvnv4xfp1laxwn7v";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/client_model";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_model";
+      rev = "6f3806018612930941127f2a7c6c453ba2c527d2";
+      sha256 = "1413ibprinxhni51p0755dp57r9wvbw7xgj9nmdaxmhzlqhc86j4";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/common";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/common";
+      rev = "0866df4b85a18d652b6965be022d007cdf076822";
+      sha256 = "0zw4rxs6zh9vgxz5wwhjnwa6mgac8jh7mb63viircgh08r889chp";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/procfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/procfs";
+      rev = "e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2";
+      sha256 = "18hwygbawbqilz7h8fl25xpbciwalkslb4igqn4cr9d8sqp7d3np";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "976c720a22c8eb4eb6a0b4348ad85ad12491a506";
+      sha256 = "0a2gxvqzacrj9k8h022zhr8fchhn9afc6a511m07j71dzw9g4y3m";
+    };
+  }
+  {
+    goPackagePath = "github.com/tebeka/snowball";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tebeka/snowball";
+      rev = "6b06bd306c4e4442a63e546752278920ae487934";
+      sha256 = "110akijkb55k5h7m6mra8fircvi4sxd5xq7lcjgyiqj96srq8v2k";
+    };
+  }
+  {
+    goPackagePath = "github.com/twpayne/go-geom";
+    fetch = {
+      type = "git";
+      url = "https://github.com/twpayne/go-geom";
+      rev = "6753ad11e46b04e21b3f286b342e73a8c4be8216";
+      sha256 = "0qyrdnp7j7lmj0qb0p7k45m757zvbwn78s1apiy46zfnb5415df1";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "22ddb68eccda408bbf17759ac18d3120ce0d4f3f";
+      sha256 = "07ks6qal02iz24vv54qyb90wmsg9vwqc14abf68rakprpy26qwsg";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "d1e1b351919c6738fdeb9893d5c998b161464f0c";
+      sha256 = "0qzbfah03z992zyygfp7imjjas5np2gcar5aanx5y3av5g68ggjp";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "abf9c25f54453410d0c6668e519582a9e1115027";
+      sha256 = "0dmpqjfif2zg6776d366js60k21g81jvsr3jm9dc7fv7w3282al4";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "836efe42bb4aa16aaa17b9c155d8813d336ed720";
+      sha256 = "11s7bjk0karl1lx8v4n6dvdnsh702x4f2qlmnqac2qdz8hdswmi1";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/genproto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-genproto";
+      rev = "b0a3dcfcd1a9bd48e63634bd8802960804cf8315";
+      sha256 = "0lkj73lyr4dzj2pxgmild0i1bl6kdgrxa3c8m44j5ms537pyxcpr";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/grpc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/grpc/grpc-go";
+      rev = "2bb318258959db281674bc6fd67b5167b7ff0d65";
+      sha256 = "1g8ir87ksr8549801vdgb0n6rmxws05ky50bkgjv86370h146cqm";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "a5b47d31c556af34a302ce5d659e6fea44d90de0";
+      sha256 = "0v6l48fshdjrqzyq1kwn22gy7vy434xdr1i0lm3prsf6jbln9fam";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11073,6 +11073,8 @@ with pkgs;
 
   dex-oidc = callPackage ../servers/dex { };
 
+  dgraph = callPackage ../servers/dgraph { };
+    
   dico = callPackage ../servers/dico { };
 
   dict = callPackage ../servers/dict {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

