### PR TITLE
update packages: watchman, feh, whois, duc, evemu and debianutils

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -619,6 +619,7 @@
   vrthra = "Rahul Gopinath <rahul@gopinath.org>";
   vyp = "vyp <elisp.vim@gmail.com>";
   wedens = "wedens <kirill.wedens@gmail.com>";
+  willibutz = "Willi Butz <willibutz@posteo.de>";
   willtim = "Tim Philip Williams <tim.williams.public@gmail.com>";
   winden = "Antonio Vargas Gonzalez <windenntw@gmail.com>";
   wizeman = "Ricardo M. Correia <rcorreia@wizy.org>";

--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -6,11 +6,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "feh-${version}";
-  version = "2.19.1";
+  version = "2.19.3";
 
   src = fetchurl {
     url = "http://feh.finalrewind.org/${name}.tar.bz2";
-    sha256 = "1d4ycmai3dpajl0bdr9i56646g4h5j1lb95jjn0nckwcddcj927c";
+    sha256 = "1l3yvv0l0ggwlfyhk84p2g9mrqvzqrg1fgalf88kzppvb9jppjay";
   };
 
   outputs = [ "out" "man" "doc" ];
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     description = "A light-weight image viewer";
     homepage = https://derf.homelinux.org/projects/feh/;
     license = licenses.mit;
-    maintainers = [ maintainers.viric ];
+    maintainers = [ maintainers.viric maintainers.willibutz ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/wordnet/default.nix
+++ b/pkgs/applications/misc/wordnet/default.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchurl, tcl, tk, xlibsWrapper, makeWrapper}:
 
-let version = "3.0"; in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
+  version = "3.0";
   name = "wordnet-${version}";
   src = fetchurl {
     url = "http://wordnetcode.princeton.edu/${version}/WordNet-${version}.tar.bz2";

--- a/pkgs/development/tools/watchman/default.nix
+++ b/pkgs/development/tools/watchman/default.nix
@@ -1,20 +1,22 @@
-{ stdenv, lib, config, fetchFromGitHub, autoconf, automake, pcre
-, confFile ? config.watchman.confFile or null
+{ stdenv, lib, config, fetchFromGitHub, autoconf, automake, pcre,
+  libtool, pkgconfig, openssl,
+  confFile ? config.watchman.confFile or null
 }:
 
 stdenv.mkDerivation rec {
   name = "watchman-${version}";
 
-  version = "4.7.0";
+  version = "4.9.0";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "watchman";
     rev = "v${version}";
-    sha256 = "0xnd7jvrmyxhlw2ggd37swv1mk6vw9j91fdxps6njgvnlfg9zs5n";
+    sha256 = "0fdaj5pmicm6j17d5q7px800m5rmam1a400x3hv1iiifnmhgnkal";
   };
 
-  buildInputs = [ autoconf automake pcre ];
+  buildInputs = [ pcre openssl ];
+  nativeBuildInputs = [ autoconf automake pkgconfig libtool ];
 
   configureFlags = [
       "--enable-lenient"
@@ -25,6 +27,10 @@ stdenv.mkDerivation rec {
       # https://github.com/facebook/watchman/issues/178
       "--disable-statedir"
   ];
+
+  prePatch = ''
+    patchShebangs .
+  '';
 
   preConfigure = ''
     ./autogen.sh

--- a/pkgs/tools/misc/debianutils/default.nix
+++ b/pkgs/tools/misc/debianutils/default.nix
@@ -1,16 +1,12 @@
 { stdenv, fetchurl }:
 
-let
-  checksums = {
-    "4.8.1" = "09phylg8ih1crgxjadkdb8idbpj9ap62a7cbh8qdx2gyvh5mqf9c";
-  };
-in stdenv.mkDerivation rec {
-  version = "4.8.1";
+stdenv.mkDerivation rec {
+  version = "4.8.2";
   name = "debianutils-${version}";
 
   src = fetchurl {
     url = "mirror://debian/pool/main/d/debianutils/debianutils_${version}.tar.xz";
-    sha256 = checksums."${version}";
+    sha256 = "0s3w3svcsh984zinkxvpzxi7dc0ginqk0nk299fkrr6k7wlmzssd";
   };
 
   meta = {

--- a/pkgs/tools/misc/duc/default.nix
+++ b/pkgs/tools/misc/duc/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "duc-${version}";
-  version = "1.4.1";
+  version = "1.4.3";
 
   src = fetchFromGitHub {
     owner = "zevv";
     repo = "duc";
     rev = "${version}";
-    sha256 = "0rnar2zacsb9rvdmp1a62xixhy69s5vh0nwgrklqxhb19qkzhdp7";
+    sha256 = "1h7vll8a78ijan9bmnimmsviywmc39x8h9iikx8vm98kwyxi4xif";
   };
 
   buildInputs = [ autoreconfHook pkgconfig tokyocabinet cairo pango ncurses ];

--- a/pkgs/tools/networking/whois/default.nix
+++ b/pkgs/tools/networking/whois/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, perl, gettext }:
 
 stdenv.mkDerivation rec {
-  version = "5.2.17";
+  version = "5.2.18";
   name = "whois-${version}";
 
   src = fetchFromGitHub {
     owner = "rfc1036";
     repo = "whois";
     rev = "v${version}";
-    sha256 = "15jnzk0js8wxiapz1bw7jnck0fl3mcli56f9635z9x7vk63ss68z";
+    sha256 = "0jzyq1rj6balc6a28swzgspv55xhkc75dw6wsn159in4ap61bzmi";
   };
 
   buildInputs = [ perl gettext ];
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       select the appropriate WHOIS server for most queries.
     '';
 
-    homepage = http://packages.qa.debian.org/w/whois.html;
+    homepage = https://packages.qa.debian.org/w/whois.html;
     license = licenses.gpl2;
     maintainers = with maintainers; [ fpletz ];
     platforms = platforms.linux;

--- a/pkgs/tools/system/evemu/default.nix
+++ b/pkgs/tools/system/evemu/default.nix
@@ -4,14 +4,14 @@
 
 stdenv.mkDerivation rec {
   name = "evemu-${version}";
-  version = "2.4.0";
+  version = "2.6.0";
 
   # We could have downloaded a release tarball from cgit, but it changes hash
   # each time it is downloaded :/
   src = fetchgit {
     url = git://git.freedesktop.org/git/evemu;
     rev = "refs/tags/v${version}";
-    sha256 = "07iha13xrpf4z59rzl9cm2h1zkc5xhyipbd3ajd3c1d4hhpn9w9s";
+    sha256 = "1m38fxwy2s82vb2qm9aqxinws12akmqqq7q66is931lc3awqkbah";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Records and replays device descriptions and events to emulate input devices through the kernel's input system";
-    homepage = http://www.freedesktop.org/wiki/Evemu/;
+    homepage = https://www.freedesktop.org/wiki/Evemu/;
     repositories.git = git://git.freedesktop.org/git/evemu;
     license = licenses.gpl2;
     maintainers = [ maintainers.amorsillo ];


### PR DESCRIPTION
###### Things done
- updated the packages
- refactored wordnet a bit
- added myself to maintainers.nix

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

