### PR TITLE
allegro: fix sandboxed build with nixUnstable

### DIFF
--- a/pkgs/development/libraries/allegro/default.nix
+++ b/pkgs/development/libraries/allegro/default.nix
@@ -12,6 +12,10 @@ stdenv.mkDerivation rec {
     sha256 = "1p0ghkmpc4kwij1z9rzxfv7adnpy4ayi0ifahlns1bdzgmbyf88v";
   };
 
+  patches = [
+    ./nix-unstable-sandbox-fix.patch
+  ];
+
   buildInputs = [
     texinfo libXext xextproto libX11 xproto libXpm libXt libXcursor
     alsaLib cmake zlib libpng libvorbis libXxf86dga libXxf86misc

--- a/pkgs/development/libraries/allegro/nix-unstable-sandbox-fix.patch
+++ b/pkgs/development/libraries/allegro/nix-unstable-sandbox-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/docs/CMakeLists.txt b/docs/CMakeLists.txt
+index 32ed053..73ba87f 100644
+--- a/docs/CMakeLists.txt
++++ b/docs/CMakeLists.txt
+@@ -72,7 +72,7 @@ foreach(page ${DOC_SRCS})
+     string(REPLACE "._tx" "" basename ${basename})
+ 
+     set(page ${CMAKE_CURRENT_SOURCE_DIR}/${page})
+-    if(${page} MATCHES "/build/")
++    if(${page} MATCHES ".+/build/")
+         set(txt_out ${CMAKE_CURRENT_BINARY_DIR}/build/${basename}.txt)
+         set(html_out ${CMAKE_CURRENT_BINARY_DIR}/build/${basename}.html)
+     else()


### PR DESCRIPTION
In Nix 1.12 sandboxed builds are performed in /build/ directory which conflicts
with the regex in docs/CMakeLists.txt, and generated documentation ends up in
wrong directory -> https://hydra.nixos.org/build/53914969/nixlog/1 -> CTRL-F
abi.txt

###### Motivation for this change

sandboxed build fails with nixUnstable, related to https://github.com/NixOS/nixpkgs/issues/28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

