### PR TITLE
vbam: svn-1507 -> git-ceef480

### DIFF
--- a/pkgs/misc/emulators/vbam/default.nix
+++ b/pkgs/misc/emulators/vbam/default.nix
@@ -1,9 +1,10 @@
 { stdenv
 , cairo
 , cmake
-, fetchsvn
+, fetchFromGitHub
 , ffmpeg
 , gettext
+, gtk2-x11
 , libpng
 , libpthreadstubs
 , libXdmcp
@@ -11,18 +12,21 @@
 , mesa
 , openal
 , pkgconfig
-, SDL
+, SDL2
+, sfml
 , wxGTK
 , zip
 , zlib
 }:
 
-stdenv.mkDerivation {
-  name = "VBAM-1507";
-  src = fetchsvn {
-    url = "svn://svn.code.sf.net/p/vbam/code/trunk";
-    rev = 1507;
-    sha256 = "0fqvgi5s0sacqr9yi7kv1klqlvfzr13sjq5ikipirz0jv50kjxa7";
+stdenv.mkDerivation rec {
+  name = "visualboyadvance-m-${version}";
+  version = "unstable-2017-09-04";
+  src = fetchFromGitHub {
+    owner = "visualboyadvance-m";
+    repo = "visualboyadvance-m";
+    rev = "ceef480";
+    sha256 = "1lpmlj8mv6fwlfg9m58hzggx8ld6cnjvaqx5ka5sffxd9v95qq2l";
   };
 
   buildInputs = [
@@ -30,14 +34,12 @@ stdenv.mkDerivation {
     cmake
     ffmpeg
     gettext
-    libpng
-    libpthreadstubs
-    libXdmcp
-    libxshmfence
+    gtk2-x11
     mesa
     openal
     pkgconfig
-    SDL
+    SDL2
+    sfml
     wxGTK
     zip
     zlib


### PR DESCRIPTION
###### Motivation for this change

this fixes building with GCC6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

