### PR TITLE
corebird: 1.5.1 -> 1.6

### DIFF
--- a/pkgs/applications/networking/corebird/default.nix
+++ b/pkgs/applications/networking/corebird/default.nix
@@ -3,14 +3,14 @@
 , glib_networking }:
 
 stdenv.mkDerivation rec {
-  version = "1.5.1";
+  version = "1.6";
   name = "corebird-${version}";
 
   src = fetchFromGitHub {
     owner = "baedert";
     repo = "corebird";
     rev = version;
-    sha256 = "1qajb4xms3vsfm5sg91z9ka0nrzgfi0fjgjxqm7snhkfgxlkph7w";
+    sha256 = "1bxjlamdy5d2j3xdahmxf6lwc7f6xdfxbzi712ppvh1dwggw654v";
   };
 
   preConfigure = ''
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ automake autoconf libtool pkgconfig wrapGAppsHook ];
 
   buildInputs = [
-    gtk3 json_glib sqlite libsoup gettext vala_0_32 gnome3.rest gnome3.dconf gnome3.gspell glib_networking
+    gtk3 json_glib sqlite libsoup gettext vala_0_32 gnome3.dconf gnome3.gspell glib_networking
   ] ++ (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good (gst-plugins-bad.override { gtkSupport = true; }) gst-libav ]);
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Version update. Drops rest dependency (now vendored, see changelog at https://github.com/baedert/corebird/releases/tag/1.6).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

