### PR TITLE
mpich2: 1.4 -> 3.2

### DIFF
--- a/pkgs/development/libraries/mpich2/default.nix
+++ b/pkgs/development/libraries/mpich2/default.nix
@@ -1,33 +1,17 @@
 { stdenv, fetchurl, python, perl, gfortran }:
 
-let version = "1.4"; in
-stdenv.mkDerivation {
-  name = "mpich2-${version}";
+stdenv.mkDerivation  rec {
+  name = "mpich-${version}";
+  version = "3.2";
 
   src = fetchurl {
-    url = "http://www.mcs.anl.gov/research/projects/mpich2/downloads/tarballs/${version}/mpich2-${version}.tar.gz";
+    url = "http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz";
     sha256 = "0bvvk4n9g4rmrncrgs9jnkcfh142i65wli5qp1akn9kwab1q80z6";
   };
 
   configureFlags = "--enable-shared --enable-sharedlib";
 
-  buildInputs = [ python perl gfortran ];
-  propagatedBuildInputs = stdenv.lib.optional (stdenv ? glibc) stdenv.glibc;
-
-  patchPhase =
-    '' for i in $(find -type f -not -name Makefile.\*)
-       do
-         if grep -q /usr/bin/env "$i"
-         then
-             interpreter="$(cat $i | grep /usr/bin/env | sed -'es|^.*/usr/bin/env \([^ ]\+\).*$|\1|g')"
-             echo "file \`$i' -> interpreter \`$interpreter'"
-             path="$(type -P $interpreter)"
-             echo "\`/usr/bin/env $interpreter' -> \`$path' in \`$i'..."
-             sed -i "$i" -e "s|/usr/bin/env $interpreter|$path|g"
-         fi
-       done
-       true
-    '';
+  buildInputs = [ perl gfortran ];
 
   meta = {
     description = "Implementation of the Message Passing Interface (MPI) standard";


### PR DESCRIPTION
###### Motivation for this change
Encountered this as a dependency while trying to upgrade ParaView to a newer version.

###### Things done

Built locally.  Did not test any of the existing packages which might depend on that.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

