### PR TITLE
unblock 17.03: ibus: disabling the emoji dict

### DIFF
--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
     "--disable-memconf"
     "--enable-ui"
     "--enable-python-library"
+    "--disable-emoji-dict"
     "--with-emoji-json-file=${nodePackages.emojione}/lib/node_modules/emojione/emoji.json"
   ];
 


### PR DESCRIPTION
###### Motivation for this change

ibus currently blocks the channel release-17.03 due to a build timeout. This fixes the timeout by disabling the hanging component.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
