### PR TITLE
gnome3: Add dleyna service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -193,6 +193,7 @@
   ./services/databases/stanchion.nix
   ./services/databases/virtuoso.nix
   ./services/desktops/accountsservice.nix
+  ./services/desktops/dleyna-renderer.nix
   ./services/desktops/geoclue2.nix
   ./services/desktops/gnome3/at-spi2-core.nix
   ./services/desktops/gnome3/evolution-data-server.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -194,6 +194,7 @@
   ./services/databases/virtuoso.nix
   ./services/desktops/accountsservice.nix
   ./services/desktops/dleyna-renderer.nix
+  ./services/desktops/dleyna-server.nix
   ./services/desktops/geoclue2.nix
   ./services/desktops/gnome3/at-spi2-core.nix
   ./services/desktops/gnome3/evolution-data-server.nix

--- a/nixos/modules/services/desktops/dleyna-renderer.nix
+++ b/nixos/modules/services/desktops/dleyna-renderer.nix
@@ -1,0 +1,28 @@
+# dleyna-renderer service.
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  ###### interface
+  options = {
+    services.dleyna-renderer = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable dleyna-renderer service, a DBus service
+          for handling DLNA renderers.
+        '';
+      };
+    };
+  };
+
+
+  ###### implementation
+  config = mkIf config.services.dleyna-renderer.enable {
+    environment.systemPackages = [ pkgs.dleyna-renderer ];
+
+    services.dbus.packages = [ pkgs.dleyna-renderer ];
+  };
+}

--- a/nixos/modules/services/desktops/dleyna-server.nix
+++ b/nixos/modules/services/desktops/dleyna-server.nix
@@ -1,0 +1,28 @@
+# dleyna-server service.
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  ###### interface
+  options = {
+    services.dleyna-server = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable dleyna-server service, a DBus service
+          for handling DLNA servers.
+        '';
+      };
+    };
+  };
+
+
+  ###### implementation
+  config = mkIf config.services.dleyna-server.enable {
+    environment.systemPackages = [ pkgs.dleyna-server ];
+
+    services.dbus.packages = [ pkgs.dleyna-server ];
+  };
+}

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -94,6 +94,7 @@ in {
     services.udisks2.enable = true;
     services.accounts-daemon.enable = true;
     services.geoclue2.enable = mkDefault true;
+    services.dleyna-renderer.enable = mkDefault true;
     services.gnome3.at-spi2-core.enable = true;
     services.gnome3.evolution-data-server.enable = true;
     services.gnome3.gnome-disks.enable = mkDefault true;

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -95,6 +95,7 @@ in {
     services.accounts-daemon.enable = true;
     services.geoclue2.enable = mkDefault true;
     services.dleyna-renderer.enable = mkDefault true;
+    services.dleyna-server.enable = mkDefault true;
     services.gnome3.at-spi2-core.enable = true;
     services.gnome3.evolution-data-server.enable = true;
     services.gnome3.gnome-disks.enable = mkDefault true;

--- a/pkgs/desktops/gnome-3/apps/gnome-photos/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-photos/default.nix
@@ -2,7 +2,8 @@
 , pkgconfig, gtk3, glib
 , makeWrapper, itstool, gegl, babl, lcms2
 , desktop_file_utils, gmp, libmediaart, wrapGAppsHook
-, gnome3, librsvg, gdk_pixbuf, libexif, gexiv2, geocode_glib }:
+, gnome3, librsvg, gdk_pixbuf, libexif, gexiv2, geocode_glib
+, dleyna-renderer }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
@@ -18,7 +19,7 @@ stdenv.mkDerivation rec {
                   gnome3.gfbgraph gnome3.grilo-plugins gnome3.grilo
                   gnome3.gnome_online_accounts gnome3.gnome_desktop
                   lcms2 libexif gnome3.tracker libxml2 desktop_file_utils
-                  wrapGAppsHook gexiv2 geocode_glib ];
+                  wrapGAppsHook gexiv2 geocode_glib dleyna-renderer ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/gnome-3/core/gnome-online-miners/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-online-miners/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, glib, gnome3, libxml2
-, libsoup, json_glib, gmp, openssl, makeWrapper }:
+, libsoup, json_glib, gmp, openssl, dleyna-server, makeWrapper }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
@@ -8,7 +8,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ glib gnome3.libgdata libxml2 libsoup gmp openssl
                   gnome3.grilo gnome3.libzapojit gnome3.grilo-plugins
                   gnome3.gnome_online_accounts makeWrapper gnome3.libmediaart
-                  gnome3.tracker gnome3.gfbgraph json_glib gnome3.rest ];
+                  gnome3.tracker gnome3.gfbgraph json_glib gnome3.rest
+                  dleyna-server ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/gnome-3/core/grilo-plugins/default.nix
+++ b/pkgs/desktops/gnome-3/core/grilo-plugins/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, file, intltool, glib, sqlite
 , gnome3, libxml2, gupnp, gssdp, lua5, liboauth, gupnp_av
