### PR TITLE
ply: Allow building for git-fetched kernels

### DIFF
--- a/pkgs/os-specific/linux/ply/default.nix
+++ b/pkgs/os-specific/linux/ply/default.nix
@@ -16,9 +16,17 @@ in stdenv.mkDerivation {
   };
 
   preAutoreconf = ''
-    # ply wants to install header fails to its build directory
-    # use 7z to handle multiple archive formats transparently
-    7z x ${kernel.src} -so | 7z x -aoa -si -ttar
+    # If kernel sources are a folder (i.e. fetched from git), we just copy them in
+    # Since they are owned by uid 0 and read-only, we need to fix permissions
+    if [ -d ${kernel.src} ]; then
+      cp -r ${kernel.src} linux-${kernel.version}
+      chown -R $(whoami): linux-${kernel.version}
+      chmod -R a+w linux-${kernel.version}
+    else
+      # ply wants to install header files to its build directory
+      # use 7z to handle multiple archive formats transparently
+      7z x ${kernel.src} -so | 7z x -aoa -si -ttar
+    fi
 
     configureFlagsArray+=(--with-kerneldir=$(echo $(pwd)/linux-*))
     ./autogen.sh --prefix=$out


### PR DESCRIPTION
###### Motivation for this change
#28643 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

