### PR TITLE
coin3d: include fix for newer compilers

### DIFF
--- a/pkgs/development/libraries/coin3d/default.nix
+++ b/pkgs/development/libraries/coin3d/default.nix
@@ -16,6 +16,9 @@ stdenv.mkDerivation rec {
       sha256 = "076dyc52swk8qc7ylps53fg6iqmd52x8s7m18i80x49dd109yw20";
     })
     ./gcc-4.8.patch # taken from FC-17 source rpm
+    # see https://bitbucket.org/Coin3D/coin/issues/128/crash-in-cc_memalloc_deallocate
+    # patch adapted from https://bitbucket.org/Coin3D/coin/pull-requests/75/added-fix-for-issue-128-provided-by-fedora/diff
+    ./sbhashentry.patch
   ];
 
   buildInputs = [ mesa ];

--- a/pkgs/development/libraries/coin3d/sbhashentry.patch
+++ b/pkgs/development/libraries/coin3d/sbhashentry.patch
@@ -1,0 +1,25 @@
+diff -u --label /tmp/Coin-3.1.3/src/misc/SbHash.h --label \#\<buffer\ SbHash.h\> /tmp/Coin-3.1.3/src/misc/SbHash.h /tmp/buffer-content-21756V0
+--- a/src/misc/SbHash.h
++++ b/src/misc/SbHash.h
+@@ -88,8 +88,8 @@
+     SbHashEntry<Type, Key> * entry = static_cast<SbHashEntry<Type, Key> *>( ptr);
+     cc_memalloc_deallocate(entry->memhandler, ptr);
+   }
+-  SbHashEntry(const Key & key, const Type & obj) : key(key), obj(obj) {}
+-
++  SbHashEntry(const Key & key, const Type & obj, cc_memalloc *memhandler)
++		: key(key), obj(obj), memhandler(memhandler) {}
+   Key key;
+   Type obj;
+   SbHashEntry<Type, Key> * next;
+@@ -218,7 +218,7 @@
+     /* Key not already in the hash table; insert a new
+      * entry as the first element in the bucket
+      */
+-    entry = new (this->memhandler) SbHashEntry<Type, Key>(key, obj);
++    entry = new (this->memhandler) SbHashEntry<Type, Key>(key, obj, this->memhandler);
+     entry->next = this->buckets[i];
+     this->buckets[i] = entry;
+
+
+Diff finished.  Sat Sep  9 19:50:32 2017


### PR DESCRIPTION
This manifests as a segfault in any applications that use the library.

###### Motivation for this change
Without this, FreeCAD just segfaults when started.  Thus, this is somehow also related to #28643, since FreeCAD builds, but does not run correctly without this.

###### Things done

Created a patch that fixes this issue.  See the comments in the commit for references.

1. Built FreeCAD without this patch and run -> segfault
2. Built FreeCAD and coin3d with this patch -> no segfault

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

