### PR TITLE
nestopia: 1.46.2 -> 1.47

### DIFF
--- a/pkgs/misc/emulators/nestopia/default.nix
+++ b/pkgs/misc/emulators/nestopia/default.nix
@@ -1,11 +1,17 @@
-{ stdenv, fetchurl, pkgconfig, SDL2, alsaLib, gtk3, mesa_glu, makeWrapper
-, mesa, libarchive, libao, unzip, xdg_utils, gsettings_desktop_schemas }:
+{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, SDL2, alsaLib, gtk3, mesa_glu,
+  makeWrapper, mesa, libarchive, libao, unzip, xdg_utils, gsettings_desktop_schemas,
+  epoxy, gdk_pixbuf
+}:
 
 stdenv.mkDerivation rec {
-  name = "nestopia-1.46.2";
-  src = fetchurl {
-    url = https://github.com/rdanbrook/nestopia/archive/1.46.2.tar.gz;
-    sha256 = "07h49xwvg61dx20rk5p4r3ax2ar5y0ppvm60cqwqljyi9rdfbh7p";
+  version = "1.47";
+  name = "nestopia-${version}";
+
+  src = fetchFromGitHub {
+    owner = "rdanbrook";
+    repo = "nestopia";
+    rev = "${version}";
+    sha256 = "0frr0gvjh5mxzdhj0ii3sh671slgnzlm8naqlc4h87rx4p4sz2y2";
   };
 
   # nondeterministic failures when creating directories
@@ -13,8 +19,22 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  buildInputs = [ pkgconfig SDL2 alsaLib gtk3 mesa_glu mesa makeWrapper
-                  libarchive libao unzip xdg_utils gsettings_desktop_schemas ];
+  buildInputs = [
+    pkgconfig
+    SDL2
+    alsaLib
+    epoxy
+    gtk3
+    gdk_pixbuf
+    mesa_glu
+    mesa
+    makeWrapper
+    libarchive
+    libao
+    unzip
+    xdg_utils
+    gsettings_desktop_schemas
+  ];
 
   installPhase = ''
     mkdir -p $out/{bin,share/nestopia}
@@ -28,7 +48,15 @@ stdenv.mkDerivation rec {
      done
   '';
 
-  patches = [ ./build-fix.patch ];
+  patches = [
+    #(fetchpatch {
+    #  url = "https://github.com/rdanbrook/nestopia/commit/f4bc74ac4954328b25e961e7afb7337377084079.patch";
+    #  name = "gcc6.patch";
+    #  sha256 = "1jy0c85xsfk9hrv5a6v0kk48d94864qb62yyni9fp93kyl33y2p4";
+    #})
+    ./gcc6.patch
+    ./build-fix.patch
+  ];
 
   meta = {
     homepage = http://0ldsk00l.ca/nestopia/;

--- a/pkgs/misc/emulators/nestopia/default.nix
+++ b/pkgs/misc/emulators/nestopia/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, SDL2, alsaLib, gtk3, mesa_glu,
-  makeWrapper, mesa, libarchive, libao, unzip, xdg_utils, gsettings_desktop_schemas,
-  epoxy, gdk_pixbuf
+{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, SDL2, alsaLib, gtk3, mesa_glu
+, makeWrapper, mesa, libarchive, libao, unzip, xdg_utils, gsettings_desktop_schemas
+, epoxy, gdk_pixbuf, gnome3, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   buildInputs = [
-    pkgconfig
     SDL2
     alsaLib
     epoxy
@@ -28,12 +27,17 @@ stdenv.mkDerivation rec {
     gdk_pixbuf
     mesa_glu
     mesa
-    makeWrapper
     libarchive
     libao
     unzip
     xdg_utils
-    gsettings_desktop_schemas
+    gnome3.adwaita-icon-theme
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    makeWrapper
+    wrapGAppsHook
   ];
 
   installPhase = ''

--- a/pkgs/misc/emulators/nestopia/gcc6.patch
+++ b/pkgs/misc/emulators/nestopia/gcc6.patch
@@ -1,0 +1,92 @@
+From f4bc74ac4954328b25e961e7afb7337377084079 Mon Sep 17 00:00:00 2001
+From: David Seifert <soap@gentoo.org>
+Date: Sat, 31 Dec 2016 18:21:18 +0200
+Subject: [PATCH] Fix compiling in C++14 mode
+
+* Left shifting a negative signed is undefined behaviour
+* Fix incorrect printf() specifiers found with -Wformat
+---
+ source/core/NstCore.hpp            | 4 ++--
+ source/unix/gtkui/gtkui.cpp        | 2 +-
+ source/unix/gtkui/gtkui.h          | 1 -
+ source/unix/gtkui/gtkui_cheats.cpp | 8 ++++----
+ source/unix/video.cpp              | 2 +-
+ 5 files changed, 8 insertions(+), 9 deletions(-)
+
+diff --git a/source/core/NstCore.hpp b/source/core/NstCore.hpp
+index 50e20f6..420cc4a 100644
+--- a/source/core/NstCore.hpp
++++ b/source/core/NstCore.hpp
+@@ -279,14 +279,14 @@ namespace Nes
+ 		template<typename T>
+ 		inline long signed_shl(T v,uint c)
+ 		{
+-			enum {NATIVE = T(-7) << 1 == -14};
++			enum {NATIVE = -(T(7) << 1) == -14};
+ 			return Helper::ShiftSigned<T,NATIVE>::Left( v, c );
+ 		}
+ 
+ 		template<typename T>
+ 		inline long signed_shr(T v,uint c)
+ 		{
+-			enum {NATIVE = T(-7) >> 1 == -4 || T(-7) >> 1 == -3};
++			enum {NATIVE = -(T(7) >> 1) == -4 || -(T(7) >> 1) == -3};
+ 			return Helper::ShiftSigned<T,NATIVE>::Right( v, c );
+ 		}
+ 
+diff --git a/source/unix/gtkui/gtkui.cpp b/source/unix/gtkui/gtkui.cpp
+index 3cfeeab..d4a5e2d 100644
+--- a/source/unix/gtkui/gtkui.cpp
++++ b/source/unix/gtkui/gtkui.cpp
+@@ -438,7 +438,7 @@ void gtkui_message(const char* message) {
+ 				GTK_DIALOG_DESTROY_WITH_PARENT,
+ 				GTK_MESSAGE_INFO,
+ 				GTK_BUTTONS_OK,
+-				message);
++				"%s", message);
+ 	gtk_dialog_run(GTK_DIALOG(messagewindow));
+ 	gtk_widget_destroy(messagewindow);
+ }
+diff --git a/source/unix/gtkui/gtkui_cheats.cpp b/source/unix/gtkui/gtkui_cheats.cpp
+index afc01b0..e7b691a 100644
+--- a/source/unix/gtkui/gtkui_cheats.cpp
++++ b/source/unix/gtkui/gtkui_cheats.cpp
+@@ -373,7 +373,7 @@ void gtkui_cheats_fill_tree(char *filename) {
+ 				else if (node.GetChild(L"address")) { // Raw
+ 					char rawbuf[11];
+ 					snprintf(rawbuf, sizeof(rawbuf),
+-								"%04x %02x %02x",
++								"%04lu %02lu %02lu",
+ 								node.GetChild(L"address").GetUnsignedValue(),
+ 								node.GetChild(L"value").GetUnsignedValue(),
+ 								node.GetChild(L"compare").GetUnsignedValue());
+@@ -545,13 +545,13 @@ gboolean gtkui_cheats_scan_list(GtkTreeModel *model, GtkTreePath *path, GtkTreeI
+ 			int addr, value, compare;
+ 			char buf[5];
+ 			
+-			snprintf(buf, sizeof(buf), "%c%c%c%c\0", rawcode[0], rawcode[1], rawcode[2], rawcode[3]);
++			snprintf(buf, sizeof(buf), "%c%c%c%c", rawcode[0], rawcode[1], rawcode[2], rawcode[3]);
+ 			sscanf(buf, "%x", &addr);
+ 			
+-			snprintf(buf, sizeof(buf), "%c%c\0", rawcode[5], rawcode[6]);
++			snprintf(buf, sizeof(buf), "%c%c", rawcode[5], rawcode[6]);
+ 			sscanf(buf, "%x", &value);
+ 			
+-			snprintf(buf, sizeof(buf), "%c%c\0", rawcode[8], rawcode[9]);
++			snprintf(buf, sizeof(buf), "%c%c", rawcode[8], rawcode[9]);
+ 			sscanf(buf, "%x", &compare);
+ 			
+ 			code.address = addr;
+diff --git a/source/unix/video.cpp b/source/unix/video.cpp
+index 3eff19d..c34bb22 100644
+--- a/source/unix/video.cpp
++++ b/source/unix/video.cpp
+@@ -757,7 +757,7 @@ void video_screenshot(const char* filename) {
+ 	if (filename == NULL) {
+ 		// Set the filename
+ 		char sshotpath[512];
+-		snprintf(sshotpath, sizeof(sshotpath), "%sscreenshots/%s-%d-%d.png", nstpaths.nstdir, nstpaths.gamename, time(NULL), rand() % 899 + 100);
++		snprintf(sshotpath, sizeof(sshotpath), "%sscreenshots/%s-%ld-%d.png", nstpaths.nstdir, nstpaths.gamename, time(NULL), rand() % 899 + 100);
+ 		
+ 		// Save the file
+ 		lodepng_encode32_file(sshotpath, (const unsigned char*)pixels, rendersize.w, rendersize.h);


### PR DESCRIPTION
###### Motivation for this change
fixes build with gcc6.

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

