### PR TITLE
physlock: 0.5 -> 11-dev

### DIFF
--- a/nixos/modules/services/security/physlock.nix
+++ b/nixos/modules/services/security/physlock.nix
@@ -99,6 +99,8 @@ in
       '';
     };
 
+    security.pam.services.physlock = {};
+
   };
 
 }

--- a/pkgs/misc/screensavers/physlock/default.nix
+++ b/pkgs/misc/screensavers/physlock/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, pam, systemd }:
 
 stdenv.mkDerivation rec {
-  version = "0.5";
+  version = "11-dev";
   name = "physlock-v${version}";
   src = fetchFromGitHub {
     owner = "muennich";
     repo = "physlock";
-    rev = "v${version}";
-    sha256 = "102kdixrf7xxsxr69lbz73i1ss7959716cmdf8d5kbnhmk6argv7";
+    rev = "31cc383afc661d44b6adb13a7a5470169753608f";
+    sha256 = "0j6v8li3vw9y7vwh9q9mk1n1cnwlcy3bgr1jgw5gcv2am2yi4vx3";
   };
+
+  buildInputs = [ pam systemd ];
 
   preConfigure = ''
     substituteInPlace Makefile \
@@ -16,8 +18,10 @@ stdenv.mkDerivation rec {
       --replace "-m 4755 -o root -g root" ""
   '';
 
+  makeFlags = "SESSION=systemd";
+
   meta = with stdenv.lib; {
-    description = "A secure suspend/hibernate-friendly alternative to `vlock -an` without PAM support";
+    description = "A secure suspend/hibernate-friendly alternative to `vlock -an`";
     license = licenses.gpl2;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
Update physlock to a more current version which supports PAM and
systemd-logind.  Amongst others, this should work now with the slim
login manager without any additional configuration, because it does
not rely on the utmp mechanism anymore.

###### Motivation for this change
The old physlock version did not support PAM, and relied on the session manager
creating utmp entries.  This version supports getting the necessary information via
systemd-logind, so that it works from X as well as the terminals out of the box.

###### Things done

Updated Package source to new version.
Changed service file to add the corresponding PAM service

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

