### PR TITLE
jenkins: fixed-output derivation to avoid rebuilds

### DIFF
--- a/pkgs/development/tools/continuous-integration/jenkins/default.nix
+++ b/pkgs/development/tools/continuous-integration/jenkins/default.nix
@@ -9,9 +9,13 @@ stdenv.mkDerivation rec {
     sha256 = "1hmj5f14qpq58018q2jmdd4j36v2idsbb9caiakxfy08gppzhz00";
   };
 
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "11vy3wsc9b45146ninynq18ip2d99wfbl2sas9h1i418jxw88lf5";
+
   buildCommand = ''
-    mkdir -p "$out/webapps"
-    cp "$src" "$out/webapps/jenkins.war"
+    mkdir -p "$out/webapps/"
+    ln -s "${src}" "$out/webapps/jenkins.war"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
see also #27754 (comment) for motivation.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested via `nixos/tests/jenkins.nix`(had to raise the timeout)
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

