### PR TITLE
lizardfs: 3.10.2 -> 3.11.3

### DIFF
--- a/pkgs/tools/filesystems/lizardfs/default.nix
+++ b/pkgs/tools/filesystems/lizardfs/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   name = "lizardfs-${version}";
-  version = "3.10.2";
+  version = "3.11.3";
 
   src = fetchFromGitHub {
     owner = "lizardfs";
     repo = "lizardfs";
     rev = "v${version}";
-    sha256 = "0xw6skprxw0wcbqh4yx8f8a4q00x0sfz42llqgd047bcbga1k5zg";
+    sha256 = "1njgj242vgpdqb1di321jfqk4al5lk72x2iyp0nldy7h6r98l2ww";
   };
 
   buildInputs = 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

