### PR TITLE
aften: init at 0.0.8

### DIFF
--- a/pkgs/development/libraries/aften/default.nix
+++ b/pkgs/development/libraries/aften/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, cmake }:
+
+stdenv.mkDerivation rec {
+	name = "aften-${version}";
+	version = "0.0.8";
+	src = fetchurl {
+		url = "mirror://sourceforge/aften/${name}.tar.bz2";
+		sha256 = "02hc5x9vkgng1v9bzvza9985ifrjd7fjr7nlpvazp4mv6dr89k47";
+	};
+
+	nativeBuildInputs = [ cmake ];
+
+	cmakeFlags = [ "-DSHARED=ON" ];
+
+	meta = {
+		description = "An audio encoder which generates compressed audio streams based on ATSC A/52 specification";
+		homepage = "http://aften.sourceforge.net/";
+		license = stdenv.lib.licenses.lgpl2;
+		platforms = stdenv.lib.platforms.unix;
+	};
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7510,6 +7510,8 @@ with pkgs;
 
   afflib = callPackage ../development/libraries/afflib { };
 
+  aften = callPackage ../development/libraries/aften { };
+
   alure = callPackage ../development/libraries/alure { };
 
   agg = callPackage ../development/libraries/agg { };


### PR DESCRIPTION
Aften is an audio encoder which generates compressed audio streams based on
ATSC A/52 specification. This type of audio is also known as AC-3 or Dolby®
Digital and is one of the audio codecs used in DVD-Video content.

Homepage: http://aften.sourceforge.net/

###### Motivation for this change

`libjack2` in `nixpkgs` is broken on darwin. The configure phase fails with the following error:

```
Checking for library aften               : not found
```

So this PR adds the aften library to `nixpkgs`. Unfortunately, this is not enough to completely fix `libjack2` (the configure phase goes through, but there are build errors related to `CoreFoundation`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

