### PR TITLE
mysql-workbench: fix build with gcc6

### DIFF
--- a/pkgs/applications/misc/mysql-workbench/default.nix
+++ b/pkgs/applications/misc/mysql-workbench/default.nix
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
     sha256 = "1bxd828nrawmym6d8awh1vrni8dsbwh1k5am1lrq5ihp5c3kw9ka";
   };
 
-  buildInputs = [ cmake pkgconfig glibc gnome_keyring gtk gtk.dev gtkmm pcre swig python sudo
+  buildInputs = [ cmake pkgconfig gnome_keyring gtk gtk.dev gtkmm pcre swig python sudo
     paramiko mysql libxml2 libctemplate libmysqlconnectorcpp vsqlite tinyxml gdal libiodbc file
     libpthreadstubs libXdmcp libuuid libzip libgnome_keyring libgnome_keyring.dev jre autoconf
     automake libtool boost glibmm glibmm.dev libsigcxx pangomm libX11 pexpect pycrypto openssl


### PR DESCRIPTION
###### Motivation for this change

This fixes the build of mysql-workench (see #28643).

An update is available (6.3.9) but it will require more work to get it in `nixpkgs` (gtk3 migration). I leave it for later work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

