### PR TITLE
WIP: gmime3: init at 3.0.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, fixDarwinDylibNames, gdb
 , pkgconfig, gnupg
-, xapian, gmime, talloc, zlib
+, xapian, gmime3, talloc, zlib, glib
 , doxygen, perl
 , pythonPackages
 , bash-completion
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     pkgconfig gnupg # undefined dependencies
-    xapian gmime talloc zlib  # dependencies described in INSTALL
+    xapian gmime3 glib talloc zlib  # dependencies described in INSTALL
     doxygen perl  # (optional) api docs
     pythonPackages.sphinx pythonPackages.python  # (optional) documentation -> doc/INSTALL
     bash-completion  # (optional) dependency to install bash completion

--- a/pkgs/development/libraries/gmime/3.0.nix
+++ b/pkgs/development/libraries/gmime/3.0.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, pkgconfig, glib, gpgme, zlib, libgpgerror, libidn, gobjectIntrospection }:
+
+stdenv.mkDerivation rec {
+  name = "gmime-3.0.1";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gmime/3.0/${name}.tar.xz";
+    sha256 = "001y93b8mq9alzkvli6vfh3pzdcn5c5iy206ml23lzhhhvm5k162";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  buildInputs = [
+    glib gpgme zlib libgpgerror libidn gobjectIntrospection
+  ];
+  nativeBuildInputs = [ pkgconfig ];
+
+  configureFlags = [ "--enable-introspection=yes" ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = https://github.com/jstedfast/gmime/;
+    description = "A C/C++ library for creating, editing and parsing MIME messages and structures";
+    maintainers = [ stdenv.lib.maintainers.chaoflow ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8105,6 +8105,8 @@ with pkgs;
 
   gmime = callPackage ../development/libraries/gmime { };
 
+  gmime3 = callPackage ../development/libraries/gmime/3.0.nix { };
+
   gmm = callPackage ../development/libraries/gmm { };
 
   gmp4 = callPackage ../development/libraries/gmp/4.3.2.nix { }; # required by older GHC versions


### PR DESCRIPTION
###### Motivation for this change

Personal motivation is for using it with notmuch, but as it is the latest and stable release of the library, seems to be good idea to have it in the repository.

I have used the same maintainer as there is for 2.6, but I would be glad to be the maintainer.

cc @chaoflow 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

