### PR TITLE
ktorrent: 5.0.1 -> 5.1.0

### DIFF
--- a/pkgs/applications/networking/p2p/ktorrent/default.nix
+++ b/pkgs/applications/networking/p2p/ktorrent/default.nix
@@ -1,41 +1,33 @@
 { stdenv, fetchurl, cmake
 , extra-cmake-modules, qtbase, qtscript
-, ki18n, kio, knotifications, knotifyconfig, kdoctools, kross, kcmutils, kdelibs4support
+, karchive, kcrash, kdnssd, ki18n, kio, knotifications, knotifyconfig
+, kdoctools, kross, kcmutils, kwindowsystem
 , libktorrent, boost, taglib, libgcrypt, kplotting
 }:
 
 stdenv.mkDerivation rec {
-  name = pname + "-" + version;
-
-  pname = "ktorrent";
-  version = "5.0.1";
+  name = "ktorrent-${version}";
+  version = "${libktorrent.mainVersion}.0";
 
   src = fetchurl {
-    url = http://download.kde.org/stable/ktorrent/5.0/ktorrent-5.0.1.tar.xz;
-    sha256 = "1rbr932djmn1la6vs2sy1zdf39fmla8vwzfn76h7csncbp5fw3yh";
+    url    = "mirror://kde/stable/ktorrent/${libktorrent.mainVersion}/${name}.tar.xz";
+    sha256 = "18w6qh09k84qpzaxxb76a4g59k4mx5wk897vqp1wwv80g0pqhmrw";
   };
 
-  patches =
-    [ (fetchurl {
-        url = https://cgit.kde.org/ktorrent.git/patch/?id=f48acc22f0105ce6bac63294d248873ae231c6cc;
-        sha256 = "0jm4y35w2ypbjzf165rnjr224nq4w651ydnpd9zdn3inxh8r4s0v";
-      })
-    ];
+  nativeBuildInputs = [ cmake kdoctools extra-cmake-modules ];
 
-  nativeBuildInputs = [ kdoctools extra-cmake-modules ];
-
-  buildInputs =
-    [ cmake qtbase qtscript
-      ki18n kio knotifications knotifyconfig kross kcmutils kdelibs4support
-      libktorrent taglib libgcrypt kplotting
-    ];
+  buildInputs = [
+    qtbase qtscript
+    karchive kcrash kdnssd ki18n kio knotifications knotifyconfig kross kcmutils kwindowsystem
+    libktorrent taglib libgcrypt kplotting
+  ];
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "KDE integrated BtTorrent client";
-    homepage = https://www.kde.org/applications/internet/ktorrent/;
-    maintainers = [ stdenv.lib.maintainers.eelco ];
-    platforms = stdenv.lib.platforms.linux;
+    homepage    = https://www.kde.org/applications/internet/ktorrent/;
+    maintainers = with maintainers; [ eelco ];
+    platforms   = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libktorrent/default.nix
+++ b/pkgs/development/libraries/libktorrent/default.nix
@@ -3,27 +3,35 @@
 , boost, gmp, qca-qt5, libgcrypt
 }:
 
-stdenv.mkDerivation rec {
-  name = "libktorrent-2.0.1";
+let
+    mainVersion = "5.1";
+
+in stdenv.mkDerivation rec {
+  name = "libktorrent-2.1";
 
   src = fetchurl {
-    url = http://download.kde.org/stable/ktorrent/5.0/libktorrent-2.0.1.tar.xz;
-    sha256 = "0hiz4wm8jkymp24r6f1g8svj3pw9qspbjajf512m3j8s3bhrw3f7";
+    url    = "mirror://kde/stable/ktorrent/${mainVersion}/${name}.tar.xz";
+    sha256 = "0vz2dwc4xd80q56g6r5bx5wqdl9fxcibxmw2irahqhbkxk7drvry";
   };
 
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];
+
   buildInputs = [ karchive kcrash ki18n kio solid qca-qt5 libgcrypt ];
 
   propagatedBuildInputs = [ gmp boost ];
 
   enableParallelBuilding = true;
 
-  meta = {
+  passthru = {
+    inherit mainVersion;
+  };
+
+  meta = with stdenv.lib; {
     description = "A BitTorrent library used by KTorrent";
-    homepage = https://www.kde.org/applications/internet/ktorrent/;
-    maintainers = [ stdenv.lib.maintainers.eelco ];
-    platforms = stdenv.lib.platforms.linux;
+    homepage    = https://www.kde.org/applications/internet/ktorrent/;
+    maintainers = with maintainers; [ eelco ];
+    platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Regular update and while it works, ktorrent will segfault on exit (works fine otherwise) so I don't want to merge this directly if that is not OK.

Cc: @edolstra as ktorrent maintainer

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

