### PR TITLE
python.withPackages: ignore collisions

### DIFF
--- a/pkgs/development/interpreters/python/with-packages.nix
+++ b/pkgs/development/interpreters/python/with-packages.nix
@@ -1,3 +1,6 @@
 { buildEnv, pythonPackages }:
 
-f: let packages = f pythonPackages; in buildEnv.override { extraLibs = packages; }
+f: let packages = f pythonPackages; in buildEnv.override {
+  extraLibs = packages;
+  ignoreCollisions = true;
+}


### PR DESCRIPTION
###### Motivation for this change

Some Python packages have paths that will otherwise collide. As an example:

```
nix-build --no-out-link --expr '(import ./. {}).python.withPackages (ps: with ps; [pylint pytest])'
these derivations will be built:
  /nix/store/p45ffzp7h06vsp76lss76mvrz0xc10z2-python-2.7.13-env.drv
building path(s) ‘/nix/store/j1dvlk4207vi7szx41jjipbafyxyi6h7-python-2.7.13-env’
collision between `/nix/store/r8vhvakvxac14rggwfxddyqhhpwsn5pf-python2.7-logilab-common-0.63.2/bin/.pytest-wrapped' and `/nix/store/8mv8wrrmnads4lqmh0nic1xfdgwdvdxx-python2.7-pytest-3.0.7/bin/.pytest-wrapped'
builder for ‘/nix/store/p45ffzp7h06vsp76lss76mvrz0xc10z2-python-2.7.13-env.drv’ failed with exit code 25
error: build of ‘/nix/store/p45ffzp7h06vsp76lss76mvrz0xc10z2-python-2.7.13-env.drv’ failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

