### PR TITLE
secretstorage init at version 2.3.1 

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -577,6 +577,7 @@
   tavyc = "Octavian Cerna <octavian.cerna@gmail.com>";
   ltavard = "Laure Tavard <laure.tavard@univ-grenoble-alpes.fr>";
   teh = "Tom Hunger <tehunger@gmail.com>";
+  teto = "Matthieu Coudron <mcoudron@hotmail.com>";
   telotortium = "Robert Irelan <rirelan@gmail.com>";
   thall = "Niclas Thall <niclas.thall@gmail.com>";
   thammers = "Tobias Hammerschmidt <jawr@gmx.de>";

--- a/pkgs/development/python-modules/secretstorage/default.nix
+++ b/pkgs/development/python-modules/secretstorage/default.nix
@@ -13,7 +13,6 @@ buildPythonPackage rec {
     sha256 = "1sjd2jjbxgkkxyrfwx89x0hsnn39w2cr2qkxbg1iz52znr4sqism";
   };
 
-  postPatch = "patchShebangs .";
   propagatedBuildInputs = [ dbus-python cryptography ];
 
   doCheck = false; # requires dbus session
@@ -23,5 +22,6 @@ buildPythonPackage rec {
     description = "Python bindings to FreeDesktop.org Secret Service API";
     license = licenses.bsdOriginal;
     platforms = platforms.linux;
+    maintainer = with maintainers; [ teto ];
   };
 }

--- a/pkgs/development/python-modules/secretstorage/default.nix
+++ b/pkgs/development/python-modules/secretstorage/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, pkgs, buildPythonPackage, dbus-python, python, cryptography }:
+
+buildPythonPackage rec {
+  pname = "secretstorage";
+  version = "2.3.1";
+  name = "${pname}-${version}";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "mitya57";
+    repo = "secretstorage";
+    rev = "2636a47b45aff51a21dfaf1cbd9f1f3c1347f7f4";
+    sha256 = "1xs35ywqxxriwhm79kvivad0hszcm4ah29v34vbshlqvc66qr171";
+  };
+
+  postPatch = "patchShebangs .";
+  propagatedBuildInputs = [ dbus-python cryptography ];
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mitya57/secretstorage";
+    description = "Python bindings to FreeDesktop.org Secret Service API";
+    license = lib.licenses.bsdOriginal;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/secretstorage/default.nix
+++ b/pkgs/development/python-modules/secretstorage/default.nix
@@ -1,25 +1,27 @@
-{ stdenv, lib, pkgs, buildPythonPackage, dbus-python, python, cryptography }:
+{ stdenv, fetchFromGitHub, buildPythonPackage
+, dbus-python, cryptography }:
 
 buildPythonPackage rec {
   pname = "secretstorage";
   version = "2.3.1";
   name = "${pname}-${version}";
 
-  src = pkgs.fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "mitya57";
     repo = "secretstorage";
-    rev = "2636a47b45aff51a21dfaf1cbd9f1f3c1347f7f4";
-    sha256 = "1xs35ywqxxriwhm79kvivad0hszcm4ah29v34vbshlqvc66qr171";
+    rev = version;
+    sha256 = "1sjd2jjbxgkkxyrfwx89x0hsnn39w2cr2qkxbg1iz52znr4sqism";
   };
 
   postPatch = "patchShebangs .";
   propagatedBuildInputs = [ dbus-python cryptography ];
-  doCheck = false;
+
+  doCheck = false; # requires dbus session
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/mitya57/secretstorage";
     description = "Python bindings to FreeDesktop.org Secret Service API";
-    license = lib.licenses.bsdOriginal;
+    license = licenses.bsdOriginal;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21364,6 +21364,8 @@ in {
     };
   };
 
+  secretstorage = callPackage ../development/python-modules/secretstorage { };
+
   semantic = buildPythonPackage rec {
     name = "semantic-1.0.3";
 


### PR DESCRIPTION
###### Motivation for this change

A program I use (i3pystatus) has modules depending on this python module (via the keyring python module).
https://pypi.python.org/pypi/SecretStorage

I've tested it through:
`nix-shell -p python36Packages.keyring -p python36Packages.secretstorage -I ~/nixpkgs --command "keyring set gmail password"`
This is my first PR to nixpkgs so this might need more work. I'll try to look into the sandboxing thing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

