### PR TITLE
tests: add some basic stdenv/cc-wrapper tests

### DIFF
--- a/pkgs/test/cc-wrapper/cc-main.c
+++ b/pkgs/test/cc-wrapper/cc-main.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+  fprintf(stderr, "ok\n");
+  return 0;
+}

--- a/pkgs/test/cc-wrapper/cflags-main.c
+++ b/pkgs/test/cc-wrapper/cflags-main.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <foo.h>
+
+int main(int argc, char **argv)
+{
+  if (foo() != 42)
+    return 1;
+  fprintf(stderr, "ok\n");
+  return 0;
+}

--- a/pkgs/test/cc-wrapper/core-foundation-main.c
+++ b/pkgs/test/cc-wrapper/core-foundation-main.c
@@ -1,0 +1,7 @@
+#include <CoreFoundation/CoreFoundation.h>
+
+int main(int argc, char** argv)
+{
+  CFShow(CFSTR("ok"));
+  return 0;
+}

--- a/pkgs/test/cc-wrapper/cxx-main.cc
+++ b/pkgs/test/cc-wrapper/cxx-main.cc
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+  std::cerr << "ok" << std::endl;
+  return 0;
+}

--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -1,0 +1,45 @@
+{ stdenv }:
+
+let
+  shlib = if stdenv.isDarwin then "dylib" else "so";
+in
+
+stdenv.mkDerivation {
+  name = "cc-wrapper-test";
+
+  buildCommand = ''
+    NIX_DEBUG=1 $CC -v
+    NIX_DEBUG=1 $CXX -v
+
+    printf "checking whether compiler builds valid C binaries... " >&2
+    $CC -o cc-check ${./cc-main.c}
+    ./cc-check
+
+    printf "checking whether compiler builds valid C++ binaries... " >&2
+    $CXX -o cxx-check ${./cxx-main.cc}
+    ./cxx-check
+
+    ${stdenv.lib.optionalString (stdenv.isDarwin && stdenv.cc.isClang) ''
+      printf "checking whether compiler can build with CoreFoundation.framework... " >&2
+      mkdir -p foo/lib
+      $CC -framework CoreFoundation -o core-foundation-check ${./core-foundation-main.c}
+      ./core-foundation-check
+    ''}
+
+    printf "checking whether compiler uses NIX_CFLAGS_COMPILE... " >&2
+    mkdir -p foo/include
+    cp ${./foo.c} foo/include/foo.h
+    NIX_CFLAGS_COMPILE="-Ifoo/include -DVALUE=42" $CC -o cflags-check ${./cflags-main.c}
+    ./cflags-check
+
+    printf "checking whether compiler uses NIX_LDFLAGS... " >&2
+    mkdir -p foo/lib
+    $CC -shared ${stdenv.lib.optionalString stdenv.isDarwin "-Wl,-install_name,@rpath/libfoo.dylib"} -DVALUE=42 -o foo/lib/libfoo.${shlib} ${./foo.c}
+    NIX_LDFLAGS="-L$NIX_BUILD_TOP/foo/lib -rpath $NIX_BUILD_TOP/foo/lib" $CC -lfoo -o ldflags-check ${./ldflags-main.c}
+    ./ldflags-check
+
+    touch $out
+  '';
+
+  meta.platforms = stdenv.lib.platforms.all;
+}

--- a/pkgs/test/cc-wrapper/foo.c
+++ b/pkgs/test/cc-wrapper/foo.c
@@ -1,0 +1,4 @@
+unsigned int foo(void)
+{
+  return VALUE;
+}

--- a/pkgs/test/cc-wrapper/ldflags-main.c
+++ b/pkgs/test/cc-wrapper/ldflags-main.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+extern unsigned int foo(void);
+
+int main(int argc, char **argv)
+{
+  if (foo() != 42) {
+    return 1;
+  }
+  fprintf(stderr, "ok\n");
+  return 0;
+}

--- a/pkgs/test/stdenv-inputs/bar.c
+++ b/pkgs/test/stdenv-inputs/bar.c
@@ -1,0 +1,3 @@
+unsigned int bar(void) {
+  return 42;
+}

--- a/pkgs/test/stdenv-inputs/cc-main.c
+++ b/pkgs/test/stdenv-inputs/cc-main.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+  fprintf(stderr, "ok\n");
+  return 0;
+}

