### PR TITLE
stdenv-setup: fix substituteAll with set -eu

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -49,6 +49,7 @@ rec {
     # TODO(@Ericson2314): Make this more modular, and not O(n^2).
     let
       supportedHardeningFlags = [ "fortify" "stackprotector" "pie" "pic" "strictoverflow" "format" "relro" "bindnow" ];
+      # hardeningDisable additionally supports "all".
       erroneousHardeningFlags = lib.subtractLists supportedHardeningFlags (hardeningEnable ++ lib.remove "all" hardeningDisable);
     in if builtins.length erroneousHardeningFlags != 0
     then abort ("mkDerivation was called with unsupported hardening flags: " + lib.generators.toPretty {} {

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -473,14 +473,14 @@ substitute() {
     shift 2
 
     if [ ! -f "$input" ]; then
-      echo "${FUNCNAME[0]}(): ERROR: file '$input' does not exist" >&2
+      echo "substitute(): ERROR: file '$input' does not exist" >&2
       return 1
     fi
 
     local content
     # read returns non-0 on EOF, so we want read to fail
     if IFS='' read -r -N 0 content < "$input"; then
-        echo "${FUNCNAME[0]}(): ERROR: File \"$input\" has null bytes, won't process" >&2
+        echo "substitute(): ERROR: File \"$input\" has null bytes, won't process" >&2
         return 1
     fi
 
@@ -497,10 +497,8 @@ substitute() {
                 shift 2
                 # check if the used nix attribute name is a valid bash name
                 if ! [[ "$varName" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
-                    echo "${FUNCNAME[0]}(): WARNING: substitution variables should be valid bash names," >&2
-                    echo "  \"$varName\" isn't and therefore was skipped; it might be caused" >&2
-                    echo "  by multi-line phases in variables - see #14907 for details." >&2
-                    continue
+                    echo "substitute(): ERROR: substitution variables must be valid Bash names, \"$varName\" isn't." >&2
+                    return 1
                 fi
                 pattern="@$varName@"
                 replacement="${!varName}"
@@ -513,7 +511,7 @@ substitute() {
                 ;;
 
             *)
-                echo "${FUNCNAME[0]}(): ERROR: Invalid command line argument: $1" >&2
+                echo "substitute(): ERROR: Invalid command line argument: $1" >&2
                 return 1
                 ;;
         esac
@@ -532,17 +530,24 @@ substituteInPlace() {
     substitute "$fileName" "$fileName" "$@"
 }
 
+# List the names of the environment variables that are valid Bash names.
+listVars() {
+    # "export" prints "declare -x name=value", quoted for eval.
+    declare() {
+        echo "${2%%=*}"
+    }
+    eval "$(export)"
+    unset declare
+}
 
-# Substitute all environment variables that do not start with an upper-case
-# character or underscore. Note: other names that aren't bash-valid
-# will cause an error during `substitute --subst-var`.
+# Substitute all environment variables that start with a lowercase character and
+# are valid Bash names.
 substituteAll() {
     local input="$1"
     local output="$2"
     local -a args=()
 
-    # Select all environment variables that start with a lowercase character.
-    for varName in $(env | sed -e $'s/^\([a-z][^= \t]*\)=.*/\\1/; t \n d'); do
+    for varName in $(listVars | grep '^[a-z]'); do
         if [ "${NIX_DEBUG:-}" = "1" ]; then
             echo "@${varName}@ -> '${!varName}'"
         fi

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -530,15 +530,6 @@ substituteInPlace() {
     substitute "$fileName" "$fileName" "$@"
 }
 
-# List the names of the environment variables that are valid Bash names.
-listVars() {
-    # "export" prints "declare -x name=value", quoted for eval.
-    declare() {
-        echo "${2%%=*}"
-    }
-    eval "$(export)"
-    unset declare
-}
 
 # Substitute all environment variables that start with a lowercase character and
 # are valid Bash names.
@@ -547,9 +538,9 @@ substituteAll() {
     local output="$2"
     local -a args=()
 
-    for varName in $(listVars | grep '^[a-z]'); do
+    for varName in $(awk 'BEGIN { for (v in ENVIRON) if (v ~ /^[a-z][a-zA-Z0-9_]*$/) print v }'); do
         if [ "${NIX_DEBUG:-}" = "1" ]; then
-            echo "@${varName}@ -> '${!varName}'"
+            printf "@%s@ -> %q\n" "${varName}" "${!varName}"
         fi
         args+=("--subst-var" "$varName")
     done


### PR DESCRIPTION
###### Motivation for this change

Environment variable filter in substituteAll was not precise and produced undefined and invalid variable names.  Vladimír Čunát tried to fix that in [1], but `env -0` did not work during Darwin bootstrap, so [2] reverted this change and replaced an error due to invalid variables with a warning.  Recently in #28057 John Ericson added `set -u` to `setup.sh` and undefined variables made the setup fail during e.g. `nix-build -A gnat` with `setup: line 519: !varName: unbound variable`.

This patch fixes the cause of such warnings as [3]:

     WARNING: substitution variables should be valid bash names,
       "ccLDFlags+" isn't and therefore was skipped; it might be caused
       by multi-line phases in variables - see #14907 for details.

[1] https://github.com/NixOS/nixpkgs/commit/62fc8859c10dd18b005b9bcaa0b429103d7661d9
[2] https://github.com/NixOS/nixpkgs/commit/81df0354290389128077e00edfd2368eeeea0c24
[3] https://github.com/NixOS/nixpkgs/pull/14907#issuecomment-240309994

###### Things done

Tested building some packages (e.g. `nix`) on NixOS and Darwin.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
