### PR TITLE
libipfix: init at 110209

### DIFF
--- a/pkgs/development/libraries/libipfix/default.nix
+++ b/pkgs/development/libraries/libipfix/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "libipfix-${version}";
+  version = "110209";
+  src = fetchurl {
+    url = " http://sourceforge.net/projects/libipfix/files/libipfix/libipfix_110209.tgz";
+    sha256 = "0h7v0sxjjdc41hl5vq2x0yhyn04bczl11bqm97825mivrvfymhn6";
+  };
+  meta = with stdenv.lib; {
+    homepage = http://libipfix.sourceforge.net/;
+    description = "The libipfix C-library implements the IPFIX protocol defined by the IP Flow Information Export working group of the IETF.";
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lewo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2974,6 +2974,8 @@ with pkgs;
 
   libfann = callPackage ../development/libraries/libfann { };
 
+  libipfix = callPackage ../development/libraries/libipfix { };
+
   libircclient = callPackage ../development/libraries/libircclient { };
 
   libite = callPackage ../development/libraries/libite { };


### PR DESCRIPTION
###### Motivation for this change
This is an old library which is still used by the OpenContrail project.

###### Things done
I'm executing binariues that are using this lib.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

