### PR TITLE
Trying a less disruptive patch for Cuneiform

### DIFF
--- a/pkgs/tools/graphics/cuneiform/default.nix
+++ b/pkgs/tools/graphics/cuneiform/default.nix
@@ -1,18 +1,24 @@
-{ stdenv, fetchbzr, cmake, patchelf, imagemagick }:
+{ stdenv, fetchurl, cmake, patchelf, imagemagick }:
 
 stdenv.mkDerivation rec {
   name = "cuneiform-${version}";
   version = "1.1.0";
 
-  src = fetchbzr {
-    url = "lp:~f0ma/cuneiform-linux/devel";
-    rev = "540";
-    sha256 = "0sj7v3plf2rrc2vzxl946h9yfribc0jfn4b3ffppghxk2g6kicsb";
+  src = fetchurl {
+    url = "https://launchpad.net/cuneiform-linux/1.1/1.1/+download/cuneiform-linux-1.1.0.tar.bz2";
+    sha256 = "1bdvppyfx2184zmzcylskd87cxv56d8f32jf7g1qc8779l2hszjp";
   };
 
-  buildInputs = [
-    cmake imagemagick
+  patches = [
+  (fetchurl {
+    url = "https://git.archlinux.org/svntogit/community.git/plain/cuneiform/trunk/build-fix.patch?id=a2ec92f05de006b56d16ac6a6c370d54a554861a";
+    sha256 = "19cmrlx4khn30qqrpyayn7bicg8yi0wpz1x1bvqqrbvr3kwldxyj";
+  })
   ];
+
+  buildInputs = [ imagemagick ];
+
+  nativeBuildInputs = [ cmake ];
 
   meta = {
     description = "Multi-language OCR system";


### PR DESCRIPTION
###### Motivation for this change

The package pyocr is broken on Hydra.

While investigating this, I ran into the following [discussion](https://github.com/NixOS/nixpkgs/commit/48a941e29faa95e897fda56e55415f9bb57660f3) and [apparent solution on master](https://github.com/NixOS/nixpkgs/commit/491f5be49b9b802962f698fe77835f4647b34b38)

However, the fix was not cherry-picked to the 17.09 branch yet. 

The present PR does so; I've tested it by building cuneiform and the pyocr package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
