### PR TITLE
ipfs improvements

### DIFF
--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -8,6 +8,7 @@ let
   cfg = config.services.ipfs;
 
   ipfsFlags = toString ([
+    (optionalString (cfg.serviceFdlimit != null) "--manage-fdlimit=true")
     (optionalString cfg.autoMount   "--mount")
     (optionalString cfg.autoMigrate "--migrate")
     (optionalString cfg.enableGC    "--enable-gc")
@@ -129,6 +130,15 @@ in
         default = [];
       };
 
+      serviceFdlimit = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        description = ''
+          The fdlimit for the IPFS systemd unit or `null` to have the daemon attempt to manage it.
+        '';
+        example = 256*1024;
+      };
+
     };
   };
 
@@ -219,7 +229,7 @@ in
         Group = cfg.group;
         Restart = "on-failure";
         RestartSec = 1;
-      };
+      } // optionalAttrs (cfg.serviceFdlimit != null) { LimitNOFILE = cfg.serviceFdlimit; };
     };
 
     systemd.services.ipfs-offline = {
@@ -242,7 +252,7 @@ in
         Group = cfg.group;
         Restart = "on-failure";
         RestartSec = 1;
-      };
+      } // optionalAttrs (cfg.serviceFdlimit != null) { LimitNOFILE = cfg.serviceFdlimit; };
     };
 
     systemd.services.ipfs-norouting = {
@@ -265,7 +275,7 @@ in
         Group = cfg.group;
         Restart = "on-failure";
         RestartSec = 1;
-      };
+      } // optionalAttrs (cfg.serviceFdlimit != null) { LimitNOFILE = cfg.serviceFdlimit; };
     };
 
   };


### PR DESCRIPTION
###### Motivation for this change
Ipfs service needs more configurability.

###### Things done
See commit messages.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

