### PR TITLE
gerrit: init at 2.14.3

### DIFF
--- a/pkgs/applications/version-management/gerrit/default.nix
+++ b/pkgs/applications/version-management/gerrit/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "gerrit-${version}";
+  version = "2.14.3";
+
+  src = fetchurl {
+    url = "https://gerrit-releases.storage.googleapis.com/gerrit-${version}.war";
+    sha256 = "db602d06b11bfa81f1cb016c4717a99699828eda08afb2caa504175a2ea4b9c3";
+  };
+
+  buildCommand = ''
+    mkdir -p "$out"/webapps
+    cp "${src}" "$out"/webapps/gerrit-${version}.war
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.gerritcodereview.com/index.md;
+    license = licenses.asl20;
+    description = "A web based code review and repository management for the git version control system";
+    maintainers = with maintainers; [ jammerful ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/version-management/gerrit/default.nix
+++ b/pkgs/applications/version-management/gerrit/default.nix
@@ -6,12 +6,15 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://gerrit-releases.storage.googleapis.com/gerrit-${version}.war";
-    sha256 = "db602d06b11bfa81f1cb016c4717a99699828eda08afb2caa504175a2ea4b9c3";
+    sha256 = "1hxrlhp5l5q4lp5b5bq8va7856cnm4blfv01rgqq3yhvn432sq6v";
   };
 
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "1wg7bbhwgi9sxn7skxb9gwaydq9jzpdhglwgq5kihj7r269fmr4k";
+
   buildCommand = ''
-    mkdir -p "$out"/webapps
-    cp "${src}" "$out"/webapps/gerrit-${version}.war
+    install -D ${src} "$out"/webapps/gerrit-${version}.war
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2141,6 +2141,8 @@ with pkgs;
 
   genimage = callPackage ../tools/filesystems/genimage { };
 
+  gerrit = callPackage ../applications/version-management/gerrit { };
+
   geteltorito = callPackage ../tools/misc/geteltorito { };
 
   getmail = callPackage ../tools/networking/getmail { };


### PR DESCRIPTION
###### Motivation for this change

Add a new version control and code review application to nixpkgs. Will follow up with a NixOS module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

