### PR TITLE
rustup: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/development/tools/rust/rustup/default.nix
+++ b/pkgs/development/tools/rust/rustup/default.nix
@@ -4,15 +4,15 @@
 
 rustPlatform.buildRustPackage rec {
   name = "rustup-${version}";
-  version = "1.2.0";
+  version = "1.3.0";
 
-  depsSha256 = "06bfz5kyj3k0yxv55dq0s1arx34sy1jjfrpgd83rf99026vcm5x2";
+  depsSha256 = "078hssgffgpakv735p1xg60kic151r2dvpdr9sipb63lwqr4dxfb";
 
   src = fetchFromGitHub {
     owner = "rust-lang-nursery";
     repo = "rustup.rs";
     rev = version;
-    sha256 = "0qwl27wh7j03h511bd8fq5fif5xcmkiyy9rm3hri7czjqr01mw0v";
+    sha256 = "199jlqqidzak7nxmv2nzjzv7zfzy9z7hw6h8d8wf1rbfdwd9l6hs";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

There was a newer rustup version (1.3.0) available.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

