### PR TITLE
vaultenv: init at 0.5.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -686,6 +686,9 @@ self: super: {
   # It makes no sense to have intero-nix-shim in Hackage, so we publish it here only.
   intero-nix-shim = self.callPackage ../tools/haskell/intero-nix-shim {};
 
+  # vaultenv is not available from Hackage.
+  vaultenv = self.callPackage ../tools/haskell/vaultenv { };
+
   # https://github.com/Philonous/hs-stun/pull/1
   # Remove if a version > 0.1.0.1 ever gets released.
   stunclient = overrideCabal super.stunclient (drv: {

--- a/pkgs/development/tools/haskell/vaultenv/default.nix
+++ b/pkgs/development/tools/haskell/vaultenv/default.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, fetchurl, async, base, bytestring, http-conduit, lens
+, lens-aeson, optparse-applicative, retry, stdenv, text, unix
+, unordered-containers, utf8-string
+}:
+
+mkDerivation rec {
+  pname = "vaultenv";
+  version = "0.5.0";
+
+  src = fetchurl {
+    url = "https://github.com/channable/vaultenv/archive/v${version}.tar.gz";
+    sha256 = "0hdcxq88cf3ygnikkppyg3fcf7xmwm9zif7274j3n34p9vd8xci3";
+  };
+
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    async base bytestring http-conduit lens lens-aeson
+    optparse-applicative retry text unix unordered-containers
+    utf8-string
+  ];
+  homepage = "https://github.com/channable/vaultenv";
+  description = "Runs processes with secrets from HashiCorp Vault";
+  license = stdenv.lib.licenses.bsd3;
+  maintainers = with stdenv.lib.maintainers; [ lnl7 ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19114,6 +19114,8 @@ with pkgs;
 
   vault = callPackage ../tools/security/vault { };
 
+  vaultenv = haskellPackages.vaultenv;
+
   vbam = callPackage ../misc/emulators/vbam {
     ffmpeg = ffmpeg_2;
   };


### PR DESCRIPTION
###### Motivation for this change

Not sure what the preferred way is to add haskell packages like this that are not on hackage.
/cc @peti 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
