### PR TITLE
xiphos: 4.0.3 -> 4.0.6

### DIFF
--- a/pkgs/applications/misc/xiphos/default.nix
+++ b/pkgs/applications/misc/xiphos/default.nix
@@ -1,27 +1,29 @@
-{stdenv, fetchurl, pkgconfig
+{stdenv, fetchFromGitHub, pkgconfig
 , python
 , intltool
 , docbook2x, docbook_xml_dtd_412, libxslt
 , sword, clucene_core, biblesync
 , gnome_doc_utils
 , libgsf, gconf
-, gtkhtml, libgtkhtml, libglade, scrollkeeper
+, gtkhtml, libglade, scrollkeeper
 , webkitgtk
-, dbus_glib, enchant, isocodes, libuuid
+, dbus_glib, enchant, isocodes, libuuid, icu
 }:
 
 stdenv.mkDerivation rec {
   name = "xiphos-${version}";  
-  version = "4.0.3-20150806";
+  version = "4.0.6";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/project/gnomesword/Xiphos/4.0.3/${name}.tar.gz";
-    sha256 = "1xkvhpasdlda2rp0874znz158z4rjh1hpynwy13d96kjxq4npiqv";
+  src = fetchFromGitHub {
+    owner = "crosswire";
+    repo = "xiphos";
+    rev = "${version}";
+    sha256 = "02xyy6rxxxaqbjbhdp813f0vp1jpfzqscjdbdc0qcd4yvi3baj5f";
   };
 
   buildInputs = [ pkgconfig python intltool docbook2x docbook_xml_dtd_412 libxslt
-                  sword clucene_core biblesync gnome_doc_utils libgsf gconf gtkhtml libgtkhtml
-                  libglade scrollkeeper webkitgtk dbus_glib enchant isocodes libuuid ];
+                  sword clucene_core biblesync gnome_doc_utils libgsf gconf gtkhtml
+                  libglade scrollkeeper webkitgtk dbus_glib enchant isocodes libuuid icu ];
 
   prePatch = ''
     patchShebangs .;
@@ -33,7 +35,7 @@ stdenv.mkDerivation rec {
   '';
   
   configurePhase = ''
-    python waf configure --prefix=$out    
+    python waf configure --prefix=$out --enable-webkit2
   '';
   
   buildPhase = ''

--- a/pkgs/desktops/gnome-2/default.nix
+++ b/pkgs/desktops/gnome-2/default.nix
@@ -66,6 +66,8 @@ let overridden = set // overrides; set = with overridden; {
 
   gtkhtml = callPackage ./platform/gtkhtml { };
 
+  gtkhtml4 = callPackage ./platform/gtkhtml/4.x.nix { };
+
   # Required for nautilus
   inherit (libunique);
 

--- a/pkgs/desktops/gnome-2/platform/gtkhtml/4.x.nix
+++ b/pkgs/desktops/gnome-2/platform/gtkhtml/4.x.nix
@@ -1,0 +1,15 @@
+{ stdenv, fetchurl, pkgconfig, gtk3, intltool,
+GConf, enchant, isocodes, gnome_icon_theme, gsettings_desktop_schemas }:
+
+stdenv.mkDerivation rec {
+  version = "4.10.0";
+  name = "gtkhtml-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gtkhtml/4.10/${name}.tar.xz";
+    sha256 = "1hq6asgb5n9q3ryx2vngr4jyi8lg65lzpnlgrgcwayiczcj68fya";
+  };
+
+  propagatedBuildInputs = [ gsettings_desktop_schemas gtk3 gnome_icon_theme GConf ];
+  buildInputs = [pkgconfig intltool enchant isocodes ];
+}

--- a/pkgs/development/libraries/webkitgtk/2.17.nix
+++ b/pkgs/development/libraries/webkitgtk/2.17.nix
@@ -1,0 +1,106 @@
+{ stdenv, fetchurl, perl, python2, ruby, bison, gperf, cmake
+, pkgconfig, gettext, gobjectIntrospection, libnotify, gnutls
+, gtk2, gtk3, wayland, libwebp, enchant, xlibs, libxkbcommon, epoxy, at_spi2_core
+, libxml2, libsoup, libsecret, libxslt, harfbuzz, libpthreadstubs, pcre, nettle, libtasn1, p11_kit
+, libidn, libedit, readline, mesa, libintlOrEmpty
+, enableGeoLocation ? true, geoclue2, sqlite
+, gst-plugins-base, gst-plugins-bad
+}:
+
+assert enableGeoLocation -> geoclue2 != null;
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  name = "webkitgtk-${version}";
+  version = "2.17.91";
+
+  meta = {
+    description = "Web content rendering engine, GTK+ port";
+    homepage = http://webkitgtk.org/;
+    license = licenses.bsd2;
+    platforms = with platforms; linux ++ darwin;
+    hydraPlatforms = [];
+    maintainers = with maintainers; [ ];
+  };
+
+  postConfigure = optionalString stdenv.isDarwin ''
+    substituteInPlace Source/WebKit2/CMakeFiles/WebKit2.dir/link.txt \
+        --replace "../../lib/libWTFGTK.a" ""
+    substituteInPlace Source/JavaScriptCore/CMakeFiles/JavaScriptCore.dir/link.txt \
+        --replace "../../lib/libbmalloc.a" ""
+    sed -i "s|[\./]*\.\./lib/lib[^\.]*\.a||g" \
+        Source/JavaScriptCore/CMakeFiles/LLIntOffsetsExtractor.dir/link.txt \
+        Source/JavaScriptCore/shell/CMakeFiles/jsc.dir/link.txt \
+        Source/JavaScriptCore/shell/CMakeFiles/testb3.dir/link.txt \
+        Source/WebKit2/CMakeFiles/DatabaseProcess.dir/link.txt \
+        Source/WebKit2/CMakeFiles/NetworkProcess.dir/link.txt \
+        Source/WebKit2/CMakeFiles/webkit2gtkinjectedbundle.dir/link.txt \
+        Source/WebKit2/CMakeFiles/WebProcess.dir/link.txt
+    substituteInPlace Source/JavaScriptCore/CMakeFiles/JavaScriptCore.dir/link.txt \
+        --replace "../../lib/libWTFGTK.a" "-Wl,-all_load ../../lib/libWTFGTK.a"
+  '';
+
+  src = fetchurl {
+    url = "http://webkitgtk.org/releases/${name}.tar.xz";
+    sha256 = "0f158gqb2lvv3v5z6s7gjgwms69fgsjkd8whfks8cq6cybiy9y37";
+  };
+
+  # see if we can clean this up....
+
+  patches = [  
+    ./finding-harfbuzz-icu.patch
+    ./gstreamergl-2.17.patch
+  ] ++ optionals stdenv.isDarwin [
+    ./PR-152650-2.patch
+    ./PR-153138.patch
+    ./PR-157554.patch
+    ./PR-157574.patch
+  ];
+
+  cmakeFlags = [
+  "-DPORT=GTK"
+  "-DUSE_LIBHYPHEN=0"
+  ]
+  ++ optional stdenv.isLinux "-DENABLE_GLES2=ON"
+  ++ optionals stdenv.isDarwin [
+  "-DUSE_SYSTEM_MALLOC=ON"
+  "-DUSE_ACCELERATE=0"
+  "-DENABLE_INTROSPECTION=ON"
+  "-DENABLE_MINIBROWSER=OFF"
+  "-DENABLE_PLUGIN_PROCESS_GTK2=OFF"
+  "-DENABLE_MINIBROWSER=OFF"
+  "-DENABLE_VIDEO=ON"
+  "-DENABLE_QUARTZ_TARGET=ON"
+  "-DENABLE_X11_TARGET=OFF"
+  "-DENABLE_OPENGL=OFF"
+  "-DENABLE_WEB_AUDIO=OFF"
+  "-DENABLE_WEBGL=OFF"
+  "-DENABLE_GRAPHICS_CONTEXT_3D=OFF"
+  "-DENABLE_GTKDOC=OFF"
+  ];
+
+  # XXX: WebKit2 missing include path for gst-plugins-base.
+  # Filled: https://bugs.webkit.org/show_bug.cgi?id=148894
+  NIX_CFLAGS_COMPILE = "-I${gst-plugins-base.dev}/include/gstreamer-1.0 -I${gst-plugins-bad}/include/gstreamer-1.0"
+                     + (optionalString stdenv.isDarwin " -lintl");
+
+  nativeBuildInputs = [
+    cmake perl python2 ruby bison gperf sqlite
+    pkgconfig gettext gobjectIntrospection
+  ];
+
+  buildInputs = libintlOrEmpty ++ [
+    gtk2 libwebp enchant libnotify gnutls pcre nettle libidn
+    libxml2 libsecret libxslt harfbuzz libpthreadstubs libtasn1 p11_kit
+    gst-plugins-base gst-plugins-bad libxkbcommon epoxy at_spi2_core
+  ] ++ optional enableGeoLocation geoclue2
+    ++ (with xlibs; [ libXdmcp libXt libXtst ])
+    ++ optionals stdenv.isDarwin [ libedit readline mesa ]
+    ++ optional stdenv.isLinux wayland;
+
+  propagatedBuildInputs = [
+    libsoup gtk3
+  ];
+
+  enableParallelBuilding = true;
+}

