### PR TITLE
kupfer: init at 319

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -113,6 +113,7 @@
   cleverca22 = "Michael Bishop <cleverca22@gmail.com>";
   cmcdragonkai = "Roger Qiu <roger.qiu@matrix.ai>";
   cmfwyp = "cmfwyp <cmfwyp@riseup.net>";
+  cobbal = "Andrew Cobb <andrew.cobb@gmail.com>";
   coconnor = "Corey O'Connor <coreyoconnor@gmail.com>";
   codsl = "codsl <codsl@riseup.net>";
   codyopel = "Cody Opel <codyopel@gmail.com>";

--- a/pkgs/applications/misc/kupfer/default.nix
+++ b/pkgs/applications/misc/kupfer/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, makeWrapper
+, fetchurl
+, intltool
+, python3Packages
+, gtk3
+, dbus
+, libwnck3
+, keybinder3
+, hicolor_icon_theme
+}:
+
+let inherit (python3Packages) mkPythonDerivation pygobject3 pyxdg dbus-python docutils;
+in  mkPythonDerivation rec {
+  name = "kupfer-${version}";
+  version = "319";
+  # Since this is an application, don't prefix it with python3.x-
+  namePrefix = "";
+
+  src = fetchurl {
+    url = "https://github.com/kupferlauncher/kupfer/releases/download/v${version}/kupfer-v${version}.tar.xz";
+    sha256 = "0c9xjx13r8ckfr4az116bhxsd3pk78v04c3lz6lqhraak0rp4d92";
+  };
+
+  buildInputs = [ intltool hicolor_icon_theme docutils ];
+  propagatedBuildInputs = [ pygobject3 gtk3 pyxdg dbus dbus-python libwnck3 keybinder3 ];
+
+  configurePhase = ''
+    ./waf configure --prefix=$prefix
+  '';
+
+  buildPhase = ''
+    ./waf
+  '';
+
+  installPhase = ''
+    ./waf install
+
+    # TODO: we're capturing unneeded build inputs here...
+    wrapProgram $out/bin/kupfer \
+        --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
+        --prefix PYTHONPATH : "$PYTHONPATH" \
+        --set PYTHONNOUSERSITE 1
+  '';
+
+  meta = with lib; {
+    description = "A smart, quick launcher";
+    homepage    = "https://kupferlauncher.github.io/";
+    license     = licenses.gpl3;
+  };
+}

--- a/pkgs/applications/misc/kupfer/default.nix
+++ b/pkgs/applications/misc/kupfer/default.nix
@@ -60,6 +60,7 @@ buildPythonApplication rec {
     description = "A smart, quick launcher";
     homepage    = "https://kupferlauncher.github.io/";
     license     = licenses.gpl3;
+    maintainers = with maintainers; [ cobbal ];
     platforms   = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/kupfer/default.nix
+++ b/pkgs/applications/misc/kupfer/default.nix
@@ -24,7 +24,7 @@ buildPythonApplication rec {
 
   nativeBuildInputs = [ wrapGAppsHook intltool ];
   buildInputs = [ hicolor_icon_theme docutils libwnck3 keybinder3 ];
-  propagatedBuildInputs = [ pygobject3 gtk3 pyxdg dbus-python ];
+  propagatedBuildInputs = [ pygobject3 gtk3 pyxdg dbus-python pycairo ];
 
   configurePhase = ''
     runHook preConfigure
@@ -47,7 +47,7 @@ buildPythonApplication rec {
     python ./waf install
 
     gappsWrapperArgs+=(
-      "--prefix" "PYTHONPATH" : pythonPath
+      "--prefix" "PYTHONPATH" : "${pythonPath}"
       "--set" "PYTHONNOUSERSITE" "1"
     )
 

--- a/pkgs/applications/misc/kupfer/default.nix
+++ b/pkgs/applications/misc/kupfer/default.nix
@@ -1,5 +1,4 @@
-{ lib
-, stdenv
+{ stdenv
 , makeWrapper
 , fetchurl
 , intltool
@@ -9,44 +8,58 @@
 , libwnck3
 , keybinder3
 , hicolor_icon_theme
+, wrapGAppsHook
 }:
 
-let inherit (python3Packages) mkPythonDerivation pygobject3 pyxdg dbus-python docutils;
-in  mkPythonDerivation rec {
+with python3Packages;
+
+buildPythonApplication rec {
   name = "kupfer-${version}";
   version = "319";
-  # Since this is an application, don't prefix it with python3.x-
-  namePrefix = "";
 
   src = fetchurl {
     url = "https://github.com/kupferlauncher/kupfer/releases/download/v${version}/kupfer-v${version}.tar.xz";
     sha256 = "0c9xjx13r8ckfr4az116bhxsd3pk78v04c3lz6lqhraak0rp4d92";
   };
 
-  buildInputs = [ intltool hicolor_icon_theme docutils ];
-  propagatedBuildInputs = [ pygobject3 gtk3 pyxdg dbus dbus-python libwnck3 keybinder3 ];
+  nativeBuildInputs = [ wrapGAppsHook intltool ];
+  buildInputs = [ hicolor_icon_theme docutils libwnck3 keybinder3 ];
+  propagatedBuildInputs = [ pygobject3 gtk3 pyxdg dbus-python ];
 
   configurePhase = ''
-    ./waf configure --prefix=$prefix
+    runHook preConfigure
+    python ./waf configure --prefix=$prefix
+    runHook postConfigure
   '';
 
   buildPhase = ''
-    ./waf
+    runHook preBuild
+    python ./waf
+    runHook postBuild
   '';
 
-  installPhase = ''
-    ./waf install
+  installPhase = let
+    pythonPath = (stdenv.lib.concatMapStringsSep ":"
+      (m: "${m}/lib/${python.libPrefix}/site-packages")
+      propagatedBuildInputs);
+  in ''
+    runHook preInstall
+    python ./waf install
 
-    # TODO: we're capturing unneeded build inputs here...
-    wrapProgram $out/bin/kupfer \
-        --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-        --prefix PYTHONPATH : "$PYTHONPATH" \
-        --set PYTHONNOUSERSITE 1
+    gappsWrapperArgs+=(
+      "--prefix" "PYTHONPATH" : pythonPath
+      "--set" "PYTHONNOUSERSITE" "1"
+    )
+
+    runHook postInstall
   '';
 
-  meta = with lib; {
+  doCheck = false; # no tests
+
+  meta = with stdenv.lib; {
     description = "A smart, quick launcher";
     homepage    = "https://kupferlauncher.github.io/";
     license     = licenses.gpl3;
+    platforms   = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14976,6 +14976,8 @@ with pkgs;
     go = go_1_7;
   };
 
+  kupfer = callPackage ../applications/misc/kupfer { };
+
   lame = callPackage ../development/libraries/lame { };
 
   larswm = callPackage ../applications/window-managers/larswm { };


### PR DESCRIPTION
###### Motivation for this change

Added a package for [kupfer](https://kupferlauncher.github.io/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I think that the closure is a little bloated, because I'm grabbing the $PYTHONPATH from the build environment instead of using the wrapPython scripts, but I couldn't figure out how to get them to work when the binaries are wrappers themselves.