### PR TITLE
skypeforlinux: 5.3.0.1 -> 5.4.0.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, dpkg, makeWrapper
-, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib, gnome2
-, libnotify, nspr, nss, systemd, xorg }:
+, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib, glibc, gnome2, libsecret
+, libnotify, nspr, nss, systemd, xorg, libv4l, libstdcxx5 }:
 
 let
 
-  version = "5.3.0.1";
+  version = "5.4.0.1";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
@@ -17,6 +17,9 @@ let
     fontconfig
     freetype
     glib
+    libsecret
+    glibc
+    libstdcxx5
 
     gnome2.GConf
     gnome2.gdk_pixbuf
@@ -30,6 +33,7 @@ let
     nss
     stdenv.cc.cc
     systemd
+    libv4l
 
     xorg.libxkbfile
     xorg.libX11
@@ -50,7 +54,7 @@ let
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_${version}_amd64.deb";
-        sha256 = "08sf9nqnznsydw4965w7ixwwba54hjc02ga7vcnz9vpx5hln3nrz";
+        sha256 = "1idjgmn0kym7jml30xq6zrcp8qinx64kgnxlw8m0ys4z6zlw0c8z";
       }
     else
       throw "Skype for linux is not supported on ${stdenv.system}";
@@ -77,9 +81,10 @@ in stdenv.mkDerivation {
   '';
 
   postFixup = ''
-     patchelf \
-      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "$out/share/skypeforlinux:${rpath}" "$out/share/skypeforlinux/skypeforlinux"
+    for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* -or -name \*.node\* \) ); do
+                patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+                patchelf --set-rpath ${rpath}:$out/share/skypeforlinux $file || true
+    done
 
     ln -s "$out/share/skypeforlinux/skypeforlinux" "$out/bin/skypeforlinux"
 


### PR DESCRIPTION
###### Motivation for this change
update skypeforlinux to 5.4.0.1; Fix autologin issue

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

