### PR TITLE
haskell: fix build of attoparsec-data

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -15,6 +15,13 @@ with haskellLib;
 
 self: super: {
 
+  attoparsec-time_1 = super.attoparsec-time_1.override {
+    doctest = super.doctest_0_13_0;
+  };
+  attoparsec-data = super.attoparsec-data.override {
+    attoparsec-time = self.attoparsec-time_1;
+  };
+
   # This used to be a core package provided by GHC, but then the compiler
   # dropped it. We define the name here to make sure that old packages which
   # depend on this library still evaluate (even though they won't compile


### PR DESCRIPTION
@FPtje and me are fixing the Haskell failures in https://github.com/NixOS/nixpkgs/issues/28643 at the [Release sprint for NixOS 17.09](https://www.meetup.com/Amsterdam-Nix-Meetup/events/242002341/) in Amsterdam.

@peti this PR fixes: https://hydra.nixos.org/build/60421889

