### PR TITLE
slic3r: fix build with gcc6

### DIFF
--- a/pkgs/applications/misc/slic3r/default.nix
+++ b/pkgs/applications/misc/slic3r/default.nix
@@ -12,6 +12,10 @@ stdenv.mkDerivation rec {
     sha256 = "1z8h11k29b7z49z5k8ikyfiijyycy1q3krlzi8hfd0vdybvymw21";
   };
 
+  patches = [
+    ./gcc6.patch
+  ];
+
   buildInputs = with perlPackages; [ perl makeWrapper which
     EncodeLocale MathClipper ExtUtilsXSpp threads
     MathConvexHullMonotoneChain MathGeometryVoronoi MathPlanePath Moo
@@ -31,6 +35,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     export SLIC3R_NO_AUTO=true
+    export LD=$CXX
     export PERL5LIB="./xs/blib/arch/:./xs/blib/lib:$PERL5LIB"
 
     substituteInPlace Build.PL \

--- a/pkgs/applications/misc/slic3r/gcc6.patch
+++ b/pkgs/applications/misc/slic3r/gcc6.patch
@@ -1,0 +1,40 @@
+diff --git i/xs/src/libslic3r/Config.hpp w/xs/src/libslic3r/Config.hpp
+index 49e999b..d9b65d8 100644
+--- i/xs/src/libslic3r/Config.hpp
++++ w/xs/src/libslic3r/Config.hpp
+@@ -65,7 +65,7 @@ class ConfigOptionFloat : public ConfigOption
+     
+     bool deserialize(std::string str) {
+         std::istringstream iss(str);
+-        return iss >> this->value;
++        return bool(iss >> this->value);
+     };
+ };
+ 
+@@ -124,7 +124,7 @@ class ConfigOptionInt : public ConfigOption
+     
+     bool deserialize(std::string str) {
+         std::istringstream iss(str);
+-        return iss >> this->value;
++        return bool(iss >> this->value);
+     };
+ };
+ 
+@@ -249,7 +249,7 @@ class ConfigOptionPercent : public ConfigOption
+     bool deserialize(std::string str) {
+         // don't try to parse the trailing % since it's optional
+         std::istringstream iss(str);
+-        return iss >> this->value;
++        return bool(iss >> this->value);
+     };
+ };
+ 
+@@ -279,7 +279,7 @@ class ConfigOptionFloatOrPercent : public ConfigOption
+     bool deserialize(std::string str) {
+         this->percent = str.find_first_of("%") != std::string::npos;
+         std::istringstream iss(str);
+-        return iss >> this->value;
++        return bool(iss >> this->value);
+     };
+ };
+ 


### PR DESCRIPTION
###### Motivation for this change

related to #28643
Fixes issues with compile, but fails on link with error:

```
ld -shared -O2 -L/nix/store/sgjc1147vi5hd57ck9xgck5xjkydg5lz-glibc-2.25/lib -fstack-protector-strong -o blib/arch/auto/Slic3r/XS/XS.so buildtmp/XS.o src/libslic3r/BridgeDetector.o src/libslic3r/Polygon.o src/libslic3r/Polyline.o src/poly2tri/sweep/sweep.o src/libslic3r/Surface.o src/admesh/stl_io.o src/poly2tri/sweep/cdt.o src/libslic3r/Config.o src/libslic3r/ClipperUtils.o src/polypartition.o src/libslic3r/Geometry.o src/admesh/connect.o src/libslic3r/PrintObject.o src/libslic3r/Line.o src/libslic3r/LayerRegion.o src/admesh/util.o src/libslic3r/ExPolygonCollection.o src/libslic3r/TriangleMesh.o src/libslic3r/utils.o src/poly2tri/sweep/sweep_context.o src/admesh/stlinit.o src/libslic3r/SVG.o src/libslic3r/MultiPoint.o src/libslic3r/PrintConfig.o src/libslic3r/Extruder.o src/libslic3r/Flow.o src/libslic3r/ExPolygon.o src/libslic3r/PlaceholderParser.o src/libslic3r/Print.o src/libslic3r/Model.o src/poly2tri/common/shapes.o src/libslic3r/Layer.o src/libslic3r/GUI/3DScene.o src/libslic3r/PrintRegion.o src/libslic3r/BoundingBox.o src/libslic3r/Point.o src/libslic3r/ExtrusionEntityCollection.o src/libslic3r/GCodeWriter.o src/poly2tri/sweep/advancing_front.o src/admesh/normals.o src/libslic3r/ExtrusionEntity.o src/admesh/shared.o src/libslic3r/SurfaceCollection.o src/libslic3r/PolylineCollection.o src/clipper.o src/libslic3r/MotionPlanner.o -lstdc++
buildtmp/XS.o: In function `_GLOBAL__sub_I_XS.c':
XS.c:(.text.startup+0x1a): undefined reference to `__dso_handle'
/nix/store/yf4p5w2v4h4i8rja9zw1akp007av624j-binutils-2.28.1/bin/ld: buildtmp/XS.o: relocation R_X86_64_PC32 against undefined hidden symbol `__dso_handle' can not be used when making a shared object
/nix/store/yf4p5w2v4h4i8rja9zw1akp007av624j-binutils-2.28.1/bin/ld: final link failed: Bad value
error building blib/arch/auto/Slic3r/XS/XS.so from buildtmp/XS.o src/libslic3r/BridgeDetector.o src/libslic3r/Polygon.o src/libslic3r/Polyline.o src/poly2tri/sweep/sweep.o src/libslic3r/Surface.o src/admesh/stl_io.o src/poly2tri/sweep/cdt.o src/libslic3r/Config.o src/libslic3r/ClipperUtils.o src/polypartition.o src/libslic3r/Geometry.o src/admesh/connect.o src/libslic3r/PrintObject.o src/libslic3r/Line.o src/libslic3r/LayerRegion.o src/admesh/util.o src/libslic3r/ExPolygonCollection.o src/libslic3r/TriangleMesh.o src/libslic3r/utils.o src/poly2tri/sweep/sweep_context.o src/admesh/stlinit.o src/libslic3r/SVG.o src/libslic3r/MultiPoint.o src/libslic3r/PrintConfig.o src/libslic3r/Extruder.o src/libslic3r/Flow.o src/libslic3r/ExPolygon.o src/libslic3r/PlaceholderParser.o src/libslic3r/Print.o src/libslic3r/Model.o src/poly2tri/common/shapes.o src/libslic3r/Layer.o src/libslic3r/GUI/3DScene.o src/libslic3r/PrintRegion.o src/libslic3r/BoundingBox.o src/libslic3r/Point.o src/libslic3r/ExtrusionEntityCollection.o src/libslic3r/GCodeWriter.o src/poly2tri/sweep/advancing_front.o src/admesh/normals.o src/libslic3r/ExtrusionEntity.o src/admesh/shared.o src/libslic3r/SurfaceCollection.o src/libslic3r/PolylineCollection.o src/clipper.o src/libslic3r/MotionPlanner.o at /nix/store/7q2hps69zkj501lsmvnd2ry95mmdbh80-perl-5.24.2/lib/perl5/5.24.2/ExtUtils/CBuilder/Base.pm line 321.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

