### PR TITLE
swc: remove setuid from install script

### DIFF
--- a/pkgs/development/libraries/swc/default.nix
+++ b/pkgs/development/libraries/swc/default.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ wld wayland xwayland fontconfig pixman libdrm libinput libevdev libxkbcommon libxcb xcbutilwm ];
 
+  prePatch = ''
+    substituteInPlace launch/local.mk --replace 4755 755
+  '';
+
   makeFlags = "PREFIX=$(out)";
   installPhase = "PREFIX=$out make install";
 


### PR DESCRIPTION
###### Motivation for this change

swc doesn't build:

- https://hydra.nixos.org/build/59180744
- https://github.com/NixOS/nixpkgs/issues/28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

