### PR TITLE
firefoxPackages: tor-browser: reorganize and update

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -1,5 +1,5 @@
 { pname, version, updateScript ? null
-, src, patches ? [], overrides ? {}, meta
+, src, patches ? [], extraConfigureFlags ? [], overrides ? {}, meta
 , isTorBrowserLike ? false }:
 
 { lib, stdenv, pkgconfig, pango, perl, python, zip, libIDL
@@ -29,7 +29,6 @@
 # Set to `privacySupport` or `false`.
 
 , webrtcSupport ? !privacySupport
-, loopSupport ? !privacySupport || !isTorBrowserLike
 , geolocationSupport ? !privacySupport
 , googleAPISupport ? geolocationSupport
 , crashreporterSupport ? false
@@ -48,7 +47,6 @@
 }:
 
 assert stdenv.cc ? libc && stdenv.cc.libc != null;
-assert !isTorBrowserLike -> loopSupport; # can't be disabled on firefox :(
 
 let
   flag = tf: x: [(if tf then "--enable-${x}" else "--disable-${x}")];
@@ -147,8 +145,6 @@ stdenv.mkDerivation (rec {
   ++ flag ffmpegSupport "ffmpeg"
   ++ lib.optional (!ffmpegSupport) "--disable-gstreamer"
   ++ flag webrtcSupport "webrtc"
-  ++ lib.optionals isTorBrowserLike
-       (flag loopSupport "loop")
   ++ flag geolocationSupport "mozril-geoloc"
   ++ lib.optional googleAPISupport "--with-google-api-keyfile=ga"
   ++ flag crashreporterSupport "crashreporter"
@@ -159,7 +155,8 @@ stdenv.mkDerivation (rec {
                     else [ "--disable-debug" "--enable-release"
                            "--enable-optimize"
                            "--enable-strip" ])
-  ++ lib.optional enableOfficialBranding "--enable-official-branding";
+  ++ lib.optional enableOfficialBranding "--enable-official-branding"
+  ++ extraConfigureFlags;
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -1,5 +1,5 @@
 { pname, version, updateScript ? null
-, src, patches ? [], extraConfigureFlags ? [], overrides ? {}, meta
+, src, patches ? [], extraConfigureFlags ? [], extraMakeFlags ? [], overrides ? {}, meta
 , isTorBrowserLike ? false }:
 
 { lib, stdenv, pkgconfig, pango, perl, python, zip, libIDL
@@ -43,7 +43,7 @@
 # option. However, in Firefox's case, those binaries may not be
 # distributed without permission from the Mozilla Foundation, see
 # http://www.mozilla.org/foundation/trademarks/.
-, enableOfficialBranding ? false
+, enableOfficialBranding ? isTorBrowserLike
 }:
 
 assert stdenv.cc ? libc && stdenv.cc.libc != null;
@@ -157,6 +157,16 @@ stdenv.mkDerivation (rec {
                            "--enable-strip" ])
   ++ lib.optional enableOfficialBranding "--enable-official-branding"
   ++ extraConfigureFlags;
+
+  preBuild = lib.optionalString (enableOfficialBranding && isTorBrowserLike) ''
+    buildFlagsArray=("MOZ_APP_DISPLAYNAME=Tor Browser")
+  '';
+
+  makeFlags = lib.optionals enableOfficialBranding [
+    "MOZILLA_OFFICIAL=1"
+    "BUILD_OFFICIAL=1"
+  ]
+  ++ extraMakeFlags;
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -95,7 +95,7 @@ rec {
 
 in rec {
 
-  tor-browser = common (rec {
+  tor-browser-6-5 = common (rec {
     pname = "tor-browser";
     version = "6.5.2";
     isTorBrowserLike = true;
@@ -112,5 +112,21 @@ in rec {
     stdenv = overrideCC stdenv gcc5;
     ffmpegSupport = false;
   };
+
+  tor-browser-7-0 = common (rec {
+    pname = "tor-browser";
+    version = "7.0.1";
+    isTorBrowserLike = true;
+
+    # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
+    src = fetchFromGitHub {
+      owner = "SLNOS";
+      repo  = "tor-browser";
+      rev   = "tor-browser-52.3.0esr-7.0-1-slnos";
+      sha256 = "0szbf8gjbl4dnrb4igy4mq5858i1y6ki4skhdw63iqqdd8w9v4yv";
+    };
+  } // commonAttrs) {};
+
+  tor-browser = tor-browser-7-0;
 
 })

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -49,6 +49,7 @@ rec {
     pname = "tor-browser";
     version = "6.5.2";
     isTorBrowserLike = true;
+    extraConfigureFlags = [ "--disable-loop" ];
 
     # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
     src = fetchFromGitHub {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -45,20 +45,9 @@ rec {
     };
   } {};
 
-  tor-browser = common rec {
-    pname = "tor-browser";
-    version = "6.5.2";
-    isTorBrowserLike = true;
-    extraConfigureFlags = [ "--disable-loop" ];
+} // (let
 
-    # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
-    src = fetchFromGitHub {
-      owner = "SLNOS";
-      repo  = "tor-browser";
-      rev   = "tor-browser-45.8.0esr-6.5-2";
-      sha256 = "0vbcp1qlxjlph0dqibylsyvb8iah3lnzdxc56hllpvbn51vrp39j";
-    };
-
+  commonAttrs = {
     overrides = {
       unpackPhase = ''
         # fetchFromGitHub produces ro sources, root dir gets a name that
@@ -102,9 +91,26 @@ rec {
       homepage = https://www.torproject.org/projects/torbrowser.html;
       platforms = lib.platforms.linux;
     };
-  } {
+  };
+
+in rec {
+
+  tor-browser = common (rec {
+    pname = "tor-browser";
+    version = "6.5.2";
+    isTorBrowserLike = true;
+    extraConfigureFlags = [ "--disable-loop" ];
+
+    # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
+    src = fetchFromGitHub {
+      owner = "SLNOS";
+      repo  = "tor-browser";
+      rev   = "tor-browser-45.8.0esr-6.5-2";
+      sha256 = "0vbcp1qlxjlph0dqibylsyvb8iah3lnzdxc56hllpvbn51vrp39j";
+    };
+  } // commonAttrs) {
     stdenv = overrideCC stdenv gcc5;
     ffmpegSupport = false;
   };
 
-}
+})


### PR DESCRIPTION
###### Motivation for this change
Update. The old version is kept because we can. Also for regression testing.

###### Things done
- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Seriously.
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

