### PR TITLE
NixOS Manual: document assertions and warnings

### DIFF
--- a/nixos/doc/manual/configuration/summary.xml
+++ b/nixos/doc/manual/configuration/summary.xml
@@ -113,7 +113,8 @@ manual</link> for the rest.</para>
       </row>
       <row>
         <entry><literal>assert 1 + 1 == 2; "yes!"</literal></entry>
-        <entry>Assertion check (evaluates to <literal>"yes!"</literal>)</entry>
+        <entry>Assertion check (evaluates to <literal>"yes!"</literal>). See <xref
+    linkend="sec-assertions"/> for using assertions in modules</entry>
       </row>
       <row>
         <entry><literal>let x = "foo"; y = "bar"; in x + y</literal></entry>

--- a/nixos/doc/manual/development/assertions.xml
+++ b/nixos/doc/manual/development/assertions.xml
@@ -1,0 +1,75 @@
+<section xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xi="http://www.w3.org/2001/XInclude"
+        version="5.0"
+        xml:id="sec-assertions">
+
+<title>Warnings and Assertions</title>
+
+<para>
+  When configuration problems are detectable in a module, it is a good
+  idea to write an assertion or warning. Doing so provides clear
+  feedback to the user and prevents errors after the build.
+</para>
+
+<para>
+  Although Nix has the <literal>abort</literal> and
+  <literal>builtins.trace</literal> <link xlink:href="https://nixos.org/nix/manual/#ssec-builtins">functions</link> to perform such tasks,
+  they are not ideally suited for NixOS modules. Instead of these
+  functions, you can declare your warnings and assertions using the
+  NixOS module system.
+</para>
+
+<section>
+
+<title>Warnings</title>
+
+<para>
+  This is an example of using <literal>warnings</literal>.
+</para>
+
+<programlisting>
+<![CDATA[
+{ config, lib, ... }:
+{
+  config = lib.mkIf config.services.foo.enable {
+    warnings =
+      if config.services.foo.bar
+      then [ ''You have enabled the bar feature of the foo service.
+               This is known to cause some specific problems in certain situations.
+               '' ]
+      else [];
+  }
+}
+]]>
+</programlisting>
+
+</section>
+
+<section>
+
+<title>Assertions</title>
+
+
+<para>
+  This example, extracted from the <link xlink:href="https://github.com/NixOS/nixpkgs/blob/release-17.09/nixos/modules/services/logging/syslogd.nix"><literal>syslogd</literal> module</link> shows how to use <literal>assertions</literal>. Since there can only be one active syslog daemon at a time, an assertion is useful to prevent such a broken system from being built.
+</para>
+
+<programlisting>
+<![CDATA[
+{ config, lib, ... }:
+{
+  config = lib.mkIf config.services.syslogd.enable {
+    assertions =
+      [ { assertion = !config.services.rsyslogd.enable;
+          message = "rsyslogd conflicts with syslogd";
+        }
+      ];
+  }
+}
+]]>
+</programlisting>
+
+</section>
+
+</section>

--- a/nixos/doc/manual/development/assertions.xml
+++ b/nixos/doc/manual/development/assertions.xml
@@ -52,7 +52,12 @@
 
 
 <para>
-  This example, extracted from the <link xlink:href="https://github.com/NixOS/nixpkgs/blob/release-17.09/nixos/modules/services/logging/syslogd.nix"><literal>syslogd</literal> module</link> shows how to use <literal>assertions</literal>. Since there can only be one active syslog daemon at a time, an assertion is useful to prevent such a broken system from being built.
+  This example, extracted from the
+  <link xlink:href="https://github.com/NixOS/nixpkgs/blob/release-17.09/nixos/modules/services/logging/syslogd.nix">
+    <literal>syslogd</literal> module
+  </link> shows how to use <literal>assertions</literal>. Since there
+  can only be one active syslog daemon at a time, an assertion is useful to
+  prevent such a broken system from being built.
 </para>
 
 <programlisting>

--- a/nixos/doc/manual/development/writing-modules.xml
+++ b/nixos/doc/manual/development/writing-modules.xml
@@ -178,6 +178,7 @@ in {
 <xi:include href="option-declarations.xml" />
 <xi:include href="option-types.xml" />
 <xi:include href="option-def.xml" />
+<xi:include href="assertions.xml" />
 <xi:include href="meta-attributes.xml" />
 <xi:include href="replace-modules.xml" />
 


### PR DESCRIPTION
###### Motivation for this change

assertions and warnings in NixOS modules were not documented yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

