### PR TITLE
hubstaff: init at 1.2.14

### DIFF
--- a/pkgs/applications/misc/hubstaff/default.nix
+++ b/pkgs/applications/misc/hubstaff/default.nix
@@ -1,0 +1,64 @@
+{ stdenv, fetchurl, unzip, makeWrapper, libX11, zlib, libSM, libICE, libXext
+, freetype, libXrender, fontconfig, libXft, libXinerama, libnotify, glib
+, gtk3, libappindicator-gtk3, curl }:
+
+let
+
+  version = "1.2.14-36df5e3";
+
+  rpath = stdenv.lib.makeLibraryPath
+    [ libX11 zlib libSM libICE libXext freetype libXrender fontconfig libXft
+      libXinerama stdenv.cc.cc.lib libnotify glib gtk3 libappindicator-gtk3
+      curl ];
+
+in
+
+stdenv.mkDerivation {
+  name = "hubstaff-${version}";
+
+  src = fetchurl {
+    url = "https://hubstaff-production.s3.amazonaws.com/downloads/HubstaffClient/Builds/Release/${version}/Hubstaff-${version}.sh";
+    sha256 = "0yzhxk9zppj94llnf8naa6ca61f7c8jaj6b1m25zffnnz37m1sdb";
+  };
+
+  nativeBuildInputs = [ unzip makeWrapper ];
+
+  unpackCmd = ''
+    # MojoSetups have a ZIP file at the end. ZIP’s magic string is
+    # most often PK\x03\x04. This *should* work for future updates,
+    # but feel free to come up with something more reasonable.
+    dataZipOffset=$(grep --max-count=1 --byte-offset --only-matching --text $'PK\x03\x04' $curSrc | cut -d: -f1)
+    dd bs=$dataZipOffset skip=1 if=$curSrc of=data.zip 2>/dev/null
+    unzip -q data.zip "data/*"
+    rm data.zip
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    # TODO: handle 32-bit arch?
+    rm -r x86
+
+    opt=$out/opt/hubstaff
+    mkdir -p $out/bin $opt
+    cp -r . $opt/
+
+    prog=$opt/x86_64/HubstaffClient.bin.x86_64
+
+    patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) $prog
+    wrapProgram $prog --prefix LD_LIBRARY_PATH : ${rpath}
+
+    ln -s $prog $out/bin/HubstaffClient
+
+    # Why is this needed? SEGV otherwise.
+    ln -s $opt/data/resources $opt/x86_64/resources
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Time tracking software";
+    homepage = https://hubstaff.com/;
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.michalrus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14615,6 +14615,8 @@ with pkgs;
 
   ht = callPackage ../applications/editors/ht { };
 
+  hubstaff = callPackage ../applications/misc/hubstaff { };
+
   hue-cli = callPackage ../tools/networking/hue-cli { };
 
   hugin = callPackage ../applications/graphics/hugin { };


### PR DESCRIPTION
###### Motivation for this change

Commonly used for time tracking in remote teams.

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).