### PR TITLE
misc pkgs: Reorganize dependencies ahead of #26805

### DIFF
--- a/pkgs/development/libraries/glew/1.10.nix
+++ b/pkgs/development/libraries/glew/1.10.nix
@@ -13,9 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "01zki46dr5khzlyywr3cg615bcal32dazfazkf360s1znqh17i4r";
   };
 
-  nativeBuildInputs = [ x11 libXmu libXi ];
-  propagatedNativeBuildInputs = [ mesa_glu ]; # GL/glew.h includes GL/glu.h
-  buildInputs = [] ++ optionals stdenv.isDarwin [ AGL ];
+  buildInputs = [ x11 libXmu libXi ] ++ optionals stdenv.isDarwin [ AGL ];
+  propagatedBuildInputs = [ mesa_glu ]; # GL/glew.h includes GL/glu.h
 
   patchPhase = ''
     sed -i 's|lib64|lib|' config/Makefile.linux

--- a/pkgs/development/libraries/glew/default.nix
+++ b/pkgs/development/libraries/glew/default.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "out" "dev" "doc" ];
 
-  nativeBuildInputs = [ xlibsWrapper libXmu libXi ];
-  propagatedNativeBuildInputs = [ mesa_glu ]; # GL/glew.h includes GL/glu.h
+  buildInputs = [ xlibsWrapper libXmu libXi ];
+  propagatedBuildInputs = [ mesa_glu ]; # GL/glew.h includes GL/glu.h
 
   patchPhase = ''
     sed -i 's|lib64|lib|' config/Makefile.linux

--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/default.nix
@@ -7,7 +7,7 @@ mkDerivation {
 
   outputs = [ "out" ];  # this package has no runtime components
 
-  propagatedNativeBuildInputs = [ cmake pkgconfig ];
+  propagatedBuildInputs = [ cmake pkgconfig ];
 
   setupHook = ./setup-hook.sh;
 

--- a/pkgs/development/pure-modules/glpk/default.nix
+++ b/pkgs/development/pure-modules/glpk/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   glpkWithExtras = lib.overrideDerivation glpk (attrs: {
-    propagatedNativeBuildInputs = [ gmp libtool libmysql libiodbc ];
+    propagatedBuildInputs = [ gmp libtool libmysql libiodbc ];
 
     CPPFLAGS = "-I${gmp.dev}/include";
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
                        "--with-gmp=yes" ];
   });
 
-  buildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure glpkWithExtras ];
   makeFlags = "libdir=$(out)/lib prefix=$(out)/";
   setupHook = ../generic-setup-hook.sh;

--- a/pkgs/development/tools/misc/autoconf/2.13.nix
+++ b/pkgs/development/tools/misc/autoconf/2.13.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "07krzl4czczdsgzrrw9fiqx35xcf32naf751khg821g5pqv12qgh";
   };
 
-  buildInputs = [m4 perl lzma];
+  nativebuildInputs = [ lzma ];
+  buildInputs = [ m4 perl ];
 
   doCheck = true;
 

--- a/pkgs/development/tools/misc/help2man/default.nix
+++ b/pkgs/development/tools/misc/help2man/default.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "0lvp4306f5nq08f3snffs5pp1zwv8l35z6f5g0dds51zs6bzdv6l";
   };
 
-  buildInputs = [ makeWrapper perl gettext LocaleGettext ];
+  nativeBuildInputs = [ makeWrapper gettext LocaleGettext ];
+  buildInputs = [ perl LocaleGettext ];
 
   doCheck = false;                                # target `check' is missing
 

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "lib" ];
 
-  propagatedNativeBuildInputs = [ m4 ];
   nativeBuildInputs = [ perl help2man ];
+  propagatedBuildInputs = [ m4 ];
 
   # Don't fixup "#! /bin/sh" in Libtool, otherwise it will use the
   # "fixed" path in generated files!

--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ flex bison texinfo help2man autoreconfHook ];
 
-  propagatedNativeBuildInputs = [ m4 ];
+  propagatedBuildInputs = [ m4 ];
 
   crossAttrs = {
     preConfigure = ''

--- a/pkgs/development/tools/parsing/flex/2.6.1.nix
+++ b/pkgs/development/tools/parsing/flex/2.6.1.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ bison ];
 
