### PR TITLE
mxu11x0: 1.3.11 -> 1.3.11+git2017-07-13

### DIFF
--- a/pkgs/os-specific/linux/mxu11x0/default.nix
+++ b/pkgs/os-specific/linux/mxu11x0/default.nix
@@ -1,16 +1,13 @@
 { stdenv, fetchFromGitHub, kernel }:
 
-# it doesn't compile anymore on 3.14
-assert stdenv.lib.versionAtLeast kernel.version "3.18";
-
 stdenv.mkDerivation {
-  name = "mxu11x0-1.3.11-${kernel.version}";
+  name = "mxu11x0-1.3.11+git2017-07-13-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "ellysh";
     repo = "mxu11x0";
-    rev = "de54053d6f297785d77aba9e9c880001519ffddf";
-    sha256 = "1zmqanw22pgaj3b3lnciq33w6svm5ngg6g0k5xxwwijixg8ri3lf";
+    rev = "cbbb5ec2045939209117cb5fcd6c7c23bcc109ef";
+    sha256 = "0wf44pnz5aclvg2k1f8ljnwws8hh6191i5h06nz95ijbxhwz63w4";
   };
 
   preBuild = ''
@@ -19,6 +16,7 @@ stdenv.mkDerivation {
     sed -i -e 's|/lib/modules|${kernel.dev}/lib/modules|' driver/mxconf
     sed -i -e 's|/lib/modules|${kernel.dev}/lib/modules|' driver/Makefile
   '';
+  
   installPhase = ''
     install -v -D -m 644 ./driver/mxu11x0.ko "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/usb/serial/mxu11x0.ko"
     install -v -D -m 644 ./driver/mxu11x0.ko "$out/lib/modules/${kernel.modDirVersion}/misc/mxu11x0.ko"
@@ -36,5 +34,6 @@ stdenv.mkDerivation {
     license = licenses.gpl1;
     maintainers = with maintainers; [ uralbash ];
     platforms = platforms.linux;
+    broken = (versionOlder kernel.version "4.9");
   };
 }


### PR DESCRIPTION
###### Motivation for this change
#28643 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

