### PR TITLE
qfsm: fix build with gcc 6

### DIFF
--- a/pkgs/applications/science/electronics/qfsm/default.nix
+++ b/pkgs/applications/science/electronics/qfsm/default.nix
@@ -10,7 +10,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ qt4 cmake graphviz pkgconfig ];
 
-  patches = [ ./drop-hardcoded-prefix.patch ];
+  patches = [
+    ./drop-hardcoded-prefix.patch
+    ./gcc6-fixes.patch
+  ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/applications/science/electronics/qfsm/gcc6-fixes.patch
+++ b/pkgs/applications/science/electronics/qfsm/gcc6-fixes.patch
@@ -1,0 +1,20 @@
+--- qfsm-0.54.0-Source-orig/src/FileIO.cpp	2015-01-02 19:01:46.000000000 +0100
++++ qfsm-0.54.0-Source/src/FileIO.cpp	2017-09-11 19:53:30.579488402 +0200
+@@ -1617,7 +1617,7 @@
+   QString ext;
+ 
+   if (!imp)
+-    return FALSE;
++    return NULL;
+ 
+   Project* p=NULL;
+   importdlg->setAcceptMode(QFileDialog::AcceptOpen);
+@@ -1641,7 +1641,7 @@
+   ifstream fin(act_importfile);
+ 
+   if (!fin)
+-    return FALSE;
++    return NULL;
+ 
+   emit setWaitCursor();
+ 


### PR DESCRIPTION
###### Motivation for this change
fixes one item in #28643

###### Things done

Built locally, ran the resulting binary.
Program runs as expected, but there was a segfault when exiting.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

