### PR TITLE
tests/elk: Fixed failing build on i686.

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -240,7 +240,7 @@ in rec {
   tests.etcd = hydraJob (import tests/etcd.nix { system = "x86_64-linux"; });
   tests.ec2-nixops = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-nixops;
   tests.ec2-config = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-config;
-  tests.elk = callTest tests/elk.nix {};
+  tests.elk = hydraJob (import tests/elk.nix { system = "x86_64-linux"; });
   tests.env = callTest tests/env.nix {};
   tests.ferm = callTest tests/ferm.nix {};
   tests.firefox = callTest tests/firefox.nix {};


### PR DESCRIPTION
###### Motivation for this change
Too much memory is required for the test. See: https://hydra.nixos.org/build/60147911


###### Things done
`nix-build nixos/release.nix -A tests.elk`
