### PR TITLE
dnscrypt-wrapper module: fix permissions and options

### DIFF
--- a/nixos/modules/services/networking/dnscrypt-wrapper.nix
+++ b/nixos/modules/services/networking/dnscrypt-wrapper.nix
@@ -45,7 +45,7 @@ let
   rotateKeys = ''
     # check if keys are not expired
     keyValid() {
-      fingerprint=$(dnscrypt-wrapper --show-provider-publickey-fingerprint | awk '{print $(NF)}')
+      fingerprint=$(dnscrypt-wrapper --show-provider-publickey | awk '{print $(NF)}')
       dnscrypt-proxy --test=${toString (cfg.keys.checkInterval + 1)} \
         --resolver-address=127.0.0.1:${toString cfg.port} \
         --provider-name=${cfg.providerName} \
@@ -56,9 +56,10 @@ let
 
     # archive old keys and restart the service
     if ! keyValid; then
+      echo "certificate soon to become invalid; backing up old cert"
       mkdir -p oldkeys
-      mv ${cfg.providerName}.key oldkeys/${cfg.providerName}-$(date +%F-%T).key
-      mv ${cfg.providerName}.crt oldkeys/${cfg.providerName}-$(date +%F-%T).crt
+      mv -v ${cfg.providerName}.key oldkeys/${cfg.providerName}-$(date +%F-%T).key
+      mv -v ${cfg.providerName}.crt oldkeys/${cfg.providerName}-$(date +%F-%T).crt
       systemctl restart dnscrypt-wrapper
     fi
   '';
@@ -169,6 +170,7 @@ in {
 
       path   = with pkgs; [ dnscrypt-wrapper dnscrypt-proxy gawk ];
       script = rotateKeys;
+      serviceConfig.User = "dnscrypt-wrapper";
     };
 
 


### PR DESCRIPTION


###### Motivation for this change

When keys get refreshed a folder with the permissions of the root user
get created in the home directory of the user dnscrypt-wrapper. This
prevents the service from restarting.

In addition to that the parameters of dnscrypt-wrapper have
changed in upstream and in the newly packaged software.

###### Things done

- Tested on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of the service
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

