### PR TITLE
clang-stdenv: move libstdcxxHook to cc-wrapper

### DIFF
--- a/pkgs/development/compilers/llvm/3.7/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/default.nix
@@ -1,4 +1,7 @@
-{ newScope, stdenv, cmake, libxml2, python2, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun }:
+{ newScope, stdenv, libstdcxxHook, cmake, libxml2, python2, isl, fetchurl
+, overrideCC, wrapCC, ccWrapperFun, darwin
+}:
+
 let
   callPackage = newScope (self // { inherit stdenv cmake libxml2 python2 isl version fetch; });
 
@@ -22,20 +25,35 @@ let
       inherit clang-tools-extra_src stdenv;
     };
 
-    clang = wrapCC self.clang-unwrapped;
+    clang = if stdenv.cc.isGNU then self.libstdcxxClang else self.libcxxClang;
+
+    libstdcxxClang = ccWrapperFun {
+      cc = self.clang-unwrapped;
+      /* FIXME is this right? */
+      inherit (stdenv.cc) libc nativeTools nativeLibc;
+      extraPackages = [ libstdcxxHook ];
+    };
 
     libcxxClang = ccWrapperFun {
       cc = self.clang-unwrapped;
-      isClang = true;
-      inherit (self) stdenv;
       /* FIXME is this right? */
       inherit (stdenv.cc) libc nativeTools nativeLibc;
       extraPackages = [ self.libcxx self.libcxxabi ];
     };
 
-    stdenv = overrideCC stdenv self.clang;
+    stdenv = stdenv.override (drv: {
+      allowedRequisites = null;
+      cc = self.clang;
+      # Don't include the libc++ and libc++abi from the original stdenv.
+      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
+    });
 
-    libcxxStdenv = overrideCC stdenv self.libcxxClang;
+    libcxxStdenv = stdenv.override (drv: {
+      allowedRequisites = null;
+      cc = self.libcxxClang;
+      # Don't include the libc++ and libc++abi from the original stdenv.
+      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
+    });
 
     lldb = callPackage ./lldb.nix {};
 

--- a/pkgs/development/compilers/llvm/3.8/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/default.nix
@@ -1,4 +1,4 @@
-{ newScope, stdenv, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun }:
+{ newScope, stdenv, libstdcxxHook, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun, darwin }:
 let
   callPackage = newScope (self // { inherit stdenv isl version fetch; });
 
@@ -22,20 +22,35 @@ let
       inherit clang-tools-extra_src stdenv;
     };
 
-    clang = wrapCC self.clang-unwrapped;
+    clang = if stdenv.cc.isGNU then self.libstdcxxClang else self.libcxxClang;
+
+    libstdcxxClang = ccWrapperFun {
+      cc = self.clang-unwrapped;
+      /* FIXME is this right? */
+      inherit (stdenv.cc) libc nativeTools nativeLibc;
+      extraPackages = [ libstdcxxHook ];
+    };
 
     libcxxClang = ccWrapperFun {
       cc = self.clang-unwrapped;
-      isClang = true;
-      inherit (self) stdenv;
       /* FIXME is this right? */
       inherit (stdenv.cc) libc nativeTools nativeLibc;
       extraPackages = [ self.libcxx self.libcxxabi ];
     };
 
-    stdenv = overrideCC stdenv self.clang;
+    stdenv = stdenv.override (drv: {
+      allowedRequisites = null;
+      cc = self.clang;
+      # Don't include the libc++ and libc++abi from the original stdenv.
+      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
+    });
 
-    libcxxStdenv = overrideCC stdenv self.libcxxClang;
+    libcxxStdenv = stdenv.override (drv: {
+      allowedRequisites = null;
+      cc = self.libcxxClang;
+      # Don't include the libc++ and libc++abi from the original stdenv.
+      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
+    });
 
     lldb = callPackage ./lldb.nix {};
 

--- a/pkgs/development/compilers/llvm/3.9/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/default.nix
@@ -1,4 +1,4 @@
-{ newScope, stdenv, isl, fetchurl, overrideCC, wrapCC, darwin, ccWrapperFun }:
+{ newScope, stdenv, libstdcxxHook, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun, darwin }:
 let
   callPackage = newScope (self // { inherit stdenv isl version fetch; });
 
@@ -22,20 +22,35 @@ let
       inherit clang-tools-extra_src stdenv;
     };
 
-    clang = wrapCC self.clang-unwrapped;
+    clang = if stdenv.cc.isGNU then self.libstdcxxClang else self.libcxxClang;
+
+    libstdcxxClang = ccWrapperFun {
+      cc = self.clang-unwrapped;
+      /* FIXME is this right? */
+      inherit (stdenv.cc) libc nativeTools nativeLibc;
+      extraPackages = [ libstdcxxHook ];
+    };
 
     libcxxClang = ccWrapperFun {
       cc = self.clang-unwrapped;
-      isClang = true;
-      inherit (self) stdenv;
       /* FIXME is this right? */
       inherit (stdenv.cc) libc nativeTools nativeLibc;
       extraPackages = [ self.libcxx self.libcxxabi ];
     };
 
