### PR TITLE
hsevm: v0.3.2 -> v0.6.4

### DIFF
--- a/pkgs/applications/altcoins/hsevm.nix
+++ b/pkgs/applications/altcoins/hsevm.nix
@@ -1,23 +1,24 @@
-{ aeson, ansi-wl-pprint, base, base16-bytestring
-, base64-bytestring, binary, brick, bytestring, containers
-, cryptonite, data-dword, deepseq, directory, filepath, ghci-pretty
-, here, HUnit, lens, lens-aeson, memory, mtl, optparse-generic
-, process, QuickCheck, quickcheck-text, readline, rosezipper
-, stdenv, tasty, tasty-hunit, tasty-quickcheck, temporary, text
-, text-format, unordered-containers, vector, vty
-, mkDerivation, fetchFromGitHub, lib
-, ncurses, zlib, bzip2, solc
+{ mkDerivation, abstract-par, aeson, ansi-wl-pprint, base
+, base16-bytestring, base64-bytestring, binary, brick, bytestring
+, cereal, containers, cryptonite, data-dword, deepseq, directory
+, filepath, ghci-pretty, here, HUnit, lens, lens-aeson, memory
+, monad-par, mtl, optparse-generic, process, QuickCheck
+, quickcheck-text, readline, rosezipper, scientific, stdenv, tasty, tasty-hunit
+, tasty-quickcheck, temporary, text, text-format
+, unordered-containers, vector, vty
+, fetchFromGitHub, lib, makeWrapper
+, ncurses, zlib, bzip2, solc, coreutils
 }:
 
 lib.overrideDerivation (mkDerivation rec {
   pname = "hsevm";
-  version = "0.3.2";
+  version = "0.6.4";
 
   src = fetchFromGitHub {
     owner = "dapphub";
     repo = "hsevm";
     rev = "v${version}";
-    sha256 = "1c6zpphs03yfvyfbv1cjf04qh5q2miq7rpd7kx2cil77msi8hxw4";
+    sha256 = "01b67k9cam4gvsi07q3vx527m1w6p6xll64k1nl27bc8ik6jh8l9";
   };
 
   isLibrary = false;
@@ -26,15 +27,16 @@ lib.overrideDerivation (mkDerivation rec {
 
   postInstall = ''
     rm -rf $out/{lib,share}
+    wrapProgram $out/bin/hsevm --add-flags '+RTS -N$((`${coreutils}/bin/nproc` - 1)) -RTS'
   '';
 
   extraLibraries = [
-    aeson ansi-wl-pprint base base16-bytestring base64-bytestring
-    binary brick bytestring containers cryptonite data-dword deepseq
-    directory filepath ghci-pretty lens lens-aeson memory mtl
-    optparse-generic process QuickCheck quickcheck-text readline
-    rosezipper temporary text text-format unordered-containers vector
-    vty
+    abstract-par aeson ansi-wl-pprint base base16-bytestring
+    base64-bytestring binary brick bytestring cereal containers
+    cryptonite data-dword deepseq directory filepath ghci-pretty lens
+    lens-aeson memory monad-par mtl optparse-generic process QuickCheck
+    quickcheck-text readline rosezipper scientific temporary text text-format
+    unordered-containers vector vty
   ];
   executableHaskellDepends = [
     readline zlib bzip2
@@ -50,4 +52,5 @@ lib.overrideDerivation (mkDerivation rec {
   maintainers = [stdenv.lib.maintainers.dbrock];
 }) (attrs: {
   buildInputs = attrs.buildInputs ++ [solc];
+  nativeBuildInputs = attrs.nativeBuildInputs ++ [makeWrapper];
 })


### PR DESCRIPTION
###### Motivation for this change
Features etc, but also Cabal version bound fixes to make build work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

