### PR TITLE
steam: Get rid of newStdcpp option, always on

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -5,16 +5,11 @@
 , extraPkgs ? pkgs: [ ] # extra packages to add to targetPkgs
 , nativeOnly ? false
 , runtimeOnly ? false
-, newStdcpp ? false
 }:
 
 let
   commonTargetPkgs = pkgs: with pkgs;
     let
-      primus2 = if newStdcpp then primus else primus.override {
-        stdenv = overrideInStdenv stdenv [ useOldCXXAbi ];
-        stdenv_i686 = overrideInStdenv pkgsi686Linux.stdenv [ useOldCXXAbi ];
-      };
       tzdir = "${pkgs.tzdata}/share/zoneinfo";
       # I'm not sure if this is the best way to add things like this
       # to an FHSUserEnv
@@ -38,7 +33,7 @@ let
       # Zoneinfo
       etc-zoneinfo
     ] ++ lib.optional withJava jdk
-      ++ lib.optional withPrimus primus2
+      ++ lib.optional withPrimus primus
       ++ extraPkgs pkgs;
 
 in buildFHSUserEnv rec {
@@ -68,7 +63,7 @@ in buildFHSUserEnv rec {
     xlibs.libpciaccess
 
     (steamPackages.steam-runtime-wrapped.override {
-      inherit nativeOnly runtimeOnly newStdcpp;
+      inherit nativeOnly runtimeOnly;
     })
   ];
 

--- a/pkgs/games/steam/runtime-wrapped.nix
+++ b/pkgs/games/steam/runtime-wrapped.nix
@@ -1,11 +1,9 @@
 { stdenv, lib, perl, pkgs, steam-runtime
 , nativeOnly ? false
 , runtimeOnly ? false
-, newStdcpp ? false
 }:
 
 assert !(nativeOnly && runtimeOnly);
-assert newStdcpp -> !runtimeOnly;
 
 let 
   runtimePkgs = with pkgs; [
@@ -79,7 +77,7 @@ let
     SDL2_mixer
     gstreamer
     gst-plugins-base
-  ] ++ lib.optional (!newStdcpp) gcc48.cc;
+  ];
 
   overridePkgs = with pkgs; [
     libgpgerror
@@ -88,7 +86,8 @@ let
     openalSoft
     libva
     vulkan-loader
-  ] ++ lib.optional newStdcpp gcc.cc;
+    gcc.cc
+  ];
 
   ourRuntime = if runtimeOnly then []
                else if nativeOnly then runtimePkgs ++ overridePkgs


### PR DESCRIPTION
###### Motivation for this change
#25957 
When running without dedicated acceleration (which is common in hybrid graphics laptop setups) it appears it's no longer possible to *not* use `newStdcpp`. This PR makes it the only possibility. This requires testing from someone running with a dedicated setup, I will attempt to find such a person to test it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

