### PR TITLE
deer: init at 1.4

### DIFF
--- a/pkgs/shells/zsh-deer/default.nix
+++ b/pkgs/shells/zsh-deer/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, perl }:
+
+let
+  version = "1.4";
+  name = "deer-${version}";
+in stdenv.mkDerivation {
+  inherit name;
+
+  src = fetchFromGitHub {
+    owner = "Vifon";
+    repo = "deer";
+    rev = "v${version}";
+    sha256 = "1xnbnbi0zk2xsyn8dqsmyxqlfnl36pb1wwibnlp0dxixw6sfymyl";
+  };
+
+  prePatch = ''
+    sed -i '157s/perl/'\
+    "$(echo ${perl}/bin/perl | sed 's/\//\\\//g')"'/' \
+    deer
+  '';
+
+  patches = [ ./realpath.patch ];
+
+  installPhase = ''
+    mkdir -p $out/share/zsh/site-functions/
+    cp deer $out/share/zsh/site-functions/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Ranger-like file navigation for zsh";
+    homepage = "https://github.com/Vifon/deer";
+    license = licenses.gpl3Plus;
+    maintainers = maintainers.vyp;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/shells/zsh-deer/default.nix
+++ b/pkgs/shells/zsh-deer/default.nix
@@ -14,9 +14,8 @@ in stdenv.mkDerivation {
   };
 
   prePatch = ''
-    sed -i '157s/perl/'\
-    "$(echo ${perl}/bin/perl | sed 's/\//\\\//g')"'/' \
-    deer
+    substituteInPlace deer \
+      --replace " perl " " ${perl}/bin/perl "
   '';
 
   patches = [ ./realpath.patch ];

--- a/pkgs/shells/zsh-deer/realpath.patch
+++ b/pkgs/shells/zsh-deer/realpath.patch
@@ -1,0 +1,28 @@
+From ceadb2f11119143af4f590ea6b05a531483219b5 Mon Sep 17 00:00:00 2001
+From: xd1le <elisp.vim@gmail.com>
+Date: Wed, 30 Aug 2017 17:27:20 +1000
+Subject: [PATCH] use realpath instead of python to calculate relative path
+
+---
+ deer | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/deer b/deer
+index 3d89dea..804a871 100644
+--- a/deer
++++ b/deer
+@@ -259,10 +259,7 @@ deer-get-relative()
+ {
+     local TMP
+     TMP=${1:-${DEER_DIRNAME%/}/$DEER_BASENAME[$DEER_DIRNAME]}
+-    TMP="`python -c '
+-import sys, os
+-print(os.path.relpath(sys.argv[1], sys.argv[2]))
+-' $TMP ${DEER_STARTDIR:-$PWD}`"
++    TMP="`realpath --relative-to=${DEER_STARTDIR:-$PWD} $TMP`"
+     print -R $TMP:q
+ }
+ 
+-- 
+2.14.1
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1597,6 +1597,8 @@ with pkgs;
 
   debootstrap = callPackage ../tools/misc/debootstrap { };
 
+  deer = callPackage ../shells/zsh-deer { };
+
   detox = callPackage ../tools/misc/detox { };
 
   devilspie2 = callPackage ../applications/misc/devilspie2 {


### PR DESCRIPTION
I wrote the patch. Unfortunately it's Nix specific because upstream
rejected it because Ubuntu Trusty's version of realpath doesn't seem to
have the `--relative-to` option. (Upstream used to use realpath before).
But for Nix, our version of realpath is recent enough. Also, upstream
will probably use realpath again anyway in May 2019 when Ubuntu Trusty
becomes unsupported, so this patch should probably be used.

###### Motivation for this change

I want to use this

- https://github.com/Vifon/deer

I thought about putting it under `pkgs/applications/misc` because that's where ranger is, and this is inspired by ranger, but this isn't really an 'application' like ranger is, it's a zsh function, so I decided to place it under `pkgs/shells/zsh-deer` instead.

I'm not sure how darwin would handle the use of `realpath` (I don't use it)? Will it just work, or should I be using `${coreutils}/bin/realpath` instead?

Also, for the prePatch phase, I tried to do the following instead because I thought it would read better, but it didn't work, it said unknown option to sed command s (meaning probably the slashes didn't get escaped properly):

``` nix
{
  prePatch = ''
    sed -i '157s/perl/'\
    ${builtins.replaceStrings ["/"] ["\\/"] "${perl}/bin/perl"}'/' \
    deer
  '';
}
```

But I don't know what I'm doing wrong? For example:


``` nix-repl
nix-repl> builtins.replaceStrings ["/"] ["\\/"] "/nix/store/hash/foo/bar"
"\\/nix\\/store\\/hash\\/foo\\/bar"

```

The output seems to be correct in that it displays a string which should eventually evaluate to a literal `\/nix\/store\/hash\/foo\/bar` value, so it should be properly escaped for sed, right?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

