### PR TITLE
graylogPlugins: update existing and add new plugins

### DIFF
--- a/pkgs/tools/misc/graylog/plugins.nix
+++ b/pkgs/tools/misc/graylog/plugins.nix
@@ -25,10 +25,10 @@ in {
   aggregates = glPlugin rec {
     name = "graylog-aggregates-${version}";
     pluginName = "graylog-plugin-aggregates";
-    version = "1.1.1";
+    version = "2.0.0";
     src = fetchurl {
       url = "https://github.com/cvtienhoven/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
-      sha256 = "1wx5i8ls7dgffsy35i91gkrj6p9nh2jbar9pgas190lfb9yk45bx";
+      sha256 = "0crgb49msjkvfpksbfhq2hlkc904j184wm1wp6q0x6lzhn07hm8y";
     };
     meta = {
       homepage = https://github.com/cvtienhoven/graylog-plugin-aggregates;
@@ -48,13 +48,39 @@ in {
       description = "SSO support for Graylog through trusted HTTP headers set by load balancers or authentication proxies";
     };
   };
+  dnsresolver = glPlugin rec {
+    name = "graylog-dnsresolver-${version}";
+    pluginName = "graylog-plugin-dnsresolver";
+    version = "1.1.2";
+    src = fetchurl {
+      url = "https://github.com/graylog-labs/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      sha256 = "01s7wm6bwcpmdrl35gjp6rrqxixs2s9km2bdgzhv8pn25j5qnw28";
+    };
+    meta = {
+      homepage = https://github.com/graylog-labs/graylog-plugin-dnsresolver;
+      description = "Message filter plugin can be used to do DNS lookups for the source field in Graylog messages";
+    };
+  };
+  filter-messagesize = glPlugin rec {
+    name = "graylog-filter-messagesize-${version}";
+    pluginName = "graylog-plugin-filter-messagesize";
+    version = "0.0.2";
+    src = fetchurl {
+      url = "https://github.com/graylog-labs/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      sha256 = "1vx62yikd6d3lbwsfiyf9j6kx8drvn4xhffwv27fw5jzhfqr61ji";
+    };
+    meta = {
+      homepage = https://github.com/graylog-labs/graylog-plugin-filter-messagesize;
+      description = "Prints out all messages that have an estimated size crossing a configured threshold during processing";
+    };
+  };
   internal-logs = glPlugin rec {
     name = "graylog-internal-logs-${version}";
     pluginName = "graylog-plugin-internal-logs";
-    version = "1.0.0";
+    version = "2.3.0";
     src = fetchurl {
       url = "https://github.com/graylog-labs/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
-      sha256 = "1abl7wwr59k9vvr2fmrlrx4ipsjjl8xryqy19fy5irxhpwp93ixl";
+      sha256 = "05r4m2gf1hj1b889rmpb6b5a6q2xd0qkl1rpj107yd219j2grzf4";
     };
     meta = {
       homepage = https://github.com/graylog-labs/graylog-plugin-internal-logs;
@@ -66,11 +92,11 @@ in {
     pluginName = "graylog-plugin-ipanonymizer";
     version = "1.1.2";
     src = fetchurl {
-      url = "https://github.com/Graylog2/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      url = "https://github.com/graylog-labs/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
       sha256 = "0hd66751hp97ddkn29s1cmjmc2h1nrp431bq7d2wq16iyxxlygri";
     };
     meta = {
-      homepage = https://github.com/Graylog2/graylog-plugin-ipanonymizer;
+      homepage = https://github.com/graylog-labs/graylog-plugin-ipanonymizer;
       description = "A graylog-server plugin that replaces the last octet of IP addresses in messages with xxx";
     };
   };
@@ -85,6 +111,19 @@ in {
     meta = {
       homepage = https://github.com/graylog-labs/graylog-plugin-jabber;
       description = "Jabber Alarmcallback Plugin for Graylog";
+    };
+  };
+  metrics = glPlugin rec {
+    name = "graylog-metrics-${version}";
+    pluginName = "graylog-plugin-metrics";
+    version = "1.3.0";
+    src = fetchurl {
+      url = "https://github.com/graylog-labs/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      sha256 = "1v1yzmqp43kxigh3fymdwki7pn21sk2ym3kk4nn4qv4zzkhz59vp";
+    };
+    meta = {
+      homepage = https://github.com/graylog-labs/graylog-plugin-metrics;
+      description = "An output plugin for integrating Graphite, Ganglia and StatsD with Graylog";
     };
   };
   mongodb-profiler = glPlugin rec {
@@ -113,6 +152,19 @@ in {
       description = "Graylog NetFlow plugin";
     };
   };
+  pagerduty = glPlugin rec {
+    name = "graylog-pagerduty-${version}";
+    pluginName = "graylog-plugin-pagerduty";
+    version = "1.3.0";
+    src = fetchurl {
+      url = "https://github.com/graylog-labs/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      sha256 = "1g63c6rm5pkz7f0d73wb2lmk4zm430jqnhihbyq112cm4i7ymglh";
+    };
+    meta = {
+      homepage = https://github.com/graylog-labs/graylog-plugin-pagerduty;
+      description = "An alarm callback plugin for integrating PagerDuty into Graylog";
+    };
+  };
   redis = glPlugin rec {
     name = "graylog-redis-${version}";
     pluginName = "graylog-plugin-redis";
@@ -126,16 +178,29 @@ in {
       description = "Redis plugin for Graylog";
     };
   };
+  slack = glPlugin rec {
+    name = "graylog-slack-${version}";
+    pluginName = "graylog-plugin-slack";
+    version = "2.4.0";
+    src = fetchurl {
+      url = "https://github.com/graylog-labs/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      sha256 = "0v8ilfhs8bnx87pjxg1i3p2vxw61rwpg4k3zhga7slavx70y986p";
+    };
+    meta = {
+      homepage = https://github.com/graylog-labs/graylog-plugin-slack;
+      description = "Can notify Slack or Mattermost channels about triggered alerts in Graylog (Alarm Callback)";
+    };
+  };
   spaceweather = glPlugin rec {
     name = "graylog-spaceweather-${version}";
     pluginName = "graylog-plugin-spaceweather";
     version = "1.0";
     src = fetchurl {
-      url = "https://github.com/Graylog2/${pluginName}/releases/download/${version}/spaceweather-input.jar";
+      url = "https://github.com/graylog-labs/${pluginName}/releases/download/${version}/spaceweather-input.jar";
       sha256 = "1mwqy3fhyy4zdwyrzvbr565xwf96xs9d3l70l0khmrm848xf8wz4";
     };
     meta = {
-      homepage = https://github.com/Graylog2/graylog-plugin-spaceweather;
+      homepage = https://github.com/graylog-labs/graylog-plugin-spaceweather;
       description = "Correlate proton density to the response time of your app and the ion temperature to your exception rate.";
     };
   };
@@ -152,16 +217,29 @@ in {
       description = "Graylog Processing Pipeline functions to enrich log messages with IoC information from threat intelligence databases";
     };
   };
+  twiliosms = glPlugin rec {
+    name = "graylog-twiliosms-${version}";
+    pluginName = "graylog-plugin-twiliosms";
+    version = "1.0.0";
+    src = fetchurl {
+      url = "https://github.com/graylog-labs/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      sha256 = "0kwfv1zfj0fmxh9i6413bcsaxrn1vdwrzb6dphvg3dx27wxn1j1a";
+    };
+    meta = {
+      homepage = https://github.com/graylog-labs/graylog-plugin-twiliosms;
+      description = "An alarm callback plugin for integrating the Twilio SMS API into Graylog";
+    };
+  };
   twitter = glPlugin rec {
     name = "graylog-twitter-${version}";
     pluginName = "graylog-plugin-twitter";
     version = "2.0.0";
     src = fetchurl {
-      url = "https://github.com/Graylog2/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
+      url = "https://github.com/graylog-labs/${pluginName}/releases/download/${version}/${pluginName}-${version}.jar";
       sha256 = "1pi34swy9nzq35a823zzvqrjhb6wsg302z31vk2y656sw6ljjxyh";
     };
     meta = {
-      homepage = https://github.com/Graylog2/graylog-plugin-twitter;
+      homepage = https://github.com/graylog-labs/graylog-plugin-twitter;
       description = "Graylog input plugin that reads Twitter messages based on keywords in realtime";
     };
   };


### PR DESCRIPTION
###### Motivation for this change
* Updates for existing plugins
* Some plugins were moved to graylog-labs GitHub organization (updated download URL and homepage)
* Added new plugins

graylog-aggregates: 1.1.1 -> 2.0.0
graylog-dnsresolver: init at 1.1.2
graylog-filter-messagesize: init at 0.0.2
graylog-internal-logs: 1.0.0 -> 2.3.0
graylog-metrics: init at 1.3.0
graylog-pagerduty: init at 1.3.0
graylog-slack: init at 2.4.0
graylog-twiliosms: init at 1.0.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

