### PR TITLE
bitcoin-xt: 0.11F -> 0.11G2

### DIFF
--- a/pkgs/applications/altcoins/bitcoin-xt.nix
+++ b/pkgs/applications/altcoins/bitcoin-xt.nix
@@ -1,22 +1,22 @@
 { stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, openssl, db48, boost
-, zlib, miniupnpc, qt4, utillinux, protobuf, qrencode, curl
+, zlib, miniupnpc, qt4, utillinux, protobuf, qrencode, curl, libevent
 , withGui }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec{
 
   name = "bitcoin" + (toString (optional (!withGui) "d")) + "-xt-" + version;
-  version = "0.11F";
+  version = "0.11G2";
 
   src = fetchFromGitHub {
     owner = "bitcoinxt";
     repo = "bitcoinxt";
     rev = "v${version}";
-    sha256 = "13s5k9mxmlbf49p5hc546x20y5dslfp6g9hi6nw5yja5bngbwr24";
+    sha256 = "071rljvsabyc9j64v248qfb7zfqpfl84hpsnvlavin235zljq8qs";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
-  buildInputs = [ openssl db48 boost zlib
+  buildInputs = [ openssl db48 boost zlib libevent
                   miniupnpc utillinux protobuf curl ]
                   ++ optionals withGui [ qt4 qrencode ];
 

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -11,8 +11,8 @@ rec {
   bitcoin-classic  = callPackage ./bitcoin-classic.nix { withGui = true; };
   bitcoind-classic = callPackage ./bitcoin-classic.nix { withGui = false; };
 
-  bitcoin-xt  = callPackage ./bitcoin-xt.nix { withGui = true; };
-  bitcoind-xt = callPackage ./bitcoin-xt.nix { withGui = false; };
+  bitcoin-xt  = callPackage ./bitcoin-xt.nix { withGui = true; boost = pkgs.boost; };
+  bitcoind-xt = callPackage ./bitcoin-xt.nix { withGui = false; boost = pkgs.boost; };
 
   btc1 = callPackage ./btc1.nix { withGui = true; };
   btc1d = callPackage ./btc1.nix { withGui = false; };


### PR DESCRIPTION
###### Motivation for this change

zero hydra failures: https://github.com/NixOS/nixpkgs/issues/28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

