### PR TITLE
pythonPackages.psd-tools: init at 1.4

### DIFF
--- a/pkgs/development/python-modules/psd-tools/default.nix
+++ b/pkgs/development/python-modules/psd-tools/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi,
+  docopt, pillow
+}:
+
+buildPythonPackage rec {
+  pname = "psd-tools";
+  name = "${pname}-${version}";
+  version = "1.4";
+
+  meta = {
+    description = "Python package for reading Adobe Photoshop PSD files";
+    homepage = https://github.com/kmike/psd-tools;
+    license = lib.licenses.mit;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0g2vss5hwlk96w0yj42n7ia56mly51n92f2rlbrifhn8hfbxd38s";
+  };
+
+  propagatedBuildInputs = [ docopt pillow ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16910,6 +16910,8 @@ in {
     protobuf = pkgs.protobuf2_5;
   };
 
+  psd-tools = callPackage ../development/python-modules/psd-tools { };
+
   psutil = buildPythonPackage rec {
     name = "psutil-${version}";
     version = "4.3.0";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

