### PR TITLE
xplanet: gcc6 patch

### DIFF
--- a/pkgs/applications/science/astronomy/xplanet/default.nix
+++ b/pkgs/applications/science/astronomy/xplanet/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig freetype pango libpng libtiff giflib libjpeg netpbm ];
 
-  patches = [ ./giflib.patch ];
+  patches = [
+    ./giflib.patch
+    ./gcc6.patch
+  ];
 
   meta = {
     description = "Renders an image of the earth or other planets into the X root window";

--- a/pkgs/applications/science/astronomy/xplanet/gcc6.patch
+++ b/pkgs/applications/science/astronomy/xplanet/gcc6.patch
@@ -1,0 +1,128 @@
+diff --git c/src/libannotate/addArcs.cpp i/src/libannotate/addArcs.cpp
+index 2ee06c0..0ff5478 100644
+--- c/src/libannotate/addArcs.cpp
++++ i/src/libannotate/addArcs.cpp
+@@ -258,7 +258,7 @@ addArcs(PlanetProperties *planetProperties, Planet *planet,
+         {
+             ifstream inFile(arcFile.c_str());
+             char *line = new char[MAX_LINE_LENGTH];
+-            while (inFile.getline (line, MAX_LINE_LENGTH, '\n') != NULL)
++            while (inFile.getline (line, MAX_LINE_LENGTH, '\n'))
+                 readArcFile(line, planet, view, projection,
+                             planetProperties, annotationMap);
+             
+@@ -292,7 +292,7 @@ addArcs(View *view, multimap<double, Annotation *> &annotationMap)
+         {
+             ifstream inFile(arcFile.c_str());
+             char *line = new char[256];
+-            while (inFile.getline (line, 256, '\n') != NULL)
++            while (inFile.getline (line, 256, '\n'))
+                 readArcFile(line, NULL, view, NULL, NULL, annotationMap);
+ 
+             inFile.close();
+diff --git c/src/libannotate/addMarkers.cpp i/src/libannotate/addMarkers.cpp
+index 6a8a835..b35d820 100644
+--- c/src/libannotate/addMarkers.cpp
++++ i/src/libannotate/addMarkers.cpp
+@@ -423,7 +423,7 @@ addMarkers(PlanetProperties *planetProperties, Planet *planet,
+         {
+             ifstream inFile(markerFile.c_str());
+             char *line = new char[MAX_LINE_LENGTH];
+-            while (inFile.getline (line, MAX_LINE_LENGTH, '\n') != NULL)
++            while (inFile.getline (line, MAX_LINE_LENGTH, '\n'))
+             {
+                 unsigned char color[3];
+                 memcpy(color, planetProperties->MarkerColor(), 3);
+@@ -469,7 +469,7 @@ addMarkers(View *view, const int width, const int height,
+         {
+             ifstream inFile(markerFile.c_str());
+             char *line = new char[MAX_LINE_LENGTH];
+-            while (inFile.getline (line, MAX_LINE_LENGTH, '\n') != NULL)
++            while (inFile.getline (line, MAX_LINE_LENGTH, '\n'))
+             {
+                 unsigned char color[3];
+                 memcpy(color, options->Color(), 3);
+diff --git c/src/libannotate/addSatellites.cpp i/src/libannotate/addSatellites.cpp
+index 2634339..c9ff0b0 100644
+--- c/src/libannotate/addSatellites.cpp
++++ i/src/libannotate/addSatellites.cpp
+@@ -488,10 +488,10 @@ loadSatelliteVector(PlanetProperties *planetProperties)
+         {
+             ifstream inFile(tleFile.c_str());
+             char lines[3][80];
+-            while (inFile.getline(lines[0], 80) != NULL)
++            while (inFile.getline(lines[0], 80))
+             {
+-                if ((inFile.getline(lines[1], 80) == NULL) 
+-                    || (inFile.getline(lines[2], 80) == NULL))
++                if ((inFile.getline(lines[1], 80))
++                    || (inFile.getline(lines[2], 80)))
+                 {
+                     ostringstream errStr;
+                     errStr << "Malformed TLE file (" << tleFile << ")?\n";
+@@ -542,7 +542,7 @@ addSatellites(PlanetProperties *planetProperties, Planet *planet,
+         {
+             ifstream inFile(satFile.c_str());
+             char *line = new char[MAX_LINE_LENGTH];
+-            while (inFile.getline (line, MAX_LINE_LENGTH, '\n') != NULL)
++            while (inFile.getline (line, MAX_LINE_LENGTH, '\n'))
+                 readSatelliteFile(line, planet, view, projection,
+                                   planetProperties, annotationMap);
+             
+diff --git c/src/libmultiple/RayleighScattering.cpp i/src/libmultiple/RayleighScattering.cpp
+index d885173..7c25c1c 100644
+--- c/src/libmultiple/RayleighScattering.cpp
++++ i/src/libmultiple/RayleighScattering.cpp
+@@ -369,7 +369,7 @@ RayleighScattering::readConfigFile(string configFile)
+ 
+     diskTemplate_.clear();
+     limbTemplate_.clear();
+-    while (inFile.getline(line, MAX_LINE_LENGTH, '\n') != NULL)
++    while (inFile.getline(line, MAX_LINE_LENGTH, '\n'))
+     {
+         int i = 0;
+         while (isDelimiter(line[i]))
+@@ -439,7 +439,7 @@ RayleighScattering::readBlock(ifstream &inFile,
+     values.clear();
+ 
+     char line[MAX_LINE_LENGTH];
+-    while (inFile.getline(line, MAX_LINE_LENGTH, '\n') != NULL)
++    while (inFile.getline(line, MAX_LINE_LENGTH, '\n'))
+     {
+         int i = 0;
+         while (isDelimiter(line[i]))
+@@ -470,7 +470,7 @@ RayleighScattering::readValue(ifstream &inFile,
+                               double &value)
+ {
+     char line[MAX_LINE_LENGTH];
+-    while (inFile.getline(line, MAX_LINE_LENGTH, '\n') != NULL)
++    while (inFile.getline(line, MAX_LINE_LENGTH, '\n'))
+     {
+         int i = 0;
+         while (isDelimiter(line[i]))
+diff --git c/src/libmultiple/drawStars.cpp i/src/libmultiple/drawStars.cpp
+index ff07c49..22e41a0 100644
+--- c/src/libmultiple/drawStars.cpp
++++ i/src/libmultiple/drawStars.cpp
+@@ -41,7 +41,7 @@ drawStars(DisplayBase *display, View *view)
+     ifstream inFile(starMap.c_str());
+ 
+     char line[MAX_LINE_LENGTH];
+-    while (inFile.getline(line, MAX_LINE_LENGTH, '\n') != NULL)
++    while (inFile.getline(line, MAX_LINE_LENGTH, '\n'))
+     {
+         if (line[0] == '#') continue;
+ 
+diff --git c/src/readConfig.cpp i/src/readConfig.cpp
+index cc1964f..2946690 100644
+--- c/src/readConfig.cpp
++++ i/src/readConfig.cpp
+@@ -550,7 +550,7 @@ readConfigFile(string configFile, PlanetProperties *planetProperties[])
+ 
+         ifstream inFile(configFile.c_str());
+         char *line = new char[256];
+-        while (inFile.getline(line, 256, '\n') != NULL)
++        while (inFile.getline(line, 256, '\n'))
+             readConfig(line, planetProperties);
+         
+         // This condition will only be true if [default] is the only


### PR DESCRIPTION
###### Motivation for this change
Fixes xplanet building with gcc6

Related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

