### PR TITLE
xsv: 0.12.1 -> 0.12.2

### DIFF
--- a/pkgs/tools/text/xsv/default.nix
+++ b/pkgs/tools/text/xsv/default.nix
@@ -4,16 +4,16 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "xsv-${version}";
-  version = "0.12.1";
+  version = "0.12.2";
 
   src = fetchFromGitHub {
     owner = "BurntSushi";
     repo = "xsv";
     rev = "${version}";
-    sha256 = "0xmjx5grwjrx2zsqmpblid9pqpwkk9pv468ffqlza3w35n9x5dax";
+    sha256 = "0z1z3b6nzaid510jaikkawvpmv4kjphzz84p0hppq6vcp5jy00s2";
   };
 
-  depsSha256 = "0gdbxgykhy6wm89mbdvl7ck2v0f66hwlm0m1q7r64bkb7i10fmkd";
+  depsSha256 = "13hy835871zxdnakwsr4bjm4krahlz4aqk5lh0rw78avfla89q9q";
 
   meta = with stdenv.lib; {
     description = "A fast CSV toolkit written in Rust";


### PR DESCRIPTION
###### Motivation for this change

Update xsv again to the last version. Bad hash in #27813

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

