### PR TITLE
trezord: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/servers/trezord/default.nix
+++ b/pkgs/servers/trezord/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchgit, curl, cmake, boost, gcc5, protobuf, pkgconfig, jsoncpp
+{ stdenv, fetchgit, curl, cmake, boost, gcc, protobuf, pkgconfig, jsoncpp
 , libusb1, libmicrohttpd
 }:
 
 let
-  version = "1.2.0";
+  version = "1.2.1";
 in
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url    = "https://github.com/trezor/trezord";
     rev    = "refs/tags/v${version}";
-    sha256 = "1606j5cfngryk4q21yiga1zvc3zpx4q8vqn6ljrvr679hpvlwni4";
+    sha256 = "1iaxmwyidjdcrc6jg0859v6v5x3qnz5b0p78pq0bypvmgyijhpm4";
   };
 
   meta = with stdenv.lib; {
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    gcc5
+    gcc
     pkgconfig
   ];
 


### PR DESCRIPTION

###### Motivation for this change

Progress on: #28643


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

