### PR TITLE
luaPackages.luacheck : init at 0.20.0

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -71,6 +71,32 @@ let
     };
   };
 
+  luacheck = buildLuaPackage rec {
+    pname = "luacheck";
+    version = "0.20.0";
+    name = "${pname}${version}";
+
+    src = fetchFromGitHub {
+      owner = "mpeterv";
+      repo = "luacheck";
+      rev = "${version}";
+      sha256 = "0ahfkmqcjhlb7r99bswy1sly6d7p4pyw5f4x4fxnxzjhbq0c5qcs";
+    };
+
+    propagatedBuildInputs = [ lua ];
+
+    installPhase = ''
+      ${lua}/bin/lua install.lua $out
+      '';
+
+    meta = with stdenv.lib; {
+      description = "A tool for linting and static analysis of Lua code";
+      homepage = https://github.com/mpeterv/luacheck;
+      license = licenses.mit;
+      platforms = platforms.unix;
+    };
+  };
+
   luaevent = buildLuaPackage rec {
     version = "0.4.3";
     name = "luaevent-${version}";


### PR DESCRIPTION
###### Motivation for this change
add lua [linter](https://github.com/mpeterv/luacheck)

I want to move this to [separated expression](https://github.com/NixOS/nixpkgs/issues/25375#issuecomment-315313691) but I have no working example to follow.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

    $ nix-shell -I nixpkgs=/nix/nixpkgs/ -p luaPackages.luacheck --run 'cat test.lua; luacheck test.lua; lua -v; lua test.lua'
    local t = 1
    T = 10

    print(t,T)
    Checking test.lua                                 2 warnings

        test.lua:2:1: setting non-standard global variable T
        test.lua:4:9: accessing undefined variable T

    Total: 2 warnings / 0 errors in 1 file
    Lua 5.2.3  Copyright (C) 1994-2013 Lua.org, PUC-Rio
    1       10
