### PR TITLE
kdevelop: 5.1.1 -> 5.1.2

### DIFF
--- a/pkgs/applications/editors/kdevelop5/kdevelop-pg-qt.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop-pg-qt.nix
@@ -2,16 +2,15 @@
 
 let
   pname = "kdevelop-pg-qt";
-  version = "2.0";
-  dirVersion = "2.0.0";
+  version = "2.1.0";
 
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   
   src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${dirVersion}/src/${name}.tar.xz";
-    sha256 = "2f778d324b7c0962e8bb5f62dd2643bac1a6f3ac971d145b6aace7cd61878993";
+    url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
+    sha256 = "20d84d25bd40610bd6c0964e4fe0642e56c41b76a65575122dc5196649621e5d";
   };
 
   nativeBuildInputs = [ cmake pkgconfig extra-cmake-modules ];

--- a/pkgs/applications/editors/kdevelop5/kdevelop.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop.nix
@@ -9,7 +9,7 @@
 
 let
   pname = "kdevelop";
-  version = "5.1.1";
+  version = "5.1.2";
 
 in
 mkDerivation rec {
@@ -17,7 +17,7 @@ mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
-    sha256 = "0a01a4ffb2f01802cf4945521a3149a8f82c21fa8a97935991f1854b7db5d754";
+    sha256 = "af54e807847d145fe5f3eb55962ed0d22e6363c2bc6c32167e51ca4823c00ac7";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/editors/kdevelop5/kdevplatform.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevplatform.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, cmake, gettext, pkgconfig, extra-cmake-modules
+{ stdenv, fetchurl, cmake, gettext, pkgconfig, extra-cmake-modules
 , boost, subversion, apr, aprutil, kwindowsystem
 , qtscript, qtwebkit, grantlee, karchive, kconfig, kcoreaddons, kguiaddons, kiconthemes, ki18n
 , kitemmodels, kitemviews, kio, kparts, sonnet, kcmutils, knewstuff, knotifications
@@ -6,7 +6,7 @@
 
 let
   pname = "kdevplatform";
-  version = "5.1.1";
+  version = "5.1.2";
 
 in
 stdenv.mkDerivation rec {
@@ -14,16 +14,8 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://kde/stable/kdevelop/${version}/src/${name}.tar.xz";
-    sha256 = "3159440512b1373c1a4b35f401ba1f81217de9578372b45137af141eeda6e726";
+    sha256 = "e622ddad552a678baaf1166d5cbdc5fd1192d2324300c52ef2d25f1c6778664a";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "kdevplatform-project-selection.patch";
-      url = "https://cgit.kde.org/kdevplatform.git/patch/?id=da4c0fdfcf21dc2a8f48a2b1402213a32effd47a";
-      sha256 = "16ws8l6dciy2civjnsaj03ml2bzvg4a9g7gd4iyx4hprw65zrcxm";
-    })
-  ];
 
   nativeBuildInputs = [ cmake gettext pkgconfig extra-cmake-modules ];
 


### PR DESCRIPTION
###### Motivation for this change

New minor version.
Tested same change on release-17.03 branch and it works. Tested on master and it builds but I can't easily test that it works due to Qt version conflicts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

