### PR TITLE
Qucs: version update and adms dependency

### DIFF
--- a/pkgs/applications/science/electronics/adms/default.nix
+++ b/pkgs/applications/science/electronics/adms/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, libtool, autoreconfHook, flex, bison, gperf,
+  libxml2, perl, perlPackages, gd }:
+
+stdenv.mkDerivation rec {
+  version = "2.3.6";
+  name = "adms-${version}";
+
+  src = fetchFromGitHub {
+    owner = "Qucs";
+    repo = "adms";
+    rev = "release-${version}";
+    sha256 = "1pcwq5khzdq4x33lid9hq967gv78dr5i4f2sk8m8rwkfqb9vdzrg";
+  };
+
+  buildInputs = [ autoreconfHook flex bison gperf libxml2 perl gd perlPackages.XMLLibXML ];
+  configureFlags = [ "--enable-maintainer-mode" ];
+
+  meta = {
+    description = "automatic device model synthesizer";
+    homepage = https://github.com/Qucs/adms;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [disassembler];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/applications/science/electronics/qucs/cmakelists.patch
+++ b/pkgs/applications/science/electronics/qucs/cmakelists.patch
@@ -1,0 +1,34 @@
+diff --git i/qucs-core/CMakeLists.txt w/qucs-core/CMakeLists.txt
+index 2dbbd41..d174b50 100644
+--- i/qucs-core/CMakeLists.txt
++++ w/qucs-core/CMakeLists.txt
+@@ -158,26 +158,9 @@ ENDIF()
+ 
+ #
+ # Need Bison
+-#
+-# This is a HACK to get arround a PATH issue with Qt Creator on OSX.
+-# It seams impossible to pass a custom PATH to Qt Creator on OSX, ie, cannot prepend `/usr/local/bin/` for intance.
+-# The FIND_PACKAGE fails. For now we provide a fallback with a custom FIND_PROGRAM. The variable BISON_DIR is also available.
+-IF(WIN32)
+-  FIND_PACKAGE(BISON 2.4 REQUIRED)
+-  IF(BISON_FOUND)
+-    #MESSAGE(STATUS "Found bison: ${BISON_EXECUTABLE} / Version: ${BISON_VERSION}" )
+-  ENDIF()
+-ELSE()  # Linux, OSX
+-  # use -DBISON_DIR=/path/ to provide the path to bison
+-  FIND_PROGRAM( BISON_EXECUTABLE bison
+-    PATHS /usr/local/bin/ /opt/local/bin/ /usr/bin ${BISON_DIR}
+-    DOC "bison path"
+-    NO_DEFAULT_PATH )
+-  IF(BISON_EXECUTABLE )
+-    MESSAGE(STATUS "Found bison: " ${BISON_EXECUTABLE})
+-  ELSE()
+-	  MESSAGE(FATAL_ERROR "Unable to find bison. Try to provide -DBISON_DIR=[path]")
+-  ENDIF()
++FIND_PACKAGE(BISON 2.4 REQUIRED)
++IF(BISON_FOUND)
++  #MESSAGE(STATUS "Found bison: ${BISON_EXECUTABLE} / Version: ${BISON_VERSION}" )
+ ENDIF()
+ 
+ #

--- a/pkgs/applications/science/electronics/qucs/default.nix
+++ b/pkgs/applications/science/electronics/qucs/default.nix
@@ -1,16 +1,23 @@
-{stdenv, fetchurl, flex, bison, qt4, libX11 }:
+{stdenv, fetchFromGitHub, flex, bison, qt4, libX11, cmake, gperf, adms }:
 
 stdenv.mkDerivation rec {
-  name = "qucs-0.0.18";
+  version = "0.0.19";
+  name = "qucs-${version}";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/qucs/${name}.tar.gz";
-    sha256 = "3609a18b57485dc9f19886ac6694667f3251702175bd1cbbbea37981b2c482a7";
+  src = fetchFromGitHub {
+    owner = "Qucs";
+    repo = "qucs";
+    rev = "qucs-${version}";
+    sha256 = "106h3kjyg7c0hkmzkin7h8fcl32n60835121b2qqih8ixi6r5id6";
   };
 
   QTDIR=qt4;
 
-  buildInputs = [ flex bison qt4 libX11 ];
+  patches = [
+    ./cmakelists.patch
+  ];
+
+  buildInputs = [ flex bison qt4 libX11 cmake gperf adms ];
 
   meta = {
     description = "Integrated circuit simulator";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18409,6 +18409,8 @@ with pkgs;
 
   ### SCIENCE / ELECTRONICS
 
+  adms = callPackage ../applications/science/electronics/adms { };
+
   eagle = callPackage ../applications/science/electronics/eagle { };
 
   caneda = callPackage ../applications/science/electronics/caneda { };
@@ -18431,6 +18433,7 @@ with pkgs;
   pcb = callPackage ../applications/science/electronics/pcb { };
 
   qucs = callPackage ../applications/science/electronics/qucs { };
+
 
   xoscope = callPackage ../applications/science/electronics/xoscope { };
 


### PR DESCRIPTION
###### Motivation for this change
fixes build with gcc6. Adds a new package adms that the latest release of qucs uses. Also, uses cmake to build qucs now. autoreconfHook was used for adms instead of cmake because instructions say cmake for that project doesn't work for building yet.

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

