### PR TITLE
rr: 4.5.0 -> 5.0.0

### DIFF
--- a/pkgs/development/tools/analysis/rr/default.nix
+++ b/pkgs/development/tools/analysis/rr/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchFromGitHub, cmake, libpfm, zlib, pkgconfig, python2Packages, which, procps, gdb }:
+{ stdenv, fetchFromGitHub, cmake, libpfm, zlib, pkgconfig, python2Packages, which, procps, gdb, capnproto }:
 
 stdenv.mkDerivation rec {
-  version = "4.5.0";
+  version = "5.0.0";
   name = "rr-${version}";
 
   src = fetchFromGitHub {
     owner = "mozilla";
     repo = "rr";
     rev = version;
-    sha256 = "114g1yhpjfyxcn0fkvnfi03lhrs11pj0a1945j2j8z90hx4dwba8";
+    sha256 = "1cc1dbq129qlmrysk7cmaihcd9c93csi79dv3kqsnnprbz480z9i";
   };
 
   postPatch = ''
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    cmake libpfm zlib python2Packages.python pkgconfig python2Packages.pexpect which procps gdb
+    cmake libpfm zlib python2Packages.python pkgconfig python2Packages.pexpect which procps gdb capnproto
   ];
   cmakeFlags = [
     "-DCMAKE_C_FLAGS_RELEASE:STRING="


### PR DESCRIPTION
###### Motivation for this change

http://robert.ocallahan.org/2017/09/rr-50-released.html

Not mentioned there, and important to me and at least a few other NixOS users I know,
is that this adds support for Kaby Lake processors:

http://robert.ocallahan.org/2017/09/rr-50-released.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

