### PR TITLE
Minor fixes plus rework of submodule section

### DIFF
--- a/nixos/doc/manual/development/option-declarations.xml
+++ b/nixos/doc/manual/development/option-declarations.xml
@@ -137,8 +137,8 @@ services.xserver.displayManager.enable = mkOption {
 };</screen></example>
 
 <example xml:id='ex-option-declaration-eot-backend-sddm'><title>Extending
-    <literal>services.foo.backend</literal> in the <literal>sddm</literal>
-    module</title>
+    <literal>services.xserver.displayManager.enable</literal> in the 
+    <literal>sddm</literal> module</title>
 <screen>
 services.xserver.displayManager.enable = mkOption {
   type = with types; nullOr (enum [ "sddm" ]);

--- a/nixos/doc/manual/development/option-types.xml
+++ b/nixos/doc/manual/development/option-types.xml
@@ -175,7 +175,6 @@
 <example xml:id='ex-submodule-direct'><title>Directly defined submodule</title>
 <screen>
 options.mod = mkOption {
-  name = "mod";
   description = "submodule example";
   type = with types; listOf (submodule {
     options = {

--- a/nixos/doc/manual/development/option-types.xml
+++ b/nixos/doc/manual/development/option-types.xml
@@ -157,26 +157,26 @@
 
 <section xml:id='section-option-types-submodule'><title>Submodule</title>
 
-  <para>Submodule is a very powerful type that defines a set of sub-options that 
-    are handled like a separate module.
-    It is especially interesting when used with composed types like 
-    <literal>attrsOf</literal> or <literal>listOf</literal>.</para>
+  <para>Submodule is a very powerful type that defines a set of sub-options that
+    are handled like a separate module.</para>
 
-  <para>The submodule type take a parameter <replaceable>o</replaceable>, that 
-    should be a set, or a function returning a set with an 
-    <literal>options</literal> key defining the sub-options.
-    The option set can be defined directly (<xref linkend='ex-submodule-direct' 
-      />) or as reference (<xref linkend='ex-submodule-reference' />).</para>
+  <para>The <literal>submodule</literal> type takes a parameter
+    <replaceable>o</replaceable>, that should be a set, or a function returning a
+    set with an <literal>options</literal> key defining the sub-options.
+    Submodule option definitions are type-checked accordingly to the options
+    declarations.
+    It is possible to declare submodule options inside a submodule sub-options
+    for even higher modularity.</para>
 
-  <para>Submodule option definitions are type-checked accordingly to the options 
-    declarations. It is possible to declare submodule options inside a submodule 
-    sub-options for even higher modularity.</para>
+  <para>The option set can be defined directly
+    (<xref linkend='ex-submodule-direct' />) or as reference
+    (<xref linkend='ex-submodule-reference' />).</para>
 
 <example xml:id='ex-submodule-direct'><title>Directly defined submodule</title>
 <screen>
 options.mod = mkOption {
   description = "submodule example";
-  type = with types; listOf (submodule {
+  type = with types; submodule {
     options = {
       foo = mkOption {
         type = int;
@@ -185,10 +185,10 @@ options.mod = mkOption {
         type = str;
       };
     };
-  });
+  };
 };</screen></example>
 
-<example xml:id='ex-submodule-reference'><title>Submodule defined as a 
+<example xml:id='ex-submodule-reference'><title>Submodule defined as a
     reference</title>
 <screen>
 let
@@ -205,13 +205,16 @@ let
 in
 options.mod = mkOption {
   description = "submodule example";
-  type = with types; listOf (submodule modOptions);
+  type = with types; submodule modOptions;
 };</screen></example>
 
-<section><title>Composed with <literal>listOf</literal></title>
-
-  <para>When composed with <literal>listOf</literal>, submodule allows multiple 
-    definitions of the submodule option set.</para>
+  <para> The submodule type is especially interesting when used with composed
+    types like <literal>attrsOf</literal> or <literal>listOf</literal>.
+    When composed with <literal>listOf</literal>
+    (<xref linkend='ex-submodule-listof-declaration' />),
+    <literal>submodule</literal> allows multiple definitions of the submodule
+    option set (<xref linkend='ex-submodule-listof-definition' />).</para>
+    
 
 <example xml:id='ex-submodule-listof-declaration'><title>Declaration of a list 
     of submodules</title>
@@ -238,13 +241,11 @@ config.mod = [
   { foo = 2; bar = "two"; }
 ];</screen></example>
 
-</section>
-
-
-<section><title>Composed with <literal>attrsOf</literal></title>
-
-  <para>When composed with <literal>attrsOf</literal>, submodule allows multiple 
-    named definitions of the submodule option set.</para>
+  <para>When composed with <literal>attrsOf</literal>
+    (<xref linkend='ex-submodule-attrsof-declaration' />),
+    <literal>submodule</literal> allows multiple named definitions of the
+    submodule option set (<xref linkend='ex-submodule-attrsof-definition' />).
+  </para>
 
 <example xml:id='ex-submodule-attrsof-declaration'><title>Declaration of 
     attribute sets of submodules</title>
@@ -269,7 +270,6 @@ options.mod = mkOption {
 config.mod.one = { foo = 1; bar = "one"; };
 config.mod.two = { foo = 2; bar = "two"; };</screen></example>
 
-</section>
 </section>
 
 <section><title>Extending types</title>

--- a/nixos/doc/manual/development/option-types.xml
+++ b/nixos/doc/manual/development/option-types.xml
@@ -157,16 +157,16 @@
 
 <section xml:id='section-option-types-submodule'><title>Submodule</title>
 
-  <para>Submodule is a very powerful type that defines a set of sub-options that
-    are handled like a separate module.</para>
+  <para><literal>submodule</literal> is a very powerful type that defines a set
+    of sub-options that are handled like a separate module.</para>
 
-  <para>The <literal>submodule</literal> type takes a parameter
-    <replaceable>o</replaceable>, that should be a set, or a function returning a
-    set with an <literal>options</literal> key defining the sub-options.
-    Submodule option definitions are type-checked accordingly to the options
-    declarations.
-    It is possible to declare submodule options inside a submodule sub-options
-    for even higher modularity.</para>
+  <para>It takes a parameter <replaceable>o</replaceable>, that should be a set,
+    or a function returning a set with an <literal>options</literal> key
+    defining the sub-options.
+    Submodule option definitions are type-checked accordingly to the
+    <literal>options</literal> declarations.
+    Of course, you can nest submodule option definitons for even higher
+    modularity.</para>
 
   <para>The option set can be defined directly
     (<xref linkend='ex-submodule-direct' />) or as reference
@@ -208,8 +208,9 @@ options.mod = mkOption {
   type = with types; submodule modOptions;
 };</screen></example>
 
-  <para> The submodule type is especially interesting when used with composed
-    types like <literal>attrsOf</literal> or <literal>listOf</literal>.
+  <para>The <literal>submodule</literal> type is especially interesting when
+    used with composed types like <literal>attrsOf</literal> or
+    <literal>listOf</literal>.
     When composed with <literal>listOf</literal>
     (<xref linkend='ex-submodule-listof-declaration' />),
     <literal>submodule</literal> allows multiple definitions of the submodule
@@ -217,7 +218,7 @@ options.mod = mkOption {
     
 
 <example xml:id='ex-submodule-listof-declaration'><title>Declaration of a list 
-    of submodules</title>
+    nof submodules</title>
 <screen>
 options.mod = mkOption {
   description = "submodule example";


### PR DESCRIPTION
###### Motivation for this change

The minor fixes should be sefl-explanatory.

The submodule section was a bit awkward to read. (See comment to commit 48a4.) I also tried to correct the use of literal submodule, i.e. wrapping it into `<submodule>` tags when it referred to the submodule type and not the submodule concept. Not sure if I got that completely right, though.

I had to edit the first two examples. Please review them carefully.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

