### PR TITLE
coreutils: fix on Darwin

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -24,8 +24,7 @@ stdenv.mkDerivation rec {
   # FIXME needs gcc 4.9 in bootstrap tools
   hardeningDisable = [ "stackprotector" ];
 
-  patches = optional hostPlatform.isCygwin ./coreutils-8.23-4.cygwin.patch
-    ++ optional hostPlatform.isDarwin stdenv.secure-format-patch;
+  patches = optional hostPlatform.isCygwin ./coreutils-8.23-4.cygwin.patch;
 
   # The test tends to fail on btrfs and maybe other unusual filesystems.
   postPatch = optionalString (!hostPlatform.isDarwin) ''


### PR DESCRIPTION
This should fix coreutils after it got upgraded to 8.28. Needs porting to 17.09.

I'm currently running a bootstrap build on 10.12 and 10.13 so don't merge until this is known to work on both, but I don't expect anything to break.