### PR TITLE
lftp: fix build on darwin

### DIFF
--- a/pkgs/tools/networking/lftp/default.nix
+++ b/pkgs/tools/networking/lftp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gnutls, pkgconfig, readline, zlib, libidn, gmp, libiconv }:
+{ stdenv, fetchurl, gnutls, pkgconfig, readline, zlib, libidn2, gmp, libiconv, gettext }:
 
 stdenv.mkDerivation rec {
   name = "lftp-${version}";
@@ -14,7 +14,11 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gnutls readline zlib libidn gmp libiconv ];
+
+  buildInputs = [ gnutls readline zlib libidn2 gmp libiconv ]
+    ++ stdenv.lib.optional stdenv.isDarwin gettext;
+
+  hardeningDisable = stdenv.lib.optional stdenv.isDarwin "format";
 
   configureFlags = [
     "--with-readline=${readline.dev}"


### PR DESCRIPTION
###### Motivation for this change

`lftp` doesn't build on Darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

- Add `gettext` (which provides `-lintl`) to prevent failing with

```
ld: library not found for -lintl
clang-4.0: error: linker command failed with exit code 1 (use -v to see invocation)
```

- Disable `format` hardening to prevent failing with

```
/nix/store/hwx5i1w9q29m2rh8i8gs2l3yk3bpz67z-bash-4.4-p12/bin/bash ../libtool --silent  --tag=CXX   --mode=compile clang++ -DHAVE_CONFIG_H -I. -I../lib  -I../lib -I../trio   -O2 -Wall -Wwrite-strings -Woverloaded-virtual -fno-exceptions -fno-rtti -fno-implement-inlines -c -o ProtoLog.lo ProtoLog.cc
/nix/store/hwx5i1w9q29m2rh8i8gs2l3yk3bpz67z-bash-4.4-p12/bin/bash ../libtool --silent  --tag=CXX   --mode=compile clang++ -DHAVE_CONFIG_H -I. -I../lib  -I../lib -I../trio   -O2 -Wall -Wwrite-strings -Woverloaded-virtual -fno-exceptions -fno-rtti -fno-implement-inlines -c -o Filter.lo Filter.cc
/nix/store/hwx5i1w9q29m2rh8i8gs2l3yk3bpz67z-bash-4.4-p12/bin/bash ../libtool --silent  --tag=CXX   --mode=compile clang++ -DHAVE_CONFIG_H -I. -I../lib  -I../lib -I../trio   -O2 -Wall -Wwrite-strings -Woverloaded-virtual -fno-exceptions -fno-rtti -fno-implement-inlines -c -o SignalHook.lo SignalHook.cc
/nix/store/hwx5i1w9q29m2rh8i8gs2l3yk3bpz67z-bash-4.4-p12/bin/bash ../libtool --silent  --tag=CXX   --mode=compile clang++ -DHAVE_CONFIG_H -I. -I../lib  -I../lib -I../trio   -O2 -Wall -Wwrite-strings -Woverloaded-virtual -fno-exceptions -fno-rtti -fno-implement-inlines -c -o FileCopy.lo FileCopy.cc
FileCopy.cc:141:12: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
         debug((9,_("copy: destination file is already complete\n")));
         ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../lib/config.h:2010:18: note: expanded from macro '_'
                 ^
./log.h:84:59: note: expanded from macro 'debug'
                                                          ^
FileCopy.cc:141:12: note: treat the string as an argument to avoid this
         debug((9,_("copy: destination file is already complete\n")));
                  ^
                  "%s",
../lib/config.h:2010:18: note: expanded from macro '_'
                 ^
./log.h:84:59: note: expanded from macro 'debug'
                                                          ^
FileCopy.cc:182:12: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
         debug((9,_("copy: put is broken\n")));
         ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
../lib/config.h:2010:18: note: expanded from macro '_'
                 ^
./log.h:84:59: note: expanded from macro 'debug'
                                                          ^
FileCopy.cc:182:12: note: treat the string as an argument to avoid this
         debug((9,_("copy: put is broken\n")));
                  ^
                  "%s",
../lib/config.h:2010:18: note: expanded from macro '_'
                 ^
./log.h:84:59: note: expanded from macro 'debug'
                                                          ^
FileCopy.cc:251:18: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
               debug((9,_("copy: all data received, but get rolled back\n")));
               ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../lib/config.h:2010:18: note: expanded from macro '_'
                 ^
./log.h:84:59: note: expanded from macro 'debug'
                                                          ^
FileCopy.cc:251:18: note: treat the string as an argument to avoid this
               debug((9,_("copy: all data received, but get rolled back\n")));
                        ^
                        "%s",
../lib/config.h:2010:18: note: expanded from macro '_'
                 ^
./log.h:84:59: note: expanded from macro 'debug'
                                                          ^
3 errors generated.
make[2]: *** [Makefile:2264: FileCopy.lo] Error 1
make[2]: Leaving directory '/private/var/folders/jt/qgrx8lp10ylbdlnb93t54r6c0000gn/T/nix-build-lftp-4.8.0.drv-3/lftp-4.8.0/src'
make[1]: *** [Makefile:1669: all-recursive] Error 1
make[1]: Leaving directory '/private/var/folders/jt/qgrx8lp10ylbdlnb93t54r6c0000gn/T/nix-build-lftp-4.8.0.drv-3/lftp-4.8.0'
make: *** [Makefile:1614: all] Error 2
note: keeping build directory ‘/private/var/folders/jt/qgrx8lp10ylbdlnb93t54r6c0000gn/T/nix-build-lftp-4.8.0.drv-3’
builder for ‘/nix/store/94d2rwf1yylm2i9xl634ismkqks5bsg2-lftp-4.8.0.drv’ failed with exit code 2
error: build of ‘/nix/store/94d2rwf1yylm2i9xl634ismkqks5bsg2-lftp-4.8.0.drv’ failed
nix-build -A lftp -I nixpkgs=. --keep-failed  48.30s user 20.00s system 68% cpu 1:39.76 total
```

---

