### PR TITLE
docker: Package in module, tests

### DIFF
--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -126,14 +126,23 @@ in
         '';
       };
     };
+
+    package = mkOption {
+      default = pkgs.docker;
+      type = types.package;
+      example = pkgs.docker-edge;
+      description = ''
+        Docker package to be used in the module.
+      '';
+    };
   };
 
   ###### implementation
 
   config = mkIf cfg.enable (mkMerge [{
-      environment.systemPackages = [ pkgs.docker ];
+      environment.systemPackages = [ cfg.package ];
       users.extraGroups.docker.gid = config.ids.gids.docker;
-      systemd.packages = [ pkgs.docker ];
+      systemd.packages = [ cfg.package ];
 
       systemd.services.docker = {
         wantedBy = optional cfg.enableOnBoot "multi-user.target";
@@ -142,7 +151,7 @@ in
           ExecStart = [
             ""
             ''
-              ${pkgs.docker}/bin/dockerd \
+              ${cfg.package}/bin/dockerd \
                 --group=docker \
                 --host=fd:// \
                 --log-driver=${cfg.logDriver} \
@@ -180,7 +189,7 @@ in
         serviceConfig.Type = "oneshot";
 
         script = ''
-          ${pkgs.docker}/bin/docker system prune -f ${toString cfg.autoPrune.flags}
+          ${cfg.package}/bin/docker system prune -f ${toString cfg.autoPrune.flags}
         '';
 
         startAt = optional cfg.autoPrune.enable cfg.autoPrune.dates;

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -81,6 +81,8 @@ in rec {
         (all nixos.tests.boot.uefiUsb)
         (all nixos.tests.boot-stage1)
         nixos.tests.hibernate.x86_64-linux # i686 is flaky, see #23107
+        nixos.tests.docker.x86_64-linux
+        nixos.tests.docker-edge.x86_64-linux
         (all nixos.tests.ecryptfs)
         (all nixos.tests.ipv6)
         (all nixos.tests.i3wm)

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -234,6 +234,7 @@ in rec {
   tests.containers-hosts = callTest tests/containers-hosts.nix {};
   tests.containers-macvlans = callTest tests/containers-macvlans.nix {};
   tests.docker = hydraJob (import tests/docker.nix { system = "x86_64-linux"; });
+  tests.docker-edge = hydraJob (import tests/docker-edge.nix { system = "x86_64-linux"; });
   tests.dnscrypt-proxy = callTest tests/dnscrypt-proxy.nix { system = "x86_64-linux"; };
   tests.ecryptfs = callTest tests/ecryptfs.nix {};
   tests.etcd = hydraJob (import tests/etcd.nix { system = "x86_64-linux"; });

--- a/nixos/tests/docker-edge.nix
+++ b/nixos/tests/docker-edge.nix
@@ -11,7 +11,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       { config, pkgs, ... }:
         {
           virtualisation.docker.enable = true;
-          virtualisation.docker.package = pkgs.docker;
+          virtualisation.docker.package = pkgs.docker-edge;
 
           users.users = {
             noprivs = {
@@ -42,6 +42,6 @@ import ./make-test.nix ({ pkgs, ...} : {
     $docker->succeed("docker stop sleeping");
 
     # Must match version twice to ensure client and server versions are correct
-    $docker->succeed('[ $(docker version | grep ${pkgs.docker.version} | wc -l) = "2" ]');
+    $docker->succeed('[ $(docker version | grep ${pkgs.docker-edge.version} | wc -l) = "2" ]');
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
Easy selection for `docker` for `docker-edge` for the module.
Adding test for `docker-edge`, checking correct package is indeed selection in existing test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

