### PR TITLE
rawtherapee: 5.0-r1 -> 5.2

### DIFF
--- a/pkgs/applications/graphics/rawtherapee/default.nix
+++ b/pkgs/applications/graphics/rawtherapee/default.nix
@@ -3,14 +3,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "5.0-r1";
+  version = "5.2";
   name = "rawtherapee-" + version;
 
   src = fetchFromGitHub {
     owner = "Beep6581";
     repo = "RawTherapee";
-    rev = version + "-gtk3";
-    sha256 = "06v3ir5562yg4zk9z8kc8a7sw7da88193sizjlk74gh5d3smgr4q";
+    rev = version;
+    sha256 = "0i3cr3335bw8yxxzn6kcdx6ccinlnxzrdbgl3ld1kym1w2n5449k";
   };
 
   buildInputs = [
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DPROC_TARGET_NUMBER=2"
+    "-DCACHE_NAME_SUFFIX=\"\""
   ];
 
   CMAKE_CXX_FLAGS = "-std=c++11 -Wno-deprecated-declarations -Wno-unused-result";


### PR DESCRIPTION
###### Motivation for this change

Update to the latest version of rawtherapee

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Also added some flags found in http://rawpedia.rawtherapee.com/Linux#Compile_RawTherapee