### PR TITLE
redshift-plasma-applet: add kwindowsystem to buildInputs

### DIFF
--- a/pkgs/applications/misc/redshift-plasma-applet/default.nix
+++ b/pkgs/applications/misc/redshift-plasma-applet/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cmake, extra-cmake-modules, plasma-framework, redshift, fetchFromGitHub, }:
+{ stdenv, cmake, extra-cmake-modules, plasma-framework, kwindowsystem, redshift, fetchFromGitHub, }:
 
 let version = "1.0.18"; in
 
@@ -29,7 +29,10 @@ stdenv.mkDerivation {
     extra-cmake-modules
   ];
 
-  buildInputs = [ plasma-framework ];
+  buildInputs = [
+    plasma-framework
+    kwindowsystem
+  ];
 
   meta = with stdenv.lib; {
     description = "KDE Plasma 5 widget for controlling Redshift";


### PR DESCRIPTION
###### Motivation for this change

Fix build which was broken by the upgrade to KDE Frameworks 5.37
Progress on: #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

