### PR TITLE
Add matrix-python-sdk (pypi: matrix-client)

### DIFF
--- a/pkgs/development/python-modules/matrix-client/default.nix
+++ b/pkgs/development/python-modules/matrix-client/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pythonPackages
+}:
+
+buildPythonPackage rec {
+  pname = "matrix-client";
+  version = "0.0.6";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15kx5px26hwr0sxpyjk4w61fjnabg1b57hwys1nyarc0jx4qjhiq";
+  };
+
+  checkInputs = with pythonPackages; [ tox pytest flake8 responses ];
+
+  propagatedBuildInputs = with pythonPackages; [ requests ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Matrix Client-Server SDK";
+    homepage = https://github.com/matrix-org/matrix-python-sdk;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olejorgenb ];
+  };
+}

--- a/pkgs/development/python-modules/matrix-client/default.nix
+++ b/pkgs/development/python-modules/matrix-client/default.nix
@@ -1,7 +1,8 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
-, pythonPackages
+, requests
+, tox, pytest, flake8, responses
 }:
 
 buildPythonPackage rec {
@@ -14,9 +15,9 @@ buildPythonPackage rec {
     sha256 = "15kx5px26hwr0sxpyjk4w61fjnabg1b57hwys1nyarc0jx4qjhiq";
   };
 
-  checkInputs = with pythonPackages; [ tox pytest flake8 responses ];
+  checkInputs = [ tox pytest flake8 responses ];
 
-  propagatedBuildInputs = with pythonPackages; [ requests ];
+  propagatedBuildInputs = [ requests ];
 
   checkPhase = ''
     pytest

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5460,7 +5460,7 @@ in {
   };
 
   easydict = callPackage ../development/python-modules/easydict { };
-  
+
   EasyProcess = buildPythonPackage rec {
     name = "EasyProcess-0.2.3";
 
@@ -7289,17 +7289,17 @@ in {
   logfury = buildPythonPackage rec {
     name = "logfury-${version}";
     version = "0.1.2";
-  
+
     src = pkgs.fetchurl {
       url = "mirror://pypi/l/logfury/${name}.tar.gz";
       sha256 = "1lywirv3d1lw691mc4mfpz7ak6r49klri43bbfgdnvsfppxminj2";
     };
-  
+
     buildInputs =
       [ self.funcsigs
         self.six
       ];
-  
+
     meta = with pkgs.stdenv.lib; {
       description = "Logfury is for python library maintainers. It allows for responsible, low-boilerplate logging of method calls.";
       homepage = "https://github.com/ppolewicz/logfury";
@@ -28755,17 +28755,17 @@ EOF
 
   cymem = callPackage ../development/python-modules/cymem { };
 
-  ftfy = callPackage ../development/python-modules/ftfy { };    
+  ftfy = callPackage ../development/python-modules/ftfy { };
 
-  murmurhash = callPackage ../development/python-modules/murmurhash { };      
+  murmurhash = callPackage ../development/python-modules/murmurhash { };
 
-  plac = callPackage ../development/python-modules/plac { };        
-  
+  plac = callPackage ../development/python-modules/plac { };
+
   preshed = callPackage ../development/python-modules/preshed { };
 
-  thinc = callPackage ../development/python-modules/thinc { };  
+  thinc = callPackage ../development/python-modules/thinc { };
 
-  spacy = callPackage ../development/python-modules/spacy { };  
+  spacy = callPackage ../development/python-modules/spacy { };
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12539,7 +12539,7 @@ in {
     inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
   };
 
-  matrix-client = callPackage ../development/python-modules/matrix-client/default.nix { pythonPackages = self; };
+  matrix-client = callPackage ../development/python-modules/matrix-client/default.nix { };
 
   mccabe = callPackage ../development/python-modules/mccabe { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12539,6 +12539,7 @@ in {
     inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
   };
 
+  matrix-client = callPackage ../development/python-modules/matrix-client/default.nix { pythonPackages = self; };
 
   mccabe = callPackage ../development/python-modules/mccabe { };
 


### PR DESCRIPTION
Python libraries for https://matrix.org/

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

