### PR TITLE
metasploit: 4.14.25 -> 4.16.1

### DIFF
--- a/pkgs/tools/security/metasploit/Gemfile
+++ b/pkgs/tools/security/metasploit/Gemfile
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem "metasploit-framework", git: "https://github.com/rapid7/metasploit-framework", ref: "refs/tags/4.14.25"
+gem "metasploit-framework", git: "https://github.com/rapid7/metasploit-framework", ref: "refs/tags/4.16.1"

--- a/pkgs/tools/security/metasploit/Gemfile.lock
+++ b/pkgs/tools/security/metasploit/Gemfile.lock
@@ -1,15 +1,17 @@
 GIT
   remote: https://github.com/rapid7/metasploit-framework
-  revision: 8a194207f07c2b8c91c1a72e57c25683d4e9f744
-  ref: refs/tags/4.14.25
+  revision: dbec1c2d2ae4bd77276cbfb3c6ee2902048b9453
+  ref: refs/tags/4.16.1
   specs:
-    metasploit-framework (4.14.25)
+    metasploit-framework (4.16.1)
       actionpack (~> 4.2.6)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
       backports
       bcrypt
+      bcrypt_pbkdf
       bit-struct
+      dnsruby
       filesize
       jsobfu
       json
@@ -17,9 +19,9 @@ GIT
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.2.32)
+      metasploit-payloads (= 1.3.1)
       metasploit_data_models
-      metasploit_payloads-mettle (= 0.1.9)
+      metasploit_payloads-mettle (= 0.2.0)
       msgpack
       nessus_rest
       net-ssh
@@ -32,9 +34,12 @@ GIT
       packetfu
       patch_finder
       pcaprub
-      pg
+      pdf-reader
+      pg (= 0.20.0)
       railties
       rb-readline
+      rbnacl (< 5.0.0)
+      rbnacl-libsodium
       recog
       redcarpet
       rex-arch
@@ -46,7 +51,7 @@ GIT
       rex-mime
       rex-nop
       rex-ole
-      rex-powershell
+      rex-powershell (< 0.1.73)
       rex-random_identifier
       rex-registry
       rex-rop_builder
@@ -64,62 +69,69 @@ GIT
       tzinfo
       tzinfo-data
       windows_error
+      xdr
       xmlrpc
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (4.2.8)
-      actionview (= 4.2.8)
-      activesupport (= 4.2.8)
+    Ascii85 (1.0.2)
+    actionpack (4.2.9)
+      actionview (= 4.2.9)
+      activesupport (= 4.2.9)
       rack (~> 1.6)
       rack-test (~> 0.6.2)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (4.2.8)
-      activesupport (= 4.2.8)
+    actionview (4.2.9)
+      activesupport (= 4.2.9)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activemodel (4.2.8)
-      activesupport (= 4.2.8)
+    activemodel (4.2.9)
+      activesupport (= 4.2.9)
       builder (~> 3.1)
-    activerecord (4.2.8)
-      activemodel (= 4.2.8)
-      activesupport (= 4.2.8)
+    activerecord (4.2.9)
+      activemodel (= 4.2.9)
+      activesupport (= 4.2.9)
       arel (~> 6.0)
-    activesupport (4.2.8)
+    activesupport (4.2.9)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
+    afm (0.2.2)
     arel (6.0.4)
     arel-helpers (2.4.0)
       activerecord (>= 3.1.0, < 6)
     backports (3.8.0)
     bcrypt (3.1.11)
+    bcrypt_pbkdf (1.0.0)
     bindata (2.4.0)
     bit-struct (0.16)
     builder (3.2.3)
+    dnsruby (1.60.2)
     erubis (2.7.0)
-    faraday (0.12.1)
+    faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
+    ffi (1.9.18)
     filesize (0.1.1)
-    i18n (0.8.4)
+    hashery (2.1.2)
+    i18n (0.8.6)
     jsobfu (0.4.2)
       rkelly-remix
     json (2.1.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     metasm (1.0.3)
-    metasploit-concern (2.0.4)
+    metasploit-concern (2.0.5)
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-credential (2.0.10)
+    metasploit-credential (2.0.12)
       metasploit-concern
       metasploit-model
       metasploit_data_models
@@ -132,8 +144,8 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.2.32)
-    metasploit_data_models (2.0.14)
+    metasploit-payloads (1.3.1)
+    metasploit_data_models (2.0.15)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
       arel-helpers
@@ -143,15 +155,15 @@ GEM
       postgres_ext
       railties (~> 4.2.6)
       recog (~> 2.0)
