### PR TITLE
jigdo: fix gcc build failures

### DIFF
--- a/pkgs/applications/misc/jigdo/default.nix
+++ b/pkgs/applications/misc/jigdo/default.nix
@@ -9,10 +9,13 @@ stdenv.mkDerivation {
     sha256 = "1qvqzgzb0dzq82fa1ffs6hyij655rajnfwkljk1y0mnkygnha1xv";
   };
 
-  patches = fetchurl {
-    url = http://ftp.de.debian.org/debian/pool/main/j/jigdo/jigdo_0.7.3-3.diff.gz;
-    sha256 = "0cp4jz3sg9g86vprh90pmwpcfla79f0dr50w14yh01k0yaq70fs8";
-  };
+  patches = [
+    (fetchurl {
+      url = http://ftp.de.debian.org/debian/pool/main/j/jigdo/jigdo_0.7.3-4.diff.gz;
+      sha256 = "03zsh57fijciiv23lf55k6fbfhhzm866xjhx83x54v5s1g2h6m8y";
+    })
+    ./sizewidth.patch
+  ];
 
   buildInputs = [ db gtk2 bzip2 ];
 

--- a/pkgs/applications/misc/jigdo/sizewidth.patch
+++ b/pkgs/applications/misc/jigdo/sizewidth.patch
@@ -1,0 +1,40 @@
+diff --git i/src/mkimage.cc w/src/mkimage.cc
+index 02e65b1..b263796 100755
+--- i/src/mkimage.cc
++++ w/src/mkimage.cc
+@@ -285,27 +285,27 @@ bostream& JigdoDescVec::put(bostream& file, MD5Sum* md) const {
+ //______________________________________________________________________
+ 
+ namespace {
+-  const int SIZE_WIDTH = 12;
++  const int MKIMAGE_SIZE_WIDTH = 12;
+ }
+ 
+ ostream& JigdoDesc::ImageInfo::put(ostream& s) const {
+-  s << "image-info  " << setw(SIZE_WIDTH) << size() << "              "
++  s << "image-info  " << setw(MKIMAGE_SIZE_WIDTH) << size() << "              "
+     << md5() << ' ' << blockLength() << '\n';
+   return s;
+ }
+ ostream& JigdoDesc::UnmatchedData::put(ostream& s) const {
+-  s << "in-template " << setw(SIZE_WIDTH) << offset() << ' '
+-    << setw(SIZE_WIDTH) << size() << '\n';
++  s << "in-template " << setw(MKIMAGE_SIZE_WIDTH) << offset() << ' '
++    << setw(MKIMAGE_SIZE_WIDTH) << size() << '\n';
+   return s;
+ }
+ ostream& JigdoDesc::MatchedFile::put(ostream& s) const {
+-  s << "need-file   " << setw(SIZE_WIDTH) << offset() << ' '
+-    << setw(SIZE_WIDTH) << size() << ' ' << md5() << ' ' << rsync() << '\n';
++  s << "need-file   " << setw(MKIMAGE_SIZE_WIDTH) << offset() << ' '
++    << setw(MKIMAGE_SIZE_WIDTH) << size() << ' ' << md5() << ' ' << rsync() << '\n';
+   return s;
+ }
+ ostream& JigdoDesc::WrittenFile::put(ostream& s) const {
+-  s << "have-file   " << setw(SIZE_WIDTH) << offset() << ' '
+-    << setw(SIZE_WIDTH) << size() << ' ' << md5() << ' ' << rsync() << '\n';
++  s << "have-file   " << setw(MKIMAGE_SIZE_WIDTH) << offset() << ' '
++    << setw(MKIMAGE_SIZE_WIDTH) << size() << ' ' << md5() << ' ' << rsync() << '\n';
+   return s;
+ }
+ 


### PR DESCRIPTION
###### Motivation for this change
renames a constant in a source file because SIZE_WIDTH is a gcc 6 macro.

Related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

