### PR TITLE
caneda: fix build with gcc6

### DIFF
--- a/pkgs/applications/science/electronics/caneda/default.nix
+++ b/pkgs/applications/science/electronics/caneda/default.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake qt4 libxml2 libxslt ];
 
+  patches = [
+    ./gcc6.patch
+  ];
+
   postInstall = ''
     mkdir $out/share/caneda/components
     cp -R ${srcComponents}/* $out/share/caneda/components

--- a/pkgs/applications/science/electronics/caneda/gcc6.patch
+++ b/pkgs/applications/science/electronics/caneda/gcc6.patch
@@ -1,0 +1,13 @@
+diff --git c/src/cgraphicsscene.cpp i/src/cgraphicsscene.cpp
+index ac2929a..c399706 100644
+--- c/src/cgraphicsscene.cpp
++++ i/src/cgraphicsscene.cpp
+@@ -1436,7 +1436,7 @@ namespace Caneda
+             QPointF newPos = m_currentWiringWire->mapFromScene(pos);
+             QPointF refPos = m_currentWiringWire->port1()->pos();
+ 
+-            if( abs(refPos.x()-newPos.x()) > abs(refPos.y()-newPos.y()) ) {
++            if( (refPos.x()-newPos.x()) > (refPos.y()-newPos.y()) ) {
+                 m_currentWiringWire->movePort2(QPointF(newPos.x(), refPos.y()));
+             }
+             else {


### PR DESCRIPTION
###### Motivation for this change
fixes build with gcc6.

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

