### PR TITLE
More basic system tests

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -82,6 +82,7 @@ in rec {
         (all nixos.tests.boot-stage1)
         nixos.tests.hibernate.x86_64-linux # i686 is flaky, see #23107
         (all nixos.tests.ecryptfs)
+        (all nixos.tests.env)
         (all nixos.tests.ipv6)
         (all nixos.tests.i3wm)
         (all nixos.tests.keymap.azerty)

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -115,6 +115,7 @@ in rec {
         (all nixos.tests.sddm.default)
         (all nixos.tests.simple)
         (all nixos.tests.slim)
+        (all nixos.tests.sysctl)
         (all nixos.tests.udisks2)
         (all nixos.tests.xfce)
 

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -93,6 +93,7 @@ in rec {
         (all nixos.tests.plasma5)
         (all nixos.tests.kernel-latest)
         (all nixos.tests.kernel-lts)
+        (all nixos.tests.kernel-params)
         #(all nixos.tests.lightdm)
         (all nixos.tests.login)
         (all nixos.tests.misc)

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -309,6 +309,7 @@ in rec {
   tests.slim = callTest tests/slim.nix {};
   tests.smokeping = callTest tests/smokeping.nix {};
   tests.snapper = callTest tests/snapper.nix {};
+  tests.sysctl = callTest tests/sysctl.nix {};
   tests.taskserver = callTest tests/taskserver.nix {};
   tests.tomcat = callTest tests/tomcat.nix {};
   tests.udisks2 = callTest tests/udisks2.nix {};

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -264,6 +264,7 @@ in rec {
   tests.kernel-copperhead = tests/kernel-copperhead.nix {};
   tests.kernel-latest = tests/kernel-latest.nix {};
   tests.kernel-lts = tests/kernel-lts.nix {};
+  tests.kernel-params = tests/kernel-params.nix {};
   tests.keystone = callTest tests/keystone.nix {};
   tests.kubernetes = hydraJob (import tests/kubernetes.nix { system = "x86_64-linux"; });
   tests.latestKernel.login = callTest tests/login.nix { latestKernel = true; };

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -240,6 +240,7 @@ in rec {
   tests.ec2-nixops = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-nixops;
   tests.ec2-config = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-config;
   tests.elk = callTest tests/elk.nix {};
+  tests.env = callTest tests/env.nix {};
   tests.ferm = callTest tests/ferm.nix {};
   tests.firefox = callTest tests/firefox.nix {};
   tests.firewall = callTest tests/firewall.nix {};

--- a/nixos/tests/env.nix
+++ b/nixos/tests/env.nix
@@ -1,0 +1,35 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "environment";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ nequissimus ];
+  };
+
+  machine = { config, lib, pkgs, ... }:
+    {
+      boot.kernelPackages = pkgs.linuxPackages;
+      environment.etc."plainFile".text = ''
+        Hello World
+      '';
+      environment.etc."folder/with/file".text = ''
+        Foo Bar!
+      '';
+
+      environment.sessionVariables = {
+        TERMINFO_DIRS = "/run/current-system/sw/share/terminfo";
+        NIXCON = "awesome";
+      };
+    };
+
+  testScript =
+    ''
+      $machine->succeed('[ -L "/etc/plainFile" ]');
+      $machine->succeed('cat "/etc/plainFile" | grep "Hello World"');
+      $machine->succeed('[ -d "/etc/folder" ]');
+      $machine->succeed('[ -d "/etc/folder/with" ]');
+      $machine->succeed('[ -L "/etc/folder/with/file" ]');
+      $machine->succeed('cat "/etc/plainFile" | grep "Hello World"');
+
+      $machine->succeed('echo ''${TERMINFO_DIRS} | grep "/run/current-system/sw/share/terminfo"');
+      $machine->succeed('echo ''${NIXCON} | grep "awesome"');
+    '';
+})

--- a/nixos/tests/kernel-params.nix
+++ b/nixos/tests/kernel-params.nix
@@ -1,0 +1,24 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "kernel-params";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ nequissimus ];
+  };
+
+  machine = { config, lib, pkgs, ... }:
+    {
+      boot.kernelPackages = pkgs.linuxPackages;
+      boot.kernelParams = [
+        "nohibernate"
+        "page_poison=1"
+        "vsyscall=none"
+      ];
+    };
+
+  testScript =
+    ''
+      $machine->fail("cat /proc/cmdline | grep page_poison=0");
+      $machine->succeed("cat /proc/cmdline | grep nohibernate");
+      $machine->succeed("cat /proc/cmdline | grep page_poison=1");
+      $machine->succeed("cat /proc/cmdline | grep vsyscall=none");
+    '';
+})

--- a/nixos/tests/sysctl.nix
+++ b/nixos/tests/sysctl.nix
@@ -1,0 +1,25 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "sysctl";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ nequissimus ];
+  };
+
+  machine = { config, lib, pkgs, ... }:
+    {
+      boot.kernelPackages = pkgs.linuxPackages;
+      boot.kernel.sysctl = {
+        "kernel.dmesg_restrict" = true; # Restrict dmesg access
+        "net.core.bpf_jit_enable" = false; # Turn off bpf JIT
+        "user.max_user_namespaces" = 0; # Disable user namespaces
+        "vm.swappiness" = 2; # Low swap usage
+      };
+    };
+
+  testScript =
+    ''
+      $machine->succeed("sysctl kernel.dmesg_restrict | grep 'kernel.dmesg_restrict = 1'");
+      $machine->succeed("sysctl net.core.bpf_jit_enable | grep 'net.core.bpf_jit_enable = 0'");
+      $machine->succeed("sysctl user.max_user_namespaces | grep 'user.max_user_namespaces = 0'");
+      $machine->succeed("sysctl vm.swappiness | grep 'vm.swappiness = 2'");
+    '';
+})


### PR DESCRIPTION
- sysctl: Check that `boot.kernel.sysctl` commands are properly applied
- kernelParams: Ensure `boot.kernelParams` are applied
- environment: Create file directly in `/etc` and one in sub-directories and verify structure/content, `environment.sessionVariables` should show up in the environment

I declared all three of them release-blocking