### PR TITLE
ocamlPackages.ppx_deriving: 4.1 -> 4.2

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -1,23 +1,23 @@
 { stdenv, buildOcaml, ocaml, fetchzip
-, cppo, ppx_tools, result, ounit
+, cppo, ppx_tools, ppx_derivers, result, ounit, ocaml-migrate-parsetree
 }:
 
 buildOcaml rec {
   name = "ppx_deriving";
-  version = "4.1";
+  version = "4.2";
 
   minimumSupportedOcamlVersion = "4.02";
 
   src = fetchzip {
     url = "https://github.com/whitequark/${name}/archive/v${version}.tar.gz";
-    sha256 = "0cy9p8d8cbcxvqyyv8fz2z9ypi121zrgaamdlp4ld9f3jnwz7my9";
+    sha256 = "0scsg45wp6xdqj648fz155r4yngyl2xcd3hdszfzqwdpbax33914";
   };
 
   hasSharedObjects = true;
 
   buildInputs = [ cppo ounit ];
   propagatedBuildInputs =
-    [ ppx_tools result ];
+    [ ppx_tools ppx_derivers result ocaml-migrate-parsetree ];
 
   installPhase = "OCAMLPATH=$OCAMLPATH:`ocamlfind printconf destdir` make install";
 
@@ -25,6 +25,5 @@ buildOcaml rec {
     description = "deriving is a library simplifying type-driven code generation on OCaml >=4.02.";
     maintainers = [ maintainers.maurer ];
     license = licenses.mit;
-    broken = versionAtLeast ocaml.version "4.05";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This fixes compilation of ppx_deriving with OCaml 4.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

