### PR TITLE
Update kubes to 1.7.0

### DIFF
--- a/nixos/modules/services/cluster/kubernetes.nix
+++ b/nixos/modules/services/cluster/kubernetes.nix
@@ -8,13 +8,6 @@ let
   skipAttrs = attrs: map (filterAttrs (k: v: k != "enable"))
     (filter (v: !(hasAttr "enable" v) || v.enable) attrs);
 
-  infraContainer = pkgs.dockerTools.buildImage {
-    name = "pause";
-    tag = "latest";
-    contents = cfg.package.pause;
-    config.Cmd = "/bin/pause";
-  };
-
   kubeconfig = pkgs.writeText "kubeconfig" (builtins.toJSON {
     apiVersion = "v1";
     kind = "Config";
@@ -601,7 +594,6 @@ in {
         after = [ "network.target" "docker.service" "kube-apiserver.service" ];
         path = with pkgs; [ gitMinimal openssh docker utillinux iproute ethtool thin-provisioning-tools iptables ];
         preStart = ''
-          docker load < ${infraContainer}
           rm /opt/cni/bin/* || true
           ${concatMapStringsSep "\n" (p: "ln -fs ${p.plugins}/* /opt/cni/bin") cfg.kubelet.cni.packages}
         '';

--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -17,13 +17,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "kubernetes-${version}";
-  version = "1.6.9";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "kubernetes";
     repo = "kubernetes";
     rev = "v${version}";
-    sha256 = "08qv2ljycxkhxam8lz8wv9gq5sxcwvg2pnxiqdy4f49ki1cdj0iq";
+    sha256 = "0jsn2l5y006dpfwsiz7npdqr10lrpj5zgr1bxlj86c59l58mvy9a";
   };
 
   buildInputs = [ removeReferencesTo makeWrapper which go rsync go-bindata ];
@@ -38,6 +38,11 @@ stdenv.mkDerivation rec {
     echo "true" > "hack/update-munge-docs.sh"
 
     patchShebangs ./hack
+  '';
+
+  preBuild = ''
+    echo "verion:"
+    go version
   '';
 
   WHAT="--use_go_build ${concatStringsSep " " components}";

--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -60,6 +60,10 @@ stdenv.mkDerivation rec {
     $out/bin/kubectl completion bash > $out/share/bash-completion/completions/kubectl
   '';
 
+  preFixup = ''
+     find $out/bin -type f -exec remove-references-to -t ${go} '{}' +
+   '';
+
 
   meta = {
     description = "Production-Grade Container Scheduling and Management";

--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -8,7 +8,6 @@
     "cmd/kube-controller-manager"
     "cmd/kube-proxy"
     "plugin/cmd/kube-scheduler"
-    "cmd/kube-dns"
     "federation/cmd/federation-apiserver"
     "federation/cmd/federation-controller-manager"
   ]
@@ -18,18 +17,18 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "kubernetes-${version}";
-  version = "1.5.6";
+  version = "1.6.9";
 
   src = fetchFromGitHub {
     owner = "kubernetes";
     repo = "kubernetes";
     rev = "v${version}";
-    sha256 = "0mkg4vgz9szgq1k5ignkdr5gmg703xlq8zsrr422a1qfqb8zp15w";
+    sha256 = "08qv2ljycxkhxam8lz8wv9gq5sxcwvg2pnxiqdy4f49ki1cdj0iq";
   };
 
   buildInputs = [ removeReferencesTo makeWrapper which go rsync go-bindata ];
 
-  outputs = ["out" "man" "pause"];
+  outputs = ["out" "man"];
 
   postPatch = ''
     substituteInPlace "hack/lib/golang.sh" --replace "_cgo" ""
@@ -45,22 +44,17 @@ stdenv.mkDerivation rec {
 
   postBuild = ''
     ./hack/generate-docs.sh
-    (cd build/pause && cc pause.c -o pause)
   '';
 
   installPhase = ''
-    mkdir -p "$out/bin" "$out/share/bash-completion/completions" "$man/share/man" "$pause/bin"
+    mkdir -p "$out/bin" "$out/share/bash-completion/completions" "$man/share/man"
 
     cp _output/local/go/bin/* "$out/bin/"
-    cp build/pause/pause "$pause/bin/pause"
     cp -R docs/man/man1 "$man/share/man"
 
     $out/bin/kubectl completion bash > $out/share/bash-completion/completions/kubectl
   '';
 
-  preFixup = ''
-    find $out/bin $pause/bin -type f -exec remove-references-to -t ${go} '{}' +
-  '';
 
   meta = {
     description = "Production-Grade Container Scheduling and Management";

--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -40,11 +40,6 @@ stdenv.mkDerivation rec {
     patchShebangs ./hack
   '';
 
-  preBuild = ''
-    echo "verion:"
-    go version
-  '';
-
   WHAT="--use_go_build ${concatStringsSep " " components}";
 
   postBuild = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14902,7 +14902,7 @@ with pkgs;
   ktorrent = libsForQt5.callPackage ../applications/networking/p2p/ktorrent { };
 
   kubernetes = callPackage ../applications/networking/cluster/kubernetes {
-    go = go_1_7;
+    go = go_1_8;
   };
 
   lame = callPackage ../development/libraries/lame { };


### PR DESCRIPTION
###### Motivation for this change
Need access to breaking changes from the Kubernetes api, present in the new version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

