### PR TITLE
pythonPackages.flask-mail: init at 0.9.1

### DIFF
--- a/pkgs/development/python-modules/flask-mail/default.nix
+++ b/pkgs/development/python-modules/flask-mail/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi,
+  blinker, flask, mock, nose, speaklater
+}:
+
+buildPythonPackage rec {
+  pname = "Flask-Mail";
+  name = "${pname}-${version}";
+  version = "0.9.1";
+
+  meta = {
+    description = "Flask-Mail is a Flask extension providing simple email sending capabilities.";
+    homepage = "https://pypi.python.org/pypi/Flask-Mail";
+    license = lib.licenses.bsd3;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hazjc351s3gfbhk975j8k65cg4gf31yq404yfy0gx0bjjdfpr92";
+  };
+
+  propagatedBuildInputs = [ blinker flask ];
+  buildInputs = [ blinker mock nose speaklater ];
+
+  doCheck = false;
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9723,6 +9723,8 @@ in {
 
   flask_ldap_login = callPackage ../development/python-modules/flask-ldap-login.nix { };
 
+  flask_mail = callPackage ../development/python-modules/flask-mail { };
+
   flask_migrate = callPackage ../development/python-modules/flask-migrate { };
 
   flask_oauthlib = callPackage ../development/python-modules/flask-oauthlib.nix { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

