### PR TITLE
darwin-stdenv: Don't use `nativeTools`

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -79,15 +79,17 @@ in rec {
           inherit shell;
           inherit (last) stdenv;
 
-          nativeTools  = true;
-          nativePrefix = bootstrapTools;
+          nativeTools  = false;
           nativeLibc   = false;
           buildPackages = lib.optionalAttrs (last ? stdenv) {
             inherit (last) stdenv;
           };
           libc         = last.pkgs.darwin.Libsystem;
           isClang      = true;
-          cc           = { name = "clang-9.9.9"; outPath = bootstrapTools; };
+          cc           = { name = "clang-9.9.9";     outPath = bootstrapTools; };
+          binutils     = { name = "binutils-9.9.9";  outPath = bootstrapTools; };
+          coreutils    = { name = "coreutils-9.9.9"; outPath = bootstrapTools; };
+          gnugrep      = { name = "gnugrep-9.9.9";   outPath = bootstrapTools; };
         };
 
         preHook = stage0.stdenv.lib.optionalString (shell == "${bootstrapTools}/bin/bash") ''

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -269,7 +269,16 @@ in rec {
     extraPreHook = ''
       export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
     '';
-    overrides = persistent;
+    overrides = self: super: (persistent self super) // {
+      # Hack to make sure we don't link ncurses in bootstrap tools. The proper
+      # solution is to avoid passing -L/nix-store/...-bootstrap-tools/lib,
+      # quite a sledgehammer just to get the C runtime.
+      gettext = super.gettext.overrideAttrs (old: {
+         configureFlags = old.configureFlags ++ [
+           "--disable-curses"
+         ];
+      });
+    };
   };
 
   stdenvDarwin = prevStage: let


### PR DESCRIPTION
###### Motivation for this change

Now, we'll actually use the wrapped ld to link.

Unfortunately this necessitates the `--disable-curses` hack, but that can hopefully be done away with by either copying clang out of the bootstrap tools, or keeping the derivations separate in bootstrap tools (like the Nix store itself).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] ~~NixOS~~
   - [x] macOS
   - [ ] ~~Linux~~
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

