### PR TITLE
enchive: init at 3.3

### DIFF
--- a/pkgs/tools/security/enchive/default.nix
+++ b/pkgs/tools/security/enchive/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "enchive-${version}";
+  version = "3.3";
+  src = fetchFromGitHub {
+    owner = "skeeto";
+    repo = "enchive";
+    rev = version;
+    sha256 = "0i3b0v5dqz56m5ppzm3332yxkw17dxs2zpvf48769ljgjy74irfl";
+  };
+
+  makeFlags = ["PREFIX=$(out)"];
+
+  postInstall = ''
+    mkdir -p $out/share/emacs/site-lisp/
+    cp -v "$src/enchive-mode.el" "$out/share/emacs/site-lisp/"
+  '';
+
+  meta = {
+    description = "Encrypted personal archives";
+    homepage = https://github.com/skeeto/enchive;
+    license = stdenv.lib.licenses.unlicense;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.nico202 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -565,6 +565,8 @@ with pkgs;
     gconf = gnome2.GConf;
  };
 
+ enchive = callPackage ../tools/security/enchive { };
+
   enpass = callPackage ../tools/security/enpass { };
 
   ezstream = callPackage ../tools/audio/ezstream { };


### PR DESCRIPTION
> Enchive is a tool to encrypt files to yourself for long-term archival. It's a focused, simple alternative to more complex solutions such as GnuPG or encrypted filesystems. Enchive has no external dependencies and is trivial to build for local use. Portability is emphasized over performance.
[github repo](
https://github.com/skeeto/enchive)

The readme says it's compatible with:
> Linux, BSD, macOS, Windows

But I tested it only under NixOS, platforms might need to be adjusted

Also, I do not know how to pre-compile the emacs mode that comes with it