### PR TITLE
oprofile: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/tools/profiling/oprofile/default.nix
+++ b/pkgs/development/tools/profiling/oprofile/default.nix
@@ -5,11 +5,11 @@
 assert withGUI -> qt4 != null;
 
 stdenv.mkDerivation rec {
-  name = "oprofile-1.1.0";
+  name = "oprofile-1.2.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/oprofile/${name}.tar.gz";
-    sha256 = "0v1nn38h227bgxjwqf22rjp2iqgjm4ls3gckzifks0x6w5nrlxfg";
+    sha256 = "0zd5ih6gmm1pkqavd9laa93iff7qv5jkbfjznhlyxl5p826gk5gb";
   };
 
   buildInputs = [ binutils zlib popt pkgconfig linuxHeaders libiberty_static ]

--- a/pkgs/development/tools/profiling/oprofile/default.nix
+++ b/pkgs/development/tools/profiling/oprofile/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, binutils, popt, zlib, pkgconfig, linuxHeaders
+{ stdenv, fetchurl, binutils, popt, zlib, pkgconfig, linuxHeaders, coreutils
 , libiberty_static, withGUI ? false , qt4 ? null}:
 
 # libX11 is needed because the Qt build stuff automatically adds `-lX11'.
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/oprofile/${name}.tar.gz";
     sha256 = "0zd5ih6gmm1pkqavd9laa93iff7qv5jkbfjznhlyxl5p826gk5gb";
   };
+
+  postPatch = ''
+    substituteInPlace opjitconv/opjitconv.c \
+      --replace "/bin/rm" "${coreutils}/bin/rm" \
+      --replace "/bin/cp" "${coreutils}/bin/cp"
+  '';
 
   buildInputs = [ binutils zlib popt pkgconfig linuxHeaders libiberty_static ]
     ++ stdenv.lib.optionals withGUI [ qt4 ];


### PR DESCRIPTION
###### Motivation for this change

The build failed for release 17.09 . The newer version includes bug fixes when compiling with newer gcc version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

