### PR TITLE
vim module: allow to set global vimrc

### DIFF
--- a/nixos/modules/programs/vim.nix
+++ b/nixos/modules/programs/vim.nix
@@ -12,12 +12,25 @@ in {
       description = ''
         When enabled, installs vim and configures vim to be the default editor
         using the EDITOR environment variable.
+        '';
+    };
+
+    vimrc = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Global vimrc configuration
       '';
     };
   };
 
   config = mkIf cfg.defaultEditor {
-        environment.systemPackages = [ pkgs.vim ];
-        environment.variables = { EDITOR = mkOverride 900 "vim"; };
+    environment.systemPackages = [ pkgs.vim_configurable ];
+    environment.variables = { EDITOR = mkOverride 900 "vim"; };
+
+    environment.etc."vimrc" = {
+      enable = cfg.vimrc != "";
+      text = cfg.vimrc;
+    };
   };
 }

--- a/nixos/modules/programs/vim.nix
+++ b/nixos/modules/programs/vim.nix
@@ -6,31 +6,36 @@ let
   cfg = config.programs.vim;
 in {
   options.programs.vim = {
+    enable = mkOption {
+      type = types.bool;
+      default = cfg.defaultEditor;
+      description = "When enabled, installs vim globally";
+    };
+
     defaultEditor = mkOption {
       type = types.bool;
       default = false;
       description = ''
-        When enabled, installs vim and configures vim to be the default editor
-        using the EDITOR environment variable.
-        '';
+        Configures vim to be the default editor using the EDITOR environment
+        variable and installs vim globally by default.
+      '';
     };
 
     vimrc = mkOption {
       type = types.lines;
       default = "";
-      description = ''
-        Global vimrc configuration
-      '';
+      description = "Global vimrc configuration";
     };
   };
 
-  config = mkIf cfg.defaultEditor {
-    environment.systemPackages = [ pkgs.vim_configurable ];
-    environment.variables = { EDITOR = mkOverride 900 "vim"; };
+  config = mkMerge [{
+    environment.systemPackages = mkIf cfg.enable [ pkgs.vim_configurable ];
 
     environment.etc."vimrc" = {
       enable = cfg.vimrc != "";
       text = cfg.vimrc;
     };
-  };
+  } (mkIf cfg.defaultEditor {
+    environment.variables = { EDITOR = mkOverride 900 "vim"; };
+  })];
 }


### PR DESCRIPTION
###### Motivation for this change

I would like to have global vimrc config. This is optional and should not break anything.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

