### PR TITLE
nginx service: enable websocket proxy support with recommendedProxySe…

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -27,6 +27,8 @@ let
     proxy_set_header        X-Forwarded-Host $host;
     proxy_set_header        X-Forwarded-Server $host;
     proxy_set_header        Accept-Encoding "";
+    proxy_set_header        Upgrade $http_upgrade;
+    proxy_set_header        Connection "upgrade";
   '';
 
   upstreamConfig = toString (flip mapAttrsToList cfg.upstreams (name: upstream: ''
@@ -97,7 +99,7 @@ let
         proxy_connect_timeout   90;
         proxy_send_timeout      90;
         proxy_read_timeout      90;
-        proxy_http_version      1.0;
+        proxy_http_version      1.1;
         include ${recommendedProxyConfig};
       ''}
 


### PR DESCRIPTION
###### Motivation for this change

Enable websocket support when `recommendedProxySettings = true;`

This means the forwarding connection will always be HTTP/1.1 which seems
reasonable these days.

Further it passes allong the Upgrade header to the upstream proxy.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

