### PR TITLE
coqPackages.QuickChick: fix

### DIFF
--- a/pkgs/development/coq-modules/QuickChick/default.nix
+++ b/pkgs/development/coq-modules/QuickChick/default.nix
@@ -1,20 +1,38 @@
-{stdenv, fetchgit, coq, coqPackages}:
+{ stdenv, fetchgit, coq, ssreflect }:
 
-let revision = "ee436635a34873c79f49c3d2d507194216f6e8e9"; in
+let param =
+  {
+    "8.4" = {
+      version = "20160529";
+      rev = "a9e89f1d4246a787bf1d8873072077a319635c3e";
+      sha256 = "14ng71p890q12xvsj00si2a3fjcbsap2gy0r8sxpw4zndnlq74wa";
+    };
+
+    "8.5" = {
+      version = "20170512";
+      rev = "31eb050ae5ce57ab402db9726fb7cd945a0b4d03";
+      sha256 = "033ch10i5wmqyw8j6wnr0dlbnibgfpr1vr0c07q3yj6h23xkmqpg";
+    };
+
+    "8.6" = {
+      version = "20170616";
+      rev = "366ee3f8e599b5cab438a63a09713f44ac544c5a";
+      sha256 = "06kwnrfndnr6w8bmaa2s0i0rkqyv081zj55z3vcyn0wr6x6mlsz9";
+    };
+  }."${coq.coq-version}"
+; in
 
 stdenv.mkDerivation rec {
 
-  name = "coq-QuickChick-${coq.coq-version}-${version}";
-  version = "20170710-${builtins.substring 0 7 revision}";
+  name = "coq${coq.coq-version}-QuickChick-${param.version}";
 
   src = fetchgit {
     url = git://github.com/QuickChick/QuickChick.git;
-    rev = revision;
-    sha256 = "0sq14j1kl4m4plyxj2dbkfwa6iqipmf9w7mxxxcbsm718m0xf1gr";
+    inherit (param) rev sha256;
   };
 
   buildInputs = [ coq.ocaml coq.camlp5 ];
-  propagatedBuildInputs = [ coq coqPackages.ssreflect ];
+  propagatedBuildInputs = [ coq ssreflect ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Use the most recent versions of branches coq8.4pl6 and coq8.5-legacy
with the corresponding versions of Coq.

Use a two month old version with Coq-8.6 to avoid issue #45:
https://github.com/QuickChick/QuickChick/issues/45

###### Motivation for this change

QuickChick is broken, for all versions of Coq.

cc maintainer: @jwiegley 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

