### PR TITLE
mate desktop: some improvements

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/mate.nix
+++ b/nixos/modules/services/x11/desktop-managers/mate.nix
@@ -60,10 +60,7 @@ in
       '';
     };
 
-    environment.systemPackages = [
-      pkgs.hicolor_icon_theme
-      pkgs.mate.mate-icon-theme
-    ]  ++
+    environment.systemPackages =
       pkgs.mate.basePackages ++
       (removePackagesByName
         pkgs.mate.extraPackages

--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk3, libxml2, libsecret, poppler, itstool, mate, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, gtk3, libxml2, libsecret, poppler, itstool, mate, hicolor_icon_theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "atril-${version}";
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
     libsecret
     libxml2
     poppler
+    hicolor_icon_theme
     mate.mate-desktop
   ];
 

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -23,6 +23,7 @@ let
     mate-icon-theme = callPackage ./mate-icon-theme { };
     mate-icon-theme-faenza = callPackage ./mate-icon-theme-faenza { };
     mate-menus = callPackage ./mate-menus { };
+    mate-notification-daemon = callPackage ./mate-notification-daemon { };
     mate-panel = callPackage ./mate-panel { };
     mate-session-manager = callPackage ./mate-session-manager { };
     mate-settings-daemon = callPackage ./mate-settings-daemon { };
@@ -41,6 +42,7 @@ let
       mate-desktop
       mate-icon-theme
       mate-menus
+      mate-notification-daemon
       mate-panel
       mate-session-manager
       mate-settings-daemon

--- a/pkgs/desktops/mate/engrampa/default.nix
+++ b/pkgs/desktops/mate/engrampa/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, gnome3, mate, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, gnome3, mate, hicolor_icon_theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "engrampa-${version}";
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     libxml2
     gnome3.gtk
     mate.caja
+    hicolor_icon_theme
     mate.mate-desktop
   ];
 

--- a/pkgs/desktops/mate/eom/default.nix
+++ b/pkgs/desktops/mate/eom/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, dbus_glib, exempi, lcms2, libexif, libjpeg, librsvg, libxml2, shared_mime_info, gnome3, mate, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, dbus_glib, exempi, lcms2, libexif, libjpeg, librsvg, libxml2, shared_mime_info, gnome3, mate, hicolor_icon_theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "eom-${version}";
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
     pkgconfig
     intltool
     itstool
+    hicolor_icon_theme
     wrapGAppsHook
   ];
 

--- a/pkgs/desktops/mate/libmateweather/default.nix
+++ b/pkgs/desktops/mate/libmateweather/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     "--enable-locations-compression"
   ];
 
+  preFixup = "rm -f $out/share/icons/mate/icon-theme.cache";
+
   meta = with stdenv.lib; {
     description = "Library to access weather information from online services for MATE";
     homepage = https://github.com/mate-desktop/libmateweather;

--- a/pkgs/desktops/mate/mate-control-center/default.nix
+++ b/pkgs/desktops/mate/mate-control-center/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, dbus_glib, libxklavier, libcanberra_gtk3, librsvg, desktop_file_utils, gnome3, mate, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, dbus_glib, libxklavier, libcanberra_gtk3, librsvg, desktop_file_utils, gnome3, mate, hicolor_icon_theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-control-center-${version}";
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     librsvg
     gnome3.gtk
     gnome3.dconf
+    hicolor_icon_theme
     mate.mate-desktop
     mate.libmatekbd
     mate.mate-menus

--- a/pkgs/desktops/mate/mate-control-center/default.nix
+++ b/pkgs/desktops/mate/mate-control-center/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, dbus_glib, libxklavier, libcanberra_gtk3, desktop_file_utils, gnome3, mate, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, dbus_glib, libxklavier, libcanberra_gtk3, librsvg, desktop_file_utils, gnome3, mate, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-control-center-${version}";
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     dbus_glib
     libxklavier
     libcanberra_gtk3
+    librsvg
     gnome3.gtk
     gnome3.dconf
     mate.mate-desktop

--- a/pkgs/desktops/mate/mate-control-center/default.nix
+++ b/pkgs/desktops/mate/mate-control-center/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, dbus_glib, libxklavier, libcanberra_gtk3, librsvg, desktop_file_utils, gnome3, mate, hicolor_icon_theme, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, dbus_glib,
+  libxklavier, libcanberra_gtk3, librsvg, libappindicator-gtk3,
+  desktop_file_utils, gnome3, mate, hicolor_icon_theme, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   name = "mate-control-center-${version}";
@@ -25,6 +28,7 @@ stdenv.mkDerivation rec {
     libxklavier
     libcanberra_gtk3
     librsvg
+    libappindicator-gtk3
     gnome3.gtk
     gnome3.dconf
     hicolor_icon_theme

--- a/pkgs/desktops/mate/mate-desktop/default.nix
+++ b/pkgs/desktops/mate/mate-desktop/default.nix
@@ -20,11 +20,6 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gnome3.dconf
     gnome3.gtk
-    gnome3.defaultIconTheme
-  ];
-
-  propagatedUserEnvPkgs = [
-    gnome3.gnome_themes_standard
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/mate/mate-notification-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-notification-daemon/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, pkgconfig, intltool, dbus_glib, libcanberra_gtk3,
+  libnotify, libwnck3, gnome3, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "mate-notification-daemon-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "0";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "0rhhv99ipxy7l4fdgwvqp3g0c3d4njq0fhkag2vs1nwc6kx0h7sc";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    dbus_glib
+    libcanberra_gtk3
+    libnotify
+    libwnck3
+    gnome3.gtk
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Notification daemon for MATE";
+    homepage = https://github.com/mate-desktop/mate-notification-daemon;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/desktops/mate/mate-panel/default.nix
+++ b/pkgs/desktops/mate/mate-panel/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, glib, dbus_glib, libwnck3, librsvg, libxml2, gnome3, mate, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, glib, dbus_glib, libwnck3, librsvg, libxml2, gnome3, mate, hicolor_icon_theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-panel-${version}";
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     libwnck3
     librsvg
     libxml2
+    hicolor_icon_theme
     gnome3.gtk
     gnome3.dconf
     mate.libmateweather

--- a/pkgs/desktops/mate/mate-session-manager/default.nix
+++ b/pkgs/desktops/mate/mate-session-manager/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, dbus_glib, systemd, xtrans, xorg, gnome3, mate, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, dbus_glib, systemd, xtrans, xorg, gnome3, mate, hicolor_icon_theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-session-manager-${version}";
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
     dbus_glib
     systemd
     xtrans
+    hicolor_icon_theme
     xorg.libSM
     gnome3.gtk3
     gnome3.gsettings_desktop_schemas


### PR DESCRIPTION
###### Motivation for this change

Improvements to the mate desktop packages:
- mate-desktop: remove unneeded dependencies gnome3.defaultIconTheme and gnome3.gnome_themes_standard
- mate-control-center: add dependence librsvg, needed by the mate-control-center application
- mate: remove icon cache
- mate-control-center: add dependence libappindicator
- mate-notification-daemon: init at 1.18.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).