-  propagatedNativeBuildInputs = [ m4 ];
+  propagatedBuildInputs = [ m4 ];
 
   postConfigure = stdenv.lib.optionalString (stdenv.isDarwin || stdenv.isCygwin) ''
     sed -i Makefile -e 's/-no-undefined//;'

--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ bison ];
 
-  propagatedNativeBuildInputs = [ m4 ];
+  propagatedBuildInputs = [ m4 ];
 
   postConfigure = stdenv.lib.optionalString (stdenv.isDarwin || stdenv.isCygwin) ''
     sed -i Makefile -e 's/-no-undefined//;'

--- a/pkgs/misc/my-env/default.nix
+++ b/pkgs/misc/my-env/default.nix
@@ -62,11 +62,7 @@
     , cleanupCmds ? "", shell ? "${pkgs.bashInteractive}/bin/bash --norc"}:
 
 mkDerivation {
-  # The setup.sh script from stdenv will expect the native build inputs in
-  # the nativeBuildInputs environment variable.
-  nativeBuildInputs = [ ] ++ buildInputs;
-  # Trick to bypass the stdenv usual change of propagatedBuildInputs => propagatedNativeBuildInputs
-  propagatedBuildInputs2 = propagatedBuildInputs;
+  inherit buildInputs propagatedBuildInputs;
 
   name = "env-${name}";
   phases = [ "buildPhase" "fixupPhase" ];
@@ -89,8 +85,8 @@ mkDerivation {
         "$setupNew" > "$s"
     cat >> "$out/dev-envs/''${name/env-/}" << EOF
       defaultNativeBuildInputs="$defaultNativeBuildInputs"
-      nativeBuildInputs="$nativeBuildInputs"
-      propagatedBuildInputs="$propagatedBuildInputs2"
+      buildInputs="$buildInputs"
+      propagatedBuildInputs="$propagatedBuildInputs"
       # the setup-new script wants to write some data to a temp file.. so just let it do that and tidy up afterwards
       tmp="\$("${pkgs.coreutils}/bin/mktemp" -d)"
       NIX_BUILD_TOP="\$tmp"

--- a/pkgs/servers/x11/xorg/xwayland.nix
+++ b/pkgs/servers/x11/xorg/xwayland.nix
@@ -6,7 +6,7 @@ with stdenv.lib;
 overrideDerivation xorgserver (oldAttrs: {
 
   name = "xwayland-${xorgserver.version}";
-  propagatedNativeBuildInputs = oldAttrs.propagatedNativeBuildInputs
+  propagatedBuildInputs = oldAttrs.propagatedBuildInputs
     ++ [wayland wayland-protocols epoxy libxslt makeWrapper libunwind];
   configureFlags = [
     "--disable-docs"

--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake zlib gettext libtool ] ++ xorg.xorgserver.nativeBuildInputs;
 
-  propagatedNativeBuildInputs = xorg.xorgserver.propagatedNativeBuildInputs;
+  propagatedBuildInputs = xorg.xorgserver.propagatedBuildInputs;
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/misc/kdecoration-viewer/default.nix
+++ b/pkgs/tools/misc/kdecoration-viewer/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1cc4xxv72a82p1w9r76090xba7g069r41bi4zx32k4gz3vyl1am6";
   };
 
-  buildInputs = [ cmake extra-cmake-modules qtquickcontrols kconfigwidgets kdeclarative kdecoration ];
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
+  buildInputs = [ qtquickcontrols kconfigwidgets kdeclarative kdecoration ];
 
   meta = with stdenv.lib; {
     description = "Allows to preview a KDecoration plugin";


### PR DESCRIPTION
###### Motivation for this change

These dependencies were improperly classified. There's no symptoms today, but when I change the propagation logic those packages would break. With this change they ought to work before and after.

###### Things done

The https://hydra.mayflower.de job didn't quite finish, but I consider this good enough to merge to staging. I'll retarget this branch for the 17.09 backport next, where we'll be more careful.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- So far so good https://hydra.mayflower.de/eval/1512
- Built stdenv with downstream PR on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

