### PR TITLE
haskell: introduce failOnAllWarnings

### DIFF
--- a/doc/languages-frameworks/haskell.md
+++ b/doc/languages-frameworks/haskell.md
@@ -875,12 +875,17 @@ to your own Haskell packages and integrate that in a Continuous Integration
 server like [hydra](https://nixos.org/hydra/) to assure your packages maintain a
 minimum level of quality. This section discusses some of these functions.
 
+#### failOnAllWarnings
+
+Applying `haskell.lib.failOnAllWarnings` to a Haskell package enables the
+`-Wall` and `-Werror` GHC options to turn all warnings into build failures.
+
 #### buildStrictly
 
-Applying `haskell.lib.buildStrictly` to a Haskell package enables the `-Wall`
-and `-Werror` GHC options to turn all warnings into build failures. Additionally
-the source of your package is gotten from first invoking `cabal sdist` to ensure
-all needed files are listed in the Cabal file.
+Applying `haskell.lib.buildStrictly` to a Haskell package calls
+`failOnAllWarnings` on the given package to turn all warnings into build
+failures. Additionally the source of your package is gotten from first invoking
+`cabal sdist` to ensure all needed files are listed in the Cabal file.
 
 #### checkUnusedPackages
 

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -117,7 +117,9 @@ rec {
     '';
   });
 
-  buildStrictly = pkg: buildFromSdist (appendConfigureFlag pkg "--ghc-option=-Wall --ghc-option=-Werror");
+  buildStrictly = pkg: buildFromSdist (failOnAllWarnings pkg);
+
+  failOnAllWarnings = drv: appendConfigureFlag drv "--ghc-option=-Wall --ghc-option=-Werror";
 
   checkUnusedPackages =
     { ignoreEmptyImports ? false


### PR DESCRIPTION
@peti applying `haskell.lib.failOnAllWarnings` to a Haskell package enables the `-Wall` and `-Werror` GHC options to turn all warnings into build failures.
