### PR TITLE
mkvtoolnix: 14.0.0 -> 15.0.0, libebml: 1.3.4 -> 1.3.5

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -10,13 +10,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "mkvtoolnix-${version}";
-  version = "14.0.0";
+  version = "15.0.0";
 
   src = fetchFromGitHub {
     owner = "mbunkus";
     repo = "mkvtoolnix";
     rev = "release-${version}";
-    sha256 = "1ygc2qrd074vz2yw4iqml5ir31kkvkv7pz3hcfy423p9s06xi1k2";
+    sha256 = "06n0hbp484zpsjvnzp6p0nzzssym3illxdicn3y1jf8gy971rxi0";
   };
 
   nativeBuildInputs = [ pkgconfig autoconf automake gettext drake ruby docbook_xsl libxslt ];

--- a/pkgs/development/libraries/libebml/default.nix
+++ b/pkgs/development/libraries/libebml/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "libebml-1.3.4";
+  name = "libebml-1.3.5";
 
   src = fetchurl {
-    url = "http://dl.matroska.org/downloads/libebml/${name}.tar.bz2";
-    sha256 = "11zka6z9ncywyjr1gfm5cnii33ln7y3w6s86kiacchip2g7kw3f5";
+    url = "http://dl.matroska.org/downloads/libebml/${name}.tar.xz";
+    sha256 = "005a0ipqnfbsq47zrc61zszi439jw32q5xd6dc1jyb3lc0zl266q";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

- Update `mkvtoolnix` to version 15.0.0
- Update `libebml` to version 1.3.5 (needed by the new version of `mkvtoolnix`)

[Release announcement on blog](https://www.bunkus.org/blog/2017/08/mkvtoolnix-v15-0-0-released/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).