### PR TITLE
glusterfs service: Ensure dirs needed by `glusterfind` exist

### DIFF
--- a/nixos/modules/services/network-filesystems/glusterfs.nix
+++ b/nixos/modules/services/network-filesystems/glusterfs.nix
@@ -50,11 +50,19 @@ in
       after = [ "rpcbind.service" "network.target" "local-fs.target" ];
       before = [ "network-online.target" ];
 
-      # The copying of hooks is due to upstream bug https://bugzilla.redhat.com/show_bug.cgi?id=1452761
       preStart = ''
         install -m 0755 -d /var/log/glusterfs
+      ''
+      # The copying of hooks is due to upstream bug https://bugzilla.redhat.com/show_bug.cgi?id=1452761
+      + ''
         mkdir -p /var/lib/glusterd/hooks/
         ${rsync}/bin/rsync -a ${glusterfs}/var/lib/glusterd/hooks/ /var/lib/glusterd/hooks/
+      ''
+      # `glusterfind` needs dirs that upstream installs at `make install` phase
+      # https://github.com/gluster/glusterfs/blob/v3.10.2/tools/glusterfind/Makefile.am#L16-L17
+      + ''
+        mkdir -p /var/lib/glusterd/glusterfind/.keys
+        mkdir -p /var/lib/glusterd/hooks/1/delete/post/
       '';
 
       serviceConfig = {

--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -28,7 +28,7 @@ let
       pkgs.flask
       pkgs.prettytable
       pkgs.requests
-      pkgs.xattr
+      pkgs.pyxattr
     ]))
     # NOTE: `python2` has to be *AFTER* the above `python2.withPackages`,
     #       to ensure that the packages are available but the `toPythonPath`

--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -73,6 +73,9 @@ rec {
     ./glusterfs-use-PATH-instead-of-hardcodes.patch
     ./glusterfs-fix-unsubstituted-autoconf-macros.patch
     ./glusterfs-python-remove-find_library.patch
+    # Remove when https://bugzilla.redhat.com/show_bug.cgi?id=1489610 is fixed
+    ./glusterfs-fix-bug-1489610-glusterfind-var-data-under-prefix.patch
+    ./glusterfs-glusterfind-log-remote-node_cmd-error.patch
   ];
 
    # Note that the VERSION file is something that is present in release tarballs

