### PR TITLE
apple misc pkgs: `buildInputs` -> `nativeBuildInputs`

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
@@ -1,7 +1,7 @@
 { stdenv, cctools, appleDerivation }:
 
 appleDerivation {
-  buildInputs = [ cctools ];
+  nativeBuildInputs = [ cctools ];
 
   postPatch = ''
     substituteInPlace makefile \

--- a/pkgs/os-specific/darwin/apple-source-releases/Libc/825_40_1.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libc/825_40_1.nix
@@ -3,7 +3,7 @@
 appleDerivation {
   phases = [ "unpackPhase" "installPhase" ];
 
-  buildInputs = [ ed unifdef ];
+  nativeBuildInputs = [ ed unifdef ];
 
   installPhase = ''
     export SRCROOT=$PWD

--- a/pkgs/os-specific/darwin/apple-source-releases/Libc/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libc/default.nix
@@ -3,7 +3,7 @@
 appleDerivation {
   phases = [ "unpackPhase" "installPhase" ];
 
-  buildInputs = [ ed unifdef ];
+  nativeBuildInputs = [ ed unifdef ];
 
   # TODO: asl.h actually comes from syslog project now
   installPhase = ''

--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
@@ -5,7 +5,7 @@
 appleDerivation rec {
   phases = [ "unpackPhase" "installPhase" ];
 
-  buildInputs = [ cpio ];
+  nativeBuildInputs = [ cpio ];
 
   installPhase = ''
     export NIX_ENFORCE_PURITY=

--- a/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/default.nix
@@ -16,7 +16,8 @@ let recentAdvCmds = fetchzip {
 };
 
 in appleDerivation {
-  buildInputs = [ bsdmake perl yacc flex ];
+  nativeBuildInputs = [ bsdmake perl yacc flex ];
+  buildInputs = [ flex ];
 
   patchPhase = ''
     substituteInPlace BSDmakefile \

--- a/pkgs/os-specific/darwin/apple-source-releases/bootstrap_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/bootstrap_cmds/default.nix
@@ -1,7 +1,7 @@
 { stdenv, appleDerivation, yacc, flex }:
 
 appleDerivation {
-  buildInputs = [ yacc flex ];
+  nativeBuildInputs = [ yacc flex ];
 
   buildPhase = ''
     cd migcom.tproj

--- a/pkgs/os-specific/darwin/apple-source-releases/bsdmake/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/bsdmake/default.nix
@@ -1,7 +1,7 @@
 { stdenv, appleDerivation, fetchurl, fetchpatch, makeWrapper }:
 
 appleDerivation {
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   patchPhase = ''
     substituteInPlace mk/bsd.prog.mk \
@@ -27,9 +27,9 @@ appleDerivation {
     for file in $(find . -name '*.c'); do
       obj="$(basename "$file" .c).o"
       objs+=("$obj")
-      cc -c "$file" -o "$obj" -DDEFSHELLNAME='"sh"' -D__FBSDID=__RCSID -mdynamic-no-pic -g
+      $CC -c "$file" -o "$obj" -DDEFSHELLNAME='"sh"' -D__FBSDID=__RCSID -mdynamic-no-pic -g
     done
-    cc "''${objs[@]}" -o bsdmake
+    $CC "''${objs[@]}" -o bsdmake
   '';
 
   installPhase = ''

--- a/pkgs/os-specific/darwin/apple-source-releases/configd/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/configd/default.nix
@@ -3,7 +3,8 @@
 appleDerivation {
   meta.broken = stdenv.cc.nativeLibc;
 
-  buildInputs = [ launchd bootstrap_cmds ppp IOKit eap8021x ];
+  nativeBuildInputs = [ bootstrap_cmds ];
+  buildInputs = [ launchd ppp IOKit eap8021x ];
 
   propagatedBuildInputs = [ Security ];
 

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -29,7 +29,8 @@ let
       sha256 = "0l45mvyags56jfi24rawms8j2ihbc45mq7v13pkrrwppghqrdn52";
     };
 
-    buildInputs = [ autoconf automake libtool_2 libuuid ] ++
+    nativeBuildInputs = [ autoconf automake libtool_2 ];
+    buildInputs = [ libuuid ] ++
       # Only need llvm and clang if the stdenv isn't already clang-based (TODO: just make a stdenv.cc.isClang)
       stdenv.lib.optionals (!stdenv.isDarwin) [ llvm clang ] ++
       stdenv.lib.optionals stdenv.isDarwin [ libcxxabi libobjc ];


### PR DESCRIPTION
###### Motivation for this change

Better clarity, good if anything is every cross compiled, and robust to stopping putting `buildInputs` on the path.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

