### PR TITLE
pitivi: fix path to gst-python

### DIFF
--- a/pkgs/applications/video/pitivi/default.nix
+++ b/pkgs/applications/video/pitivi/default.nix
@@ -46,6 +46,8 @@ in stdenv.mkDerivation rec {
     dbus-python
   ]);
 
+  PYTHONPATH = "${python3Packages.gst-python}/lib/${python3Packages.python.sitePackages}";
+
   meta = with stdenv.lib; {
     description = "Non-Linear video editor utilizing the power of GStreamer";
     homepage    = "http://pitivi.org/";


### PR DESCRIPTION
###### Motivation for this change

To make the program start up. Without this the startup errors out as follows:

```
$ ./result/bin/pitivi 

(gst-plugin-scanner:8821): GStreamer-WARNING **: Failed to load plugin '/nix/store/0afmvlyh2b6pdnpn1wanzcm5paf6afl1-gst-transcoder-1.8.0/lib/gstreamer-1.0/libgsttranscoderplugin.so': libgstpbutils-1.0.so.0: cannot open shared object file: No such file or directory

** (gst-plugin-scanner:8821): CRITICAL **: pygobject initialization failed

** (.pitivi-wrapped:8820): WARNING **: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files
Failed to initialize modules
Traceback (most recent call last):
  File "/nix/store/5i5g1zsbp091gzjk7280l6c23b86333x-pitivi-0.96/bin/.pitivi-wrapped", line 132, in <module>
    _initialize_modules()
  File "/nix/store/5i5g1zsbp091gzjk7280l6c23b86333x-pitivi-0.96/bin/.pitivi-wrapped", line 109, in _initialize_modules
    initialize_modules()
  File "/nix/store/5i5g1zsbp091gzjk7280l6c23b86333x-pitivi-0.96/lib/pitivi/python/pitivi/check.py", line 338, in initialize_modules
    from pitivi.utils import validate
  File "/nix/store/5i5g1zsbp091gzjk7280l6c23b86333x-pitivi-0.96/lib/pitivi/python/pitivi/utils/validate.py", line 29, in <module>
    from pitivi.utils import timeline as timelineUtils
  File "/nix/store/5i5g1zsbp091gzjk7280l6c23b86333x-pitivi-0.96/lib/pitivi/python/pitivi/utils/timeline.py", line 25, in <module>
    from pitivi.utils import ui
  File "/nix/store/5i5g1zsbp091gzjk7280l6c23b86333x-pitivi-0.96/lib/pitivi/python/pitivi/utils/ui.py", line 539, in <module>
    (_("%d fps") % 12, Gst.Fraction(12.0, 1.0)),
TypeError: object() takes no parameters
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).