### PR TITLE
ena: 20160629 -> 1.2.0

### DIFF
--- a/pkgs/os-specific/linux/ena/default.nix
+++ b/pkgs/os-specific/linux/ena/default.nix
@@ -1,13 +1,14 @@
 { lib, stdenv, fetchFromGitHub, kernel, kmod }:
 
 stdenv.mkDerivation rec {
-  name = "ena-20160629-${kernel.version}";
+  version = "1.2.0";
+  name = "ena-${version}-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "amzn";
     repo = "amzn-drivers";
-    rev = "b594ac1ea9e0c70e8e95803a0cfd9f5f06ac097e";
-    sha256 = "03w6xgv3lfn28n38mj9cdi3px5zjyrbxnflpd3ggivkv6grf9fp7";
+    rev = "ena_linux_${version}";
+    sha256 = "0m0jqd6gyk4r43w6p5dvp1djg2qgvyhnzmg53sszlh55mlgla714";
   };
 
   hardeningDisable = [ "pic" ];


### PR DESCRIPTION
###### Motivation for this change
For #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Built against `linuxPackages`, `linuxPackages_hardened` and `linuxPackages_hardened_copperhead`.