### PR TITLE
slock: adds ability to add custom patches

### DIFF
--- a/pkgs/misc/screensavers/slock/default.nix
+++ b/pkgs/misc/screensavers/slock/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   installFlags = "DESTDIR=\${out} PREFIX=";
 
-  patchPhase = "sed -i '/chmod u+s/d' Makefile";
+  postPatch = "sed -i '/chmod u+s/d' Makefile";
 
   preBuild = optionalString (conf != null) ''
     cp ${writeText "config.def.h" conf} config.def.h

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19065,7 +19065,9 @@ with pkgs;
 
   seafile-shared = callPackage ../misc/seafile-shared { };
 
-  slock = callPackage ../misc/screensavers/slock { };
+  slock = callPackage ../misc/screensavers/slock {
+    conf = config.slock.conf or null;
+  };
 
   smokeping = callPackage ../tools/networking/smokeping {
     inherit fping rrdtool;


### PR DESCRIPTION
###### Motivation for this change
I needed to add patches to slock so I added the patches argument.
Usage:
```nix
{
  nixpkgs.config.packageOverrides = pkgs: {
    slock = pkgs.slock.override {
      patches = [ ./patch.diff ];
    };
  };
}
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

