### PR TITLE
solc: v0.4.13 -> v0.4.16

### DIFF
--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchzip, fetchgit, boost, cmake }:
+{ stdenv, fetchzip, fetchgit, boost, cmake, z3 }:
 
 let
-  version = "0.4.13";
-  rev = "0fb4cb1ab9bb4b6cc72e28cc5a1753ad14781f14";
-  sha256 = "0rhrm0bmk5s2358j40yx7dzr1938q17dchzflrxw6y7yvkhscxrm";
+  version = "0.4.16";
+  rev = "d7661dd97460250b4e1127b9e7ea91e116143780";
+  sha256 = "1fd69pdhkkkvbkrxipkck1icpqkpdskjzar48a1yzdsx3l8s4lil";
   jsoncppURL = https://github.com/open-source-parsers/jsoncpp/archive/1.7.7.tar.gz;
   jsoncpp = fetchzip {
     url = jsoncppURL;
@@ -27,12 +27,13 @@ stdenv.mkDerivation {
       --replace '${jsoncppURL}' ${jsoncpp}
     substituteInPlace cmake/EthCompilerSettings.cmake \
       --replace 'add_compile_options(-Werror)' ""
-    substituteInPlace cmake/EthDependencies.cmake \
-      --replace 'set(Boost_USE_STATIC_LIBS ON)'   \
-                'set(Boost_USE_STATIC_LIBS OFF)'
   '';
 
-  buildInputs = [ boost cmake ];
+  cmakeFlags = [
+    "-DBoost_USE_STATIC_LIBS=OFF"
+  ];
+
+  buildInputs = [ boost cmake z3 ];
 
   meta = {
     description = "Compiler for Ethereum smart contract language Solidity";

--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -33,7 +33,8 @@ stdenv.mkDerivation {
     "-DBoost_USE_STATIC_LIBS=OFF"
   ];
 
-  buildInputs = [ boost cmake z3 ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost z3 ];
 
   meta = {
     description = "Compiler for Ethereum smart contract language Solidity";


### PR DESCRIPTION
Also add the Z3 SMT solver as a dependency, since the new solc can use
it for checking assertions and stuff (which is awesome).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

