### PR TITLE
Kubernetes 1.5.2 -> 1.6.9

### DIFF
--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -8,7 +8,6 @@
     "cmd/kube-controller-manager"
     "cmd/kube-proxy"
     "plugin/cmd/kube-scheduler"
-    "cmd/kube-dns"
     "federation/cmd/federation-apiserver"
     "federation/cmd/federation-controller-manager"
   ]
@@ -18,18 +17,18 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "kubernetes-${version}";
-  version = "1.5.6";
+  version = "1.6.9";
 
   src = fetchFromGitHub {
     owner = "kubernetes";
     repo = "kubernetes";
     rev = "v${version}";
-    sha256 = "0mkg4vgz9szgq1k5ignkdr5gmg703xlq8zsrr422a1qfqb8zp15w";
+    sha256 = "08qv2ljycxkhxam8lz8wv9gq5sxcwvg2pnxiqdy4f49ki1cdj0iq";
   };
 
   buildInputs = [ removeReferencesTo makeWrapper which go rsync go-bindata ];
 
-  outputs = ["out" "man" "pause"];
+  outputs = ["out" "man"];
 
   postPatch = ''
     substituteInPlace "hack/lib/golang.sh" --replace "_cgo" ""
@@ -45,22 +44,17 @@ stdenv.mkDerivation rec {
 
   postBuild = ''
     ./hack/generate-docs.sh
-    (cd build/pause && cc pause.c -o pause)
   '';
 
   installPhase = ''
-    mkdir -p "$out/bin" "$out/share/bash-completion/completions" "$man/share/man" "$pause/bin"
+    mkdir -p "$out/bin" "$out/share/bash-completion/completions" "$man/share/man"
 
     cp _output/local/go/bin/* "$out/bin/"
-    cp build/pause/pause "$pause/bin/pause"
     cp -R docs/man/man1 "$man/share/man"
 
     $out/bin/kubectl completion bash > $out/share/bash-completion/completions/kubectl
   '';
 
-  preFixup = ''
-    find $out/bin $pause/bin -type f -exec remove-references-to -t ${go} '{}' +
-  '';
 
   meta = {
     description = "Production-Grade Container Scheduling and Management";


### PR DESCRIPTION
###### Motivation for this change
I needed the new version because of breaking api changes.

###### Things done
Updated the version, removed stale references to `pause` in the output.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

