### PR TITLE
svgbobrus: init at 2017-08-29

### DIFF
--- a/pkgs/applications/misc/svgbobrus/default.nix
+++ b/pkgs/applications/misc/svgbobrus/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+with rustPlatform;
+
+let
+  rev = "ab1c44b49657e856ab7e03e6c80c6972206504da";
+in
+buildRustPackage rec {
+  name = "svgbob";
+  name = "svgbobrus";
+  version = "29-08-2017";
+
+  src = fetchFromGitHub {
+    owner = "ivanceras";
+    repo = "svgbobrus";
+    inherit rev;
+    sha256 = "1bbh6inrif2y8159j4y1nvnrcf3fscrhb3zrshfms4847pms42cs";
+  };
+
+  depsSha256 = "1zd1wbx8ix4722r5j2w8293h90s0lyp1ia8ax9198ilpivbhm5ns";
+
+  sourceRoot = "${name}-${rev}-src/svgbob_cli";
+
+  dontPatchELF = true;
+
+  meta = with stdenv.lib; {
+    description = "Convert your ascii diagram scribbles into happy little SVG";
+    homepage = https://github.com/ivanceras/svgbobrus;
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ matthiasbeyer ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6674,6 +6674,8 @@ with pkgs;
 
   svg2tikz = python27Packages.svg2tikz;
 
+  svgbob = callPackage ../applications/misc/svgbobrus { };
+
   pyrex = pyrex095;
 
   pyrex095 = callPackage ../development/interpreters/pyrex/0.9.5.nix { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Pinging @kevincox as requested.

This fails with

```
ERROR: The Cargo.lock file doesn't exist
```
