### PR TITLE
fcitx-unikey: fix build

### DIFF
--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-unikey/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-unikey/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake fcitx gettext pkgconfig ];
 
+  NIX_CFLAGS_COMPILE = "-Wno-narrowing";
+
   preInstall = ''
     substituteInPlace src/cmake_install.cmake \
       --replace ${fcitx} $out


### PR DESCRIPTION
###### Motivation for this change

Fix the build of fcitx-unikey.

Related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

