### PR TITLE
salt: 2016.11.5 -> 2017.7.1, patch fix

### DIFF
--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -8,12 +8,12 @@
 
 python2Packages.buildPythonApplication rec {
   pname = "salt";
-  version = "2016.11.5";
+  version = "2017.7.1";
   name = "${pname}-${version}";
 
   src = python2Packages.fetchPypi {
     inherit pname version;
-    sha256 = "1gpq6s87vy782z4b5h6s7zwndcxnllbdr2wldxr9hyp4lfj2f55q";
+    sha256 = "079kymgxyzhf47dd42l7f42jp45gx5im4k3g31bj25p1s0aq91py";
   };
 
   propagatedBuildInputs = with python2Packages; [

--- a/pkgs/tools/admin/salt/fix-libcrypto-loading.patch
+++ b/pkgs/tools/admin/salt/fix-libcrypto-loading.patch
@@ -1,11 +1,14 @@
 diff --git a/salt/utils/rsax931.py b/salt/utils/rsax931.py
-index 9eb1f4a..d764f7a 100644
+index f827cc6db8..b728595186 100644
 --- a/salt/utils/rsax931.py
 +++ b/salt/utils/rsax931.py
-@@ -36,7 +36,6 @@ def _load_libcrypto():
-                 'libcrypto.so*'))
+@@ -47,6 +47,9 @@ def _load_libcrypto():
              lib = lib[0] if len(lib) > 0 else None
--        if lib:
--            return cdll.LoadLibrary(lib)
-+        return cdll.LoadLibrary('@libcrypto@')
+         if lib:
+             return cdll.LoadLibrary(lib)
++        else:
++            return cdll.LoadLibrary('@libcrypto@')
++
          raise OSError('Cannot locate OpenSSL libcrypto')
+ 
+ 


### PR DESCRIPTION
###### Motivation for this change

Apart from regular update, I've changed the libcrypto patch. It didn't work well with `salt-ssh` (that code failed on remote machines)

https://github.com/saltstack/salt/issues/43350

ping @aneeshusa for review

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
