### PR TITLE
xssproxy: init at 1.0.0

### DIFF
--- a/pkgs/misc/screensavers/xssproxy/default.nix
+++ b/pkgs/misc/screensavers/xssproxy/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, glib, pkgconfig, xorg, dbus }:
+
+let rev = "1.0.0"; in
+
+stdenv.mkDerivation {
+  name = "xssproxy-${rev}";
+
+  src = fetchFromGitHub {
+    owner = "timakro";
+    repo = "xssproxy";
+    rev = "v${rev}";
+    sha256 = "0c83wmipnsdnbihc5niyczs7jrkss2s8n6iwwjdia7hkjzbd0hl7";
+  };
+
+  buildInputs = [ glib pkgconfig xorg.libX11 xorg.libXScrnSaver dbus ];
+
+  makeFlags = [
+    "bindir=$(out)/bin"
+    "man1dir=$(out)/share/man/man1"
+  ];
+
+  meta = {
+    description = "Forward freedesktop.org Idle Inhibition Service calls to Xss";
+    homepage = https://github.com/timakro/xssproxy;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ benley ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17007,6 +17007,8 @@ with pkgs;
 
   xss-lock = callPackage ../misc/screensavers/xss-lock { };
 
+  xssproxy = callPackage ../misc/screensavers/xssproxy { };
+
   xsynth_dssi = callPackage ../applications/audio/xsynth-dssi { };
 
   xterm = callPackage ../applications/misc/xterm { };


### PR DESCRIPTION
###### Motivation for this change
https://www.reddit.com/r/xmonad/comments/6wclw7/xssproxy_suspends_the_screensaver_when_watching/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

