### PR TITLE
mate: add the MATE desktop environment

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -20,6 +20,7 @@ in
   imports = [
     ./none.nix ./xterm.nix ./xfce.nix ./plasma5.nix ./lumina.nix
     ./lxqt.nix ./enlightenment.nix ./gnome3.nix ./kodi.nix ./maxx.nix
+    ./mate.nix
   ];
 
   options = {

--- a/nixos/modules/services/x11/desktop-managers/mate.nix
+++ b/nixos/modules/services/x11/desktop-managers/mate.nix
@@ -1,0 +1,79 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  # Remove packages of ys from xs, based on their names
+  removePackagesByName = xs: ys:
+    let
+      pkgName = drv: (builtins.parseDrvName drv.name).name;
+      ysNames = map pkgName ys;
+    in
+      filter (x: !(builtins.elem (pkgName x) ysNames)) xs;
+
+  xcfg = config.services.xserver;
+  cfg = xcfg.desktopManager.mate;
+
+in
+
+{
+  options = {
+
+    services.xserver.desktopManager.mate.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable the MATE desktop environment";
+    };
+
+    environment.mate.excludePackages = mkOption {
+      default = [];
+      example = literalExample "[ pkgs.mate.mate-terminal pkgs.mate.pluma ]";
+      type = types.listOf types.package;
+      description = "Which MATE packages to exclude from the default environment";
+    };
+
+  };
+
+  config = mkIf (xcfg.enable && cfg.enable) {
+
+    services.xserver.desktopManager.session = singleton {
+      name = "mate";
+      bgSupport = true;
+      start = ''
+        # Set GTK_DATA_PREFIX so that GTK+ can find the themes
+        export GTK_DATA_PREFIX=${config.system.path}
+
+        # Find theme engines
+        export GTK_PATH=${config.system.path}/lib/gtk-3.0:${config.system.path}/lib/gtk-2.0
+
+        export XDG_MENU_PREFIX=mate
+
+        # Find the mouse
+        export XCURSOR_PATH=~/.icons:${config.system.path}/share/icons
+
+        # Update user dirs as described in http://freedesktop.org/wiki/Software/xdg-user-dirs/
+        ${pkgs.xdg-user-dirs}/bin/xdg-user-dirs-update
+
+        ${pkgs.mate.mate-session-manager}/bin/mate-session &
+        waitPID=$!
+      '';
+    };
+
+    environment.systemPackages =
+      pkgs.mate.basePackages ++
+      (removePackagesByName
+        pkgs.mate.extraPackages
+        config.environment.mate.excludePackages);
+
+    services.dbus.packages = [
+      pkgs.gnome3.dconf
+      pkgs.at_spi2_core
+    ];
+
+    services.gnome3.gnome-keyring.enable = true;
+
+    environment.pathsToLink = [ "/share" ];    
+  };
+
+}

--- a/nixos/modules/services/x11/desktop-managers/mate.nix
+++ b/nixos/modules/services/x11/desktop-managers/mate.nix
@@ -60,7 +60,10 @@ in
       '';
     };
 
-    environment.systemPackages =
+    environment.systemPackages = [
+      pkgs.hicolor_icon_theme
+      pkgs.mate.mate-icon-theme
+    ]  ++
       pkgs.mate.basePackages ++
       (removePackagesByName
         pkgs.mate.extraPackages
@@ -73,7 +76,7 @@ in
 
     services.gnome3.gnome-keyring.enable = true;
 
-    environment.pathsToLink = [ "/share" ];    
+    environment.pathsToLink = [ "/share" ];
   };
 
 }

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -10,6 +10,7 @@ rec {
   };
   engrampa = callPackage ./engrampa { };
   eom = callPackage ./eom { };
+  libmatekbd = callPackage ./libmatekbd { };
   mate-common = callPackage ./mate-common { };
   mate-desktop = callPackage ./mate-desktop { };
   mate-icon-theme = callPackage ./mate-icon-theme { };
