### PR TITLE
haskell: fix grakn-0.2.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -908,4 +908,6 @@ self: super: {
   # https://github.com/jtdaugherty/text-zipper/issues/11
   text-zipper = dontCheck super.text-zipper;
 
+  # https://github.com/graknlabs/grakn-haskell/pull/1
+  grakn = dontCheck (doJailbreak super.grakn);
 }


### PR DESCRIPTION
@peti this fixes the [build of grakn](https://hydra.nixos.org/build/60422279).