### PR TITLE
uwsgi: enable plugins by default

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4698,7 +4698,7 @@ with pkgs;
   usbmuxd = callPackage ../tools/misc/usbmuxd {};
 
   uwsgi = callPackage ../servers/uwsgi {
-    plugins = [];
+    plugins = [ "cgi" "php" "python2" "python3" "rack" ];
     withPAM = stdenv.isLinux;
     withSystemd = stdenv.isLinux;
   };


### PR DESCRIPTION
###### Motivation for this change

Plugins are just shared libraries. Enabling all supported plugins
makes it easier to use uwsgi without needing to recompile it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

