### PR TITLE
kiwix: use default gcc

### DIFF
--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -29,10 +29,6 @@ let
               then { tar = xulrunner64_tar; sdk = xulrunnersdk64_tar; }
               else { tar = xulrunner32_tar; sdk = xulrunnersdk32_tar; };
 
-  ctpp2_ = ctpp2.override { inherit stdenv; };
-  xapian_ = xapian.override { inherit stdenv; };
-  zimlib_ = zimlib.override { inherit stdenv; };
-
   pugixml = stdenv.mkDerivation rec {
     version = "1.2";
     name = "pugixml-${version}";
@@ -67,8 +63,8 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    zip pkgconfig python zlib xapian_ which icu libmicrohttpd
-    lzma zimlib_ ctpp2_ aria2 wget bc libuuid makeWrapper pugixml
+    zip pkgconfig python zlib xapian which icu libmicrohttpd
+    lzma zimlib ctpp2 aria2 wget bc libuuid makeWrapper pugixml
   ];
 
   postUnpack = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14920,9 +14920,7 @@ with pkgs;
 
   kipi-plugins = libsForQt5.callPackage ../applications/graphics/kipi-plugins { };
 
-  kiwix = callPackage ../applications/misc/kiwix {
-    stdenv = overrideCC stdenv gcc49;
-  };
+  kiwix = callPackage ../applications/misc/kiwix { };
 
   kmplayer = kde4.callPackage ../applications/video/kmplayer { };
 


### PR DESCRIPTION
###### Motivation for this change
Less different gcc versions when possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Tested `kiwix-serve`works
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

