### PR TITLE
docker: 17.06.1-ce -> 17.06.2-ce

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -177,13 +177,13 @@ rec {
   # https://github.com/docker/docker-ce/blob/v${version}/components/engine/hack/dockerfile/binaries-commits
 
   docker_17_06 = dockerGen rec {
-    version = "17.06.1-ce";
-    rev = "874a7374f31c77aca693d025101b2de1b20b96c2"; # git commit
-    sha256 = "08xhww2rhpyj73zgh5maycs85zpc0sm3ak8yyyd92dwgncmyi2im";
-    runcRev = "2d41c047c83e09a6d61d464906feb2a2f3c52aa4";
-    runcSha256 = "0v5iv29ck6lkxvxh7a56gfrlgfs0bjvjhrq3p6qqv9qjzv825byq";
-    containerdRev = "3addd840653146c90a254301d6c3a663c7fd6429";
-    containerdSha256 = "0as4s5wd57pdh1cyavkccpgs46kvlhr41v07qrv0phzffdhq3d5j";
+    version = "17.06.2-ce";
+    rev = "cec0b72a9940e047e945a09e1febd781e88366d6"; # git commit
+    sha256 = "1scqx28vzh72ziq00lbx92vsb896mj974j8f0zg11y6qc5n5jx3l";
+    runcRev = "810190ceaa507aa2727d7ae6f4790c76ec150bd2";
+    runcSha256 = "0f1x1z262qg579qb1w21axj3mibq4fbff3gamliw49sdqqnb7vk3";
+    containerdRev = "6e23458c129b551d5c9871e5174f6b1b7f6d1170";
+    containerdSha256 = "12kzc5z1nhxdbizzr494ywilbs6rdv39v5ql7lmfzwh350gwlg93";
     tiniRev = "949e6facb77383876aeff8a6944dde66b3089574";
     tiniSha256 = "0zj4kdis1vvc6dwn4gplqna0bs7v6d1y2zc8v80s3zi018inhznw";
   };


### PR DESCRIPTION
###### Motivation for this change
Update, considering this is Docker LTS, it should go into 17.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

