### PR TITLE
pythonPackages.pytest-flake8: fix strict mode

### DIFF
--- a/pkgs/development/python-modules/pytest-flake8/default.nix
+++ b/pkgs/development/python-modules/pytest-flake8/default.nix
@@ -1,4 +1,4 @@
-{lib, buildPythonPackage, fetchPypi, pytest, flake8}:
+{lib, buildPythonPackage, fetchPypi, fetchpatch, pytest, flake8}:
 
 buildPythonPackage rec {
   name = "${pname}-${version}";
@@ -15,6 +15,16 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "1za5i09gz127yraigmcl443w6149714l279rmlfxg1bl2kdsc45a";
   };
+
+  patches = [
+    # Fix pytest strict mode (pull request #24)
+    # https://github.com/tholo/pytest-flake8/pull/24
+    (fetchpatch {
+      name = "fix-compatibility-with-pytest-strict-mode.patch";
+      url = "https://github.com/tholo/pytest-flake8/commit/434e1b07b4b77bfe1ddb9b2b54470c6c3815bb1a.patch";
+      sha256 = "0idwgkwwysx2cibnykd81yxrgqzkpf42j99jmpnanqzi99qnc3wx";
+    })
+  ];
 
   checkPhase = ''
     pytest --ignore=nix_run_setup.py .


### PR DESCRIPTION
###### Motivation for this change

One test was failing in pytest-flake8 so I added a pull request patch to fix it. See https://github.com/tholo/pytest-flake8/pull/24.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

