### PR TITLE
PyBrain: Mark as broken

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27081,6 +27081,7 @@ EOF
       description = "Modular Machine Learning Library for Python";
       license = licenses.bsd3;
       maintainers = with maintainers; [ NikolaMandic ];
+      broken = true;
     };
   };
 


### PR DESCRIPTION
It's broken on all versions of Python (I've tried 2.7, 3.4, 3.5, 3.6)

I think the root cause is that PyBrain is not working with numpy >= 1.12.0 as I reported here:
https://github.com/pybrain/pybrain/issues/217

(The relevant release notes may be found here):
https://docs.scipy.org/doc/numpy-1.12.0/release.html#compatibility-notes

The PyBrain github repo does not seem very active (last commit 18 months ago, last release 3 years),
so I have some doubts as to whether this will be fixed any time soon.

I suppose an alternative solution could be to reintroduce the explicit dependency to numpy 1.11. But,
this is not entirely trivial: in c9b4a2f31991, the versions 1.10, 1.11, 1.12 were folded into a single version.
Also, the numpy dependency is not a direct one, but is implied via scipy

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

