### PR TITLE
john: workaroud for build failure

### DIFF
--- a/pkgs/tools/security/john/default.nix
+++ b/pkgs/tools/security/john/default.nix
@@ -26,7 +26,13 @@ stdenv.mkDerivation rec {
     }' run/*.conf
   '';
 
-  preConfigure = "cd src";
+  preConfigure = ''
+    cd src
+    # Makefile.in depends on AS and LD being set to CC, which is set by default in configure.ac.
+    # This ensures we override the environment variables set in cc-wrapper/setup-hook.sh
+    export AS=$CC
+    export LD=$CC
+  '';
   configureFlags = [ "--disable-native-macro" ];
 
   buildInputs = [ openssl nss nspr kerberos gmp zlib libpcap re2 gcc ];


### PR DESCRIPTION
###### Motivation for this change

Fix this build toward #28643 .

The issue appears to be that john's Makefile.in depends on AS and LD be set to CC. For example, it assumes that AS can act as a preprocessor and uses commandline options not available in `as` (like `-c` or `-DAC_BUILT`)
See:
https://github.com/magnumripper/JohnTheRipper/blob/f09bb77afcf5d35226cdcad6a64ecfd0caa64e24/src/Makefile.in#L56
https://github.com/magnumripper/JohnTheRipper/blob/f09bb77afcf5d35226cdcad6a64ecfd0caa64e24/src/Makefile.in#L714

By default, their configure script sets AS and LD to CC--which is why this package used to build before recent setup-hook changes. See:
https://github.com/magnumripper/JohnTheRipper/blob/f09bb77afcf5d35226cdcad6a64ecfd0caa64e24/src/configure.ac#L268

Following the discussion in #28106, I've overridden AS and LD to just use CC.

CC @Ericson2314 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

