### PR TITLE
chrome-gnome-shell: refactor

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -200,6 +200,7 @@
   ./services/desktops/dleyna-server.nix
   ./services/desktops/geoclue2.nix
   ./services/desktops/gnome3/at-spi2-core.nix
+  ./services/desktops/gnome3/chrome-gnome-shell.nix
   ./services/desktops/gnome3/evolution-data-server.nix
   ./services/desktops/gnome3/gnome-disks.nix
   ./services/desktops/gnome3/gnome-documents.nix

--- a/nixos/modules/services/desktops/gnome3/chrome-gnome-shell.nix
+++ b/nixos/modules/services/desktops/gnome3/chrome-gnome-shell.nix
@@ -1,0 +1,27 @@
+# Chrome GNOME Shell native host connector.
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  ###### interface
+  options = {
+    services.gnome3.chrome-gnome-shell.enable = mkEnableOption ''
+      Chrome GNOME Shell native host connector, a DBus service
+      allowing to install GNOME Shell extensions from a web browser.
+    '';
+  };
+
+
+  ###### implementation
+  config = mkIf config.services.gnome3.chrome-gnome-shell.enable {
+    environment.etc = {
+      "chromium/native-messaging-hosts/org.gnome.chrome_gnome_shell.json".source = "${pkgs.chrome-gnome-shell}/etc/chromium/native-messaging-hosts/org.gnome.chrome_gnome_shell.json";
+      "opt/chrome/native-messaging-hosts/org.gnome.chrome_gnome_shell.json".source = "${pkgs.chrome-gnome-shell}/etc/opt/chrome/native-messaging-hosts/org.gnome.chrome_gnome_shell.json";
+    };
+
+    environment.systemPackages = [ pkgs.chrome-gnome-shell ];
+
+    services.dbus.packages = [ pkgs.chrome-gnome-shell ];
+  };
+}

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -8,7 +8,7 @@
 , google_talk_plugin, fribid, gnome3/*.gnome_shell*/
 , esteidfirefoxplugin
 , vlc_npapi
-, browserpass
+, browserpass, chrome-gnome-shell
 , libudev
 , kerberos
 }:
@@ -63,6 +63,7 @@ let
       nativeMessagingHosts =
         ([ ]
           ++ lib.optional (cfg.enableBrowserpass or false) browserpass
+          ++ lib.optional (cfg.enableGnomeExtensions or false) chrome-gnome-shell
           ++ extraNativeMessagingHosts
         );
       libs = (if ffmpegSupport then [ ffmpeg ] else with gst_all; [ gstreamer gst-plugins-base ])

--- a/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
@@ -26,6 +26,9 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "GNOME Shell integration for Chrome";
+    longDescription = ''
+      To use the integration, install the <link xlink:href="https://wiki.gnome.org/Projects/GnomeShellIntegrationForChrome/Installation">browser extension</link>, and then set <option>services.gnome3.chrome-gnome-shell.enable</option> to <literal>true</literal>.
+    '';
     license = licenses.gpl3;
     maintainers = gnome3.maintainers;
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
@@ -27,7 +27,7 @@ in stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "GNOME Shell integration for Chrome";
     longDescription = ''
-      To use the integration, install the <link xlink:href="https://wiki.gnome.org/Projects/GnomeShellIntegrationForChrome/Installation">browser extension</link>, and then set <option>services.gnome3.chrome-gnome-shell.enable</option> to <literal>true</literal>.
+      To use the integration, install the <link xlink:href="https://wiki.gnome.org/Projects/GnomeShellIntegrationForChrome/Installation">browser extension</link>, and then set <option>services.gnome3.chrome-gnome-shell.enable</option> to <literal>true</literal>. For Firefox based browsers, you will also need to build the wrappers with <option>nixpkgs.config.firefox.enableGnomeExtensions</option> set to <literal>true</literal>.
     '';
     license = licenses.gpl3;
     maintainers = gnome3.maintainers;

