### PR TITLE
gnome-pomodoro: Update for compatibility with GNOME 3.24

### DIFF
--- a/pkgs/desktops/gnome-3/misc/pomodoro/default.nix
+++ b/pkgs/desktops/gnome-3/misc/pomodoro/default.nix
@@ -1,40 +1,34 @@
-{ stdenv, fetchFromGitHub, which, intltool, pkgconfig, libtool, makeWrapper,
-  dbus_glib, libcanberra_gtk2, gst_all_1, vala_0_32, gnome3, gtk3, gst-plugins-base,
-  glib, gobjectIntrospection, telepathy_glib
+{ stdenv, fetchFromGitHub, autoconf-archive, appstream-glib, intltool, pkgconfig, libtool, wrapGAppsHook,
+  dbus_glib, libcanberra_gtk2, gst_all_1, vala_0_34, gnome3, gtk3,
+  glib, gobjectIntrospection, libpeas
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.11.2";
+  version = "0.13.3";
   name = "gnome-shell-pomodoro-${version}";
 
   src = fetchFromGitHub {
-      owner = "codito";
-      repo = "gnome-pomodoro";
-      rev = "${version}";
-      sha256 = "0x656drq8vnvdj1x6ghnglgpa0z8yd2yj9dh5iqprwjv0z3qkw4l";
+    owner = "codito";
+    repo = "gnome-pomodoro";
+    rev = "${version}";
+    sha256 = "1hi4mdzyz2f8k19bkfzrrnavsbkr621w0bfpza8ij2yccpxz81h2";
   };
 
-  configureScript = ''./autogen.sh'';
+  configureScript = "./autogen.sh";
 
-  buildInputs = [
-    which intltool glib gobjectIntrospection pkgconfig libtool
-    makeWrapper dbus_glib libcanberra_gtk2 vala_0_32 gst_all_1.gstreamer
-    gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
-    gnome3.gsettings_desktop_schemas gnome3.gnome_desktop
-    gnome3.gnome_common gnome3.gnome_shell gtk3 telepathy_glib
-    gnome3.defaultIconTheme
+  nativeBuildInputs = [
+    autoconf-archive libtool intltool appstream-glib
+    wrapGAppsHook pkgconfig
   ];
 
-  preBuild = ''
-    sed -i 's|\$(INTROSPECTION_GIRDIR)|${gnome3.gnome_desktop}/share/gir-1.0|' \
-      vapi/Makefile
-  '';
-
-  preFixup = ''
-    wrapProgram $out/bin/gnome-pomodoro \
-        --prefix XDG_DATA_DIRS : \
-        "$out/share:$GSETTINGS_SCHEMAS_PATH:$XDG_DATA_DIRS"
-  '';
+  buildInputs = [
+    glib gobjectIntrospection libpeas
+    dbus_glib libcanberra_gtk2 vala_0_34 gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
+    gnome3.gsettings_desktop_schemas
+    gnome3.gnome_common gnome3.gnome_shell gtk3
+    gnome3.defaultIconTheme
+  ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/codito/gnome-shell-pomodoro;


### PR DESCRIPTION
The app itself works fine. The extension does not load due to missing schemas, even though they are listed in dconf-editor:

```
$ journalctl | tail
Extension "pomodoro@arun.codito.in" had error: Schema org.gnome.pomodoro.preferences could not be found for extension pomodoro@arun.codito.in. Please check your installation.
```

In order to fix this you must add the package to `services.xserver.desktopManager.gnome3.sessionPath` like other extensions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

