### PR TITLE
Tensorflow1.3 dependencies

### DIFF
--- a/pkgs/development/libraries/protobuf/3.3.nix
+++ b/pkgs/development/libraries/protobuf/3.3.nix
@@ -1,0 +1,6 @@
+{ callPackage, lib, ... }:
+
+lib.overrideDerivation (callPackage ./generic-v3.nix {
+  version = "3.3.0";
+  sha256 = "1258yz9flyyaswh3izv227kwnhwcxn4nwavdz9iznqmh24qmi59w";
+}) (attrs: { NIX_CFLAGS_COMPILE = "-Wno-error"; })

--- a/pkgs/development/libraries/science/math/cudnn/8.0-6.0/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/8.0-6.0/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, requireFile
+, cudatoolkit
+, fetchurl
+}:
+
+stdenv.mkDerivation rec {
+  version = "6.0";
+  cudatoolkit_version = "8.0";
+
+  name = "cudatoolkit-${cudatoolkit_version}-cudnn-${version}";
+
+  src = fetchurl {
+    url = "http://developer.download.nvidia.com/compute/redist/cudnn/v6.0/cudnn-8.0-linux-x64-v6.0.tgz";
+    sha256 = "173zpgrk55ri8if7s5yngsc89ajd6hz4pss4cdxlv6lcyh5122cv";
+  };
+
+  installPhase = ''
+    function fixRunPath {
+      p=$(patchelf --print-rpath $1)
+      patchelf --set-rpath "$p:${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ]}" $1
+    }
+    fixRunPath lib64/libcudnn.so
+
+    mkdir -p $out
+    cp -a include $out/include
+    cp -a lib64 $out/lib64
+  '';
+
+  propagatedBuildInputs = [
+    cudatoolkit
+  ];
+
+  meta = with stdenv.lib; {
+    description = "NVIDIA CUDA Deep Neural Network library (cuDNN)";
+    homepage = https://developer.nvidia.com/cudnn;
+    license = stdenv.lib.licenses.unfree;
+    maintainers = with maintainers; [ jpbernardy ];
+  };
+}

--- a/pkgs/development/python-modules/backports_weakref/default.nix
+++ b/pkgs/development/python-modules/backports_weakref/default.nix
@@ -1,0 +1,20 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "backports.weakref";
+  version = "1.0rc1";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "14i8m3lspykdfpzf50grij3z286j9q8f32f2bnwdicv659qvy4w8";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Backports of new features in Python’s weakref module";
+    license = licenses.psfl;
+    maintainers = with maintainers; [ jpbernardy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9905,10 +9905,9 @@ with pkgs;
 
   protobuf = protobuf2_6;
   protobuf3_0 = lowPrio (callPackage ../development/libraries/protobuf/3.0.nix { });
-  # 3.0.0-beta-2 is only introduced for tensorflow. remove this version when tensorflow is moved to 3.0.
-  protobuf3_0_0b2 = lowPrio (callPackage ../development/libraries/protobuf/3.0.0-beta-2.nix { });
   protobuf3_1 = callPackage ../development/libraries/protobuf/3.1.nix { };
   protobuf3_2 = callPackage ../development/libraries/protobuf/3.2.nix { };
+  protobuf3_3 = callPackage ../development/libraries/protobuf/3.3.nix { };
   protobuf2_6 = callPackage ../development/libraries/protobuf/2.6.nix { };
   protobuf2_5 = callPackage ../development/libraries/protobuf/2.5.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1554,6 +1554,10 @@ with pkgs;
     cudatoolkit = cudatoolkit8;
   };
 
+  cudnn60_cudatoolkit80 = callPackage ../development/libraries/science/math/cudnn/8.0-6.0 {
+    cudatoolkit = cudatoolkit8;
+  };
+
   curlFull = curl.override {
     idnSupport = true;
     ldapSupport = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17003,7 +17003,11 @@ in {
   });
 
   protobuf = self.protobuf2_6;
-  # only required by tensorflow
+  protobuf3_3 = callPackage ../development/python-modules/protobuf.nix {
+    disabled = isPyPy;
+    doCheck = !isPy3k;
+    protobuf = pkgs.protobuf3_3;
+  };
   protobuf3_2 = callPackage ../development/python-modules/protobuf.nix {
     disabled = isPyPy;
     doCheck = !isPy3k;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -28657,9 +28657,12 @@ EOF
 
   preshed = callPackage ../development/python-modules/preshed { };
 
+  backports_weakref = callPackage ../development/python-modules/backports_weakref { }; 
+
   thinc = callPackage ../development/python-modules/thinc { };
 
   spacy = callPackage ../development/python-modules/spacy { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12377,12 +12377,12 @@ in {
   };
 
   markdown = buildPythonPackage rec {
-    version = "2.6.7";
+    version = "2.6.8";
     name = "markdown-${version}";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/M/Markdown/Markdown-${version}.tar.gz";
-      sha256 = "1h055llfd0ps0ig7qb3v1j9068xv90dc9s7xkhkgz9zg8r4g5sys";
+      sha256 = "0cqfhr1km2s5d8jm6hbwgkrrj9hvkjf2gab3s2axlrw1clgaij0a";
     };
 
     # error: invalid command 'test'


### PR DESCRIPTION
###### Motivation for this change

This branch prepares for tensorflow 1.3 by adding the necessary dependencies.
Unfortunately, this branch does not add tensorflow 1.3 itself because of a circular dependency between tensorflow and tensorflow_tensorboard.

Reviewers: please advise as how to deal with such a circular dependency between python packages. The manual https://nixos.org/nixpkgs/manual/#how-to-solve-circular-dependencies prescribe to override the packages to remove the offending dependency however it is silent on how this should be done.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

