### PR TITLE
Revert "gnu global: set path of default gtags.conf in wrapper"

### DIFF
--- a/pkgs/development/tools/misc/global/default.nix
+++ b/pkgs/development/tools/misc/global/default.nix
@@ -34,10 +34,8 @@ stdenv.mkDerivation rec {
     cp -v *.el "$out/share/emacs/site-lisp"
 
     wrapProgram $out/bin/gtags \
-      --prefix GTAGSCONF : "$out/share/gtags/gtags.conf" \
       --prefix PYTHONPATH : "$(toPythonPath ${pythonPackages.pygments})"
     wrapProgram $out/bin/global \
-      --prefix GTAGSCONF : "$out/share/gtags/gtags.conf" \
       --prefix PYTHONPATH : "$(toPythonPath ${pythonPackages.pygments})"
   '';
 


### PR DESCRIPTION
This reverts commit bd0d64730a90c8447245e415a2d10982ca95ba35.

Setting GTAGSCONF is not an adequate solution as it prevents the use of
it and the way it was done also breaks gtags when it is called by
global.

Fixes NixOS/nixpkgs#26971

###### Motivation for this change

Setting GTAGSCONF is not an adequate solution as it prevents the use of
it and the way it was done also breaks gtags when it is called by
global.

See also #26971.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

