### PR TITLE
samba: 4.5.10 -> 4.5.13

### DIFF
--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -19,11 +19,11 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "samba-${version}";
-  version = "4.5.10";
+  version = "4.5.13";
 
   src = fetchurl {
     url = "mirror://samba/pub/samba/stable/${name}.tar.gz";
-    sha256 = "053p8wc6l31rrdn91d04ndn8fz7vrbd4f7sc1ps7wlnmyvsm7dvw";
+    sha256 = "0kfhhjz8v4d1bixz7wnsxgr21dwc6xvhzhb703xrnijr48npdi2z";
   };
 
   outputs = [ "out" "dev" "man" ];


### PR DESCRIPTION
###### Motivation for this change

upgrade

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

