### PR TITLE
nixos/piwik: Adjust to recent NixOS changes, use nginx's virtualHost instead of replicating

### DIFF
--- a/nixos/modules/services/web-apps/piwik-doc.xml
+++ b/nixos/modules/services/web-apps/piwik-doc.xml
@@ -79,16 +79,6 @@
           You can safely ignore this, unless you need a plugin that needs JavaScript tracker access.
         </para>
       </listitem>
-
-      <listitem>
-        <para>
-          Sending mail from piwik, e.g. for the password reset function, might not work out of the box:
-          There's a problem with using <command>sendmail</command> from <literal>php-fpm</literal> that is
-          being investigated at <link xlink:href="https://github.com/NixOS/nixpkgs/issues/26611" />.
-          If you have (or don't have) this problem as well, please report it. You can enable SMTP as method
-          to send mail in piwik's <quote>General Settings</quote> > <quote>Mail Server Settings</quote> instead.
-        </para>
-      </listitem>
     </itemizedlist>
   </section>
 

--- a/nixos/modules/services/web-apps/piwik.nix
+++ b/nixos/modules/services/web-apps/piwik.nix
@@ -173,7 +173,6 @@ in {
 
         # allow to override SSL settings if necessary, i.e. when using another method than ACME
         # but enable them by default, as sensitive login and piwik data should not be transmitted in clear text.
-        addSSL = mkDefault true;
         forceSSL = mkDefault true;
         enableACME = mkDefault true;
 


### PR DESCRIPTION
###### Motivation for this change
Get the piwik module up to date again:

* Make piwik work with changes introduced by #27426 by using the nginx virtualHost module, which greatly improves flexibility of the piwik nginx setup. This leads to showing all nginx vhost options in the piwik part of the options documentation again, which one could see as a downside of this approach. Also, the defaults mentioned in those options do not take into account the defaults set at [this](https://github.com/NixOS/nixpkgs/compare/master...florianjacob:piwik-improve-config?expand=1#diff-f8c1b8b576a6940611cf0574b73b4c0dR169), but I found no way how this could be solved and therefore documented the defaults [in the option description](https://github.com/NixOS/nixpkgs/compare/master...florianjacob:piwik-improve-config?expand=1#diff-f8c1b8b576a6940611cf0574b73b4c0dR74)
* Resolve #27704 by improving documentation and not requiring `webServerUser` if nginx module is used.
* Remove manual part on mail sending issues with piwik as #26611 was resolved and it now works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

