### PR TITLE
rocksndiamonds: init at 4.0.0.2

### DIFF
--- a/pkgs/development/libraries/SDL2_mixer/default.nix
+++ b/pkgs/development/libraries/SDL2_mixer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, autoconf, pkgconfig, which
+{ stdenv, lib, fetchurl, autoreconfHook, pkgconfig, which
 , SDL2, libogg, libvorbis, smpeg2, flac, libmodplug
 , enableNativeMidi ? false, fluidsynth ? null }:
 
@@ -11,17 +11,14 @@ stdenv.mkDerivation rec {
     sha256 = "0pv9jzjpcjlbiaybvwrb4avmv46qk7iqxlnqrd2dfj82c4mgc92s";
   };
 
-  nativeBuildInputs = [ autoconf pkgconfig which ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig which ];
 
   propagatedBuildInputs = [ SDL2 libogg libvorbis fluidsynth smpeg2 flac libmodplug ];
 
   patches = [ ./libmodplug.patch ];
 
-  preConfigure = ''
-    ./autogen.sh
-  '';
-
-  configureFlags = [ "--disable-music-ogg-shared" ] ++ lib.optional enableNativeMidi "--enable-music-native-midi-gpl";
+  configureFlags = [ "--disable-music-ogg-shared" ]
+    ++ lib.optional enableNativeMidi "--enable-music-native-midi-gpl";
 
   meta = with stdenv.lib; {
     description = "SDL multi-channel audio mixer library";

--- a/pkgs/development/libraries/SDL2_mixer/default.nix
+++ b/pkgs/development/libraries/SDL2_mixer/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, lib, fetchurl, SDL2, libogg, libvorbis, smpeg, flac, enableNativeMidi ? false, fluidsynth ? null }:
+{ stdenv, lib, fetchurl, autoconf, pkgconfig, which
+, SDL2, libogg, libvorbis, smpeg2, flac, libmodplug
+, enableNativeMidi ? false, fluidsynth ? null }:
 
 stdenv.mkDerivation rec {
   name = "SDL2_mixer-${version}";
@@ -9,7 +11,15 @@ stdenv.mkDerivation rec {
     sha256 = "0pv9jzjpcjlbiaybvwrb4avmv46qk7iqxlnqrd2dfj82c4mgc92s";
   };
 
-  propagatedBuildInputs = [ SDL2 libogg libvorbis fluidsynth smpeg flac ];
+  nativeBuildInputs = [ autoconf pkgconfig which ];
+
+  propagatedBuildInputs = [ SDL2 libogg libvorbis fluidsynth smpeg2 flac libmodplug ];
+
+  patches = [ ./libmodplug.patch ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
 
   configureFlags = [ "--disable-music-ogg-shared" ] ++ lib.optional enableNativeMidi "--enable-music-native-midi-gpl";
 

--- a/pkgs/development/libraries/SDL2_mixer/libmodplug.patch
+++ b/pkgs/development/libraries/SDL2_mixer/libmodplug.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.in b/configure.in
+index d511646..77dc3fe 100644
+--- a/configure.in
++++ b/configure.in
+@@ -258,7 +258,7 @@ if test x$enable_music_mod = xyes -a x$enable_music_mod_modplug = xyes; then
+             have_libmodplug_lib=yes
+         ], [dnl
+             AC_CHECK_HEADER([libmodplug/modplug.h], [have_libmodplug_hdr=yes])
+-            AC_CHECK_LIB([modplug], [have_libmodplug_lib=yes])
++            AC_CHECK_LIB([modplug], [ModPlug_Load], [have_libmodplug_lib=yes])
+         ])
+ 
+     if test x$have_libmodplug_hdr = xyes -a x$have_libmodplug_lib = xyes; then

