### PR TITLE
rssguard: 3.4.0 -> 3.4.2

### DIFF
--- a/pkgs/applications/networking/feedreaders/rssguard/default.nix
+++ b/pkgs/applications/networking/feedreaders/rssguard/default.nix
@@ -2,13 +2,15 @@
 
 stdenv.mkDerivation rec {
   name = "rssguard-${version}";
-  version = "3.4.0";
+  version = "3.4.2";
 
   src = fetchgit {
     url = https://github.com/martinrotter/rssguard;
     rev = "refs/tags/${version}";
-    sha256 = "1cdpfjj2lm1q2qh0w0mh505blcmi4n78458d3z3c1zn9ls9b9zsp";
-    fetchSubmodules = true;
+    sha256 = "0iy0fd3qr2dm0pc6xr7sin6cjfxfa0pxhxiwzs55dhsdk9zir62s";
+    # Submodules are required only for Windows (and one of them is a huge binary
+    # package ~400MB). See project wiki for more details.
+    fetchSubmodules = false;
   };
 
   buildInputs =  [ qtwebengine qttools ];


### PR DESCRIPTION
###### Motivation for this change

Upgrade rssguard.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

