### PR TITLE
nixos: update glibc locales link

### DIFF
--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -43,7 +43,7 @@ with lib;
           <literal>"all"</literal> means that all locales supported by
           Glibc will be installed.  A full list of supported locales
           can be found at <link
-          xlink:href="http://sourceware.org/cgi-bin/cvsweb.cgi/libc/localedata/SUPPORTED?cvsroot=glibc"/>.
+          xlink:href="https://sourceware.org/git/?p=glibc.git;a=blob;f=localedata/SUPPORTED"/>.
         '';
       };
 

--- a/pkgs/development/libraries/glibc/locales.nix
+++ b/pkgs/development/libraries/glibc/locales.nix
@@ -3,7 +3,7 @@
    locales are included; otherwise, just the locales listed in
    `locales'.  See localedata/SUPPORTED in the Glibc source tree for
    the list of all supported locales:
-   http://sourceware.org/cgi-bin/cvsweb.cgi/libc/localedata/SUPPORTED?cvsroot=glibc
+   https://sourceware.org/git/?p=glibc.git;a=blob;f=localedata/SUPPORTED
 */
 
 { stdenv, callPackage, writeText


### PR DESCRIPTION
Old URL redirects to https://sourceware.org/viewvc
Old URL: http://sourceware.org/cgi-bin/cvsweb.cgi/libc/localedata/SUPPORTED?cvsroot=glibc
New URL: https://sourceware.org/git/?p=glibc.git;a=blob;f=localedata/SUPPORTED