### PR TITLE
pythonPackages.serpy: init at 0.1.1

### DIFF
--- a/pkgs/development/python-modules/serpy/default.nix
+++ b/pkgs/development/python-modules/serpy/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi,
+  flake8, py, pyflakes, six, tox
+}:
+
+buildPythonPackage rec {
+  pname = "serpy";
+  name = "${pname}-${version}";
+  version = "0.1.1";
+
+  meta = {
+    description = "ridiculously fast object serialization";
+    homepage = https://github.com/clarkduvall/serpy;
+    license = lib.licenses.mit;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0r9wn99x9nbqxfancnq9jh3cn83i1b6gc79xj0ipnxixp661yj5i";
+  };
+
+  buildInputs = [ flake8 py pyflakes tox ];
+  propagatedBuildInputs = [ six ];
+
+  # ImportError: No module named 'tests
+  doCheck = false;
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20688,6 +20688,8 @@ in {
     '';
   };
 
+  serpy = callPackage ../development/python-modules/serpy { };
+
   setuptools_scm = callPackage ../development/python-modules/setuptools_scm { };
 
   setuptoolsDarcs = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

