### PR TITLE
spice-vdagent module: start in foreground so logs are visible

### DIFF
--- a/nixos/modules/services/misc/spice-vdagentd.nix
+++ b/nixos/modules/services/misc/spice-vdagentd.nix
@@ -22,8 +22,7 @@ in
         mkdir -p "/var/run/spice-vdagentd/"
       '';
       serviceConfig = {
-        Type = "forking";
-        ExecStart = "${pkgs.spice-vdagent}/bin/spice-vdagentd";
+        ExecStart = "${pkgs.spice-vdagent}/bin/spice-vdagentd -d -x";
       };
     };
   };


### PR DESCRIPTION
###### Motivation for this change

Ability to see logs for spice-vdagent

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

