### PR TITLE
caps: fix build with gcc6

### DIFF
--- a/pkgs/applications/audio/caps/default.nix
+++ b/pkgs/applications/audio/caps/default.nix
@@ -6,6 +6,14 @@ stdenv.mkDerivation rec {
     url = "http://www.quitte.de/dsp/caps_${version}.tar.bz2";
     sha256 = "081zx0i2ysw5nmy03j60q9j11zdlg1fxws81kwanncdgayxgwipp";
   };
+
+  patches = [
+    (fetchurl {
+      url = "https://anonscm.debian.org/cgit/pkg-multimedia/caps.git/plain/debian/patches/0001-Avoid-ambiguity-in-div-invocation.patch";
+      sha256 = "1b1pb5yfskiw8zi1lkj572l2ajpirh4amq538vggwvlpv1fqfway";
+    })
+  ];
+
   configurePhase = ''
     echo "PREFIX = $out" > defines.make
   '';


### PR DESCRIPTION
###### Motivation for this change

fix build with gcc6, related to https://github.com/NixOS/nixpkgs/issues/28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

