### PR TITLE
ipfs: workaround for upstream bug; other small fixes

### DIFF
--- a/nixos/tests/ipfs.nix
+++ b/nixos/tests/ipfs.nix
@@ -23,8 +23,7 @@ import ./make-test.nix ({ pkgs, ...} : {
         services.ipfs = {
           enable = true;
           defaultMode = "norouting";
-          # not yet. See #28621
-          #autoMount = true;
+          autoMount = true;
         };
         networking.firewall.allowedTCPPorts = [ 4001 ];
       };
@@ -51,7 +50,6 @@ import ./make-test.nix ({ pkgs, ...} : {
 
     $getter->mustSucceed("ipfs --api /ip4/127.0.0.1/tcp/5001 swarm connect /ip4/$addrIp/tcp/4001/ipfs/$addrId");
     $getter->mustSucceed("[ -n \"\$(ipfs --api /ip4/127.0.0.1/tcp/5001 cat /ipfs/$ipfsHash | grep fnord)\" ]");
-    # not yet. See #28621
-    # $getter->mustSucceed("[ -n \"$(cat /ipfs/$ipfsHash | grep fnord)\" ]");
+    $getter->mustSucceed("[ -n \"$(cat /ipfs/$ipfsHash | grep fnord)\" ]");
     '';
 })


### PR DESCRIPTION
###### Motivation for this change
Temporary workaround for https://github.com/ipfs/go-ipfs/issues/4214

###### Things done
Running `ipfs repo fsck` prestart should be safe, and fixes the service not starting after an unclean exit.

Also, the ipfs autoMount now works, although I had to take the suboptimal approach of adding a line to `environment.etc."fuse.conf".text`.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

