### PR TITLE
numix-cursor-theme: init at 2016011

### DIFF
--- a/pkgs/data/icons/numix-cursor-theme/default.nix
+++ b/pkgs/data/icons/numix-cursor-theme/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  version = "20160110";
+
+  package-name = "numix-cursor-theme";
+
+  name = "${package-name}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "numixproject";
+    repo = package-name;
+    rev = "e92186d9df47c04d4e0a778eb6941ef58590b179";
+    sha256 = "1sr4pisgrn3632phsiny2fyr2ib6l51fnjdsanmh9ampagl4ly7g";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -dm 755 $out/share/icons
+    cp -dr --no-preserve='ownership' Numix{,-Light} $out/share/icons/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Numix cursor theme";
+    homepage = https://numixproject.org;
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ offline ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13143,6 +13143,8 @@ with pkgs;
 
   numix-icon-theme-square = callPackage ../data/icons/numix-icon-theme-square { };
 
+  numix-cursor-theme = callPackage ../data/icons/numix-cursor-theme { };
+
   oldstandard = callPackage ../data/fonts/oldstandard { };
 
   oldsindhi = callPackage ../data/fonts/oldsindhi { };


### PR DESCRIPTION
###### Motivation for this change

I like this cursor theme, let's add it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

