### PR TITLE
Mednafen: 0.9.38.7 -> 0.9.47 

### DIFF
--- a/pkgs/misc/emulators/mednafen/default.nix
+++ b/pkgs/misc/emulators/mednafen/default.nix
@@ -4,18 +4,20 @@
 , SDL, SDL_net, zlib
 }:
 
+with stdenv.lib;
 stdenv.mkDerivation rec {
 
-  name = "mednafen-${meta.version}";
+  name = "mednafen-${version}";
+  version = "0.9.47";
 
   src = fetchurl {
-    url = "http://mednafen.fobby.net/releases/files/${name}.tar.bz2";
-    sha256 = "1n6y7b86sv11vd6rv8if3wr4qyihkjai9km1s4smqcisi3pvxcqv";
+    url = "https://mednafen.github.io/releases/files/${name}.tar.xz";
+    sha256 = "0flz6bjkzs9qrw923s4cpqrz4b2dhc2w7pd8mgw0l1xbmrh7w4si";
   };
 
-  buildInputs = with stdenv.lib;
-  [ pkgconfig libX11 mesa freeglut libjack2 libcdio libsndfile libsamplerate SDL SDL_net zlib ];
-  
+  buildInputs =
+  [ pkgconfig libX11 mesa freeglut libjack2 libcdio
+    libsndfile libsamplerate SDL SDL_net zlib ];
 
   # Install docs
   postInstall = ''
@@ -25,9 +27,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    version = "0.9.38.7";
     description = "A portable, CLI-driven, SDL+OpenGL-based, multi-system emulator";
-    homepage = http://mednafen.sourceforge.net/;
+    homepage = http://mednafen.github.io/;
     license = licenses.gpl2;
     maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.linux;

--- a/pkgs/misc/emulators/mednafen/server.nix
+++ b/pkgs/misc/emulators/mednafen/server.nix
@@ -2,22 +2,22 @@
 
 stdenv.mkDerivation rec {
 
-  name = "mednafen-server-${meta.version}";
+  name = "mednafen-server-${version}";
+  version = "0.5.2";
 
   src = fetchurl {
-    url = "http://mednafen.fobby.net/releases/files/${name}.tar.gz";
-    sha256="06fal6hwrb8gw94yp7plhcz55109128cgp35m7zs5vvjf1zfhcs9";
+    url = "https://mednafen.github.io/releases/files/mednafen-server-0.5.2.tar.xz";
+    sha256 = "0xm7dj5nwnrsv69r72rcnlw03jm0l8rmrg3s05gjfvxyqmlb36dq";
   };
 
   postInstall = ''
-    mkdir -p $out/share/$name 
+    mkdir -p $out/share/$name
     install -m 644 -t $out/share/$name standard.conf
   '';
 
   meta = with stdenv.lib; {
-    version = "0.5.2";
     description = "Netplay server for Mednafen";
-    homepage = http://mednafen.sourceforge.net/;
+    homepage = http://mednafen.github.io/;
     license = licenses.gpl2;
     maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change

Also, update mednafen-server expression.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

