### PR TITLE
cc-wrapper: More intelligent sierra hack

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -183,7 +183,9 @@ stdenv.mkDerivation {
     '' else ''
       ldInner="ld-reexport-delegate"
       wrap "$ldInner" ${./macos-sierra-reexport-hack.bash} ''${ld:-$ldPath/ld}
-      wrap ld ${./ld-wrapper.sh} "$out/bin/$ldInner"
+      cp ${./ld-wrapper.sh} ./ld-wrapper.sh
+      patch < ${./direct-dylib.patch}
+      wrap ld ./ld-wrapper.sh "$out/bin/$ldInner"
       unset ldInner
     '') + ''
 

--- a/pkgs/build-support/cc-wrapper/direct-dylib.patch
+++ b/pkgs/build-support/cc-wrapper/direct-dylib.patch
@@ -1,0 +1,22 @@
+diff --git a/pkgs/build-support/cc-wrapper/ld-wrapper.sh b/pkgs/build-support/cc-wrapper/ld-wrapper.sh
+index 056cfa9..42952f8 100644
+--- a/ld-wrapper.sh
++++ b/ld-wrapper.sh
+@@ -121,7 +121,7 @@ if [ "$NIX_DONT_SET_RPATH" != 1 ]; then
+             # will get into the next 'elif'. We don't want
+             # the dynamic linker path rpath to go always first.
+             n=$((n + 1))
+-        elif [[ "$p" =~ ^[^-].*\.so($|\.) ]]; then
++        elif [[ "$p" =~ ^[^-].*\.(so|dylib)($|\.) ]]; then
+             # This is a direct reference to a shared library, so add
+             # its directory to the rpath.
+             path="$(dirname "$p")";
+@@ -138,7 +138,7 @@ if [ "$NIX_DONT_SET_RPATH" != 1 ]; then
+ 
+     for i in $libPath; do
+         for j in $libs; do
+-            if [ -f "$i/lib$j.so" ]; then
++            if [[ -f "$i/lib$j.so" || -f "$i/lib$j.dylib" ]]; then
+                 addToRPath $i
+                 break
+             fi

--- a/pkgs/build-support/cc-wrapper/macos-sierra-reexport-hack.bash
+++ b/pkgs/build-support/cc-wrapper/macos-sierra-reexport-hack.bash
@@ -2,107 +2,245 @@
 
 set -eu -o pipefail
 
+# For cmd | while read; do ...; done
+shopt -s lastpipe
+
 path_backup="$PATH"
 if [ -n "@coreutils_bin@" ]; then
   PATH="@coreutils_bin@/bin"
 fi
 
-declare -r recurThreshold=300
+declare -ri recurThreshold=200
+declare -i overflowCount=0
 
-declare overflowCount=0
-for ((n=0; n < $#; ++n)); do
-    case "${!n}" in
-        -l*) let overflowCount+=1 ;;
-        -reexport-l*) let overflowCount+=1 ;;
-        *) ;;
+declare -ar origArgs=("$@")
+
+# Throw away what we won't need
+declare -a parentArgs=()
+
+while (( $# )); do
+    case "$1" in
+        -l)
+            echo "cctools LD does not support '-l foo'" >&2
+            exit 1
+            ;;
+        -lazy_library | -reexport_library | -upward_library | -weak_library)
+            overflowCount+=1
+            shift 2
+            ;;
+        -l* | *.so | *.dylib | -lazy-l* | -reexport-l* | -upward-l* | -weak-l*)
+            overflowCount+=1
+            shift 1
+            ;;
+        *.a | *.o)
+            shift 1
+            ;;
+        -L | -F)
+            # Evidentally ld doesn't like using the child's RPATH, so it still
+            # needs these.
+            parentArgs+=("$1" "$2")
+            shift 2
+            ;;
+        -L?* | -F?*)
+            parentArgs+=("$1")
+            shift 1
+            ;;
+        -o)
+            outputName="$2"
+            parentArgs+=("$1" "$2")
+            shift 2
+            ;;
+        -install_name | -dylib_install_name | -dynamic-linker | -plugin)
+            parentArgs+=("$1" "$2")
+            shift 2
+            ;;
+        -rpath)
+            # Only an rpath to the child is needed, which we will add
+            shift 2
+            ;;
+        *)
+            if [[ -f "$1" ]]; then
+                # Propabably a non-standard object file like Haskell's
+                # `.dyn_o`. Skip it like other inputs
+                :
+            else
+                parentArgs+=("$1")
+            fi
+            shift 1
+            ;;
     esac
 done
 
