### PR TITLE
synergy: fix check with gcc6

### DIFF
--- a/pkgs/applications/misc/synergy/default.nix
+++ b/pkgs/applications/misc/synergy/default.nix
@@ -16,9 +16,15 @@ stdenv.mkDerivation rec {
 
   patches = [ ./openssl-1.1.patch ];
 
+  patch_gcc6 = fetchpatch {
+    url = https://raw.githubusercontent.com/gentoo/gentoo/20e2bff3697ebf5f291e9907b34aae3074a36b53/dev-cpp/gmock/files/gmock-1.7.0-gcc6.patch;
+    sha256 = "0j3f381x1lf8qci9pfv6mliggl8qs2w05v5lw3rs3gn7aibg174d";
+  };
+
   postPatch = ''
     ${unzip}/bin/unzip -d ext/gmock-1.6.0 ext/gmock-1.6.0.zip
     ${unzip}/bin/unzip -d ext/gtest-1.6.0 ext/gtest-1.6.0.zip
+    patch -d ext/gmock-1.6.0 -p1 -i ${patch_gcc6}
   ''
     # We have XRRNotifyEvent (libXrandr), but with the upstream CMakeLists.txt
     # it's not able to find it (it's trying to search the store path of libX11


### PR DESCRIPTION
Currently `synergy` check phase fails as in https://github.com/google/googletest/issues/705

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
