### PR TITLE
webkitgtk24x: fix build with gcc6

### DIFF
--- a/pkgs/development/libraries/webkitgtk/2.4.nix
+++ b/pkgs/development/libraries/webkitgtk/2.4.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, python, ruby, bison, gperf, flex
+{ stdenv, fetchurl, fetchpatch, perl, python, ruby, bison, gperf, flex
 , pkgconfig, which, gettext, gobjectIntrospection
 , gtk2, gtk3, wayland, libwebp, enchant, sqlite
 , libxml2, libsoup, libsecret, libxslt, harfbuzz, xorg
@@ -44,6 +44,10 @@ stdenv.mkDerivation rec {
   '';
   patches = [
     ./webcore-svg-libxml-cflags.patch
+    (fetchpatch {
+      url = https://raw.githubusercontent.com/gentoo/gentoo/7c5457e265bd40c156a8fe6b2ff94a4e34bcea8e/net-libs/webkit-gtk/files/webkit-gtk-2.4.9-gcc-6.patch;
+      sha256 = "0ll93dr5vxd40wvly1jaw41lvw86krac0jc6k6cacrps4i5ql5j0";
+    })
   ] ++ optionals stdenv.isDarwin [
     ./configure.patch
     ./quartz-webcore.patch


### PR DESCRIPTION
###### Motivation for this change

`webkitgtk24x-gtk2` and `webkitgtk24x-gtk3` fail to build with gcc6.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested building `webkitgtk24x-gtk2` and `webkitgtk24x-gtk3`.