### PR TITLE
kde_workspace: Adds missing buildInputs

### DIFF
--- a/pkgs/desktops/kde-4.14/kde-workspace.nix
+++ b/pkgs/desktops/kde-4.14/kde-workspace.nix
@@ -1,7 +1,7 @@
 { stdenv, kde, kdelibs, qimageblitz, libdbusmenu_qt, xorg, lm_sensors
 , pciutils, libraw1394, libusb1, python, libqalculate, akonadi
 , xkeyboard_config, kdepimlibs, pam, boost, gpsd, prison
-, libjpeg, pkgconfig, kactivities, qjson, udev, fetchurl
+, libjpeg, pkgconfig, kactivities, qjson, udev, fetchurl, cln
 }:
 
 kde {
@@ -11,11 +11,11 @@ kde {
     [ kdelibs qimageblitz libdbusmenu_qt xorg.libxcb xorg.xcbutilimage libjpeg
       xorg.xcbutilrenderutil xorg.xcbutilkeysyms xorg.libpthreadstubs xorg.libXdmcp
       xorg.libxkbfile xorg.libXcomposite  xorg.libXtst
-      xorg.libXdamage xorg.libXft
+      xorg.libXdamage xorg.libXft xorg.libXScrnSaver
 
       python boost qjson lm_sensors /* gpsd */ libraw1394 pciutils udev
       akonadi pam libusb1 libqalculate kdepimlibs  prison
-      kactivities
+      kactivities cln
     ];
 
   patches = [ ./files/ksysguard-0001-disable-signalplottertest.patch ];


### PR DESCRIPTION
###### Motivation for this change
Progress on: https://github.com/NixOS/nixpkgs/issues/28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

