### PR TITLE
mupen64plus: 1.5 -> 2.5

### DIFF
--- a/pkgs/misc/emulators/mupen64plus/default.nix
+++ b/pkgs/misc/emulators/mupen64plus/default.nix
@@ -1,35 +1,27 @@
-{stdenv, fetchurl, which, pkgconfig, SDL, gtk2, mesa, SDL_ttf}:
+{stdenv, lib, fetchurl, boost, dash, freetype, libpng, pkgconfig, SDL, which, zlib }:
 
-stdenv.mkDerivation {
-  name = "mupen64plus-1.5";
+stdenv.mkDerivation rec {
+  name = "mupen64plus-${version}";
+  version = "2.5";
+
   src = fetchurl {
-    url = http://mupen64plus.googlecode.com/files/Mupen64Plus-1-5-src.tar.gz;
-    sha256 = "0gygfgyr2sg4yx77ijk133d1ra0v1yxi4xjxrg6kp3zdjmhdmcjq";
+    url = "https://github.com/mupen64plus/mupen64plus-core/releases/download/${version}/mupen64plus-bundle-src-${version}.tar.gz";
+    sha256 = "0rmsvfn4zfvbhz6gf1xkb7hnwflv6sbklwjz2xk4dlpj4vcbjxcw";
   };
 
-  buildInputs = [ which pkgconfig SDL gtk2 mesa SDL_ttf ];
+  buildInputs = [ boost dash freetype libpng pkgconfig SDL which zlib ];
 
-  hardeningDisable = [ "format" ];
-
-  preConfigure = ''
-    # Some C++ incompatibility fixes
-    sed -i -e 's|char \* extstr = strstr|const char * extstr = strstr|' glide64/Main.cpp
-    sed -i -e 's|char \* extstr = strstr|const char * extstr = strstr|' glide64/Combine.cpp
-
-    # Fix some hardcoded paths
-    sed -i -e "s|/usr/local|$out|g" main/main.c
-
-    # Remove PATH environment variable from install script
-    sed -i -e "s|export PATH=|#export PATH=|" ./install.sh
+  buildPhase = ''
+    dash m64p_build.sh PREFIX="$out" COREDIR="$out/lib/" PLUGINDIR="$out/lib/mupen64plus" SHAREDIR="$out/share/mupen64plus"
   '';
-
-  buildPhase = "make all";
-  installPhase = "PREFIX=$out make install";
+  installPhase = ''
+    dash m64p_install.sh DESTDIR="$out" PREFIX=""
+  '';
 
   meta = {
     description = "A Nintendo 64 Emulator";
     license = stdenv.lib.licenses.gpl2Plus;
-    homepage = http://code.google.com/p/mupen64plus;
+    homepage = http://www.mupen64plus.org/;
     maintainers = [ stdenv.lib.maintainers.sander ];
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18844,9 +18844,7 @@ with pkgs;
 
   mongoc = callPackage ../development/libraries/mongoc { };
 
-  mupen64plus = callPackage ../misc/emulators/mupen64plus {
-    stdenv = overrideCC stdenv gcc49;
-  };
+  mupen64plus = callPackage ../misc/emulators/mupen64plus { };
 
   mynewt-newt = callPackage ../tools/package-management/mynewt-newt { };
 


### PR DESCRIPTION
###### Motivation for this change

building with GCC6
getting zero hydra errors: https://github.com/NixOS/nixpkgs/issues/28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

