### PR TITLE
pythonPackages.asana: init at 0.6.2

### DIFF
--- a/pkgs/development/python-modules/asana/default.nix
+++ b/pkgs/development/python-modules/asana/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildPythonPackage, fetchPypi,
+  pytest, requests, requests_oauthlib, six
+}:
+
+buildPythonPackage rec {
+  pname = "asana";
+  version = "0.6.2";
+  name = "${pname}-${version}";
+
+  meta = {
+    description = "Python client library for Asana";
+    homepage = https://github.com/asana/python-asana;
+    license = lib.licenses.mit;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0skai72392n3i1c4bl3hn2kh5lj990qsbasdwkbjdcy6vq57jggf";
+  };
+
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ requests requests_oauthlib six ];
+
+  patchPhase = ''
+    echo > requirements.txt
+    sed -i "s/requests~=2.9.1/requests >=2.9.1/" setup.py
+    sed -i "s/requests_oauthlib~=0.6.1/requests_oauthlib >=0.6.1/" setup.py
+  '';
+
+  # ERROR: file not found: tests
+  doCheck = false; 
+
+  checkPhase = ''
+    py.test tests
+  '';
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -119,6 +119,8 @@ in {
 
   ansicolor = callPackage ../development/python-modules/ansicolor { };
 
+  asana = callPackage ../development/python-modules/asana { };
+
   asn1crypto = callPackage ../development/python-modules/asn1crypto { };
 
   astropy = callPackage ../development/python-modules/astropy {  };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

