### PR TITLE
lilypond-unstable: 2.19.24 -> 2.19.65

### DIFF
--- a/pkgs/misc/lilypond/unstable.nix
+++ b/pkgs/misc/lilypond/unstable.nix
@@ -1,19 +1,25 @@
-{ stdenv, fetchurl, guile, rsync, lilypond }:
+{ stdenv, fetchurl, fetchgit, guile, rsync, lilypond, gyre-fonts }:
 
 with stdenv.lib;
 
+let urw-fonts = fetchgit {
+  url = "http://git.ghostscript.com/urw-core35-fonts.git";
+  rev = "1f28a6fcd2176256a995db907d9ffe6e1b9b83e9";
+  sha256 = "1nlx95l1pw5lxqp2v0rn9a7lqrsbbhzr0dy3cybk55r4a8awbr2a";
+}; in
+
 overrideDerivation lilypond (p: rec {
   majorVersion = "2.19";
-  minorVersion = "24";
+  minorVersion = "65";
   version="${majorVersion}.${minorVersion}";
   name = "lilypond-${version}";
 
   src = fetchurl {
     url = "http://download.linuxaudio.org/lilypond/sources/v${majorVersion}/lilypond-${version}.tar.gz";
-    sha256 = "0wd57swrfc2nvkj10ipdbhq6gpnckiafg2b2kpd8aydsyp248iln";
+    sha256 = "0k2jy7z58j62c5cv1308ac62d6jri17wip76xrbq8s6jq6jl7phd";
   };
 
-  configureFlags = [ "--disable-documentation" "--with-fonts-dir=${p.urwfonts}"];
+  configureFlags = [ "--disable-documentation" "--with-urwotf-dir=${urw-fonts}" "--with-texgyre-dir=${gyre-fonts}/share/fonts/truetype/"];
 
   buildInputs = p.buildInputs ++ [ rsync ];
 


### PR DESCRIPTION
###### Motivation for this change

ZHF #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Briefly tested `lilypond` on NixOS.

Does not build on darwin.