### PR TITLE
clementine: fix build with gcc6

### DIFF
--- a/pkgs/applications/audio/projectm/default.nix
+++ b/pkgs/applications/audio/projectm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, cmake
+{ stdenv, fetchurl, fetchpatch, pkgconfig, cmake
 , glew, ftgl, ttf_bitstream_vera
 , withQt ? true, qt4
 , withLibvisual ? false, libvisual, SDL
@@ -24,7 +24,13 @@ stdenv.mkDerivation {
     sha256 = "1vh6jk68a0jdb6qwppb6f8cbgmhnv2ba3bcavzfd6sq06gq08cji";
   };
 
+  patch_gcc6 = fetchpatch {
+    url = https://raw.githubusercontent.com/gentoo/gentoo/45abd63abc6644b6e177c057b5b42d894dbf8e29/media-libs/libprojectm/files/libprojectm-2.1.0-fix-c++14.patch;
+    sha256 = "1i50scxv1jlqvb3jm3sql89a7wqckxhlpvnhz20vvmm1kii6lrsn";
+  };
+
   patchPhase = ''
+    patch -d src/libprojectM -p1 -i "$patch_gcc6"
     sed -i 's:''${LIBVISUAL_PLUGINSDIR}:''${CMAKE_INSTALL_PREFIX}/lib/libvisual-0.4:' \
       src/projectM-libvisual/CMakeLists.txt
   '';


### PR DESCRIPTION
###### Motivation for this change

`projectm` bundled with `clementine` fails to build with gcc6. We fix system `projectm` and let `clementine` use it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
