### PR TITLE
python.pkgs.recaptcha-client: disable broken versions

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18890,6 +18890,8 @@ in {
       sha256 = "28c6853c1d13d365b7dc71a6b05e5ffb56471f70a850de318af50d3d7c0dea2f";
     };
 
+    disabled = isPy35 || isPy36;
+
     meta = {
       description = "A CAPTCHA for Python using the reCAPTCHA service";
       homepage = http://recaptcha.net/;


### PR DESCRIPTION
It seems that the recaptcha-client package is no longer maintained.

* The latest released version (1.0.6) is from the year 2011;
* The project page does not mention which Python versions are supported
* The project is hosted on google code, which is discontinued, e.g. making it impossible to create an issue asking about which Python versions are supported.

I was able to successfully build with Python versions 3.3, 3.4, but not
3.5, 3.6.

###### Motivation for this change

The package was showing as broken on Hydra.

The package initially broke on a missing dependency on Crypto, but was broken even after that, e.g.

The package imports `urllib2`, but 

> The urllib2 module has been split across several modules in Python 3 named urllib.request and urllib.error. The 2to3 tool will automatically adapt imports when converting your sources to Python 3.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).