### PR TITLE
alacritty: 2017-07-25 -> 2017-08-28

### DIFF
--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -29,16 +29,16 @@ let
 in
 
 buildRustPackage rec {
-  name = "alacritty-unstable-2017-07-25";
+  name = "alacritty-unstable-2017-08-28";
 
   src = fetchFromGitHub {
     owner = "jwilm";
     repo = "alacritty";
-    rev = "49c73f6d55e5a681a0e0f836cd3e9fe6af30788f";
-    sha256 = "0h5hrb2g0fpc6xn94hmvxjj21cqbj4vgqkznvd64jl84qbyh1xjl";
+    rev = "c4ece6dde3c9dcf825a44aa775535a65c0c376a6";
+    sha256 = "1n1ncz45h0zgprsm2wkj11i9wwpg3kba4wv5mcs1xx793aq16x82";
   };
 
-  depsSha256 = "1pbb0swgpsbd6x3avxz6fv3q31dg801li47jibz721a4n9c0rssx";
+  depsSha256 = "19lrj4i6vzmf22r6xg99zcwvzjpiar8pqin1m2nvv78xzxx5yvgb";
 
   buildInputs = [
     cmake


### PR DESCRIPTION
With jwilm/alacritty#761, we should now be able to update `alacritty` again in nixpkgs.
Declaring this as WIP since we need a Crates index update before we can find `winit` 0.7.6.