### PR TITLE
pythonPackages.flask-marshmallow: init at 2.13.5 (+ dependencies)

### DIFF
--- a/pkgs/development/python-modules/flask-marshmallow/default.nix
+++ b/pkgs/development/python-modules/flask-marshmallow/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi,
+  flask, six, marshmallow
+}:
+
+buildPythonPackage rec {
+  pname = "flask-marshmallow";
+  name = "${pname}-${version}";
+  version = "0.8.0";
+
+  meta = {
+    homepage = "https://github.com/marshmallow-code/flask-marshmallow";
+    description = "Flask + marshmallow for beautiful APIs";
+    license = lib.licenses.mit;
+  }; 
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1fa6xgxrn9bbc2pazbg46iw3ykvpcwib5b5s46qn59ndwj77lifi";
+  };
+
+  propagatedBuildInputs = [ flask marshmallow ];
+  buildInputs = [ six ];
+
+  doCheck = false;
+}

--- a/pkgs/development/python-modules/marshmallow-sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/marshmallow-sqlalchemy/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi,
+  marshmallow, sqlalchemy
+}:
+
+buildPythonPackage rec {
+  pname = "marshmallow-sqlalchemy";
+  name = "${pname}-${version}";
+  version = "0.13.1";
+
+  meta = {
+    homepage = "https://github.com/marshmallow-code/marshmallow-sqlalchemy";
+    description = "SQLAlchemy integration with marshmallow ";
+    license = lib.licenses.mit;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0082ca2wwc9bymzkp1mr1l5h6rq0k1csv3vcq8ab24x0hdyg5qgk";
+  };
+
+  propagatedBuildInputs = [ marshmallow sqlalchemy ];
+
+  doCheck = false;
+}

--- a/pkgs/development/python-modules/marshmallow/default.nix
+++ b/pkgs/development/python-modules/marshmallow/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi,
+  dateutil, simplejson
+}:
+
+buildPythonPackage rec {
+  pname = "marshmallow";
+  name = "${pname}-${version}";
+  version = "2.13.5";
+
+  meta = {
+    homepage = "https://github.com/marshmallow-code/marshmallow";
+    description = ''
+      A lightweight library for converting complex objects to and from
+      simple Python datatypes.
+    '';
+    license = lib.licenses.mit;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "048rzdkvnais51xdiy27nail5vxjb4ggw3vd60prn1q11lf16wig";
+  };
+
+  propagatedBuildInputs = [ dateutil simplejson ];
+
+  doCheck = false;
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12263,6 +12263,8 @@ in {
 
   marshmallow = callPackage ../development/python-modules/marshmallow { };
 
+  marshmallow-sqlalchemy = callPackage ../development/python-modules/marshmallow-sqlalchemy { };
+
   manuel = buildPythonPackage rec {
     name = "manuel-${version}";
     version = "1.8.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9723,6 +9723,8 @@ in {
 
   flask_ldap_login = callPackage ../development/python-modules/flask-ldap-login.nix { };
 
+  flask_marshmallow = callPackage ../development/python-modules/flask-marshmallow { };
+
   flask_migrate = callPackage ../development/python-modules/flask-migrate { };
 
   flask_oauthlib = callPackage ../development/python-modules/flask-oauthlib.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12261,6 +12261,8 @@ in {
     };
   };
 
+  marshmallow = callPackage ../development/python-modules/marshmallow { };
+
   manuel = buildPythonPackage rec {
     name = "manuel-${version}";
     version = "1.8.0";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