--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -139,8 +139,14 @@ rec {
     # Luckily, `libexec` scripts are never supposed to be invoked straight from PATH,
     # instead they are invoked directly from `gluster` or `glusterd`, which is why it is
     # sufficient to set PYTHONPATH for those executables.
+    #
+    # Exceptions to these rules are the `glusterfind` `brickfind.py` and `changelog.py`
+    # crawlers, which are directly invoked on other gluster nodes using a remote SSH command
+    # issues by `glusterfind`.
 
     wrapProgram $out/share/glusterfs/scripts/eventsdash.py --set PATH "$GLUSTER_PATH" --set PYTHONPATH "$GLUSTER_PYTHONPATH" --set LD_LIBRARY_PATH "$GLUSTER_LD_LIBRARY_PATH"
+    wrapProgram $out/libexec/glusterfs/glusterfind/brickfind.py --set PATH "$GLUSTER_PATH" --set PYTHONPATH "$GLUSTER_PYTHONPATH" --set LD_LIBRARY_PATH "$GLUSTER_LD_LIBRARY_PATH"
+    wrapProgram $out/libexec/glusterfs/glusterfind/changelog.py --set PATH "$GLUSTER_PATH" --set PYTHONPATH "$GLUSTER_PYTHONPATH" --set LD_LIBRARY_PATH "$GLUSTER_LD_LIBRARY_PATH"
     '';
 
   doInstallCheck = true;

--- a/pkgs/tools/filesystems/glusterfs/glusterfs-fix-bug-1489610-glusterfind-var-data-under-prefix.patch
+++ b/pkgs/tools/filesystems/glusterfs/glusterfs-fix-bug-1489610-glusterfind-var-data-under-prefix.patch
@@ -1,0 +1,27 @@
+From 965eb1e08e10ff82bb91d485dc24672acc7c72cf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Niklas=20Hamb=C3=BCchen?= <mail@nh2.me>
+Date: Fri, 8 Sep 2017 00:51:53 +0200
+Subject: [PATCH] Fix "glusterfind saves var data under $prefix instead of
+ localstatedir". Fixes #1489610
+
+Change-Id: I6d71297fb7a5a9d12cc3726b4a4ad94efcd644f9
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 0c3a38689..d508fda71 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1057,7 +1057,7 @@ if test "x$prefix" = xNONE; then
+ 	prefix=$ac_default_prefix
+ fi
+ GLUSTERFS_LIBEXECDIR="$(eval echo $prefix)/libexec/glusterfs"
+-GLUSTERFSD_MISCDIR="$(eval echo $prefix)/var/lib/misc/glusterfsd"
++GLUSTERFSD_MISCDIR="$(eval echo $localstatedir)/var/lib/misc/glusterfsd"
+ prefix=$old_prefix
+ 
+ ### Dirty hacky stuff to make LOCALSTATEDIR work
+-- 
+2.12.0
+

--- a/pkgs/tools/filesystems/glusterfs/glusterfs-glusterfind-log-remote-node_cmd-error.patch
+++ b/pkgs/tools/filesystems/glusterfs/glusterfs-glusterfind-log-remote-node_cmd-error.patch
@@ -1,0 +1,49 @@
+From 92a6b84a37e7e2e0ec0655ca45cedb64ab72080e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Niklas=20Hamb=C3=BCchen?= <mail@nh2.me>
+Date: Fri, 8 Sep 2017 02:40:01 +0200
+Subject: [PATCH] glusterfind: Log remote stderr on `node_cmd` error.
+
+The problem of lost stderr was introduced in
+commit feea851fad4f89b48bfe89fe3b75250cc7bd6501.
+
+Change-Id: Ic98f9bc9682ae3bd9c3ebea3855667fc8ba2843d
+---
+ tools/glusterfind/src/main.py | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/tools/glusterfind/src/main.py b/tools/glusterfind/src/main.py
+index c125f970a..6fffce4b3 100644
+--- a/tools/glusterfind/src/main.py
++++ b/tools/glusterfind/src/main.py
+@@ -75,12 +75,27 @@ def node_cmd(host, host_uuid, task, cmd, args, opts):
+             cmd = ["ssh",
+                    "-oNumberOfPasswordPrompts=0",
+                    "-oStrictHostKeyChecking=no",
++                   # We force TTY allocation (-t -t) so that Ctrl+C is handed
++                   # through; see:
++                   #   https://bugzilla.redhat.com/show_bug.cgi?id=1382236
++                   # Note that this turns stderr of the remote `cmd`
++                   # into stdout locally.
+                    "-t",
+                    "-t",
+                    "-i", pem_key_path,
+                    "root@%s" % host] + cmd
+ 
+-        execute(cmd, exit_msg="%s - %s failed" % (host, task), logger=logger)
++        (returncode, err, out) = execute(cmd, logger=logger)
++        if returncode != 0:
++            # Because the `-t -t` above turns the remote stderr into
++            # local stdout, we need to log both stderr and stdout
++            # here to print all error messages.
++            fail("%s - %s failed; stdout (including remote stderr):\n"
++                 "%s\n"
++                 "stderr:\n"
++                 "%s" % (host, task, out, err),
++                 returncode,
++                 logger=logger)
+ 
+         if opts.get("copy_outfile", False) and not localdir:
+             cmd_copy = ["scp",
+-- 
+2.12.0
+


### PR DESCRIPTION
###### Motivation for this change

Without these dirs, `glusterfind` errors like this:

```
# glusterfind create test1 myvol
Failed to copy public key to /var/lib/glusterd/glusterfind/.keys: [Errno 2] No such file or directory: '/var/lib/glusterd/glusterfind/.keys/test1_myvol_secret.pem.pub'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

FYI @bachp who's another user of this service.

---

I would also like to have this change in 17.09, please let me know if I need to open a separate PR for that.