### PR TITLE
pythonPackages.django: 1.10.7 -> 1.10.8 (release 17.03)

### DIFF
--- a/pkgs/development/python-modules/django/1_10.nix
+++ b/pkgs/development/python-modules/django/1_10.nix
@@ -4,12 +4,12 @@
 }:
 buildPythonPackage rec {
   name = "Django-${version}";
-  version = "1.10.7";
+  version = "1.10.8";
   disabled = pythonOlder "2.7";
 
   src = fetchurl {
     url = "http://www.djangoproject.com/m/releases/1.10/${name}.tar.gz";
-    sha256 = "1f5hnn2dzfr5szk4yc47bs4kk2nmrayjcvgpqi2s4l13pjfpfgar";
+    sha256 = "1fwqqh2zbcy9dy0lnvk338s11llnnfz2k56bf84w0wv56ayq7vyl";
   };
 
   patches = [


### PR DESCRIPTION
Fixes CVE-2017-12794
See https://docs.djangoproject.com/en/1.10/releases/1.10.8/

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

