### PR TITLE
tpm-tools: fix misleading-indentation error

### DIFF
--- a/pkgs/tools/security/tpm-tools/default.nix
+++ b/pkgs/tools/security/tpm-tools/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ perl ];
   buildInputs = [ trousers openssl opencryptoki ];
 
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=misleading-indentation" ];
+
   meta = with stdenv.lib; {
     description = "Management tools for TPM hardware";
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change
disabling the warning fixes:
```
tpm_present.c:358:5: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Related to #28643 even though it is already marked as fixed.
