### PR TITLE
gargoyle: 2017-03-12 -> 2017-05-17

### DIFF
--- a/pkgs/games/gargoyle/darwin.patch
+++ b/pkgs/games/gargoyle/darwin.patch
@@ -1,39 +1,3 @@
-From 06255a8b5a378a2484cd0faa1dd718d5b4e98042 Mon Sep 17 00:00:00 2001
-From: Orivej Desh <orivej@gmx.fr>
-Date: Fri, 17 Mar 2017 08:43:57 +0000
-Subject: [PATCH] darwin
-
----
- Jamrules        | 5 ++---
- Jamshared       | 2 +-
- support/Jamfile | 4 ++--
- tads/Jamfile    | 4 ++--
- terps/Jamfile   | 4 ++--
- 5 files changed, 9 insertions(+), 10 deletions(-)
-
-diff --git a/Jamrules b/Jamrules
-index 698220d..2294dfc 100644
---- a/Jamrules
-+++ b/Jamrules
-@@ -141,8 +141,7 @@ switch $(OS)
-     case MACOSX :
-         Echo "OS is MACOSX (cocoa)" ;
-         SUFDLL = .dylib ;
--        MAINARCH = -arch i386 ;
--        CCFLAGS = -Wno-pointer-sign $(MAINARCH) $(ALTARCH) ;
-+        CCFLAGS = -Wno-pointer-sign $(ALTARCH) ;
-         PKGCONFIG = "pkg-config freetype2" ;
-         GARGLKCCFLAGS = "`$(PKGCONFIG) --cflags`" ;
-         SHRLINKLIBS += "`$(PKGCONFIG) --libs`" -ljpeg -lpng -lz ;
-@@ -155,7 +154,7 @@ switch $(OS)
-             SHRLINKLIBS += -lSDL_mixer -lSDL -lsmpeg -lvorbisfile ;
-         }
- 
--        LINK = $(CC) -headerpad_max_install_names $(FRAMEWORKS) $(MAINARCH) $(ALTARCH) ;
-+        LINK = $(CC) $(FRAMEWORKS) $(ALTARCH) ;
- 
- 
-     case * :
 diff --git a/Jamshared b/Jamshared
 index 13db835..fd42928 100644
 --- a/Jamshared
@@ -47,21 +11,6 @@ index 13db835..fd42928 100644
      }
  }
  else
-diff --git a/support/Jamfile b/support/Jamfile
-index aedf8fe..70cfefd 100644
---- a/support/Jamfile
-+++ b/support/Jamfile
-@@ -41,8 +41,8 @@ if $(USESDL) = yes
-         ;
- 
-     if $(OS) = MINGW   { SubDirCcFlags -DSDL_SOUND_DLL_EXPORTS ; }
--    if $(OS) = SOLARIS { SubDirCcFlags -I/usr/include/SDL -fPIC ; }
--    if $(OS) = MACOSX  { SubDirCcFlags -I/opt/local/include/SDL -fPIC ; }
-+    if $(OS) = SOLARIS { SubDirCcFlags -ISDL -fPIC ; }
-+    if $(OS) = MACOSX  { SubDirCcFlags -ISDL -fPIC ; }
- 
-     SEARCH_SOURCE =
-         [ FDirName $(TOP) support sdl_sound ]
 diff --git a/tads/Jamfile b/tads/Jamfile
 index 1f8829d..d8455eb 100644
 --- a/tads/Jamfile
@@ -77,6 +26,17 @@ index 1f8829d..d8455eb 100644
  }
  
  SEARCH_SOURCE =
+diff --git a/tads/tads3/vmtz.cpp b/tads/tads3/vmtz.cpp
+index 5e193a1..dce46f7 100644
+--- a/tads/tads3/vmtz.cpp
++++ b/tads/tads3/vmtz.cpp
+@@ -1985,5 +1985,5 @@ void CVmTimeZone::query(vmtzquery *result, int32_t dayno, int32_t daytime,
+              *   up until that moment
+              */
+-            result->set(tcur > 0 ? tcur - 1 : tcur);
++            result->set(tcur != 0 ? tcur - 1 : tcur);
+            return;
+        }
 diff --git a/terps/Jamfile b/terps/Jamfile
 index b5f6d52..2d1ccdb 100644
 --- a/terps/Jamfile
@@ -92,6 +52,3 @@ index b5f6d52..2d1ccdb 100644
      }
  
      SUBDIRC++FLAGS = $(SUBDIRCCFLAGS) ;
--- 
-2.12.0
-

--- a/pkgs/games/gargoyle/default.nix
+++ b/pkgs/games/gargoyle/default.nix
@@ -1,8 +1,10 @@
-{ stdenv, fetchFromGitHub, jam, pkgconfig, gtk2, SDL, SDL_mixer, SDL_sound, smpeg, libvorbis }:
+{ stdenv, fetchFromGitHub, jam, libtool, pkgconfig, gtk2, SDL, SDL_mixer, SDL_sound, smpeg, libvorbis }:
 
 let
 
-  jamenv = if stdenv.isDarwin then ''
+  jamenv = ''
+    unset AR
+  '' + (if stdenv.isDarwin then ''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${SDL.dev}/include/SDL"
     export GARGLKINI="$out/Applications/Gargoyle.app/Contents/Resources/garglk.ini"
   '' else ''
@@ -12,21 +14,21 @@ let
     export _APPDIR=libexec/gargoyle
     export _LIBDIR=libexec/gargoyle
     export GARGLKINI="$out/etc/garglk.ini"
-  '';
+  '');
 
 in
 
 stdenv.mkDerivation {
-  name = "gargoyle-2017-03-12";
+  name = "gargoyle-2017-05-17";
 
   src = fetchFromGitHub {
     owner = "garglk";
     repo = "garglk";
-    rev = "7d8fe875927c332ea30d75656bc982354b42f602";
-    sha256 = "00nac7j84gfql1cr11cs9ad4j1gsxrnkqfx6mis4ijf7d6px3sih";
+    rev = "2da2824748b0b99107f481801f818efc54a43d3a";
+    sha256 = "184lgylcbhj205pfccwgl7avs0pczwrc53nvkzhj2p5inxak20kk";
   };
 
-  nativeBuildInputs = [ jam pkgconfig ];
+  nativeBuildInputs = [ jam pkgconfig ] ++ stdenv.lib.optional stdenv.isDarwin libtool;
 
   buildInputs = [ gtk2 SDL SDL_mixer ] ++ (
     if stdenv.isDarwin then [ smpeg libvorbis ] else [ SDL_sound ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17262,7 +17262,9 @@ with pkgs;
 
   garden-of-coloured-lights = callPackage ../games/garden-of-coloured-lights { allegro = allegro4; };
 
-  gargoyle = callPackage ../games/gargoyle { };
+  gargoyle = callPackage ../games/gargoyle {
+    libtool = darwin.cctools;
+  };
 
   gav = callPackage ../games/gav { };
 


### PR DESCRIPTION
###### Motivation for this change

This updates gargoyle and fixes build by unexporting `AR`, as in 4f88ceff49792d1e57f8af269400e2b7a74d0db5.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
