### PR TITLE
phpPackages.couchbase: init at 2.3.4

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -29,6 +29,38 @@ let
     sha256 = "0vv2w5fkkw9n7qdmi5aq50416zxmvyzjym8kb6j1v8kd4xcsjjgw";
   };
 
+  couchbase = buildPecl rec {
+    name = "couchbase-${version}";
+    version = "2.3.4";
+
+    buildInputs = [ pkgs.libcouchbase pcs ];
+
+    src = pkgs.fetchFromGitHub {
+      owner = "couchbase";
+      repo = "php-couchbase";
+      rev = "v${version}";
+      sha256 = "0rdlrl7vh4kbxxj9yxp54xpnnrxydpa9fab7dy4nas474j5vb2bp";
+    };
+
+    configureFlags = [ "--with-couchbase" ];
+
+    patches = [
+      (pkgs.writeText "php-couchbase.patch" ''
+        --- a/config.m4
+        +++ b/config.m4
+        @@ -9,7 +9,7 @@ if test "$PHP_COUCHBASE" != "no"; then
+             LIBCOUCHBASE_DIR=$PHP_COUCHBASE
+           else
+             AC_MSG_CHECKING(for libcouchbase in default path)
+        -    for i in /usr/local /usr; do
+        +    for i in ${pkgs.libcouchbase}; do
+               if test -r $i/include/libcouchbase/couchbase.h; then
+                 LIBCOUCHBASE_DIR=$i
+                 AC_MSG_RESULT(found in $i)
+      '')
+    ];
+  };
+
   imagick = buildPecl {
     name = "imagick-3.4.3RC1";
     sha256 = "0siyxpszjz6s095s2g2854bhprjq49rf22v6syjiwvndg1pc9fsh";


### PR DESCRIPTION
###### Motivation for this change

Adds couchbase php extension at 2.3.4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