-, gmime, json_glib, avahi, tracker, itstool }:
+, gmime, json_glib, avahi, tracker, dleyna-server, itstool }:
 
 stdenv.mkDerivation rec {
   major = "0.3";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ gnome3.grilo libxml2 gupnp gssdp gnome3.libgdata
                   lua5 liboauth gupnp_av sqlite gnome3.gnome_online_accounts
                   gnome3.totem-pl-parser gnome3.rest gmime json_glib
-                  avahi gnome3.libmediaart tracker intltool itstool ];
+                  avahi gnome3.libmediaart tracker dleyna-server intltool itstool ];
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/action/show/Projects/Grilo;

--- a/pkgs/development/libraries/dleyna-connector-dbus/default.nix
+++ b/pkgs/development/libraries/dleyna-connector-dbus/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, autoreconfHook, pkgconfig, fetchFromGitHub, dbus, dleyna-core, glib }:
+
+stdenv.mkDerivation rec {
+  name = "dleyna-connector-dbus";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "01org";
+    repo = name;
+    rev = "${version}";
+    sha256 = "0vziq5gwjm79yl2swch2mz6ias20nvfddf5cqgk9zbg25cb9m117";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ dbus dleyna-core glib ];
+
+  meta = with stdenv.lib; {
+    description = "A D-Bus API for the dLeyna services";
+    homepage = http://01.org/dleyna;
+    maintainers = [ maintainers.jtojnar ];
+    platforms = platforms.linux;
+    license = licenses.lgpl21;
+  };
+}

--- a/pkgs/development/libraries/dleyna-core/0001-Search-connectors-in-DLEYNA_CONNECTOR_PATH.patch
+++ b/pkgs/development/libraries/dleyna-core/0001-Search-connectors-in-DLEYNA_CONNECTOR_PATH.patch
@@ -1,0 +1,95 @@
+From bf549a028a5da122b7a4206529711b969c2ecd48 Mon Sep 17 00:00:00 2001
+From: Jan Tojnar <jtojnar@gmail.com>
+Date: Fri, 1 Sep 2017 13:49:06 +0200
+Subject: [PATCH] Search connectors in DLEYNA_CONNECTOR_PATH
+
+Previously, the connectors would only be looked for in a single
+directory, specified during compilation. This patch allows to
+traverse a list of directories provided by an environment variable.
+---
+ libdleyna/core/connector-mgr.c | 63 ++++++++++++++++++++++++++++--------------
+ 1 file changed, 42 insertions(+), 21 deletions(-)
+
+diff --git a/libdleyna/core/connector-mgr.c b/libdleyna/core/connector-mgr.c
+index eafb16c..8041c67 100644
+--- a/libdleyna/core/connector-mgr.c
++++ b/libdleyna/core/connector-mgr.c
+@@ -34,33 +34,54 @@ const dleyna_connector_t *dleyna_connector_mgr_load(const gchar *name)
+ 	const dleyna_connector_t *connector;
+ 	dleyna_connector_get_interface_t get_interface;
+ 	gchar *path;
++	const gchar *connector_path;
++	gchar **connector_path_list;
++	gsize i;
+ 
+ 	DLEYNA_LOG_DEBUG("Enter");
+ 
+-	path = g_strdup_printf("%s/%s%s.so", CONNECTOR_DIR,
+-			       DLEYNA_CONNECTOR_LIB_PATTERN, name);
+-	module = g_module_open(path, G_MODULE_BIND_LAZY);
+-	g_free(path);
++	connector_path = g_getenv ("DLEYNA_CONNECTOR_PATH");
++	if (!connector_path) {
++		DLEYNA_LOG_DEBUG ("DLEYNA_CONNECTOR_PATH not set");
++		connector_path = CONNECTOR_DIR;
++	} else {
++		DLEYNA_LOG_DEBUG ("DLEYNA_CONNECTOR_PATH set to %s", connector_path);
++	}
++
++	connector_path_list = g_strsplit (connector_path, G_SEARCHPATH_SEPARATOR_S, 0);
++
++	for (i = 0; connector_path_list[i]; i++) {
++		path = g_strdup_printf("%s/%s%s.so", connector_path_list[i],
++				       DLEYNA_CONNECTOR_LIB_PATTERN, name);
++		module = g_module_open(path, G_MODULE_BIND_LAZY);
++		g_free(path);
++
++		if (module) {
++			if (!g_connectors)
++				g_connectors = g_hash_table_new(g_direct_hash,
++								g_direct_equal);
++
++			if (g_module_symbol(module, "dleyna_connector_get_interface",
++					    (gpointer *)&get_interface)) {
++				connector = get_interface();
++				g_hash_table_insert(g_connectors, (gpointer)connector,
++						    module);
++
++				break;
++			} else {
++				connector = NULL;
++				g_module_close(module);
++				DLEYNA_LOG_CRITICAL(
++						"Connector '%s' entry point not found",
++						name);
++			}
+ 
+-	if (module) {
+-		if (!g_connectors)
+-			g_connectors = g_hash_table_new(g_direct_hash,
+-							g_direct_equal);
+-
+-		if (g_module_symbol(module, "dleyna_connector_get_interface",
+-				    (gpointer *)&get_interface)) {
+-			connector = get_interface();
+-			g_hash_table_insert(g_connectors, (gpointer)connector,
+-					    module);
+-		} else {
+-			connector = NULL;
+-			g_module_close(module);
+-			DLEYNA_LOG_CRITICAL(
+-					"Connector '%s' entry point not found",
+-					name);
+ 		}
++	}
+ 
+-	} else {
++	g_strfreev (connector_path_list);
++
++	if (!module) {
+ 		connector = NULL;
+ 		DLEYNA_LOG_CRITICAL("Connector '%s' not found", name);
+ 	}
+-- 
+2.14.1
+

--- a/pkgs/development/libraries/dleyna-core/default.nix
+++ b/pkgs/development/libraries/dleyna-core/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, autoreconfHook, pkgconfig, fetchFromGitHub, gupnp }:
+
+stdenv.mkDerivation rec {
+  name = "dleyna-core";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "01org";
+    repo = name;
+    rev = "v${version}";
+    sha256 = "1x5vj5zfk95avyg6g3nf6gar250cfrgla2ixj2ifn8pcick2d9vq";
+  };
+
+  setupHook = ./setup-hook.sh;
+
+  patches = [ ./0001-Search-connectors-in-DLEYNA_CONNECTOR_PATH.patch ];
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  propagatedBuildInputs = [ gupnp ];
+
+  meta = with stdenv.lib; {
+    description = "Library of utility functions that are used by the higher level dLeyna";
+    homepage = http://01.org/dleyna;
+    maintainers = [ maintainers.jtojnar ];
+    platforms = platforms.linux;
+    license = licenses.lgpl21;
+  };
+}

