### PR TITLE
btc1: init at 1.14.5

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -545,6 +545,7 @@
   smironov = "Sergey Mironov <grrwlf@gmail.com>";
   snyh = "Xia Bin <snyh@snyh.org>";
   solson = "Scott Olson <scott@solson.me>";
+  sorpaas = "Wei Tang <hi@that.world>";
   spacefrogg = "Michael Raitza <spacefrogg-nixos@meterriblecrew.net>";
   spencerjanssen = "Spencer Janssen <spencerjanssen@gmail.com>";
   spinus = "Tomasz Czyż <tomasz.czyz@gmail.com>";

--- a/pkgs/applications/altcoins/btc1.nix
+++ b/pkgs/applications/altcoins/btc1.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, pkgconfig, autoreconfHook, openssl, db48, boost
+, zlib, miniupnpc, qt4, utillinux, protobuf, qrencode, libevent
+, withGui }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec{
+  name = "bit1" + (toString (optional (!withGui) "d")) + "-" + version;
+  version = "1.14.5";
+
+  src = fetchurl {
+    url = "https://github.com/btc1/bitcoin/archive/v${version}.tar.gz";
+    sha256 = "1az6bbblh3adgcs16r9cjz8jacg6sbwfpg8zzfzkbp9h9j85ass5";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [ openssl db48 boost zlib
+                  miniupnpc protobuf libevent]
+                  ++ optionals stdenv.isLinux [ utillinux ]
+                  ++ optionals withGui [ qt4 qrencode ];
+
+  configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
+                     ++ optionals withGui [ "--with-gui=qt4" ];
+
+  meta = {
+    description = "Peer-to-peer electronic cash system (btc1 client)";
+    longDescription= ''
+      Bitcoin is a free open source peer-to-peer electronic cash system that is
+      completely decentralized, without the need for a central server or trusted
+      parties. Users hold the crypto keys to their own money and transact directly
+      with each other, with the help of a P2P network to check for double-spending.
+
+      btc1 is an implementation of a Bitcoin full node with segwit2x hard fork
+      support.
+    '';
+    homepage = "https://github.com/btc1/bitcoin";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sorpaas ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -14,6 +14,9 @@ rec {
   bitcoin-xt  = callPackage ./bitcoin-xt.nix { withGui = true; };
   bitcoind-xt = callPackage ./bitcoin-xt.nix { withGui = false; };
 
+  btc1 = callPackage ./btc1.nix { withGui = true; };
+  btc1d = callPackage ./btc1.nix { withGui = false; };
+
   dashpay = callPackage ./dashpay.nix { };
 
   dogecoin  = callPackage ./dogecoin.nix { withGui = true; };


### PR DESCRIPTION
###### Motivation for this change

A portion of Bitcoin users (including the super-majority of the miners) decided to hard fork to segwit2x around this November. At that time this will not be compatible with the Bitcoin Core client.

1.14.5 is known as "the Production Release".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

