### PR TITLE
flyway: init at 4.2.0

### DIFF
--- a/pkgs/development/tools/flyway/default.nix
+++ b/pkgs/development/tools/flyway/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, jre_headless, makeWrapper }:
+  let
+    version = "4.2.0";
+  in
+    stdenv.mkDerivation {
+      name = "flyway-${version}";
+      src = fetchurl {
+        url = "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.2.0/flyway-commandline-${version}.tar.gz";
+        sha256 = "1fxj760qx6apsz50p60c9n79k6bqkjcv2zfgab0awvmdvdy4k661";
+      };
+      buildInputs = [ makeWrapper ];
+      dontBuild = true;
+      dontStrip = true;
+      installPhase = ''
+        mkdir -pv $out/bin
+        mkdir -pv $out/share/flyway
+        cp -v -r sql $out/share/flyway
+        cp -v -r jars $out/share/flyway
+        cp -v -r lib $out/share/flyway
+        cp -v -r drivers $out/share/flyway
+        makeWrapper "${jre_headless}/bin/java" $out/bin/flyway \
+          --add-flags "-Djava.security.egd=file:/dev/../dev/urandom" \
+          --add-flags "-cp '$out/share/flyway/lib/*:$out/share/flyway/drivers/*'" \
+          --add-flags "org.flywaydb.commandline.Main"
+      '';
+      meta = with stdenv.lib; {
+        description = "Evolve your Database Schema easily and reliably across all your instances";
+        homepage = "https://flywaydb.org/";
+        license = licenses.asl20;
+        platforms = platforms.linux;
+        maintainers = maintainers.cmcdragonkai;
+      };
+    }

--- a/pkgs/development/tools/flyway/default.nix
+++ b/pkgs/development/tools/flyway/default.nix
@@ -12,12 +12,8 @@
       dontBuild = true;
       dontStrip = true;
       installPhase = ''
-        mkdir -pv $out/bin
-        mkdir -pv $out/share/flyway
-        cp -v -r sql $out/share/flyway
-        cp -v -r jars $out/share/flyway
-        cp -v -r lib $out/share/flyway
-        cp -v -r drivers $out/share/flyway
+        mkdir -p $out/bin $out/share/flyway
+        cp -r sql jars lib drivers $out/share/flyway
         makeWrapper "${jre_headless}/bin/java" $out/bin/flyway \
           --add-flags "-Djava.security.egd=file:/dev/../dev/urandom" \
           --add-flags "-cp '$out/share/flyway/lib/*:$out/share/flyway/drivers/*'" \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7825,6 +7825,8 @@ with pkgs;
   fltk13 = callPackage ../development/libraries/fltk { };
   fltk = self.fltk13;
 
+  flyway = callPackage ../development/tools/flyway { };
+
   fplll = callPackage ../development/libraries/fplll {};
   fplll_20160331 = callPackage ../development/libraries/fplll/20160331.nix {};
 


### PR DESCRIPTION
###### Motivation for this change

Added Flyway for SQL migrations!

Note that flyway doesn't work without those directories copied into the $out/share/flyway!

So to use it on your on local directory do things like `flyway -locations=filesystem:sql` or point to a local configuration file that does this `flyway -configFile=./flyway.conf`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

