### PR TITLE
weechat: add FHS wrapper

### DIFF
--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -8,6 +8,7 @@
 , pythonPackages
 , rubySupport ? true, ruby
 , tclSupport ? true, tcl
+, homeDir ? null, lib
 , extraBuildInputs ? [] }:
 
 assert guileSupport -> guile != null;
@@ -62,13 +63,15 @@ stdenv.mkDerivation rec {
     # Fix '_res_9_init: undefined symbol' error
     + (stdenv.lib.optionalString stdenv.isDarwin "-DBIND_8_COMPAT=1 -lresolv");
 
-  postInstall = with stdenv.lib; ''
+  postInstall = let
+    homeDirOption = lib.optionalString (homeDir != null) "--add-flags '-d ${homeDir}'";
+  in with stdenv.lib; ''
     NIX_PYTHONPATH="$out/lib/${python.libPrefix}/site-packages"
     wrapProgram "$out/bin/weechat" \
       ${optionalString perlSupport "--prefix PATH : ${perl}/bin"} \
       --prefix PATH : ${pythonPackages.python}/bin \
       --prefix PYTHONPATH : "$PYTHONPATH" \
-      --prefix PYTHONPATH : "$NIX_PYTHONPATH"
+      --prefix PYTHONPATH : "$NIX_PYTHONPATH" ${homeDirOption}
   '';
 
   meta = {

--- a/pkgs/applications/networking/irc/weechat/wrapper.nix
+++ b/pkgs/applications/networking/irc/weechat/wrapper.nix
@@ -1,0 +1,29 @@
+let
+  weechatDefault = "$HOME/.weechat";
+in
+  { weechat, plugins ? {}, buildFHSUserEnv
+  , homeDir ? weechatDefault, term ? "xterm" }:
+
+  let
+    weechat' =
+      if homeDir == weechatDefault
+      then weechat
+      else weechat.override { inherit homeDir; };
+
+    termScript = ''
+      export TERM=${term}
+    '';
+
+    pluginScripts = map (a: ''
+      mkdir -p ${homeDir}/$(dirname ${a})
+      cp -f ${plugins."${a}"}/share/$(basename ${a}) ${homeDir}/${a}
+    '') (builtins.attrNames plugins);
+  in
+    buildFHSUserEnv {
+      name = "weechat-wrapper";
+
+      targetPkgs = (_: [ weechat' ] ++ (builtins.attrValues plugins));
+      runScript = "${weechat'}/bin/weechat";
+
+      profile = builtins.concatStringsSep "\n" ([ termScript ] ++ pluginScripts);
+    }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16920,6 +16920,8 @@ with pkgs;
     inherit (luaPackages) cjson;
   };
 
+  weechat-wrapper = callPackage ../applications/networking/irc/weechat/wrapper.nix { };
+
   westonLite = callPackage ../applications/window-managers/weston {
     pango = null;
     freerdp = null;


### PR DESCRIPTION
###### Motivation for this change

In #28738 I added a derivation for a LUA script which makes it possible to connect to Matrix servers from WeeChat. @fpletz asked which approaches might be used to load this module into weechat itself.

I started building a simple FHS environment (which is needed unfortunately since the HOME dir of WeeChat will experience imperative changes during runtime) to make it possible use a user environment with WeeChat and a declarative configuration.

The following expression (which I used for testing purposes) generates a weechat executable with the `weechat-matrix-bridge` derivation:

``` nix
{ pkgs ? import <nixpkgs>{} }:
pkgs.weechat-wrapper.override {
  plugins = {
    "lua/autoload/matrix.lua" = pkgs.weechat-matrix-bridge;
  };
  homeDir = "$HOME/.weechat-test"; # any writable dir possible here :-)
}
```

The key in `plugins` describes the path inside WeeChat's home dir to the script, the value is the package of the plugin.
The script must be available in `${weechat-matrix-bridge}/share/<filename of the script to be loaded>` (see `weechat-matrix-bridge` and the code of the FHS wrapper for further reference).

__Note:__ this is a proposal, I'm not 100% about this FHS-based approach ATM and happy about discussion :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

