### PR TITLE
pythonPackages.django-sampledata-helper: init at 0.4.1 (+dependency sampledata 0.3.7)

### DIFF
--- a/pkgs/development/python-modules/django-sampledatahelper/default.nix
+++ b/pkgs/development/python-modules/django-sampledatahelper/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi,
+  django, nose, pillow, sampledata, six, versiontools
+}:
+
+buildPythonPackage rec {
+  pname = "django-sampledatahelper";
+  name = "${pname}-${version}";
+  version = "0.4.1";
+
+  meta = {
+    description = "Helper class for generate sample data for django apps development";
+    homepage = https://github.com/kaleidos/django-sampledatahelper;
+    license = lib.licenses.bsd3;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1795zg73lajcsfyd8i8cprb2v93d4csifjnld6bfnya90ncsbl4n";
+  };
+
+  buildInputs = [ django nose pillow sampledata six versiontools ];
+  propagatedBuildInputs = [ django sampledata ];
+
+  # HACK To prevent collision with pythonPackages.sampledata
+  preBuild = ''
+    rm tests/*
+  '';
+
+  # ERROR: test_image_from_directory (tests.tests.TestImageHelpers)
+  doCheck = false;
+}

--- a/pkgs/development/python-modules/sampledata/default.nix
+++ b/pkgs/development/python-modules/sampledata/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi,
+  nose, pytz, six, versiontools
+}:
+
+buildPythonPackage rec {
+  pname = "sampledata";
+  name = "${pname}-${version}";
+  version = "0.3.7";
+
+  meta = {
+    description = "Sample Data generator for Python ";
+    homepage = https://github.com/jespino/sampledata;
+    license = lib.licenses.bsd3;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1kx2j49lag30d32zhzsr50gl5b949wa4lcdap2filg0d07picsdh";
+  };
+
+  buildInputs = [ nose versiontools ];
+  propagatedBuildInputs = [ pytz six ];
+
+# ERROR: test_image_path_from_directory (tests.tests.TestImageHelpers)
+# ERROR: test_image_stream (tests.tests.TestImageHelpers)
+  doCheck = false;
+
+  checkPhase = ''
+    nosetests -e "TestImageHelpers"
+  '';
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20564,6 +20564,8 @@ in {
     propagatedBuildInputs = [ self.cffi ];
   };
 
+  sampledata = callPackage ../development/python-modules/sampledata { };
+
   scapy = buildPythonPackage rec {
     name = "scapy-2.2.0";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8861,6 +8861,8 @@ in {
 
   django_polymorphic = callPackage ../development/python-modules/django-polymorphic { };
 
+  django-sampledatahelper = callPackage ../development/python-modules/django-sampledatahelper { };
+
   django_tagging = callPackage ../development/python-modules/django_tagging { };
 
   django_tagging_0_3 = self.django_tagging.overrideAttrs (attrs: rec {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

