### PR TITLE
bombono: init at 1.2.4

### DIFF
--- a/pkgs/applications/video/bombono/default.nix
+++ b/pkgs/applications/video/bombono/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, wrapGAppsHook, gtk2, boost, gnome2, scons,
+mjpegtools, libdvdread, dvdauthor, gettext, dvdplusrwtools, libxmlxx, ffmpeg,
+enca, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "bombono-${version}";
+  version = "1.2.4";
+  src = fetchFromGitHub {
+    owner = "muravjov";
+    repo = "bombono-dvd";
+    rev = version;
+    sha256 = "1lz1vik6abn1i1pvxhm55c9g47nxxv755wb2ijszwswwrwgvq5b9";
+  };
+
+  nativeBuildInputs = [ wrapGAppsHook scons pkgconfig gettext ];
+
+  buildInputs = [
+    gtk2 gnome2.gtkmm mjpegtools libdvdread dvdauthor boost dvdplusrwtools
+    libxmlxx ffmpeg enca
+    ];
+
+  buildPhase = ''
+    scons PREFIX=$out
+    '';
+
+  installPhase = ''
+    scons install
+    '';
+
+  meta = {
+    description = "a DVD authoring program for personal computers";
+    homepage = "http://www.bombono.org/";
+    license = stdenv.lib.licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13483,6 +13483,8 @@ with pkgs;
 
   bluejeans = callPackage ../applications/networking/browsers/mozilla-plugins/bluejeans { };
 
+  bombono = callPackage ../applications/video/bombono {};
+
   bomi = libsForQt5.callPackage ../applications/video/bomi {
     youtube-dl = pythonPackages.youtube-dl;
     pulseSupport = config.pulseaudio or true;


### PR DESCRIPTION
###### Motivation for this change

add bombono on nixos

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