@@ -20,6 +21,7 @@ rec {
 
   basePackages = [
     caja
+    libmatekbd
     mate-common
     mate-desktop
     mate-icon-theme

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -17,6 +17,7 @@ rec {
   mate-desktop = callPackage ./mate-desktop { };
   mate-icon-theme = callPackage ./mate-icon-theme { };
   mate-icon-theme-faenza = callPackage ./mate-icon-theme-faenza { };
+  mate-menus = callPackage ./mate-menus { };
   mate-terminal = callPackage ./mate-terminal { };
   mate-themes = callPackage ./mate-themes { };
   pluma = callPackage ./pluma { };
@@ -29,6 +30,7 @@ rec {
     mate-common
     mate-desktop
     mate-icon-theme
+    mate-menus
     mate-themes
   ];
 

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -12,6 +12,7 @@ rec {
   eom = callPackage ./eom { };
   libmatekbd = callPackage ./libmatekbd { };
   libmatemixer = callPackage ./libmatemixer { };
+  libmateweather = callPackage ./libmateweather { };
   mate-common = callPackage ./mate-common { };
   mate-desktop = callPackage ./mate-desktop { };
   mate-icon-theme = callPackage ./mate-icon-theme { };
@@ -24,6 +25,7 @@ rec {
     caja
     libmatekbd
     libmatemixer
+    libmateweather
     mate-common
     mate-desktop
     mate-icon-theme

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -15,6 +15,7 @@ rec {
   libmateweather = callPackage ./libmateweather { };
   marco = callPackage ./marco { };
   mate-common = callPackage ./mate-common { };
+  mate-control-center = callPackage ./mate-control-center { };
   mate-desktop = callPackage ./mate-desktop { };
   mate-icon-theme = callPackage ./mate-icon-theme { };
   mate-icon-theme-faenza = callPackage ./mate-icon-theme-faenza { };
@@ -31,6 +32,7 @@ rec {
     libmateweather
     marco
     mate-common
+    mate-control-center
     mate-desktop
     mate-icon-theme
     mate-menus

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -1,57 +1,62 @@
-{ callPackage, pkgs }:
+{ pkgs, newScope }:
 
-rec {
+let
+  callPackage = newScope self;
 
-  atril = callPackage ./atril { };
-  caja = callPackage ./caja { };
-  caja-extensions = callPackage ./caja-extensions { };
-  cajaWithExtensions = callPackage ./caja/cajaWithExtensions.nix {
-    extensions = [ caja-extensions ];
-  };
-  engrampa = callPackage ./engrampa { };
-  eom = callPackage ./eom { };
-  libmatekbd = callPackage ./libmatekbd { };
-  libmatemixer = callPackage ./libmatemixer { };
-  libmateweather = callPackage ./libmateweather { };
-  marco = callPackage ./marco { };
-  mate-common = callPackage ./mate-common { };
-  mate-control-center = callPackage ./mate-control-center { };
-  mate-desktop = callPackage ./mate-desktop { };
-  mate-icon-theme = callPackage ./mate-icon-theme { };
-  mate-icon-theme-faenza = callPackage ./mate-icon-theme-faenza { };
-  mate-menus = callPackage ./mate-menus { };
-  mate-panel = callPackage ./mate-panel { };
-  mate-session-manager = callPackage ./mate-session-manager { };
-  mate-settings-daemon = callPackage ./mate-settings-daemon { };
-  mate-terminal = callPackage ./mate-terminal { };
-  mate-themes = callPackage ./mate-themes { };
-  pluma = callPackage ./pluma { };
+  self = rec {
 
-  basePackages = [
-    caja
-    libmatekbd
-    libmatemixer
-    libmateweather
-    marco
-    mate-common
-    mate-control-center
-    mate-desktop
-    mate-icon-theme
-    mate-menus
-    mate-panel
-    mate-session-manager
-    mate-settings-daemon
-    mate-themes
-  ];
+    atril = callPackage ./atril { };
+    caja = callPackage ./caja { };
+    caja-extensions = callPackage ./caja-extensions { };
+    cajaWithExtensions = callPackage ./caja/cajaWithExtensions.nix {
+      extensions = [ caja-extensions ];
+    };
+    engrampa = callPackage ./engrampa { };
+    eom = callPackage ./eom { };
+    libmatekbd = callPackage ./libmatekbd { };
+    libmatemixer = callPackage ./libmatemixer { };
+    libmateweather = callPackage ./libmateweather { };
+    marco = callPackage ./marco { };
+    mate-common = callPackage ./mate-common { };
+    mate-control-center = callPackage ./mate-control-center { };
+    mate-desktop = callPackage ./mate-desktop { };
+    mate-icon-theme = callPackage ./mate-icon-theme { };
+    mate-icon-theme-faenza = callPackage ./mate-icon-theme-faenza { };
+    mate-menus = callPackage ./mate-menus { };
+    mate-panel = callPackage ./mate-panel { };
+    mate-session-manager = callPackage ./mate-session-manager { };
+    mate-settings-daemon = callPackage ./mate-settings-daemon { };
+    mate-terminal = callPackage ./mate-terminal { };
+    mate-themes = callPackage ./mate-themes { };
+    pluma = callPackage ./pluma { };
 
-  extraPackages = [
-    atril
-    cajaWithExtensions
-    engrampa
-    eom
-    mate-icon-theme-faenza
-    mate-terminal
-    pluma
-  ];
+    basePackages = [
+      caja
+      libmatekbd
+      libmatemixer
+      libmateweather
+      marco
+      mate-common
+      mate-control-center
+      mate-desktop
+      mate-icon-theme
+      mate-menus
+      mate-panel
+      mate-session-manager
+      mate-settings-daemon
+      mate-themes
+    ];
+
+    extraPackages = [
+      atril
+      cajaWithExtensions
+      engrampa
+      eom
+      mate-icon-theme-faenza
+      mate-terminal
+      pluma
+    ];
   
-}
+  };
+
+in self

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -21,6 +21,7 @@ rec {
   mate-icon-theme-faenza = callPackage ./mate-icon-theme-faenza { };
   mate-menus = callPackage ./mate-menus { };
   mate-panel = callPackage ./mate-panel { };
+  mate-session-manager = callPackage ./mate-session-manager { };
   mate-settings-daemon = callPackage ./mate-settings-daemon { };
   mate-terminal = callPackage ./mate-terminal { };
   mate-themes = callPackage ./mate-themes { };
@@ -38,6 +39,7 @@ rec {
     mate-icon-theme
     mate-menus
     mate-panel
+    mate-session-manager
     mate-settings-daemon
     mate-themes
   ];

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -1,5 +1,7 @@
 { callPackage, pkgs }:
+
 rec {
+
   atril = callPackage ./atril { };
   caja = callPackage ./caja { };
   caja-extensions = callPackage ./caja-extensions { };
@@ -8,11 +10,30 @@ rec {
   };
   engrampa = callPackage ./engrampa { };
   eom = callPackage ./eom { };
-  pluma = callPackage ./pluma { };
   mate-common = callPackage ./mate-common { };
   mate-desktop = callPackage ./mate-desktop { };
   mate-icon-theme = callPackage ./mate-icon-theme { };
   mate-icon-theme-faenza = callPackage ./mate-icon-theme-faenza { };
   mate-terminal = callPackage ./mate-terminal { };
   mate-themes = callPackage ./mate-themes { };
+  pluma = callPackage ./pluma { };
+
+  basePackages = [
+    caja
+    mate-common
+    mate-desktop
+    mate-icon-theme
+    mate-themes
+  ];
+
+  extraPackages = [
+    atril
+    cajaWithExtensions
+    engrampa
+    eom
+    mate-icon-theme-faenza
+    mate-terminal
+    pluma
+  ];
+  
 }

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -13,6 +13,7 @@ rec {
   libmatekbd = callPackage ./libmatekbd { };
   libmatemixer = callPackage ./libmatemixer { };
   libmateweather = callPackage ./libmateweather { };
+  marco = callPackage ./marco { };
   mate-common = callPackage ./mate-common { };
   mate-desktop = callPackage ./mate-desktop { };
   mate-icon-theme = callPackage ./mate-icon-theme { };
@@ -27,6 +28,7 @@ rec {
     libmatekbd
     libmatemixer
     libmateweather
+    marco
     mate-common
     mate-desktop
     mate-icon-theme

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -11,6 +11,7 @@ rec {
   engrampa = callPackage ./engrampa { };
   eom = callPackage ./eom { };
   libmatekbd = callPackage ./libmatekbd { };
+  libmatemixer = callPackage ./libmatemixer { };
   mate-common = callPackage ./mate-common { };
   mate-desktop = callPackage ./mate-desktop { };
   mate-icon-theme = callPackage ./mate-icon-theme { };
@@ -22,6 +23,7 @@ rec {
   basePackages = [
     caja
     libmatekbd
+    libmatemixer
     mate-common
     mate-desktop
     mate-icon-theme

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -19,6 +19,7 @@ rec {
   mate-icon-theme = callPackage ./mate-icon-theme { };
   mate-icon-theme-faenza = callPackage ./mate-icon-theme-faenza { };
   mate-menus = callPackage ./mate-menus { };
+  mate-settings-daemon = callPackage ./mate-settings-daemon { };
   mate-terminal = callPackage ./mate-terminal { };
   mate-themes = callPackage ./mate-themes { };
   pluma = callPackage ./pluma { };
@@ -33,6 +34,7 @@ rec {
     mate-desktop
     mate-icon-theme
     mate-menus
+    mate-settings-daemon
     mate-themes
   ];
 

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -20,6 +20,7 @@ rec {
   mate-icon-theme = callPackage ./mate-icon-theme { };
   mate-icon-theme-faenza = callPackage ./mate-icon-theme-faenza { };
   mate-menus = callPackage ./mate-menus { };
+  mate-panel = callPackage ./mate-panel { };
   mate-settings-daemon = callPackage ./mate-settings-daemon { };
   mate-terminal = callPackage ./mate-terminal { };
   mate-themes = callPackage ./mate-themes { };
@@ -36,6 +37,7 @@ rec {
     mate-desktop
     mate-icon-theme
     mate-menus
+    mate-panel
     mate-settings-daemon
     mate-themes
   ];

--- a/pkgs/desktops/mate/libmatekbd/default.nix
+++ b/pkgs/desktops/mate/libmatekbd/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, pkgconfig, intltool, gtk3, libxklavier }:
+
+stdenv.mkDerivation rec {
+  name = "libmatekbd-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "2";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "030bl18qbjm7l92bp1bhs7v82bp8j3mv7c1j1a4gd89iz4611pq3";
+  };
+
+  nativeBuildInputs = [ pkgconfig intltool ];
+
+  buildInputs = [ gtk3 libxklavier ];
+
+  meta = with stdenv.lib; {
+    description = "Keyboard management library for MATE";
+    homepage = https://github.com/mate-desktop/libmatekbd;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/desktops/mate/libmatemixer/default.nix
+++ b/pkgs/desktops/mate/libmatemixer/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, pkgconfig, intltool, glib
+, alsaSupport ? stdenv.isLinux, alsaLib
+, pulseaudioSupport ? stdenv.config.pulseaudio or true, libpulseaudio
+, ossSupport ? false
+ }:
+
+stdenv.mkDerivation rec {
+  name = "libmatemixer-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "0";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "09vyxnlnalws318gsafdfi5c6jwpp92pbafn1ddlqqds23ihk4mr";
+  };
+
+  nativeBuildInputs = [ pkgconfig intltool ];
+
+  buildInputs = [ glib ]
+    ++ stdenv.lib.optional alsaSupport alsaLib
+    ++ stdenv.lib.optional pulseaudioSupport libpulseaudio;
+
+  configureFlags = stdenv.lib.optional ossSupport "--enable-oss";
+
+  meta = with stdenv.lib; {
+    description = "Mixer library for MATE";
+    homepage = https://github.com/mate-desktop/libmatemixer;
+    license = with licenses; [ gpl2 lgpl2 ];
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/desktops/mate/libmateweather/default.nix
+++ b/pkgs/desktops/mate/libmateweather/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, pkgconfig, intltool, gtk3, libsoup, tzdata }:
+
+stdenv.mkDerivation rec {
+  name = "libmateweather-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "1";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "0z6vfh42fv9rqjrraqfpf6h9nd9h662bxy3l3r48j19xvxrwmx3a";
+  };
+
+  nativeBuildInputs = [ pkgconfig intltool ];
+
+  buildInputs = [ gtk3 libsoup tzdata ];
+
+  configureFlags = [
+    "--with-zoneinfo-dir=${tzdata}/share/zoneinfo"
+    "--enable-locations-compression"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Library to access weather information from online services for MATE";
+    homepage = https://github.com/mate-desktop/libmateweather;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/desktops/mate/marco/default.nix
+++ b/pkgs/desktops/mate/marco/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, libcanberra_gtk3, libgtop, gnome2, gnome3, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "marco-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "1";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "0lwbp9wyd66hl5d7g272l8g3k1pb9s4s2p9fb04750a58w87d8k5";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    itstool
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    libxml2
+    libcanberra_gtk3
+    libgtop
+    gnome2.startup_notification
+    gnome3.gtk
+    gnome3.zenity
+  ];
+  
+  meta = with stdenv.lib; {
+    description = "MATE default window manager";
+    homepage = https://github.com/mate-desktop/marco;
+    license = [ licenses.gpl2 ];
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/desktops/mate/mate-control-center/default.nix
+++ b/pkgs/desktops/mate/mate-control-center/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, dbus_glib, libxklavier, libcanberra_gtk3, desktop_file_utils, gnome3, mate, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "mate-control-center-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "2";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "0flnn0h8f5aqyccwrlv7qxchvr3kqmlfdga6wq28d55zkpv5m7dl";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    itstool
+    desktop_file_utils
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    libxml2
+    dbus_glib
+    libxklavier
+    libcanberra_gtk3
+    gnome3.gtk
+    gnome3.dconf
+    mate.mate-desktop
+    mate.libmatekbd
+    mate.mate-menus
+    mate.marco
+    mate.mate-settings-daemon
+  ];
+
+  configureFlags = "--disable-update-mimedb";
+
+  meta = with stdenv.lib; {
+    description = "Utilities to configure the MATE desktop";
+    homepage = https://github.com/mate-desktop/mate-control-center;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/desktops/mate/mate-desktop/default.nix
+++ b/pkgs/desktops/mate/mate-desktop/default.nix
@@ -11,8 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "12iv2y4dan962fs7vkkxbjkp77pbvjnwfa43ggr0zkdsc3ydjbbg";
   };
 
-  propagatedUserEnvPkgs = [
-    gnome3.gnome_themes_standard
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    wrapGAppsHook
   ];
 
   buildInputs = [
@@ -21,10 +23,8 @@ stdenv.mkDerivation rec {
     gnome3.defaultIconTheme
   ];
 
-  nativeBuildInputs = [
-    pkgconfig
-    intltool
-    wrapGAppsHook
+  propagatedUserEnvPkgs = [
+    gnome3.gnome_themes_standard
   ];
 
   meta = with stdenv.lib; {
@@ -32,5 +32,6 @@ stdenv.mkDerivation rec {
     homepage = http://mate-desktop.org;
     license = licenses.gpl2;
     platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
   };
 }

--- a/pkgs/desktops/mate/mate-icon-theme/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, iconnamingutils, hicolor_icon_theme }:
+{ stdenv, fetchurl, pkgconfig, intltool, iconnamingutils, librsvg, hicolor_icon_theme, gtk3 }:
 
 stdenv.mkDerivation rec {
   name = "mate-icon-theme-${version}";
@@ -13,8 +13,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool iconnamingutils ];
 
-  buildInputs = [ hicolor_icon_theme ];
-
+  buildInputs = [ librsvg hicolor_icon_theme ];
+  
+  postInstall = ''
+    for theme in "$out"/share/icons/*; do
+      "${gtk3.out}/bin/gtk-update-icon-cache" "$theme"
+    done
+  '';
+  
   meta = {
     description = "Icon themes from MATE";
     homepage = http://mate-desktop.org;

--- a/pkgs/desktops/mate/mate-menus/default.nix
+++ b/pkgs/desktops/mate/mate-menus/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, pkgconfig, intltool, glib, gobjectIntrospection, python }:
+
+stdenv.mkDerivation rec {
+  name = "mate-menus-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "0";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "05kyr37xqv6hm1rlvnqd5ng0x1n883brqynkirkk5drl56axnz7h";
+  };
+
+  nativeBuildInputs = [ pkgconfig intltool ];
+
+  buildInputs = [ glib gobjectIntrospection python ];
+
+  makeFlags = [
+    "INTROSPECTION_GIRDIR=$(out)/share/gir-1.0/"
+    "INTROSPECTION_TYPELIBDIR=$(out)/lib/girepository-1.0"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Menu system for MATE";
+    homepage = https://github.com/mate-desktop/mate-menus;
+    license = with licenses; [ gpl2 lgpl2 ];
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/desktops/mate/mate-panel/default.nix
+++ b/pkgs/desktops/mate/mate-panel/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, glib, dbus_glib, libwnck3, librsvg, libxml2, gnome3, mate, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "mate-panel-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "4";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "1n565ff1n7jrfx223i3cl3m69wjda506nvbn8gra7m1jwdfzpbw1";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    itstool
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    dbus_glib
+    libwnck3
+    librsvg
+    libxml2
+    gnome3.gtk
+    gnome3.dconf
+    mate.libmateweather
+    mate.mate-desktop
+    mate.mate-menus
+  ];
+
+  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
+
+  makeFlags = [
+    "INTROSPECTION_GIRDIR=$(out)/share/gir-1.0/"
+    "INTROSPECTION_TYPELIBDIR=$(out)/lib/girepository-1.0"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "The MATE panel";
+    homepage = https://github.com/mate-desktop/mate-panel;
+    license = with licenses; [ gpl2 lgpl2 ];
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/desktops/mate/mate-session-manager/default.nix
+++ b/pkgs/desktops/mate/mate-session-manager/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, dbus_glib, systemd, xtrans, xorg, gnome3, mate, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "mate-session-manager-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "1";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "0i0xq6041x2qmb26x9bawx0qpfkgjn6x9w3phnm9s7rc4s0z20ll";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    dbus_glib
+    systemd
+    xtrans
+    xorg.libSM
+    gnome3.gtk3
+    gnome3.gsettings_desktop_schemas
+    mate.mate-desktop
+  ];
+
+  meta = with stdenv.lib; {
+    description = "MATE Desktop session manager";
+    homepage = https://github.com/mate-desktop/mate-session-manager;
+    license = with licenses; [ gpl2 lgpl2 ];
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/desktops/mate/mate-settings-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-settings-daemon/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchurl, pkgconfig, intltool, glib, dbus_glib, libxklavier, libcanberra_gtk3, libnotify, nss, polkit, gnome3, mate, wrapGAppsHook
+, pulseaudioSupport ? stdenv.config.pulseaudio or true, libpulseaudio
+}:
+
+stdenv.mkDerivation rec {
+  name = "mate-settings-daemon-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "1";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "07b2jkxqv07njdrgkdck93d872p6lch1lrvi7ydnpicspg3rfid6";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    dbus_glib
+    libxklavier
+    libcanberra_gtk3
+    libnotify
+    nss
+    polkit
+    gnome3.gtk
+    gnome3.dconf
+    mate.mate-desktop
+    mate.libmatekbd
+    mate.libmatemixer
+  ] ++ stdenv.lib.optional pulseaudioSupport libpulseaudio;
+
+  configureFlags = stdenv.lib.optional pulseaudioSupport "--enable-pulse";
+
+  meta = with stdenv.lib; {
+    description = "MATE settings daemon";
+    homepage = https://github.com/mate-desktop/mate-settings-daemon;
+    license = with licenses; [ gpl2 lgpl21 ];
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17821,9 +17821,7 @@ with pkgs;
     inherit (lib) makeScope;
   });
 
-  mate = recurseIntoAttrs (callPackage ../desktops/mate {
-    callPackage = newScope pkgs.mate;
-  });
+  mate = recurseIntoAttrs (callPackage ../desktops/mate { });
 
   maxx = callPackage ../desktops/maxx { };
 


### PR DESCRIPTION
###### Motivation for this change

Currently `mate` is small set of packages from the [MATE desktop environment](http://mate-desktop.org/). This PR adds a few more packages, and a desktop option used by the `X11` service. With this the user will be able to log in to the MATE desktop environment.

Tested with `nixos-rebuild build-vm`.

Changes:
- `mate`: organize packages in base and extra
- `mate-desktop`: add maintainer
- `libmatekbd`: init at 1.18.2
- `libmatemixer`: init at 1.18.0
- `libmateweather`: init at 1.18.1
- `mate-menus`: init at 1.18.0
- `marco`: init at 1.18.1
- `mate-settings-daemon`: init at 1.18.1
- `mate-control-center`: init at 1.18.2
- `mate-panel`: init at 1.18.4
- `mate-session-manager`: init at 1.18.1
- `mate`: add the MATE desktop environment

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).