### PR TITLE
pies: 1.2 -> 1.3

### DIFF
--- a/pkgs/servers/pies/default.nix
+++ b/pkgs/servers/pies/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "12r7rjjyibjdj08dvwbp0iflfpzl4s0zhn6cr6zj3hwf9gbzgl1g";
   };
 
+  configureFlags = ["--sysconfdir=/etc"];
+
   hardeningDisable = [ "format" ];
 
   doCheck = true;

--- a/pkgs/servers/pies/default.nix
+++ b/pkgs/servers/pies/default.nix
@@ -1,12 +1,14 @@
 { fetchurl, stdenv }:
 
 stdenv.mkDerivation rec {
-  name = "pies-1.2";
+  name = "pies-1.3";
 
   src = fetchurl {
     url = "mirror://gnu/pies/${name}.tar.bz2";
-    sha256 = "18w0dbg77i56cx1bwa789w0qi3l4xkkbascxcv2b6gbm0zmjg1g6";
+    sha256 = "12r7rjjyibjdj08dvwbp0iflfpzl4s0zhn6cr6zj3hwf9gbzgl1g";
   };
+
+  hardeningDisable = [ "format" ];
 
   doCheck = true;
 


### PR DESCRIPTION
Also, disable format hardening or build fails.

###### Motivation for this change

#28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Unsure how to test, but `pies` seems to do what it did previously: complain I don't have a configuration file :innocent:.