### PR TITLE
terraform: provide plugins for 0.10

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildGoPackage, fetchpatch, fetchFromGitHub }:
+{ stdenv, lib, buildEnv, buildGoPackage, fetchpatch, fetchFromGitHub, makeWrapper }:
 
 let
   goPackagePath = "github.com/hashicorp/terraform";
@@ -37,6 +37,36 @@ let
         maintainers = with maintainers; [ jgeerds zimbatm peterhoeg ];
       };
     } // attrs');
+
+  pluggable = terraform:
+    let
+      withPlugins = plugins: stdenv.mkDerivation {
+        name = "${terraform.name}-with-plugins";
+        buildInputs = [ makeWrapper ];
+
+        buildCommand = ''
+          mkdir -p $out/bin/
+          makeWrapper "${terraform.bin}/bin/terraform" "$out/bin/terraform" \
+            --set NIX_TERRAFORM_PLUGIN_DIR "${buildEnv { name = "tf-plugin-env"; paths = plugins terraform.plugins; }}/bin"
+        '';
+
+        passthru = {
+          withPlugins = newplugins: withPlugins (x: newplugins x ++ plugins x);
+
+          # Ouch
+          overrideDerivation = f: (pluggable (terraform.overrideDerivation f)).withPlugins plugins;
+          overrideAttrs = f: (pluggable (terraform.overrideAttrs f)).withPlugins plugins;
+          override = x: (pluggable (terraform.override x)).withPlugins plugins;
+        };
+      };
+    in withPlugins (_: []);
+
+  plugins = {
+    aws = import providers/aws.nix { inherit stdenv lib buildGoPackage fetchFromGitHub; };
+    azurerm = import providers/azurerm.nix { inherit stdenv lib buildGoPackage fetchFromGitHub; };
+    google = import providers/google.nix { inherit stdenv lib buildGoPackage fetchFromGitHub; };
+    kubernetes = import providers/kubernetes.nix { inherit stdenv lib buildGoPackage fetchFromGitHub; };
+  };
 in {
   terraform_0_8_5 = generic {
     version = "0.8.5";
@@ -55,8 +85,10 @@ in {
     doCheck = false;
   };
 
-  terraform_0_10 = generic {
+  terraform_0_10 = pluggable (generic {
     version = "0.10.2";
     sha256 = "1q7za7jcfqv914a3ynfl7hrqbgwcahgm418kivjrac6p1q26w502";
-  };
+    patches = [ ./provider-path.patch ];
+    passthru = { inherit plugins; };
+  });
 }

--- a/pkgs/applications/networking/cluster/terraform/provider-path.patch
+++ b/pkgs/applications/networking/cluster/terraform/provider-path.patch
@@ -1,0 +1,16 @@
+diff --git a/command/init.go b/command/init.go
+index 403ca245b..05d98329a 100644
+--- a/command/init.go
++++ b/command/init.go
+@@ -64,6 +64,11 @@ func (c *InitCommand) Run(args []string) int {
+ 		return 1
+ 	}
+ 
++	val, ok := os.LookupEnv("NIX_TERRAFORM_PLUGIN_DIR")
++	if ok {
++		flagPluginPath = append(flagPluginPath, val)
++	}
++
+ 	if len(flagPluginPath) > 0 {
+ 		c.pluginPath = flagPluginPath
+ 		c.getPlugins = false

--- a/pkgs/applications/networking/cluster/terraform/providers/aws.nix
+++ b/pkgs/applications/networking/cluster/terraform/providers/aws.nix
@@ -1,0 +1,16 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "terraform-provider-aws";
+  name = "${pname}-${version}";
+  version = "0.1.4";
+
+  goPackagePath = "github.com/terraform-providers/terraform-provider-aws";
+
+  src = fetchFromGitHub {
+    owner  = "terraform-providers";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "0hqyvp1bgyfqq2lkjq5m5qxybagnxl9zrqiqfnlrfigdp0y31iz8";
+  };
+}

--- a/pkgs/applications/networking/cluster/terraform/providers/azurerm.nix
+++ b/pkgs/applications/networking/cluster/terraform/providers/azurerm.nix
@@ -1,0 +1,16 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "terraform-provider-azurerm";
+  name = "${pname}-${version}";
+  version = "0.1.5";
+
+  goPackagePath = "github.com/terraform-providers/terraform-provider-azurerm";
+
+  src = fetchFromGitHub {
+    owner  = "terraform-providers";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "02g8wnzwaii24nx5iin1yd4bx0rx22ly8aqhwa39mr5hsjj1qy4k";
+  };
+}

--- a/pkgs/applications/networking/cluster/terraform/providers/google.nix
+++ b/pkgs/applications/networking/cluster/terraform/providers/google.nix
@@ -1,0 +1,16 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "terraform-provider-google";
+  name = "${pname}-${version}";
+  version = "0.1.3";
+
+  goPackagePath = "github.com/terraform-providers/terraform-provider-google";
+
+  src = fetchFromGitHub {
+    owner  = "terraform-providers";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "1aa1hz0yc4g746m6dl04hc70rcrzx0py8kpdch3kim475bspclnf";
+  };
+}

--- a/pkgs/applications/networking/cluster/terraform/providers/kubernetes.nix
+++ b/pkgs/applications/networking/cluster/terraform/providers/kubernetes.nix
@@ -1,0 +1,16 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "terraform-provider-kubernetes";
+  name = "${pname}-${version}";
+  version = "1.0.0";
+
+  goPackagePath = "github.com/terraform-providers/terraform-provider-kubernetes";
+
+  src = fetchFromGitHub {
+    owner  = "terraform-providers";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "1kh7a83f98v6b4v3zj84ddhrg2hya4nmvrw0mjc26q12g4z2d5g6";
+  };
+}


### PR DESCRIPTION
Obviously very much a WIP, but this is the sort of thing I had in mind. I don't really care how we plug the plugins into it, but this way seemed to work and didn't take too much hackery.

To use, try:

`terraform_0_10.withPlugins [ terraform_0_10.providers.aws ]`

That should get you a version of terraform that:

1. Uses the aws provider compiled from source by Nix
2. Doesn't automatically download precompiled providers from their plugin repository

Feedback welcome! I've been considering making `withPlugins` take a function from the available plugins for that version of terraform, so you could write something like `withPlugins (p: [ p.aws ])` or something.

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/28537

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

