### PR TITLE
firehol: init at 3.1.4, iprange: init at 1.0.3

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -429,6 +429,7 @@
   ./services/networking/fakeroute.nix
   ./services/networking/ferm.nix
   ./services/networking/firefox/sync-server.nix
+  ./services/networking/fireqos.nix
   ./services/networking/firewall.nix
   ./services/networking/flannel.nix
   ./services/networking/flashpolicyd.nix

--- a/nixos/modules/services/networking/fireqos.nix
+++ b/nixos/modules/services/networking/fireqos.nix
@@ -1,0 +1,52 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.fireqos;
+  fireqosConfig = pkgs.writeText "fireqos.conf" "${cfg.config}";
+in {
+  options.services.fireqos = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If enabled, FireQOS will be launched with the specified
+        configuration given in `config`.
+      '';
+    };
+
+    config = mkOption {
+      type = types.str;
+      default = "";
+      example = ''
+        interface wlp3s0 world-in input rate 10mbit ethernet
+          class web commit 50kbit
+            match tcp ports 80,443
+
+        interface wlp3s0 world-out input rate 10mbit ethernet
+          class web commit 50kbit
+            match tcp ports 80,443
+      '';
+      description = ''
+        The FireQOS configuration goes here.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.fireqos = {
+      description = "FireQOS";
+      after = [ "network.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = "${pkgs.firehol}/bin/fireqos start ${fireqosConfig}";
+        ExecStop = [
+          "${pkgs.firehol}/bin/fireqos stop"
+          "${pkgs.firehol}/bin/fireqos clear_all_qos"
+        ];
+      };
+    };
+  };
+}

--- a/pkgs/applications/networking/firehol/default.nix
+++ b/pkgs/applications/networking/firehol/default.nix
@@ -1,0 +1,79 @@
+{ stdenv, lib, fetchFromGitHub, pkgs
+, autoconf, automake, curl, iprange, iproute, ipset, iptables, iputils
+, kmod, nettools, procps, tcpdump, traceroute, utillinux, whois
+
+# Just install FireQOS without FireHOL
+, onlyQOS ? true
+}:
+
+stdenv.mkDerivation rec {
+  name = "firehol-${version}";
+  version = "3.1.4";
+
+  src = fetchFromGitHub {
+    owner = "firehol";
+    repo = "firehol";
+    rev = "v${version}";
+    sha256 = "121kjq5149r11k58lr9mkqns2k8jbdbjg2k93v8v7axhng6js7s9";
+  };
+
+  patches = [
+    # configure tries to determine if `ping6` or the newer, combined
+    # `ping` is installed by using `ping -6` which would fail.
+    (pkgs.writeText "firehol-ping6.patch"
+      ''
+      --- a/m4/ax_check_ping_ipv6.m4
+      +++ b/m4/ax_check_ping_ipv6.m4
+      @@ -42,16 +42,16 @@ AC_DEFUN([AX_CHECK_PING_IPV6],
+
+           AC_CACHE_CHECK([whether ]PING[ has working -6 option], [ac_cv_ping_6_opt],
+           [
+      -        ac_cv_ping_6_opt=no
+      -        if test -n "$PING"; then
+      -            echo "Trying '$PING -6 -c 1 ::1'" >&AS_MESSAGE_LOG_FD
+      -            $PING -6 -c 1 ::1 > conftest.out 2>&1
+      -            if test "$?" = 0; then
+      -                ac_cv_ping_6_opt=yes
+      -            fi
+      -            cat conftest.out >&AS_MESSAGE_LOG_FD
+      -            rm -f conftest.out
+      -        fi
+      +        ac_cv_ping_6_opt=yes
+      +        #if test -n "$PING"; then
+      +        #    echo "Trying '$PING -6 -c 1 ::1'" >&AS_MESSAGE_LOG_FD
+      +        #    $PING -6 -c 1 ::1 > conftest.out 2>&1
+      +        #    if test "$?" = 0; then
+      +        #        ac_cv_ping_6_opt=yes
+      +        #    fi
+      +        #    cat conftest.out >&AS_MESSAGE_LOG_FD
+      +        #    rm -f conftest.out
+      +        #fi
+           ])
+
+           AS_IF([test "x$ac_cv_ping_6_opt" = "xyes"],[
+      '')
+  ];
+  
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [
+    curl iprange iproute ipset iptables iputils kmod
+    nettools procps tcpdump traceroute utillinux whois
+  ];
+
+  preConfigure = "./autogen.sh";
+  configureFlags = [ "--localstatedir=/var"
+                     "--disable-doc" "--disable-man" ] ++
+                   lib.optional onlyQOS [ "--disable-firehol" ];
+
+  meta = with stdenv.lib; {
+    description = "A firewall for humans";
+    longDescription = ''
+      FireHOL, an iptables stateful packet filtering firewall for humans!
+      FireQOS, a TC based bandwidth shaper for humans!
+    '';
+    homepage = http://firehol.org/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ geistesk ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/firehol/iprange.nix
+++ b/pkgs/applications/networking/firehol/iprange.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "iprange-${version}";
+  version = "1.0.3";
+
+  src = fetchurl {
+    url = "https://github.com/firehol/iprange/releases/download/v${version}/iprange-${version}.tar.xz";
+    sha256 = "0lwgl5ybrhsv43llq3kgdjpvgyfl43f3nxm0g8a8cd7zmn754bg2";
+  };
+
+  meta = with stdenv.lib; {
+    description = "manage IP ranges";
+    homepage = https://github.com/firehol/iprange;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ geistesk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1982,6 +1982,8 @@ with pkgs;
 
   finger_bsd = callPackage ../tools/networking/bsd-finger { };
 
+  iprange = callPackage ../applications/networking/firehol/iprange.nix {};
+
   fio = callPackage ../tools/system/fio { };
 
   flamerobin = callPackage ../applications/misc/flamerobin { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1984,6 +1984,8 @@ with pkgs;
 
   iprange = callPackage ../applications/networking/firehol/iprange.nix {};
 
+  firehol = callPackage ../applications/networking/firehol {};
+
   fio = callPackage ../tools/system/fio { };
 
   flamerobin = callPackage ../applications/misc/flamerobin { };


### PR DESCRIPTION
###### Motivation for this change
This commit adds the [FireHOL-software](https://firehol.org/) (v3.1.4) and it's dependency [iprange](https://github.com/firehol/iprange) (v1.0.3). The FireHOL-package also contains FireQOS, which is a human-friendly `tc`-wrapper. A NixOS-module to interact with FireQOS was also provided.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
