### PR TITLE
pythonPackages.django-sites: init at 0.9

### DIFF
--- a/pkgs/development/python-modules/django-sites/default.nix
+++ b/pkgs/development/python-modules/django-sites/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi, django }:
+
+buildPythonPackage rec {
+  pname = "django-sites";
+  name = "${pname}-${version}";
+  version = "0.9";
+
+  meta = {
+    description = ''
+      Alternative implementation of django "sites" framework
+      based on settings instead of models.
+    '';
+    homepage = https://github.com/niwinz/django-sites;
+    license = lib.licenses.bsd3;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "05nrydk4a5a99qrxjrcnacs8nbbq5pfjikdpj4w9yn5yfayp057s";
+  };
+
+  propagatedBuildInputs = [ django ];
+
+  # django.core.exceptions.ImproperlyConfigured: Requested settings, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
+  doCheck = false;
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8861,6 +8861,8 @@ in {
 
   django_polymorphic = callPackage ../development/python-modules/django-polymorphic { };
 
+  django-sites = callPackage ../development/python-modules/django-sites { };
+
   django_tagging = callPackage ../development/python-modules/django_tagging { };
 
   django_tagging_0_3 = self.django_tagging.overrideAttrs (attrs: rec {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

