### PR TITLE
Gitlab runner improve

### DIFF
--- a/nixos/modules/services/continuous-integration/gitlab-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner.nix
@@ -96,10 +96,20 @@ in
       example = literalExample "pkgs.gitlab-runner_1_11";
     };
 
+    packages = mkOption {
+      default = [ pkgs.bash pkgs.docker-machine ];
+      defaultText = "[ pkgs.bash pkgs.docker-machine ]";
+      type = types.listOf types.package;
+      description = ''
+        Packages to add to PATH for the gitlab-runner process.
+      '';
+    };
+
   };
 
   config = mkIf cfg.enable {
     systemd.services.gitlab-runner = {
+      path = cfg.packages;
       environment = config.networking.proxy.envVars;
       description = "Gitlab Runner";
       after = [ "network.target" ]

--- a/nixos/modules/services/continuous-integration/gitlab-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner.nix
@@ -100,6 +100,7 @@ in
 
   config = mkIf cfg.enable {
     systemd.services.gitlab-runner = {
+      environment = config.networking.proxy.envVars;
       description = "Gitlab Runner";
       after = [ "network.target" ]
         ++ optional hasDocker "docker.service";


### PR DESCRIPTION
###### Motivation for this change

Fix several shortcoming of the gitlab-runner service:
- Honor proxy
- Allow to add additional tools to the PATH, this allows to use for example the `docker+machine` runner type.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