-    metasploit_payloads-mettle (0.1.9)
+    metasploit_payloads-mettle (0.2.0)
     mini_portile2 (2.2.0)
-    minitest (5.10.2)
+    minitest (5.10.3)
     msgpack (1.1.0)
     multipart-post (2.0.0)
     nessus_rest (0.1.6)
     net-ssh (4.1.0)
     network_interface (0.0.1)
-    nexpose (6.0.0)
+    nexpose (6.1.1)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
     octokit (4.7.0)
@@ -162,6 +174,12 @@ GEM
       pcaprub
     patch_finder (1.0.2)
     pcaprub (0.12.4)
+    pdf-reader (2.0.0)
+      Ascii85 (~> 1.0.0)
+      afm (~> 0.2.1)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     pg (0.20.0)
     pg_array_parser (0.0.9)
     postgres_ext (3.0.0)
@@ -180,25 +198,29 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    railties (4.2.8)
-      actionpack (= 4.2.8)
-      activesupport (= 4.2.8)
+    railties (4.2.9)
+      actionpack (= 4.2.9)
+      activesupport (= 4.2.9)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
-    rb-readline (0.5.4)
-    recog (2.1.8)
+    rb-readline (0.5.5)
+    rbnacl (4.0.2)
+      ffi
+    rbnacl-libsodium (1.0.13)
+      rbnacl (>= 3.0.1)
+    recog (2.1.12)
       nokogiri
     redcarpet (3.4.0)
-    rex-arch (0.1.8)
+    rex-arch (0.1.11)
       rex-text
-    rex-bin_tools (0.1.3)
+    rex-bin_tools (0.1.4)
       metasm
       rex-arch
       rex-core
       rex-struct2
       rex-text
-    rex-core (0.1.10)
+    rex-core (0.1.12)
     rex-encoder (0.1.4)
       metasm
       rex-arch
@@ -226,9 +248,10 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.6)
+    rex-socket (0.1.8)
       rex-core
-    rex-sslscan (0.1.4)
+    rex-sslscan (0.1.5)
+      rex-core
       rex-socket
       rex-text
     rex-struct2 (0.1.2)
@@ -237,6 +260,7 @@ GEM
       rex-text
     rkelly-remix (0.0.7)
     robots (0.10.1)
+    ruby-rc4 (0.1.5)
     ruby_smb (0.0.18)
       bindata
       rubyntlm
@@ -248,13 +272,17 @@ GEM
       faraday (~> 0.8, < 1.0)
     sqlite3 (1.3.13)
     sshkey (1.9.0)
-    thor (0.19.4)
+    thor (0.20.0)
     thread_safe (0.3.6)
+    ttfunk (1.5.1)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     tzinfo-data (1.2017.2)
       tzinfo (>= 1.0.0)
     windows_error (0.1.2)
+    xdr (2.0.0)
+      activemodel (>= 4.2.7)
+      activesupport (>= 4.2.7)
     xmlrpc (0.3.0)
 
 PLATFORMS
@@ -264,4 +292,4 @@ DEPENDENCIES
   metasploit-framework!
 
 BUNDLED WITH
-   1.14.6
+   1.15.0

--- a/pkgs/tools/security/metasploit/default.nix
+++ b/pkgs/tools/security/metasploit/default.nix
@@ -4,6 +4,10 @@
 # 1. increment version number in expression and in Gemfile
 # 2. run $ nix-shell --command "bundler install && bundix"
 #    in metasploit in nixpkgs
+# 3. run $ sed -i '/[ ]*dependencies =/d' gemset.nix
+# 4. run $ nix-build -A metasploit ../../../../
+# 5. update sha256sum in expression
+# 6. run step 3 again
 
 let
   env = bundlerEnv {
@@ -13,13 +17,13 @@ let
   };
 in stdenv.mkDerivation rec {
   name = "metasploit-framework-${version}";
-  version = "4.14.25";
+  version = "4.16.1";
 
   src = fetchFromGitHub {
     owner = "rapid7";
     repo = "metasploit-framework";
     rev = version;
-    sha256 = "0cp1ybq29a0r7kabg4p2yj0qm90hjvr4xxp0pynb2g406sbyycjm";
+    sha256 = "1vilyy0dqzp8kbbpvs2zrv2ac7s39w2vv7mrbzgcjgh2bj7c6bg1";
   };
 
   buildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/metasploit/gemset.nix
+++ b/pkgs/tools/security/metasploit/gemset.nix
@@ -2,42 +2,42 @@
   actionpack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "09fbazl0ja80na2wadfp3fzmdmdy1lsb4wd2yg7anbj0zk0ap7a9";
+      sha256 = "1kgrq74gp2czzxr0f2sqrc98llz03lgq498300z2z5n4khgznwc4";
       type = "gem";
     };
