### PR TITLE
interception-tools: init at 0.1.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -224,6 +224,7 @@
   ./services/hardware/brltty.nix
   ./services/hardware/freefall.nix
   ./services/hardware/illum.nix
+  ./services/hardware/interception-tools.nix
   ./services/hardware/irqbalance.nix
   ./services/hardware/nvidia-optimus.nix
   ./services/hardware/pcscd.nix

--- a/nixos/modules/services/hardware/interception-tools.nix
+++ b/nixos/modules/services/hardware/interception-tools.nix
@@ -1,0 +1,61 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.interception-tools;
+in {
+  options.services.interception-tools = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to enable the interception tools service.";
+    };
+
+    plugins = mkOption {
+      type = types.listOf types.package;
+      default = [ pkgs.interception-tools-plugins.caps2esc ];
+      description = ''
+        A list of interception tools plugins that will be made available to use
+        inside the udevmon configuration.
+      '';
+    };
+
+    udevmonConfig = mkOption {
+      type = types.either types.str types.path;
+      default = ''
+        - JOB: "intercept -g $DEVNODE | caps2esc | uinput -d $DEVNODE"
+          DEVICE:
+            EVENTS:
+              EV_KEY: [KEY_CAPSLOCK, KEY_ESC]
+      '';
+      example = ''
+        - JOB: "intercept -g $DEVNODE | y2z | x2y | uinput -d $DEVNODE"
+          DEVICE:
+            EVENTS:
+              EV_KEY: [KEY_X, KEY_Y]
+      '';
+      description = ''
+        String of udevmon YAML configuration, or path to a udevmon YAML
+        configuration file.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.interception-tools = {
+      description = "Interception tools";
+      path = [ pkgs.bash pkgs.interception-tools ] ++ cfg.plugins;
+      serviceConfig = {
+        ExecStart = ''
+          ${pkgs.interception-tools}/bin/udevmon -c \
+          ${if builtins.typeOf cfg.udevmonConfig == "path"
+          then cfg.udevmonConfig
+          else pkgs.writeText "udevmon.yaml" cfg.udevmonConfig}
+        '';
+        Nice = -20;
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+}

--- a/pkgs/tools/inputmethods/interception-tools/caps2esc.nix
+++ b/pkgs/tools/inputmethods/interception-tools/caps2esc.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, cmake }:
+
+let
+  version = "0.1.0";
+  pname = "interception-tools-caps2esc";
+in stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://gitlab.com/interception/linux/plugins/caps2esc/repository/v${version}/archive.tar.gz";
+    sha256 = "1fdxqp54gwsrm2c63168l256nfwdk4mvgr7nlwdv62wd3l7zzrg8";
+  };
+
+  buildInputs = [ cmake ];
+
+  meta = {
+    homepage = "https://gitlab.com/interception/linux/plugins/caps2esc";
+    description = "Transforming the most useless key ever into the most useful one";
+    license = stdenv.lib.licenses.mit;
+    maintainers = stdenv.lib.maintainers.vyp;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/interception-tools/default.nix
+++ b/pkgs/tools/inputmethods/interception-tools/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, fetchFromGitHub, pkgconfig, cmake, libyamlcppWithoutBoost,
+  libevdev, libudev }:
+
+let
+  version = "0.1.1";
+  baseName = "interception-tools";
+in stdenv.mkDerivation {
+  name = "${baseName}-${version}";
+
+  src = fetchurl {
+    url = "https://gitlab.com/interception/linux/tools/repository/v${version}/archive.tar.gz";
+    sha256 = "14g4pphvylqdb922va322z1pbp12ap753hcf7zf9sii1ikvif83j";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ cmake libevdev libudev libyamlcppWithoutBoost ];
+
+  prePatch = ''
+    substituteInPlace CMakeLists.txt --replace \
+      '"/usr/include/libevdev-1.0"' \
+      "\"$(pkg-config --cflags libevdev | cut -c 3-)\""
+  '';
+
+  patches = [ ./fix-udevmon-configuration-job-path.patch ];
+
+  meta = {
+    description = "A minimal composable infrastructure on top of libudev and libevdev";
+    homepage = "https://gitlab.com/interception/linux/tools";
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = stdenv.lib.maintainers.vyp;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/interception-tools/fix-udevmon-configuration-job-path.patch
+++ b/pkgs/tools/inputmethods/interception-tools/fix-udevmon-configuration-job-path.patch
@@ -1,0 +1,32 @@
+From d3a5d661b80f3597368f517ebaeddfdfaafc1bf2 Mon Sep 17 00:00:00 2001
+From: xd1le <elisp.vim@gmail.com>
+Date: Mon, 28 Aug 2017 00:19:09 +1000
+Subject: [PATCH] fix udevmon configuration job path
+
+For some reason, the udevmon job $PATH seems to be empty (or otherwise
+seems to point to `/no-such-path`). This commit fixes that by setting
+its $PATH to the same $PATH that the parent udevmon process has.
+---
+ udevmon.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/udevmon.cpp b/udevmon.cpp
+index ebdd909..b523efd 100644
+--- a/udevmon.cpp
++++ b/udevmon.cpp
+@@ -237,8 +237,11 @@ private:
+             case 0: {
+                 char *command[] = {(char *)"sh", (char *)"-c",
+                                    (char *)job.c_str(), nullptr};
++                std::string path = getenv("PATH");
+                 std::string variables = "DEVNODE=" + devnode;
+-                char *environment[]   = {(char *)variables.c_str(), nullptr};
++                std::string pathenv = "PATH=" + path;
++                char *environment[] = {(char *)variables.c_str(),
++                                       (char *)pathenv.c_str(), nullptr};
+                 execvpe(command[0], command, environment);
+                 std::fprintf(stderr,
+                              R"(exec failed for devnode %s, job "%s" )"
+-- 
+2.14.1
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1450,6 +1450,11 @@ with pkgs;
     plugins = [ ];
   };
 
+  interception-tools = callPackage ../tools/inputmethods/interception-tools { };
+  interception-tools-plugins = {
+    caps2esc = callPackage ../tools/inputmethods/interception-tools/caps2esc.nix { };
+  };
+
   brotli = callPackage ../tools/compression/brotli { };
 
   brotliUnstable = callPackage ../tools/compression/brotli/unstable.nix { };
@@ -9382,6 +9387,23 @@ with pkgs;
   libyaml = callPackage ../development/libraries/libyaml { };
 
   libyamlcpp = callPackage ../development/libraries/libyaml-cpp { };
+
+  # interception-tools needs this. This should be removed when there is a new
+  # release of libyamlcpp, i.e. when the version of libyamlcpp is newer than
+  # 0.5.3.
+  libyamlcppWithoutBoost = libyamlcpp.overrideAttrs (oldAttrs: rec {
+    name = "libyaml-cpp-${version}";
+    version = "2017-08-25";
+
+    src = fetchFromGitHub {
+      owner = "jbeder";
+      repo = "yaml-cpp";
+      rev = "beb44b872c07c74556314e730c6f20a00b32e8e5";
+      sha256 = "1qkr3i5lin6m36w5rbimc7pjx3nx686xnjb6lw00xf67iqrl4h4m";
+    };
+
+    buildInputs = [ cmake ];
+  });
 
   libykneomgr = callPackage ../development/libraries/libykneomgr { };
 


### PR DESCRIPTION
The latest release of libyamlcpp in nixpkgs does not build because it
uses an older version of boost than the one in nixpkgs and therefore
expects a particular header file which does not exist in the latest
boost anymore. For this reason, a later (git) version of libyamlcpp is
used here (which actually doesn't even require boost).

The substituteInPlace in the prePatch phase is needed because libevdev
places its headers in non-standard places, meaning Nix cannot normally
find them. The `cut` command removes the first two "-I" characters from
the output of `pkg-config`. This needs to be in the prePatch phase
because otherwise Nix will patch these lines to `/var/empty`, meaning
you would have less specific replacement (in case other lines are also
patched to `/var/empty`).

I wrote the patch. (I believe it is NixOS specific.)

###### Motivation for this change

I want to use this:

- https://gitlab.com/interception/linux/tools
- https://gitlab.com/interception/linux/plugins/caps2esc

I wasn't sure if I should have changed libyamlcpp in nixpkgs instead, because it doesn't have a new release (but this package requires a newer version). And also I'm not sure if updating it would break packages using it.. how are such library updates handled in nixpkgs? 😕

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---