### PR TITLE
pfixtools: patch to work with gcc 6

### DIFF
--- a/pkgs/servers/mail/postfix/pfixtools.nix
+++ b/pkgs/servers/mail/postfix/pfixtools.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation {
 
   src = pfixtoolsSrc;
 
-  patches = [ ./0001-Fix-build-with-unbound-1.6.1.patch ];
+  patches = [ ./0001-Fix-build-with-unbound-1.6.1.patch
+              ./suppress-nonnull-compare-err.patch ];
 
   buildInputs = [git gperf pcre unbound libev tokyocabinet pkgconfig bash libsrs2];
 
@@ -49,5 +50,6 @@ stdenv.mkDerivation {
     license = with lib.licenses; [ bsd3 ];
     homepage = https://github.com/Fruneau/pfixtools;
     platforms = stdenv.lib.platforms.linux;
+    maintainers = with lib.maintainers; [ jerith666 ];
   };
 }

--- a/pkgs/servers/mail/postfix/suppress-nonnull-compare-err.patch
+++ b/pkgs/servers/mail/postfix/suppress-nonnull-compare-err.patch
@@ -1,0 +1,10 @@
+--- a/common/mk/cflags.mk.orig	2017-09-04 10:32:46.834540915 -0400
++++ b/common/mk/cflags.mk	2017-09-04 10:32:50.168528033 -0400
+@@ -98,6 +98,7 @@
+ CFLAGSBASE += -Wparentheses
+ # warn about missing declarations
+ CFLAGSBASE += -Wmissing-declarations
++CFLAGSBASE += -Wno-error=nonnull-compare
+ 
+ CFLAGS=$(CFLAGSBASE)
+ LDFLAGS=$(LDFLAGSBASE)


### PR DESCRIPTION
###### Motivation for this change

Progress on: #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'd also like this merged into `master`; LMK if a separate pull request makes that easier.