### PR TITLE
terminology: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/desktops/enlightenment/terminology.nix
+++ b/pkgs/desktops/enlightenment/terminology.nix
@@ -2,16 +2,23 @@
 
 stdenv.mkDerivation rec {
   name = "terminology-${version}";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/apps/terminology/${name}.tar.xz";
-    sha256 = "13rl1k22yf8qrpzdm5nh6ij641fibadr2ww1r7rnz7mbhzj3d4gb";
+    sha256 = "05ncxvzb9rzkyjvd95hzn8lswqdwr8cix6rd54nqn9559jibh4ns";
   };
 
-  nativeBuildInputs = [ (pkgconfig.override { vanilla = true; }) makeWrapper ];
+  nativeBuildInputs = [
+    (pkgconfig.override { vanilla = true; })
+    makeWrapper
+  ];
 
-  buildInputs = [ efl pcre curl ];
+  buildInputs = [
+    efl
+    pcre
+    curl
+  ];
 
   postInstall = ''
     for f in $out/bin/*; do


### PR DESCRIPTION
###### Motivation for this change

Update to version 1.1.1.

[News](https://www.enlightenment.org/news/terminology_1_1_1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).