### PR TITLE
factorio: fix darwin build

### DIFF
--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -9,6 +9,8 @@
 assert releaseType == "alpha"
     || releaseType == "headless"
     || releaseType == "demo";
+assert stdenv.system == "x86_64-linux"
+    || stdenv.system == "i686-linux";
 
 let
 


### PR DESCRIPTION
###### Motivation for this change

I've fixed this package to restrict to Linux.
In macOS with latest source tree (including #29038), `nix-env -qa` shows **attribute 'x86_64-darwin' missing** error.
This error raise when reference *binDists.x86_64-darwin* of factorio package.

```console
$ nix-env -qa --show-trace factorio
error: while evaluating ‘callPackageWith’ at /Users/lufia/nixpkgs/lib/customisation.nix:113:35, called from /Users/lufia/nixpkgs/pkgs/top-level/all-packages.nix:17345:14:
while evaluating ‘makeOverridable’ at /Users/lufia/nixpkgs/lib/customisation.nix:72:24, called from /Users/lufia/nixpkgs/lib/customisation.nix:117:8:
while evaluating anonymous function at /Users/lufia/nixpkgs/pkgs/games/factorio/default.nix:1:1, called from /Users/lufia/nixpkgs/lib/customisation.nix:74:12:
while evaluating ‘mkDerivation’ at /Users/lufia/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:15:5, called from /Users/lufia/nixpkgs/pkgs/games/factorio/default.nix:169:4:
while evaluating ‘addPassthru’ at /Users/lufia/nixpkgs/lib/customisation.nix:135:22, called from /Users/lufia/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:153:7:
while evaluating anonymous function at /Users/lufia/nixpkgs/pkgs/stdenv/generic/check-meta.nix:5:1, called from /Users/lufia/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:154:22:
while evaluating ‘throwEvalHelp’ at /Users/lufia/nixpkgs/pkgs/stdenv/generic/check-meta.nix:128:19, called from /Users/lufia/nixpkgs/pkgs/stdenv/generic/check-meta.nix:194:17:
while evaluating the attribute ‘name’ at /Users/lufia/nixpkgs/pkgs/games/factorio/default.nix:73:5:
attribute ‘x86_64-darwin’ missing, at /Users/lufia/nixpkgs/pkgs/games/factorio/default.nix:29:12
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

