### PR TITLE
rubygems: 2.6.10 -> 2.6.13

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -151,12 +151,12 @@ let
           sed -i "s|'--with-baseruby=${baseruby}/bin/ruby'||" $rbConfig
         '';
 
-        meta = {
-          license = stdenv.lib.licenses.ruby;
-          homepage = http://www.ruby-lang.org/en/;
+        meta = with stdenv.lib; {
           description = "The Ruby language";
-          maintainers = with stdenv.lib.maintainers; [ vrthra manveru ];
-          platforms = stdenv.lib.platforms.all;
+          homepage    = http://www.ruby-lang.org/en/;
+          license     = licenses.ruby;
+          maintainers = with maintainers; [ vrthra manveru ];
+          platforms   = platforms.all;
         };
 
         passthru = rec {

--- a/pkgs/development/interpreters/ruby/rubygems-src.nix
+++ b/pkgs/development/interpreters/ruby/rubygems-src.nix
@@ -1,6 +1,6 @@
 { fetchurl
-, version ? "2.6.10"
-, sha256 ? "364c0eee8e0c9e8ab4879c5035832e5a27f0c97292d2264af5ae0020585280f0"
+, version ? "2.6.13"
+, sha256 ? "1j98ww8cz9y4wwshg7p4i4acrmls3ywkyj1nlkh4k3bywwm50hfh"
 }:
 fetchurl {
   url = "http://production.cf.rubygems.org/rubygems/rubygems-${version}.tgz";


### PR DESCRIPTION
###### Motivation for this change

A bunch of nasty CVEs: https://www.ruby-lang.org/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/

I haven't run ```nox-review wip``` as it causes quite a lot of packages to be rebuilt but I did compile all versions of ruby. Do we push something like this to staging first?

Cc: @grahamc 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

