### PR TITLE
cc-wrapper: Remove redundant hardening

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -68,7 +68,8 @@ if [[ -z "${hardeningDisableMap[all]:-}" ]]; then
           hardeningLDFlags+=('-z' 'now')
           ;;
         *)
-          echo "Hardening flag unknown: $flag" >&2
+          # Ignore unsupported. Checked in Nix that at least *some*
+          # tool supports each flag.
           ;;
       esac
     fi

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -43,6 +43,7 @@ if [[ -z "${hardeningDisableMap[all]:-}" ]]; then
           hardeningCFlags+=('-fPIE')
           if [[ ! ("$*" =~ " -shared " || "$*" =~ " -static ") ]]; then
             if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling LDFlags -pie >&2; fi
+            hardeningCFlags+=('-pie')
             hardeningLDFlags+=('-pie')
           fi
           ;;

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -138,7 +138,7 @@ if [ "$dontLink" != 1 ]; then
 
     # Add the flags that should only be passed to the compiler when
     # linking.
-    extraAfter+=($NIX_@infixSalt@_CFLAGS_LINK "${hardeningLDFlags[@]}")
+    extraAfter+=($NIX_@infixSalt@_CFLAGS_LINK)
 
     # Add the flags that should be passed to the linker (and prevent
     # `ld-wrapper' from adding NIX_@infixSalt@_LDFLAGS again).

--- a/pkgs/os-specific/linux/devmem2/default.nix
+++ b/pkgs/os-specific/linux/devmem2/default.nix
@@ -8,8 +8,9 @@ stdenv.mkDerivation rec {
     sha256 = "14f1k7v6i1yaxg4xcaaf5i4aqn0yabba857zjnbg9wiymy82qf7c";
   };
 
+  hardeningDisable = [ "format" ];  # fix compile error
+
   buildCommand = ''
-    export hardeningDisable=format  # fix compile error
     cc "$src" -o devmem2
     install -D devmem2 "$out/bin/devmem2"
   '';

--- a/pkgs/os-specific/linux/firmware/fwupdate/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupdate/default.nix
@@ -17,7 +17,7 @@ let version = "8"; in
       buildInputs = [ gnu-efi libsmbios popt pkgconfig gettext ];
       propagatedBuildInputs = [ efivar ];
       # TODO: Just apply the disable to the efi subdir
-      hardeningDisable = "all";
+      hardeningDisable = [ "all" ];
       patchPhase = ''
         sed -i 's|/usr/include/smbios_c/token.h|smbios_c/token.h|' \
           linux/libfwup.c

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -41,7 +41,20 @@ rec {
     , __propagatedImpureHostDeps ? []
     , sandboxProfile ? ""
     , propagatedSandboxProfile ? ""
+
+    , hardeningEnable ? []
+    , hardeningDisable ? []
     , ... } @ attrs:
+
+    # TODO(@Ericson2314): Make this more modular, and not O(n^2).
+    let allHardeningFlags = [
+      "fortify" "stackprotector" "pie" "pic" "strictoverflow" "format" "relro"
+      "bindnow"
+    ];
+    in assert lib.all
+      (flag: lib.elem flag allHardeningFlags)
+      (hardeningEnable ++ hardeningDisable);
+
     let
       dependencies = map lib.chooseDevOutputs [
         (map (drv: drv.nativeDrv or drv) nativeBuildInputs

--- a/pkgs/tools/networking/envoy/default.nix
+++ b/pkgs/tools/networking/envoy/default.nix
@@ -233,7 +233,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./nixos.patch ];
 
-  hardeningDisable = "all";
+  hardeningDisable = [ "all" ];
   dontPatchELF = true;
   dontStrip = true;
 


### PR DESCRIPTION
###### Motivation for this change

I can't find these flags (`-z relno` `-z now`) documented for GCC anywhere, and they are already passed to ld anyways.

Based on https://github.com/NixOS/nixpkgs/commit/aff1f4ab948b921ceaf2b81610f2f82454302b4b, I think these were accidentally passed to the C compiler from the beginning.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built stdenv on platform(s)
   - [x] NixOS --- https://hydra.mayflower.de/jobset/mayflower/hydra-jobs-hardening-redundancy
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

