### PR TITLE
k9copy: fix build with gcc6

### DIFF
--- a/pkgs/applications/video/k9copy/default.nix
+++ b/pkgs/applications/video/k9copy/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation rec {
     sha256 = "0dp06rwihks50c57bbv04d6bj2qc88isl91971r4lii2xp0qn7sg";
   };
 
+  patches = [
+    ./gcc6.patch
+  ];
+
   cmakeFlags = [
     "-DQT5_BUILD=ON"
     "-DCMAKE_MINIMUM_REQUIRED_VERSION=3.0"

--- a/pkgs/applications/video/k9copy/gcc6.patch
+++ b/pkgs/applications/video/k9copy/gcc6.patch
@@ -1,0 +1,26 @@
+diff --git c/src/backup/k9dvdbackup.cpp i/src/backup/k9dvdbackup.cpp
+index f5e4859..82fa392 100755
+--- c/src/backup/k9dvdbackup.cpp
++++ i/src/backup/k9dvdbackup.cpp
+@@ -907,7 +907,7 @@ k9Vobu * k9DVDBackup::remapOffset(uint32_t _sector,uint32_t *_offset,int _dir) {
+ 
+ 
+         if ((vobu1 !=NULL) && (vobu2!=NULL)) {
+-            *_offset = abs(vobu1->newSector - vobu2->newSector)  | maskOffset1 ;
++            *_offset = (vobu1->newSector - vobu2->newSector)  | maskOffset1 ;
+             *_offset |= maskOffset2;
+             return vobu2;
+         }
+diff --git c/src/backup/k9execcopy.cpp i/src/backup/k9execcopy.cpp
+index d59222c..35de923 100644
+--- c/src/backup/k9execcopy.cpp
++++ i/src/backup/k9execcopy.cpp
+@@ -306,7 +306,7 @@ void k9ExecCopy::createMkv(k9DVDTitle *_title,const QString &_filename,QMultiMap
+ 
+ #if QT_VERSION >= 0x050000
+     m_progressDialog=new QProgressDialog(k9Dialogs::getMainWidget() );
+-    m_progressDialog->setCancelButton(false);
++    m_progressDialog->setCancelButton(0);
+ 
+ #else
+     m_progressDialog=new KProgressDialog(k9Dialogs::getMainWidget() );


### PR DESCRIPTION
###### Motivation for this change
fixes build for k9copy.

Related: #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

