### PR TITLE
nginx: add ModSecurity Nginx Connector

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -47,6 +47,16 @@
     '';
   };
 
+  modsecurity-beta = {
+    src = fetchFromGitHub {
+      owner = "SpiderLabs";
+      repo = "ModSecurity-nginx";
+      rev = "abbf2c47f6f3205484a1a9db618e067dce213b89";
+      sha256 = "04ar51bnqjca6g4p2irymgdmc8rh5nsi8ml43srm4krllnkvw8qn";
+    };
+    inputs = [ pkgs.curl pkgs.geoip pkgs.libmodsecurity pkgs.libxml2 pkgs.lmdb pkgs.yajl ];
+  };
+
   echo = {
     src = fetchFromGitHub {
       owner = "openresty";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11273,6 +11273,16 @@ with pkgs;
     modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders nginxModules.shibboleth ];
   };
 
+  nginxStableModSecurity-beta = callPackage ../servers/http/nginx/stable.nix {
+    modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders modsecurity-beta ];
+  };
+
+  nginxMainlineModSecurity-beta = callPackage ../servers/http/nginx/mainline.nix {
+    modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders modsecurity-beta ];
+  };
+
+  libmodsecurity = callPackage ../tools/security/libmodsecurity { };
+
   ngircd = callPackage ../servers/irc/ngircd { };
 
   nix-binary-cache = callPackage ../servers/http/nix-binary-cache {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11273,16 +11273,6 @@ with pkgs;
     modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders nginxModules.shibboleth ];
   };
 
-  nginxStableModSecurity-beta = callPackage ../servers/http/nginx/stable.nix {
-    modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders modsecurity-beta ];
-  };
-
-  nginxMainlineModSecurity-beta = callPackage ../servers/http/nginx/mainline.nix {
-    modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders modsecurity-beta ];
-  };
-
-  libmodsecurity = callPackage ../tools/security/libmodsecurity { };
-
   ngircd = callPackage ../servers/irc/ngircd { };
 
   nix-binary-cache = callPackage ../servers/http/nix-binary-cache {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

