### PR TITLE
pythonPackages.linuxfd: init at 1.4.4

### DIFF
--- a/pkgs/development/python-modules/linuxfd/default.nix
+++ b/pkgs/development/python-modules/linuxfd/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "linuxfd";
+  version = "1.4.4";
+
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b8bf6847b5c8e50e0842024d2911bfc1048db9abf37582a310cd57070971d692";
+  };
+
+  # no tests
+  doCheck = false;
+
+  meta = {
+    description = "Python bindings for the Linux eventfd/signalfd/timerfd/inotify syscalls";
+    homepage = https://github.com/FrankAbelbeck/linuxfd;
+    license = with lib.licenses; [ lgpl3 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4529,6 +4529,8 @@ in {
 
   libtmux = callPackage ../development/python-modules/libtmux { };
 
+  linuxfd = callPackage ../development/python-modules/linuxfd { };
+
   locket = buildPythonPackage rec {
     name = "locket-${version}";
     version = "0.2.0";


### PR DESCRIPTION
###### Motivation for this change

Add linuxfd package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