-    version = "4.2.8";
+    version = "4.2.9";
   };
   actionview = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1mg4a8143q2wjhjq4mngl69jkv249z5jvg0jkdribdv4zkg586rp";
+      sha256 = "04kgp4gmahw31miz8xdq1pns14qmvvzd14fgfv7fg9klkw3bxyyp";
       type = "gem";
     };
-    version = "4.2.8";
+    version = "4.2.9";
   };
   activemodel = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "11vhh7zmp92880s5sx8r32v2p0b7xg039mfr92pjynpkz4q901ld";
+      sha256 = "1qxmivny0ka5s3iyap08sn9bp2bd9wrhqp2njfw26hr9wsjk5kfv";
       type = "gem";
     };
-    version = "4.2.8";
+    version = "4.2.9";
   };
   activerecord = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1kk4dhn8jfhqfsf1dmb3a183gix6k46xr6cjkxj0rp51w2za1ns0";
+      sha256 = "18i790dfhi4ndypd1pj9pv08knpxr2sayvvwfq7axj5jfwgpmrqb";
       type = "gem";
     };
-    version = "4.2.8";
+    version = "4.2.9";
   };
   activesupport = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0wibdzd2f5l5rlsw1a1y3j3fhw2imrrbkxggdraa6q9qbdnc66hi";
+      sha256 = "1d0a362p3m2m2kljichar2pwq0qm4vblc3njy1rdzm09ckzd45sp";
       type = "gem";
     };
-    version = "4.2.8";
+    version = "4.2.9";
   };
   addressable = {
     source = {
@@ -46,6 +46,14 @@
       type = "gem";
     };
     version = "2.5.1";
+  };
+  afm = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06kj9hgd0z8pj27bxp2diwqh6fv7qhwwm17z64rhdc4sfn76jgn8";
+      type = "gem";
+    };
+    version = "0.2.2";
   };
   arel = {
     source = {
@@ -63,6 +71,14 @@
     };
     version = "2.4.0";
   };
+  Ascii85 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0j95sbxd18kc8rhcnvl1w37kflqpax1r12h1x47gh4xxn3mz4m7q";
+      type = "gem";
+    };
+    version = "1.0.2";
+  };
   backports = {
     source = {
       remotes = ["https://rubygems.org"];
@@ -78,6 +94,14 @@
       type = "gem";
     };
     version = "3.1.11";
+  };
+  bcrypt_pbkdf = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0cj4k13c7qvvck7y25i3xarvyqq8d27vl61jddifkc7llnnap1hv";
+      type = "gem";
+    };
+    version = "1.0.0";
   };
   bindata = {
     source = {
@@ -103,6 +127,14 @@
     };
     version = "3.2.3";
   };
+  dnsruby = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qfvpkka69f8vnmda3zhkr54fjpf7pwgmbx0gcsxg3jd6c7sjs1d";
+      type = "gem";
+    };
+    version = "1.60.2";
+  };
   erubis = {
     source = {
       remotes = ["https://rubygems.org"];
@@ -114,10 +146,18 @@
   faraday = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1wkx9844vacsk2229xbc27djf6zw15kqd60ifr78whf9mp9v6l03";
+      sha256 = "1gyqsj7vlqynwvivf9485zwmcj04v1z7gq362z0b8zw2zf4ag0hw";
       type = "gem";
     };
-    version = "0.12.1";
+    version = "0.13.1";
+  };
+  ffi = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "034f52xf7zcqgbvwbl20jwdyjwznvqnwpbaps9nk18v9lgb1dpx0";
+      type = "gem";
+    };
+    version = "1.9.18";
   };
   filesize = {
     source = {
@@ -127,13 +167,21 @@
     };
     version = "0.1.1";
   };
+  hashery = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qj8815bf7q6q7llm5rzdz279gzmpqmqqicxnzv066a020iwqffj";
+      type = "gem";
+    };
+    version = "2.1.2";
+  };
   i18n = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1j491wrfzham4nk8q4bifah3lx7nr8wp9ahfb7vd3hxn71v7kic7";
+      sha256 = "1i3aqvzfsj786kwjj70jsjpxm6ffw5pwhalzr2abjfv2bdc7k9kw";
       type = "gem";
     };
