### PR TITLE
photivo: fixes build with gcc6

### DIFF
--- a/pkgs/applications/graphics/photivo/default.nix
+++ b/pkgs/applications/graphics/photivo/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
       name = "lensfun-0.3.patch";
       sha256 = "0ys45x4r4bjjlx0zpd5d56rgjz7k8gxili4r4k8zx3zfka4a3zwv";
     })
+    ./gcc6.patch
   ];
 
   postPatch = '' # kinda icky

--- a/pkgs/applications/graphics/photivo/gcc6.patch
+++ b/pkgs/applications/graphics/photivo/gcc6.patch
@@ -1,0 +1,13 @@
+diff --git c/Sources/ptImage.cpp i/Sources/ptImage.cpp
+index 9c95093..623c157 100755
+--- c/Sources/ptImage.cpp
++++ i/Sources/ptImage.cpp
+@@ -5291,7 +5291,7 @@ ptImage* ptImage::Box(const uint16_t MaxRadius, float* Mask) {
+         NewRow = NewRow < 0? -NewRow : NewRow > Height1? Height1_2-NewRow : NewRow ;
+         NewRow *= m_Width;
+         for(j = -IntRadius; j <= IntRadius; j++) {
+-          if (Dist[abs(i)][abs(j)] < Radius) {
++          if (Dist[int16_t(abs(i))][int16_t(abs(j))] < Radius) {
+             NewCol = Col+j;
+             NewCol = NewCol < 0? -NewCol : NewCol > Width1? Width1_2-NewCol : NewCol ;
+ 


### PR DESCRIPTION
###### Motivation for this change
fixes build

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

