### PR TITLE
copyq: 2.9.0 -> 3.0.3

### DIFF
--- a/pkgs/applications/misc/copyq/cmake-modules.patch
+++ b/pkgs/applications/misc/copyq/cmake-modules.patch
@@ -1,0 +1,12 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index d910299e..69888477 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -99,6 +99,7 @@ endif()
+ 
+ # Qt modules
+ if (WITH_QT5)
++    find_package(Qt5 REQUIRED COMPONENTS Network Svg Xml Script)
+     qt5_use_modules(copyq Widgets Network Svg Xml Script ${copyq_Qt5_Modules})
+ else()
+     set(QT_USE_QTNETWORK TRUE)

--- a/pkgs/applications/misc/copyq/default.nix
+++ b/pkgs/applications/misc/copyq/default.nix
@@ -1,19 +1,27 @@
-{ stdenv, fetchFromGitHub, cmake, qt4, libXfixes, libXtst}:
+{ stdenv, fetchFromGitHub, cmake, qt5, libXfixes, libXtst, git
+, webkitSupport ? true
+}:
 
 stdenv.mkDerivation rec {
   name = "CopyQ-${version}";
-  version = "2.9.0";
+  version = "3.0.3";
 
   src  = fetchFromGitHub {
     owner = "hluk";
     repo = "CopyQ";
     rev = "v${version}";
-    sha256 = "1gnqsfh50w3qcnbghkpjr5qs42fgl6643lmg4mg4wam8a852s64f";
+    sha256 = "0wpxqrg4mn8xjsrwsmlhh731s2kr6afnzpqif1way0gi7fqr73jl";
   };
 
+  patches = [
+    ./cmake-modules.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
-  
-  buildInputs = [ qt4 libXfixes libXtst ];
+
+  buildInputs = [
+    git qt5.full libXfixes libXtst
+  ] ++ stdenv.lib.optional webkitSupport qt5.qtwebkit;
 
   meta = with stdenv.lib; {
     homepage    = https://hluk.github.io/CopyQ;


### PR DESCRIPTION
Update CopyQ to 3.0.3. This required a change to qt5 and a cmake patch ([reported upstream](https://github.com/hluk/CopyQ/pull/770)) like the one for kdenlive #26160. Added an explicit `qtwebkit` dependency which optionally can be turned off (2.9.0 had `qtwebkit` support by default since it used `qt4`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

