### PR TITLE
pythonPackages.premailer: init at 3.0.1

### DIFF
--- a/pkgs/development/python-modules/premailer/default.nix
+++ b/pkgs/development/python-modules/premailer/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi,
+  cssselect, cssutils, lxml, mock, nose, requests
+}:
+
+buildPythonPackage rec {
+  pname = "premailer";
+  name = "${pname}-${version}";
+  version = "3.0.1";
+
+  meta = {
+    description = "Turns CSS blocks into style attributes ";
+    homepage = https://github.com/peterbe/premailer;
+    license = lib.licenses.bsd3;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0cmlvqx1dvy16k5q5ylmr43nlfpb9k2zl3q7s4kzhf0lml4wqwaf";
+  };
+
+  buildInputs = [ mock nose ];
+  propagatedBuildInputs = [ cssselect cssutils lxml requests ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16822,6 +16822,8 @@ in {
     };
   };
 
+  premailer = callPackage ../development/python-modules/premailer { };
+
   prettytable = buildPythonPackage rec {
     name = "prettytable-0.7.1";
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

