### PR TITLE
jrnl: support journal encryption by default

### DIFF
--- a/pkgs/applications/misc/jrnl/default.nix
+++ b/pkgs/applications/misc/jrnl/default.nix
@@ -1,0 +1,30 @@
+{ pkgs
+, stdenv
+, pythonPackages
+, fetchurl
+}:
+
+with pythonPackages;
+
+buildPythonApplication rec {
+  name = "jrnl-${version}";
+  version = "1.9.7";
+  disabled = isPy3k;
+
+  src = fetchurl {
+    url = "mirror://pypi/j/jrnl/${name}.tar.gz";
+    sha256 = "af599a863ac298533685a7236fb86307eebc00a38eb8bb96f4f67b5d83227ec8";
+  };
+
+  propagatedBuildInputs = with pkgs; [
+    pytz six tzlocal keyring argparse dateutil_1_5
+    parsedatetime pycrypto
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = http://maebert.github.io/jrnl/;
+    description = "A simple command line journal application that stores your journal in a plain text file";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zalakain ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2732,6 +2732,8 @@ with pkgs;
 
   jo = callPackage ../development/tools/jo { };
 
+  jrnl = callPackage ../applications/misc/jrnl { };
+
   jscoverage = callPackage ../development/tools/misc/jscoverage { };
 
   jsduck = callPackage ../development/tools/jsduck { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11503,27 +11503,6 @@ in {
     inherit (self) systemd pytest;
   };
 
-  jrnl = buildPythonPackage rec {
-    name = "jrnl-1.9.7";
-    disabled = isPy3k;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/j/jrnl/${name}.tar.gz";
-      sha256 = "af599a863ac298533685a7236fb86307eebc00a38eb8bb96f4f67b5d83227ec8";
-    };
-
-    propagatedBuildInputs = with self; [
-      pytz six tzlocal keyring argparse dateutil_1_5
-      parsedatetime
-    ];
-
-    meta = {
-      homepage = http://maebert.github.io/jrnl/;
-      description = "A simple command line journal application that stores your journal in a plain text file";
-      license = licenses.mit;
-    };
-  };
-
   jsonnet = buildPythonPackage {
     inherit (pkgs.jsonnet) name src;
   };


### PR DESCRIPTION
###### Motivation for this change

Currently `jrnl` doesn't support encrypted journals because it doesn't depend on `pycrypto`. I enabled encryption by default, as I think it's a small dependency and the feature is a commonly used one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

