### PR TITLE
racket: 6.9 -> 6.10

### DIFF
--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -33,11 +33,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "racket-${version}";
-  version = "6.9";
+  version = "6.10";
 
   src = fetchurl {
     url = "http://mirror.racket-lang.org/installers/${version}/${name}-src.tgz";
-    sha256 = "1cd218ee2ba1dc683de858a866c6666eb72a11adee8d1df6cdd59c5c5a47b714";
+    sha256 = "1mqnyj3bawad12dygsb11f2dbnkjp7q6d7ra714rqyw8mxix5ws0";
   };
 
   FONTCONFIG_FILE = fontsConf;
@@ -52,8 +52,7 @@ stdenv.mkDerivation rec {
     cd src/build
   '';
 
-  shared = if stdenv.isDarwin then "dylib" else "shared";
-  configureFlags = [ "--enable-${shared}" "--enable-lt=${libtool}/bin/libtool" ]
+  configureFlags = [ "--enable-lt=${libtool}/bin/libtool" ]
                    ++ stdenv.lib.optional disableDocs [ "--disable-docs" ]
                    ++ stdenv.lib.optional stdenv.isDarwin [ "--enable-xonx" ];
 

--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -47,12 +47,14 @@ stdenv.mkDerivation rec {
   buildInputs = [ fontconfig libffi libtool makeWrapper sqlite ];
 
   preConfigure = ''
+    unset AR
     substituteInPlace src/configure --replace /usr/bin/uname ${coreutils}/bin/uname
     mkdir src/build
     cd src/build
   '';
 
-  configureFlags = [ "--enable-lt=${libtool}/bin/libtool" ]
+  shared = if stdenv.isDarwin then "dylib" else "shared";
+  configureFlags = [ "--enable-${shared}"  "--enable-lt=${libtool}/bin/libtool" ]
                    ++ stdenv.lib.optional disableDocs [ "--disable-docs" ]
                    ++ stdenv.lib.optional stdenv.isDarwin [ "--enable-xonx" ];
 


### PR DESCRIPTION
###### Motivation for this change
Update racket to the current version.

###### Things done
The compilation with the previous used `--enable-shared`-flag failed for the current version. However, compiling without this flag succeeded.
Furthermore the `src/README` says that even the distributed binaries are compiled without it.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

