### PR TITLE
scitools: init at 0.9.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -258,6 +258,7 @@
   j-keck = "Jürgen Keck <jhyphenkeck@gmail.com>";
   jagajaga = "Arseniy Seroka <ars.seroka@gmail.com>";
   jammerful = "jammerful <jammerful@gmail.com>";
+  jamtrott = "James D. Trotter <james.trotter@gmail.com>";
   jansol = "Jan Solanti <jan.solanti@paivola.fi>";
   javaguirre = "Javier Aguirre <contacto@javaguirre.net>";
   jb55 = "William Casarin <jb55@jb55.com>";

--- a/pkgs/development/python-modules/scitools/default.nix
+++ b/pkgs/development/python-modules/scitools/default.nix
@@ -18,5 +18,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python library for scientific computing";
     homepage = https://github.com/hplgit/scitools;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ jamtrott ];
   };
 }

--- a/pkgs/development/python-modules/scitools/default.nix
+++ b/pkgs/development/python-modules/scitools/default.nix
@@ -1,0 +1,20 @@
+{lib, fetchurl, python, buildPythonPackage, numpy, matplotlib}:
+
+buildPythonPackage rec {
+  pname = "scitools";
+  version = "0.9.0";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/hplgit/scitools/archive/scitools-${version}.tar.gz";
+    sha256 = "1aj3i56aim542krynza46plxbci7dfhq9rq7hwfw4946rjbm3klc";
+  };
+
+  buildInputs = [ matplotlib ];
+  propagatedBuildInputs = [ numpy ];
+
+  meta = {
+    description = "Python library for scientific computing";
+    homepage = https://github.com/hplgit/scitools;
+  };
+}

--- a/pkgs/development/python-modules/scitools/default.nix
+++ b/pkgs/development/python-modules/scitools/default.nix
@@ -1,13 +1,15 @@
-{lib, fetchurl, python, buildPythonPackage, numpy, matplotlib}:
+{stdenv, fetchFromGitHub, python, buildPythonPackage, numpy, matplotlib}:
 
 buildPythonPackage rec {
   pname = "scitools";
   version = "0.9.0";
   name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/hplgit/scitools/archive/scitools-${version}.tar.gz";
-    sha256 = "1aj3i56aim542krynza46plxbci7dfhq9rq7hwfw4946rjbm3klc";
+  src = fetchFromGitHub {
+    owner = "hplgit";
+    repo = "scitools";
+    rev = "${name}";
+    sha256 = "07yxbc7spr7vy72lg3czv4r4q2f0wq17vszlnsfmsb2ix8jajp4d";
   };
 
   buildInputs = [ matplotlib ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20085,6 +20085,8 @@ in {
     inherit (pkgs) gfortran glibcLocales;
   };
 
+  scitools = callPackage ../development/python-modules/scitools { };
+
   scripttest = buildPythonPackage rec {
     version = "1.3";
     name = "scripttest-${version}";


### PR DESCRIPTION
###### Motivation for this change
Add the scitools Python package, which contains many useful tools for scientific computing in Python. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