--- a/pkgs/development/libraries/dleyna-core/setup-hook.sh
+++ b/pkgs/development/libraries/dleyna-core/setup-hook.sh
@@ -1,0 +1,9 @@
+addDleynaConnectorPath () {
+    if test -d "$1/lib/dleyna-1.0/connectors"
+    then
+        export DLEYNA_CONNECTOR_PATH="${DLEYNA_CONNECTOR_PATH}${DLEYNA_CONNECTOR_PATH:+:}$1/lib/dleyna-1.0/connectors"
+    fi
+}
+
+envHooks+=(addDleynaConnectorPath)
+

--- a/pkgs/development/libraries/dleyna-renderer/default.nix
+++ b/pkgs/development/libraries/dleyna-renderer/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, autoreconfHook, pkgconfig, fetchFromGitHub, dleyna-connector-dbus, dleyna-core, gssdp, gupnp, gupnp_av, gupnp_dlna, libsoup, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "dleyna-renderer";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "01org";
+    repo = name;
+    rev = "${version}";
+    sha256 = "0jy54aq8hgrvzchrvfzqaj4pcn0cfhafl9bv8a9p6j82yjk4pvpp";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig makeWrapper ];
+  buildInputs = [ dleyna-core dleyna-connector-dbus gssdp gupnp gupnp_av gupnp_dlna libsoup ];
+
+  preFixup = ''
+    wrapProgram "$out/libexec/dleyna-renderer-service" \
+      --set DLEYNA_CONNECTOR_PATH "$DLEYNA_CONNECTOR_PATH"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Library to discover and manipulate Digital Media Renderers";
+    homepage = http://01.org/dleyna;
+    maintainers = [ maintainers.jtojnar ];
+    platforms = platforms.linux;
+    license = licenses.lgpl21;
+  };
+}

--- a/pkgs/development/libraries/dleyna-server/default.nix
+++ b/pkgs/development/libraries/dleyna-server/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, autoreconfHook, makeWrapper, pkgconfig, fetchFromGitHub, dleyna-core, dleyna-connector-dbus, gssdp, gupnp, gupnp_av, gupnp_dlna, libsoup }:
+
+stdenv.mkDerivation rec {
+  name = "dleyna-server";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "01org";
+    repo = name;
+    rev = "${version}";
+    sha256 = "13a2i6ms27s46yxdvlh2zm7pim7jmr5cylnygzbliz53g3gxxl3j";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig makeWrapper ];
+  buildInputs = [ dleyna-core dleyna-connector-dbus gssdp gupnp gupnp_av gupnp_dlna libsoup ];
+
+  preFixup = ''
+    wrapProgram "$out/libexec/dleyna-server-service" \
+      --set DLEYNA_CONNECTOR_PATH "$DLEYNA_CONNECTOR_PATH"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Library to discover, browse and manipulate Digital Media Servers";
+    homepage = http://01.org/dleyna;
+    maintainers = [ maintainers.jtojnar ];
+    platforms = platforms.linux;
+    license = licenses.lgpl21;
+  };
+}

