### PR TITLE
dia: enable on darwin, 0.97 -> 2017-06-22

### DIFF
--- a/pkgs/applications/graphics/dia/default.nix
+++ b/pkgs/applications/graphics/dia/default.nix
@@ -45,6 +45,6 @@ stdenv.mkDerivation rec {
     description = "Gnome Diagram drawing software";
     homepage = http://live.gnome.org/Dia;
     maintainers = with stdenv.lib.maintainers; [raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/applications/graphics/dia/default.nix
+++ b/pkgs/applications/graphics/dia/default.nix
@@ -11,11 +11,6 @@ stdenv.mkDerivation rec {
     sha256 = "0d3x6w0l6fwd0l8xx06y1h56xf8ss31yzia3a6xr9y28xx44x492";
   };
 
-  correctPersistence = fetchurl {
-    url = https://launchpadlibrarian.net/132677658/persistence;
-    sha256 = "1rv6zv9i03bna4bdp1wzn72lg7kdwi900y1izdq0imibi54nxjsk";
-  };
-
   buildInputs =
     [ gtk2 perlXMLParser libxml2 gettext python libxml2Python docbook5
       libxslt docbook_xsl libart_lgpl
@@ -31,14 +26,6 @@ stdenv.mkDerivation rec {
   # It have no reasons to exist in a redistribuable package
   postInstall = ''
     rm $out/share/icons/hicolor/icon-theme.cache
-
-    cd "$out"/bin/
-    mv dia .dia-wrapped
-    echo '#! ${stdenv.shell}' >> dia
-    echo 'test -f "$HOME/.dia/persistence" || cp ${correctPersistence} "$HOME/.dia/persistence" ' >> dia
-    echo 'chmod u+rw "$HOME/.dia/persistence" ' >> dia
-    echo "\"$out/bin/"'.dia-wrapped" "$@"' >> dia
-    chmod a+x dia
   '';
 
   meta = {

--- a/pkgs/applications/graphics/dia/default.nix
+++ b/pkgs/applications/graphics/dia/default.nix
@@ -1,26 +1,32 @@
-{stdenv, fetchurl, gtk2, pkgconfig, perl, perlXMLParser, libxml2, gettext
-, python, libxml2Python, docbook5, docbook_xsl, libxslt, intltool, libart_lgpl
-, withGNOME ? false, libgnomeui }:
+{ stdenv, fetchgit, autoconf, automake, libtool, gtk2, pkgconfig, perl,
+perlXMLParser, libxml2, gettext, python, libxml2Python, docbook5, docbook_xsl,
+libxslt, intltool, libart_lgpl, withGNOME ? false, libgnomeui,
+gtk-mac-integration }:
 
 stdenv.mkDerivation rec {
-  name = "dia-${minVer}.3";
-  minVer = "0.97";
+  name = "dia-${version}";
+  version = "0.97.3.20170622";
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/dia/${minVer}/${name}.tar.xz";
-    sha256 = "0d3x6w0l6fwd0l8xx06y1h56xf8ss31yzia3a6xr9y28xx44x492";
+  src = fetchgit {
+    url = git://git.gnome.org/dia;
+    rev = "b86085dfe2b048a2d37d587adf8ceba6fb8bc43c";
+    sha256 = "1fyxfrzdcs6blxhkw3bcgkksaf3byrsj4cbyrqgb4869k3ynap96";
   };
 
   buildInputs =
     [ gtk2 perlXMLParser libxml2 gettext python libxml2Python docbook5
-      libxslt docbook_xsl libart_lgpl
-    ] ++ stdenv.lib.optional withGNOME libgnomeui;
+      libxslt docbook_xsl libart_lgpl ]
+      ++ stdenv.lib.optional withGNOME libgnomeui
+      ++ stdenv.lib.optional stdenv.isDarwin gtk-mac-integration;
 
-  nativeBuildInputs = [ pkgconfig intltool perl ];
+  nativeBuildInputs = [ autoconf automake libtool pkgconfig intltool perl ];
 
+  preConfigure = ''
+    NOCONFIGURE=1 ./autogen.sh # autoreconfHook is not enough
+  '';
   configureFlags = stdenv.lib.optionalString withGNOME "--enable-gnome";
 
-  patches = [ ];
+  hardeningDisable = [ "format" ];
 
   # This file should normally require a gtk-update-icon-cache -q /usr/share/icons/hicolor command
   # It have no reasons to exist in a redistribuable package


### PR DESCRIPTION
###### Motivation for this change

Releases of Dia have stopped in 2014, but there are some ongoing improvements in git. Darwin support is already available in 0.97.3, but there is a bug with colors that is fixed in master.
I also found that "persistence" bug was fixed between 0.97.2 and 0.97.3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @7c6f434c