### PR TITLE
mbuffer: 20160613 -> 20170806

### DIFF
--- a/pkgs/tools/misc/mbuffer/default.nix
+++ b/pkgs/tools/misc/mbuffer/default.nix
@@ -3,19 +3,19 @@
  } :
 
 stdenv.mkDerivation rec {
-  version = "20160613";
+  version = "20170806";
   name = "mbuffer-${version}";
 
   src = fetchurl {
     url = "http://www.maier-komor.de/software/mbuffer/mbuffer-${version}.tgz";
-    sha256 = "1za9yqfn23axnp4zymdsrjkqcci3wxywqw3bv4dxms57q1ljiab7";
+    sha256 = "0kbvxrd1k0509whgyl7w20cmqn5q16vjjh7d9glpl2j4lfd66ljw";
   };
 
   buildInputs = [ openssl ];
 
   meta = {
     homepage = http://www.maier-komor.de/mbuffer.html;
-    description  = "mbuffer is a tool for buffering data streams with a large set of unique features";
+    description  = "A tool for buffering data streams with a large set of unique features";
     license = stdenv.lib.licenses.gpl3;
     maintainers = with stdenv.lib.maintainers; [ tokudan ];
     platforms = with stdenv.lib.platforms; allBut darwin;


### PR DESCRIPTION
###### Motivation for this change

Update mbuffer to current version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

