### PR TITLE
pythonPackages.diff-match-patch: init at 20121119

### DIFF
--- a/pkgs/development/python-modules/diff-match-patch/default.nix
+++ b/pkgs/development/python-modules/diff-match-patch/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "diff-match-patch";
+  name = "${pname}-${version}";
+  version = "20121119";
+
+  meta = {
+    homepage = https://code.google.com/p/google-diff-match-patch/;
+    description = "Diff, Match and Patch libraries for Plain Text";
+    license = lib.licenses.asl20;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0k1f3v8nbidcmmrk65m7h8v41jqi37653za9fcs96y7jzc8mdflx";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -165,6 +165,8 @@ in {
 
   distorm3 = callPackage ../development/python-modules/distorm3 { };
 
+  diff-match-patch= callPackage ../development/python-modules/diff-match-patch { };
+
   h5py = callPackage ../development/python-modules/h5py {
     hdf5 = pkgs.hdf5;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