--- a/pkgs/development/libraries/gupnp-av/default.nix
+++ b/pkgs/development/libraries/gupnp-av/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "gupnp-av-${version}";
   majorVersion = "0.12";
-  version = "${majorVersion}.7";
+  version = "${majorVersion}.10";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gupnp-av/${majorVersion}/${name}.tar.xz";
-    sha256 = "35e775bc4f7801d65dcb710905a6b8420ce751a239b5651e6d830615dc906ea8";
+    sha256 = "0nmq6wlbfsssanv3jgv2z0nhfkv8vzfr3gq5qa8svryvvn2fyf40";
   };
   
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/gupnp-dlna/default.nix
+++ b/pkgs/development/libraries/gupnp-dlna/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, pkgconfig,  gobjectIntrospection, gupnp, gst_plugins_base }:
+
+stdenv.mkDerivation rec {
+  name = "gupnp-dlna-${version}";
+  majorVersion = "0.10";
+  version = "${majorVersion}.5";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gupnp-dlna/${majorVersion}/${name}.tar.xz";
+    sha256 = "0spzd2saax7w776p5laixdam6d7smyynr9qszhbmq7f14y13cghj";
+  };
+
+  nativeBuildInputs = [ pkgconfig gobjectIntrospection ];
+  buildInputs = [ gupnp gst_plugins_base ];
+
+  meta = {
+    homepage = https://wiki.gnome.org/Projects/GUPnP/;
+    description = "Library to ease DLNA-related bits for applications using GUPnP";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/gupnp/default.nix
+++ b/pkgs/development/libraries/gupnp/default.nix
@@ -2,12 +2,12 @@
  
 stdenv.mkDerivation rec {
   name = "gupnp-${version}";
-  majorVersion = "0.20";
-  version = "${majorVersion}.14";
+  majorVersion = "1.0";
+  version = "${majorVersion}.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gupnp/${majorVersion}/gupnp-${version}.tar.xz";
-    sha256 = "77ffb940ba77c4a6426d09d41004c75d92652dcbde86c84ac1c847dbd9ad59bd";
+    sha256 = "043nqxlj030a3wvd6x4c9z8fjarjjjsl2pjarl0nn70ig6kzswsi";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1753,6 +1753,8 @@ with pkgs;
 
   dleyna-core = callPackage ../development/libraries/dleyna-core { };
 
+  dleyna-renderer = callPackage ../development/libraries/dleyna-renderer { };
+
   dmd_2_067_1 = callPackage ../development/compilers/dmd/2.067.1.nix {
     stdenv = if stdenv.hostPlatform.isDarwin then
                stdenv

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2496,6 +2496,8 @@ with pkgs;
 
   gupnp_av = callPackage ../development/libraries/gupnp-av {};
 
+  gupnp_dlna = callPackage ../development/libraries/gupnp-dlna {};
+
   gupnp_igd = callPackage ../development/libraries/gupnp-igd {};
 
   gupnp-tools = callPackage ../tools/networking/gupnp-tools {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1749,6 +1749,8 @@ with pkgs;
 
   disper = callPackage ../tools/misc/disper { };
 
+  dleyna-core = callPackage ../development/libraries/dleyna-core { };
+
   dmd_2_067_1 = callPackage ../development/compilers/dmd/2.067.1.nix {
     stdenv = if stdenv.hostPlatform.isDarwin then
                stdenv

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1749,6 +1749,8 @@ with pkgs;
 
   disper = callPackage ../tools/misc/disper { };
 
+  dleyna-connector-dbus = callPackage ../development/libraries/dleyna-connector-dbus { };
+
   dleyna-core = callPackage ../development/libraries/dleyna-core { };
 
   dmd_2_067_1 = callPackage ../development/compilers/dmd/2.067.1.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1755,6 +1755,8 @@ with pkgs;
 
   dleyna-renderer = callPackage ../development/libraries/dleyna-renderer { };
 
+  dleyna-server = callPackage ../development/libraries/dleyna-server { };
+
   dmd_2_067_1 = callPackage ../development/compilers/dmd/2.067.1.nix {
     stdenv = if stdenv.hostPlatform.isDarwin then
                stdenv


### PR DESCRIPTION
###### Motivation for this change
dleyna services provide DLNA support for applications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

