### PR TITLE
Turn boot.kernelParams into an attribute set

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -41,21 +41,21 @@ let
     LABEL boot
     MENU LABEL NixOS ${config.system.nixosLabel}${config.isoImage.appendToMenuLabel}
     LINUX /boot/bzImage
-    APPEND init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}
+    APPEND init=${config.system.build.toplevel}/init ${toString config.boot.kernelParamList}
     INITRD /boot/initrd
 
     # A variant to boot with 'nomodeset'
     LABEL boot-nomodeset
     MENU LABEL NixOS ${config.system.nixosVersion}${config.isoImage.appendToMenuLabel} (with nomodeset)
     LINUX /boot/bzImage
-    APPEND init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams} nomodeset
+    APPEND init=${config.system.build.toplevel}/init ${toString config.boot.kernelParamList} nomodeset
     INITRD /boot/initrd
 
     # A variant to boot with 'copytoram'
     LABEL boot-copytoram
     MENU LABEL NixOS ${config.system.nixosVersion}${config.isoImage.appendToMenuLabel} (with copytoram)
     LINUX /boot/bzImage
-    APPEND init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams} copytoram
+    APPEND init=${config.system.build.toplevel}/init ${toString config.boot.kernelParamList} copytoram
     INITRD /boot/initrd
   '';
 
@@ -77,19 +77,19 @@ let
     echo "title NixOS Live CD" > $out/loader/entries/nixos-livecd.conf
     echo "linux /boot/bzImage" >> $out/loader/entries/nixos-livecd.conf
     echo "initrd /boot/initrd" >> $out/loader/entries/nixos-livecd.conf
-    echo "options init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}" >> $out/loader/entries/nixos-livecd.conf
+    echo "options init=${config.system.build.toplevel}/init ${toString config.boot.kernelParamList}" >> $out/loader/entries/nixos-livecd.conf
 
     # A variant to boot with 'nomodeset'
     echo "title NixOS Live CD (with nomodeset)" > $out/loader/entries/nixos-livecd-nomodeset.conf
     echo "linux /boot/bzImage" >> $out/loader/entries/nixos-livecd-nomodeset.conf
     echo "initrd /boot/initrd" >> $out/loader/entries/nixos-livecd-nomodeset.conf
-    echo "options init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams} nomodeset" >> $out/loader/entries/nixos-livecd-nomodeset.conf
+    echo "options init=${config.system.build.toplevel}/init ${toString config.boot.kernelParamList} nomodeset" >> $out/loader/entries/nixos-livecd-nomodeset.conf
 
     # A variant to boot with 'copytoram'
     echo "title NixOS Live CD (with copytoram)" > $out/loader/entries/nixos-livecd-copytoram.conf
     echo "linux /boot/bzImage" >> $out/loader/entries/nixos-livecd-copytoram.conf
     echo "initrd /boot/initrd" >> $out/loader/entries/nixos-livecd-copytoram.conf
-    echo "options init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams} copytoram" >> $out/loader/entries/nixos-livecd-copytoram.conf
+    echo "options init=${config.system.build.toplevel}/init ${toString config.boot.kernelParamList} copytoram" >> $out/loader/entries/nixos-livecd-copytoram.conf
 
     echo "default nixos-livecd" > $out/loader/loader.conf
     echo "timeout ${builtins.toString config.boot.loader.timeout}" >> $out/loader/loader.conf

--- a/nixos/modules/installer/cd-dvd/system-tarball-fuloong2f.nix
+++ b/nixos/modules/installer/cd-dvd/system-tarball-fuloong2f.nix
@@ -26,7 +26,7 @@ let
   # A clue for the kernel loading
   kernelParams = pkgs.writeText "kernel-params.txt" ''
     Kernel Parameters:
-      init=/boot/init systemConfig=/boot/init ${toString config.boot.kernelParams}
+      init=/boot/init systemConfig=/boot/init ${toString config.boot.kernelParamList}
   '';
 
   # System wide nixpkgs config

--- a/nixos/modules/installer/cd-dvd/system-tarball-sheevaplug.nix
+++ b/nixos/modules/installer/cd-dvd/system-tarball-sheevaplug.nix
@@ -30,7 +30,7 @@ let
   # A clue for the kernel loading
   kernelParams = pkgs.writeText "kernel-params.txt" ''
     Kernel Parameters:
-      init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}
+      init=${config.system.build.toplevel}/init ${toString config.boot.kernelParamList}
   '';
 
 

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -115,7 +115,7 @@ let
       systemd = config.systemd.package;
 
       inherit children;
-      kernelParams = config.boot.kernelParams;
+      kernelParams = config.boot.kernelParamList;
       installBootLoader =
         config.system.build.installBootLoader
         or "echo 'Warning: do not know how to make this configuration bootable; please enable a boot loader.' 1>&2; true";

--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -62,7 +62,7 @@ in {
         text = ''
           #!ipxe
           dhcp
-          kernel bzImage init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams} console=ttyS0
+          kernel bzImage init=${config.system.build.toplevel}/init ${toString config.boot.kernelParamList} console=ttyS0
           initrd initrd
           boot
         '';

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -420,7 +420,7 @@ in {
         );
       '';
       extraConfig = ''
-        boot.kernelParams = lib.mkAfter [ "console=tty0" ];
+        boot.kernelParams.console = lib.mkForce "tty0";
       '';
       enableOCR = true;
       preBootCommands = ''

--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -123,7 +123,7 @@ let
 
     cat > /mnt/grub/grub.cfg <<GRUB
     set root=hd0,1
-    linux /linux ${concatStringsSep " " cfg.boot.kernelParams}
+    linux /linux ${concatStringsSep " " cfg.boot.kernelParamList}
     initrd /initrd
     boot
     GRUB


### PR DESCRIPTION
**Note that this pull request is only a suggestion, currently untested and requires discussion, please do not merge it!**

This fixes #28277 and also its subsequent pull request #28392.

The problem with #28392 was that it has simply sorted the list of `boot.kernelParams` within its apply function by converting it into an attrset and back to a list. This had the disadvantage, that it's no longer possible to include store paths in parameter values and it also didn't allow items to be ordered, which breaks passing arguments to init by separating them with `--`.

In order to address #28277 properly, we turn `boot.kernelParams` into an attribute set in addition with a `coercedTo` type for backwards-compatibility with the list of strings that we had so far.

Being an attrset this allows us to deduplicate and sort the kernel parameters in a more meaningful way and gives us an error whenever a value is defined twice as well as an option to use priorities to override existing values.

For example if we want to set `console=tty0` while already defined in another module, we can simply do so like this:

```nix
{ lib, ... }: {
  boot.kernelParams.console = lib.mkForce "tty0";
}
```

To support passing arguments to init we now have another option called `boot.initArgs`, which will be unordered to support custom init systems and also added to the kernel parameters separated by `--`.

Cc: @volth, @edolstra
Fixes: #28277