### PR TITLE
keyring: 8.4.1 -> 10.4.0

### DIFF
--- a/pkgs/development/python-modules/keyring/default.nix
+++ b/pkgs/development/python-modules/keyring/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, secretstorage
+, fs, gdata, python_keyczar, pyasn1, pycrypto, six, setuptools_scm
+, mock, pytest_28, pytestrunner }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "keyring";
+  version = "10.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "09iv50c14mdmdk7sjd6bb47yg7347gymh6r8c0q4gfnzs173y6lh";
+  };
+
+  buildInputs = [
+    fs gdata python_keyczar pyasn1 pycrypto six setuptools_scm
+  ];
+
+  checkInputs = [ mock pytest_28 pytestrunner ];
+
+  propagatedBuildInputs = [ secretstorage ];
+
+  checkPhase = ''
+    py.test $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Store and access your passwords safely";
+    homepage    = "https://pypi.python.org/pypi/keyring";
+    license     = licenses.psfl;
+    maintainers = with maintainers; [ lovek323 ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11191,15 +11191,18 @@ in {
   };
 
   keyring = buildPythonPackage rec {
-    name = "keyring-8.4.1";
+    name = "keyring-${version}";
+    version = "10.4.0";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/k/keyring/${name}.tar.gz";
-      sha256 = "1286sh5g53168qxbl4g5bmns9ci0ld0jl3h44b7h8is5nw1421ar";
+      sha256 = "09iv50c14mdmdk7sjd6bb47yg7347gymh6r8c0q4gfnzs173y6lh";
     };
 
     buildInputs = with self;
       [ fs gdata python_keyczar mock pyasn1 pycrypto pytest_28 six setuptools_scm pytestrunner ];
+
+    propagatedBuildInputs = [ self.secretstorage ];
 
     checkPhase = ''
       py.test $out

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11190,32 +11190,7 @@ in {
     };
   };
 
-  keyring = buildPythonPackage rec {
-    name = "keyring-${version}";
-    version = "10.4.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/k/keyring/${name}.tar.gz";
-      sha256 = "09iv50c14mdmdk7sjd6bb47yg7347gymh6r8c0q4gfnzs173y6lh";
-    };
-
-    buildInputs = with self;
-      [ fs gdata python_keyczar mock pyasn1 pycrypto pytest_28 six setuptools_scm pytestrunner ];
-
-    propagatedBuildInputs = [ self.secretstorage ];
-
-    checkPhase = ''
-      py.test $out
-    '';
-
-    meta = {
-      description = "Store and access your passwords safely";
-      homepage    = "https://pypi.python.org/pypi/keyring";
-      license     = licenses.psfl;
-      maintainers = with maintainers; [ lovek323 ];
-      platforms   = platforms.unix;
-    };
-  };
+  keyring = callPackage ../development/python-modules/keyring { };
 
   klaus = buildPythonPackage rec {
     version = "0.9.1";
@@ -27487,7 +27462,7 @@ EOF
 
   preshed = callPackage ../development/python-modules/preshed { };
 
-  backports_weakref = callPackage ../development/python-modules/backports_weakref { }; 
+  backports_weakref = callPackage ../development/python-modules/backports_weakref { };
 
   thinc = callPackage ../development/python-modules/thinc { };
 
@@ -27496,7 +27471,7 @@ EOF
   behave = callPackage ../development/python-modules/behave { };
 
   pyhamcrest = callPackage ../development/python-modules/pyhamcrest { };
- 
+
   parse = callPackage ../development/python-modules/parse { };
 
   parse-type = callPackage ../development/python-modules/parse-type { };


### PR DESCRIPTION
###### Motivation for this change
Bumped the library thinking it would fix an offlineimap bug but it didn't. Rather than losing the bump I send it here.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

