### PR TITLE
edk2: 2014-12-10 -> UDK2017

### DIFF
--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (edk2.setup "OvmfPkg/OvmfPkg${targetArch}.dsc" {
     export OUTPUT_FD=$fd
 
     for file in \
-      "${edk2.src}"/{UefiCpuPkg,MdeModulePkg,IntelFrameworkModulePkg,PcAtChipsetPkg,FatBinPkg,EdkShellBinPkg,MdePkg,ShellPkg,OptionRomPkg,IntelFrameworkPkg};
+      "${edk2.src}"/{UefiCpuPkg,MdeModulePkg,IntelFrameworkModulePkg,PcAtChipsetPkg,FatBinPkg,EdkShellBinPkg,MdePkg,ShellPkg,OptionRomPkg,IntelFrameworkPkg,FatPkg,CryptoPkg,SourceLevelDebugPkg};
     do
       ln -sv "$file" .
     done

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, libuuid, python2, iasl }:
+{ stdenv, fetchFromGitHub, libuuid, python2, iasl }:
 
 let
   pythonEnv = python2.withPackages(ps: [ps.tkinter]);
@@ -13,10 +13,11 @@ else
 edk2 = stdenv.mkDerivation {
   name = "edk2-2014-12-10";
 
-  src = fetchgit {
-    url = git://github.com/tianocore/edk2;
-    rev = "684a565a04";
-    sha256 = "0s9ywb8w7xzlnmm4kwzykxkrdaw53b7pky121cc9wjkllzqwyxrb";
+  src = fetchFromGitHub {
+    owner = "tianocore";
+    repo = "edk2";
+    rev = "vUDK2017";
+    sha256 = "0sswa028644yr8fbl8j6rhrdm717fj29h4dys3ygklmjhss90a2g";
   };
 
   buildInputs = [ libuuid pythonEnv];


### PR DESCRIPTION
###### Motivation for this change
Newer upstream version. This also includes a fix for OVMF, which it otherwise breaks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).