### PR TITLE
go-ethereum: 1.6.6 -> 1.6.7

### DIFF
--- a/pkgs/applications/altcoins/go-ethereum.nix
+++ b/pkgs/applications/altcoins/go-ethereum.nix
@@ -1,19 +1,27 @@
-{ stdenv, lib, clang, buildGoPackage, fetchgit }:
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "go-ethereum-${version}";
-  version = "1.6.6";
-  rev = "refs/tags/v${version}";
+  version = "1.6.7";
   goPackagePath = "github.com/ethereum/go-ethereum";
 
-  buildInputs = [ clang ];
-  preBuild = "export CC=clang";
+  # Fixes Cgo related build failures (see https://github.com/NixOS/nixpkgs/issues/25959 )
+  hardeningDisable = [ "fortify" ];
 
-  src = fetchgit {
-    inherit rev;
-    url = "https://${goPackagePath}";
-    sha256 = "066s7fp9pbyq670xwnib4p7zaxs941r9kpvj2hm6bkr28yrpvp1a";
+  src = fetchFromGitHub {
+    owner = "ethereum";
+    repo = "go-ethereum";
+    rev = "v${version}";
+    sha256 = "19cq0pmif4y33v34jzvam4mcszl8vf2saf2gzfz01l4x1iv4hf1r";
   };
+
+  # Fix cyclic referencing on Darwin
+  postInstall = stdenv.lib.optionalString (stdenv.isDarwin) ''
+    for file in $bin/bin/*; do
+      # Not all files are referencing $out/lib so consider this step non-critical
+      install_name_tool -delete_rpath $out/lib $file || true
+    done
+  '';
 
   meta = {
     homepage = https://ethereum.github.io/go-ethereum/;


### PR DESCRIPTION
###### Motivation for this change
Version update, fix build with gcc.

`geth` and `swarm` binaries are segfaulting on Darwin. Would be great if someone could take a look at this (backtrace can be found here https://gist.github.com/adisbladis/ee62ac868ae46f041589bcb4c1426962).
It's still an improvement since the current package does not even build on Darwin because of cyclic references.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

