### PR TITLE
Moe: init at 1.9

### DIFF
--- a/pkgs/applications/editors/moe/default.nix
+++ b/pkgs/applications/editors/moe/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl
+, lzip, ncurses
+}:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+
+  name = "moe-${version}";
+  version = "1.9";
+
+  src = fetchurl {
+    url = "mirror://gnu/moe/${name}.tar.lz";
+    sha256 = "1wsfzy0iia0c89wnx1ilzw54wqcmlp2nz8mkpvc393z0zagrx48q";
+  };
+
+  nativeBuildInputs = [ lzip ];
+  buildInputs = [ ncurses ];
+
+  meta = {
+    description = "A small, 8-bit clean editor";
+    longDescription = ''
+      GNU moe is a powerful, 8-bit clean, console text editor for ISO-8859 and
+      ASCII character encodings. It has a modeless, user-friendly interface,
+      online help, multiple windows, unlimited undo/redo capability, unlimited
+      line length, unlimited buffers, global search/replace (on all buffers at
+      once), block operations, automatic indentation, word wrapping, file name
+      completion, directory browser, duplicate removal from prompt histories,
+      delimiter matching, text conversion from/to UTF-8, romanization, etc.
+    '';
+    homepage = http://www.gnu.org/software/moe/;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.linux;
+  };
+}
+# TODO: a configurable, global moerc file

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14601,6 +14601,8 @@ with pkgs;
 
   mi2ly = callPackage ../applications/audio/mi2ly {};
 
+  moe =  callPackage ../applications/editors/moe { };
+
   praat = callPackage ../applications/audio/praat { };
 
   quvi = callPackage ../applications/video/quvi/tool.nix {


### PR DESCRIPTION
Moe is a small text editor.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

