### PR TITLE
nixos/hydra: Fix #27314 and add test case

### DIFF
--- a/nixos/modules/services/continuous-integration/hydra/default.nix
+++ b/nixos/modules/services/continuous-integration/hydra/default.nix
@@ -270,8 +270,8 @@ in
 
           ${optionalString haveLocalDB ''
             if ! [ -e ${baseDir}/.db-created ]; then
-              ${config.services.postgresql.package}/bin/createuser hydra
-              ${config.services.postgresql.package}/bin/createdb -O hydra hydra
+              ${pkgs.sudo}/bin/sudo -u ${config.services.postgresql.superUser} ${config.services.postgresql.package}/bin/createuser hydra
+              ${pkgs.sudo}/bin/sudo -u ${config.services.postgresql.superUser} ${config.services.postgresql.package}/bin/createdb -O hydra hydra
               touch ${baseDir}/.db-created
             fi
           ''}

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -38,9 +38,6 @@ let
 
   pre84 = versionOlder (builtins.parseDrvName postgresql.name).version "8.4";
 
-  # NixOS traditionally used `root` as superuser, most other distros use `postgres`. From 17.09
-  # we also try to follow this standard
-  superuser = (if versionAtLeast config.system.stateVersion "17.09" then "postgres" else "root");
 
 in
 
@@ -151,6 +148,16 @@ in
           Contents of the <filename>recovery.conf</filename> file.
         '';
       };
+      superUser = mkOption {
+        type = types.str;
+        default= if versionAtLeast config.system.stateVersion "17.09" then "postgres" else "root";
+        internal = true;
+        description = ''
+          NixOS traditionally used `root` as superuser, most other distros use `postgres`.
+          From 17.09 we also try to follow this standard. Internal since changing this value
+          would lead to breakage while setting up databases.
+        '';
+        };
     };
 
   };
@@ -215,7 +222,7 @@ in
           ''
             # Initialise the database.
             if ! test -e ${cfg.dataDir}/PG_VERSION; then
-              initdb -U ${superuser}
+              initdb -U ${cfg.superUser}
               # See postStart!
               touch "${cfg.dataDir}/.first_startup"
             fi
@@ -247,14 +254,14 @@ in
         # Wait for PostgreSQL to be ready to accept connections.
         postStart =
           ''
-            while ! ${pkgs.sudo}/bin/sudo -u ${superuser} psql --port=${toString cfg.port} -d postgres -c "" 2> /dev/null; do
+            while ! ${pkgs.sudo}/bin/sudo -u ${cfg.superUser} psql --port=${toString cfg.port} -d postgres -c "" 2> /dev/null; do
                 if ! kill -0 "$MAINPID"; then exit 1; fi
                 sleep 0.1
             done
 
             if test -e "${cfg.dataDir}/.first_startup"; then
               ${optionalString (cfg.initialScript != null) ''
-                ${pkgs.sudo}/bin/sudo -u ${superuser} psql -f "${cfg.initialScript}" --port=${toString cfg.port} -d postgres
+                ${pkgs.sudo}/bin/sudo -u ${cfg.superUser} psql -f "${cfg.initialScript}" --port=${toString cfg.port} -d postgres
               ''}
               rm -f "${cfg.dataDir}/.first_startup"
             fi

--- a/nixos/tests/hydra.nix
+++ b/nixos/tests/hydra.nix
@@ -1,0 +1,32 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "hydra-init-localdb";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ pstn ];
+  };
+
+  machine =
+    { config, pkgs, ... }:
+
+    {
+      services.hydra = {
+        enable = true;
+
+        #Hydra needs those settings to start up, so we add something not harmfull.
+        hydraURL = "example.com";
+        notificationSender = "example@example.com";
+      };
+    };
+
+  testScript =
+    ''
+      # let the system boot up
+      $machine->waitForUnit("multi-user.target");
+      # test whether the database is running
+      $machine->succeed("systemctl status postgresql.service");
+      # test whether the actual hydra daemons are running
+      $machine->succeed("systemctl status hydra-queue-runner.service");
+      $machine->succeed("systemctl status hydra-init.service");
+      $machine->succeed("systemctl status hydra-evaluator.service");
+      $machine->succeed("systemctl status hydra-send-stats.service");
+     '';
+})


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/27314 Is a blocker for nixos-17.09.
I fixed this bug by exporting the postgresql user switch to a separate file and calling it from hydras and postgresql definitions. I believe this is the correct path, because this switch is probably going to break other modules too and in this manner it can be fixed in the same way for every module.

It might be that the nix code itself isn't elegant since I didn't do so much with it previously and I'm happy for any suggestions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

