### PR TITLE
klick: fix build with gcc6

### DIFF
--- a/pkgs/applications/audio/klick/default.nix
+++ b/pkgs/applications/audio/klick/default.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ scons pkgconfig libsamplerate libsndfile liblo libjack2 boost ];
+  NIX_CFLAGS_COMPILE = "-fpermissive";
 
   buildPhase = ''
     mkdir -p $out


### PR DESCRIPTION
###### Motivation for this change
fixes build with gcc6 by setting -fpermissive CFLAG.

related to #28643

Ideally should be fixed by patching the offending problems upstream or in a patch file, but this gets it building in the mean time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

