### PR TITLE
armagetronad: 0.2.8.3.3 -> 0.2.8.3.4

### DIFF
--- a/pkgs/games/armagetronad/default.nix
+++ b/pkgs/games/armagetronad/default.nix
@@ -2,15 +2,15 @@
 
 let
   versionMajor = "0.2.8";
-  versionMinor = "3.3";
+  versionMinor = "3.4";
   version = "${versionMajor}.${versionMinor}";
 in
 
 stdenv.mkDerivation {
   name = "armagetron-${version}";
   src = fetchurl {
-    url = "https://launchpad.net/armagetronad/${versionMajor}/0.2.8.3.x/+download/armagetronad-${version}.src.tar.bz2";
-    sha256 = "1s55irhg60fpmhy8wwxpdq7c45r1mqch6zpicyb2wf9ln60xgwnx";
+    url = "https://launchpad.net/armagetronad/${versionMajor}/${versionMajor}.${versionMinor}/+download/armagetronad-${version}.src.tar.bz2";
+    sha256 = "157pp84wf0q3bdb72rnbm3ck0czwx2ply6lyhj8z7kfdc7csdbr3";
   };
 
   NIX_LDFLAGS = [ "-lSDL_image" ];


### PR DESCRIPTION
###### Motivation for this change

* minor update
* fixes build (cc #28643)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

