### PR TITLE
jackmix: don't fail on deprecated definitions

### DIFF
--- a/pkgs/applications/audio/jackmix/default.nix
+++ b/pkgs/applications/audio/jackmix/default.nix
@@ -7,6 +7,8 @@ stdenv.mkDerivation rec {
     sha256 = "18f5v7g66mgarhs476frvayhch7fy4nyjf2xivixc061ipn0m82j";
   };
 
+  patches = [ ./no_error.patch ];
+
   buildInputs = [
     pkgconfig
     scons
@@ -31,5 +33,3 @@ stdenv.mkDerivation rec {
     platforms = stdenv.lib.platforms.linux;
   };
 }
-
-

--- a/pkgs/applications/audio/jackmix/no_error.patch
+++ b/pkgs/applications/audio/jackmix/no_error.patch
@@ -1,0 +1,13 @@
+diff --git a/SConstruct b/SConstruct
+index 4290fa5..0a7a679 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -16,7 +16,7 @@ env = Environment(
+ env.Replace( LIBS="" )
+ env.Replace( LIBPATH="" )
+
+-env.MergeFlags( ['-Wall', '-Werror', '-g', '-fpic'] )
++env.MergeFlags( ['-g', '-fpic'] )
+
+ tests = { }
+ tests.update( env['PKGCONFIG_TESTS'] )


### PR DESCRIPTION
###### Motivation for this change

Jackmix uses functions of jack that are marked deprecated. The quick fix is to not fail on warnings.

This will make jackmix compile in #28643.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