--- a/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
@@ -1,31 +1,33 @@
-{stdenv, lib, python, dbus, fetchgit, cmake, coreutils, jq, gobjectIntrospection, python27Packages, makeWrapper, gnome3, wrapGAppsHook}:
+{stdenv, fetchurl, cmake, ninja, jq, python3, gnome3, wrapGAppsHook}:
 
-stdenv.mkDerivation rec {
-name="chrome-gnome-shell";
-  src = fetchgit {
-    url = "git://git.gnome.org/chrome-gnome-shell";
-    rev = "7d99523e90805cb65027cc2f5f1191a957dcf276";
-    sha256 = "0qc34dbhsz5yf4z5bx6py08h561rcxw9928drgk9256g3vnygnbc";
+let
+  version = "9";
+
+  inherit (python3.pkgs) python pygobject3 requests;
+in stdenv.mkDerivation rec {
+  name = "chrome-gnome-shell-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/chrome-gnome-shell/${version}/${name}.tar.xz";
+    sha256 = "0j6lzlp3jvkpnkk8s99y3m14xiq94rjwjzy2pbfqgv084ahzmz8i";
   };
 
- buildInputs = [ gnome3.gnome_shell makeWrapper jq dbus gobjectIntrospection
- python python27Packages.requests python27Packages.pygobject3 wrapGAppsHook];
+  nativeBuildInputs = [ cmake ninja jq wrapGAppsHook ];
+  buildInputs = [ gnome3.gnome_shell python pygobject3 requests ];
 
- preConfigure = ''
-   mkdir build usr etc
-   cd build
-   ${cmake}/bin/cmake -DCMAKE_INSTALL_PREFIX=$out/usr -DBUILD_EXTENSION=OFF ../
-   substituteInPlace cmake_install.cmake --replace "/etc" "$out/etc"
- '';
-
- postInstall = ''
-    rm $out/etc/opt/chrome/policies/managed/chrome-gnome-shell.json
-    rm $out/etc/chromium/policies/managed/chrome-gnome-shell.json
-    wrapProgram $out/usr/bin/chrome-gnome-shell \
-      --prefix PATH : '"${dbus}/bin"' \
-      --prefix PATH : '"${gnome3.gnome_shell}/bin"' \
-      --prefix PYTHONPATH : "$PYTHONPATH"
-
+  preConfigure = ''
+    substituteInPlace CMakeLists.txt --replace "/etc" "$out/etc"
   '';
+  # cmake setup hook changes /etc/opt into /var/empty
+  dontFixCmake = true;
 
+  cmakeFlags = [ "-DBUILD_EXTENSION=OFF" ];
+  wrapPrefixVariables = [ "PYTHONPATH" ];
+
+  meta = with stdenv.lib; {
+    description = "GNOME Shell integration for Chrome";
+    license = licenses.gpl3;
+    maintainers = gnome3.maintainers;
+    platforms = platforms.linux;
+  };
 }


### PR DESCRIPTION
The native connector requires a D-Bus service. For firefox it is also necessary to enable the host connector, for example by setting `nixpkgs.config.firefox.enableGnomeExtensions` to `true`.

<del>

Unfortunately, it still does not work because the browsers require manifest files, [Chromium](https://developer.chrome.com/extensions/nativeMessaging) in `/etc/chromium/native-messaging-hosts` and [Firefox](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging) in `/usr/lib64/mozilla/native-messaging-hosts`.

One way to make it work is to copy the files to local folder:

```bash
# Firefox
mkdir ~/.mozilla/native-messaging-hosts
cp $(dirname $(readlink -f $(which chrome-gnome-shell)))/../lib/mozilla/native-messaging-hosts/org.gnome.chrome_gnome_shell.json ~/.mozilla/native-messaging-hosts
# Chromium
mkdir ~/.config/chromium/NativeMessagingHosts
cp $(dirname $(readlink -f $(which chrome-gnome-shell)))/../etc/chromium/native-messaging-hosts/org.gnome.chrome_gnome_shell.json ~/.config/chromium/NativeMessagingHosts
```
</del>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @dyrnade