### PR TITLE
Fix gst-python's pygi overrides dir

### DIFF
--- a/pkgs/applications/video/pitivi/default.nix
+++ b/pkgs/applications/video/pitivi/default.nix
@@ -46,8 +46,6 @@ in stdenv.mkDerivation rec {
     dbus-python
   ]);
 
-  PYTHONPATH = "${python3Packages.gst-python}/lib/${python3Packages.python.sitePackages}";
-
   meta = with stdenv.lib; {
     description = "Non-Linear video editor utilizing the power of GStreamer";
     homepage    = "http://pitivi.org/";

--- a/pkgs/development/python-modules/gst-python/default.nix
+++ b/pkgs/development/python-modules/gst-python/default.nix
@@ -24,9 +24,9 @@ stdenv.mkDerivation rec {
   # XXX: in the Libs.private field of python3.pc
   buildInputs = [ ncurses ];
 
-  preConfigure = ''
-    export configureFlags="$configureFlags --with-pygi-overrides-dir=$out/lib/${python.sitePackages}/gi/overrides"
-  '';
+  configureFlags = [
+    "--with-pygi-overrides-dir=$(out)/${python.sitePackages}/gi/overrides"
+  ];
 
   propagatedBuildInputs = [ gst-plugins-base pygobject3 ];
 


### PR DESCRIPTION
###### Motivation for this change

To properly fix the issue brought up in #29126.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).