### PR TITLE
gnome3.gpaste: Add GPaste service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -205,6 +205,7 @@
   ./services/desktops/gnome3/gnome-online-miners.nix
   ./services/desktops/gnome3/gnome-terminal-server.nix
   ./services/desktops/gnome3/gnome-user-share.nix
+  ./services/desktops/gnome3/gpaste.nix
   ./services/desktops/gnome3/gvfs.nix
   ./services/desktops/gnome3/seahorse.nix
   ./services/desktops/gnome3/sushi.nix

--- a/nixos/modules/services/desktops/gnome3/gpaste.nix
+++ b/nixos/modules/services/desktops/gnome3/gpaste.nix
@@ -1,0 +1,30 @@
+# GPaste daemon.
+{ config, lib, ... }:
+
+with lib;
+
+let
+  gnome3 = config.environment.gnome3.packageSet;
+in
+{
+  ###### interface
+  options = {
+    services.gnome3.gpaste = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable GPaste, a clipboard manager.
+        '';
+      };
+    };
+  };
+
+  ###### implementation
+  config = mkIf config.services.gnome3.gpaste.enable {
+    environment.systemPackages = [ gnome3.gpaste ];
+    services.dbus.packages = [ gnome3.gpaste ];
+    services.xserver.desktopManager.gnome3.sessionPath = [ gnome3.gpaste ];
+    systemd.packages = [ gnome3.gpaste ];
+  };
+}

--- a/pkgs/desktops/gnome-3/3.24/misc/gpaste/default.nix
+++ b/pkgs/desktops/gnome-3/3.24/misc/gpaste/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig vala wrapGAppsHook ];
-  buildInputs = [ glib gjs mutter
+  buildInputs = [ glib gjs mutter gnome3.adwaita-icon-theme
                   gtk3 gnome3.gnome_control_center dbus
                   clutter pango appstream-glib systemd gobjectIntrospection ];
 

--- a/pkgs/desktops/gnome-3/3.24/misc/gpaste/default.nix
+++ b/pkgs/desktops/gnome-3/3.24/misc/gpaste/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, autoreconfHook, pkgconfig, vala_0_32, glib, gjs, mutter
-, pango, gtk3, gnome3, dbus, clutter, appstream-glib, makeWrapper, systemd, gobjectIntrospection }:
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, vala, glib, gjs, mutter
+, pango, gtk3, gnome3, dbus, clutter, appstream-glib, wrapGAppsHook, systemd, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
   version = "3.24.2";
@@ -10,28 +10,16 @@ stdenv.mkDerivation rec {
     sha256 = "16142jfpkz8qfs7zp9k3c5l9pnvxbr5yygj8jdpx6by1142s6340";
   };
 
-  buildInputs = [ autoreconfHook pkgconfig vala_0_32 glib gjs mutter
+  nativeBuildInputs = [ autoreconfHook pkgconfig vala wrapGAppsHook ];
+  buildInputs = [ glib gjs mutter
                   gtk3 gnome3.gnome_control_center dbus
-                  clutter pango appstream-glib makeWrapper systemd gobjectIntrospection ];
+                  clutter pango appstream-glib systemd gobjectIntrospection ];
 
   configureFlags = [ "--with-controlcenterdir=$(out)/gnome-control-center/keybindings"
                      "--with-dbusservicesdir=$(out)/share/dbus-1/services"
                      "--with-systemduserunitdir=$(out)/etc/systemd/user" ];
 
   enableParallelBuilding = true;
-
-  preFixup =
-    let
-      libPath = stdenv.lib.makeLibraryPath
-        [ glib gtk3 clutter pango ];
-    in
-    ''
-      for i in $out/libexec/gpaste/*; do
-        wrapProgram $i \
-          --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
-          --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH"
-      done
-    '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/Keruspe/GPaste;


### PR DESCRIPTION
###### Motivation for this change
This makes GPaste finally work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

