### PR TITLE
git-open: 1.3.0 -> 1.3.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-open/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-open/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "git-open-${version}";
-  version = "1.3.0";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "paulirish";
     repo = "git-open";
     rev = "v${version}";
-    sha256 = "005am4phf7j4ybc9k1hqsxjb7gv2i56a3axrza866pwwx1ayrhpq";
+    sha256 = "1klj41vqgyyigqzi6s1ykz9vd8wvaq3skin63pi989dlsjf7igyr";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
Update git-open to 1.3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

