### PR TITLE
tests: fix ipfs test, test actual networking functionality

### DIFF
--- a/nixos/tests/ipfs.nix
+++ b/nixos/tests/ipfs.nix
@@ -11,27 +11,47 @@ import ./make-test.nix ({ pkgs, ...} : {
       {
         services.ipfs = {
           enable = true;
+          defaultMode = "norouting";
           gatewayAddress = "/ip4/127.0.0.1/tcp/2323";
           apiAddress = "/ip4/127.0.0.1/tcp/2324";
         };
+        networking.firewall.allowedTCPPorts = [ 4001 ];
       };
     getter =
       { config, pkgs, ... }:
       {
-         services.ipfs.enable = true;
+        services.ipfs = {
+          enable = true;
+          defaultMode = "norouting";
+          # not yet. See #28621
+          #autoMount = true;
+        };
+        networking.firewall.allowedTCPPorts = [ 4001 ];
       };
   };
 
   testScript = ''
     startAll;
-    $adder->waitForUnit("ipfs");
-    # * => needs ipfs dht (internet)
-    # $getter->waitForUnit("ipfs");
+    $adder->waitForUnit("ipfs-norouting");
+    $getter->waitForUnit("ipfs-norouting");
+
+    # wait until api is available
     $adder->waitUntilSucceeds("ipfs --api /ip4/127.0.0.1/tcp/2324 id");
-    $adder->mustSucceed("([[ -n '$(ipfs --api /ip4/127.0.0.1/tcp/2324 config Addresses.gatewayAddress | grep /ip4/127.0.0.1/tcp/2323)' ]])");
-    # * $getter->waitUntilSucceeds("ipfs --api /ip4/127.0.0.1/tcp/5001 id");
-    # * my $ipfsHash = $adder->mustSucceed("echo fnord | ipfs --api /ip4/127.0.0.1/tcp/2324 add | cut -d' ' -f2");
-    $adder->mustSucceed("([[ -n '$(echo fnord | ipfs --api /ip4/127.0.0.1/tcp/2324 add | grep added)' ]])");
-    # * $getter->mustSucceed("ipfs --api /ip4/127.0.0.1/tcp/5001 cat $ipfsHash");
+    my $addrId = $adder->succeed("ipfs --api /ip4/127.0.0.1/tcp/2324 id -f=\"<id>\"");
+    my $addrIp = (split /[ \/]+/, $adder->succeed("ip -o -4 addr show dev eth1"))[3];
+
+    $adder->mustSucceed("[ -n \"\$(ipfs --api /ip4/127.0.0.1/tcp/2324 config Addresses.Gateway | grep /ip4/127.0.0.1/tcp/2323)\" ]");
+
+    # wait until api is available
+    $getter->waitUntilSucceeds("ipfs --api /ip4/127.0.0.1/tcp/5001 id");
+    my $ipfsHash = $adder->mustSucceed("echo fnord | ipfs --api /ip4/127.0.0.1/tcp/2324 add | cut -d' ' -f2");
+    chomp($ipfsHash);
+
+    $adder->mustSucceed("[ -n \"\$(echo fnord | ipfs --api /ip4/127.0.0.1/tcp/2324 add | grep added)\" ]");
+
+    $getter->mustSucceed("ipfs --api /ip4/127.0.0.1/tcp/5001 swarm connect /ip4/$addrIp/tcp/4001/ipfs/$addrId");
+    $getter->mustSucceed("[ -n \"\$(ipfs --api /ip4/127.0.0.1/tcp/5001 cat /ipfs/$ipfsHash | grep fnord)\" ]");
+    # not yet. See #28621
+    # $getter->mustSucceed("[ -n \"$(cat /ipfs/$ipfsHash | grep fnord)\" ]");
     '';
 })


### PR DESCRIPTION
###### Motivation for this change

test IPFS properly, once #28621 is merged, mounting and reading from fuse can be tested as well

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

