### PR TITLE
rtags: Fix configure phase errors

### DIFF
--- a/pkgs/development/tools/rtags/default.nix
+++ b/pkgs/development/tools/rtags/default.nix
@@ -1,16 +1,11 @@
-{ stdenv, lib, fetchgit, cmake, llvmPackages, openssl, writeScript, apple_sdk, bash, emacs }:
+{ stdenv, lib, fetchgit, cmake, llvmPackages, openssl, writeScript, apple_sdk, bash, emacs, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "rtags-${version}";
   version = "2.12";
 
-  buildInputs = [ cmake llvmPackages.llvm openssl llvmPackages.clang emacs ]
+  buildInputs = [ cmake llvmPackages.llvm openssl llvmPackages.clang emacs pkgconfig ]
     ++ lib.optionals stdenv.isDarwin [ apple_sdk.libs.xpc apple_sdk.frameworks.CoreServices ];
-
-  preConfigure = ''
-    export LIBCLANG_CXXFLAGS="-isystem ${llvmPackages.clang.cc}/include $(llvm-config --cxxflags) -fexceptions" \
-           LIBCLANG_LIBDIR="${llvmPackages.clang.cc}/lib"
-  '';
 
 
   src = fetchgit {
@@ -24,6 +19,11 @@ stdenv.mkDerivation rec {
       rm $out/src/rct/tests/testfile_*.txt
     '';
   };
+
+  preConfigure = ''
+    export LIBCLANG_CXXFLAGS="-isystem ${llvmPackages.clang.cc}/include $(llvm-config --cxxflags) -fexceptions" \
+           LIBCLANG_LIBDIR="${llvmPackages.clang.cc}/lib"
+  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -269,8 +269,11 @@ let
 
   rtags = melpaBuild rec {
     pname = "rtags";
-    version = "2.0"; # really, it's some arbitrary git hash
+    version = "2.12";
     src = external.rtags.src;
+
+    configurePhase = ":";
+
     propagatedUserEnvPkgs = [ external.rtags ];
     fileSpecs = [ "src/*.el" ];
     inherit (external.rtags) meta;


### PR DESCRIPTION
Add pkgconfig as buildinput, so that the install path is correctly set with cmake. PkgConfig is an optional dependency for rtags, but they say it's necessary if you want to replace the prefix with
CMAKE_INSTALL_PREFIX. See for explanation the [rtags repository](https://github.com/Andersbakken/rtags/blob/caad9ac494f09960bd60a00061279efacc8d1d26/cmake/BashCompletion.cmake#L13)

Furthermore, I let the configurePhase of the rtags emacs package be a noop, since it only needs to copy the emacs lisp files.

###### Motivation for this change

This closes issue #24618

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

