### PR TITLE
jfbview: 0.5.3 -> 0.5.4

### DIFF
--- a/pkgs/os-specific/linux/jfbview/default.nix
+++ b/pkgs/os-specific/linux/jfbview/default.nix
@@ -15,14 +15,16 @@ in
 
 stdenv.mkDerivation rec {
   name = "${package}-${version}";
-  version = "0.5.3";
+  version = "0.5.4";
 
   src = fetchFromGitHub {
-    sha256 = "18iyvisslqp5ibhix00j4y7q8fmf2a79chflimc78xf52x4m2p5q";
-    rev = version;
     repo = "JFBView";
     owner = "jichu4n";
+    rev = version;
+    sha256 = "0p12b5n07yfkmfswjdb3a4c5c50jcphl030n3i71djcq4jjvrxlw";
   };
+
+  hardeningDisable = [ "format" ];
 
   buildInputs = [
     freetype harfbuzz jbig2dec libjpeg libX11 mujs mupdf ncurses openjpeg


### PR DESCRIPTION
###### Motivation for this change
fixes build for gcc6 for jfbview and jfbpdf

related to #28643
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

