### PR TITLE
riot-web: init at 0.12.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, fetchpatch }:
+
+stdenv.mkDerivation rec {
+  name= "riot-web-${version}";
+  version = "0.12.2";
+
+  src = fetchurl {
+    url = "https://github.com/vector-im/riot-web/releases/download/v${version}/riot-v${version}.tar.gz";
+    sha256 = "0zyddpnng1vjli12hn1hd0w99g6sfsk80dn2ll5h9276nc677pnh";
+  };
+
+  installPhase = ''
+    mkdir -p $out/
+    cp -R . $out/
+  '';
+
+  meta = {
+    description = "A glossy Matrix collaboration client for the web";
+    homepage = http://riot.im/;
+    maintainers = with stdenv.lib.maintainers; [ bachp ];
+    license = stdenv.lib.licenses.asl20;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
@@ -20,5 +20,6 @@ stdenv.mkDerivation rec {
     maintainers = with stdenv.lib.maintainers; [ bachp ];
     license = stdenv.lib.licenses.asl20;
     platforms = stdenv.lib.platforms.all;
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1141,6 +1141,8 @@ with pkgs;
 
   ring-daemon = callPackage ../applications/networking/instant-messengers/ring-daemon { };
 
+  riot-web = callPackage ../applications/networking/instant-messengers/riot/riot-web.nix { };
+
   rsyslog = callPackage ../tools/system/rsyslog {
     hadoop = null; # Currently Broken
     czmq = czmq3;


### PR DESCRIPTION
###### Motivation for this change

This is only the web appication that can be used together with a web server.
In a later step the desktop version based on electron can be added and use
this package too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (no binary but index.html opened in browser)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

