### PR TITLE
mps: 1.115.0 -> 1.116.0

### DIFF
--- a/pkgs/development/libraries/mps/default.nix
+++ b/pkgs/development/libraries/mps/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mps-${version}";
-  version = "1.115.0";
+  version = "1.116.0";
 
   src = fetchurl {
     url    = "http://www.ravenbrook.com/project/mps/release/${version}/mps-kit-${version}.tar.gz";
-    sha256 = "156xdl16r44nn8svnrgfaklwrgpc3y0rxzqyp0jbdp55c6rlfl6l";
+    sha256 = "1k7vnanpgawnj84x2xs6md57pfib9p7c3acngqzkl3c2aqw8qay0";
   };
 
   buildInputs = [ autoreconfHook sqlite ];


### PR DESCRIPTION
###### Motivation for this change

Update to most recent upstream release, 1.115.0 doesn't build with gcc6. Related to https://github.com/NixOS/nixpkgs/issues/28643.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

