### PR TITLE
dockerTools.pullImage: change the docker deamon readiness mechanism

### DIFF
--- a/pkgs/build-support/docker/pull.sh
+++ b/pkgs/build-support/docker/pull.sh
@@ -25,7 +25,7 @@ done
 # run docker daemon
 dockerd -H tcp://127.0.0.1:5555 -H unix:///var/run/docker.sock &
 
-until $(curl --output /dev/null --silent --connect-timeout 2 http://127.0.0.1:5555); do
+until docker ps 2>/dev/null; do
   printf '.'
   sleep 1
 done


### PR DESCRIPTION
###### Motivation for this change
To wait for the docker deamon, curl requests are sent. However, if a
http proxy is set, it will respond instead of the docker daemon. The script will then fail because docker is not up and running.
To avoid this, we send docker ps command instead of curl command.

###### Things done

I successfully pull ubuntu images and also run the nixpkgs docker example:
```
nix-build ./ -A nix-build ./ -A dockerTools.examples.nix
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

