### PR TITLE
freewheeling: UNSTABLE -> 0.6.2

### DIFF
--- a/pkgs/applications/audio/freewheeling/default.nix
+++ b/pkgs/applications/audio/freewheeling/default.nix
@@ -1,20 +1,23 @@
-{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, gnutls, freetype
+{ lib, stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, gnutls, freetype
 , SDL, SDL_gfx, SDL_ttf, liblo, libxml2, alsaLib, libjack2, libvorbis
-, libSM, libsndfile, libogg
+, libSM, libsndfile, libogg, libtool
 }:
+let
+  makeSDLFlags = map (p: "-I${lib.getDev p}/include/SDL");
+in
 
 stdenv.mkDerivation rec {
   name = "freewheeling-${version}";
-  version = "2016-11-15";
+  version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = "free-wheeling";
     repo = "freewheeling";
-    rev = "05ef3bf150fa6ba1b1d437b1fd70ef363289742f";
-    sha256 = "19plf7r0sq4271ln5bya95mp4i1j30x8hsxxga2kla27z953n9ih";
+    rev = "v${version}";
+    sha256 = "01hmp0jxzxpb5sl0x91hdlwmbw9n4yffrpra4f89s4n8cixrz3d9";
   };
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook libtool ];
   buildInputs = [
     freetype SDL SDL_gfx SDL_ttf
     liblo libxml2 libjack2 alsaLib libvorbis libsndfile libogg libSM
@@ -22,8 +25,7 @@ stdenv.mkDerivation rec {
       configureFlags = oldAttrs.configureFlags ++ [ "--enable-openssl-compatibility" ];
     }))
   ];
-
-  patches = [ ./am_path_sdl.patch ./xml.patch ];
+  NIX_CFLAGS_COMPILE = makeSDLFlags [ SDL SDL_ttf SDL_gfx ] ++ [ "-I${libxml2.dev}/include/libxml2" ];
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
###### Motivation for this change
fixes build failures in hydra

related #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

