### PR TITLE
tigervnc: correct default ssh client path

### DIFF
--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -5,7 +5,7 @@
 , cmake, gettext, libtool
 , glproto, mesa_glu
 , gnutls, pam, nettle
-, xterm }:
+, xterm, openssh }:
 
 with stdenv.lib;
 
@@ -90,6 +90,11 @@ stdenv.mkDerivation rec {
   propagatedNativeBuildInputs = xorg.xorgserver.propagatedNativeBuildInputs;
 
   enableParallelBuilding = true;
+
+  postPatch = ''
+    substituteInPlace vncviewer/vncviewer.cxx \
+     --replace '"/usr/bin/ssh' '"${openssh}/bin/ssh'
+     '';
 
   meta = {
     homepage = http://www.tigervnc.org/;

--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   inherit fontDirectories;
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e '/^\$cmd \.= " -pn";/a$cmd .= " -xkbdir ${xkeyboard_config}/etc/X11/xkb";' unix/vncserver
     fontPath=
     for i in $fontDirectories; do
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
       done
     done
     sed -i -e '/^\$cmd \.= " -pn";/a$cmd .= " -fp '"$fontPath"'";' unix/vncserver
+    substituteInPlace vncviewer/vncviewer.cxx \
+       --replace '"/usr/bin/ssh' '"${openssh}/bin/ssh'
   '';
 
   dontUseCmakeBuildDir = true;
@@ -90,11 +92,6 @@ stdenv.mkDerivation rec {
   propagatedNativeBuildInputs = xorg.xorgserver.propagatedNativeBuildInputs;
 
   enableParallelBuilding = true;
-
-  postPatch = ''
-    substituteInPlace vncviewer/vncviewer.cxx \
-     --replace '"/usr/bin/ssh' '"${openssh}/bin/ssh'
-     '';
 
   meta = {
     homepage = http://www.tigervnc.org/;


### PR DESCRIPTION
The -via command sets up an ssh tunnel, but is hardcoded to /usr/bin/ssh
upstream.  This patches it to use the nixpkgs openssh client.

###### Motivation for this change

Currently the -via command does not work without manually setting the VNC_VIA_CMD environment variable

Fixes #29003 

CC @viric 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

