### PR TITLE
pythonPackages.pyjwkest: init at 1.3.2 (+dependency cryptodomex 3.4.5)

### DIFF
--- a/pkgs/development/python-modules/pycryptodomex/default.nix
+++ b/pkgs/development/python-modules/pycryptodomex/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "pycryptodomex";
+  name = "${pname}-${version}";
+  version = "3.4.5";
+
+  meta = {
+    description = "A self-contained cryptographic library for Python";
+    homepage = https://www.pycryptodome.org;
+    license = lib.licenses.bsd2;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1n5w5ls5syapmb39kavqgz2sa9pinzx4c9dvwa2147gj0hkh87wj";
+  };
+}

--- a/pkgs/development/python-modules/pyjwkest/default.nix
+++ b/pkgs/development/python-modules/pyjwkest/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi,
+  future, pycryptodomex, pytest, requests, six
+}:
+
+buildPythonPackage rec {
+  pname = "pyjwkest";
+  name = "${pname}-${version}";
+  version = "1.3.2";
+
+  meta = {
+    description = "Implementation of JWT, JWS, JWE and JWK";
+    homepage = https://github.com/rohe/pyjwkest;
+    license = lib.licenses.asl20;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "11rrswsmma3wzi2qnmq929323yc6i9fkjsv8zr7b3vajd72yr49d";
+  };
+
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ future pycryptodomex requests six ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -215,6 +215,8 @@ in {
 
   pycryptodome = callPackage ../development/python-modules/pycryptodome { };
 
+  pycryptodomex = callPackage ../development/python-modules/pycryptodomex { };
+
   PyChromecast = callPackage ../development/python-modules/pychromecast {
     protobuf = self.protobuf3_2;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -241,6 +241,8 @@ in {
     libglade = pkgs.gnome2.libglade;
   };
 
+  pyjwkest = callPackage ../development/python-modules/pyjwkest { };
+
   pyqt4 = callPackage ../development/python-modules/pyqt/4.x.nix {
     pythonPackages = self;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

