### PR TITLE
gosu: init at 2.0.1

### DIFF
--- a/pkgs/tools/misc/gosu/default.nix
+++ b/pkgs/tools/misc/gosu/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchgit, fetchhg, fetchbzr, fetchsvn }:
+
+buildGoPackage rec {
+  name = "gosu-${version}";
+  version = "2017-05-09";
+  rev = "e87cf95808a7b16208515c49012aa3410bc5bba8";
+
+  goPackagePath = "github.com/tianon/gosu";
+
+  src = fetchgit {
+    inherit rev;
+    url = "https://github.com/tianon/gosu";
+    sha256 = "1qp1cfx0hrr4qlnh7rhjb4xlxv9697flmgzzl6jcdkrpk1f0bz8m";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = {
+    description= "Tool that avoids TTY and signal-forwarding behavior of sudo and su";
+    homepage = "https://github.com/tianon/gosu";
+    licence = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/misc/gosu/deps.nix
+++ b/pkgs/tools/misc/gosu/deps.nix
@@ -1,0 +1,11 @@
+[
+  {
+    goPackagePath = "github.com/opencontainers/runc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/opencontainers/runc";
+      rev = "5274430fee9bc930598cfd9c9dbd33213f79f96e";
+      sha256 = "149057gm2y1mc45s7bh43c1ngjg1m54jkpaxw534ir9v5mb1zsxx";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1081,6 +1081,8 @@ with pkgs;
 
   gorilla-bin = callPackage ../tools/security/gorilla-bin { };
 
+  gosu = callPackage ../tools/misc/gosu { };
+
   gringo = callPackage ../tools/misc/gringo { };
 
   gti = callPackage ../tools/misc/gti { };


### PR DESCRIPTION
###### Motivation for this change

Gosu tool was removed with the go package rewrite. The package is mainly used in Docker images, but not limited to it.

It's used in a popular series of blog post by Luca Bruno aka @lethalman .
http://lethalman.blogspot.si/2016/04/cheap-docker-images-with-nix_15.html

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