--- a/pkgs/development/libraries/smpeg2/default.nix
+++ b/pkgs/development/libraries/smpeg2/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchsvn, autoconf, automake, libtool, m4, pkgconfig, makeWrapper, SDL2 }:
+
+stdenv.mkDerivation rec {
+  name = "smpeg2-svn${version}";
+  version = "412";
+
+  src = fetchsvn {
+    url = svn://svn.icculus.org/smpeg/trunk;
+    rev = version;
+    sha256 = "1irf2d8f150j8cx8lbb0pz1rijap536crsz0mw871xrh6wd2fd96";
+  };
+
+  patches = [
+    ./gcc6.patch
+    ./sdl2.patch
+  ];
+
+  nativeBuildInputs = [ autoconf automake pkgconfig makeWrapper ];
+
+  buildInputs = [ SDL2 ];
+
+  preConfigure = ''
+    sh autogen.sh
+  '';
+
+  postInstall = ''
+    sed -e 's,#include "\(SDL.*.h\)",#include <SDL2/\1>,' -i $out/include/smpeg2/*.h
+
+    wrapProgram $out/bin/smpeg2-config \
+      --prefix PATH ":" "${pkgconfig}/bin" \
+      --prefix PKG_CONFIG_PATH ":" "${SDL2.dev}/lib/pkgconfig"
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://icculus.org/smpeg/;
+    description = "SDL2 MPEG Player Library";
+    license = licenses.lgpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ orivej ];
+  };
+}

--- a/pkgs/development/libraries/smpeg2/gcc6.patch
+++ b/pkgs/development/libraries/smpeg2/gcc6.patch
@@ -1,0 +1,33 @@
+--- a/audio/hufftable.cpp
++++ b/audio/hufftable.cpp
+@@ -9,6 +9,7 @@
+ #include "config.h"
+ #endif
+ 
++#include <climits>
+ #include "MPEGaudio.h"
+ 
+ static const unsigned int
+@@ -550,11 +551,11 @@ htd33[ 31][2]={{ 16,  1},{  8,  1},{  4,
+ 
+ const HUFFMANCODETABLE MPEGaudio::ht[HTN]=
+ {
+-  { 0, 0-1, 0-1, 0,  0, htd33},
++  { 0, UINT_MAX, UINT_MAX, 0,  0, htd33},
+   { 1, 2-1, 2-1, 0,  7,htd01},
+   { 2, 3-1, 3-1, 0, 17,htd02},
+   { 3, 3-1, 3-1, 0, 17,htd03},
+-  { 4, 0-1, 0-1, 0,  0, htd33},
++  { 4, UINT_MAX, UINT_MAX, 0,  0, htd33},
+   { 5, 4-1, 4-1, 0, 31,htd05},
+   { 6, 4-1, 4-1, 0, 31,htd06},
+   { 7, 6-1, 6-1, 0, 71,htd07},
+@@ -564,7 +565,7 @@ const HUFFMANCODETABLE MPEGaudio::ht[HTN
+   {11, 8-1, 8-1, 0,127,htd11},
+   {12, 8-1, 8-1, 0,127,htd12},
+   {13,16-1,16-1, 0,511,htd13},
+-  {14, 0-1, 0-1, 0,  0, htd33},
++  {14, UINT_MAX, UINT_MAX, 0,  0, htd33},
+   {15,16-1,16-1, 0,511,htd15},
+   {16,16-1,16-1, 1,511,htd16},
+   {17,16-1,16-1, 2,511,htd16},

--- a/pkgs/development/libraries/smpeg2/sdl2.patch
+++ b/pkgs/development/libraries/smpeg2/sdl2.patch
@@ -1,0 +1,22 @@
+diff --git a/smpeg2-config.in b/smpeg2-config.in
+index 5cce954..0e61939 100644
+--- a/smpeg2-config.in
++++ b/smpeg2-config.in
+@@ -42,7 +42,7 @@ while test $# -gt 0; do
+       if test @includedir@ != /usr/include ; then
+         includes=-I@includedir@
+       fi
+-      echo $includes -I@includedir@/smpeg2 `@SDL_CONFIG@ --cflags`
++      echo $includes -I@includedir@/smpeg2 `@SDL2_CONFIG@ --cflags`
+       ;;
+     --libs)
+       if [ "`uname`" = "SunOS" ]; then
+@@ -50,7 +50,7 @@ while test $# -gt 0; do
+       else
+         libdirs="-L@libdir@ @SMPEG_RLD_FLAGS@"
+       fi
+-      echo $libdirs -lsmpeg2 `@SDL_CONFIG@ --libs`
++      echo $libdirs -lsmpeg2 `@SDL2_CONFIG@ --libs`
+       ;;
+     *)
+       echo "${usage}" 1>&2

--- a/pkgs/development/python-modules/pygame_sdl2/default.nix
+++ b/pkgs/development/python-modules/pygame_sdl2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgs, buildPythonPackage, fetchFromGitHub
+{ stdenv, pkgs, buildPythonPackage, fetchFromGitHub, isPy27
 , cython, SDL2, SDL2_image, SDL2_ttf, SDL2_mixer, libjpeg, libpng }:
 
 buildPythonPackage rec {
@@ -17,6 +17,9 @@ buildPythonPackage rec {
     SDL2 SDL2_image SDL2_ttf SDL2_mixer
     cython libjpeg libpng
   ];
+
+
+  doCheck = isPy27; # python3 tests are non-functional
 
   postInstall = ''
     ( cd "$out"/include/python*/ ;

--- a/pkgs/games/rocksndiamonds/default.nix
+++ b/pkgs/games/rocksndiamonds/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl, makeDesktopItem, SDL2, SDL2_image, SDL2_mixer, SDL2_net }:
+
+stdenv.mkDerivation rec {
+  name = "${project}-${version}";
+  project = "rocksndiamonds";
+  version = "4.0.0.2";
+
+  src = fetchurl {
+    url = "https://www.artsoft.org/RELEASES/unix/${project}/${name}.tar.gz";
+    sha256 = "0dzn6vlayvnkjm64zwva337rn07lc21kq93m2h8zz8j3wpl11pb4";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "rocksndiamonds";
+    exec = "rocksndiamonds";
+    icon = "rocksndiamonds";
+    comment = meta.description;
+    desktopName = "Rocks'n'Diamonds";
+    genericName = "Tile-based puzzle";
+    categories = "Game;LogicGame;";
+  };
+
+  buildInputs = [ SDL2 SDL2_image SDL2_mixer SDL2_net ];
+
+  preBuild = ''
+    dataDir="$out/share/rocksndiamonds"
+    makeFlags+="RO_GAME_DIR=$dataDir"
+  '';
+
+  installPhase = ''
+    appDir=$out/share/applications
+    iconDir=$out/share/icons/hicolor/32x32/apps
+    mkdir -p $out/bin $appDir $iconDir $dataDir
+    cp rocksndiamonds $out/bin/
+    ln -s ${desktopItem}/share/applications/* $appDir/
+    ln -s $dataDir/graphics/gfx_classic/RocksIcon32x32.png $iconDir/rocksndiamonds.png
+    cp -r docs graphics levels music sounds $dataDir
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Scrolling tile-based arcade style puzzle game";
+    homepage = https://www.artsoft.org/rocksndiamonds/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ orivej ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17513,6 +17513,8 @@ with pkgs;
 
   robotfindskitten = callPackage ../games/robotfindskitten { };
 
+  rocksndiamonds = callPackage ../games/rocksndiamonds { };
+
   saga = callPackage ../applications/gis/saga { };
 
   samplv1 = callPackage ../applications/audio/samplv1 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10299,6 +10299,8 @@ with pkgs;
 
   smpeg = callPackage ../development/libraries/smpeg { };
 
+  smpeg2 = callPackage ../development/libraries/smpeg2 { };
+
   snack = callPackage ../development/libraries/snack {
         # optional
   };


### PR DESCRIPTION
###### Motivation for this change

Rocks'n'diamonds has music in MOD format: to support it `SDL2_mixer` has to be built with `libmodplug` (which is its default, or alternatively with `libmikmod`). Since `SDL2_mixer` has to be changed and its configure fails to find `smpeg2` (the previous `smpeg` was for SDL1 and could not be used with SDL2), this adds `smpeg2`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).