### PR TITLE
pythonPackages.django-jinja: init at 2.2.2

### DIFF
--- a/pkgs/development/python-modules/django-jinja2/default.nix
+++ b/pkgs/development/python-modules/django-jinja2/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi,
+  django, jinja2, pytz, tox
+ }:
+
+buildPythonPackage rec {
+  pname = "django-jinja";
+  name = "${pname}-${version}";
+  version = "2.2.2";
+
+  meta = {
+    description = "Simple and nonobstructive jinja2 integration with Django";
+    homepage = https://github.com/niwinz/django-jinja;
+    license = lib.licenses.bsd3;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "099b99iprkvlsndrjmw4v3i3i60i9gm1aq5r88z15r7vgmv6sigj";
+  };
+
+  buildInputs = [ django pytz tox ];
+  propagatedBuildInputs = [ django jinja2 ];
+
+  # python installed: The directory '/homeless-shelter/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.,appdirs==1.4.3,Django==1.11.1,django-jinja==2.2.2,Jinja2==2.9.6,MarkupSafe==1.0,packaging==16.8,pyparsing==2.2.0,pytz==2017.2,six==1.10.0
+  doCheck = false;
+  checkPhase = ''
+    tox
+  '';
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8859,6 +8859,8 @@ in {
 
   django_guardian = callPackage ../development/python-modules/django_guardian.nix { };
 
+  django-jinja = callPackage ../development/python-modules/django-jinja2 { };
+
   django_polymorphic = callPackage ../development/python-modules/django-polymorphic { };
 
   django_tagging = callPackage ../development/python-modules/django_tagging { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

