### PR TITLE
Skypeforlinux september updates

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, dpkg, makeWrapper
-, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib, gnome2
-, libnotify, nspr, nss, systemd, xorg }:
+, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib, glibc, gnome2, libsecret
+, libnotify, nspr, nss, systemd, xorg, libv4l, libstdcxx5 }:
 
 let
 
-  version = "5.3.0.1";
+  version = "8.6.76.56247";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
@@ -17,6 +17,9 @@ let
     fontconfig
     freetype
     glib
+    libsecret
+    glibc
+    libstdcxx5
 
     gnome2.GConf
     gnome2.gdk_pixbuf
@@ -30,6 +33,7 @@ let
     nss
     stdenv.cc.cc
     systemd
+    libv4l
 
     xorg.libxkbfile
     xorg.libX11
@@ -50,7 +54,7 @@ let
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_${version}_amd64.deb";
-        sha256 = "08sf9nqnznsydw4965w7ixwwba54hjc02ga7vcnz9vpx5hln3nrz";
+        sha256 = "0ycl2l38jp6dl4gfavirc25c5rsgsmcsfiqpa0bb72pgxjqpwgzh";
       }
     else
       throw "Skype for linux is not supported on ${stdenv.system}";
@@ -74,6 +78,11 @@ in stdenv.mkDerivation {
 
     # Otherwise it looks "suspicious"
     chmod -R g-w $out
+
+     for file in $(find $out -type f  ); do
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+      patchelf --set-rpath ${rpath}:$out/share/skypeforlinux $file || true
+    done
   '';
 
   postFixup = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16120,7 +16120,13 @@ with pkgs;
 
   siproxd = callPackage ../applications/networking/siproxd { };
 
-  skypeforlinux = callPackage ../applications/networking/instant-messengers/skypeforlinux { };
+  inherit (callPackage ../applications/networking/instant-messengers/skypeforlinux {})
+    skypeforlinux_5_4
+    skypeforlinux_8_6
+  ;
+
+
+  skypeforlinux = skypeforlinux_5_4;
 
   skype4pidgin = callPackage ../applications/networking/instant-messengers/pidgin-plugins/skype4pidgin { };
 


### PR DESCRIPTION
###### Motivation for this change
Update skypeforlinux to 5.4.0.1. Fixes autologin issue.

Add skypeforlinux 8.6.76.56247 (Preview). 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

