### PR TITLE
WIP: Add NetworkManager-sstp

### DIFF
--- a/nixos/modules/config/no-x-libs.nix
+++ b/nixos/modules/config/no-x-libs.nix
@@ -30,6 +30,7 @@ with lib;
       dbus = pkgs.dbus.override { x11Support = false; };
       networkmanager_fortisslvpn = pkgs.networkmanager_fortisslvpn.override { withGnome = false; };
       networkmanager_l2tp = pkgs.networkmanager_l2tp.override { withGnome = false; };
+      networkmanager_sstp = pkgs.networkmanager_sstp.override { withGnome = false; };
       networkmanager_openconnect = pkgs.networkmanager_openconnect.override { withGnome = false; };
       networkmanager_openvpn = pkgs.networkmanager_openvpn.override { withGnome = false; };
       networkmanager_pptp = pkgs.networkmanager_pptp.override { withGnome = false; };

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -130,7 +130,8 @@ in {
         default = { inherit networkmanager modemmanager wpa_supplicant
                             networkmanager_openvpn networkmanager_vpnc
                             networkmanager_openconnect networkmanager_fortisslvpn
-                            networkmanager_pptp networkmanager_l2tp; };
+                            networkmanager_pptp networkmanager_l2tp
+                            networkmanager_sstp; };
         internal = true;
       };
 
@@ -251,6 +252,9 @@ in {
       }
       { source = "${networkmanager_l2tp}/etc/NetworkManager/VPN/nm-l2tp-service.name";
         target = "NetworkManager/VPN/nm-l2tp-service.name";
+      }
+      { source = "${networkmanager_sstp}/etc/NetworkManager/VPN/nm-sstp-service.name";
+        target = "NetworkManager/VPN/nm-sstp-service.name";
       }
       { source = "${networkmanager_strongswan}/etc/NetworkManager/VPN/nm-strongswan-service.name";
         target = "NetworkManager/VPN/nm-strongswan-service.name";

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -187,7 +187,7 @@ in {
       { inherit (pkgs) networkmanager modemmanager wpa_supplicant;
         inherit (gnome3) networkmanager_openvpn networkmanager_vpnc
                          networkmanager_openconnect networkmanager_fortisslvpn networkmanager_pptp
-                         networkmanager_l2tp; };
+                         networkmanager_l2tp networkmanager_sstp; };
 
     # Needed for themes and backgrounds
     environment.pathsToLink = [ "/share" ];

--- a/pkgs/desktops/gnome-3/3.22/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/default.nix
@@ -220,6 +220,10 @@ let
     inherit gnome3;
   };
 
+  networkmanager_sstp = pkgs.networkmanager_sstp.override {
+    inherit gnome3;
+  };
+
   networkmanagerapplet = pkgs.networkmanagerapplet.override {
     inherit gnome3 gsettings_desktop_schemas glib_networking;
   };

--- a/pkgs/tools/networking/network-manager/sstp.nix
+++ b/pkgs/tools/networking/network-manager/sstp.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, networkmanager, sstp-client, ppp, intltool
+, pkgconfig, libsecret, withGnome ? true, gnome3 }:
+
+stdenv.mkDerivation rec {
+  name    = "${pname}${if withGnome then "-gnome" else ""}-${version}";
+  pname   = "NetworkManager-sstp";
+  major   = "1.2";
+  version = "${major}.2";
+
+  src = fetchFromGitHub {
+    owner  = "enaess";
+    repo   = "network-manager-sstp";
+    rev    = "${version}";
+    sha256 = "4449b09c7debaf6b086ca020052b55beb86753ad6b22180db1b8dde824b7340d";
+  };
+
+  buildInputs = [ networkmanager sstp-client ppp libsecret ]
+    ++ stdenv.lib.optionals withGnome [ gnome3.gtk gnome3.libgnome_keyring
+                                        gnome3.networkmanagerapplet ];
+
+  nativeBuildInputs = [ intltool pkgconfig ];
+
+  postPatch = ''
+    sed -i -e 's%"\(/usr/sbin\|/usr/pkg/sbin\|/usr/local/sbin\)/[^"]*",%%g' ./src/nm-sstp-service.c
+
+    substituteInPlace ./src/nm-sstp-service.c \
+      --replace /sbin/sstp-client ${sstp-client}/bin/sstp-client \
+      --replace /sbin/pppd ${ppp}/bin/pppd
+  '';
+
+  configureFlags =
+    if withGnome then "--with-gnome --with-gtkver=3" else "--without-gnome";
+
+  meta = {
+    description = "SSTP plugin for NetworkManager";
+    inherit (networkmanager.meta) maintainers platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3378,6 +3378,8 @@ with pkgs;
 
   networkmanager_l2tp = callPackage ../tools/networking/network-manager/l2tp.nix { };
 
+  networkmanager_sstp = callPackage ../tools/networking/network-manager/sstp.nix { };
+
   networkmanager_vpnc = callPackage ../tools/networking/network-manager/vpnc.nix { };
 
   networkmanager_openconnect = callPackage ../tools/networking/network-manager/openconnect.nix { };
@@ -11096,7 +11098,7 @@ with pkgs;
   dex-oidc = callPackage ../servers/dex { };
 
   dgraph = callPackage ../servers/dgraph { };
-    
+
   dico = callPackage ../servers/dico { };
 
   dict = callPackage ../servers/dict {
@@ -18678,7 +18680,7 @@ with pkgs;
   hplip_3_15_9 = callPackage ../misc/drivers/hplip/3.15.9.nix { };
 
   hplipWithPlugin_3_15_9 = hplip_3_15_9.override { withPlugin = true; };
-  
+
   epkowa = callPackage ../misc/drivers/epkowa { };
 
   illum = callPackage ../tools/system/illum { };


### PR DESCRIPTION
###### Motivation for this change

Add support for SSTP VPNs.

###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---