### PR TITLE
xcbuild: fix sdk dir name issue

### DIFF
--- a/pkgs/development/tools/xcbuild/platform.nix
+++ b/pkgs/development/tools/xcbuild/platform.nix
@@ -228,6 +228,6 @@ stdenv.mkDerivation {
 
     mkdir -p $out/Developer/SDKs/
     cd $out/Developer/SDKs/
-    ln -s ${sdk}
+    cp -r ${sdk} nix.nixpkgs.sdk
   '';
 }


### PR DESCRIPTION
Previously, this error was coming up in xcbuild:

ld: malformed 32-bit x.y.z version number: 1068638

It’s an interesting error because it only happens with certain hashes for the
nixpkgs sdk. For instance, on latest nixpkgs unstable channel, the hash for the
xcbuild sdk is:

/nix/store/w6mwbdaz9calyii0fyxspl51f1068638-nix.nixpkgs.sdk

that is an issue we pass -isysroot ${sdk} to clang where it will interpret that
hanging "1068638". It would probably go away as soon as the hash changes but
this hacky fix will solve the problem.

###### Motivation for this change

Broken pinentry-mac:

https://hydra.nixos.org/build/59720871/nixlog/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

