### PR TITLE
libcxx-stdenv: fix for darwin

### DIFF
--- a/pkgs/development/compilers/llvm/4/default.nix
+++ b/pkgs/development/compilers/llvm/4/default.nix
@@ -57,7 +57,12 @@ let
       extraBuildInputs = if stdenv.cc.isGNU then [ libstdcxxHook ] else drv.extraBuildInputs;
     });
 
-    libcxxStdenv = overrideCC stdenv self.libcxxClang;
+    libcxxStdenv = stdenv.override (drv: {
+      allowedRequisites = null;
+      cc = self.libcxxClang;
+      # Don't include the libc++ and libc++abi from the original stdenv.
+      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
+    });
 
     lld = callPackage ./lld.nix {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5308,7 +5308,7 @@ with pkgs;
   #Use this instead of stdenv to build with clang
   clangStdenv = if stdenv.isDarwin then stdenv else lowPrio llvmPackages.stdenv;
   clang-sierraHack-stdenv = overrideCC stdenv clang-sierraHack;
-  libcxxStdenv = lowPrio llvmPackages.libcxxStdenv;
+  libcxxStdenv = if stdenv.isDarwin then stdenv else lowPrio llvmPackages.libcxxStdenv;
 
   clean = callPackage ../development/compilers/clean { };
 


### PR DESCRIPTION
###### Motivation for this change

Building something with `llvmPackages.libcxxStdenv` on darwin fails.

```
In file included from /nix/store/lm7bpsys535kxfljlkpw23l9k3rvbsgl-cxx-main.cc:1:
In file included from /nix/store/0hfqkfzq503hhxmh0rqjaym23pyhlfcn-libc++-4.0.1/include/c++/v1/iostream:38:
In file included from /nix/store/0hfqkfzq503hhxmh0rqjaym23pyhlfcn-libc++-4.0.1/include/c++/v1/ios:215:
In file included from /nix/store/0hfqkfzq503hhxmh0rqjaym23pyhlfcn-libc++-4.0.1/include/c++/v1/iosfwd:90:
/nix/store/0hfqkfzq503hhxmh0rqjaym23pyhlfcn-libc++-4.0.1/include/c++/v1/wchar.h:133:77: error: use of undeclared identifier 'wcschr'
wchar_t* __libcpp_wcschr(const wchar_t* __s, wchar_t __c) {return (wchar_t*)wcschr(__s, __c);}
                                                                            ^
...
/nix/store/0hfqkfzq503hhxmh0rqjaym23pyhlfcn-libc++-4.0.1/include/c++/v1/string.h:78:13: note: candidate disabled: <no message provided>
      char* strchr(      char* __s, int __c) {return __libcpp_strchr(__s, __c);}
            ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---