### PR TITLE
bitcoin-classic: 1.2.5 -> 1.3.6

### DIFF
--- a/pkgs/applications/altcoins/bitcoin-classic.nix
+++ b/pkgs/applications/altcoins/bitcoin-classic.nix
@@ -7,13 +7,13 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   name = "bitcoin" + (toString (optional (!withGui) "d")) + "-classic-" + version;
-  version = "1.2.5";
+  version = "1.3.6";
 
   src = fetchFromGitHub {
     owner = "bitcoinclassic";
     repo = "bitcoinclassic";
     rev = "v${version}";
-    sha256 = "00spils0gv8krx2nyxrf6j1dl81wmxk8xjkqc22cv7nsdnakzrvm";
+    sha256 = "129gkg035gv7zmc463jl2spvdh0fl4q8v4jdaslfnp34hbwi1p07";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, pkgs }:
+{ callPackage, boost155, boost162, boost163, openssl_1_1_0, haskellPackages }:
 
 rec {
 
@@ -8,8 +8,8 @@ rec {
   bitcoin-unlimited  = callPackage ./bitcoin-unlimited.nix { withGui = true; };
   bitcoind-unlimited = callPackage ./bitcoin-unlimited.nix { withGui = false; };
 
-  bitcoin-classic  = callPackage ./bitcoin-classic.nix { withGui = true; boost = pkgs.boost; };
-  bitcoind-classic = callPackage ./bitcoin-classic.nix { withGui = false; boost = pkgs.boost; };
+  bitcoin-classic  = callPackage ./bitcoin-classic.nix { withGui = true; boost = boost162; };
+  bitcoind-classic = callPackage ./bitcoin-classic.nix { withGui = false; boost = boost162; };
 
   bitcoin-xt  = callPackage ./bitcoin-xt.nix { withGui = true; };
   bitcoind-xt = callPackage ./bitcoin-xt.nix { withGui = false; };
@@ -22,12 +22,12 @@ rec {
   dogecoin  = callPackage ./dogecoin.nix { withGui = true; };
   dogecoind = callPackage ./dogecoin.nix { withGui = false; };
 
-  freicoin = callPackage ./freicoin.nix { boost = pkgs.boost155; };
+  freicoin = callPackage ./freicoin.nix { boost = boost155; };
   go-ethereum = callPackage ./go-ethereum.nix { };
   go-ethereum-classic = callPackage ./go-ethereum-classic { };
 
-  hivemind = callPackage ./hivemind.nix { withGui = true; boost = pkgs.boost162; };
-  hivemindd = callPackage ./hivemind.nix { withGui = false; boost = pkgs.boost162; };
+  hivemind = callPackage ./hivemind.nix { withGui = true; boost = boost162; };
+  hivemindd = callPackage ./hivemind.nix { withGui = false; boost = boost162; };
 
   litecoin  = callPackage ./litecoin.nix { withGui = true; };
   litecoind = callPackage ./litecoin.nix { withGui = false; };
@@ -43,7 +43,7 @@ rec {
   seth = callPackage ./seth.nix { };
   dapp = callPackage ./dapp.nix { };
 
-  hsevm = (pkgs.haskellPackages.callPackage ./hsevm.nix {});
+  hsevm = (haskellPackages.callPackage ./hsevm.nix {});
 
   primecoin  = callPackage ./primecoin.nix { withGui = true; };
   primecoind = callPackage ./primecoin.nix { withGui = false; };
@@ -52,7 +52,7 @@ rec {
 
   zcash = callPackage ./zcash {
     withGui = false;
-    openssl = pkgs.openssl_1_1_0;
-    boost = pkgs.boost163;
+    openssl = openssl_1_1_0;
+    boost = boost163;
   };
 }

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -8,8 +8,8 @@ rec {
   bitcoin-unlimited  = callPackage ./bitcoin-unlimited.nix { withGui = true; };
   bitcoind-unlimited = callPackage ./bitcoin-unlimited.nix { withGui = false; };
 
-  bitcoin-classic  = callPackage ./bitcoin-classic.nix { withGui = true; };
-  bitcoind-classic = callPackage ./bitcoin-classic.nix { withGui = false; };
+  bitcoin-classic  = callPackage ./bitcoin-classic.nix { withGui = true; boost = pkgs.boost; };
+  bitcoind-classic = callPackage ./bitcoin-classic.nix { withGui = false; boost = pkgs.boost; };
 
   bitcoin-xt  = callPackage ./bitcoin-xt.nix { withGui = true; };
   bitcoind-xt = callPackage ./bitcoin-xt.nix { withGui = false; };


### PR DESCRIPTION
###### Motivation for this change

zero hydra failures: https://github.com/NixOS/nixpkgs/issues/28643

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

