### PR TITLE
yices: 2.5.2 -> 2.5.3, libpoly: 0.1.3 -> 0.1.4

### DIFF
--- a/pkgs/applications/science/logic/poly/default.nix
+++ b/pkgs/applications/science/logic/poly/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fetchurl, gmp, cmake, python}:
 
-let version = "0.1.3";
+let version = "0.1.4";
 in
 
 stdenv.mkDerivation {
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://github.com/SRI-CSL/libpoly/archive/v${version}.tar.gz";
-    sha256 = "0nd90585imnznyp04vg6a5ixxkd3bavhv1437397aj2k3dfc0y2k";
+    sha256 = "16x1pk2a3pcb5a0dzyw28ccjwkhmbsck4hy80ss7kx0dd7qgpi7j";
   };
 
   buildInputs = [ cmake gmp python ];

--- a/pkgs/applications/science/logic/yices/default.nix
+++ b/pkgs/applications/science/logic/yices/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name    = "yices-${version}";
-  version = "2.5.2";
+  version = "2.5.3";
 
   src = fetchurl {
-    url = "http://yices.csl.sri.com/cgi-bin/yices2-newnewdownload.cgi?file=${name}-src.tar.gz&accept=I+Agree";
+    url = "https://github.com/SRI-CSL/yices2/archive/Yices-${version}.tar.gz";
     name = "${name}-src.tar.gz";
-    sha256 = "18mjnwg0pwc0fx4f99l7hxsi10mb5skkzk0k1m3xv5kx3qfnghs0";
+    sha256 = "0a3zzbvmgyiljzqn6xmc037gismm779p696jywk09j2pqbvp52ac";
   };
 
   patchPhase = ''patchShebangs tests/regress/check.sh'';
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   # only installing the libyices.so.2.5.1 file.
   installPhase = ''
       make install LDCONFIG=true
-      (cd $out/lib && ln -s -f libyices.so.2.5.2 libyices.so.2.5)
+      (cd $out/lib && ln -s -f libyices.so.2.5.3 libyices.so.2.5)
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

