### PR TITLE
duplicityBackup module: init at v1.3.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -151,6 +151,7 @@
   ./services/backup/almir.nix
   ./services/backup/bacula.nix
   ./services/backup/crashplan.nix
+  ./services/backup/duplicity-backup.nix
   ./services/backup/mysql-backup.nix
   ./services/backup/postgresql-backup.nix
   ./services/backup/rsnapshot.nix

--- a/nixos/modules/services/backup/duplicity-backup.nix
+++ b/nixos/modules/services/backup/duplicity-backup.nix
@@ -1,0 +1,174 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.duplicityBackup;
+
+  cfgPackage = pkgs.duplicity-backup-sh;
+
+  duplicityBackupConfig = cfg: ''
+    ROOT="${cfg.root}"
+    DEST="${cfg.destination}"
+    ${optionalString (cfg.include != []) ''INCLIST=(
+      ${concatMapStringsSep " " (x: ''"${x}"'') cfg.include}
+    )''}
+    ${optionalString (cfg.exclude != []) ''EXCLIST=(
+      ${concatMapStringsSep " " (x: ''"${x}"'') cfg.exclude}
+    )''}
+    ENCRYPTION="${if cfg.encryption.enable
+      then "yes" else "no"
+    }"
+    ${optionalString cfg.encryption.enable ''
+      PASSPHRASE="${cfg.encryption.passphrase}"
+    ''}
+    CLEAN_UP_TYPE="${if cfg.cleanup.enable then cfg.cleanup.type else "none"}"
+    ${optionalString cfg.cleanup.enable '' 
+      CLEAN_UP_VARIABLE="${cfg.cleanup.var}"
+    ''}
+    HOSTNAME=${config.networking.hostName}
+    STATIC_OPTIONS="${cfg.options}"
+    LOGDIR="/var/log/duplicity-backup/"
+    LOG_FILE="duplicity-$(date +%Y-%m-%d_%H-%M).txt"
+    VERBOSITY="-v3"
+    ${cfg.extraConfig}
+  '';
+
+in {
+
+  options = {
+    services.duplicityBackup = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable Duplicity.
+        '';
+      };
+
+      onCalendar = mkOption {
+        type = types.str;
+        default = "02:00";
+        description = ''
+          Create backup on given date/time/interval, which must be in the
+          format described in
+          <citerefentry><refentrytitle>systemd.time</refentrytitle>
+          <manvolnum>7</manvolnum></citerefentry>.
+        '';
+      };
+
+      options = mkOption {
+        type = types.str;
+        default = "";
+        description = "Options to run duplicity with.";
+      };
+
+      extraConfig = mkOption {
+        type = types.str;
+        default = "";
+        description = "Extra configuration.";
+      };
+
+      root = mkOption {
+        type = types.str;
+        description = "Root-directory to backups.";
+      };
+
+      destination = mkOption {
+        type = types.str;
+        description = "Destination to store backups at.";
+      };
+
+      include = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          List of directories to include.
+          Include everything if empty.
+        '';
+      };
+
+      exclude = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = "List of directories to exclude.";
+      };
+
+      encryption = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Whether to enable encryption.";
+        };
+        passphrase = mkOption {
+          type = types.str;
+          description = "Passphrase used for encryption.";
+        };
+      };
+
+      cleanup = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Whether to cleanup old backups.";
+        };
+        type = mkOption {
+          type = types.str;
+          default = "remove-all-but-n-full";
+          description = "CLEAN_UP_TYPE";
+        };
+        var = mkOption {
+          type = types.str;
+          default = "4";
+          description = "CLEAN_UP_VARIABLE";
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.etc = [
+      {
+        source = pkgs.writeTextFile {
+          name = "duplicity-backup.conf";
+          text = (duplicityBackupConfig cfg);
+        };
+        target = "duplicity-backup.conf";
+        mode = "0400";
+      }
+    ];
+
+    system.activationScripts.duplicity-backup = stringAfter [
+      "stdio" "users"
+    ] ''
+      mkdir -m 0700 -p /var/log/duplicity-backup
+      chown root /var/log/duplicity-backup
+    '';
+
+    systemd.services.duplicity-backup = {
+      description = "Incremental Backup using duplicity-backup.sh";
+      after = [ "network.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        PermissionsStartOnly = true;
+      };
+      script = ''
+        ${cfgPackage}/bin/duplicity-backup.sh \
+          -c /etc/duplicity-backup.conf \
+          --backup
+      '';
+    };
+
+    systemd.timers.duplicity-backup = {
+      wantedBy = [ "multi-user.target" ];
+      timerConfig = {
+        Unit = "duplicity-backup.service";
+        OnCalendar = cfg.onCalendar;
+        Persistent = "true";
+      };
+    };
+  };
+
+}

--- a/pkgs/tools/backup/duplicity-backup-sh/default.nix
+++ b/pkgs/tools/backup/duplicity-backup-sh/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, makeWrapper
+, bash, coreutils, gawk, gnugrep, which
+, duplicity, gnupg
+}:
+
+stdenv.mkDerivation rec {
+  name = "duplicity-backup-sh-${version}";
+  version = "v1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "zertrin";
+    repo = "duplicity-backup.sh";
+    rev = "${version}";
+    sha256 = "0wswm91j2k457p067x07qgdwsjlxm5vqbs8nlg1hy4z02ihqriq6";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    mkdir -p "$out/share/duplicity-backup.sh"
+    sed -i 's|/usr/bin/env bash|${bash}/bin/bash|' duplicity-backup.sh
+    mv duplicity-backup.sh "$out/bin"
+    wrapProgram "$out/bin/duplicity-backup.sh" \
+      --prefix PATH : "${stdenv.lib.makeBinPath [
+        bash coreutils gawk gnugrep which
+        duplicity gnupg
+      ]}"
+    mv duplicity-backup.conf.example "$out/share/duplicity-backup.sh/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Bash wrapper script for automated backups with duplicity";
+    longDescription = ''
+      duplicity-backup.sh is a wrapper script derived from the
+      dt-s3-backup.sh script of Damon Timm and designed to automate and
+      simplify the remote backup process of duplicity on Amazon S3
+      instances or other backup destinations.
+    '';
+    homepage = https://zertrin.org/projects/duplicity-backup/;
+    license = licenses.gpl3;
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1749,6 +1749,8 @@ with pkgs;
     gnupg = gnupg1;
   };
 
+  duplicity-backup-sh = callPackage ../tools/backup/duplicity-backup-sh { };
+
   duply = callPackage ../tools/backup/duply { };
 
   dvdisaster = callPackage ../tools/cd-dvd/dvdisaster { };


### PR DESCRIPTION
###### Motivation for this change

I wanted to be able to configure encrypted backup using duplicity.
this service is using duplicity-backup.sh to configure and run duplicity

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

