### PR TITLE
ParaView: 4.0.1 -> 5.4.0

### DIFF
--- a/pkgs/applications/graphics/paraview/default.nix
+++ b/pkgs/applications/graphics/paraview/default.nix
@@ -1,40 +1,46 @@
-{ fetchurl, stdenv, cmake, qt4
-, hdf5
-, mpich2
-, python
-, libxml2
-, mesa, libXt
-}:
+{stdenv, fetchFromGitHub, cmake
+,full, python, mesa, libXt }:
 
 stdenv.mkDerivation rec {
-  name = "paraview-4.0.1";
-  src = fetchurl {
-    url = "http://paraview.org/files/v4.0/ParaView-v4.0.1-source.tgz";
-    sha256 = "1qj8dq8gqpsw75sv4sdc7xm1xcpv0ilsddnrcfhha0zfhp0gq10y";
+  name = "paraview-${version}";
+  version = "5.4.0";
+
+  # fetching from GitHub instead of taking an "official" source
+  # tarball because of missing submodules there
+  src = fetchFromGitHub {
+    owner = "Kitware";
+    repo = "ParaView";
+    rev = "v${version}";
+    sha256 = "0h1vkgwm10mc5mnr3djp81lxr5pi0hyj776z77hiib6xm5596q9n";
+    fetchSubmodules = true;
   };
 
-  # [  5%] Generating vtkGLSLShaderLibrary.h
-  # ../../../bin/ProcessShader: error while loading shared libraries: libvtksys.so.pv3.10: cannot open shared object file: No such file or directory
-  preConfigure = ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/paraview-3.98 -rpath ../../../../../../lib -rpath ../../../../../lib -rpath ../../../../lib -rpath ../../../lib -rpath ../../lib -rpath ../lib"
-  '';
-  cmakeFlags = [
-    "-DPARAVIEW_USE_SYSTEM_HDF5:BOOL=ON"
-    "-DVTK_USE_SYSTEM_LIBXML2:BOOL=ON"
-    "-DPARAVIEW_ENABLE_PYTHON:BOOL=ON"
-#  use -DPARAVIEW_INSTALL_THIRD_PARTY_LIBRARIES:BOOL=OFF \ to fix make install error: http://www.cmake.org/pipermail/paraview/2011-February/020268.html
-    "-DPARAVIEW_INSTALL_THIRD_PARTY_LIBRARIES:BOOL=OFF"
-    "-DCMAKE_SKIP_BUILD_RPATH=ON"
-    "-DVTK_USE_RPATH:BOOL=ON"
-    "-DPARAVIEW_INSTALL_DEVELOPMENT=ON"
-  ];
+   cmakeFlags = [
+     "-DPARAVIEW_ENABLE_PYTHON=ON"
+     "-DPARAVIEW_INSTALL_DEVELOPMENT_FILES=ON"
+   ];
 
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1138466
-  NIX_CFLAGS_COMPILE = "-DGLX_GLXEXT_LEGACY";
+  # During build, binaries are called that rely on freshly built
+  # libraries.  These reside in build/lib, and are not found by
+  # default.
+  preBuild = ''
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
+  '';
 
   enableParallelBuilding = true;
 
-  buildInputs = [ cmake qt4 hdf5 mpich2 python libxml2 mesa libXt ];
+  buildInputs = [ cmake
+   python
+   mesa
+   libXt
+
+   # theoretically the following should be fine, but there is an error
+   # due to missing libqminimal when not using qt5.full
+
+   # qtbase qtx11extras qttools
+   full
+   ];
+
 
   meta = {
     homepage = http://www.paraview.org/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15698,7 +15698,7 @@ with pkgs;
 
   pavucontrol = callPackage ../applications/audio/pavucontrol { };
 
-  paraview = callPackage ../applications/graphics/paraview { };
+  paraview = libsForQt5.callPackage ../applications/graphics/paraview { };
 
   packet = callPackage ../development/tools/packet { };
 


### PR DESCRIPTION
###### Motivation for this change
This should take care of one item of #28643.

*NOTE*:
While the main executable `paraview` in $out/bin runs fine, ldd reports missing dependencies on the .so-files in $out/lib/paraview-5.4.

###### Things done
Removed Dependency on MPI

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