-    stdenv = overrideCC stdenv self.clang;
+    stdenv = stdenv.override (drv: {
+      allowedRequisites = null;
+      cc = self.clang;
+      # Don't include the libc++ and libc++abi from the original stdenv.
+      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
+    });
 
-    libcxxStdenv = overrideCC stdenv self.libcxxClang;
+    libcxxStdenv = stdenv.override (drv: {
+      allowedRequisites = null;
+      cc = self.libcxxClang;
+      # Don't include the libc++ and libc++abi from the original stdenv.
+      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
+    });
 
     lldb = callPackage ./lldb.nix {};
 

--- a/pkgs/development/compilers/llvm/4/default.nix
+++ b/pkgs/development/compilers/llvm/4/default.nix
@@ -37,14 +37,17 @@ let
     llvm-manpages = lowPrio self.llvm.man;
     clang-manpages = lowPrio self.clang-unwrapped.man;
 
-    clang = wrapCC self.clang-unwrapped;
+    clang = if stdenv.cc.isGNU then self.libstdcxxClang else self.libcxxClang;
 
-    openmp = callPackage ./openmp.nix {};
+    libstdcxxClang = ccWrapperFun {
+      cc = self.clang-unwrapped;
+      /* FIXME is this right? */
+      inherit (stdenv.cc) libc nativeTools nativeLibc;
+      extraPackages = [ libstdcxxHook ];
+    };
 
     libcxxClang = ccWrapperFun {
       cc = self.clang-unwrapped;
-      isClang = true;
-      inherit (self) stdenv;
       /* FIXME is this right? */
       inherit (stdenv.cc) libc nativeTools nativeLibc;
       extraPackages = [ self.libcxx self.libcxxabi ];
@@ -53,11 +56,16 @@ let
     stdenv = stdenv.override (drv: {
       allowedRequisites = null;
       cc = self.clang;
-      # Use the gcc libstdc++ when targeting linux.
-      extraBuildInputs = if stdenv.cc.isGNU then [ libstdcxxHook ] else drv.extraBuildInputs;
+      # Don't include the libc++ and libc++abi from the original stdenv.
+      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
     });
 
-    libcxxStdenv = overrideCC stdenv self.libcxxClang;
+    libcxxStdenv = stdenv.override (drv: {
+      allowedRequisites = null;
+      cc = self.libcxxClang;
+      # Don't include the libc++ and libc++abi from the original stdenv.
+      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
+    });
 
     lld = callPackage ./lld.nix {};
 
@@ -66,6 +74,8 @@ let
     libcxx = callPackage ./libc++ {};
 
     libcxxabi = callPackage ./libc++abi.nix {};
+
+    openmp = callPackage ./openmp.nix {};
   };
 
 in self

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5308,7 +5308,7 @@ with pkgs;
   #Use this instead of stdenv to build with clang
   clangStdenv = if stdenv.isDarwin then stdenv else lowPrio llvmPackages.stdenv;
   clang-sierraHack-stdenv = overrideCC stdenv clang-sierraHack;
-  libcxxStdenv = lowPrio llvmPackages.libcxxStdenv;
+  libcxxStdenv = if stdenv.isDarwin then stdenv else lowPrio llvmPackages.libcxxStdenv;
 
   clean = callPackage ../development/compilers/clean { };
 
@@ -19410,8 +19410,8 @@ with pkgs;
   # `recurseIntoAttrs` for sake of hydra, not nix-env
   tests = recurseIntoAttrs {
     cc-wrapper = callPackage ../test/cc-wrapper { };
-    cc-wrapper-clang = callPackage ../test/cc-wrapper { stdenv = clangStdenv; };
-    cc-wrapper-libcxx = callPackage ../test/cc-wrapper { stdenv = libcxxStdenv; };
+    cc-wrapper-clang = callPackage ../test/cc-wrapper { stdenv = llvmPackages.stdenv; };
+    cc-wrapper-libcxx = callPackage ../test/cc-wrapper { stdenv = llvmPackages.libcxxStdenv; };
     stdenv-inputs = callPackage ../test/stdenv-inputs { };
 
     macOSSierraShared = callPackage ../test/macos-sierra-shared {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19412,6 +19412,8 @@ with pkgs;
     cc-wrapper = callPackage ../test/cc-wrapper { };
     cc-wrapper-clang = callPackage ../test/cc-wrapper { stdenv = llvmPackages.stdenv; };
     cc-wrapper-libcxx = callPackage ../test/cc-wrapper { stdenv = llvmPackages.libcxxStdenv; };
+    cc-wrapper-clang-39 = callPackage ../test/cc-wrapper { stdenv = llvmPackages_39.stdenv; };
+    cc-wrapper-libcxx-39 = callPackage ../test/cc-wrapper { stdenv = llvmPackages_39.libcxxStdenv; };
     stdenv-inputs = callPackage ../test/stdenv-inputs { };
 
     macOSSierraShared = callPackage ../test/macos-sierra-shared {};


### PR DESCRIPTION
###### Motivation for this change

Fixes #29204

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested via one or more nixpkgs test(s) (`tests.cc-wrapper`)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
