### PR TITLE
tools/system/supervise: init at 1.0.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -98,6 +98,7 @@
   canndrew = "Andrew Cann <shum@canndrew.org>";
   carlsverre = "Carl Sverre <accounts@carlsverre.com>";
   casey = "Casey Rodarmor <casey@rodarmor.net>";
+  catern = "Spencer Baugh <sbaugh@catern.com>";
   caugner = "Claas Augner <nixos@caugner.de>";
   cdepillabout = "Dennis Gosnell <cdep.illabout@gmail.com>";
   cfouche = "Chaddaï Fouché <chaddai.fouche@gmail.com>";

--- a/pkgs/development/python-modules/supervise_api/default.nix
+++ b/pkgs/development/python-modules/supervise_api/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, supervise
+}:
+
+buildPythonPackage rec {
+  pname = "supervise_api";
+  version = "0.1.5";
+
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1pqqlw80cjdgrlpvdmydkyhsrr4s531mn6bfkshm68j9gk4kq6px";
+  };
+
+  propagatedBuildInputs = [ supervise ];
+
+  # no tests
+  doCheck = false;
+
+  meta = {
+    description = "An API for running processes safely and securely";
+    homepage = https://github.com/catern/supervise;
+    license = lib.licenses.lgpl3;
+    maintainers = with stdenv.lib.maintainers; [ catern ];
+  };
+}

--- a/pkgs/tools/system/supervise/default.nix
+++ b/pkgs/tools/system/supervise/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+
+  name = "supervise-${version}";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "catern";
+    repo = "supervise";
+    rev = "v${version}";
+    sha256 = "1cjdxgns3gh2ir4kcmjdmc480w8sm49inws0ihhjmnisjy4100lg";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp supervise unlinkwait -t $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/catern/supervise;
+    description = "A minimal unprivileged process supervisor making use of modern Linux features";
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ catern ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11736,6 +11736,8 @@ with pkgs;
 
   s6-rc = callPackage ../tools/system/s6-rc { };
 
+  supervise = callPackage ../tools/system/supervise { };
+
   spamassassin = callPackage ../servers/mail/spamassassin {
     inherit (perlPackages) HTMLParser NetDNS NetAddrIP DBFile
       HTTPDate MailDKIM LWP IOSocketSSL;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -291,6 +291,8 @@ in {
 
   sip = callPackage ../development/python-modules/sip { };
 
+  supervise_api = callPackage ../development/python-modules/supervise_api { };
+
   tables = callPackage ../development/python-modules/tables {
     hdf5 = pkgs.hdf5.override { zlib = pkgs.zlib; };
   };


### PR DESCRIPTION
###### Motivation for this change

Add supervise utility https://github.com/catern/supervise

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

