### PR TITLE
network-interfaces-scripted: don't add 'lo' as device dependency

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -71,7 +71,7 @@ let
              (hasAttr dev cfg.vswitches) ||
              (hasAttr dev cfg.wlanInterfaces)
           then [ "${dev}-netdev.service" ]
-          else optional (dev != null && !config.boot.isContainer) (subsystemDevice dev);
+          else optional (dev != null && dev != "lo" && !config.boot.isContainer) (subsystemDevice dev);
 
         networkLocalCommands = {
           after = [ "network-setup.service" ];


### PR DESCRIPTION
systemd does not create device units for loopback devices,
since they are not physical.

tested with:

```
interfaces.lo.ip4 = [ { address = "172.23.42.73"; prefixLength = 29; } ];
interfaces.lo.ip6 = [ { address = "fd42:23:42:dd02::1"; prefixLength = 128; } ];
```

cc @mweinelt

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

