### PR TITLE
gnome-disk-utility: fix missing schemas for gnome-disk-image-mounter

### DIFF
--- a/pkgs/desktops/gnome-3/3.24/core/gnome-disk-utility/default.nix
+++ b/pkgs/desktops/gnome-3/3.24/core/gnome-disk-utility/default.nix
@@ -1,6 +1,6 @@
 { stdenv, intltool, fetchurl, pkgconfig, udisks2, libsecret, libdvdread
-, bash, gtk3, glib, makeWrapper, cracklib, libnotify
-, itstool, gnome3, librsvg, gdk_pixbuf, libxml2, python
+, bash, gtk3, glib, wrapGAppsHook, cracklib, libnotify
+, itstool, gnome3, gdk_pixbuf, libxml2, python
 , libcanberra_gtk3, libxslt, libtool, docbook_xsl, libpwquality }:
 
 stdenv.mkDerivation rec {
@@ -16,14 +16,8 @@ stdenv.mkDerivation rec {
                   libxslt libtool libsecret libpwquality cracklib
                   libnotify libdvdread libcanberra_gtk3 docbook_xsl
                   gdk_pixbuf gnome3.defaultIconTheme
-                  librsvg udisks2 gnome3.gnome_settings_daemon
-                  gnome3.gsettings_desktop_schemas makeWrapper libxml2 ];
-
-  preFixup = ''
-    wrapProgram "$out/bin/gnome-disks" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
-  '';
+                  udisks2 gnome3.gnome_settings_daemon
+                  gnome3.gsettings_desktop_schemas wrapGAppsHook libxml2 ];
 
   meta = with stdenv.lib; {
     homepage = https://en.wikipedia.org/wiki/GNOME_Disks;


### PR DESCRIPTION
Continuation of #28053
    
gnome-disk-image-mounter from gnome-disk-utility was not wrapped, resulting in an error due to the inability to find gsettings schemas.
    
This commit replaces the manual wrapping of gnome-disks binary with wrapGAppsHook so that all binaries are wrapped correctly.


- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @globin @fpletz @vcunat 
