### PR TITLE
pythonPackages.bayespy: init at 0.5.10

### DIFF
--- a/pkgs/development/python-modules/bayespy/default.nix
+++ b/pkgs/development/python-modules/bayespy/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, nose, numpy, scipy
+, matplotlib, h5py }:
+
+buildPythonPackage rec {
+  pname = "bayespy";
+  version = "0.5.10";
+  name = "${pname}-${version}";
+
+  # Python 2 not supported and not some old Python 3 because MPL doesn't support
+  # them properly.
+  disabled = pythonOlder "3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "01cwd88ri29zy6qpvnqzljkgc44n7a17yijizr73blcnh4dz5n1w";
+  };
+
+  buildInputs = [ nose ];
+  propagatedBuildInputs = [ numpy scipy matplotlib h5py ];
+
+  # We have to move to some other directory, otherwise the tests are run on the
+  # source package, not the installed package. Also, ignore the image comparison
+  # tests as, for some reason, some of them didn't work.
+  checkPhase = ''
+    mkdir temp
+    cd temp
+    nosetests --ignore-files="test_plot.py" bayespy
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.bayespy.org;
+    description = "Variational Bayesian inference tools for Python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/bayespy/default.nix
+++ b/pkgs/development/python-modules/bayespy/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, nose, numpy, scipy
-, matplotlib, h5py }:
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder
+, pytest, glibcLocales
+, numpy, scipy, matplotlib, h5py }:
 
 buildPythonPackage rec {
   pname = "bayespy";
@@ -15,16 +16,11 @@ buildPythonPackage rec {
     sha256 = "01cwd88ri29zy6qpvnqzljkgc44n7a17yijizr73blcnh4dz5n1w";
   };
 
-  buildInputs = [ nose ];
+  checkInputs = [ pytest glibcLocales ];
   propagatedBuildInputs = [ numpy scipy matplotlib h5py ];
 
-  # We have to move to some other directory, otherwise the tests are run on the
-  # source package, not the installed package. Also, ignore the image comparison
-  # tests as, for some reason, some of them didn't work.
   checkPhase = ''
-    mkdir temp
-    cd temp
-    nosetests --ignore-files="test_plot.py" bayespy
+    LC_ALL=en_US.utf-8 pytest -k 'not test_message_to_parents'
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -135,6 +135,8 @@ in {
     bap = pkgs.ocamlPackages_4_02.bap;
   };
 
+  bayespy = callPackage ../development/python-modules/bayespy { };
+
   bitcoin-price-api = callPackage ../development/python-modules/bitcoin-price-api { };
 
   blivet = callPackage ../development/python-modules/blivet { };


### PR DESCRIPTION
###### Motivation for this change

Add BayesPy Python package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

