### PR TITLE
pulseaudio: enable by default in NixOS if sound is enabled

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -87,7 +87,7 @@ in {
     hardware.pulseaudio = {
       enable = mkOption {
         type = types.bool;
-        default = false;
+        default = true;
         description = ''
           Whether to enable the PulseAudio sound server.
         '';

--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -87,7 +87,8 @@ in {
     hardware.pulseaudio = {
       enable = mkOption {
         type = types.bool;
-        default = true;
+        default = config.sound.enable;
+        defaultText = "config.sound.enable";
         description = ''
           Whether to enable the PulseAudio sound server.
         '';


### PR DESCRIPTION
###### Motivation for this change

I think PulseAudio should be enabled by default. This is because I think it is the better supported option nowadays, and because it is easier to set up than ALSA.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [N/A] macOS
   - [N/A] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

