### PR TITLE
Document that systemd.services.<name>.script is the same as systemd.services.<name>.serviceConfig.ExecStart

### DIFF
--- a/nixos/modules/system/boot/systemd-unit-options.nix
+++ b/nixos/modules/system/boot/systemd-unit-options.nix
@@ -232,7 +232,10 @@ in rec {
     script = mkOption {
       type = types.lines;
       default = "";
-      description = "Shell commands executed as the service's main process.";
+      description = ''
+        Shell commands executed as the service's main process. Note that this is
+        functionally equivalent to <literal>serviceConfig.ExecStart</literal>.
+      '';
     };
 
     scriptArgs = mkOption {


### PR DESCRIPTION
###### Motivation for this change

To reduce potential confusion.

#nixos irc interaction that motivated this:

``` irc
xd1le        ┃ What's the difference between systemd.services.<name>.script and
             ┃ systemd.services.<name>.serviceConfig.ExecStart ? Not sure which
             ┃ to use.
dash         ┃ xd1le: nothing really
xd1le        ┃ dash: hmm ok then thank you
dash         ┃ xd1le: aha, here is the answer:
             ┃ https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/system/boot/systemd.nix#L256
dash         ┃ xd1le: 'script' gets written to a file and the filename put in
             ┃ ExecStart.
xd1le        ┃ dash: nice, thank you!
xd1le        ┃ dash: I feel like this should be documented to reduce future
             ┃ confusion
dash         ┃ xd1le: awesome, you should do that :)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

