### PR TITLE
nixos/calibre-server: fix ExecStart call

### DIFF
--- a/nixos/modules/services/misc/calibre-server.nix
+++ b/nixos/modules/services/misc/calibre-server.nix
@@ -42,7 +42,7 @@ in
         serviceConfig = {
           User = "calibre-server";
           Restart = "always";
-          ExecStart = "${pkgs.calibre}/bin/calibre-server --with-library=${cfg.libraryDir}";
+          ExecStart = "${pkgs.calibre}/bin/calibre-server ${cfg.libraryDir}";
         };
 
       };


### PR DESCRIPTION
calibre-server changed the way you specify the library from using
--with-library to just allowing the directory to be specified. See
https://manual.calibre-ebook.com/generated/en/calibre-server.html for
details.