### PR TITLE
dns-root-data: 2017-07-26 -> 2017-08-29

### DIFF
--- a/pkgs/data/misc/dns-root-data/default.nix
+++ b/pkgs/data/misc/dns-root-data/default.nix
@@ -4,7 +4,7 @@ let
 
   rootHints = fetchurl {
     url = "https://www.internic.net/domain/named.root";
-    sha256 = "0qsyxpj5b3i7n162qfyv76ljqbvnwjii7jk8mpfinklx0sk01473";
+    sha256 = "01n4bqf95kbvig1hahqzmmdkpn4v7mzfc1p944gq922i5j3fjr92";
   };
 
   rootKey = ./root.key;
@@ -13,7 +13,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "dns-root-data-2017-07-26";
+  name = "dns-root-data-2017-08-29";
 
   buildCommand = ''
     mkdir $out


### PR DESCRIPTION
###### Motivation for this change

https://www.internic.net/domain/named.root has been updated causing the download to fail due to a hash mismatch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

