### PR TITLE
srcml: fix build with gcc6

### DIFF
--- a/pkgs/applications/version-management/srcml/default.nix
+++ b/pkgs/applications/version-management/srcml/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, cmake, libxml2, libxslt, boost, libarchive, python, antlr }:
+{ stdenv, fetchurl, cmake, libxml2, libxslt, boost, libarchive, python, antlr,
+  curl
+}:
 
 with stdenv.lib;
 
@@ -16,8 +18,12 @@ stdenv.mkDerivation rec {
     substituteInPlace CMake/install.cmake --replace /usr/local $out
     '';
 
+  patches = [
+    ./gcc6.patch
+  ];
+
   nativeBuildInputs = [ cmake antlr ];
-  buildInputs = [ libxml2 libxslt boost libarchive python ];
+  buildInputs = [ libxml2 libxslt boost libarchive python curl ];
 
   meta = {
     description = "Infrastructure for exploration, analysis, and manipulation of source code";

--- a/pkgs/applications/version-management/srcml/gcc6.patch
+++ b/pkgs/applications/version-management/srcml/gcc6.patch
@@ -1,0 +1,26 @@
+diff --git i/CMake/config.cmake w/CMake/config.cmake
+index 28f8047..c596cf8 100644
+--- i/CMake/config.cmake
++++ w/CMake/config.cmake
+@@ -95,7 +95,7 @@ else()
+     find_package(LibXml2 REQUIRED)
+     find_package(CURL REQUIRED)
+     set(Boost_NO_BOOST_CMAKE ON)
+-    set(Boost_USE_STATIC_LIBS ON)
++    set(Boost_USE_STATIC_LIBS OFF)
+     find_package(Boost COMPONENTS program_options filesystem system thread regex date_time REQUIRED)
+ 
+     # add include directories
+diff --git i/src/libsrcml/srcml_reader_handler.hpp w/src/libsrcml/srcml_reader_handler.hpp
+index 0b23fed..c02dfef 100644
+--- i/src/libsrcml/srcml_reader_handler.hpp
++++ w/src/libsrcml/srcml_reader_handler.hpp
+@@ -456,7 +456,7 @@ public :
+ 
+             if(uri == SRCML_CPP_NS_URI) {
+ 
+-                if(archive->language != 0) {
++                if(srcml_check_language(archive->language->c_str()) != 0) {
+ 
+                     if(*archive->language == "C++" || *archive->language == "C" || *archive->language == "Objective-C")
+                         archive->options |= SRCML_OPTION_CPP | SRCML_OPTION_CPP_NOMACRO;


### PR DESCRIPTION
###### Motivation for this change
fixes build with gcc6.

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

