### PR TITLE
bossa: fix build with gcc6

### DIFF
--- a/pkgs/development/tools/misc/bossa/default.nix
+++ b/pkgs/development/tools/misc/bossa/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
 
   # Explicitly specify targets so they don't get stripped.
   makeFlags = [ "bin/bossac" "bin/bossash" "bin/bossa" ];
+  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
 
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
###### Motivation for this change
Fixes build with gcc6

Related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

