### PR TITLE
mcrl2: 201409 -> 201707

### DIFF
--- a/pkgs/applications/science/logic/mcrl2/default.nix
+++ b/pkgs/applications/science/logic/mcrl2/default.nix
@@ -2,17 +2,16 @@
  python27, python27Packages}:
 
 stdenv.mkDerivation rec {
-  version = "201409.1";
-  build_nr = "13892";
+  version = "201707";
+  build_nr = "1";
   name = "mcrl2-${version}";
 
   src = fetchurl {
-    url = "http://www.mcrl2.org/download/devel/mcrl2-${version}.${build_nr}.tar.gz";
-    sha256 = "0cknpind6rma12q93rbm638ijhy8sj8nd20wnw8l0f651wm0x036";
+    url = "http://www.mcrl2.org/download/release/mcrl2-${version}.${build_nr}.tar.gz";
+    sha256 = "1c8h94ja7271ph61zrcgnjgblxppld6v22f7f900prjgzbcfy14m";
   };
 
-  buildInputs = [ xlibs.libX11 cmake subversion mesa qt5.qtbase boost
-                  python27 python27Packages.pyyaml python27Packages.psutil ];
+  buildInputs = [ cmake mesa qt5.qtbase boost ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

Did not build. Updating to the current release, the package builds successfully. I also removed some of the dependencies, as the official build guide only specifies a subset of the ones given before.
I did test some of the resulting binaries for execution but not all.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

