### PR TITLE
profanity support for unix

### DIFF
--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://profanity.im/;
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.devhell ];
     updateWalker = true;
   };

--- a/pkgs/development/libraries/libmesode/default.nix
+++ b/pkgs/development/libraries/libmesode/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://github.com/boothj5/libmesode/;
     license = stdenv.lib.licenses.gpl3;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.devhell ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
I wanted to be able to use profanity for MacOS (in that case 10.12.6 Sierra). Currently it is only available for Linux 

###### Things done
It is really confusing what is behind the `platforms` variable. I tried switching `platforms.linux` to `platforms.unix` (maybe there is an option to be more specific). When i ran `nix-build -A profanity` nix told me that `libmesode` is not availble for unix, so i upgraded the platforms there as well.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---