### PR TITLE
jupp: init at 3.1

### DIFF
--- a/pkgs/applications/editors/jupp/default.nix
+++ b/pkgs/applications/editors/jupp/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl
+, ncurses, gpm
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "jupp-${version}";
+  version = "3.1";
+  srcName = "joe-3.1jupp31";
+
+  src = fetchurl {
+    urls = [
+      "https://www.mirbsd.org/MirOS/dist/jupp/${srcName}.tgz"
+      "http://pub.allbsd.org/MirOS/dist/jupp/${srcName}.tgz" ];
+    sha256 = "1fnf9jsd6p4jyybkhjjs328qx38ywy8w029ngc7j7kqp0ixn0l0s";
+  };
+
+  preConfigure = "chmod +x ./configure";
+
+  buildInputs = [ ncurses gpm ];
+
+  configureFlags = [
+    "--enable-curses"
+    "--enable-termcap"
+    "--enable-termidx"
+    "--enable-getpwnam"
+    "--enable-largefile"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A portable fork of Joe's editor";
+    longDescription = ''
+      This is the portable version of JOE's Own Editor, which is currently
+      developed at sourceforge, licenced under the GNU General Public License,
+      Version 1, using autoconf/automake. This version has been enhanced by
+      several functions intended for programmers or other professional users,
+      and has a lot of bugs fixed. It is based upon an older version of joe
+      because these behave better overall.
+    '';
+    homepage = http://mirbsd.de/jupp;
+    license = licenses.gpl1;
+    maintainers = with maintainers; [ AndersonTorres ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2760,6 +2760,8 @@ with pkgs;
 
   jucipp = callPackage ../applications/editors/jucipp { };
 
+  jupp = callPackage ../applications/editors/jupp { };
+
   jwhois = callPackage ../tools/networking/jwhois { };
 
   k2pdfopt = callPackage ../applications/misc/k2pdfopt { };


### PR DESCRIPTION
jupp is a fork of joe's editor.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

