### PR TITLE
ncurses: 6.0-20170729 -> 6.0-20170902

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -11,7 +11,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = if abiVersion == "5" then "5.9" else "6.0-20170729";
+  version = if abiVersion == "5" then "5.9" else "6.0-20170902";
   name = "ncurses-${version}";
 
   src = fetchurl (if abiVersion == "5" then {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "0fsn7xis81za62afan0vvm38bvgzg5wfmv1m86flqcj0nj7jjilh";
   } else {
     url = "ftp://ftp.invisible-island.net/ncurses/current/${name}.tgz";
-    sha256 = "1cfdpl2gnj8szw28jmzrw47va0yqn16g03ywyzz3bjmaqxxmmwga";
+    sha256 = "1cks4gsz4148jw6wpqia4w5jx7cfxr29g2kmpvp0ssmvwczh8dr4";
   });
 
   patches = [ ./clang.patch ] ++ lib.optional (abiVersion == "5" && stdenv.cc.isGNU) ./gcc-5.patch;


### PR DESCRIPTION
Layout issues in tig were noticed with previous ncurses version
within zsh with TERM=xterm-256color.

No issues were observed, under same test conditions,
with 6.0 or 6.0-20170902.

Setting TERM=screen worked for all ncurses versions listed above.

###### Motivation for this change
Layout issues in tig were noticed with previous ncurses version
within zsh with TERM=xterm-256color.

No issues were observed, under same test conditions,
with 6.0 or 6.0-20170902.

Setting TERM=screen worked for all ncurses versions listed above.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

