### PR TITLE
herqq: 1.0.0 -> 2.1.0

### DIFF
--- a/pkgs/development/libraries/herqq/default.nix
+++ b/pkgs/development/libraries/herqq/default.nix
@@ -1,19 +1,24 @@
-{ stdenv, fetchurl, qt4, qmake4Hook, unzip }:
+{ stdenv, qt5, unzip, fetchFromGitHub, qtmultimedia }:
 
 stdenv.mkDerivation rec {
-  name = "herqq-1.0.0";
+  version = "2.1.0";
+  name = "herqq-${version}";
 
-  buildInputs = [ qt4 unzip qmake4Hook ];
+  nativeBuildInputs = [ qt5.qmake ];
+  buildInputs = [ qt5.qtbase unzip qtmultimedia ];
+  preConfigure = "cd herqq";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/hupnp/${name}.zip";
-    sha256 = "13klwszi7h7mvdz2ap0ac4dp7lc0gswp8lzzlwidhqfmf9pwgkyb";
+  src = fetchFromGitHub {
+    owner = "ThomArmax";
+    repo = "HUPnP";
+    rev = version;
+    sha256 = "1w674rbwbhpirq70gp9rk6p068j36rwn112fx3nz613wgw63x84m";
   };
 
   meta = {
     homepage = http://herqq.org;
     description = "A software library for building UPnP devices and control points";
-    inherit (qt4.meta) platforms;
+    inherit (qt5.qtbase.meta) platforms;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/herqq/gcc6.patch
+++ b/pkgs/development/libraries/herqq/gcc6.patch
@@ -1,0 +1,1320 @@
+diff --git c/herqq/apps/simple_avtest-app/mediamanager_dialog.cpp i/herqq/apps/simple_avtest-app/mediamanager_dialog.cpp
+index c4d2ebe..707dbdb 100644
+--- c/herqq/apps/simple_avtest-app/mediamanager_dialog.cpp
++++ i/herqq/apps/simple_avtest-app/mediamanager_dialog.cpp
+@@ -306,7 +306,7 @@ void MediaManagerDialog::avTransportStateChanged(
+ {
+     foreach(const HAvtLastChangeInfo& info, infos)
+     {
+-        if (info.propertyName().compare("TransportState", Qt::CaseInsensitive) == 0)
++        if (info.propertyName().compare(QString("TransportState"), Qt::CaseInsensitive) == 0)
+         {
+             HTransportState state(info.value().toString());
+             if (state.isValid())
+diff --git c/herqq/hupnp/src/dataelements/hproduct_tokens.cpp i/herqq/hupnp/src/dataelements/hproduct_tokens.cpp
+index 40f9fda..6739a58 100644
+--- c/herqq/hupnp/src/dataelements/hproduct_tokens.cpp
++++ i/herqq/hupnp/src/dataelements/hproduct_tokens.cpp
+@@ -99,7 +99,7 @@ bool HProductToken::isValidUpnpToken() const
+ {
+     QString vrs = version();
+ 
+-    return (m_token.compare("upnp", Qt::CaseInsensitive) == 0) &&
++    return (m_token.compare(QString("upnp"), Qt::CaseInsensitive) == 0) &&
+            (vrs.size() == 3    &&
+            (vrs[0]     == '1') &&
+             vrs[1]     == '.'  &&
+@@ -110,7 +110,7 @@ bool HProductToken::isValidDlnaDocToken() const
+ {
+     QString vrs = version();
+ 
+-    bool b = m_token.compare("DLNADOC", Qt::CaseInsensitive) == 0 &&
++    bool b = m_token.compare(QString("DLNADOC"), Qt::CaseInsensitive) == 0 &&
+              vrs.size() >= 3 &&
+              vrs[0] == '1' &&
+              vrs[1] == '.';
+diff --git c/herqq/hupnp/src/dataelements/hresourcetype.cpp i/herqq/hupnp/src/dataelements/hresourcetype.cpp
+index 8ed2492..94ab1e0 100644
+--- c/herqq/hupnp/src/dataelements/hresourcetype.cpp
++++ i/herqq/hupnp/src/dataelements/hresourcetype.cpp
+@@ -56,7 +56,7 @@ HResourceType::HResourceType(const QString& resourceTypeAsStr) :
+     {
+         return;
+     }
+-    if (tmp[1].compare("schemas-upnp-org") != 0)
++    if (tmp[1].compare(QString("schemas-upnp-org")) != 0)
+     {
+         flags = 0x01;
+         tmp[1] = tmp[1].replace('.', '-');
+@@ -67,11 +67,11 @@ HResourceType::HResourceType(const QString& resourceTypeAsStr) :
+     }
+ 
+     tmp[2] = tmp[2].simplified();
+-    if (tmp[2].compare("device") == 0)
++    if (tmp[2].compare(QString("device")) == 0)
+     {
+         flags |= 0x04;
+     }
+-    else if (tmp[2].compare("service") == 0)
++    else if (tmp[2].compare(QString("service")) == 0)
+     {
+         flags |= 0x08;
+     }
+diff --git c/herqq/hupnp/src/dataelements/hserviceid.cpp i/herqq/hupnp/src/dataelements/hserviceid.cpp
+index 9b0fad6..11a8640 100644
+--- c/herqq/hupnp/src/dataelements/hserviceid.cpp
++++ i/herqq/hupnp/src/dataelements/hserviceid.cpp
+@@ -64,7 +64,7 @@ public:
+             return;
+         }
+ 
+-        if (tmp[0].compare("urn", Qt::CaseInsensitive) != 0)
++        if (tmp[0].compare(QString("urn"), Qt::CaseInsensitive) != 0)
+         {
+             HLOG_WARN_NONSTD(
+                 QString("Invalid service identifier [%1]").arg(arg));
+@@ -72,7 +72,7 @@ public:
+             return;
+         }
+ 
+-        if (tmp[1].compare("upnp-org", Qt::CaseInsensitive) != 0)
++        if (tmp[1].compare(QString("upnp-org"), Qt::CaseInsensitive) != 0)
+         {
+             tmp[1] = tmp[1].replace('.', '-');
+             if (tmp[1].isEmpty())
+@@ -85,7 +85,7 @@ public:
+         }
+ 
+         bool warned = false;
+-        if (tmp[2].compare("serviceId", Qt::CaseInsensitive) != 0)
++        if (tmp[2].compare(QString("serviceId"), Qt::CaseInsensitive) != 0)
+         {
+             HLOG_WARN_NONSTD(QString("Invalid service identifier [%1]").arg(arg));
+             warned = true;
+diff --git c/herqq/hupnp/src/devicehosting/hddoc_parser_p.cpp i/herqq/hupnp/src/devicehosting/hddoc_parser_p.cpp
+index b3a58fa..d1853e1 100644
+--- c/herqq/hupnp/src/devicehosting/hddoc_parser_p.cpp
++++ i/herqq/hupnp/src/devicehosting/hddoc_parser_p.cpp
+@@ -195,7 +195,7 @@ bool HDocParser::parseActionArguments(
+         }
+ 
+         HActionArgument createdArg;
+-        if (dirStr.compare("out", Qt::CaseInsensitive) == 0)
++        if (dirStr.compare(QString("out"), Qt::CaseInsensitive) == 0)
+         {
+             if (retValWasDefined)
+             {
+@@ -228,7 +228,7 @@ bool HDocParser::parseActionArguments(
+ 
+             outArgs->push_back(createdArg);
+         }
+-        else if (dirStr.compare("in", Qt::CaseInsensitive) == 0)
++        else if (dirStr.compare(QString("in"), Qt::CaseInsensitive) == 0)
+         {
+             if (firstOutArgFound)
+             {
+@@ -677,11 +677,11 @@ bool HDocParser::parseStateVariable(
+ 
+     QString strSendEvents = stateVariableElement.attribute("sendEvents", "no");
+     bool bSendEvents      = false;
+-    if (strSendEvents.compare("yes", Qt::CaseInsensitive) == 0)
++    if (strSendEvents.compare(QString("yes"), Qt::CaseInsensitive) == 0)
+     {
+         bSendEvents = true;
+     }
+-    else if (strSendEvents.compare("no", Qt::CaseInsensitive) != 0)
++    else if (strSendEvents.compare(QString("no"), Qt::CaseInsensitive) != 0)
+     {
+         m_lastError = InvalidServiceDescriptionError;
+         m_lastErrorDescription = QString(
+@@ -694,11 +694,11 @@ bool HDocParser::parseStateVariable(
+ 
+     QString strMulticast  = stateVariableElement.attribute("multicast", "no");
+     bool bMulticast       = false;
+-    if (strMulticast.compare("yes", Qt::CaseInsensitive) == 0)
++    if (strMulticast.compare(QString("yes"), Qt::CaseInsensitive) == 0)
+     {
+         bMulticast = true;
+     }
+-    else if (strMulticast.compare("no", Qt::CaseInsensitive) != 0)
++    else if (strMulticast.compare(QString("no"), Qt::CaseInsensitive) != 0)
+     {
+         m_lastError = InvalidServiceDescriptionError;
+         m_lastErrorDescription = QString(
+diff --git c/herqq/hupnp/src/devicehosting/messages/hevent_messages_p.cpp i/herqq/hupnp/src/devicehosting/messages/hevent_messages_p.cpp
+index 2e375a0..2d6a8cc 100644
+--- c/herqq/hupnp/src/devicehosting/messages/hevent_messages_p.cpp
++++ i/herqq/hupnp/src/devicehosting/messages/hevent_messages_p.cpp
+@@ -197,7 +197,7 @@ HSubscribeRequest::RetVal HSubscribeRequest::setContents(
+ 
+     // this appears to be an initial subscription
+ 
+-    if (nt.simplified().compare("upnp:event", Qt::CaseInsensitive) != 0)
++    if (nt.simplified().compare(QString("upnp:event"), Qt::CaseInsensitive) != 0)
+     {
+         return PreConditionFailed;
+     }
+diff --git c/herqq/hupnp/src/devicehosting/messages/hnt_p.cpp i/herqq/hupnp/src/devicehosting/messages/hnt_p.cpp
+index aacdfcf..b618ba7 100644
+--- c/herqq/hupnp/src/devicehosting/messages/hnt_p.cpp
++++ i/herqq/hupnp/src/devicehosting/messages/hnt_p.cpp
+@@ -37,7 +37,7 @@ HNt::HNt(const QString& type) :
+     m_typeValue(qMakePair(Type_Undefined, QString(""))),
+     m_subTypeValue(qMakePair(SubType_Undefined, QString("")))
+ {
+-    if (type.compare("upnp:event", Qt::CaseInsensitive) == 0)
++    if (type.compare(QString("upnp:event"), Qt::CaseInsensitive) == 0)
+     {
+         m_typeValue.first  = Type_UpnpEvent;
+         m_typeValue.second = "upnp:event";
+@@ -48,13 +48,13 @@ HNt::HNt(const QString& type, const QString& subtype) :
+     m_typeValue(qMakePair(Type_Undefined, QString(""))),
+     m_subTypeValue(qMakePair(SubType_Undefined, QString("")))
+ {
+-    if (type.compare("upnp:event", Qt::CaseInsensitive) == 0)
++    if (type.compare(QString("upnp:event"), Qt::CaseInsensitive) == 0)
+     {
+         m_typeValue.first  = Type_UpnpEvent;
+         m_typeValue.second = "upnp:event";
+     }
+ 
+-    if (subtype.compare("upnp:propchange", Qt::CaseInsensitive) == 0)
++    if (subtype.compare(QString("upnp:propchange"), Qt::CaseInsensitive) == 0)
+     {
+         m_subTypeValue.first  = SubType_UpnpPropChange;
+         m_subTypeValue.second = "upnp:propchange";
+diff --git c/herqq/hupnp/src/devicehosting/messages/htimeout_p.cpp i/herqq/hupnp/src/devicehosting/messages/htimeout_p.cpp
+index 0faf7f4..addbaaf 100644
+--- c/herqq/hupnp/src/devicehosting/messages/htimeout_p.cpp
++++ i/herqq/hupnp/src/devicehosting/messages/htimeout_p.cpp
+@@ -43,7 +43,7 @@ HTimeout::HTimeout(const QString& timeout) :
+     m_value(-1)
+ {
+     QString tmp(timeout.simplified());
+-    if (tmp.compare("infinite", Qt::CaseInsensitive) != 0)
++    if (tmp.compare(QString("infinite"), Qt::CaseInsensitive) != 0)
+     {
+         if (tmp.startsWith("Second-", Qt::CaseInsensitive))
+         {
+diff --git c/herqq/hupnp/src/general/hupnp_datatypes.cpp i/herqq/hupnp/src/general/hupnp_datatypes.cpp
+index 9f2084f..ae8e9ae 100644
+--- c/herqq/hupnp/src/general/hupnp_datatypes.cpp
++++ i/herqq/hupnp/src/general/hupnp_datatypes.cpp
+@@ -424,15 +424,15 @@ QVariant HUpnpDataTypes::convertToRightVariantType(
+ 
+     case HUpnpDataTypes::boolean:
+     {
+-        if (value.compare("true", Qt::CaseInsensitive) == 0 ||
+-            value.compare("yes", Qt::CaseInsensitive) == 0 ||
+-            value.compare("1") == 0)
++        if (value.compare(QString("true"), Qt::CaseInsensitive) == 0 ||
++            value.compare(QString("yes"), Qt::CaseInsensitive) == 0 ||
++            value.compare(QString("1")) == 0)
+         {
+             retVal = true;
+         }
+-        else if (value.compare("false", Qt::CaseInsensitive) == 0 ||
+-            value.compare("no", Qt::CaseInsensitive) == 0 ||
+-            value.compare("0") == 0)
++        else if (value.compare(QString("false"), Qt::CaseInsensitive) == 0 ||
++            value.compare(QString("no"), Qt::CaseInsensitive) == 0 ||
++            value.compare(QString("0")) == 0)
+         {
+             retVal = false;
+         }
+diff --git c/herqq/hupnp/src/http/hhttp_server_p.cpp i/herqq/hupnp/src/http/hhttp_server_p.cpp
+index eb1a56c..42e93ca 100644
+--- c/herqq/hupnp/src/http/hhttp_server_p.cpp
++++ i/herqq/hupnp/src/http/hhttp_server_p.cpp
+@@ -121,27 +121,27 @@ void HHttpServer::processRequest(HHttpAsyncOperation* op)
+     mi->setKeepAlive(HHttpUtils::keepAlive(*hdr));
+ 
+     QString method = hdr->method();
+-    if (method.compare("GET", Qt::CaseInsensitive) == 0)
++    if (method.compare(QString("GET"), Qt::CaseInsensitive) == 0)
+     {
+         processGet(op->takeMessagingInfo(), *hdr);
+     }
+-    else if (method.compare("HEAD"), Qt::CaseInsensitive)
++    else if (method.compare(QString("HEAD")), Qt::CaseInsensitive)
+     {
+         processHead(op->takeMessagingInfo(), *hdr);
+     }
+-    else if (method.compare("POST", Qt::CaseInsensitive) == 0)
++    else if (method.compare(QString("POST"), Qt::CaseInsensitive) == 0)
+     {
+         processPost(op->takeMessagingInfo(), *hdr, op->dataRead());
+     }
+-    else if (method.compare("NOTIFY", Qt::CaseInsensitive) == 0)
++    else if (method.compare(QString("NOTIFY"), Qt::CaseInsensitive) == 0)
+     {
+         processNotifyMessage(op->takeMessagingInfo(), *hdr, op->dataRead());
+     }
+-    else if (method.compare("SUBSCRIBE", Qt::CaseInsensitive) == 0)
++    else if (method.compare(QString("SUBSCRIBE"), Qt::CaseInsensitive) == 0)
+     {
+         processSubscription(op->takeMessagingInfo(), *hdr);
+     }
+-    else if (method.compare("UNSUBSCRIBE", Qt::CaseInsensitive) == 0)
++    else if (method.compare(QString("UNSUBSCRIBE"), Qt::CaseInsensitive) == 0)
+     {
+         processUnsubscription(op->takeMessagingInfo(), *hdr);
+     }
+diff --git c/herqq/hupnp/src/http/hhttp_utils_p.h i/herqq/hupnp/src/http/hhttp_utils_p.h
+index 7285190..b3ee62e 100644
+--- c/herqq/hupnp/src/http/hhttp_utils_p.h
++++ i/herqq/hupnp/src/http/hhttp_utils_p.h
+@@ -64,10 +64,10 @@ public:
+         QString connection = hdr.value("CONNECTION");
+         if (hdr.minorVersion() == 1)
+         {
+-            return connection.compare("close", Qt::CaseInsensitive) != 0;
++            return connection.compare(QString("close"), Qt::CaseInsensitive) != 0;
+         }
+ 
+-        return connection.compare("Keep-Alive", Qt::CaseInsensitive) == 0;
++        return connection.compare(QString("Keep-Alive"), Qt::CaseInsensitive) == 0;
+     }
+ 
+     // returns the URLs as a string inside brackets. This is the format used in
+diff --git c/herqq/hupnp/src/utils/hmisc_utils_p.cpp i/herqq/hupnp/src/utils/hmisc_utils_p.cpp
+index 6641d14..7ea567a 100644
+--- c/herqq/hupnp/src/utils/hmisc_utils_p.cpp
++++ i/herqq/hupnp/src/utils/hmisc_utils_p.cpp
+@@ -70,10 +70,10 @@ bool toBool(const QString& arg, bool* ok)
+     bool retVal = false, match = true;
+     if (arg == "1") { retVal = true; }
+     else if (arg == "0") { retVal = false; }
+-    else if (arg.compare("true", Qt::CaseInsensitive) == 0) { retVal = true; }
+-    else if (arg.compare("false", Qt::CaseInsensitive) == 0) { retVal =  false; }
+-    else if (arg.compare("yes", Qt::CaseInsensitive) == 0) { retVal = true; }
+-    else if (arg.compare("no", Qt::CaseInsensitive) == 0) { retVal = false; }
++    else if (arg.compare(QString("true"), Qt::CaseInsensitive) == 0) { retVal = true; }
++    else if (arg.compare(QString("false"), Qt::CaseInsensitive) == 0) { retVal =  false; }
++    else if (arg.compare(QString("yes"), Qt::CaseInsensitive) == 0) { retVal = true; }
++    else if (arg.compare(QString("no"), Qt::CaseInsensitive) == 0) { retVal = false; }
+     else { match = false; }
+ 
+     if (ok) { *ok = match; }
+diff --git c/herqq/hupnp_av/src/cds_model/cds_objects/hobject.cpp i/herqq/hupnp_av/src/cds_model/cds_objects/hobject.cpp
+index 6531929..8bd05c5 100644
+--- c/herqq/hupnp_av/src/cds_model/cds_objects/hobject.cpp
++++ i/herqq/hupnp_av/src/cds_model/cds_objects/hobject.cpp
+@@ -680,15 +680,15 @@ QString HObject::writeStatusToString(WriteStatus status)
+ HObject::WriteStatus HObject::writeStatusFromString(const QString& status)
+ {
+     WriteStatus retVal = UnknownWriteStatus;
+-    if (status.compare("writable", Qt::CaseInsensitive) == 0)
++    if (status.compare(QString("writable"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = WritableWriteStatus;
+     }
+-    else if (status.compare("protected", Qt::CaseInsensitive) == 0)
++    else if (status.compare(QString("protected"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = ProtectedWriteStatus;
+     }
+-    else if (status.compare("mixed", Qt::CaseInsensitive) == 0)
++    else if (status.compare(QString("mixed"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = MixedWriteStatus;
+     }
+diff --git c/herqq/hupnp_av/src/cds_model/hmatching_id.cpp i/herqq/hupnp_av/src/cds_model/hmatching_id.cpp
+index 25ee560..bea6ece 100644
+--- c/herqq/hupnp_av/src/cds_model/hmatching_id.cpp
++++ i/herqq/hupnp_av/src/cds_model/hmatching_id.cpp
+@@ -77,11 +77,11 @@ QString HMatchingId::toString(Type type)
+ HMatchingId::Type HMatchingId::fromString(const QString& type)
+ {
+     Type retVal = Undefined;
+-    if (type.compare("SI_SERIESID", Qt::CaseInsensitive) == 0)
++    if (type.compare(QString("SI_SERIESID"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = SeriesId;
+     }
+-    else if (type.compare("SI_PROGRAMID", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("SI_PROGRAMID"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = ProgramId;
+     }
+diff --git c/herqq/hupnp_av/src/cds_model/hscheduledtime.cpp i/herqq/hupnp_av/src/cds_model/hscheduledtime.cpp
+index 06ab6bf..e7cec20 100644
+--- c/herqq/hupnp_av/src/cds_model/hscheduledtime.cpp
++++ i/herqq/hupnp_av/src/cds_model/hscheduledtime.cpp
+@@ -108,11 +108,11 @@ QString HScheduledTime::toString(Type type)
+ HScheduledTime::Type HScheduledTime::fromString(const QString& type)
+ {
+     Type retVal = Undefined;
+-    if (type.compare("SCHEDULED_PROGRAM", Qt::CaseInsensitive) == 0)
++    if (type.compare(QString("SCHEDULED_PROGRAM"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = ScheduledProgram;
+     }
+-    else if (type.compare("ON_DEMAND", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("ON_DEMAND"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = OnDemand;
+     }
+diff --git c/herqq/hupnp_av/src/cds_model/hsortinfo.cpp i/herqq/hupnp_av/src/cds_model/hsortinfo.cpp
+index 078d719..31e1af0 100644
+--- c/herqq/hupnp_av/src/cds_model/hsortinfo.cpp
++++ i/herqq/hupnp_av/src/cds_model/hsortinfo.cpp
+@@ -115,19 +115,19 @@ QString HSortModifier::toString(Type type)
+ HSortModifier::Type HSortModifier::fromString(const QString& type)
+ {
+     Type retVal = Undefined;
+-    if (type.compare("+", Qt::CaseInsensitive) == 0)
++    if (type.compare(QString("+"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = AscendingByValue;
+     }
+-    else if (type.compare("-", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("-"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DescendingByValue;
+     }
+-    else if (type.compare("TIME+", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("TIME+"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = AscendingByTime;
+     }
+-    else if (type.compare("TIME-", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("TIME-"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DescendingByTime;
+     }
+diff --git c/herqq/hupnp_av/src/cds_model/hstatevariablecollection.cpp i/herqq/hupnp_av/src/cds_model/hstatevariablecollection.cpp
+index 65b67f8..f51e6b2 100644
+--- c/herqq/hupnp_av/src/cds_model/hstatevariablecollection.cpp
++++ i/herqq/hupnp_av/src/cds_model/hstatevariablecollection.cpp
+@@ -198,11 +198,11 @@ HStateVariableCollection::RcsInstanceType HStateVariableCollection::fromString(
+     const QString& type)
+ {
+     RcsInstanceType retVal = Undefined;
+-    if (type.compare("pre-mix", Qt::CaseInsensitive) == 0)
++    if (type.compare(QString("pre-mix"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = PreMix;
+     }
+-    else if (type.compare("post-mix", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("post-mix"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = PostMix;
+     }
+diff --git c/herqq/hupnp_av/src/cds_model/model_mgmt/hcds_dlite_serializer.cpp i/herqq/hupnp_av/src/cds_model/model_mgmt/hcds_dlite_serializer.cpp
+index 9f5712d..cd4dacb 100644
+--- c/herqq/hupnp_av/src/cds_model/model_mgmt/hcds_dlite_serializer.cpp
++++ i/herqq/hupnp_av/src/cds_model/model_mgmt/hcds_dlite_serializer.cpp
+@@ -568,7 +568,7 @@ bool HCdsDidlLiteSerializer::serializeFromXml(
+         addNamespaces(reader);
+         if (reader.readNextStartElement())
+         {
+-            if (reader.name().compare("DIDL-Lite", Qt::CaseInsensitive) != 0)
++            if (reader.name().compare(QString("DIDL-Lite"), Qt::CaseInsensitive) != 0)
+             {
+                 h_ptr->m_lastErrorDescription = "Missing mandatory DIDL-Lite element";
+                 return false;
+diff --git c/herqq/hupnp_av/src/cds_model/model_mgmt/hcdsproperty_db.cpp i/herqq/hupnp_av/src/cds_model/model_mgmt/hcdsproperty_db.cpp
+index 30af243..af03c5c 100644
+--- c/herqq/hupnp_av/src/cds_model/model_mgmt/hcdsproperty_db.cpp
++++ i/herqq/hupnp_av/src/cds_model/model_mgmt/hcdsproperty_db.cpp
+@@ -749,7 +749,7 @@ bool HCdsPropertyDbPrivate::serializeSvCollectionIn(
+ 
+     if (stateVariableReader.readNextStartElement())
+     {
+-        if (stateVariableReader.name().compare("stateVariableValuePairs", Qt::CaseInsensitive) != 0)
++        if (stateVariableReader.name().compare(QString("stateVariableValuePairs"), Qt::CaseInsensitive) != 0)
+         {
+             return false;
+         }
+diff --git c/herqq/hupnp_av/src/common/hradioband.cpp i/herqq/hupnp_av/src/common/hradioband.cpp
+index d35a559..85b7e32 100644
+--- c/herqq/hupnp_av/src/common/hradioband.cpp
++++ i/herqq/hupnp_av/src/common/hradioband.cpp
+@@ -83,23 +83,23 @@ QString HRadioBand::toString(Type type)
+ HRadioBand::Type HRadioBand::fromString(const QString& arg)
+ {
+     Type retVal = Undefined;
+-    if (arg.compare("am", Qt::CaseInsensitive) == 0)
++    if (arg.compare(QString("am"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = AM;
+     }
+-    else if (arg.compare("fm", Qt::CaseInsensitive) == 0)
++    else if (arg.compare(QString("fm"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = FM;
+     }
+-    else if (arg.compare("shortwave", Qt::CaseInsensitive) == 0)
++    else if (arg.compare(QString("shortwave"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = ShortWave;
+     }
+-    else if (arg.compare("internet", Qt::CaseInsensitive) == 0)
++    else if (arg.compare(QString("internet"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Internet;
+     }
+-    else if (arg.compare("satellite", Qt::CaseInsensitive) == 0)
++    else if (arg.compare(QString("satellite"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Satellite;
+     }
+diff --git c/herqq/hupnp_av/src/common/hstoragemedium.cpp i/herqq/hupnp_av/src/common/hstoragemedium.cpp
+index 37ab7e0..c7f2109 100644
+--- c/herqq/hupnp_av/src/common/hstoragemedium.cpp
++++ i/herqq/hupnp_av/src/common/hstoragemedium.cpp
+@@ -187,155 +187,155 @@ QString HStorageMedium::toString(Type type)
+ HStorageMedium::Type HStorageMedium::fromString(const QString& type)
+ {
+     Type retVal = Unknown;
+-    if (type.compare("UNKNOWN", Qt::CaseInsensitive) == 0)
++    if (type.compare(QString("UNKNOWN"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Unknown;
+     }
+-    else if (type.compare("DV", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("DV"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DigitalVideo;
+     }
+-    else if (type.compare("VHS", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("VHS"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = VHS;
+     }
+-    else if (type.compare("W-VHS", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("W-VHS"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = W_VHS;
+     }
+-    else if (type.compare("S-VHS", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("S-VHS"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = S_VHS;
+     }
+-    else if (type.compare("D_VHS", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("D_VHS"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = D_VHS;
+     }
+-    else if (type.compare("VHSC", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("VHSC"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = VHSC;
+     }
+-    else if (type.compare("VIDEO8", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("VIDEO8"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Video8;
+     }
+-    else if (type.compare("HI8", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("HI8"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = HI8;
+     }
+-    else if (type.compare("CD-ROM", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("CD-ROM"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = CD_ROM;
+     }
+-    else if (type.compare("CD-DA", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("CD-DA"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = CD_DA;
+     }
+-    else if (type.compare("CD-R", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("CD-R"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = CD_R;
+     }
+-    else if (type.compare("CD-RW", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("CD-RW"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = CD_RW;
+     }
+-    else if (type.compare("VIDEO-CD", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("VIDEO-CD"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Video_CD;
+     }
+-    else if (type.compare("SACD", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("SACD"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = SACD;
+     }
+-    else if (type.compare("MD-AUDIO", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("MD-AUDIO"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = MiniDiscAudio;
+     }
+-    else if (type.compare("MD-PICTURE", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("MD-PICTURE"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = MiniDiscPicture;
+     }
+-    else if (type.compare("DVD-ROM", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("DVD-ROM"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DVD_ROM;
+     }
+-    else if (type.compare("DVD-VIDEO", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("DVD-VIDEO"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DVD_Video;
+     }
+-    else if (type.compare("DVD+R", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("DVD+R"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DVD_PlusRecordable;
+     }
+-    else if (type.compare("DVD-R", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("DVD-R"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DVD_MinusRecordable;
+     }
+-    else if (type.compare("DVD+RW", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("DVD+RW"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DVD_PlusRewritable;
+     }
+-    else if (type.compare("DVD-RW", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("DVD-RW"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DVD_MinusRewritable;
+     }
+-    else if (type.compare("DVD-RAM", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("DVD-RAM"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DVD_RAM;
+     }
+-    else if (type.compare("DAT", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("DAT"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DAT;
+     }
+-    else if (type.compare("LD", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("LD"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = LD;
+     }
+-    else if (type.compare("HDD", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("HDD"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = HDD;
+     }
+-    else if (type.compare("MICRO-MV", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("MICRO-MV"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = MicroMV;
+     }
+-    else if (type.compare("NETWORK", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("NETWORK"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Network;
+     }
+-    else if (type.compare("NONE", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("NONE"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = None;
+     }
+-    else if (type.compare("NOT_IMPLEMENTED", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("NOT_IMPLEMENTED"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = NotImplemented;
+     }
+-    else if (type.compare("SD", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("SD"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = SecureDigital;
+     }
+-    else if (type.compare("PC-CARD", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("PC-CARD"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = PC_Card;
+     }
+-    else if (type.compare("MMC", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("MMC"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = MultimediaCard;
+     }
+-    else if (type.compare("CF", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("CF"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = CompactFlash;
+     }
+-    else if (type.compare("BD", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("BD"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = BluRay;
+     }
+-    else if (type.compare("MS", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("MS"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = MemoryStick;
+     }
+-    else if (type.compare("HD_DVD", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("HD_DVD"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = HD_DVD;
+     }
+diff --git c/herqq/hupnp_av/src/connectionmanager/hconnectionmanager_info.cpp i/herqq/hupnp_av/src/connectionmanager/hconnectionmanager_info.cpp
+index 89d44ae..bb364b5 100644
+--- c/herqq/hupnp_av/src/connectionmanager/hconnectionmanager_info.cpp
++++ i/herqq/hupnp_av/src/connectionmanager/hconnectionmanager_info.cpp
+@@ -57,11 +57,11 @@ HConnectionManagerInfo::Direction
+     HConnectionManagerInfo::directionFromString(const QString& arg)
+ {
+     Direction retVal = DirectionUndefined;
+-    if (arg.compare("Input", Qt::CaseInsensitive) == 0)
++    if (arg.compare(QString("Input"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DirectionInput;
+     }
+-    else if (arg.compare("Output", Qt::CaseInsensitive) == 0)
++    else if (arg.compare(QString("Output"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DirectionOutput;
+     }
+@@ -92,23 +92,23 @@ HConnectionManagerInfo::ConnectionStatus
+     HConnectionManagerInfo::statusFromString(const QString& arg)
+ {
+     ConnectionStatus retVal = StatusUnknown;
+-    if (arg.compare("Ok", Qt::CaseInsensitive) == 0)
++    if (arg.compare(QString("Ok"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = StatusOk;
+     }
+-    else if (arg.compare("Unknown", Qt::CaseInsensitive) == 0)
++    else if (arg.compare(QString("Unknown"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = StatusUnknown;
+     }
+-    else if (arg.compare("ContentFormatMismatch", Qt::CaseInsensitive) == 0)
++    else if (arg.compare(QString("ContentFormatMismatch"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = StatusContentFormatMismatch;
+     }
+-    else if (arg.compare("InsufficientBandwidth", Qt::CaseInsensitive) == 0)
++    else if (arg.compare(QString("InsufficientBandwidth"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = StatusInsufficientBandwidth;
+     }
+-    else if (arg.compare("UnreliableChannel", Qt::CaseInsensitive) == 0)
++    else if (arg.compare(QString("UnreliableChannel"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = StatusUnreliableChannel;
+     }
+diff --git c/herqq/hupnp_av/src/contentdirectory/hcontentdirectory_info.cpp i/herqq/hupnp_av/src/contentdirectory/hcontentdirectory_info.cpp
+index 5c0c0d0..743ed1e 100644
+--- c/herqq/hupnp_av/src/contentdirectory/hcontentdirectory_info.cpp
++++ i/herqq/hupnp_av/src/contentdirectory/hcontentdirectory_info.cpp
+@@ -80,11 +80,11 @@ HContentDirectoryInfo::BrowseFlag
+     HContentDirectoryInfo::browseFlagFromString(const QString& arg)
+ {
+     BrowseFlag retVal = Undefined;
+-    if (arg.compare("BrowseMetadata", Qt::CaseInsensitive) == 0)
++    if (arg.compare(QString("BrowseMetadata"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = BrowseMetadata;
+     }
+-    else if (arg.compare("BrowseDirectChildren", Qt::CaseInsensitive) == 0)
++    else if (arg.compare(QString("BrowseDirectChildren"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = BrowseDirectChildren;
+     }
+diff --git c/herqq/hupnp_av/src/contentdirectory/htransferprogressinfo.cpp i/herqq/hupnp_av/src/contentdirectory/htransferprogressinfo.cpp
+index 0a663dc..1771b6f 100644
+--- c/herqq/hupnp_av/src/contentdirectory/htransferprogressinfo.cpp
++++ i/herqq/hupnp_av/src/contentdirectory/htransferprogressinfo.cpp
+@@ -85,15 +85,15 @@ HTransferProgressInfo::~HTransferProgressInfo()
+ HTransferProgressInfo::Status HTransferProgressInfo::fromString(const QString& arg)
+ {
+     Status retVal = Error;
+-    if (arg.compare("IN_PROGRESS", Qt::CaseInsensitive) == 0)
++    if (arg.compare(QString("IN_PROGRESS"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = InProgress;
+     }
+-    else if (arg.compare("STOPPED", Qt::CaseInsensitive) == 0)
++    else if (arg.compare(QString("STOPPED"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Stopped;
+     }
+-    else if (arg.compare("COMPLETED", Qt::CaseInsensitive) == 0)
++    else if (arg.compare(QString("COMPLETED"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Completed;
+     }
+diff --git c/herqq/hupnp_av/src/hav_global.cpp i/herqq/hupnp_av/src/hav_global.cpp
+index c3f93a9..27d98a0 100644
+--- c/herqq/hupnp_av/src/hav_global.cpp
++++ i/herqq/hupnp_av/src/hav_global.cpp
+@@ -647,7 +647,7 @@ HStateVariableCollection parseStateVariableCollection(const QString& arg)
+     addNamespaces(reader);
+ 
+     if (!reader.readNextStartElement() ||
+-        reader.name().compare("stateVariableValuePairs", Qt::CaseInsensitive) != 0)
++        reader.name().compare(QString("stateVariableValuePairs"), Qt::CaseInsensitive) != 0)
+     {
+         return retVal;
+     }
+diff --git c/herqq/hupnp_av/src/mediabrowser/hmediabrowser.cpp i/herqq/hupnp_av/src/mediabrowser/hmediabrowser.cpp
+index f9e2dc4..69b7648 100644
+--- c/herqq/hupnp_av/src/mediabrowser/hmediabrowser.cpp
++++ i/herqq/hupnp_av/src/mediabrowser/hmediabrowser.cpp
+@@ -287,7 +287,7 @@ void HMediaBrowserPrivate::lastChangeReceived(
+ 
+     if (reader.readNextStartElement())
+     {
+-        if (reader.name().compare("StateEvent", Qt::CaseInsensitive) != 0)
++        if (reader.name().compare(QString("StateEvent"), Qt::CaseInsensitive) != 0)
+         {
+             return;
+         }
+diff --git c/herqq/hupnp_av/src/mediarenderer/hconnection.cpp i/herqq/hupnp_av/src/mediarenderer/hconnection.cpp
+index 651e727..9fb4958 100644
+--- c/herqq/hupnp_av/src/mediarenderer/hconnection.cpp
++++ i/herqq/hupnp_av/src/mediarenderer/hconnection.cpp
+@@ -144,7 +144,7 @@ void HConnection::lastChangeReceived(
+ 
+     if (reader.readNextStartElement())
+     {
+-        if (reader.name().compare("Event", Qt::CaseInsensitive) != 0)
++        if (reader.name().compare(QString("Event"), Qt::CaseInsensitive) != 0)
+         {
+             return;
+         }
+@@ -159,7 +159,7 @@ void HConnection::lastChangeReceived(
+     {
+         QStringRef name = reader.name();
+ 
+-        if (name.compare("InstanceID", Qt::CaseInsensitive))
++        if (name.compare(QString("InstanceID"), Qt::CaseInsensitive))
+         {
+             continue;
+         }
+@@ -205,7 +205,7 @@ void HConnection::lastChangeReceived(HAvTransportAdapter*, const QString& data)
+ 
+     if (reader.readNextStartElement())
+     {
+-        if (reader.name().compare("Event", Qt::CaseInsensitive) != 0)
++        if (reader.name().compare(QString("Event"), Qt::CaseInsensitive) != 0)
+         {
+             return;
+         }
+@@ -220,7 +220,7 @@ void HConnection::lastChangeReceived(HAvTransportAdapter*, const QString& data)
+     {
+         QStringRef name = reader.name();
+ 
+-        if (name.compare("InstanceID", Qt::CaseInsensitive))
++        if (name.compare(QString("InstanceID"), Qt::CaseInsensitive))
+         {
+             continue;
+         }
+diff --git c/herqq/hupnp_av/src/mediarenderer/hconnectionmanager_sinkservice_p.cpp i/herqq/hupnp_av/src/mediarenderer/hconnectionmanager_sinkservice_p.cpp
+index 174f423..bf7e9f2 100644
+--- c/herqq/hupnp_av/src/mediarenderer/hconnectionmanager_sinkservice_p.cpp
++++ i/herqq/hupnp_av/src/mediarenderer/hconnectionmanager_sinkservice_p.cpp
+@@ -109,7 +109,7 @@ qint32 HConnectionManagerSinkService::prepareForConnection(
+         return HConnectionManagerInfo::IncompatibleDirections;
+     }
+ 
+-    if (remoteProtocolInfo.protocol().compare("http-get", Qt::CaseInsensitive) &&
++    if (remoteProtocolInfo.protocol().compare(QString("http-get"), Qt::CaseInsensitive) &&
+         remoteProtocolInfo.protocol() != "*")
+     {
+         return HConnectionManagerInfo::IncompatibleProtocolInfo;
+diff --git c/herqq/hupnp_av/src/mediarenderer/hrendererconnection_info.cpp i/herqq/hupnp_av/src/mediarenderer/hrendererconnection_info.cpp
+index 1ad337a..0f5e209 100644
+--- c/herqq/hupnp_av/src/mediarenderer/hrendererconnection_info.cpp
++++ i/herqq/hupnp_av/src/mediarenderer/hrendererconnection_info.cpp
+@@ -1578,19 +1578,19 @@ bool HRendererConnectionInfo::hasChannelAssociated(const QString& svName)
+ {
+     bool retVal = false;
+     QString trimmed = svName.trimmed();
+-    if (trimmed.compare("Mute", Qt::CaseInsensitive) == 0)
++    if (trimmed.compare(QString("Mute"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = true;
+     }
+-    else if (trimmed.compare("Volume", Qt::CaseInsensitive) == 0)
++    else if (trimmed.compare(QString("Volume"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = true;
+     }
+-    else if (trimmed.compare("VolumeDB", Qt::CaseInsensitive) == 0)
++    else if (trimmed.compare(QString("VolumeDB"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = true;
+     }
+-    else if (trimmed.compare("Loudness", Qt::CaseInsensitive) == 0)
++    else if (trimmed.compare(QString("Loudness"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = true;
+     }
+diff --git c/herqq/hupnp_av/src/mediarenderer/htransport_sinkservice_p.cpp i/herqq/hupnp_av/src/mediarenderer/htransport_sinkservice_p.cpp
+index a614e17..fbb3258 100644
+--- c/herqq/hupnp_av/src/mediarenderer/htransport_sinkservice_p.cpp
++++ i/herqq/hupnp_av/src/mediarenderer/htransport_sinkservice_p.cpp
+@@ -449,7 +449,7 @@ qint32 HTransportSinkService::getStateVariables(
+     foreach(QString svName, stateVarNames)
+     {
+         svName = svName.trimmed();
+-        if (svName.compare("LastChange", Qt::CaseInsensitive) == 0 ||
++        if (svName.compare(QString("LastChange"), Qt::CaseInsensitive) == 0 ||
+             svName.startsWith("A_ARG", Qt::CaseInsensitive))
+         {
+             return HAvTransportInfo::InvalidStateVariableList;
+@@ -512,7 +512,7 @@ qint32 HTransportSinkService::setStateVariables(
+ 
+     if (reader.readNextStartElement())
+     {
+-        if (reader.name().compare("stateVariableValuePairs", Qt::CaseInsensitive) != 0)
++        if (reader.name().compare(QString("stateVariableValuePairs"), Qt::CaseInsensitive) != 0)
+         {
+             return UpnpInvalidArgs;
+         }
+diff --git c/herqq/hupnp_av/src/renderingcontrol/hchannel.cpp i/herqq/hupnp_av/src/renderingcontrol/hchannel.cpp
+index 751a3d9..51c1ff4 100644
+--- c/herqq/hupnp_av/src/renderingcontrol/hchannel.cpp
++++ i/herqq/hupnp_av/src/renderingcontrol/hchannel.cpp
+@@ -110,59 +110,59 @@ QString HChannel::toString(Type type)
+ HChannel::Type HChannel::fromString(const QString& type)
+ {
+     Type retVal = Undefined;
+-    if (type.compare("MASTER", Qt::CaseInsensitive) == 0)
++    if (type.compare(QString("MASTER"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Master;
+     }
+-    else if (type.compare("LF", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("LF"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = LeftFront;
+     }
+-    else if (type.compare("RF", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("RF"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = RightFront;
+     }
+-    else if (type.compare("CF", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("CF"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = CenterFront;
+     }
+-    else if (type.compare("LFE", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("LFE"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = LFE;
+     }
+-    else if (type.compare("LS", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("LS"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = LeftSurround;
+     }
+-    else if (type.compare("RS", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("RS"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = RightSurround;
+     }
+-    else if (type.compare("LFC", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("LFC"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = LeftOfCenter;
+     }
+-    else if (type.compare("RFC", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("RFC"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = RightOfCenter;
+     }
+-    else if (type.compare("SD", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("SD"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Surround;
+     }
+-    else if (type.compare("SL", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("SL"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = SideLeft;
+     }
+-    else if (type.compare("SR", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("SR"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = SideRight;
+     }
+-    else if (type.compare("T", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("T"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Top;
+     }
+-    else if (type.compare("B", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("B"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Bottom;
+     }
+diff --git c/herqq/hupnp_av/src/renderingcontrol/hrenderingcontrol_service_p.cpp i/herqq/hupnp_av/src/renderingcontrol/hrenderingcontrol_service_p.cpp
+index fd52f9a..84f5579 100644
+--- c/herqq/hupnp_av/src/renderingcontrol/hrenderingcontrol_service_p.cpp
++++ i/herqq/hupnp_av/src/renderingcontrol/hrenderingcontrol_service_p.cpp
+@@ -859,7 +859,7 @@ qint32 HRenderingControlService::setStateVariables(
+ 
+     if (reader.readNextStartElement())
+     {
+-        if (reader.name().compare("stateVariableValuePairs", Qt::CaseInsensitive) != 0)
++        if (reader.name().compare(QString("stateVariableValuePairs"), Qt::CaseInsensitive) != 0)
+         {
+             return UpnpInvalidArgs;
+         }
+diff --git c/herqq/hupnp_av/src/transport/havtransport_info.cpp i/herqq/hupnp_av/src/transport/havtransport_info.cpp
+index cb18ce0..e3fcd64 100644
+--- c/herqq/hupnp_av/src/transport/havtransport_info.cpp
++++ i/herqq/hupnp_av/src/transport/havtransport_info.cpp
+@@ -94,35 +94,35 @@ HAvTransportInfo::DrmState
+     HAvTransportInfo::drmStateFromString(const QString& state)
+ {
+     DrmState retVal = DrmState_Unknown;
+-    if (state.compare("OK", Qt::CaseInsensitive) == 0)
++    if (state.compare(QString("OK"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DrmState_Ok;
+     }
+-    else if (state.compare("UNKNOWN", Qt::CaseInsensitive) == 0)
++    else if (state.compare(QString("UNKNOWN"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DrmState_Unknown;
+     }
+-    else if (state.compare("PROCESSING_CONTENT_KEY", Qt::CaseInsensitive) == 0)
++    else if (state.compare(QString("PROCESSING_CONTENT_KEY"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DrmState_ProcessingContentKey;
+     }
+-    else if (state.compare("CONTENT_KEY_FAILURE", Qt::CaseInsensitive) == 0)
++    else if (state.compare(QString("CONTENT_KEY_FAILURE"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DrmState_ContentKeyFailure;
+     }
+-    else if (state.compare("ATTEMPTING_AUTHENTICATION", Qt::CaseInsensitive) == 0)
++    else if (state.compare(QString("ATTEMPTING_AUTHENTICATION"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DrmState_AttemptingAuthentication;
+     }
+-    else if (state.compare("FAILED_AUTHENTICATION", Qt::CaseInsensitive) == 0)
++    else if (state.compare(QString("FAILED_AUTHENTICATION"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DrmState_FailedAuthentication;
+     }
+-    else if (state.compare("NOT_AUTHENTICATED", Qt::CaseInsensitive) == 0)
++    else if (state.compare(QString("NOT_AUTHENTICATED"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DrmState_NotAuthenticated;
+     }
+-    else if (state.compare("DEVICE_REVOCATION", Qt::CaseInsensitive) == 0)
++    else if (state.compare(QString("DEVICE_REVOCATION"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = DrmState_DeviceRevocation;
+     }
+diff --git c/herqq/hupnp_av/src/transport/hmediainfo.cpp i/herqq/hupnp_av/src/transport/hmediainfo.cpp
+index 9e642c1..5f33847 100644
+--- c/herqq/hupnp_av/src/transport/hmediainfo.cpp
++++ i/herqq/hupnp_av/src/transport/hmediainfo.cpp
+@@ -180,15 +180,15 @@ HMediaInfo::MediaCategory HMediaInfo::mediaCategoryFromString(
+     const QString& category)
+ {
+     MediaCategory retVal = Undefined;
+-    if (category.compare("NO_MEDIA", Qt::CaseInsensitive) == 0)
++    if (category.compare(QString("NO_MEDIA"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = NoMedia;
+     }
+-    else if (category.compare("TRACK_AWARE", Qt::CaseInsensitive) == 0)
++    else if (category.compare(QString("TRACK_AWARE"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = TrackAware;
+     }
+-    else if (category.compare("TRACK_UNAWARE", Qt::CaseInsensitive) == 0)
++    else if (category.compare(QString("TRACK_UNAWARE"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = TrackUnaware;
+     }
+diff --git c/herqq/hupnp_av/src/transport/hplaymode.cpp i/herqq/hupnp_av/src/transport/hplaymode.cpp
+index 8d3a20e..57605f0 100644
+--- c/herqq/hupnp_av/src/transport/hplaymode.cpp
++++ i/herqq/hupnp_av/src/transport/hplaymode.cpp
+@@ -87,31 +87,31 @@ QString HPlayMode::toString(HPlayMode::Type type)
+ HPlayMode::Type HPlayMode::fromString(const QString& type)
+ {
+     Type retVal = Undefined;
+-    if (type.compare("NORMAL", Qt::CaseInsensitive) == 0)
++    if (type.compare(QString("NORMAL"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Normal;
+     }
+-    else if (type.compare("SHUFFLE", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("SHUFFLE"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Shuffle;
+     }
+-    else if (type.compare("REPEAT_ONE", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("REPEAT_ONE"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = RepeatOne;
+     }
+-    else if (type.compare("REPEAT_ALL", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("REPEAT_ALL"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = RepeatAll;
+     }
+-    else if (type.compare("RANDOM", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("RANDOM"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Random;
+     }
+-    else if (type.compare("DIRECT_1", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("DIRECT_1"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Direct_1;
+     }
+-    else if (type.compare("INTRO", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("INTRO"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Intro;
+     }
+diff --git c/herqq/hupnp_av/src/transport/hrecordmediumwritestatus.cpp i/herqq/hupnp_av/src/transport/hrecordmediumwritestatus.cpp
+index ab29f09..a1a5de0 100644
+--- c/herqq/hupnp_av/src/transport/hrecordmediumwritestatus.cpp
++++ i/herqq/hupnp_av/src/transport/hrecordmediumwritestatus.cpp
+@@ -81,23 +81,23 @@ HRecordMediumWriteStatus::Type HRecordMediumWriteStatus::fromString(
+     const QString& type)
+ {
+     Type retVal = Unknown;
+-    if (type.compare("WRITABLE", Qt::CaseInsensitive) == 0)
++    if (type.compare(QString("WRITABLE"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Writable;
+     }
+-    else if (type.compare("PROTECTED", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("PROTECTED"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Protected;
+     }
+-    else if (type.compare("NOT_WRITABLE", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("NOT_WRITABLE"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = NotWritable;
+     }
+-    else if (type.compare("NOT_IMPLEMENTED", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("NOT_IMPLEMENTED"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = NotImplemented;
+     }
+-    else if (type.compare("UNKNOWN", Qt::CaseInsensitive) != 0 && !type.isEmpty())
++    else if (type.compare(QString("UNKNOWN"), Qt::CaseInsensitive) != 0 && !type.isEmpty())
+     {
+         retVal = VendorDefined;
+     }
+diff --git c/herqq/hupnp_av/src/transport/hrecordqualitymode.cpp i/herqq/hupnp_av/src/transport/hrecordqualitymode.cpp
+index bf7dd90..b659fd7 100644
+--- c/herqq/hupnp_av/src/transport/hrecordqualitymode.cpp
++++ i/herqq/hupnp_av/src/transport/hrecordqualitymode.cpp
+@@ -88,31 +88,31 @@ QString HRecordQualityMode::toString(Type mode)
+ HRecordQualityMode::Type HRecordQualityMode::fromString(const QString& mode)
+ {
+     Type retVal = Undefined;
+-    if (mode.compare("0:EP", Qt::CaseInsensitive) == 0)
++    if (mode.compare(QString("0:EP"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Ep;
+     }
+-    else if (mode.compare("1:LP", Qt::CaseInsensitive) == 0)
++    else if (mode.compare(QString("1:LP"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Lp;
+     }
+-    else if (mode.compare("2:SP", Qt::CaseInsensitive) == 0)
++    else if (mode.compare(QString("2:SP"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Sp;
+     }
+-    else if (mode.compare("0:BASIC", Qt::CaseInsensitive) == 0)
++    else if (mode.compare(QString("0:BASIC"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Basic;
+     }
+-    else if (mode.compare("1:MEDIUM", Qt::CaseInsensitive) == 0)
++    else if (mode.compare(QString("1:MEDIUM"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Medium;
+     }
+-    else if (mode.compare("2:HIGH", Qt::CaseInsensitive) == 0)
++    else if (mode.compare(QString("2:HIGH"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = High;
+     }
+-    else if (mode.compare("NOT_IMPLEMENTED", Qt::CaseInsensitive) == 0)
++    else if (mode.compare(QString("NOT_IMPLEMENTED"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = NotImplemented;
+     }
+diff --git c/herqq/hupnp_av/src/transport/hseekinfo.cpp i/herqq/hupnp_av/src/transport/hseekinfo.cpp
+index c2ac69a..d3eee2b 100644
+--- c/herqq/hupnp_av/src/transport/hseekinfo.cpp
++++ i/herqq/hupnp_av/src/transport/hseekinfo.cpp
+@@ -102,43 +102,43 @@ QString HSeekMode::toString(Type type)
+ HSeekMode::Type HSeekMode::fromString(const QString& type)
+ {
+     Type retVal = Unknown;
+-    if (type.compare("TRACK_NR", Qt::CaseInsensitive) == 0)
++    if (type.compare(QString("TRACK_NR"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = TrackNr;
+     }
+-    else if (type.compare("ABS_TIME", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("ABS_TIME"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = AbsTime;
+     }
+-    else if (type.compare("REL_TIME", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("REL_TIME"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = RelTime;
+     }
+-    else if (type.compare("ABS_COUNT", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("ABS_COUNT"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = AbsCount;
+     }
+-    else if (type.compare("REL_COUNT", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("REL_COUNT"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = RelCount;
+     }
+-    else if (type.compare("CHANNEL_FREQ", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("CHANNEL_FREQ"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = ChannelFreq;
+     }
+-    else if (type.compare("TAPE-INDEX", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("TAPE-INDEX"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = TapeIndex;
+     }
+-    else if (type.compare("REL_TAPE-INDEX", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("REL_TAPE-INDEX"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = RelTapeIndex;
+     }
+-    else if (type.compare("FRAME", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("FRAME"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Frame;
+     }
+-    else if (type.compare("REL_FRAME", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("REL_FRAME"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = RelFrame;
+     }
+diff --git c/herqq/hupnp_av/src/transport/htransportaction.cpp i/herqq/hupnp_av/src/transport/htransportaction.cpp
+index d64b1bc..4a34b8d 100644
+--- c/herqq/hupnp_av/src/transport/htransportaction.cpp
++++ i/herqq/hupnp_av/src/transport/htransportaction.cpp
+@@ -91,31 +91,31 @@ QString HTransportAction::toString(Type type)
+ HTransportAction::Type HTransportAction::fromString(const QString& type)
+ {
+     Type retVal = Undefined;
+-    if (type.compare("PLAY", Qt::CaseInsensitive) == 0)
++    if (type.compare(QString("PLAY"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Play;
+     }
+-    else if (type.compare("STOP", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("STOP"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Stop;
+     }
+-    else if (type.compare("PAUSE", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("PAUSE"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Pause;
+     }
+-    else if (type.compare("SEEK", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("SEEK"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Seek;
+     }
+-    else if (type.compare("NEXT", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("NEXT"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Next;
+     }
+-    else if (type.compare("PREVIOUS", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("PREVIOUS"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Previous;
+     }
+-    else if (type.compare("RECORD", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("RECORD"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Record;
+     }
+diff --git c/herqq/hupnp_av/src/transport/htransportinfo.cpp i/herqq/hupnp_av/src/transport/htransportinfo.cpp
+index ecfaf0b..8ca9b1c 100644
+--- c/herqq/hupnp_av/src/transport/htransportinfo.cpp
++++ i/herqq/hupnp_av/src/transport/htransportinfo.cpp
+@@ -71,11 +71,11 @@ QString HTransportStatus::toString(HTransportStatus::Type type)
+ HTransportStatus::Type HTransportStatus::fromString(const QString& type)
+ {
+     Type retVal = Undefined;
+-    if (type.compare("OK", Qt::CaseInsensitive) == 0)
++    if (type.compare(QString("OK"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = OK;
+     }
+-    else if (type.compare("ERROR_OCCURRED", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("ERROR_OCCURRED"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = ErrorOccurred;
+     }
+diff --git c/herqq/hupnp_av/src/transport/htransportstate.cpp i/herqq/hupnp_av/src/transport/htransportstate.cpp
+index b460065..f2a1ac3 100644
+--- c/herqq/hupnp_av/src/transport/htransportstate.cpp
++++ i/herqq/hupnp_av/src/transport/htransportstate.cpp
+@@ -89,31 +89,31 @@ QString HTransportState::toString(HTransportState::Type type)
+ HTransportState::Type HTransportState::fromString(const QString& type)
+ {
+     Type retVal = Undefined;
+-    if (type.compare("NO_MEDIA_PRESENT", Qt::CaseInsensitive) == 0)
++    if (type.compare(QString("NO_MEDIA_PRESENT"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = NoMediaPresent;
+     }
+-    else if (type.compare("STOPPED", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("STOPPED"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Stopped;
+     }
+-    else if (type.compare("PLAYING", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("PLAYING"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Playing;
+     }
+-    else if (type.compare("TRANSITIONING", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("TRANSITIONING"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Transitioning;
+     }
+-    else if (type.compare("PAUSED_PLAYBACK", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("PAUSED_PLAYBACK"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = PausedPlayback;
+     }
+-    else if (type.compare("PAUSED_RECORDING", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("PAUSED_RECORDING"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = PausedRecording;
+     }
+-    else if (type.compare("RECORDING", Qt::CaseInsensitive) == 0)
++    else if (type.compare(QString("RECORDING"), Qt::CaseInsensitive) == 0)
+     {
+         retVal = Recording;
+     }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8375,7 +8375,7 @@ with pkgs;
 
   haxor-news = callPackage ../applications/misc/haxor-news { };
 
-  herqq = callPackage ../development/libraries/herqq { };
+  herqq = libsForQt5.callPackage ../development/libraries/herqq { };
 
   heyefi = haskellPackages.heyefi;
 


### PR DESCRIPTION
###### Motivation for this change
I requested an upstream release for this from a fork that has already ported to qt5.

Related to #28643

Upstream issue: https://github.com/ThomArmax/HUPnP/issues/7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

