### PR TITLE
pulseview and sigrok updates

### DIFF
--- a/pkgs/applications/science/electronics/pulseview/default.nix
+++ b/pkgs/applications/science/electronics/pulseview/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchurl, pkgconfig, cmake, glib, qt4, boost, libsigrok
-, libsigrokdecode, libserialport, libzip, udev, libusb1, libftdi, glibmm
+{ stdenv, fetchurl, pkgconfig, cmake, glib, qt5, boost, libsigrok
+, libsigrokdecode, libserialport, libzip, udev, libusb1, libftdi1, glibmm
 }:
 
 stdenv.mkDerivation rec {
-  name = "pulseview-0.3.0";
+  name = "pulseview-0.4.0";
 
   src = fetchurl {
     url = "http://sigrok.org/download/source/pulseview/${name}.tar.gz";
-    sha256 = "03jk5xpsird5ssbnwkxw57jnqvnnpivhqh1xjdhdrz02lsvjrzjz";
+    sha256 = "1f8f2342d5yam98mmcb8f9g2vslcwv486bmi4x45pxn68l82ky3q";
   };
 
-  buildInputs = [ pkgconfig cmake glib qt4 boost libsigrok
-    libsigrokdecode libserialport libzip udev libusb1 libftdi glibmm
+  buildInputs = [ pkgconfig cmake glib qt5.full boost libsigrok
+    libsigrokdecode libserialport libzip udev libusb1 libftdi1 glibmm
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/libsigrok/default.nix
+++ b/pkgs/development/tools/libsigrok/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, libzip, glib, libusb1, libftdi, check
+{ stdenv, fetchurl, pkgconfig, libzip, glib, libusb1, libftdi1, check
 , libserialport, librevisa, doxygen, glibmm, python
-, version ? "0.4.0", sha256 ? "17k63p3yhpx9qbfprgayphqqhn2hdrcph73g6fqxmrinxqziyaaz"
+, version ? "0.5.0", sha256 ? "197kr5ip98lxn7rv10zs35d1w0j7265s0xvckx0mq2l8kdvqd32c"
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "1qr02ny97navqxr56xq1a227yzf6h09m8jlvc9bnjl0bsk6887bl";
   };
 
-  buildInputs = [ pkgconfig libzip glib libusb1 libftdi check libserialport
+  buildInputs = [ pkgconfig libzip glib libusb1 libftdi1 check libserialport
     librevisa doxygen glibmm python
   ];
 

--- a/pkgs/development/tools/libsigrokdecode/default.nix
+++ b/pkgs/development/tools/libsigrokdecode/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, glib, python3, libsigrok, check }:
 
 stdenv.mkDerivation rec {
-  name = "libsigrokdecode-0.4.1";
+  name = "libsigrokdecode-0.5.0";
 
   src = fetchurl {
     url = "http://sigrok.org/download/source/libsigrokdecode/${name}.tar.gz";
-    sha256 = "15aabl9p4586v2bkj4bm4xi7l3309r9zb31sw233s5vi170p0pq6";
+    sha256 = "1hfigfj1976qk11kfsgj75l20qvyq8c9p2h4mjw23d59rsg5ga2a";
   };
 
   buildInputs = [ pkgconfig glib python3 libsigrok check ];

--- a/pkgs/development/tools/sigrok-cli/default.nix
+++ b/pkgs/development/tools/sigrok-cli/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, glib, libsigrok, libsigrokdecode }:
 
 stdenv.mkDerivation rec {
-  name = "sigrok-cli-0.6.0";
+  name = "sigrok-cli-0.7.0";
 
   src = fetchurl {
     url = "http://sigrok.org/download/source/sigrok-cli/${name}.tar.gz";
-    sha256 = "0g3jhi7azm256gnryka70wn7j3af42yk19c9kbhqffaz4i7dwbmb";
+    sha256 = "072ylscp0ppgii1k5j07hhv7dfmni4vyhxnsvxmgqgfyq9ldjsan";
   };
 
   buildInputs = [ pkgconfig glib libsigrok libsigrokdecode ];


### PR DESCRIPTION
###### Motivation for this change
This fixes gcc6 build for pulseview. Upgrading pulseview requires sigrok and sigrokdecode updates as well. All three are part of the sigrok project.

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

