### PR TITLE
pythonPackages.django-sr: init at 0.0.4

### DIFF
--- a/pkgs/development/python-modules/django-sr/default.nix
+++ b/pkgs/development/python-modules/django-sr/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi, django, nose }:
+
+buildPythonPackage rec {
+  pname = "django-sr";
+  name = "${pname}-${version}";
+  version = "0.0.4";
+
+  meta = {
+    description = "Django settings resolver";
+    homepage = https://github.com/jespino/django-sr;
+    license = lib.licenses.bsd3;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0d3yqppi1q3crcn9nxx58wzm4yw61d5m7435g6rb9wcamr9bi1im";
+  };
+
+  buildInputs = [ django nose ];
+  propagatedBuildInputs = [ django ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8861,6 +8861,8 @@ in {
 
   django_polymorphic = callPackage ../development/python-modules/django-polymorphic { };
 
+  django-sr = callPackage ../development/python-modules/django-sr { };
+
   django_tagging = callPackage ../development/python-modules/django_tagging { };
 
   django_tagging_0_3 = self.django_tagging.overrideAttrs (attrs: rec {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

