### PR TITLE
i-score: 1.0.0-a67 -> 1.0.0-b31

### DIFF
--- a/pkgs/applications/audio/i-score/default.nix
+++ b/pkgs/applications/audio/i-score/default.nix
@@ -1,8 +1,9 @@
 {
+  alsaLib,
   boost,
   cln,
   cmake,
-  fetchgit,
+  fetchFromGitHub,
   gcc,
   ginac,
   jamomacore,
@@ -10,9 +11,13 @@
   libsndfile,
   ninja,
   portaudio,
+  portmidi,
   qtbase,
   qtdeclarative,
   qtimageformats,
+  qtmultimedia,
+  qtquickcontrols2,
+  qtserialport,
   qtsvg,
   qttools,
   qtwebsockets,
@@ -21,18 +26,19 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.0-a67";
+  version = "1.0.0-b31";
   name = "i-score-${version}";
 
-  src = fetchgit {
-    url = "https://github.com/OSSIA/i-score.git";
-    rev = "ede2453b139346ae46702b5e2643c5488f8c89fb";
-    sha256 = "0cl9vdmxkshdacgpp7s2rg40b7xbsjrzw916jds9i3rpq1pcy5pj";
-    leaveDotGit = true;
-    deepClone = true;
+  src = fetchFromGitHub {
+    owner = "OSSIA";
+    repo = "i-score";
+    rev = "v${version}";
+    sha256 = "0g7s6n11w3wflrv5i2047dxx56lryms7xj0mznnlk5bii7g8dxzb";
+    fetchSubmodules = true;
   };
 
   buildInputs = [
+    alsaLib
     boost
     cln
     cmake
@@ -43,9 +49,13 @@ stdenv.mkDerivation rec {
     libsndfile
     ninja
     portaudio
+    portmidi
     qtbase
     qtdeclarative
     qtimageformats
+    qtmultimedia
+    qtquickcontrols2
+    qtserialport
     qtsvg
     qttools
     qtwebsockets
@@ -59,17 +69,11 @@ stdenv.mkDerivation rec {
     "-DISCORE_BUILD_FOR_PACKAGE_MANAGER=True"
   ];
 
-  patchPhase = ''
-    sed -e '77d' -i CMake/modules/GetGitRevisionDescription.cmake
-  '';
-
   preConfigure = ''
     export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH:$(echo "${jamomacore}/jamoma/share/cmake/Jamoma")"
   '';
 
-  installPhase = ''
-    cmake --build . --target install
-  '';
+  postInstall = ''rm $out/bin/i-score.sh'';
 
   meta = {
     description = "An interactive sequencer for the intermedia arts";


### PR DESCRIPTION
###### Motivation for this change
fixes build failures

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

