### PR TITLE
rtl8723bs: 2016-04-11 -> 2017-04-06

### DIFF
--- a/pkgs/os-specific/linux/rtl8723bs/default.nix
+++ b/pkgs/os-specific/linux/rtl8723bs/default.nix
@@ -2,13 +2,13 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "rtl8723bs-${kernel.version}-${version}";
-  version = "2016-04-11";
+  version = "2017-04-06";
 
   src = fetchFromGitHub {
     owner = "hadess";
     repo = "rtl8723bs";
-    rev = "11ab92d8ccd71c80f0102828366b14ef6b676fb2";
-    sha256 = "05q7mf12xcb00v6ba4wwvqi53q7ph5brfkj17xf6vkx4jr7xxnmm";
+    rev = "db2c4f61d48fe3b47c167c8bcd722ce83c24aca5";
+    sha256 = "0pxqya14a61vv2v5ky1ldybc0mjfin9mpvmajlmv0lls904rph7g";
   };
 
   hardeningDisable = [ "pic" ];
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/hadess/rtl8723bs;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;
-    broken = (! versionAtLeast kernel.version "3.19");
+    broken = (! versionOlder kernel.version "4.12"); # Now in kernel staging drivers
     maintainers = with maintainers; [ elitak ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
#28643 
As per hadess/rtl8723bs@3bb1d33 is now among the staging drivers in the kernel (4.12+)

The package is marked broken for 4.12+ and will build properly for 4.9.x

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

