### PR TITLE
go-ethereum-classic: 3.5.0 -> 3.5.86

### DIFF
--- a/pkgs/applications/altcoins/go-ethereum-classic/default.nix
+++ b/pkgs/applications/altcoins/go-ethereum-classic/default.nix
@@ -2,16 +2,15 @@
 
 buildGoPackage rec {
   name = "go-ethereum-classic-${version}";
-  version = "3.5.0";
-  rev = "402c1700fbefb9512e444b32fe12c2d674638ddb";
+  version = "3.5.86";
 
   goPackagePath = "github.com/ethereumproject/go-ethereum";
   subPackages = [ "cmd/evm" "cmd/geth" ];
 
   src = fetchgit {
-    inherit rev;
+    rev = "v${version}";
     url = "https://github.com/ethereumproject/go-ethereum";
-    sha256 = "15wji12wqcrgsb1glwwz4jv7rsas71bbxh7750iv2phn7jivm0fi";
+    sha256 = "1k59hl3qvx4422zqlp259566fnxq5bs67jhm0v6a1zfr1k8iqzwh";
   };
 
   goDeps = ./deps.nix;
@@ -20,5 +19,6 @@ buildGoPackage rec {
     description = "Golang implementation of Ethereum Classic";
     homepage = https://github.com/ethereumproject/go-ethereum;
     license = with lib.licenses; [ lgpl3 gpl3 ];
+    maintainers = with lib.maintainers; [ sorpaas ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

go-ethereum-classic: 3.5.0 -> 3.5.86, also added myself as a maintainer of this package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

