### PR TITLE
pinentry-mac: no ‘fill plist’ stuff

### DIFF
--- a/pkgs/tools/security/pinentry-mac/default.nix
+++ b/pkgs/tools/security/pinentry-mac/default.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "matthewbauer";
     repo = "pinentry-mac";
-    rev = "d60aa902644a1f0126ec50e79937423a3a7c3bc4";
-    sha256 = "0xp4rdyj0mw6gg1z1wraggb1qlkjb5845mibrz3nj0l692da52nq";
+    rev = "6dfef256c8ea32d642fea847f27d800f024cf51e";
+    sha256 = "0g75302697gqcxyf2hyqzvcbd5pyss1bl2xvfd40wqav7dlyvj83";
   };
 
   buildInputs = [ xcbuild libiconv Cocoa ncurses ];


### PR DESCRIPTION
fixes #26774

###### Motivation for this change

The "Fill Plist.info" stuff was only really needed for versioning pinentry. Everything seems to work fine with it disabled, so I've done that on [matthewbauer/pinentry-mac](https://github.com/matthewbauer/pinentry-mac).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

