### PR TITLE
ardour: fix build with gcc6

### DIFF
--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ alsaLib aubio boost cairomm curl doxygen dbus fftw fftwSinglePrec flac glibc
+    [ alsaLib aubio boost cairomm curl doxygen dbus fftw fftwSinglePrec flac 
       glibmm graphviz gtkmm2 libjack2 libgnomecanvas libgnomecanvasmm liblo
       libmad libogg librdf librdf_raptor librdf_rasqal libsamplerate
       libsigcxx libsndfile libusb libuuid libxml2 libxslt lilv lv2


### PR DESCRIPTION
###### Motivation for this change
ardour fails to build with gcc6. The error is `/nix/store/vqc58c85wih3gcxpv8jn8n456b5m77da-gcc-6.4.0/include/c++/6.4.0/cstdlib:75:25: fatal error: stdlib.h: No such file or directory`

May be this upstream bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70936

related to #28643

This PR fixes the build by using gcc5.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

