### PR TITLE
netmask: init at 2.4.3

### DIFF
--- a/pkgs/tools/networking/netmask/default.nix
+++ b/pkgs/tools/networking/netmask/default.nix
@@ -1,0 +1,29 @@
+{stdenv, fetchFromGitHub, automake, autoconf, texinfo}:
+
+stdenv.mkDerivation rec
+{
+  name = "netmask-${version}";
+  version = "2.4.3";
+
+  src = fetchFromGitHub {
+    owner = "tlby";
+    repo = "netmask";
+    rev = "v${version}";
+    sha256 = "1n6b9f60j7hfdbpbppgkhz3lr7pg963bxnfrq95i1d49xmx41f87";
+  };
+
+  buildInputs = [ automake autoconf texinfo ];
+
+  preConfigure = ''
+  ./autogen
+  '';
+
+  meta =
+  {
+    homepage = https://github.com/tlby/netmask;
+    description = "An IP address formatting tool ";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.jensbin ];
+  };
+}

--- a/pkgs/tools/networking/netmask/default.nix
+++ b/pkgs/tools/networking/netmask/default.nix
@@ -1,7 +1,6 @@
-{stdenv, fetchFromGitHub, automake, autoconf, texinfo}:
+{ stdenv, fetchFromGitHub, autoreconfHook, texinfo }:
 
-stdenv.mkDerivation rec
-{
+stdenv.mkDerivation rec {
   name = "netmask-${version}";
   version = "2.4.3";
 
@@ -12,18 +11,14 @@ stdenv.mkDerivation rec
     sha256 = "1n6b9f60j7hfdbpbppgkhz3lr7pg963bxnfrq95i1d49xmx41f87";
   };
 
-  buildInputs = [ automake autoconf texinfo ];
+  buildInputs = [ texinfo ];
+  nativeBuildInputs = [ autoreconfHook ];
 
-  preConfigure = ''
-  ./autogen
-  '';
-
-  meta =
-  {
+  meta = with stdenv.lib; {
     homepage = https://github.com/tlby/netmask;
     description = "An IP address formatting tool ";
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.jensbin ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.jensbin ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2658,6 +2658,8 @@ with pkgs;
 
   ipcalc = callPackage ../tools/networking/ipcalc {};
 
+  netmask = callPackage ../tools/networking/netmask {};
+
   ipv6calc = callPackage ../tools/networking/ipv6calc {};
 
   ipxe = callPackage ../tools/misc/ipxe { };


### PR DESCRIPTION
###### Motivation for this change

This is a handy tool for generating terse netmasks in several common
formats.  If you've ever maintained a firewall with more than a few rules
in it, you might use netmask to clean up and generalize sloppy rules left by
the netadmin before you.  It will also convert netmasks from one format
to another for the day you change your firewall software.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

