### PR TITLE
xflux-gui: 2016-09-21 -> 1.1.10

### DIFF
--- a/pkgs/tools/misc/xflux/gui.nix
+++ b/pkgs/tools/misc/xflux/gui.nix
@@ -4,13 +4,13 @@
 }:
 pythonPackages.buildPythonApplication rec {
   name = "xflux-gui-${version}";
-  version = "2016-09-21";
+  version = "1.1.10";
 
   src = fetchFromGitHub {
     repo = "xflux-gui";
     owner = "xflux-gui";
-    rev = "0b56204477494b473a390e8b0db043437ec14f32";
-    sha256 = "15pr8f31jnhqjlpvasnj6cmm6hw5gljphh2pxzav3zd9bp4yl56r";
+    rev = "v${version}";
+    sha256 = "1k67qg9y4c0n9ih0syx81ixbdl2x89gd4arwh71316cshskn0rc8";
   };
 
   propagatedBuildInputs = with pythonPackages; [
@@ -32,7 +32,6 @@ pythonPackages.buildPythonApplication rec {
 
   postFixup = ''
     wrapGAppsHook
-    makeWrapperArgs="''${gappsWrapperArgs[@]}"
     wrapPythonPrograms
     patchPythonScript $out/${pythonPackages.python.sitePackages}/fluxgui/fluxapp.py
   '';


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

