### PR TITLE
darwin attribute cleanup

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11837,53 +11837,8 @@ with pkgs;
 
   crda = callPackage ../os-specific/linux/crda { };
 
-  darwin = let
-    apple-source-releases = callPackage ../os-specific/darwin/apple-source-releases { };
-  in (apple-source-releases // rec {
-    cctools = callPackage ../os-specific/darwin/cctools/port.nix {
-      inherit libobjc;
-      stdenv = if stdenv.isDarwin then stdenv else libcxxStdenv;
-      inherit maloader;
-      xctoolchain = xcode.toolchain;
-    };
-
-    cf-private = callPackage ../os-specific/darwin/cf-private {
-      inherit (apple-source-releases) CF;
-      inherit osx_private_sdk;
-    };
-
-    maloader = callPackage ../os-specific/darwin/maloader {
-      inherit opencflite;
-    };
-
-    opencflite = callPackage ../os-specific/darwin/opencflite {};
-
-    swift-corefoundation = callPackage ../os-specific/darwin/swift-corefoundation {};
-
-    ios-cross = callPackage ../os-specific/darwin/ios-cross {
-      inherit (darwin) binutils;
-    };
-
-    xcode = callPackage ../os-specific/darwin/xcode {};
-
-    osx_private_sdk = callPackage ../os-specific/darwin/osx-private-sdk {};
-
-    security_tool = (newScope (darwin.apple_sdk.frameworks // darwin)) ../os-specific/darwin/security-tool {
-      Security-framework = darwin.apple_sdk.frameworks.Security;
-    };
-
-    binutils = callPackage ../os-specific/darwin/binutils { inherit cctools; };
-
-    apple_sdk = callPackage ../os-specific/darwin/apple-sdk {};
-
-    libobjc = apple-source-releases.objc4;
-
-    stubs = callPackages ../os-specific/darwin/stubs {};
-
-    usr-include = callPackage ../os-specific/darwin/usr-include {};
-
-    DarwinTools = callPackage ../os-specific/darwin/DarwinTools {};
-  });
+  # Darwin package set
+  darwin = callPackages ./darwin-packages.nix { };
 
   devicemapper = lvm2;
 

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -1,0 +1,54 @@
+{ pkgs, darwin, stdenv, callPackage, callPackages, newScope }:
+
+let
+  apple-source-releases = callPackage ../os-specific/darwin/apple-source-releases { };
+in
+
+(apple-source-releases // {
+
+  apple_sdk = callPackage ../os-specific/darwin/apple-sdk { };
+
+  binutils = callPackage ../os-specific/darwin/binutils {
+    inherit (darwin) cctools;
+  };
+
+  cctools = callPackage ../os-specific/darwin/cctools/port.nix {
+    inherit (darwin) libobjc maloader;
+    stdenv = if stdenv.isDarwin then stdenv else pkgs.libcxxStdenv;
+    xctoolchain = darwin.xcode.toolchain;
+  };
+
+  cf-private = callPackage ../os-specific/darwin/cf-private {
+    inherit (apple-source-releases) CF;
+    inherit (darwin) osx_private_sdk;
+  };
+
+  DarwinTools = callPackage ../os-specific/darwin/DarwinTools { };
+
+  maloader = callPackage ../os-specific/darwin/maloader {
+    inherit (darwin) opencflite;
+  };
+
+  ios-cross = callPackage ../os-specific/darwin/ios-cross {
+    inherit (darwin) binutils;
+  };
+
+  libobjc = apple-source-releases.objc4;
+
+  opencflite = callPackage ../os-specific/darwin/opencflite { };
+
+  osx_private_sdk = callPackage ../os-specific/darwin/osx-private-sdk { };
+
+  security_tool = (newScope (darwin.apple_sdk.frameworks // darwin)) ../os-specific/darwin/security-tool {
+    Security-framework = darwin.apple_sdk.frameworks.Security;
+  };
+
+  stubs = callPackages ../os-specific/darwin/stubs { };
+
+  swift-corefoundation = callPackage ../os-specific/darwin/swift-corefoundation { };
+
+  usr-include = callPackage ../os-specific/darwin/usr-include { };
+
+  xcode = callPackage ../os-specific/darwin/xcode { };
+
+})

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -6,6 +6,8 @@ in
 
 (apple-source-releases // {
 
+  callPackage = newScope (darwin.apple_sdk.frameworks // darwin);
+
   apple_sdk = callPackage ../os-specific/darwin/apple-sdk { };
 
   binutils = callPackage ../os-specific/darwin/binutils {
@@ -39,7 +41,7 @@ in
 
   osx_private_sdk = callPackage ../os-specific/darwin/osx-private-sdk { };
 
-  security_tool = (newScope (darwin.apple_sdk.frameworks // darwin)) ../os-specific/darwin/security-tool {
+  security_tool = darwin.callPackage ../os-specific/darwin/security-tool {
     Security-framework = darwin.apple_sdk.frameworks.Security;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Just some cleanup, use the fixpoint instead of rec and added `darwin.callPackage`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---



