### PR TITLE
centerim: 4.22.10 -> 5.0.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/centerim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/centerim/default.nix
@@ -1,24 +1,27 @@
-{stdenv, fetchurl, openssl, curl, ncurses, libjpeg
+{stdenv, fetchurl, gnused, openssl, curl, ncurses, libjpeg
 , withGpg ? true, gpgme ? null}:
 
 stdenv.mkDerivation rec {
-  version = "4.22.10";
-  debPatch = "2";
-  name = "centerim-${version}";
+  version = "5.0.1";
+  name = "centerim5-${version}";
 
   src = fetchurl {
-    url = "http://centerim.org/download/releases/${name}.tar.gz";
+    url = "http://centerim.org/download/cim5/${name}.tar.gz";
     sha256 = "0viz86jflp684vfginhl6aaw4gh2qvalc25anlwljjl3kkmibklk";
   };
-  patches = fetchurl {
-    url = "mirror://debian/pool/main/c/centerim/centerim_${version}-${debPatch}.diff.gz";
-    sha256 = "18iz3hkvr31jsyznryvyldxm9ckyrpy9sczxikrnw2i2r1xyfj8m";
-  };
+
+  CXXFLAGS = "-std=gnu++98";
 
   buildInputs = [ openssl curl ncurses libjpeg ]
     ++ stdenv.lib.optional withGpg gpgme;
 
-  configureFlags = [ "--with-openssl=${openssl.dev}" ];
+  preConfigure = ''
+    ${gnused}/bin/sed -i '1,1i#include <stdio.h>' libicq2000/libicq2000/sigslot.h
+  '';
+
+  configureFlags = [
+    "--with-openssl=${openssl.dev}"
+  ];
 
   meta = {
     homepage = http://www.centerim.org/;


### PR DESCRIPTION
###### Motivation for this change

fixes build with GCC6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

