### PR TITLE
irods-icommands: 4.2.0 -> 4.2.1

### DIFF
--- a/pkgs/tools/filesystems/irods/default.nix
+++ b/pkgs/tools/filesystems/irods/default.nix
@@ -53,11 +53,11 @@ in rec {
 
   # icommands (CLI) package, depends on the irods package
   irods-icommands = stdenv.mkDerivation (common // rec {
-     version = "4.2.0";
+     version = "4.2.1";
      name = "irods-icommands-${version}";
      src = fetchurl {
        url = "http://github.com/irods/irods_client_icommands/archive/${version}.tar.gz";
-       sha256 = "b581067c8139b5ef7897f15fc1fc79f69d2e784a0f36d96e8fa3cb260b6378ce";
+       sha256 = "1kg07frv2rf32nf53a1nxscwzgr0rpgxvp5fkmh5439knby10fqw";
      };
 
      buildInputs = common.buildInputs ++ [ irods ];


### PR DESCRIPTION
###### Motivation for this change
fixing build to match irods which is required for build to work.

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

