### PR TITLE
xxdiff-tip: 20170101 -> 20170623

### DIFF
--- a/pkgs/development/tools/misc/xxdiff/tip.nix
+++ b/pkgs/development/tools/misc/xxdiff/tip.nix
@@ -1,25 +1,25 @@
-{ stdenv, fetchFromBitbucket, qt5, flex, bison, docutils }:
+{ stdenv, fetchFromBitbucket, qtbase, flex, bison, docutils }:
 
 stdenv.mkDerivation rec {
-  name = "xxdiff-4.0.1.20170101";
+  name = "xxdiff-4.0.1.20170623";
 
   src = fetchFromBitbucket {
     owner = "blais";
     repo = "xxdiff";
-    rev = "1cf6b23ad30a845daba28a3409c65f93aec7f5e8";
-    sha256 = "0rq7grpndj85i7qzlj93jpzpfzk7bwsi55033fc63hb55rbdzz6z";
+    rev = "5e5f885dfc43559549a81c59e9e8c9525306356a";
+    sha256 = "0gbvxrkwkbvag3298j89smszghpr8ilxxfb0cvsknfqdf15b296w";
   };
 
-  nativeBuildInputs = [ flex bison qt5.qtbase docutils ];
+  nativeBuildInputs = [ flex bison docutils ];
 
-  buildInputs = [ qt5.qtbase ];
+  buildInputs = [ qtbase ];
 
   preConfigure = ''
-    ln -s ${qt5.qtbase.dev}/mkspecs/* ../__nix_qt*__/mkspecs
-    ln -s ${qt5.qtbase.dev}/bin/* ../__nix_qt*__/bin || true
+    ln -s ${qtbase.dev}/mkspecs/* ../__nix_qt*__/mkspecs
+    ln -s ${qtbase.dev}/bin/* ../__nix_qt*__/bin || true
   '';
 
-  NIX_CFLAGS_COMPILE="-I${qt5.qtbase.dev}/include/QtCore -I${qt5.qtbase.dev}/include/QtGui -I${qt5.qtbase.dev}/include/QtWidgets";
+  NIX_CFLAGS_COMPILE="-I${qtbase.dev}/include/QtCore -I${qtbase.dev}/include/QtGui -I${qtbase.dev}/include/QtWidgets";
   
   configurePhase = "${preConfigure} cd src; make -f Makefile.bootstrap";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7443,7 +7443,7 @@ with pkgs;
   xxdiff = callPackage ../development/tools/misc/xxdiff {
     bison = bison2;
   };
-  xxdiff-tip = callPackage ../development/tools/misc/xxdiff/tip.nix { };
+  xxdiff-tip = qt56.callPackage ../development/tools/misc/xxdiff/tip.nix { };
 
   yacc = bison;
 


### PR DESCRIPTION
Updates the xxdiff-tip version and fixes compilation errors by forcing qt5.6.

###### Motivation for this change

Fixes: https://github.com/NixOS/nixpkgs/issues/28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

