### PR TITLE
vscode-extension-ms-vscode-cpptools: Init at 0.12.3

### DIFF
--- a/pkgs/misc/vscode-extensions/cpptools/default.nix
+++ b/pkgs/misc/vscode-extensions/cpptools/default.nix
@@ -1,0 +1,128 @@
+{ stdenv, lib, fetchurl, vscode-utils, unzip, dos2unix, mono46, clang-tools, writeScript
+, gdbUseFixed ? true, gdb # The gdb default setting will be fixed to specified. Use version from `PATH` otherwise. 
+}:
+
+assert gdbUseFixed -> null != gdb;
+
+/*
+  Note that this version of the extension still has some nix specific issues
+  which could not be fixed merely by patching (inside a C# dll).
+
+  In particular, the debugger requires either gnome-terminal or xterm. However
+  instead of looking for the terminal executable in `PATH`, for any linux platform
+  the dll uses an hardcoded path to one of these.
+
+  So, in order for debugging to work properly, you merely need to create symlinks
+  to one of these terminals at the appropriate location.
+
+  The good news is the the utility library is open source and with some effort
+  we could build a patched version ourselves. See:
+
+  <https://github.com/Microsoft/MIEngine/blob/2885386dc7f35e0f1e44827269341e786361f28e/src/MICore/TerminalLauncher.cs#L156>
+
+  Also, the extension should eventually no longer require an external terminal. See:
+
+  <https://github.com/Microsoft/vscode-cpptools/issues/35>
+
+  Once the symbolic link temporary solution taken, everything shoud run smootly.
+*/
+
+let
+  gdbDefaultsTo = if gdbUseFixed then "${gdb}/bin/gdb" else "gdb";
+
+  langComponentBinaries = stdenv.mkDerivation {
+    name = "cpptools-language-component-binaries";
+
+    src = fetchurl {
+      url = https://download.visualstudio.microsoft.com/download/pr/11151953/d3cc8b654bffb8a2f3896d101f3c3155/Bin_Linux.zip;
+      sha256 = "12qbxsrdc73cqjb84xdck1xafzhfkcyn6bqbpcy1bxxr3b7hxbii";
+    };
+
+    buildInputs = [ unzip ];
+
+    patchPhase = ''
+      elfInterpreter="${stdenv.glibc.out}/lib/ld-linux-x86-64.so.2"
+      patchelf --set-interpreter "$elfInterpreter" ./Microsoft.VSCode.CPP.Extension.linux
+      patchelf --set-interpreter "$elfInterpreter" ./Microsoft.VSCode.CPP.IntelliSense.Msvc.linux
+      chmod a+x ./Microsoft.VSCode.CPP.Extension.linux ./Microsoft.VSCode.CPP.IntelliSense.Msvc.linux
+    '';
+
+    installPhase = ''
+      mkdir -p "$out/bin"
+      find . -mindepth 1 -maxdepth 1 | xargs cp -a -t "$out/bin"
+    '';
+  };
+
+  cpptoolsJsonFile = fetchurl {
+    url = https://download.visualstudio.microsoft.com/download/pr/11070848/7b97d6724d52cae8377c61bb4601c989/cpptools.json;
+    sha256 = "124f091aic92rzbg2vg831y22zr5wi056c1kh775djqs3qv31ja6";
+  };
+
+
+
+  openDebugAD7Script = writeScript "OpenDebugAD7" ''
+    #!${stdenv.shell}
+    BIN_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+    ${if gdbUseFixed
+        then ''
+          export PATH=''${PATH}''${PATH:+:}${gdb}/bin
+        ''
+        else ""}
+    ${mono46}/bin/mono $BIN_DIR/bin/OpenDebugAD7.exe $*
+  '';
+in
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "cpptools";
+    publisher = "ms-vscode";
+    version = "0.12.3";
+    sha256 = "1dcqy54n1w29xhbvxscd41hdrbdwar6g12zx02f6kh2f1kw34z5z";
+  };
+
+  buildInputs = [
+    dos2unix
+  ];
+
+  prePatch = ''
+    dos2unix package.json      
+  '';
+
+  patches = [
+    ./vscode-cpptools-0-12-3-package-json.patch
+  ];
+
+  postPatch = ''
+    # Patch `packages.json` so that nix's *gdb* is used as default value for `miDebuggerPath`.
+    substituteInPlace "./package.json" \
+      --replace "\"default\": \"/usr/bin/gdb\"" "\"default\": \"${gdbDefaultsTo}\""
+
+    # Prevent download/install of extensions
+    touch "./install.lock"
+
+    # Move unused files out of the way.
+    mv ./debugAdapters/bin/OpenDebugAD7.exe.config ./debugAdapters/bin/OpenDebugAD7.exe.config.unused
+
+    # Bring the `cpptools.json` file at the root of the package, same as the extension would do.
+    cp -p "${cpptoolsJsonFile}" "./cpptools.json"
+
+    # Combining the language component binaries as part of our package.
+    find "${langComponentBinaries}/bin" -mindepth 1 -maxdepth 1 | xargs cp -p -t "./bin"
+
+    # Mono runtimes from nix package (used by generated `OpenDebugAD7`).
+    rm "./debugAdapters/OpenDebugAD7"
+    cp -p "${openDebugAD7Script}" "./debugAdapters/OpenDebugAD7"
+
+    # Clang-format from nix package.
+    mkdir -p "./LLVM"
+    find "${clang-tools}" -mindepth 1 -maxdepth 1 | xargs ln -s -t "./LLVM"
+  '';
+
+    meta = with stdenv.lib; {
+      license = licenses.unfree;
+      maintainer = [ maintainers.jraygauthier ];
+      # A 32 bit linux would also be possible with some effort (specific download of binaries + 
+      # patching of the elf files with 32 bit interpreter).
+      platforms = [ "x86_64-linux" ];
+    };
+}

