### PR TITLE
Package updates: inkscape, netcat-openbsd, nasm, freeradius, curl and highlight

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -10,11 +10,11 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "inkscape-0.92.1";
+  name = "inkscape-0.92.2";
 
   src = fetchurl {
-    url = "https://media.inkscape.org/dl/resources/file/${name}.tar_XlpI7qT.bz2";
-    sha256 = "01chr3vh728dkg7l7lilwgmh5nrp784khdhjgpqjbq9dh2zhax15";
+    url = "https://media.inkscape.org/dl/resources/file/${name}.tar.bz2";
+    sha256 = "1lyghk6yarcv9nwkh6k366p6hb7rfilqcvbyji09hki59khd0a56";
   };
 
   unpackPhase = ''
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     license = "GPL";
-    homepage = http://www.inkscape.org;
+    homepage = https://www.inkscape.org;
     description = "Vector graphics editor";
     platforms = platforms.all;
     longDescription = ''

--- a/pkgs/development/compilers/nasm/default.nix
+++ b/pkgs/development/compilers/nasm/default.nix
@@ -2,17 +2,17 @@
 
 stdenv.mkDerivation rec {
   name = "nasm-${version}";
-  version = "2.12.02";
+  version = "2.13.01";
 
   src = fetchurl {
     url = "http://www.nasm.us/pub/nasm/releasebuilds/${version}/${name}.tar.bz2";
-    sha256 = "097318bjxvmffbjfd1k89parc04xf5jfxg2rr93581lccwf8kc00";
+    sha256 = "1ylqs4sqh0paia970v6hpdgq5icxns9zlg21qql232bz1apppy88";
   };
 
   meta = with stdenv.lib; {
     homepage = http://www.nasm.us/;
     description = "An 80x86 and x86-64 assembler designed for portability and modularity";
     platforms = platforms.unix;
-    maintainers = with maintainers; [ pSub ];
+    maintainers = with maintainers; [ pSub willibutz ];
   };
 }

--- a/pkgs/servers/freeradius/default.nix
+++ b/pkgs/servers/freeradius/default.nix
@@ -40,11 +40,11 @@ assert withCollectd -> collectd != null;
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "freeradius-${version}";
-  version = "3.0.14";
+  version = "3.0.15";
 
   src = fetchurl {
     url = "ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-${version}.tar.gz";
-    sha256 = "02ar0xn4dfrs95cmd4c798k95rmnzzvcryyyl2vjv53ak16igmpw";
+    sha256 = "1qygf5if2xjzl7kfzwl428ydz5q1m0j5sx077n12v7znlgnwaagx";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    homepage = http://freeradius.org/;
+    homepage = https://freeradius.org/;
     description = "A modular, high performance free RADIUS suite";
     license = stdenv.lib.licenses.gpl2;
     maintainers = with maintainers; [ sheenobu ];

--- a/pkgs/tools/networking/netcat-openbsd/default.nix
+++ b/pkgs/tools/networking/netcat-openbsd/default.nix
@@ -1,17 +1,18 @@
 {stdenv, fetchurl, pkgconfig, libbsd}:
 
 stdenv.mkDerivation rec {
-  name = "netcat-openbsd-1.105";
-  version = "1.105";
+  version = "1.130";
+  deb-version = "${version}-3";
+  name = "netcat-openbsd-${version}";
 
   srcs = [
     (fetchurl {
-      url = "mirror://debian/pool/main/n/netcat-openbsd/netcat-openbsd_1.105.orig.tar.gz";
-      sha256 = "07i1vcz8ycnfwsvz356rqmim8akfh8yhjzmhc5mqf5hmdkk3yra0";
+      url = "mirror://debian/pool/main/n/netcat-openbsd/netcat-openbsd_${version}.orig.tar.gz";
+      sha256 = "0nqy14yvclgzs98gv0fwp6jlfpfy2kk367zka648jiqbbl30awpx";
     })
     (fetchurl {
-      url = "mirror://debian/pool/main/n/netcat-openbsd/netcat-openbsd_1.105-7.debian.tar.gz";
-      sha256 = "0qxkhbwcifrps34s5mzzg79cmkvz3f96gphd3pl978pygwr5krzf";
+      url = "mirror://debian/pool/main/n/netcat-openbsd/netcat-openbsd_${deb-version}.debian.tar.xz";
+      sha256 = "0f9409vjm6v8a7m1zf5sr7wj6v5v8414i5vvxx1r45c11h69hh9a";
     })
   ];
 
@@ -26,10 +27,11 @@ stdenv.mkDerivation rec {
     install -Dm0644 nc.1 $out/share/man/man1/nc.1
   '';
 
-  meta = {
-    homepage = http://packages.debian.org/netcat-openbsd;
+  meta = with stdenv.lib; {
+    homepage = https://packages.debian.org/netcat-openbsd;
     description = "TCP/IP swiss army knife, OpenBSD variant";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ willibutz ];
   };
 
 }

--- a/pkgs/tools/text/highlight/default.nix
+++ b/pkgs/tools/text/highlight/default.nix
@@ -4,11 +4,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "highlight-${version}";
-  version = "3.35";
+  version = "3.39";
 
   src = fetchurl {
     url = "http://www.andre-simon.de/zip/${name}.tar.bz2";
-    sha256 = "8a14b49f5e0c07daa9f40b4ce674baa00bb20061079473a5d386656f6d236d05";
+    sha256 = "0z8gs69sqlyis4kvl8wwdgzywi199k73kkvn1mf9pf60npvcxwj4";
   };
 
   nativeBuildInputs = [ pkgconfig ] ++ optional stdenv.isDarwin  gcc ;


### PR DESCRIPTION
###### Things done
- highlight: 3.35 -> 3.39
- curl: 7.55.0 -> 7.55.1
- freeradius: 3.0.14 -> 3.0.15
- nasm: 2.12.02 -> 2.13.01
- netcat-openbsd: 1.105 -> 1.130
- inkscape: 0.92.1 -> 0.92.2

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

