### PR TITLE
meteor: 1.4.2.3 -> 1.5

### DIFF
--- a/pkgs/servers/meteor/default.nix
+++ b/pkgs/servers/meteor/default.nix
@@ -2,14 +2,14 @@
 
 let
   bootstrap = fetchurl {
-    url = "https://meteorinstall-4168.kxcdn.com/packages-bootstrap/1.4.2.3/meteor-bootstrap-os.linux.x86_64.tar.gz";
-    sha256 = "1x5dp8y731qai882ghy3337844lc686r15a4dd9wjx2zvy7wmwhz";
+    url = "https://meteorinstall-4168.kxcdn.com/packages-bootstrap/1.5/meteor-bootstrap-os.linux.x86_64.tar.gz";
+    sha256 = "0cwwqv88h1ji7g4zmfz34xsrxkn640wr11ddjq5c6b9ygcljci3p";
   };
 in
 
 stdenv.mkDerivation rec {
   name = "meteor-${version}";
-  version = "1.4.2.3";
+  version = "1.5";
 
   dontStrip = true;
 

--- a/pkgs/servers/meteor/main.patch
+++ b/pkgs/servers/meteor/main.patch
@@ -2,9 +2,9 @@ diff --git a/tools/cli/main.js b/tools/cli/main.js
 index 84f94bc..4fbda17 100644
 --- a/tools/cli/main.js
 +++ b/tools/cli/main.js
-@@ -484,6 +484,45 @@ var springboard = function (rel, options) {
-     process.exit(ret.wait());
-   }
+@@ -554,6 +554,44 @@
+     }).await());
+   } // Now exec; we're not coming back.
  
 +  // BEGIN HACK
 +  // patch shebang:
@@ -44,7 +44,13 @@ index 84f94bc..4fbda17 100644
 +  patchelf("mongodb", "bin", "mongo");
 +  patchelf("mongodb", "bin", "mongod");
 +  // END HACK
-+
-   // Now exec; we're not coming back.
+
    require('kexec')(executable, newArgv);
-   throw Error('exec failed?');
+
+@@ -1485,4 +1523,4 @@
+
+   process.exit(ret);
+ }).run();
+-//# sourceMappingURL=main.js.map
+\ No newline at end of file
++//# sourceMappingURL=main.js.map


### PR DESCRIPTION
###### Motivation for this change
Upgraded the [meteor](https://www.meteor.com/) package to 1.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

