### PR TITLE
pythonPackages.nilearn: 0.2.5 -> 0.3.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13288,7 +13288,7 @@ in {
   };
 
   nilearn = buildPythonPackage rec {
-    version = "0.2.5";
+    version = "0.3.1";
     name = "nilearn-${version}";
 
     # package seems to attempt Python 3 compatibility, but throws UnicodeDecodeError when building:
@@ -13296,7 +13296,7 @@ in {
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/n/nilearn/${name}.tar.gz";
-      sha256 = "1lmkrzr5x2yp129v2fvckrbdzf2kpcivdg9cacl519l3mb0acdv9";
+      sha256 = "0kkarh5cdcd2czs0bf0s1g51qas84mfxfq0dzd7k5h5l0qr4zy06";
     };
 
     checkPhase = "nosetests --exclude with_expand_user nilearn/tests";


### PR DESCRIPTION
###### Motivation for this change
Zero hydra failures #28643 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

