### PR TITLE
libsigsegv: add enableSigbusFix option (fix bug related to old kernels)

### DIFF
--- a/pkgs/development/libraries/libsigsegv/2.5.nix
+++ b/pkgs/development/libraries/libsigsegv/2.5.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl
+, enableSigbusFix ? false # required by kernels < 3.18.6
+}:
 
 stdenv.mkDerivation rec {
   name = "libsigsegv-2.5";
@@ -7,6 +9,8 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/libsigsegv/${name}.tar.gz";
     sha256 = "0fvcsq9msi63vrbpvks6mqkrnls5cfy6bzww063sqhk2h49vsyyg";
   };
+  
+  patches = if enableSigbusFix then [ ./sigbus_fix.patch ] else [ ];
 
   meta = {
     homepage = http://libsigsegv.sf.net;

--- a/pkgs/development/libraries/libsigsegv/default.nix
+++ b/pkgs/development/libraries/libsigsegv/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl
 , buildPlatform, hostPlatform
+, enableSigbusFix ? false # required by kernels < 3.18.6
 }:
 
 stdenv.mkDerivation rec {
@@ -11,6 +12,8 @@ stdenv.mkDerivation rec {
   };
 
   doCheck = hostPlatform == buildPlatform;
+  
+  patches = if enableSigbusFix then [ ./sigbus_fix.patch ] else [ ];
 
   meta = {
     homepage = http://www.gnu.org/software/libsigsegv/;

--- a/pkgs/development/libraries/libsigsegv/sigbus_fix.patch
+++ b/pkgs/development/libraries/libsigsegv/sigbus_fix.patch
@@ -1,0 +1,8 @@
+--- a/src/signals.h	2017-08-23 14:07:05.000000000 +0100
++++ b/src/signals.h	2017-08-23 14:06:53.000000000 +0100
+@@ -18,4 +18,4 @@
+ /* List of signals that are sent when an invalid virtual memory address
+    is accessed, or when the stack overflows.  */
+ #define SIGSEGV_FOR_ALL_SIGNALS(var,body) \
+-  { int var; var = SIGSEGV; { body } }
++  { int var; var = SIGSEGV; { body } var = SIGBUS; { body } }


### PR DESCRIPTION
###### Motivation for this change

An old (< 3.18.6) kernel bug keeps biting people (#28464, #6028): tests fail because the kernel wrongly emits a SIGBUS upon stack overflow. On systems with old kernels, this makes nix unusable.

Work has already been done to remove `libsigsegv` from `stdenv` bootstrapping process (https://github.com/NixOS/nixpkgs/commit/8137a8cb73833432e8da8281663b56ac01d3ba0b), however it does not solve the problem when `libsigsegv` is still required by a package and the kernel cannot be updated.


###### Things done

- Added a simple patch file: `sigbus_fix.patch`.
- Added a new `enableSigbusFix` attribute defaulting to `false`.
- Added a condition on `enableSigbusFix` to apply the patch.

I couldn't use a full-fledged Nix environment for tests, however the default behaviour (i.e. no patch, no new explicit value) is strictly unchanged.

---

