### PR TITLE
Kdeframeworks prison: Require at least Qt 5.7

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/prison.nix
+++ b/pkgs/development/libraries/kde-frameworks/prison.nix
@@ -6,7 +6,10 @@
 
 mkDerivation {
   name = "prison";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  meta = { 
+    maintainers = [ lib.maintainers.ttuegel ];
+    broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ libdmtx qrencode ];
   propagatedBuildInputs = [ qtbase ];


### PR DESCRIPTION
###### Motivation for this change
Progress on: https://github.com/NixOS/nixpkgs/issues/28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

