### PR TITLE
go: buildGoPackage: 1.8 -> 1.9

### DIFF
--- a/pkgs/applications/networking/syncthing012/default.nix
+++ b/pkgs/applications/networking/syncthing012/default.nix
@@ -5,8 +5,6 @@ buildGoPackage rec {
   version = "0.12.15";
   rev = "v${version}";
 
-  buildFlags = "--tags noupgrade,release";
-  
   goPackagePath = "github.com/syncthing/syncthing";
 
   src = fetchFromGitHub {
@@ -21,5 +19,9 @@ buildGoPackage rec {
   postPatch = ''
     # Mostly a cosmetic change
     sed -i 's,unknown-dev,${version},g' cmd/syncthing/main.go
+  '';
+
+  preBuild = ''
+    export buildFlagsArray+=("-tags" "noupgrade release")
   '';
 }

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -123,7 +123,7 @@ go.stdenv.mkDerivation (
       [ -n "$excludedPackages" ] && echo "$d" | grep -q "$excludedPackages" && return 0
       local OUT
       if ! OUT="$(go $cmd $buildFlags "''${buildFlagsArray[@]}" -v $d 2>&1)"; then
-        if ! echo "$OUT" | grep -q 'no buildable Go source files'; then
+        if ! echo "$OUT" | grep -qE '(no( buildable| non-test)?|build constraints exclude all) Go (source )?files'; then
           echo "$OUT" >&2
           return 1
         fi

--- a/pkgs/tools/filesystems/gcsfuse/default.nix
+++ b/pkgs/tools/filesystems/gcsfuse/default.nix
@@ -3,15 +3,15 @@
 
 buildGoPackage rec {
   name = "gcsfuse-${version}";
-  version = "v0.19.0";
-  rev = "81281027c0093e3f916a6e611a128ec5c3a12ece";
+  version = "0.23.0";
+  rev = "v${version}";
 
   goPackagePath = "github.com/googlecloudplatform/gcsfuse";
 
   src = fetchgit {
     inherit rev;
     url = "https://github.com/googlecloudplatform/gcsfuse";
-    sha256 = "1lj9czippsgkhr8y3r7vwxgc8i952v76v1shdv10p43gsxwyyi9a";
+    sha256 = "1qxbpsmz22l5w4b7wbgfdq4v85cfc9ka9i8h4c56nals1x5lcsnx";
   };
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12008,7 +12008,10 @@ with pkgs;
 
   cifs-utils = callPackage ../os-specific/linux/cifs-utils { };
 
-  cockroachdb = callPackage ../servers/sql/cockroachdb { };
+  cockroachdb = callPackage ../servers/sql/cockroachdb {
+    # Go 1.9 build fails with "go1.8.* required (see CONTRIBUTING.md)".
+    buildGoPackage = buildGo18Package;
+  };
 
   conky = callPackage ../os-specific/linux/conky ({
     lua = lua5_1; # conky can use 5.2, but toluapp can not

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11121,7 +11121,7 @@ with pkgs;
     go = go_1_9;
   };
 
-  buildGoPackage = buildGo18Package;
+  buildGoPackage = buildGo19Package;
 
   go2nix = callPackage ../development/tools/go2nix { };
 


### PR DESCRIPTION
###### Motivation for this change

- gcsfuse 0.23.0 has become compatible with go1.9
- syncthing012: go1.9 requires that `-tags` are space separated
- envoy was broken before this change
- #29489

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
