### PR TITLE
znc: open firewall with configured port

### DIFF
--- a/nixos/modules/services/networking/znc.nix
+++ b/nixos/modules/services/networking/znc.nix
@@ -276,6 +276,14 @@ in
           '';
         };
 
+        openFirewall = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether to open ports in the firewall for ZNC.
+          '';
+        };
+
         passBlock = mkOption {
           example = defaultPassBlock;
           type = types.string;
@@ -350,7 +358,9 @@ in
 
   config = mkIf cfg.enable {
 
-    networking.firewall.allowedTCPPorts = [ cfg.port ];
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
 
     systemd.services.znc = {
       description = "ZNC Server";

--- a/nixos/modules/services/networking/znc.nix
+++ b/nixos/modules/services/networking/znc.nix
@@ -350,6 +350,8 @@ in
 
   config = mkIf cfg.enable {
 
+    networking.firewall.allowedTCPPorts = [ cfg.port ];
+
     systemd.services.znc = {
       description = "ZNC Server";
       wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
The configuration doesn't currently open the configured port, which is
less convenient than opening it.

###### Motivation for this change

I was confused that my IRC client was not connecting to the port until I manually opened the port in my firewall configuration separately. I think it would be better if the ZNC configuration itself ensured the port was opened.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

