### PR TITLE
traefik: init at 1.3.8

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -237,6 +237,7 @@
   guillaumekoenig = "Guillaume Koenig <guillaume.edward.koenig@gmail.com>";
   guyonvarch = "Joris Guyonvarch <joris@guyonvarch.me>";
   hakuch = "Jesse Haber-Kucharsky <hakuch@gmail.com>";
+  hamhut1066 = "Hamish Hutchings <github@hamhut1066.com>";
   havvy = "Ryan Scheel <ryan.havvy@gmail.com>";
   hbunke = "Hendrik Bunke <bunke.hendrik@gmail.com>";
   hce = "Hans-Christian Esperer <hc@hcesperer.org>";

--- a/pkgs/servers/traefik/default.nix
+++ b/pkgs/servers/traefik/default.nix
@@ -1,18 +1,34 @@
-{ stdenv, fetchurl }:
+{ stdenv, buildGoPackage, fetchurl, bash, go-bindata}:
 
-stdenv.mkDerivation rec {
+buildGoPackage rec {
   name = "traefik-${version}";
   version = "v1.3.8";
 
+  goPackagePath = "github.com/containous/traefik";
+
   src = fetchurl {
-    url = "https://github.com/containous/traefik/releases/download/${version}/traefik";
-    sha256 = "09m8svkqdrvayw871azzcb05dnbhbgb3c2380dw0v4wpcd0rqr9h";
+    url = "https://github.com/containous/traefik/releases/download/${version}/traefik-${version}.src.tar.gz";
+    sha256 = "6fce36dd30bb5ae5f91e69f2950f22fe7a74b920e80c6b441a0721122f6a6174";
   };
 
-  buildCommand = ''
-    mkdir -p $out/bin
-    cp $src $out/bin/traefik
-    chmod +x $out/bin/traefik
+  buildInputs = [ go-bindata ];
+  sourceRoot = ".";
+  postUnpack = ''
+  files=`ls`
+  mkdir traefik
+  mv $files traefik/
+  export sourceRoot="traefik"
+  '';
+
+  buildPhase = ''
+  cd go/src/github.com/containous/traefik
+  ${bash}/bin/bash ./script/make.sh generate
+  CGO_ENABLED=0 GOGC=off go build -v -ldflags "-s -w" -a -installsuffix nocgo -o dist/traefik ./cmd/traefik
+  '';
+
+  installPhase = ''
+  mkdir -p $bin/bin
+  cp ./dist/traefik $bin/bin/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/traefik/default.nix
+++ b/pkgs/servers/traefik/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "traefik-${version}";
+  version = "v1.3.8";
+
+  src = fetchurl {
+    url = "https://github.com/containous/traefik/releases/download/${version}/traefik";
+    sha256 = "09m8svkqdrvayw871azzcb05dnbhbgb3c2380dw0v4wpcd0rqr9h";
+  };
+
+  buildCommand = ''
+    mkdir -p $out/bin
+    cp $src $out/bin/traefik
+    chmod +x $out/bin/traefik
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://traefik.io;
+    description = "Træfik, a modern reverse proxy";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hamhut1066 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -820,6 +820,7 @@ with pkgs;
   });
 
   caddy = callPackage ../servers/caddy { };
+  traefik = callPackage ../servers/traefik { };
 
   capstone = callPackage ../development/libraries/capstone { };
 


### PR DESCRIPTION
###### Motivation for this change
Traefik is used as a reverse proxy alternative to other tools such as nginx/caddy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

