### PR TITLE
Deduplicate some filterSource invocations

### DIFF
--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -17,6 +17,8 @@ rec {
     (type == "directory" && (baseName == ".git" || baseName == ".svn" || baseName == "CVS" || baseName == ".hg")) ||
     # Filter out backup files.
     lib.hasSuffix "~" baseName ||
+    builtins.match "^.*\.sw[a-z]$" baseName != null ||
+
     # Filter out generates files.
     lib.hasSuffix ".o" baseName ||
     lib.hasSuffix ".so" baseName ||

--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -45,19 +45,7 @@ let
     raw   = "img";
   };
 
-  # Copied from https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/installer/cd-dvd/channel.nix
-  # TODO: factor out more cleanly
-
-  # Do not include these things:
-  #   - The '.git' directory
-  #   - Result symlinks from nix-build ('result', 'result-2', 'result-bin', ...)
-  #   - VIM/Emacs swap/backup files ('.swp', '.swo', '.foo.swp', 'foo~', ...)
-  filterFn = path: type: let basename = baseNameOf (toString path); in
-    if type == "directory" then basename != ".git"
-    else if type == "symlink" then builtins.match "^result(|-.*)$" basename == null
-    else builtins.match "^((|\..*)\.sw[a-z]|.*~)$" basename == null;
-
-  nixpkgs = builtins.filterSource filterFn pkgs.path;
+  nixpkgs = lib.cleanSource pkgs.path;
 
   channelSources = pkgs.runCommand "nixos-${config.system.nixosVersion}" {} ''
     mkdir -p $out

--- a/nixos/modules/installer/cd-dvd/channel.nix
+++ b/nixos/modules/installer/cd-dvd/channel.nix
@@ -6,16 +6,7 @@
 with lib;
 
 let
-  # Do not include these things:
-  #   - The '.git' directory
-  #   - Result symlinks from nix-build ('result', 'result-2', 'result-bin', ...)
-  #   - VIM/Emacs swap/backup files ('.swp', '.swo', '.foo.swp', 'foo~', ...)
-  filterFn = path: type: let basename = baseNameOf (toString path); in
-    if type == "directory" then basename != ".git"
-    else if type == "symlink" then builtins.match "^result(|-.*)$" basename == null
-    else builtins.match "^((|\..*)\.sw[a-z]|.*~)$" basename == null;
-
-  nixpkgs = builtins.filterSource filterFn pkgs.path;
+  nixpkgs = lib.cleanSource pkgs.path;
 
   # We need a copy of the Nix expressions for Nixpkgs and NixOS on the
   # CD.  These are installed into the "nixos" channel of the root


### PR DESCRIPTION
This version should have more conventional regexes that work across many platforms and regex engines. This is an issue because up until Nix 1.11, Nix called out to the libc regex matcher, which behaved differently on Darwin and Linux. And in Nix 1.12, we're moving to std::regex which will also behave differently here.

And yes, I do actually (want to) evaluate make-disk-image.nix on Darwin ;)

cc @dezgeg who added the original `filterSource` invocation here and @grahamc who helped with the regex untangling