### PR TITLE
sword: fix build with gcc6

### DIFF
--- a/pkgs/development/libraries/sword/default.nix
+++ b/pkgs/development/libraries/sword/default.nix
@@ -16,6 +16,13 @@ stdenv.mkDerivation rec {
     patchShebangs .;
   '';
 
+  patches = [
+    (fetchurl {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/app-text/sword/files/sword-1.7.4-gcc6.patch";
+      sha256 = "0cvnya5swc7dxabir6bz6la2h1qxd32g3xi06m9b5l5ahb6g10y7";
+    })
+  ];
+
   configureFlags = "--without-conf --enable-tests=no CXXFLAGS=-Wno-unused-but-set-variable";
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Fixes build with gcc6

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

