### PR TITLE
crrcsim: build with gcc6

### DIFF
--- a/pkgs/games/crrcsim/default.nix
+++ b/pkgs/games/crrcsim/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation rec {
     mesa SDL SDL_mixer plib libjpeg
   ];
 
+  patches = [
+    ./gcc6.patch
+  ];
+
   meta = {
     description = "A model-airplane flight simulator";
     maintainers = with stdenv.lib.maintainers; [ raskin the-kenny ];

--- a/pkgs/games/crrcsim/gcc6.patch
+++ b/pkgs/games/crrcsim/gcc6.patch
@@ -1,0 +1,13 @@
+diff --git c/src/mod_video/crrc_animation.cpp i/src/mod_video/crrc_animation.cpp
+index ee7d7f4..855b106 100644
+--- c/src/mod_video/crrc_animation.cpp
++++ i/src/mod_video/crrc_animation.cpp
+@@ -84,7 +84,7 @@ void createAnimation(SimpleXMLTransfer *animation, ssgEntity* model)
+       else
+       {
+         std::cerr << "createAnimation: unknown animation type \'"
+-                  << type << "\'" << std::cerr;
++                  << type << "\'" << std::endl;
+       }
+       
+       if (anim != NULL)


### PR DESCRIPTION
###### Motivation for this change
fix gcc6 build failures

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