--- a/pkgs/development/libraries/webkitgtk/gstreamergl-2.17.patch
+++ b/pkgs/development/libraries/webkitgtk/gstreamergl-2.17.patch
@@ -1,0 +1,13 @@
+diff --git i/Source/cmake/OptionsGTK.cmake w/Source/cmake/OptionsGTK.cmake
+index d3577a8..9620dc0 100644
+--- i/Source/cmake/OptionsGTK.cmake
++++ w/Source/cmake/OptionsGTK.cmake
+@@ -94,7 +94,7 @@ WEBKIT_OPTION_DEFINE(USE_LIBSECRET "Whether to enable the persistent credential
+ 
+ # Private options specific to the GTK+ port. Changing these options is
+ # completely unsupported. They are intended for use only by WebKit developers.
+-WEBKIT_OPTION_DEFINE(USE_GSTREAMER_GL "Whether to enable support for GStreamer GL" PRIVATE ON)
++WEBKIT_OPTION_DEFINE(USE_GSTREAMER_GL "Whether to enable support for GStreamer GL" PRIVATE OFF)
+ WEBKIT_OPTION_DEFINE(USE_GSTREAMER_MPEGTS "Whether to enable support for MPEG-TS" PRIVATE OFF)
+ WEBKIT_OPTION_DEFINE(USE_REDIRECTED_XCOMPOSITE_WINDOW "Whether to use a Redirected XComposite Window for accelerated compositing in X11." PRIVATE ON)
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10703,6 +10703,11 @@ with pkgs;
     gst-plugins-base = gst_all_1.gst-plugins-base;
   };
 
+  webkitgtk217x = callPackage ../development/libraries/webkitgtk/2.17.nix {
+    harfbuzz = harfbuzz-icu;
+    gst-plugins-base = gst_all_1.gst-plugins-base;
+  };
+
   webkitgtk24x-gtk2 = webkitgtk24x-gtk3.override {
     withGtk2 = true;
     enableIntrospection = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17016,9 +17016,10 @@ with pkgs;
 
   xiphos = callPackage ../applications/misc/xiphos {
     gconf = gnome2.GConf;
-    inherit (gnome2) gtkhtml libgtkhtml libglade scrollkeeper;
+    inherit (gnome2) libglade scrollkeeper;
+    gtkhtml = gnome2.gtkhtml4;
+    webkitgtk = webkitgtk217x;
     python = python27;
-    webkitgtk = webkitgtk24x-gtk2;
   };
 
   xournal = callPackage ../applications/graphics/xournal {


### PR DESCRIPTION
###### Motivation for this change
Xiphos was failing to build because it depended on an insecure version of gtkhtml. Upgraded xiphos and using github releases now. @AndersonTorres (maintainer)

Related to #28643

gtkhtml4 and webkitgtk 2.17 were both added to get this build working.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

