### PR TITLE
theme-vertex: do not explicitly indicate the gnome version

### DIFF
--- a/pkgs/misc/themes/vertex/default.nix
+++ b/pkgs/misc/themes/vertex/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ gtk-engine-murrine ];
 
-  configureFlags = [ "--disable-unity" "--with-gnome=${gnome3.version}" ];
+  configureFlags = [ "--disable-unity" ];
 
   postInstall = ''
     mkdir -p $out/share/plank/themes


### PR DESCRIPTION
###### Motivation for this change

There is no need to explicitly indicate the gnome version when building vertex-theme.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).