### PR TITLE
moretools: fix build and 0.1a41 -> 0.1.8 

### DIFF
--- a/pkgs/development/python-modules/moretools/default.nix
+++ b/pkgs/development/python-modules/moretools/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, six, pathpy, zetup, pytest
+, decorator }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "moretools";
+  version = "0.1.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03ni7k0kcgrm3y605c29gqlyp779fx1xc3r8xb742lzd6ni30kdg";
+  };
+
+  checkPhase = ''
+    py.test test
+  '';
+
+  buildInputs = [ six pathpy pytest ];
+  propagatedBuildInputs = [ decorator zetup ];
+
+  meta = with stdenv.lib; {
+    description = ''
+      Many more basic tools for python 2/3 extending itertools, functools, operator and collections
+    '';
+    homepage = https://bitbucket.org/userzimmermann/python-moretools;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/zetup/default.nix
+++ b/pkgs/development/python-modules/zetup/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, setuptools_scm, pathpy, nbconvert
+, pytest }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "zetup";
+  version = "0.2.34";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0k4lm51b5qjy7yxy3n5z8vc5hlvjcsfsvwjgqzkr0pisysar1kpf";
+  };
+
+  checkPhase = ''
+    py.test test
+  '';
+
+  buildInputs = [ pytest pathpy nbconvert ];
+  propagatedBuildInputs = [ setuptools_scm ];
+
+  meta = with stdenv.lib; {
+    description = ''
+      Zimmermann's Extensible Tools for Unified Project setups
+    '';
+    homepage = https://github.com/zimmermanncode/zetup;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -24556,6 +24556,8 @@ EOF
     };
   };
 
+  zetup = callPackage ../development/python-modules/zetup { };
+
   zope_broken = buildPythonPackage rec {
     name = "zope.broken-3.6.0";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12976,24 +12976,7 @@ in {
     };
   });
 
-  moretools = buildPythonPackage rec {
-    name = "moretools-0.1a41";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/m/moretools/${name}.tar.gz";
-      sha256 = "1n442wprbl3cmg08233m1sr3g4z0i8hv9g6bhch7kzdmbl21399f";
-    };
-
-    buildInputs = with self; [ six pathpy setuptools ];
-    propagatedBuildInputs = with self; [ decorator ];
-
-    meta = {
-      description = "Many more basic tools for python 2/3 extending itertools, functools, operator and collections";
-      homepage = https://bitbucket.org/userzimmermann/python-moretools;
-      license = licenses.gpl3Plus;
-      platforms = platforms.linux;
-    };
-  };
+  moretools = callPackage ../development/python-modules/moretools { };
 
   moto = buildPythonPackage rec {
     version = "0.4.25";


### PR DESCRIPTION
###### Motivation for this change

Progress on: #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

