### PR TITLE
gringo: add darwin platform support

### DIFF
--- a/pkgs/tools/misc/gringo/default.nix
+++ b/pkgs/tools/misc/gringo/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl,
-  bison, re2c, scons
+  bison, re2c, scons,
+  libcxx
 }:
 
 let
@@ -21,6 +22,23 @@ stdenv.mkDerivation rec {
     ./gringo-4.5.4-to_string.patch
   ];
 
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace ./SConstruct \
+      --replace \
+        "env['CXX']            = 'g++'" \
+        "env['CXX']            = '$CXX'"
+
+    substituteInPlace ./SConstruct \
+      --replace \
+        "env['CPPPATH']        = []" \
+        "env['CPPPATH']        = ['${libcxx}/include/c++/v1']"
+
+    substituteInPlace ./SConstruct \
+      --replace \
+        "env['LIBPATH']        = []" \
+        "env['LIBPATH']        = ['${libcxx}/lib']"
+  '';
+
   buildPhase = ''
     scons WITH_PYTHON= --build-dir=release
   '';
@@ -33,7 +51,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Converts input programs with first-order variables to equivalent ground programs";
     homepage = http://potassco.sourceforge.net/;
-    platforms = platforms.linux;
+    platforms = platforms.all;
     maintainers = [ maintainers.hakuch ];
     license = licenses.gpl3Plus;
   };


### PR DESCRIPTION
###### Motivation for this change

Adding Darwin support for `gringo` will allow `aspcud` to build for Darwin as well. This is important beause `aspcud` is the recommended dependency solver for OPAM, the OCaml package manager, and currently `opam` specifically avoids using `aspcud` on Darwin (as per [this discussion](https://github.com/NixOS/nixpkgs/pull/16938#issuecomment-242964057)).

If this PR is merged, I will follow up with PRs for `aspcud` and `opam` to get everything working on Darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

