### PR TITLE
rtlwifi_new: 2016-09-12 -> 2017-07-18

### DIFF
--- a/pkgs/os-specific/linux/rtlwifi_new/default.nix
+++ b/pkgs/os-specific/linux/rtlwifi_new/default.nix
@@ -6,13 +6,13 @@ let modDestDir = "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wi
 
 in stdenv.mkDerivation rec {
   name = "rtlwifi_new-${version}";
-  version = "2016-09-12";
+  version = "2017-07-18";
 
   src = fetchFromGitHub {
     owner = "lwfinger";
     repo = "rtlwifi_new";
-    rev = "7a1b37d2121e8ab1457f002b2729fc23e6ff3e10";
-    sha256 = "0z8grf0fak2ryxwzapp9di77c4bghzkv8lffv76idkcnxgq6sclv";
+    rev = "a24cb561b4d23187ea103255336daa7ca88791a7";
+    sha256 = "1w9rx5wafcp1vc4yh7lj332bv78szl6gmx3ckr8yl6c39alqcv0d";
   };
 
   hardeningDisable = [ "pic" "format" ];


### PR DESCRIPTION
###### Motivation for this change
#28643 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

