### PR TITLE
litecoin: 0.13.2.1 -> 0.14.2

### DIFF
--- a/pkgs/applications/altcoins/litecoin.nix
+++ b/pkgs/applications/altcoins/litecoin.nix
@@ -8,13 +8,13 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   name = "litecoin" + (toString (optional (!withGui) "d")) + "-" + version;
-  version = "0.13.2.1";
+  version = "0.14.2";
 
   src = fetchFromGitHub {
     owner = "litecoin-project";
     repo = "litecoin";
     rev = "v${version}";
-    sha256 = "0hml1crml6rx7im8dfbig3znmvnk2di61ybbhrhpad5mj0yrih30";
+    sha256 = "1smadd5d2mpz2v3pyk7wqm60vdp81zqr4m3z4wfvnlz62m1m800y";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change

litecoin: 0.13.2.1 -> 0.14.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

