### PR TITLE
gmime: updated home and description

### DIFF
--- a/pkgs/development/libraries/gmime/default.nix
+++ b/pkgs/development/libraries/gmime/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    homepage = http://spruce.sourceforge.net/gmime/;
-    description = "A C/C++ library for manipulating MIME messages";
+    homepage = https://github.com/jstedfast/gmime/;
+    description = "A C/C++ library for creating, editing and parsing MIME messages and structures";
     maintainers = [ stdenv.lib.maintainers.chaoflow ];
     platforms = stdenv.lib.platforms.unix;
   };


### PR DESCRIPTION
###### Motivation for this change

GMime home has moved to Github as the list of commits clearly shows,
i.e.:

  https://github.com/jstedfast/gmime/commit/b5cbc68a67956643862d894f0e9c95a0eb803f3b

The description is updated as well to be closer to the one used there
and over at gnome.org.

cc @chaoflow 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