-    version = "0.8.4";
+    version = "0.8.6";
   };
   jsobfu = {
     source = {
@@ -170,28 +218,28 @@
   metasploit-concern = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0kqby5ycxhr0jfzvjqkdgjbqqjrg8jlmcxw8myrm0875hybyl1mq";
+      sha256 = "0v9lm225fhzhnbjcc0vwb38ybikxwzlv8116rrrkndzs8qy79297";
       type = "gem";
     };
-    version = "2.0.4";
+    version = "2.0.5";
   };
   metasploit-credential = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1zblyy2yv31zap6dzf3lpkhvnafkwbzdvr6nsqmyh95ci8yy1q6r";
+      sha256 = "1flahrcl5hf4bncqs40mry6pkffvmir85kqzkad22x3dh6crw50i";
       type = "gem";
     };
-    version = "2.0.10";
+    version = "2.0.12";
   };
   metasploit-framework = {
     source = {
       fetchSubmodules = false;
-      rev = "8a194207f07c2b8c91c1a72e57c25683d4e9f744";
-      sha256 = "0q7iv9wd65ji1cay6am4dskrlibvp3wyn66gvld8p1nfnnvn5vmq";
+      rev = "dbec1c2d2ae4bd77276cbfb3c6ee2902048b9453";
+      sha256 = "06a2dc64wl8w02zimf44hch4cap7ckw42kg1x01lmcwaa8d5q09w";
       type = "git";
       url = "https://github.com/rapid7/metasploit-framework";
     };
-    version = "4.14.25";
+    version = "4.16.1";
   };
   metasploit-model = {
     source = {
@@ -204,26 +252,26 @@
   metasploit-payloads = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1dqnyzp60da6f8kgnbpjmv5xsg1hvyyd2jkkzbh69sgwp4nw3i9g";
+      sha256 = "0icha08z4c5rnyp66xcyn9c8lbv43gx7hgs9rsm3539gj8c40znx";
       type = "gem";
     };
-    version = "1.2.32";
+    version = "1.3.1";
   };
   metasploit_data_models = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0hb2wsz3d4xgjf6dlf7nzxlv6q7rcdgn1pj79xs3g8al38zi129g";
+      sha256 = "0j3ijxn6n3ack9572a74cwknijymy41c8rx34njyhg25lx4hbvah";
       type = "gem";
     };
-    version = "2.0.14";
+    version = "2.0.15";
   };
   metasploit_payloads-mettle = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "058ijqznh4xqx3d6dph5gwdsmj96z4n46rl1mm85fyxpgpkifqd1";
+      sha256 = "1y2nfzgs17pq3xvlw14jgjcksr4h8p4miypxk9a87l1h7xv7dcgn";
       type = "gem";
     };
-    version = "0.1.9";
+    version = "0.2.0";
   };
   mini_portile2 = {
     source = {
@@ -236,10 +284,10 @@
   minitest = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "11my86fnihvpndyknn3c14hc82nhsgggnhlxh8h3bdjpmfsvl0my";
+      sha256 = "05521clw19lrksqgvg2kmm025pvdhdaniix52vmbychrn2jm7kz2";
       type = "gem";
     };
-    version = "5.10.2";
+    version = "5.10.3";
   };
   msgpack = {
     source = {
@@ -284,10 +332,10 @@
   nexpose = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0jdhhzzs3b3rav6imx8jn9920cjj83yjvz35q169y0ppla2xzqbg";
+      sha256 = "0jnyvj09z8r3chhj930fdnashbfcfv0vw2drjvsrcnm7firdhdzb";
       type = "gem";
     };
-    version = "6.0.0";
+    version = "6.1.1";
   };
   nokogiri = {
     source = {
@@ -344,6 +392,14 @@
       type = "gem";
     };
     version = "0.12.4";
+  };
+  pdf-reader = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nlammdpjy3padmzxhsql7mw31jyqp88n6bdffiarv5kzl4s3y7p";
+      type = "gem";
+    };
+    version = "2.0.0";
   };
   pg = {
     source = {
@@ -420,10 +476,10 @@
   railties = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0bavl4hj7bnl3ryqi9rvykm410kflplgingkcxasfv1gdilddh4g";
+      sha256 = "1g5jnk1zllm2fr06lixq7gv8l2cwqc99akv7886gz6lshijpfyxd";
       type = "gem";
     };
-    version = "4.2.8";
+    version = "4.2.9";
   };
   rake = {
     source = {
@@ -436,18 +492,34 @@
   rb-readline = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "170m6d2298s9kfbd4y3zzj4irsnd15qlbgi6kk93m88lkh9qzy3a";
+      sha256 = "14w79a121czmvk1s953qfzww30mqjb2zc0k9qhi0ivxxk3hxg6wy";
       type = "gem";
     };
-    version = "0.5.4";
+    version = "0.5.5";
+  };
+  rbnacl = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08dkigw8wdx53hviw1zqrs7rcrzqcwh9jd3dvwr72013z9fmyp48";
+      type = "gem";
+    };
+    version = "4.0.2";
+  };
+  rbnacl-libsodium = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1323fli41m01af13xz5xvabsjnz09si1b9l4qd2p802kq0dr61gd";
+      type = "gem";
+    };
+    version = "1.0.13";
   };
   recog = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0d12889rx9ylm0jybg9n5sqx0v413hy9zjqs9rd9qjd1kjva7y87";