-declare -a allArgs=()
+
 
 if (( "$overflowCount" <= "$recurThreshold" )); then
-    allArgs=("$@")
-else
-    declare -a childrenLookup=() childrenLink=()
-
-    while (( $# )); do
-        case "$1" in
-            -L/*)
-                childrenLookup+=("$1")
-                allArgs+=("$1")
-                ;;
-            -L)
-                echo "cctools LD does not support '-L foo' or '-l foo'" >&2
-                exit 1
-                ;;
-            -l)
-                echo "cctools LD does not support '-L foo' or '-l foo'" >&2
-                exit 1
-                ;;
-            -lazy_library | -lazy_framework | -lto_library)
-                # We aren't linking any "azy_library", "to_library", etc.
-                allArgs+=("$1")
-                ;;
-            -lazy-l | -weak-l)    allArgs+=("$1") ;;
-                # We can't so easily prevent header issues from these.
-            -lSystem)             allArgs+=("$1") ;;
-                # Special case as indirection seems like a bad idea for something
-                # so fundamental. Can be removed for simplicity.
-            -l?* | -reexport-l?*) childrenLink+=("$1") ;;
-            *)                    allArgs+=("$1") ;;
-        esac
-
-        shift
-    done
-
-    declare n=0
-    while (( $n < "${#childrenLink[@]}" )); do
-        if [[ "${childrenLink[n]}" = -l* ]]; then
-            childrenLink[n]="-reexport${childrenLink[n]}"
-        fi
-        let ++n
-    done
-    unset n
-
-    declare -r outputNameLibless=$(basename $( \
-        if [[ -z "${outputName:+isUndefined}" ]]; then
-            echo unnamed
-        elif [[ "${outputName:0:3}" = lib ]]; then
-            echo "${outputName:3}"
-        else
-            echo "${outputName}"
-        fi))
-    declare -ra children=("$outputNameLibless-reexport-delegate-0" \
-                          "$outputNameLibless-reexport-delegate-1")
-
-    mkdir -p "$out/lib"
-
-    PATH="$PATH:@out@/bin"
-
-    symbolBloatObject=$outputNameLibless-symbol-hack.o
-    if [[ ! -e $symbolBloatObject ]]; then
-        # `-Q` means use GNU Assembler rather than Clang, avoiding an awkward
-        # dependency cycle.
-        printf '.private_extern _______child_hack_foo\nchild_hack_foo:\n' \
-            | as -Q -- -o $symbolBloatObject
+    if [ -n "${NIX_DEBUG:-}" ]; then
+        echo "ld-wrapper: Only ${overflowCount} inputs counted while ${recurThreshold} is the ceiling, linking normally. " >&2
     fi
+    PATH="$path_backup"
+    exec @prog@ "${origArgs[@]}"
+fi
 
-    # first half of libs
-    ld -macosx_version_min $MACOSX_DEPLOYMENT_TARGET -arch x86_64 -dylib \
-      -o "$out/lib/lib${children[0]}.dylib" \
-      -install_name "$out/lib/lib${children[0]}.dylib" \
-      "${childrenLookup[@]}" "$symbolBloatObject" \
-      "${childrenLink[@]:0:$((${#childrenLink[@]} / 2 ))}"
 
-    # second half of libs
-    ld -macosx_version_min $MACOSX_DEPLOYMENT_TARGET -arch x86_64 -dylib \
-      -o "$out/lib/lib${children[1]}.dylib" \
-      -install_name "$out/lib/lib${children[1]}.dylib" \
-      "${childrenLookup[@]}" "$symbolBloatObject" \
-      "${childrenLink[@]:$((${#childrenLink[@]} / 2 ))}"
 
-    allArgs+=("-L$out/lib" "-l${children[0]}" "-l${children[1]}")
+if [ -n "${NIX_DEBUG:-}" ]; then
+    echo "ld-wrapper: ${overflowCount} inputs counted when ${recurThreshold} is the ceiling, inspecting further. " >&2
+fi
+
+# Collect the normalized linker input
+declare -a norm=()
+
+# Arguments are null-separated
+@prog@ --dump-normalized-lib-args "${origArgs[@]}" |
+    while IFS= read -r -d '' input; do
+        norm+=("$input")
+    done
+
+declare -i leafCount=0
+declare lastLeaf=''
+declare -a childrenInputs=() trailingInputs=()
+while (( "${#norm[@]}" )); do
+    case "${norm[0]}" in
+        -lazy_library | -upward_library)
+            # TODO(@Ericson2314): Don't do that, but intersperse children
+            # between such args.
+            echo "ld-wrapper: Warning: Potentially changing link order" >&2
+            trailingInputs+=("${norm[0]}" "${norm[1]}")
+            norm=("${norm[@]:2}")
+            ;;
+        -reexport_library | -weak_library)
+            childrenInputs+=("${norm[0]}" "${norm[1]}")
+            if [[ "${norm[1]}" != "$lastLeaf" ]]; then
+                leafCount+=1
+                lastLeaf="${norm[1]}"
+            fi
+            norm=("${norm[@]:2}")
+            ;;
+        *.so | *.dylib)
+            childrenInputs+=(-reexport_library "${norm[0]}")
+            if [[ "${norm[0]}" != "$lastLeaf" ]]; then
+                leafCount+=1
+                lastLeaf="${norm[0]}"
+            fi
+            norm=("${norm[@]:1}")
+            ;;
+        *.o | *.a)
+            # Don't delegate object files or static libs
+            parentArgs+=("${norm[0]}")
+            norm=("${norm[@]:1}")
+            ;;
+        *)
+            if [[ -f "${norm[0]}" ]]; then
+                # Propabably a non-standard object file. We'll let it by.
+                parentArgs+=("${norm[0]}")
+                norm=("${norm[@]:1}")
+            else
+                echo "ld-wrapper: Internal Error: Invalid normalized argument" >&2
+                exit -1
+            fi
+            ;;
+    esac
+done
+
+
+
+if (( "$leafCount" <= "$recurThreshold" )); then
+    if [ -n "${NIX_DEBUG:-}" ]; then
+        echo "ld-wrapper: Only ${leafCount} *dynamic* inputs counted while ${recurThreshold} is the ceiling, linking normally. " >&2
+    fi
+    PATH="$path_backup"
+    exec @prog@ "${origArgs[@]}"
+fi
+
+
+
+if [ -n "${NIX_DEBUG:-}" ]; then
+    echo "ld-wrapper: ${leafCount} *dynamic* inputs counted when ${recurThreshold} is the ceiling, delegating to children. " >&2
+fi
+
+declare -r outputNameLibless=$( \
+    if [[ -z "${outputName:+isUndefined}" ]]; then
+        echo unnamed
+        return 0;
+    fi
+    baseName=$(basename ${outputName})
+    if [[ "$baseName" = lib* ]]; then
+        baseName="${baseName:3}"
+    fi
+    echo "$baseName")
+
+declare -ra children=(
+    "$outputNameLibless-reexport-delegate-0"
+    "$outputNameLibless-reexport-delegate-1"
+)
+
+mkdir -p "$out/lib"
+
+symbolBloatObject=$outputNameLibless-symbol-hack.o
+if [[ ! -f $symbolBloatObject ]]; then
+    # `-Q` means use GNU Assembler rather than Clang, avoiding an awkward
+    # dependency cycle.
+    printf '.private_extern _______child_hack_foo\nchild_hack_foo:\n' |
+        PATH="$PATH:@out@/bin" as -Q -- -o $symbolBloatObject
+fi
+
+# Split inputs between children
+declare -a child0Inputs=() child1Inputs=("${childrenInputs[@]}")
+let "countFirstChild = $leafCount / 2" || true
+lastLeaf=''
+while (( "$countFirstChild" )); do
+    case "${child1Inputs[0]}" in
+        -reexport_library | -weak_library)
+            child0Inputs+=("${child1Inputs[0]}" "${child1Inputs[1]}")
+            if [[ "${child1Inputs[1]}" != "$lastLeaf" ]]; then
+                let countFirstChild-=1 || true
+                lastLeaf="${child1Inputs[1]}"
+            fi
+            child1Inputs=("${child1Inputs[@]:2}")
+            ;;
+        *.so | *.dylib)
+            child0Inputs+=(-reexport_library "${child1Inputs[0]}")
+            if [[ "${child1Inputs[0]}" != "$lastLeaf" ]]; then
+                let countFirstChild-=1 || true
+                lastLeaf="${child1Inputs[1]}"
+            fi
+            child1Inputs=("${child1Inputs[@]:2}")
+            ;;
+        *)
+            echo "ld-wrapper: Internal Error: Invalid delegated input" >&2
+            exit -1
+            ;;
+    esac
+done
+
+
+# First half of libs
+@out@/bin/ld \
+  -macosx_version_min $MACOSX_DEPLOYMENT_TARGET -arch x86_64 -dylib \
+  -o "$out/lib/lib${children[0]}.dylib" \
+  -install_name "$out/lib/lib${children[0]}.dylib" \
+  "$symbolBloatObject" "${child0Inputs[@]}" "${trailingInputs[@]}"
+
+# Second half of libs
+@out@/bin/ld \
+  -macosx_version_min $MACOSX_DEPLOYMENT_TARGET -arch x86_64 -dylib \
+  -o "$out/lib/lib${children[1]}.dylib" \
+  -install_name "$out/lib/lib${children[1]}.dylib" \
+  "$symbolBloatObject" "${child1Inputs[@]}" "${trailingInputs[@]}"
+
+parentArgs+=("-L$out/lib" -rpath "$out/lib")
+if [[ $outputName != *reexport-delegate* ]]; then
+	parentArgs+=("-l${children[0]}" "-l${children[1]}")
+else
+    parentArgs+=("-reexport-l${children[0]}" "-reexport-l${children[1]}")
+fi
+
+parentArgs+=("${trailingInputs[@]}")
+
+if [ -n "${NIX_DEBUG:-}" ]; then
+    echo "flags using delegated children to @prog@:" >&2
+    printf "  %q\n" "${parentArgs[@]}" >&2
 fi
 
 PATH="$path_backup"
-exec @prog@ "${allArgs[@]}"
+exec @prog@ "${parentArgs[@]}"

--- a/pkgs/os-specific/darwin/cctools/ld-dump-normalized-args.patch
+++ b/pkgs/os-specific/darwin/cctools/ld-dump-normalized-args.patch
@@ -1,0 +1,133 @@
+ cctools/ld64/src/ld/Options.cpp | 42 ++++++++++++++++++++++++++++++++++++++++-
+ cctools/ld64/src/ld/Options.h   |  6 ++++++
+ cctools/ld64/src/ld/ld.cpp      |  9 +++++++++
+ 3 files changed, 56 insertions(+), 1 deletion(-)
+
+diff --git a/cctools/ld64/src/ld/Options.cpp b/cctools/ld64/src/ld/Options.cpp
+index e7f2e32..154445a 100644
+--- a/cctools/ld64/src/ld/Options.cpp
++++ b/cctools/ld64/src/ld/Options.cpp
+@@ -133,6 +133,43 @@ bool Options::FileInfo::checkFileExists(const Options& options, const char *p)
+     return false;
+ }
+ 
++std::vector<std::string> Options::FileInfo::lib_cli_argument() const
++{
++	// fIndirectDylib unused
++	bool special = options.fReExport || options.fLazyLoad || options.fUpward;
++
++	if (options.fBundleLoader) {
++		if (special) throw "internal error; bundle loader cannot have these extra attributes";
++		return {"-bundle-loader", path};
++	} else {
++		std::vector<std::string> args = {};
++		if (options.fReExport) {
++			args.push_back("-reexport_library");
++			args.push_back(path);
++		}
++		else if (options.fLazyLoad) {
++			args.push_back("-lazy_library");
++			args.push_back(path);
++		}
++		else if (options.fUpward) {
++			args.push_back("-upward_library");
++			args.push_back(path);
++		}
++		else {
++			// bare path
++			args.push_back(path);
++		}
++
++		// This one alone can be combined with the others
++		if (options.fWeakImport) {
++			args.push_back("-weak_library");
++			args.push_back(path);
++		}
++
++		return args;
++	}
++}
++
+ 
+ Options::Options(int argc, const char* argv[])
+ 	: fOutputFile("a.out"), fArchitecture(0), fSubArchitecture(0), fArchitectureName("unknown"), fOutputKind(kDynamicExecutable), 
+@@ -199,7 +236,7 @@ Options::Options(int argc, const char* argv[])
+ 	  fMacVersionMin(ld::macVersionUnset), fIOSVersionMin(ld::iOSVersionUnset), fWatchOSVersionMin(ld::wOSVersionUnset), // ld64-port: added fWatchOSVersionMin(ld::wOSVersionUnset) - https://gist.github.com/tpoechtrager/6537a058dfb4d587fff4
+ 	  fSaveTempFiles(false), fSnapshotRequested(false), fPipelineFifo(NULL),
+ 	  fDependencyInfoPath(NULL), fDependencyFileDescriptor(-1), fMaxDefaultCommonAlign(0), fFilePreference(kModTime),
+-	  fForceTextBasedStub(false)
++	  fForceTextBasedStub(false), fDumpNormalizedLibArgs(false)
+ {
+ 	this->checkForClassic(argc, argv);
+ 	this->parsePreCommandLineEnvironmentSettings();
+@@ -2305,6 +2342,9 @@ void Options::parse(int argc, const char* argv[])
+ 				fprintf (stdout, "ld64: For information on command line options please use 'man ld'.\n");
+ 				exit (0);
+ 			}
++			else if ( strcmp(arg, "--dump-normalized-lib-args") == 0 ) {
++				fDumpNormalizedLibArgs = true;
++			}
+ 			else if ( strcmp(arg, "-arch") == 0 ) {
+ 				parseArch(argv[++i]);
+ 			}
+diff --git a/cctools/ld64/src/ld/Options.h b/cctools/ld64/src/ld/Options.h
+index 8801873..bcb4b4f 100644
+--- a/cctools/ld64/src/ld/Options.h
++++ b/cctools/ld64/src/ld/Options.h
+@@ -176,6 +176,10 @@ public:
+         // Returns true if a previous call to checkFileExists() succeeded.
+         // Returns false if the file does not exist of checkFileExists() has never been called.
+         bool missing() const { return modTime==0; }
++
++        // Serialize the file info as a command line argument that would be parsed as the same file
++        // info. Best effort if some attributes cannot be preserved through the round trip.
++        std::vector<std::string> lib_cli_argument() const;
+ 	};
+ 
+ 	struct ExtraSection {
+@@ -475,6 +479,7 @@ public:
+ 	std::string					getSDKVersionStr() const;
+ 	std::string					getPlatformStr() const;
+ 	uint8_t						maxDefaultCommonAlign() const { return fMaxDefaultCommonAlign; }
++	bool						dumpNormalizedLibArgs() const { return fDumpNormalizedLibArgs; }
+ 
+ 	static uint32_t				parseVersionNumber32(const char*);
+ 
+@@ -784,6 +789,7 @@ private:
+ 	uint8_t								fMaxDefaultCommonAlign;
+ 	FilePreference						fFilePreference;
+ 	bool								fForceTextBasedStub;
++	bool								fDumpNormalizedLibArgs;
+ };
+ 
+ 
+diff --git a/cctools/ld64/src/ld/ld.cpp b/cctools/ld64/src/ld/ld.cpp
+index f4c48d8..ec3a38e 100644
+--- a/cctools/ld64/src/ld/ld.cpp
++++ b/cctools/ld64/src/ld/ld.cpp
+@@ -49,6 +49,7 @@
+ #include <dlfcn.h>
+ #include <AvailabilityMacros.h>
+ 
++#include <iostream>
+ #include <string>
+ #include <map>
+ #include <set>
+@@ -1187,6 +1188,14 @@ int main(int argc, const char* argv[])
+ 		
+ 		// create object to track command line arguments
+ 		Options options(argc, argv);
++		if (options.dumpNormalizedLibArgs()) {
++			for (auto info : options.getInputFiles()) {
++				for (auto arg : info.lib_cli_argument()) {
++					std::cout << arg << '\0';
++				}
++			}
++			exit(0);
++		}
+ 		InternalState state(options);
+ 		
+ 		// allow libLTO to be overridden by command line -lto_library
+-- 
+2.10.1 (Apple Git-78)
+

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchFromGitHub, autoconf, automake, libtool_2
 , llvm, libcxx, libcxxabi, clang, libuuid
 , libobjc ? null
+, enableDumpNormalizedLibArgs ? false
 }:
 
 let
@@ -26,7 +27,7 @@ let
       # See https://github.com/tpoechtrager/cctools-port/issues/24. Remove when that's fixed.
       ./undo-unknown-triple.patch
       ./ld-tbd-v2.patch
-    ];
+    ] ++ stdenv.lib.optional enableDumpNormalizedLibArgs ./ld-dump-normalized-args.patch;
 
     enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4786,6 +4786,11 @@ with pkgs;
   clang-sierraHack = clang.override {
     name = "clang-wrapper-with-reexport-hack";
     useMacosReexportHack = true;
+    binutils = binutils.override {
+      cctools = darwin.cctools.override {
+        enableDumpNormalizedLibArgs = true;
+      };
+    };
   };
 
   clang_4  = llvmPackages_4.clang;
@@ -11095,13 +11100,13 @@ with pkgs;
     cmdline = callPackage ../os-specific/darwin/command-line-tools {};
     apple-source-releases = callPackage ../os-specific/darwin/apple-source-releases { };
   in apple-source-releases // rec {
-    cctools_cross = callPackage (forcedNativePackages.callPackage ../os-specific/darwin/cctools/port.nix {}).cross {
+    cctools_cross = callPackage (forcedNativePackages.callPackages ../os-specific/darwin/cctools/port.nix {}).cross {
       cross = assert targetPlatform != buildPlatform; targetPlatform;
       inherit maloader;
       xctoolchain = xcode.toolchain;
     };
 
-    cctools = (callPackage ../os-specific/darwin/cctools/port.nix {
+    cctools = (callPackages ../os-specific/darwin/cctools/port.nix {
       inherit libobjc;
       stdenv = if stdenv.isDarwin then stdenv else libcxxStdenv;
     }).native;


### PR DESCRIPTION
###### Motivation for this change

I made a patch for cctool's ld in order to get it to split out flags for all inputs in a fully-resolved normal form. I use this to avoid trying to `-reexport-l` static libraries. Linking them directly will reexport them just fine.

@TaktInc needs this for 17.03, so I'm starting here and then forward porting to master (and probably `17.09` if all goes well).

The patch itself uses `\0` as a delimiter, but perhaps `expandResponseParams` could be used to parse a more human readable output. I just bring this up if it would help upstream the patch.

N.B. as I mentioned in https://github.com/NixOS/nixpkgs/issues/24844#issuecomment-327551707, if we likewise patch GNU Binutils, we can dramatically simplify ld-wrapper (with and without the sierra hack) by not trying to resolve linker scripts on our own.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @orivej 
