### PR TITLE
python-unicorn: include explicit dependency on python 2 during build

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27498,6 +27498,7 @@ EOF
       sha256 = "0a5b4vh734b3wfkgapzzf8x18rimpmzvwwkly56da84n27wfw9bg";
     };
     setupPyBuildFlags = [ "--plat-name" "linux" ];
+    buildInputs = [ pkgs.python2 ];
     meta = with pkgs.stdenv.lib; {
       description = "Unicorn CPU emulator engine";
       homepage = "http://www.unicorn-engine.org/";


### PR DESCRIPTION
... even (or rather: specifically) when building for Python 3.

As noted in the COMPILE instructions:

https://github.com/unicorn-engine/unicorn/blob/363cbacee4c54051bc9a8e717ccbbcb276c1356d/docs/COMPILE-NIX.md

> Unicorn requires Python 2.x to compile.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

