### PR TITLE
seafile-client: add optional Shibboleth support

### DIFF
--- a/pkgs/applications/networking/seafile-client/default.nix
+++ b/pkgs/applications/networking/seafile-client/default.nix
@@ -1,5 +1,8 @@
 { stdenv, fetchurl, writeScript, pkgconfig, cmake, qtbase, qttools
-, seafile-shared, ccnet, makeWrapper }:
+, seafile-shared, ccnet, makeWrapper
+, withShibboleth ? true, qtwebengine }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   version = "6.1.0";
@@ -11,7 +14,11 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig cmake makeWrapper ];
-  buildInputs = [ qtbase qttools seafile-shared ];
+  buildInputs = [ qtbase qttools seafile-shared ]
+    ++ optional withShibboleth qtwebengine;
+
+  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ]
+    ++ optional withShibboleth "-DBUILD_SHIBBOLETH_SUPPORT=ON";
 
   postInstall = ''
     wrapProgram $out/bin/seafile-applet \


### PR DESCRIPTION
###### Motivation for this change
This is used by some universities.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @Calrama 
