### PR TITLE
libstdc++: add setup-hook

### DIFF
--- a/pkgs/development/compilers/gcc/libstdc++-hook.sh
+++ b/pkgs/development/compilers/gcc/libstdc++-hook.sh
@@ -1,0 +1,1 @@
+export NIX_CXXSTDLIB_COMPILE+="-isystem $(echo -n @gcc@/include/c++/*) -isystem $(echo -n @gcc@/include/c++/*)/$(@gcc@/bin/gcc -dumpmachine)"

--- a/pkgs/development/compilers/gcc/libstdc++-hook.sh
+++ b/pkgs/development/compilers/gcc/libstdc++-hook.sh
@@ -1,1 +1,2 @@
 export NIX_CXXSTDLIB_COMPILE+="-isystem $(echo -n @gcc@/include/c++/*) -isystem $(echo -n @gcc@/include/c++/*)/$(@gcc@/bin/gcc -dumpmachine)"
+export NIX_CXXSTDLIB_LINK=" -stdlib=libstdc++"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5354,6 +5354,10 @@ with pkgs;
 
   gccApple = throw "gccApple is no longer supported";
 
+  libstdcxxHook = makeSetupHook
+    { substitutions = { gcc = gcc-unwrapped; }; }
+    ../development/compilers/gcc/libstdc++-hook.sh;
+
   # Can't just overrideCC, because then the stdenv-cross mkDerivation will be
   # thrown away. TODO: find a better solution for this.
   crossLibcStdenv = buildPackages.makeStdenvCross {


### PR DESCRIPTION
###### Motivation for this change

An alternative for #28870, this should also allow us to get rid of `default_cxx_stdlib_compile` entirely

Fixes #28223 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---