### PR TITLE
misc pkgs: Adjust Perl dependencies

### DIFF
--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -1,6 +1,6 @@
 perl:
 
-{ buildInputs ? [], name, ... } @ attrs:
+{ nativeBuildInputs ? [], buildInputs ? [], name, ... } @ attrs:
 
 perl.stdenv.mkDerivation (
   {
@@ -27,6 +27,7 @@ perl.stdenv.mkDerivation (
   {
     name = "perl-" + name;
     builder = ./builder.sh;
+    nativeBuildInputs = nativeBuildInputs ++ [ perl ];
     buildInputs = buildInputs ++ [ perl ];
   }
 )

--- a/pkgs/development/tools/misc/autoconf/2.13.nix
+++ b/pkgs/development/tools/misc/autoconf/2.13.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
   nativebuildInputs = [ lzma ];
   buildInputs = [ m4 perl ];
 
+  configureFlags = [
+    "PERL=${perl}/bin/perl"
+    "M4=${m4}/bin/m4"
+  ];
+
   doCheck = true;
 
   # Don't fixup "#! /bin/sh" in Autoconf, otherwise it will use the

--- a/pkgs/development/tools/misc/autoconf/2.64.nix
+++ b/pkgs/development/tools/misc/autoconf/2.64.nix
@@ -10,6 +10,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ m4 perl ];
 
+  configureFlags = [
+    "PERL=${perl}/bin/perl"
+    "M4=${m4}/bin/m4"
+  ];
+
   # Work around a known issue in Cygwin.  See
   # http://thread.gmane.org/gmane.comp.sysutils.autoconf.bugs/6822 for
   # details.

--- a/pkgs/development/tools/misc/autoconf/default.nix
+++ b/pkgs/development/tools/misc/autoconf/default.nix
@@ -10,6 +10,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ m4 perl ];
 
+  configureFlags = [
+    "PERL=${perl}/bin/perl"
+    "M4=${m4}/bin/m4"
+  ];
+
   # Work around a known issue in Cygwin.  See
   # http://thread.gmane.org/gmane.comp.sysutils.autoconf.bugs/6822 for
   # details.

--- a/pkgs/development/tools/misc/automake/automake-1.15.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.15.x.nix
@@ -10,6 +10,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ perl autoconf ];
 
+  configureFlags = [
+    "AUTOCONF=${autoconf}/bin/autoconf"
+    "PERL=${perl}/bin/perl"
+  ];
+
   setupHook = ./setup-hook.sh;
 
   # Disable indented log output from Make, otherwise "make.test" will

--- a/pkgs/development/tools/misc/help2man/default.nix
+++ b/pkgs/development/tools/misc/help2man/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0lvp4306f5nq08f3snffs5pp1zwv8l35z6f5g0dds51zs6bzdv6l";
   };
 
-  nativeBuildInputs = [ makeWrapper gettext LocaleGettext ];
+  nativeBuildInputs = [ makeWrapper gettext perl LocaleGettext ];
   buildInputs = [ perl LocaleGettext ];
 
   doCheck = false;                                # target `check' is missing

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ perl help2man ];
   propagatedBuildInputs = [ m4 ];
 
+  configureFlags = [
+    "M4=${m4}/bin/m4"
+  ];
+
   # Don't fixup "#! /bin/sh" in Libtool, otherwise it will use the
   # "fixed" path in generated files!
   dontPatchShebangs = true;

--- a/pkgs/development/tools/misc/texinfo/5.2.nix
+++ b/pkgs/development/tools/misc/texinfo/5.2.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1njfwh2z34r2c4r0iqa7v24wmjzvsfyz4vplzry8ln3479lfywal";
   };
 
+  # TODO(@Ericson2314): Not sure whether Perl is actually needed at build-time.
+  nativeBuildInputs = [ perl ];
   buildInputs = [ perl xz.bin ]
     ++ optional interactive ncurses
     ++ optional doCheck procps; # for tests

--- a/pkgs/development/tools/misc/texinfo/6.3.nix
+++ b/pkgs/development/tools/misc/texinfo/6.3.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0fpr9kdjjl6nj2pc50k2zr7134hvqz8bi8pfqa7131a9lpzz6v14";
   };
 
+  # TODO(@Ericson2314): Not sure whether Perl is actually needed at build-time.
+  nativeBuildInputs = [ perl ];
   buildInputs = [ perl xz ]
     ++ optionals stdenv.isSunOS [ libiconv gawk ]
     ++ optional interactive ncurses


### PR DESCRIPTION
###### Motivation for this change

In general, it's hard to tell when Perl is actually needed at build-time, vs when it isn't but the configure script wants to run it anyways to figure out something (version, presence of perl module, etc).

@globin @fpletz This is neither essential or beautiful, but should be harmless (built it some number of rebase ago) and was part of https://github.com/NixOS/nixpkgs/pull/26805. Your call whether you want it in staging in time for 17.09.

###### Things done

I'm kicking off some local stdenv builds now.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built stdenv on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

