### PR TITLE
pythonPackages.easy-thumbnails: init at 2.4.1

### DIFF
--- a/pkgs/development/python-modules/easy-thumbnails/default.nix
+++ b/pkgs/development/python-modules/easy-thumbnails/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi,
+  django, pillow
+}:
+
+buildPythonPackage rec {
+  pname = "easy-thumbnails";
+  name = "${pname}-${version}";
+  version = "2.4.1";
+
+  meta = {
+    description = "Easy thumbnails for Django";
+    homepage = https://github.com/SmileyChris/easy-thumbnails;
+    license = lib.licenses.bsd3;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0w228b6hx8k4r15v7z62hyg99qp6xp4mdkgqs1ah64fyqxp1riaw";
+  };
+
+  propagatedBuildInputs = [ django pillow ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5452,6 +5452,8 @@ in {
     };
   };
 
+  easy-thumbnails = callPackage ../development/python-modules/easy-thumbnails { };
+
   eccodes = if (isPy27) then
       (pkgs.eccodes.overrideAttrs (oldattrs: {
     name = "${python.libPrefix}-" + oldattrs.name;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

