### PR TITLE
python.pkgs.numpy: fix patch

### DIFF
--- a/pkgs/development/python-modules/numpy/numpy-distutils-C++.patch
+++ b/pkgs/development/python-modules/numpy/numpy-distutils-C++.patch
@@ -1,23 +1,31 @@
 diff --git a/numpy/distutils/unixccompiler.py b/numpy/distutils/unixccompiler.py
-index a92ccd3..9630e91 100644
+index 6ed5eec..82a88b5 100644
 --- a/numpy/distutils/unixccompiler.py
 +++ b/numpy/distutils/unixccompiler.py
-@@ -43,10 +43,15 @@ def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts
+@@ -44,8 +44,6 @@ def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts
          if opt not in llink_s:
              self.linker_so = llink_s.split() + opt.split()
  
 -    display = '%s: %s' % (os.path.basename(self.compiler_so[0]), src)
+-
+     # gcc style automatic dependencies, outputs a makefile (-MF) that lists
+     # all headers needed by a c file as a side effect of compilation (-MMD)
+     if getattr(self, '_auto_depends', False):
+@@ -54,8 +52,15 @@ def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts
+         deps = []
+ 
      try:
--        self.spawn(self.compiler_so + cc_args + [src, '-o', obj] +
+-        self.spawn(self.compiler_so + cc_args + [src, '-o', obj] + deps +
 -                   extra_postargs, display = display)
 +        if self.detect_language(src) == 'c++':
 +            display = '%s: %s' % (os.path.basename(self.compiler_so_cxx[0]), src)
-+            self.spawn(self.compiler_so_cxx + cc_args + [src, '-o', obj] +
++            self.spawn(self.compiler_so_cxx + cc_args + [src, '-o', obj] + deps +
 +                       extra_postargs, display = display)
 +        else:
 +            display = '%s: %s' % (os.path.basename(self.compiler_so[0]), src)
-+            self.spawn(self.compiler_so + cc_args + [src, '-o', obj] +
++            self.spawn(self.compiler_so + cc_args + [src, '-o', obj] + deps +
 +                       extra_postargs, display = display)
++
      except DistutilsExecError:
          msg = str(get_exception())
          raise CompileError(msg)


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

