### PR TITLE
pythonPackages.djmail: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/djmail/default.nix
+++ b/pkgs/development/python-modules/djmail/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi,
+  celery, django, psycopg2
+}:
+
+buildPythonPackage rec {
+  pname = "djmail";
+  name = "${pname}-${version}";
+  version = "1.0.1";
+
+  meta = {
+    description = "Simple, powerfull and nonobstructive django email middleware.";
+    homepage = https://github.com/bameda/djmail;
+    license = lib.licenses.bsd3;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1827i9qcn1ki09i5pg0lmar7cxjv18avh76x1n20947p1cimf3rp";
+  };
+
+  propagatedBuildInputs = [ celery django psycopg2 ];
+
+  # django.core.exceptions.ImproperlyConfigured: Requested setting DEFAULT_INDEX_TABLESPACE, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
+  doCheck = false;
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9110,6 +9110,8 @@ in {
     };
   };
 
+  djmail = callPackage ../development/python-modules/djmail { };
+
   pillowfight = buildPythonPackage rec {
     name = "pillowfight-${version}";
     version = "0.2";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