+      sha256 = "0h023ykrrra74bpbibkyg083kafaswvraw4naw9p1ghcjzn9ggj3";
       type = "gem";
     };
-    version = "2.1.8";
+    version = "2.1.12";
   };
   redcarpet = {
     source = {
@@ -460,26 +532,26 @@
   rex-arch = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "13dyic499iblhddmy7w01ajr5l5rm6szagy6vz7sx138y21d1y6f";
+      sha256 = "1izzalmjwdyib8y0xlgys8qb60di6xyjk485ylgh14p47wkyc6yp";
       type = "gem";
     };
-    version = "0.1.8";
+    version = "0.1.11";
   };
   rex-bin_tools = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0skrbpyal6anh4g1nsaf9ypg5sd2ghxxmghasxw4p1s1i1xbmhwr";
+      sha256 = "01hi1cjr68adp47nxbjfprvn0r3b72r4ib82x9j33bf2pny6nvaw";
       type = "gem";
     };
-    version = "0.1.3";
+    version = "0.1.4";
   };
   rex-core = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "09xbslrwbc9d0rp24y1pdgc6650ciwicq4q7skjz74rprr9wj16f";
+      sha256 = "16dwf4pw7bpx8xvlv241imxvwhvjfv0cw9kl7ipsv40yazy5lzpk";
       type = "gem";
     };
-    version = "0.1.10";
+    version = "0.1.12";
   };
   rex-encoder = {
     source = {
@@ -564,18 +636,18 @@
   rex-socket = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0r39782f2qpq83wsi72213v344gq4rccch98i376fx8bayh0dygh";
+      sha256 = "0bkr64qrfy2mcv6cpp2z2rn9npgn9s0yyagzjh7kawbm80ldwf2h";
       type = "gem";
     };
-    version = "0.1.6";
+    version = "0.1.8";
   };
   rex-sslscan = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0r5cy1kng1ggjycn7a8vpval7clhr0yxhd7rgn2hasxl2p3c7i8v";
+      sha256 = "06gbx45q653ajcx099p0yxdqqxazfznbrqshd4nwiwg1p498lmyx";
       type = "gem";
     };
-    version = "0.1.4";
+    version = "0.1.5";
   };
   rex-struct2 = {
     source = {
@@ -616,6 +688,14 @@
       type = "gem";
     };
     version = "0.10.1";
+  };
+  ruby-rc4 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "00vci475258mmbvsdqkmqadlwn6gj9m01sp7b5a3zd90knil1k00";
+      type = "gem";
+    };
+    version = "0.1.5";
   };
   ruby_smb = {
     source = {
@@ -668,10 +748,10 @@
   thor = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "01n5dv9kql60m6a00zc0r66jvaxx98qhdny3klyj0p3w34pad2ns";
+      sha256 = "0nmqpyj642sk4g16nkbq6pj856adpv91lp4krwhqkh2iw63aszdl";
       type = "gem";
     };
-    version = "0.19.4";
+    version = "0.20.0";
   };
   thread_safe = {
     source = {
@@ -680,6 +760,14 @@
       type = "gem";
     };
     version = "0.3.6";
+  };
+  ttfunk = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1mgrnqla5n51v4ivn844albsajkck7k6lviphfqa8470r46c58cd";
+      type = "gem";
+    };
+    version = "1.5.1";
   };
   tzinfo = {
     source = {
@@ -704,6 +792,14 @@
       type = "gem";
     };
     version = "0.1.2";
+  };
+  xdr = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0c5cp1k4ij3xq1q6fb0f6xv5b65wy18y7bhwvsdx8wd0zyg3x96m";
+      type = "gem";
+    };
+    version = "2.0.0";
   };
   xmlrpc = {
     source = {


### PR DESCRIPTION
###### Motivation for this change

bump metasploit to latest version.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

