### PR TITLE
grml-zsh-config: generalize support to unix systems

### DIFF
--- a/pkgs/shells/grml-zsh-config/default.nix
+++ b/pkgs/shells/grml-zsh-config/default.nix
@@ -14,7 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "1xvv2mnkfqa657w8y4q2zrchhindngdzij9fbalcg1gggz4zdwcm";
   };
 
-  buildInputs = [ zsh coreutils inetutils procps txt2tags ];
+  buildInputs = [ zsh coreutils txt2tags ]
+    ++ optional stdenv.isLinux [ inetutils procps ];
 
   buildPhase = ''
     cd doc
@@ -34,7 +35,7 @@ stdenv.mkDerivation rec {
     description = "grml's zsh setup";
     homepage = http://grml.org/zsh/;
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ msteen rvolosatovs ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
grml-zsh-config supports various UNIX-like systems, but its nix derivation only claimed to support linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

