### PR TITLE
vidalia: fix build with gcc6

### DIFF
--- a/pkgs/tools/security/vidalia/default.nix
+++ b/pkgs/tools/security/vidalia/default.nix
@@ -11,7 +11,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake qt4 doxygen ];
 
-  patches = [ ./gcc-4.7.patch ];
+  patches = [ 
+    ./gcc-4.7.patch
+    (fetchurl {
+        name = "TorSettings.h.patch";
+        url = "https://aur.archlinux.org/cgit/aur.git/plain/TorSettings.h.patch?h=vidalia";
+        sha256 = "1yvgpq60mqschfawmc3l7l86w95mxc4nplj8rf7hh9z7xl9xcqii";
+    })
+  ];
 
   meta = with stdenv.lib; {
     homepage = https://www.torproject.org/projects/vidalia.html.en;


### PR DESCRIPTION
###### Motivation for this change

Fix build with gcc6. Note - the package doesn't appear to be supported upstream any more https://lists.torproject.org/pipermail/tor-talk/2015-February/036833.html but I wasn't sure if that would qualify it for being removed.

https://github.com/NixOS/nixpkgs/issues/28643

/cc @Phreedom 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

