### PR TITLE
phpPackages.yaml: init YAML extension for PHP5 and PHP7

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -105,6 +105,36 @@ let
     checkTarget = "test";
   };
 
+  yaml = if isPhp7 then yaml20 else yaml13;
+
+  yaml13 = assert !isPhp7; buildPecl {
+    name = "yaml-1.3.1";
+
+    sha256 = "1fbmgsgnd6l0d4vbjaca0x9mrfgl99yix5yf0q0pfcqzfdg4bj8q";
+
+    configureFlags = [
+      "--with-yaml=${pkgs.libyaml}"
+    ];
+
+    buildInputs = [
+      pkgs.pkgconfig
+    ];
+  };
+
+  yaml20 = assert isPhp7; buildPecl {
+    name = "yaml-2.0.2";
+
+    sha256 = "0f80zy79kyy4hn6iigpgfkwppwldjfj5g7s4gddklv3vskdb1by3";
+
+    configureFlags = [
+      "--with-yaml=${pkgs.libyaml}"
+    ];
+
+    buildInputs = [
+      pkgs.pkgconfig
+    ];
+  };
+
   # Since PHP 5.5 OPcache is integrated in the core and has to be enabled via --enable-opcache during compilation.
   zendopcache = assert isPhpOlder55; buildPecl {
     name = "zendopcache-7.0.3";


### PR DESCRIPTION
###### Motivation for this change

This allows the use of the YAML extension for PHP which allows for efficient parsing of YAML string.

###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

