### PR TITLE
Espeak gcc6 build fixes

### DIFF
--- a/pkgs/applications/audio/espeak/default.nix
+++ b/pkgs/applications/audio/espeak/default.nix
@@ -10,7 +10,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ unzip portaudio ];
 
-  patchPhase = ''
+  patches = [
+    ./gcc6.patch
+  ];
+
+  prePatch = ''
     sed -e s,/bin/ln,ln,g -i src/Makefile
     sed -e 's,^CXXFLAGS=-O2,CXXFLAGS=-O2 -D PATH_ESPEAK_DATA=\\\"$(DATADIR)\\\",' -i src/Makefile
   '' + (if portaudio.api_version == 19 then ''

--- a/pkgs/applications/audio/espeak/edit.nix
+++ b/pkgs/applications/audio/espeak/edit.nix
@@ -20,9 +20,11 @@ stdenv.mkDerivation rec {
   #  chmod +w ~/espeak-data
 
   patches = [
+    ./gcc6.patch
     ./espeakedit-fix-makefile.patch
     ./espeakedit-configurable-sox-path.patch
     ./espeakedit-configurable-path-espeak-data.patch
+    ./espeakedit-gcc6.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/audio/espeak/espeakedit-gcc6.patch
+++ b/pkgs/applications/audio/espeak/espeakedit-gcc6.patch
@@ -1,0 +1,57 @@
+diff --git i/src/compiledata.cpp w/src/compiledata.cpp
+index f1bcb30..30e9e2d 100755
+--- i/src/compiledata.cpp
++++ w/src/compiledata.cpp
+@@ -212,7 +212,7 @@ enum {
+ 	kTUNE_SPLIT,
+ };
+ 
+-static const char utf8_bom[] = {0xef,0xbb,0xbf,0};
++static const char utf8_bom[] = {char(0xef),char(0xbb),char(0xbf),0};
+ 
+ static keywtab_t k_intonation[] = {
+ 	{"tune",      0,   kTUNE},
+diff --git i/src/espeakedit.cpp w/src/espeakedit.cpp
+index bde03ea..071689d 100755
+--- i/src/espeakedit.cpp
++++ w/src/espeakedit.cpp
+@@ -744,7 +744,7 @@ void MyFrame::OnTools(wxCommandEvent& event)
+ 	int debug_flag=0;
+ 	char fname_log[sizeof(path_dsource)+12];
+ 	char err_fname[sizeof(path_home)+15];
+-	static const char utf8_bom[] = {0xef,0xbb,0xbf,0};
++	static const char utf8_bom[] = {char(0xef),char(0xbb),char(0xbf),0};
+ 
+ 	switch(event.GetId())
+ 	{
+diff --git i/src/extras.cpp w/src/extras.cpp
+index fa6ac3b..ee68f59 100644
+--- i/src/extras.cpp
++++ w/src/extras.cpp
+@@ -335,16 +335,16 @@ void Lexicon_It(int pass)
+ 	static const char *vowels1 = "aeiou";
+ 	static const char *vowels2 = "aeou";
+ 
+-	static const char ex1[] = {'a',0xc3,0xac,0};  // aì
+-	static const char ex2[] = {'e',0xc3,0xac,0};  // eì
+-	static const char ex3[] = {0xc3,0xb9,'a',0};  // ùa
+-	static const char ex4[] = {0xc3,0xb9,'e',0};  // ùe
+-	static const char ex5[] = {0xc3,0xb9,'i',0};  // ùi
+-	static const char ex6[] = {0xc3,0xb9,'o',0};  // ùo
+-	static const char ex7[] = {'c',0xc3,0xac,'a',0};  // cìa
+-	static const char ex8[] = {'c',0xc3,0xac,'o',0};  // cìo
+-	static const char ex9[] = {'c',0xc3,0xac,'u',0};  // cìu
+-	static const char ex10[] = {'g','l',0xc3,0xac,0};  // glì
++	static const char ex1[] = {'a',char(0xc3),char(0xac),0};  // aì
++	static const char ex2[] = {'e',char(0xc3),char(0xac),0};  // eì
++	static const char ex3[] = {char(0xc3),char(0xb9),'a',0};  // ùa
++	static const char ex4[] = {char(0xc3),char(0xb9),'e',0};  // ùe
++	static const char ex5[] = {char(0xc3),char(0xb9),'i',0};  // ùi
++	static const char ex6[] = {char(0xc3),char(0xb9),'o',0};  // ùo
++	static const char ex7[] = {'c',char(0xc3),char(0xac),'a',0};  // cìa
++	static const char ex8[] = {'c',char(0xc3),char(0xac),'o',0};  // cìo
++	static const char ex9[] = {'c',char(0xc3),char(0xac),'u',0};  // cìu
++	static const char ex10[] = {'g','l',char(0xc3),char(0xac),0};  // glì
+ 
+ 
+ 	static const char *exceptions[] = {ex1, ex2, ex3, ex4, ex5, ex6, ex7, ex8, ex9, ex10, NULL};

--- a/pkgs/applications/audio/espeak/gcc6.patch
+++ b/pkgs/applications/audio/espeak/gcc6.patch
@@ -1,0 +1,13 @@
+diff --git c/src/tr_languages.cpp i/src/tr_languages.cpp
+index ec210a5..9503f47 100755
+--- c/src/tr_languages.cpp
++++ i/src/tr_languages.cpp
+@@ -198,7 +198,7 @@ static const unsigned short chars_ignore_zwnj_hyphen[] = {
+ 	0x200d,  1, // zero width joiner
+ 	0, 0 };
+ 
+-const char string_ordinal[] = {0xc2,0xba,0};  // masculine ordinal character, UTF-8
++const char string_ordinal[] = {char(0xc2),char(0xba),0};  // masculine ordinal character, UTF-8
+ 
+ 
+ static Translator* NewTranslator(void)


### PR DESCRIPTION
###### Motivation for this change
Fixes both espeak builds to work with gcc6

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

