### PR TITLE
gnome3.evolution-data-server: Re-add GNOME Online Accounts support

### DIFF
--- a/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ libsecret nss nspr libical db ];
 
   # uoa irrelevant for now
-  cmakeFlags = [ "-DENABLE_UOA=OFF" "-DENABLE_GOA=OFF" ]
+  cmakeFlags = [ "-DENABLE_UOA=OFF" ]
                    ++ stdenv.lib.optionals valaSupport [
                      "-DENABLE_VALA_BINDINGS=ON" "-DENABLE_INTROSPECTION=ON"
                      "-DCMAKE_SKIP_BUILD_RPATH=OFF" ];


### PR DESCRIPTION
###### Motivation for this change
In #26879, GNOME Online Accounts support was removed resulting in repeated authentication prompts for users relying on services like Google Calendar.

This commit removes the build flag that disabled the support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

