### PR TITLE
perl-ApacheTest: mark broken

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -229,6 +229,10 @@ let self = _self // overrides; _self = with self; {
       url = mirror://cpan/authors/id/P/PH/PHRED/Apache-Test-1.38.tar.gz;
       sha256 = "321717f58636ed0aa85cba6d69fc01e2ccbc90ba71ec2dcc2134d8401af65145";
     };
+    meta = {
+      # tests fail
+      broken = true;
+
   };
 
   AppCLI = buildPerlPackage {


### PR DESCRIPTION
###### Motivation for this change
Package does not build due to failing tests. Also tried version 1.40, same problem.
Unable to find out why the tests fail.  It could be that during the test phase, a `getprotobyname('tcp')` call fails in an unexpected manner.

A quick search on my side did not turn up any packages which depend on this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

