### PR TITLE
git-fire: Init at master as of 2017-08-27

### DIFF
--- a/pkgs/tools/misc/git-fire/default.nix
+++ b/pkgs/tools/misc/git-fire/default.nix
@@ -9,15 +9,11 @@ stdenv.mkDerivation {
     rev = "d72b68ed356f726c77c60294f9220275f16c9931";
     sha256 = "1hdwkhyjjx31y0lpjkhbb4f5y9f7g70fnd4c2246cmk2rbsvj5b2";
   };
-  
-  unpackPhase = ":";
-  
+
   installPhase = ''
-    mkdir -p $out/bin 
-    cp $src/git-fire $out/bin
-    chmod +x $out/bin/git-fire
+    install -D -m755 $src/git-fire $out/bin/git-fire
   '';
-  
+
   meta = with stdenv.lib; {
     description = ''
       Push ALL changes in a git repository

--- a/pkgs/tools/misc/git-fire/default.nix
+++ b/pkgs/tools/misc/git-fire/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  name = "git-fire-unstable-2017-08-27";
+
+  src = fetchFromGitHub {
+    owner = "qw3rtman";
+    repo = "git-fire";
+    rev = "d72b68ed356f726c77c60294f9220275f16c9931";
+    sha256 = "1hdwkhyjjx31y0lpjkhbb4f5y9f7g70fnd4c2246cmk2rbsvj5b2";
+  };
+  
+  unpackPhase = ":";
+  
+  installPhase = ''
+    mkdir -p $out/bin 
+    cp $src/git-fire $out/bin
+    chmod +x $out/bin/git-fire
+  '';
+  
+  meta = with stdenv.lib; {
+    description = ''
+      Push ALL changes in a git repository
+    '';
+    longDescription = ''
+      In the event of an emergency (fire, etc.), automatically commit all changes/files in a repository, pushing to all known remotes all commits and stashes.
+    '';
+    homepage = "https://github.com/qw3rtman/git-fire";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.swflint ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -571,6 +571,8 @@ with pkgs;
 
   genymotion = callPackage ../development/mobile/genymotion { };
 
+  git-fire = callPackage ../tools/misc/git-fire { };
+
   grc = callPackage ../tools/misc/grc { };
 
   green-pdfviewer = callPackage ../applications/misc/green-pdfviewer {


### PR DESCRIPTION
###### Motivation for this change

It's a toy package, but being able to install it via nix-env instead of npm would be useful.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

