### PR TITLE
dhall: add a static top-level executable for dhall

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -93,6 +93,8 @@ with pkgs;
 
   cmark = callPackage ../development/libraries/cmark { };
 
+  dhall = haskell.lib.justStaticExecutables haskellPackages.dhall;
+
   dhallToNix = callPackage ../build-support/dhall-to-nix.nix {
     inherit (haskellPackages) dhall-nix;
   };


### PR DESCRIPTION
before

```
→ ldd $(type -p dhall) | wc -l
114
```

now

```
→ ldd $(type -p dhall) | wc -l
12
```