### PR TITLE
ixgbevf: 4.1.2 -> 4.2.1

### DIFF
--- a/pkgs/os-specific/linux/ixgbevf/default.nix
+++ b/pkgs/os-specific/linux/ixgbevf/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "ixgbevf-${version}-${kernel.version}";
-  version = "4.1.2";
+  version = "4.2.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/e1000/ixgbevf-${version}.tar.gz";
-    sha256 = "1dismhiq0asf04rv6pv2sk2m3xcy6m3bpk16gmxqybca3xa28a5b";
+    sha256 = "1666hsavaspjmf45ij396mkndzk6g0n3ibr2glfdhjfqhfy35zb8";
   };
 
   hardeningDisable = [ "pic" ];
@@ -24,5 +24,6 @@ stdenv.mkDerivation rec {
     homepage = https://sourceforge.net/projects/e1000/files/ixgbevf%20stable/;
     license = stdenv.lib.licenses.gpl2;
     priority = 20;
+    broken = (stdenv.lib.versionOlder kernel.version "4.9");
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update
#28643 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

