### PR TITLE
haskell: add combinator to enable DWARF debugging

### DIFF
--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -73,6 +73,17 @@ rec {
 
   disableHardening = drv: flags: overrideCabal drv (drv: { hardeningDisable = flags; });
 
+  # Controls if Nix should strip the binary files (removes debug symbols)
+  doStrip = drv: overrideCabal drv (drv: { dontStrip = false; });
+  dontStrip = drv: overrideCabal drv (drv: { dontStrip = true; });
+
+  # Useful for debugging segfaults with gdb. 
+  # -g: enables debugging symbols
+  # --disable-*-stripping: tell GHC not to strip resulting binaries
+  # dontStrip: see above
+  enableDWARFDebugging = drv:
+   appendConfigureFlag (dontStrip drv) "--ghc-options=-g --disable-executable-stripping --disable-library-stripping";
+
   sdistTarball = pkg: lib.overrideDerivation pkg (drv: {
     name = "${drv.pname}-source-${drv.version}";
     # Since we disable the haddock phase, we also need to override the


### PR DESCRIPTION
Tested using:

```
$ cat test-strip.nix
with (import ./. {});
with haskell.lib;

haskell.packages.ghc802.override {
  overrides = self: super: {
    microlens = enableDWARFDebugging super.microlens;
  };
}

$ nix-build -A microlens test-strip.nix
$ objdump -t <path-to-so-file>
```

This is useful for gdb debugging, as you finally get haskell symbols in `bt` output.