--- a/pkgs/test/stdenv-inputs/default.nix
+++ b/pkgs/test/stdenv-inputs/default.nix
@@ -1,0 +1,64 @@
+{ stdenv }:
+
+let
+  shlib = if stdenv.isDarwin then "dylib" else "so";
+
+  foo = stdenv.mkDerivation {
+    name = "foo-test";
+
+    unpackPhase = ":";
+
+    installPhase = ''
+      mkdir -p $out/bin $out/include $out/lib
+      $CC -o $out/bin/foo ${./cc-main.c}
+      chmod +x $out/bin/foo
+      cp ${./foo.c} $out/include/foo.h
+      $CC -shared ${stdenv.lib.optionalString stdenv.isDarwin "-Wl,-install_name,$out/lib/libfoo.dylib"} -o $out/lib/libfoo.${shlib} ${./foo.c}
+    '';
+  };
+
+  bar = stdenv.mkDerivation {
+    name = "bar-test";
+    outputs = [ "out" "dev" ];
+
+    unpackPhase = ":";
+
+    installPhase = ''
+      mkdir -p $out/bin $dev/include $dev/lib
+      $CC -o $out/bin/bar ${./cc-main.c}
+      chmod +x $out/bin/bar
+      cp ${./bar.c} $dev/include/bar.h
+      $CC -shared ${stdenv.lib.optionalString stdenv.isDarwin "-Wl,-install_name,$dev/lib/libbar.dylib"} -o $dev/lib/libbar.${shlib} ${./bar.c}
+    '';
+  };
+in
+
+stdenv.mkDerivation {
+  name = "stdenv-inputs-test";
+  phases = [ "buildPhase" ];
+
+  buildInputs = [ foo bar ];
+
+  buildPhase = ''
+    env
+
+    printf "checking whether binaries are available... " >&2
+    foo && bar
+
+    printf "checking whether compiler can find headers... " >&2
+    $CC -o include-check ${./include-main.c}
+    ./include-check
+
+    printf "checking whether compiler can find headers... " >&2
+    $CC -o include-check ${./include-main.c}
+    ./include-check
+
+    printf "checking whether compiler can find libraries... " >&2
+    $CC -lfoo -lbar -o lib-check ${./lib-main.c}
+    ./lib-check
+
+    touch $out
+  '';
+
+  meta.platforms = stdenv.lib.platforms.all;
+}

--- a/pkgs/test/stdenv-inputs/foo.c
+++ b/pkgs/test/stdenv-inputs/foo.c
@@ -1,0 +1,3 @@
+unsigned int foo(void) {
+  return 42;
+}

--- a/pkgs/test/stdenv-inputs/include-main.c
+++ b/pkgs/test/stdenv-inputs/include-main.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <foo.h>
+#include <bar.h>
+
+int main(int argc, char **argv)
+{
+  if (foo() != 42)
+    return 1;
+  if (bar() != 42)
+    return 1;
+  fprintf(stderr, "ok\n");
+  return 0;
+}

--- a/pkgs/test/stdenv-inputs/lib-main.c
+++ b/pkgs/test/stdenv-inputs/lib-main.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+extern unsigned int foo(void);
+extern unsigned int bar(void);
+
+int main(int argc, char **argv)
+{
+  if (foo() != 42)
+    return 1;
+  if (bar() != 42)
+    return 1;
+  fprintf(stderr, "ok\n");
+  return 0;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19409,6 +19409,10 @@ with pkgs;
 
   # `recurseIntoAttrs` for sake of hydra, not nix-env
   tests = recurseIntoAttrs {
+    cc-wrapper = callPackage ../test/cc-wrapper { };
+    cc-wrapper-clang = callPackage ../test/cc-wrapper { stdenv = clangStdenv; };
+    cc-wrapper-libcxx = callPackage ../test/cc-wrapper { stdenv = libcxxStdenv; };
+
     macOSSierraShared = callPackage ../test/macos-sierra-shared {};
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19412,6 +19412,7 @@ with pkgs;
     cc-wrapper = callPackage ../test/cc-wrapper { };
     cc-wrapper-clang = callPackage ../test/cc-wrapper { stdenv = clangStdenv; };
     cc-wrapper-libcxx = callPackage ../test/cc-wrapper { stdenv = libcxxStdenv; };
+    stdenv-inputs = callPackage ../test/stdenv-inputs { };
 
     macOSSierraShared = callPackage ../test/macos-sierra-shared {};
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

