### PR TITLE
calligra: 2.9.11 -> 3.0.1

### DIFF
--- a/pkgs/applications/office/calligra/2.nix
+++ b/pkgs/applications/office/calligra/2.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchurl, automoc4, cmake, perl, pkgconfig, kdelibs4, lcms2, libpng, eigen
+, exiv2, boost, sqlite, icu, vc, shared_mime_info, librevenge, libodfgen, libwpg
+, libwpd, poppler_qt4, ilmbase, gsl, qca2, marble, libvisio, libmysql, postgresql
+, freetds, fftw, glew, libkdcraw, pstoedit, opencolorio, kdepimlibs
+, kactivities, okular, git, oxygen-icons5, makeWrapper
+# TODO: not found
+#, xbase, openjpeg
+# TODO: package libWPS, Spnav, m2mml, LibEtonyek
+}:
+
+stdenv.mkDerivation rec {
+  name = "calligra-2.9.11";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/${name}/${name}.tar.xz";
+    sha256 = "02gaahp7a7m53n0hvrp3868s8w37b457isxir0z7b4mwhw7jv3di";
+  };
+
+  nativeBuildInputs = [ automoc4 cmake perl pkgconfig makeWrapper ];
+
+  buildInputs = [
+    kdelibs4 lcms2 libpng eigen
+    exiv2 boost sqlite icu vc shared_mime_info librevenge libodfgen libwpg
+    libwpd poppler_qt4 ilmbase gsl qca2 marble libvisio libmysql postgresql
+    freetds fftw glew libkdcraw opencolorio kdepimlibs
+    kactivities okular git
+  ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    for i in $out/bin/*; do
+      wrapProgram $i \
+        --prefix PATH ':' "${pstoedit.out}/bin" \
+        --prefix XDG_DATA_DIRS ':' "${oxygen-icons5}/share"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A suite of productivity applications";
+    longDescription = ''
+      Calligra Suite is a set of applications written to help
+      you to accomplish your work. Calligra includes efficient
+      and capable office components: Words for text processing,
+      Sheets for computations, Stage for presentations, Plan for
+      planning, Flow for flowcharts, Kexi for database creation,
+      Krita for painting and raster drawing, and Karbon for
+      vector graphics.
+    '';
+    homepage = http://calligra.org;
+    maintainers = with maintainers; [ phreedom ebzzry ];
+    inherit (kdelibs4.meta) platforms;
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/applications/office/calligra/default.nix
+++ b/pkgs/applications/office/calligra/default.nix
@@ -1,55 +1,65 @@
-{ stdenv, fetchurl, automoc4, cmake, perl, pkgconfig, kdelibs4, lcms2, libpng, eigen
-, exiv2, boost, sqlite, icu, vc, shared_mime_info, librevenge, libodfgen, libwpg
-, libwpd, poppler_qt4, ilmbase, gsl, qca2, marble, libvisio, libmysql, postgresql
-, freetds, fftw, glew, libkdcraw, pstoedit, opencolorio, kdepimlibs
-, kactivities, okular, git, oxygen-icons5, makeWrapper
-# TODO: not found
-#, xbase, openjpeg
-# TODO: package libWPS, Spnav, m2mml, LibEtonyek
+{
+  mkDerivation, lib, fetchurl, extra-cmake-modules, kdoctools, makeWrapper,
+  boost, qtwebkit, qtx11extras, shared_mime_info,
+  breeze-icons, kactivities, karchive, kcodecs, kcompletion, kconfig, kconfigwidgets,
+  kcoreaddons, kdbusaddons, kdiagram, kguiaddons, khtml, ki18n,
+  kiconthemes, kitemviews, kjobwidgets, kcmutils, kdelibs4support, kio, kross,
+  knotifications, knotifyconfig, kparts, ktextwidgets, kwallet, kwidgetsaddons,
+  kwindowsystem, kxmlgui, sonnet, threadweaver,
+  kcontacts, akonadi, akonadi-calendar, akonadi-contacts,
+  eigen, git, gsl, ilmbase, kproperty, kreport, lcms2, marble, libgit2, libodfgen,
+  librevenge, libvisio, libwpd, libwpg, libwps, okular, openexr, openjpeg, phonon,
+  poppler, pstoedit, qca-qt5, vc
+# TODO: package Spnav, m2mml LibEtonyek, Libqgit2
 }:
 
-stdenv.mkDerivation rec {
-  name = "calligra-2.9.11";
+mkDerivation rec {
+  pname = "calligra";
+  version = "3.0.1";
+  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://kde/stable/${name}/${name}.tar.xz";
-    sha256 = "02gaahp7a7m53n0hvrp3868s8w37b457isxir0z7b4mwhw7jv3di";
+    url = "mirror://kde/stable/${pname}/${version}/${name}.tar.xz";
+    sha256 = "1cjdd7sx1zhas6lhw0dzhrnki790jkf93f88wn6z9yrww32dsas5";
   };
 
-  nativeBuildInputs = [ automoc4 cmake perl pkgconfig makeWrapper ];
+  nativeBuildInputs = [ extra-cmake-modules kdoctools makeWrapper ];
 
   buildInputs = [
-    kdelibs4 lcms2 libpng eigen
-    exiv2 boost sqlite icu vc shared_mime_info librevenge libodfgen libwpg
-    libwpd poppler_qt4 ilmbase gsl qca2 marble libvisio libmysql postgresql
-    freetds fftw glew libkdcraw opencolorio kdepimlibs
-    kactivities okular git
+    boost qtwebkit qtx11extras shared_mime_info
+    kactivities karchive kcodecs kcompletion kconfig kconfigwidgets kcoreaddons
+    kdbusaddons kdiagram kguiaddons khtml ki18n kiconthemes kitemviews
+    kjobwidgets kcmutils kdelibs4support kio kross knotifications knotifyconfig kparts
+    ktextwidgets kwallet kwidgetsaddons kwindowsystem kxmlgui sonnet threadweaver
+    kcontacts akonadi akonadi-calendar akonadi-contacts
+    eigen git gsl ilmbase kproperty kreport lcms2 marble libgit2 libodfgen librevenge
+    libvisio libwpd libwpg libwps okular openexr openjpeg phonon poppler qca-qt5 vc
   ];
 
-  enableParallelBuilding = true;
+  propagatedUserEnvPkgs = [ kproperty ];
+
+  NIX_CFLAGS_COMPILE = "-I${ilmbase.dev}/include/OpenEXR";
 
   postInstall = ''
     for i in $out/bin/*; do
       wrapProgram $i \
         --prefix PATH ':' "${pstoedit.out}/bin" \
-        --prefix XDG_DATA_DIRS ':' "${oxygen-icons5}/share"
+        --prefix XDG_DATA_DIRS ':' "${breeze-icons}/share"
     done
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A suite of productivity applications";
     longDescription = ''
       Calligra Suite is a set of applications written to help
       you to accomplish your work. Calligra includes efficient
       and capable office components: Words for text processing,
-      Sheets for computations, Stage for presentations, Plan for
-      planning, Flow for flowcharts, Kexi for database creation,
-      Krita for painting and raster drawing, and Karbon for
+      Sheets for computations, Plan for planning, and Karbon for
       vector graphics.
     '';
-    homepage = http://calligra.org;
-    maintainers = with maintainers; [ phreedom ebzzry ];
-    inherit (kdelibs4.meta) platforms;
-    license = licenses.gpl2;
+    homepage = https://www.calligra.org/;
+    maintainers = with maintainers; [ phreedom ebzzry zraexy ];
+    platforms = platforms.linux;
+    license = with licenses; [ gpl2 lgpl2 ];
   };
 }

--- a/pkgs/applications/office/kexi/default.nix
+++ b/pkgs/applications/office/kexi/default.nix
@@ -1,0 +1,47 @@
+{
+  mkDerivation, lib, fetchurl, extra-cmake-modules, kdoctools,
+  boost, qttools, qtwebkit,
+  breeze-icons, karchive, kcodecs, kcompletion, kconfig, kconfigwidgets, kcoreaddons,
+  kcrash, kguiaddons, ki18n, kiconthemes, kitemviews, kio, ktexteditor, ktextwidgets,
+  kwidgetsaddons, kxmlgui,
+  kdb, kproperty, kreport, lcms2, libmysql, marble, postgresql
+}:
+
+mkDerivation rec {
+  pname = "kexi";
+  version = "3.0.2";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/${pname}/src/${name}.tar.xz";
+    sha256 = "1fjvjifi5ygx5gs2lzfg22j0x3r7kl4wk5jll09r8gc3dfxaiblf";
+  };
+
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+
+  buildInputs = [
+    boost qttools qtwebkit
+    breeze-icons karchive kcodecs kcompletion kconfig kconfigwidgets kcoreaddons
+    kcrash kguiaddons ki18n kiconthemes kitemviews kio ktexteditor ktextwidgets
+    kwidgetsaddons kxmlgui
+    kdb kproperty kreport lcms2 libmysql marble postgresql
+  ];
+
+  propagatedUserEnvPkgs = [ kproperty ];
+
+  meta = with lib; {
+    description = "A open source visual database applications creator, a long-awaited competitor for programs like MS Access or Filemaker";
+    longDescription = ''
+      Kexi is a visual database applications creator.
+      It can be used for creating database schemas,
+      inserting data, performing queries, and processing data.
+      Forms can be created to provide a custom interface to your data.
+      All database objects - tables, queries and forms - are stored in the database,
+      making it easy to share data and design.
+    '';
+    homepage = http://kexi-project.org/;
+    maintainers = with maintainers; [ zraexy ];
+    platforms = platforms.linux;
+    license = with licenses; [ gpl2 lgpl2 ];
+  };
+}

--- a/pkgs/development/libraries/kdb/default.nix
+++ b/pkgs/development/libraries/kdb/default.nix
@@ -1,0 +1,29 @@
+{
+  mkDerivation, lib, fetchurl,
+  extra-cmake-modules,
+  qtbase, qttranslations, kcoreaddons, python2, sqlite, postgresql, libmysql
+}:
+
+mkDerivation rec {
+  pname = "kdb";
+  version = "3.0.2";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/${pname}/src/${name}.tar.xz";
+    sha256 = "1n11xhqk3sf4a5nzvnrnj7bj21yqqqkm2d1xzfx3q82fkyah8s49";
+  };
+
+  nativeBuildInputs = [ extra-cmake-modules ];
+
+  buildInputs = [ qttranslations kcoreaddons python2 sqlite postgresql libmysql ];
+
+  propagatedBuildInputs = [ qtbase ];
+
+  meta = with lib; {
+    description = "A database connectivity and creation framework for various database vendors";
+    license = licenses.lgpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ zraexy ];
+  };
+}

--- a/pkgs/development/libraries/kproperty/default.nix
+++ b/pkgs/development/libraries/kproperty/default.nix
@@ -1,0 +1,29 @@
+{
+  mkDerivation, lib, fetchurl,
+  extra-cmake-modules,
+  qtbase, kconfig, kcoreaddons, kwidgetsaddons, kguiaddons
+}:
+
+mkDerivation rec {
+  pname = "kproperty";
+  version = "3.0.2";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/${pname}/src/${name}.tar.xz";
+    sha256 = "1hzkvdap7dzpnxlp4rfg5f24fhqjpqm2hlvv88gj4c0scbp73ynm";
+  };
+
+  nativeBuildInputs = [ extra-cmake-modules ];
+
+  buildInputs = [ kconfig kcoreaddons kwidgetsaddons kguiaddons ];
+
+  propagatedBuildInputs = [ qtbase ];
+
+  meta = with lib; {
+    description = "A property editing framework with editor widget similar to what is known from Qt Designer";
+    license = licenses.lgpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ zraexy ];
+  };
+}

--- a/pkgs/development/libraries/kreport/default.nix
+++ b/pkgs/development/libraries/kreport/default.nix
@@ -1,0 +1,27 @@
+{
+  mkDerivation, lib, fetchurl,
+  extra-cmake-modules,
+  qtbase, qtdeclarative, qtwebkit, kconfig, kcoreaddons, kwidgetsaddons, kguiaddons, kproperty, marble, python2
+}:
+
+mkDerivation rec {
+  pname = "kreport";
+  version = "3.0.2";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/${pname}/src/${name}.tar.xz";
+    sha256 = "1zd3vhf26cyp8xrq11awm9pmhnk88ppyc0riyr0gxj8y703ahkp0";
+  };
+
+  nativeBuildInputs = [ extra-cmake-modules ];
+
+  buildInputs = [ qtdeclarative qtwebkit kconfig kcoreaddons kwidgetsaddons kguiaddons kproperty marble python2 ];
+
+  meta = with lib; {
+    description = "A framework for creation and generation of reports in multiple formats";
+    license = licenses.lgpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ zraexy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13674,8 +13674,13 @@ with pkgs;
 
   calibre = libsForQt5.callPackage ../applications/misc/calibre { };
 
-  calligra = kde4.callPackage ../applications/office/calligra {
+  calligra2 = kde4.callPackage ../applications/office/calligra/2.nix {
     vc = vc_0_7;
+  };
+
+  calligra = libsForQt5.callPackage ../applications/office/calligra {
+    inherit (kdeApplications) akonadi-calendar akonadi-contacts;
+    openjpeg = openjpeg_1;
   };
 
   camlistore = callPackage ../applications/misc/camlistore { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15019,6 +15019,8 @@ with pkgs;
 
   kermit = callPackage ../tools/misc/kermit { };
 
+  kexi = libsForQt5.callPackage ../applications/office/kexi { };
+
   keyfinder = libsForQt5.callPackage ../applications/audio/keyfinder { };
 
   keyfinder-cli = libsForQt5.callPackage ../applications/audio/keyfinder-cli { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10125,6 +10125,8 @@ with pkgs;
 
     kdiagram = callPackage ../development/libraries/kdiagram { };
 
+    kproperty = callPackage ../development/libraries/kproperty { };
+
     kirigami = kirigami_1;
 
     libcommuni = callPackage ../development/libraries/libcommuni { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10123,6 +10123,8 @@ with pkgs;
       kirigami_1
       kirigami_2;
 
+    kdb = callPackage ../development/libraries/kdb { };
+
     kdiagram = callPackage ../development/libraries/kdiagram { };
 
     kproperty = callPackage ../development/libraries/kproperty { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10127,6 +10127,8 @@ with pkgs;
 
     kproperty = callPackage ../development/libraries/kproperty { };
 
+    kreport = callPackage ../development/libraries/kreport { };
+
     kirigami = kirigami_1;
 
     libcommuni = callPackage ../development/libraries/libcommuni { };


### PR DESCRIPTION
###### Motivation for this change

Update Calligra to 3.0.1 which uses KF5

Kexi has been split off and is now its own package.

Due to the fact that Author, Braindump, Flow, and Stage were removed (Flow and Stage are planned to be added back in) I have kept 2.9.11 under the `calligra2` attribute. It can be removed when `kde4` is.

I have not used Calligra much so it would be good to have someone who uses it regularly give this a try before merging.

Resolves #22966

cc @Phreedom @ebzzry 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

