### PR TITLE
desmume: fix build with gcc6 by adding debian patch

### DIFF
--- a/pkgs/misc/emulators/desmume/default.nix
+++ b/pkgs/misc/emulators/desmume/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl
+{ stdenv, fetchurl, fetchpatch
 , pkgconfig, libtool, intltool
 , libXmu
 , lua
@@ -17,6 +17,14 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/project/desmume/desmume/${version}/${name}.tar.gz";
     sha256 = "15l8wdw3q61fniy3h93d84dnm6s4pyadvh95a0j6d580rjk4pcrs";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "gcc6_fixes.patch";
+      url = "https://anonscm.debian.org/viewvc/pkg-games/packages/trunk/desmume/debian/patches/gcc6_fixes.patch?revision=15925";
+      sha256 = "0j3fmxz0mfb3f4biks03pyz8f9hy958ks6qplisl60rzq9v9qpks";
+     })
+  ];
 
   buildInputs =
   [ pkgconfig libtool intltool libXmu lua agg alsaLib soundtouch


### PR DESCRIPTION
###### Motivation for this change

The build failed in the 17.09 release branch. The reason is the switch to gcc6.
Debian already provided a patch but also removed the package from debian testing where gcc7 is used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

