### PR TITLE
shallot: init at 0.0.3

### DIFF
--- a/pkgs/tools/misc/shallot/default.nix
+++ b/pkgs/tools/misc/shallot/default.nix
@@ -1,0 +1,32 @@
+{ 
+  stdenv, fetchFromGitHub,
+  openssl
+}:
+
+let 
+  version = "0.0.3";
+in stdenv.mkDerivation {
+  name = "shallot-${version}";
+
+  src = fetchFromGitHub {
+    owner = "katmagic";
+    repo = "Shallot";
+    rev = "shallot-${version}";
+    sha256 = "0cjafdxvjkwb9vyifhh11mw0la7yfqswqwqmrfp1fy9jl7m0il9k";
+  };
+
+  buildInputs = [ openssl ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./shallot $out/bin/
+  '';
+
+  meta = {
+    description = "Shallot allows you to create customized .onion addresses for your hidden service";
+
+    license = stdenv.lib.licenses.mit;
+    homepage = https://github.com/katmagic/Shallot;
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7303,6 +7303,8 @@ with pkgs;
   sbt-with-scala-native = callPackage ../development/tools/build-managers/sbt/scala-native.nix { };
   simpleBuildTool = sbt;
 
+  shallot = callPackage ../tools/misc/shallot { };
+
   shards = callPackage ../development/tools/build-managers/shards { };
 
   shellcheck = haskell.lib.justStaticExecutables haskellPackages.ShellCheck;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

