### PR TITLE
weechat-matrix-bridge: init at 2017-03-28

### DIFF
--- a/pkgs/applications/networking/instant-messengers/weechat-matrix-bridge/default.nix
+++ b/pkgs/applications/networking/instant-messengers/weechat-matrix-bridge/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, curl, fetchFromGitHub, cjson, olm, luaffi }:
+
+stdenv.mkDerivation {
+  name = "weechat-matrix-bridge-2017-03-28";
+  src = fetchFromGitHub {
+    owner = "torhve";
+    repo = "weechat-matrix-protocol-script";
+    rev = "0052e7275ae149dc5241226391c9b1889ecc3c6b";
+    sha256 = "14x58jd44g08sfnp1gx74gq2na527v5jjpsvv1xx4b8mixwy20hi";
+  };
+
+  patches = [
+    ./library-path.patch
+  ];
+
+  buildInputs = [ curl cjson olm luaffi ];
+
+  postPatch = ''
+    substituteInPlace matrix.lua \
+      --replace "/usr/bin/curl" "${curl}/bin/curl" \
+      --replace "__NIX_LIB_PATH__" "$out/lib/?.so" \
+      --replace "__NIX_OLM_PATH__" "$out/share/?.lua"
+
+    substituteInPlace olm.lua \
+      --replace "__NIX_LIB_PATH__" "$out/lib/?.so"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{share,lib}
+
+    cp {matrix.lua,olm.lua} $out/share
+    cp ${cjson}/lib/lua/5.2/cjson.so $out/lib/cjson.so
+    cp ${olm}/lib/libolm.so $out/lib/libolm.so
+    cp ${luaffi}/lib/ffi.so $out/lib/ffi.so
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A WeeChat script in Lua that implements the matrix.org chat protocol";
+    homepage = https://github.com/torhve/weechat-matrix-protocol-script;
+    maintainers = with maintainers; [ ma27 ];
+    license = licenses.mit; # see https://github.com/torhve/weechat-matrix-protocol-script/blob/0052e7275ae149dc5241226391c9b1889ecc3c6b/matrix.lua#L53
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/weechat-matrix-bridge/library-path.patch
+++ b/pkgs/applications/networking/instant-messengers/weechat-matrix-bridge/library-path.patch
@@ -1,0 +1,28 @@
+diff --git a/matrix.lua b/matrix.lua
+index b79f500..32b37a2 100644
+--- a/matrix.lua
++++ b/matrix.lua
+@@ -43,6 +43,9 @@ This script maps this as follows:
+ 
+ ]]
+ 
++package.cpath = package.cpath .. ";__NIX_LIB_PATH__"
++package.path = package.path .. ";__NIX_OLM_PATH__"
++
+ local json = require 'cjson' -- apt-get install lua-cjson
+ local olmstatus, olm = pcall(require, 'olm') -- LuaJIT olm FFI binding ln -s ~/olm/olm.lua /usr/local/share/lua/5.1
+ local w = weechat
+diff --git a/olm.lua b/olm.lua
+index 114649c..4828371 100644
+--- a/olm.lua
++++ b/olm.lua
+@@ -17,6 +17,9 @@
+  * limitations under the License.
+  */
+ --]]
++
++package.cpath = package.cpath .. ";__NIX_LIB_PATH__"
++
+ local ffi = require'ffi'
+ 
+ ffi.cdef[[

--- a/pkgs/development/libraries/luaffi/default.nix
+++ b/pkgs/development/libraries/luaffi/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, lua, pkgconfig }:
+
+stdenv.mkDerivation {
+  name = "luaffi-2013-11-08";
+  src = fetchFromGitHub {
+    owner = "jmckaskill";
+    repo = "luaffi";
+    rev = "abc638c9341025580099dcf77795c4b320ba0e63";
+    sha256 = "1hv1y9i66p473hfy36nqj220sfrxdmbd75c1gpjvpk8073vx55ac";
+  };
+
+  buildInputs = [ lua pkgconfig ];
+
+  patches = [
+    ./makefile-errors.patch
+  ];
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp ffi.so $out/lib/ffi.so
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Standalone FFI library for calling C functions from lua. Compatible with the luajit FFI interface.";
+    homepage = https://github.com/jmckaskill/luaffi;
+    maintainers = with maintainers; [ ma27 ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/luaffi/makefile-errors.patch
+++ b/pkgs/development/libraries/luaffi/makefile-errors.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index b2b5f2c..49d4c99 100644
+--- a/Makefile
++++ b/Makefile
+@@ -6,7 +6,7 @@ LUA=lua
+ LUA_CFLAGS=`$(PKG_CONFIG) --cflags lua5.2 2>/dev/null || $(PKG_CONFIG) --cflags lua`
+ SOCFLAGS=-fPIC
+ SOCC=$(CC) -shared $(SOCFLAGS)
+-CFLAGS=-fPIC -g -Wall -Werror $(LUA_CFLAGS) -fvisibility=hidden -Wno-unused-function --std=gnu99
++CFLAGS=-fPIC -g -Wall $(LUA_CFLAGS) -fvisibility=hidden -Wno-unused-function --std=gnu99
+ 
+ MODNAME=ffi
+ MODSO=$(MODNAME).so

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16696,6 +16696,10 @@ with pkgs;
     guile = guile_2_0;
   };
 
+  weechat-matrix-bridge = callPackage ../applications/networking/instant-messengers/weechat-matrix-bridge {
+    inherit (luaPackages) cjson;
+  };
+
   westonLite = callPackage ../applications/window-managers/weston {
     pango = null;
     freerdp = null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9498,6 +9498,8 @@ with pkgs;
 
   luabind_luajit = callPackage ../development/libraries/luabind { lua = luajit; };
 
+  luaffi = callPackage ../development/libraries/luaffi { lua = lua5_1; };
+
   lzo = callPackage ../development/libraries/lzo { };
 
   mapnik = callPackage ../development/libraries/mapnik { };


### PR DESCRIPTION
###### Motivation for this change

Contains a packaged version of the LUA script which connects weechat with a matrix server.

I'm currently using it locally and it works fine, however it would be cool if more people could test it :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

