### PR TITLE
openafsClient: 1.6.20.2 -> 1.6.21

### DIFF
--- a/pkgs/servers/openafs-client/default.nix
+++ b/pkgs/servers/openafs-client/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "openafs-${version}-${kernel.version}";
-  version = "1.6.20.2";
+  version = "1.6.21";
 
   src = fetchurl {
     url = "http://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
-    sha256 = "50234820c3da9752d2ca05fb7e83b7dc5c96a0e96a0b875ebc7ae3c835607614";
+    sha256 = "ba9c1f615edd53b64fc271ad369c49a816acedca70cdd090975033469a84118f";
   };
 
   nativeBuildInputs = [ autoconf automake flex yacc perl which ];
@@ -47,6 +47,7 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = [ maintainers.z77z ];
     broken =
-      (builtins.compareVersions kernel.version  "3.18" == -1);
+      (builtins.compareVersions kernel.version  "3.18" == -1) ||
+      (builtins.compareVersions kernel.version "4.13" == 0);
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Fix build for linux kernel 4.12.

Does not build for 4.13


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Successfully built for linuxPackages_4_9 and linuxPackages_4_12.

No runtime test has been performed.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

