### PR TITLE
pulseaudio: 10.0 -> 11.0

### DIFF
--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -36,18 +36,14 @@
 
 stdenv.mkDerivation rec {
   name = "${if libOnly then "lib" else ""}pulseaudio-${version}";
-  version = "10.0";
+  version = "11.0";
 
   src = fetchurl {
     url = "http://freedesktop.org/software/pulseaudio/releases/pulseaudio-${version}.tar.xz";
-    sha256 = "0mrg8qvpwm4ifarzphl3749p7p050kdx1l6mvsaj03czvqj6h653";
+    sha256 = "0sf92knqkvqmfhrbz4vlsagzqlps72wycpmln5dygicg07a0a8q7";
   };
 
-  patches = [ ./caps-fix.patch ]
-            ++ stdenv.lib.optional stdenv.isDarwin (fetchpatch {
-              url = "https://bugs.freedesktop.org/attachment.cgi?id=127889";
-              sha256 = "063h5vmh4ykgxjbxyxjlj6qhyyxhazbh3p18p1ik69kq24nkny9m";
-            });
+  patches = [ ./caps-fix.patch ];
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
Remove darwin patch that has been included in the upstream release, tested on my desktop with a variety of programs. Nox review has not been run yet but I plan on it

###### Motivation for this change
All sorts of fixes and new hardware support! Check out the changelog here:

https://www.freedesktop.org/wiki/Software/PulseAudio/Notes/11.0/

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

