### PR TITLE
dmenu-wayland: git-2014-11-02 -> git-2017-04-07 fix build

### DIFF
--- a/pkgs/applications/misc/dmenu/wayland.nix
+++ b/pkgs/applications/misc/dmenu/wayland.nix
@@ -6,12 +6,12 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "dmenu-wayland-${version}";
-  version = "git-2014-11-02";
-  rev = "6e08b77428cc3c406ed2e90d4cae6c41df76341e";
+  version = "git-2017-04-07";
+  rev = "f385d9d18813071b4b4257bf8d4d572daeda0e70";
 
   src = fetchurl {
     url = "https://github.com/michaelforney/dmenu/archive/${rev}.tar.gz";
-    sha256 = "d0f73e442baf44a93a3b9d41a72e9cfa14f54af6049c90549f516722e3f88019";
+    sha256 = "0y1jvh2815c005ns0bsjxsmz82smw22n6jsfg2g03a1pacakp6ys";
   };
 
   buildInputs = [ swc wld wayland libxkbcommon pixman fontconfig ];
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   preConfigure = [
-    ''sed -i "s@PREFIX = /usr/local@PREFIX = $out@g; s@/usr/share/swc@$(echo "$nativeBuildInputs" | grep -o '[^ ]*-swc-[^ ]*')/share/swc@g" config.mk''
+    ''sed -i "s@PREFIX = /usr/local@PREFIX = $out@g; s@/usr/share/swc@${swc}/share/swc@g" config.mk''
   ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Didn't build for release branch 17.09 . Bumped version and fixed substitution for package to build successfully.
I did test the execution of the binaries but not the proper function of the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