--- a/pkgs/misc/vscode-extensions/cpptools/vscode-cpptools-0-12-3-package-json.patch
+++ b/pkgs/misc/vscode-extensions/cpptools/vscode-cpptools-0-12-3-package-json.patch
@@ -1,0 +1,82 @@
+diff --git a/package.json b/package.json
+index 518e839..1c17c35 100644
+--- a/package.json
++++ b/package.json
+@@ -37,7 +37,26 @@
+     "Linters"
+   ],
+   "activationEvents": [
+-    "*"
++    "onLanguage:cpp",
++    "onLanguage:c",
++    "onCommand:extension.pickNativeProcess",
++    "onCommand:extension.pickRemoteNativeProcess",
++    "onCommand:extension.provideInitialConfigurations_cppvsdbg",
++    "onCommand:extension.provideInitialConfigurations_cppdbg",
++    "onCommand:C_Cpp.ConfigurationEdit",
++    "onCommand:C_Cpp.ConfigurationSelect",
++    "onCommand:C_Cpp.SwitchHeaderSource",
++    "onCommand:C_Cpp.UnloadLanguageServer",
++    "onCommand:C_Cpp.Navigate",
++    "onCommand:C_Cpp.GoToDeclaration",
++    "onCommand:C_Cpp.PeekDeclaration",
++    "onCommand:C_Cpp.ToggleErrorSquiggles",
++    "onCommand:C_Cpp.ToggleIncludeFallback",
++    "onCommand:C_Cpp.ShowReleaseNotes",
++    "onCommand:C_Cpp.ResetDatabase",
++    "workspaceContains:.vscode/c_cpp_properties.json",
++    "onDebug:cppdbg",
++    "onDebug:cppvsdbg"
+   ],
+   "main": "./out/src/main",
+   "contributes": {
+@@ -281,8 +300,7 @@
+             "cpp"
+           ]
+         },
+-        "runtime": "node",
+-        "program": "./out/src/Debugger/Proxy/debugProxy.js",
++        "program": "./debugAdapters/OpenDebugAD7",
+         "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
+         "variables": {
+           "pickProcess": "extension.pickNativeProcess",
+@@ -722,7 +740,29 @@
+               }
+             }
+           }
+-        }
++        },
++        "configurationSnippets": [
++          {
++            "label": "C/C++: (gdb) Launch",
++            "description": "Launch with gdb.",
++            "bodyText": "{\n\t\"name\": \"(gdb) Launch\",\n\t\"type\": \"cppdbg\",\n\t\"request\": \"launch\",\n\t\"program\": \"enter program name, for example \\${workspaceRoot}/a.out\",\n\t\"args\": [],\n\t\"stopAtEntry\": false,\n\t\"cwd\": \"\\${workspaceRoot}\",\n\t\"environment\": [],\n\t\"externalConsole\": true,\n\t\"MIMode\": \"gdb\",\n\t\"setupCommands\": [\n\t    {\n\t        \"description\": \"Enable pretty-printing for gdb\",\n\t        \"text\": \"-enable-pretty-printing\",\n\t        \"ignoreFailures\": true\n\t    }\n\t]\n}"
++          },
++          {
++            "label": "C/C++: (gdb) Attach",
++            "description": "Attach with gdb.",
++            "bodyText": "{ \n\t\"name\": \"(gdb) Attach\",\n\t\"type\": \"cppdbg\",\n\t\"request\": \"attach\",\n\t\"program\": \"enter program name, for example \\${workspaceRoot}/a.out\",\n\t\"processId\": \"\\${command:pickProcess}\",\n\t\"MIMode\": \"gdb\"\n}"
++          },
++          {
++            "label": "C/C++: (gdb) Pipe Launch",
++            "description": "Pipe Launch with gdb.",
++            "bodyText": "{\n\t\"name\": \"(gdb) Pipe Launch\",\n\t\"type\": \"cppdbg\",\n\t\"request\": \"launch\",\n\t\"program\": \"enter program name, for example \\${workspaceRoot}/a.out\",\n\t\"args\": [],\n\t\"stopAtEntry\": false,\n\t\"cwd\": \"\\${workspaceRoot}\",\n\t\"environment\": [],\n\t\"externalConsole\": true,\n\t\"pipeTransport\": {\n\t\t\"debuggerPath\": \"/usr/bin/gdb\",\n\t\t\"pipeProgram\": \"/usr/bin/ssh\",\n\t\t\"pipeArgs\": [],\n\t\t\"pipeCwd\": \"\"\n\t},\n\t\"MIMode\": \"gdb\",\n\t\"setupCommands\": [\n\t    {\n\t        \"description\": \"Enable pretty-printing for gdb\",\n\t        \"text\": \"-enable-pretty-printing\",\n\t        \"ignoreFailures\": true\n\t    }\n\t]\n}"
++          },
++          {
++            "label": "C/C++: (gdb) Pipe Attach",
++            "description": "Pipe Attach with gdb.",
++            "bodyText": "{\n\t\"name\": \"(gdb) Pipe Attach\",\n\t\"type\": \"cppdbg\",\n\t\"request\": \"attach\",\n\t\"program\": \"enter program name, for example \\${workspaceRoot}/a.out\",\n\t\"processId\": \"\\${command:pickRemoteProcess}\",\n\t\"pipeTransport\": {\n\t\t\"debuggerPath\": \"/usr/bin/gdb\",\n\t\t\"pipeProgram\": \"/usr/bin/ssh\",\n\t\t\"pipeArgs\": [],\n\t\t\"pipeCwd\": \"\"\n\t},\n\t\"MIMode\": \"gdb\"\n}"
++          }
++        ]
+       },
+       {
+         "type": "cppvsdbg",
+@@ -741,7 +781,7 @@
+         "variables": {
+           "pickProcess": "extension.pickNativeProcess"
+         },
+-        "initialConfigurations": "extension.provideInitialConfigurations_cppvsdbg",
++        "initialConfigurations": "",
+         "configurationAttributes": {
+           "launch": {
+             "required": [

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, vscode-utils }:
+{ stdenv, lib, fetchurl, callPackage, vscode-utils }:
 
 let
   inherit (vscode-utils) buildVscodeExtension buildVscodeMarketplaceExtension;
@@ -22,4 +22,6 @@ rec {
       license = licenses.mit;
     };
   };
+
+  ms-vscode.cpptools = callPackage ./cpptools {};
 }


### PR DESCRIPTION
###### Motivation for this change

This is the only good C/C++ extension for vscode at the moment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

