### PR TITLE
nextcloud-client 2.3.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -97,6 +97,7 @@
   canndrew = "Andrew Cann <shum@canndrew.org>";
   carlsverre = "Carl Sverre <accounts@carlsverre.com>";
   casey = "Casey Rodarmor <casey@rodarmor.net>";
+  caugner = "Claas Augner <nixos@caugner.de>";
   cdepillabout = "Dennis Gosnell <cdep.illabout@gmail.com>";
   cfouche = "Chaddaï Fouché <chaddai.fouche@gmail.com>";
   changlinli = "Changlin Li <mail@changlinli.com>";

--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -14,12 +14,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig cmake ];
   buildInputs = [ qtbase qtwebkit qtkeychain sqlite ];
 
-  cmakeFlags = [
-    "-UCMAKE_INSTALL_LIBDIR"
-  ];
-
   preConfigure = ''
-    cmakeFlags="$cmakeFlags -DOEM_THEME_DIR=$(realpath ./nextcloudtheme) ../client"
+    cmakeFlagsArray+=("-UCMAKE_INSTALL_LIBDIR" "-DOEM_THEME_DIR=$(realpath ./nextcloudtheme)" "../client")
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchgit, cmake, pkgconfig, qtbase, qtwebkit, qtkeychain, sqlite }:
+
+stdenv.mkDerivation rec {
+  name = "nextcloud-client-${version}";
+  version = "2.3.2";
+
+  src = fetchgit {
+    url = "git://github.com/nextcloud/client_theming.git";
+    rev = "1ee750d1aeaaefc899629e85c311594603e9ac1b";
+    sha256 = "0dxyng8a7cg78z8yngiqypsb44lf5c6vkabvkfch0cl0cqmarc1a";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ qtbase qtwebkit qtkeychain sqlite ];
+
+  cmakeFlags = [
+    "-UCMAKE_INSTALL_LIBDIR"
+  ];
+
+  preConfigure = ''
+    cmakeFlags="$cmakeFlags -DOEM_THEME_DIR=$(realpath ./nextcloudtheme) ../client"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Nextcloud themed desktop client";
+    homepage = https://nextcloud.com;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ caugner ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3414,6 +3414,8 @@ with pkgs;
 
   nextcloud = callPackage ../servers/nextcloud { };
 
+  nextcloud-client = libsForQt56.callPackage ../applications/networking/nextcloud-client { };
+
   nextcloud-news-updater = callPackage ../servers/nextcloud/news-updater.nix { };
 
   ngrep = callPackage ../tools/networking/ngrep { };


### PR DESCRIPTION
###### Motivation for this change

I'm switching from Fedora to NixOS and would like to continue using the Nextcloud themed version of the owncloud-client.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

