### PR TITLE
lenmus: fixing build with gcc6

### DIFF
--- a/pkgs/applications/misc/lenmus/default.nix
+++ b/pkgs/applications/misc/lenmus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgconfig, fetchFromGitHub
+{ stdenv, pkgconfig, fetchFromGitHub, fetchpatch
 , cmake, boost
 , portmidi, sqlite
 , freetype, libpng, pngpp, zlib
@@ -21,6 +21,17 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/lenmus/lenmus/commit/421760d84694a0e6e72d0e9b1d4fd30a7e129c6f.patch";
+      sha256 = "1z1wwh0pcr8w1zlr8swx99si9y2kxx5bmavgwvy6bvdhxgm58yqs";
+    })
+    (fetchpatch {
+      url = "https://github.com/lenmus/lenmus/commit/6613d20d4051effc782203c9c6d92962a3f66b5f.patch";
+      sha256 = "01vvzzpamv90jpqbbq1f2m2b4gb9xab9z70am8i41d90nqvg6agn";
+    })
+  ];
 
   buildInputs = [
     pkgconfig


### PR DESCRIPTION
###### Motivation for this change
fixes build using two patches from upstream commits.

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

