### PR TITLE
spice-vdagent: add systemd support

### DIFF
--- a/pkgs/applications/virtualization/spice-vdagent/default.nix
+++ b/pkgs/applications/virtualization/spice-vdagent/default.nix
@@ -1,5 +1,6 @@
 {stdenv, fetchurl, pkgconfig, alsaLib, spice_protocol, glib,
- libpciaccess, libxcb, libXrandr, libXinerama, libXfixes, dbus}:
+ libpciaccess, libxcb, libXrandr, libXinerama, libXfixes, dbus,
+ systemd}:
 stdenv.mkDerivation rec {
   name = "spice-vdagent-0.17.0";
   src = fetchurl {
@@ -11,7 +12,7 @@ stdenv.mkDerivation rec {
   '';
   buildInputs = [ pkgconfig alsaLib spice_protocol glib
                   libpciaccess libxcb libXrandr libXinerama libXfixes
-                  dbus ] ;
+                  dbus systemd ] ;
   meta = {
     description = "Enhanced SPICE integration for linux QEMU guest";
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change

Support for systemd to spice-vdagent. This pull request should fix clipboard for spice.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

