### PR TITLE
neuron: 7.4 -> 7.5

### DIFF
--- a/pkgs/applications/science/biology/iv/default.nix
+++ b/pkgs/applications/science/biology/iv/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec
   { name = "iv-19";
     src = fetchurl
       { url = "http://www.neuron.yale.edu/ftp/neuron/versions/v${neuron-version}/${name}.tar.gz";
-        sha256 = "1q22vjngvn3m61mjxynkik7pxvsgc9a0ym46qpa84hmz1v86mdrw";
+        sha256 = "07a3g8zzay4h0bls7fh89dd0phn7s34c2g15pij6dsnwpmjg06yx";
       };
     nativeBuildInputs = [ patchelf ];
     buildInputs = [ libXext ];

--- a/pkgs/applications/science/biology/neuron/default.nix
+++ b/pkgs/applications/science/biology/neuron/default.nix
@@ -14,14 +14,14 @@
 
 stdenv.mkDerivation rec {
   name = "neuron-${version}";
-  version = "7.4";
+  version = "7.5";
 
   nativeBuildInputs = [ which pkgconfig automake autoconf libtool ];
   buildInputs = [ ncurses readline python mpi iv ];
 
   src = fetchurl {
     url = "http://www.neuron.yale.edu/ftp/neuron/versions/v${version}/nrn-${version}.tar.gz";
-    sha256 = "1rid8cmv5mca0vqkgwahm0prkwkbdvchgw2bdwvx4adkn8bbl0ql";
+    sha256 = "0f26v3qvzblcdjg7isq0m9j2q8q7x3vhmkfllv8lsr3gyj44lljf";
   };
 
   patches = (stdenv.lib.optional (stdenv.isDarwin) [ ./neuron-carbon-disable.patch ]);


### PR DESCRIPTION
###### Motivation for this change
fixes iv packages failing build that depends on neuron.

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

