### PR TITLE
emby: 3.2.28.0 -> 3.2.30.0

### DIFF
--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "emby-${version}";
-  version = "3.2.28.0";
+  version = "3.2.30.0";
 
   src = fetchurl {
     url = "https://github.com/MediaBrowser/Emby/releases/download/${version}/Emby.Mono.zip";
-    sha256 = "0bv0wj7rny3gh4d6qdyd8widd549ap3fl35sz3q6w9x8sqhw5nfi";
+    sha256 = "1aqal7n4a9dvy97zw4aah9a8jm4l2v1qgjgs5kvskrvir2dbid27";
   };
 
   buildInputs = with pkgs; [


### PR DESCRIPTION
###### Motivation for this change
https://github.com/MediaBrowser/Emby/releases/tag/3.2.29
https://github.com/MediaBrowser/Emby/releases/tag/3.2.30.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

