### PR TITLE
grass: compiles with libLAS

### DIFF
--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, flex, bison, pkgconfig, zlib, libtiff, libpng, fftw
 , cairo, readline, ffmpeg, makeWrapper, wxGTK30, netcdf, blas
-, proj, gdal, geos, sqlite, postgresql, mysql, python2Packages
+, proj, gdal, geos, sqlite, postgresql, mysql, python2Packages, libLAS
 }:
 
 stdenv.mkDerivation {
@@ -11,10 +11,11 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ flex bison zlib proj gdal libtiff libpng fftw sqlite pkgconfig cairo
-  readline ffmpeg makeWrapper wxGTK30 netcdf geos postgresql mysql.client blas ]
+  readline ffmpeg makeWrapper wxGTK30 netcdf geos postgresql mysql.client blas libLAS ]
     ++ (with python2Packages; [ python dateutil wxPython30 numpy ]);
 
   configureFlags = [
+    "--with-liblas=${libLAS}/bin/liblas-config"
     "--with-proj-share=${proj}/share/proj"
     "--without-opengl"
     "--with-readline"


### PR DESCRIPTION
###### Motivation for this change
this option lets grass work with lidar data. See issue #29081

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

