### PR TITLE
haskellPackages.ghc-proofs: Disable hydra builds for ghc<8.2

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-6.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-6.12.x.nix
@@ -49,6 +49,9 @@ self: super: {
   transformers = self.transformers_0_4_3_0;
   xhtml = self.xhtml_3000_2_1;
 
+  # Requires ghc 8.2
+  ghc-proofs = dontDistribute super.ghc-proofs;
+
   # We have no working cabal-install at the moment.
   cabal-install = markBroken super.cabal-install;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.0.x.nix
@@ -43,6 +43,9 @@ self: super: {
   transformers = self.transformers_0_4_3_0;
   xhtml = self.xhtml_3000_2_1;
 
+  # Requires ghc 8.2
+  ghc-proofs = dontDistribute super.ghc-proofs;
+
   # https://github.com/tibbe/hashable/issues/85
   hashable = dontCheck super.hashable;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -48,6 +48,9 @@ self: super: {
     sha256 = "193i1xmq6z0jalwmq0mhqk1khz6zz0i1hs6lgfd7ybd6qyaqnf5f";
   });
 
+  # Requires ghc 8.2
+  ghc-proofs = dontDistribute super.ghc-proofs;
+
   # haddock: No input file(s).
   nats = dontHaddock super.nats;
   bytestring-builder = dontHaddock super.bytestring-builder;

--- a/pkgs/development/haskell-modules/configuration-ghc-7.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.2.x.nix
@@ -44,6 +44,9 @@ self: super: {
   # https://github.com/haskell/cabal/issues/2322
   Cabal_1_22_4_0 = super.Cabal_1_22_4_0.override { binary = self.binary_0_8_5_1; process = self.process_1_2_3_0; };
 
+  # Requires ghc 8.2
+  ghc-proofs = dontDistribute super.ghc-proofs;
+
   # https://github.com/tibbe/hashable/issues/85
   hashable = dontCheck super.hashable;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.4.x.nix
@@ -46,6 +46,9 @@ self: super: {
   # Avoid inconsistent 'binary' versions from 'text' and 'Cabal'.
   cabal-install = super.cabal-install.overrideScope (self: super: { binary = dontCheck self.binary_0_8_5_1; });
 
+  # Requires ghc 8.2
+  ghc-proofs = dontDistribute super.ghc-proofs;
+
   # https://github.com/tibbe/hashable/issues/85
   hashable = dontCheck super.hashable;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.6.x.nix
@@ -42,6 +42,9 @@ self: super: {
   # Avoid inconsistent 'binary' versions from 'text' and 'Cabal'.
   cabal-install = super.cabal-install.overrideScope (self: super: { binary = dontCheck self.binary_0_8_5_1; });
 
+  # Requires ghc 8.2
+  ghc-proofs = dontDistribute super.ghc-proofs;
+
   # https://github.com/tibbe/hashable/issues/85
   hashable = dontCheck super.hashable;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
@@ -37,6 +37,9 @@ self: super: {
   unix = null;
   xhtml = null;
 
+  # Requires ghc 8.2
+  ghc-proofs = dontDistribute super.ghc-proofs;
+
   # https://github.com/peti/jailbreak-cabal/issues/9
   jailbreak-cabal = super.jailbreak-cabal.override { Cabal = self.Cabal_1_20_0_4; };
 

--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -44,6 +44,9 @@ self: super: {
     sha256 = "026vv2k3ks73jngwifszv8l59clg88pcdr4mz0wr0gamivkfa1zy";
   });
 
+  # Requires ghc 8.2
+  ghc-proofs = dontDistribute super.ghc-proofs;
+
   # http://hub.darcs.net/dolio/vector-algorithms/issue/9#comment-20170112T145715
   vector-algorithms = dontCheck super.vector-algorithms;
 


### PR DESCRIPTION
###### Motivation for this change
`haskellPackages.ghc-proofs` requires ghc between `8.2` and `8.4`. Building them for any other version of ghc is senseless

###### Things done

Built several versions using `nix-build`. The ghc 8.2 version compiles. The others still don't, but at least they shouldn't cause failures in hydra.

https://github.com/NixOS/nixpkgs/issues/28643
