### PR TITLE
skanlite: init at 2.0.1

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -135,6 +135,7 @@ let
       libkipi = callPackage ./libkipi.nix {};
       libkleo = callPackage ./libkleo.nix {};
       libkomparediff2 = callPackage ./libkomparediff2.nix {};
+      libksane = callPackage ./libksane.nix {};
       libksieve = callPackage ./libksieve.nix {};
       mailcommon = callPackage ./mailcommon.nix {};
       mailimporter = callPackage ./mailimporter.nix {};

--- a/pkgs/applications/kde/libksane.nix
+++ b/pkgs/applications/kde/libksane.nix
@@ -1,0 +1,16 @@
+{
+  mkDerivation, lib,
+  extra-cmake-modules, qtbase,
+  ki18n, ktextwidgets, kwallet, kwidgetsaddons,
+  sane-backends
+}:
+
+mkDerivation {
+  name = "libksane";
+  meta = with lib; {
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ pshendry ];
+  };
+  nativeBuildInputs = [ extra-cmake-modules ];
+  buildInputs = [ qtbase ki18n ktextwidgets kwallet kwidgetsaddons sane-backends ];
+}

--- a/pkgs/applications/networking/p2p/ktorrent/default.nix
+++ b/pkgs/applications/networking/p2p/ktorrent/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "KDE integrated BtTorrent client";
     homepage    = https://www.kde.org/applications/internet/ktorrent/;
+    license = licenses.gpl2;
     maintainers = with maintainers; [ eelco ];
     platforms   = platforms.linux;
   };

--- a/pkgs/applications/office/skanlite/default.nix
+++ b/pkgs/applications/office/skanlite/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, cmake, extra-cmake-modules, qtbase,
+  kcoreaddons, kdoctools, ki18n, kio, kxmlgui, ktextwidgets,
+  libksane
+}:
+
+let
+  minorVersion = "2.0";
+in stdenv.mkDerivation rec {
+  name = "skanlite-2.0.1";
+
+  src = fetchurl {
+    url    = "mirror://kde/stable/skanlite/${minorVersion}/${name}.tar.xz";
+    sha256 = "0dh2v8029gkhcf3pndcxz1zk2jgpihgd30lmplgirilxdq9l2i9v";
+  };
+
+  nativeBuildInputs = [ cmake kdoctools extra-cmake-modules ];
+
+  buildInputs = [
+    qtbase
+    kcoreaddons kdoctools ki18n kio kxmlgui ktextwidgets
+    libksane
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "KDE simple image scanning application";
+    homepage    = http://www.kde.org/applications/graphics/skanlite/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ pshendry ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10146,7 +10146,7 @@ with pkgs;
     ### KDE APPLICATIONS
 
     inherit (kdeApplications.override { libsForQt5 = self; })
-      kholidays libkdcraw libkexiv2 libkipi libkomparediff2;
+      kholidays libkdcraw libkexiv2 libkipi libkomparediff2 libksane;
 
     ### LIBRARIES
 
@@ -16266,6 +16266,8 @@ with pkgs;
   shntool = callPackage ../applications/audio/shntool { };
 
   sipp = callPackage ../development/tools/misc/sipp { };
+
+  skanlite = libsForQt5.callPackage ../applications/office/skanlite { };
 
   sonic-visualiser = libsForQt5.callPackage ../applications/audio/sonic-visualiser {
     inherit (pkgs.vamp) vampSDK;


### PR DESCRIPTION
###### Motivation for this change

Adding skanlite, a popular KDE application

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Things remaining

I'm travelling right now and I don't have a scanner available, which means I can't really test the application apart from confirming that it launches. Could someone with a scanner check this out and try it?
