### PR TITLE
aseprite: 0.9.5 -> 1.1.7

### DIFF
--- a/pkgs/applications/editors/aseprite/default.nix
+++ b/pkgs/applications/editors/aseprite/default.nix
@@ -1,47 +1,49 @@
-{ stdenv, fetchurl, cmake, pkgconfig
-, giflib, libjpeg, zlib, libpng, tinyxml, allegro
-, libX11, libXext, libXcursor, libXpm, libXxf86vm, libXxf86dga
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
+, curl, freetype, giflib, libjpeg, libpng, libwebp, pixman, tinyxml, zlib
+, libX11, libXext, libXcursor, libXxf86vm
 }:
 
 stdenv.mkDerivation rec {
-  name = "aseprite-0.9.5";
+  name = "aseprite-${version}";
+  version = "1.1.7";
 
-  src = fetchurl {
-    url = "http://aseprite.googlecode.com/files/${name}.tar.xz";
-    sha256 = "0m7i6ybj2bym4w9rybacnnaaq2jjn76vlpbp932xcclakl6kdq41";
+  src = fetchFromGitHub {
+    owner = "aseprite";
+    repo = "aseprite";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "0gd49lns2bpzbkwax5jf9x1xmg1j8ij997kcxr2596cwiswnw4di";
   };
 
+  nativeBuildInputs = [ cmake pkgconfig ];
+
   buildInputs = [
-    cmake pkgconfig
-    giflib libjpeg zlib libpng tinyxml allegro
-    libX11 libXext libXcursor libXpm libXxf86vm libXxf86dga
+    curl freetype giflib libjpeg libpng libwebp pixman tinyxml zlib
+    libX11 libXext libXcursor libXxf86vm
   ];
 
-  patchPhase = ''
-    sed -i '/^find_unittests/d' src/CMakeLists.txt
-    sed -i '/include_directories(.*third_party\/gtest.*)/d' src/CMakeLists.txt
-    sed -i '/add_subdirectory(gtest)/d' third_party/CMakeLists.txt
-    sed -i 's/png_\(sizeof\)/\1/g' src/file/png_format.cpp
-  '';
-
   cmakeFlags = ''
+    -DENABLE_UPDATER=OFF
+    -DUSE_SHARED_CURL=ON
+    -DUSE_SHARED_FREETYPE=ON
     -DUSE_SHARED_GIFLIB=ON
     -DUSE_SHARED_JPEGLIB=ON
-    -DUSE_SHARED_ZLIB=ON
     -DUSE_SHARED_LIBPNG=ON
-    -DUSE_SHARED_LIBLOADPNG=ON
+    -DUSE_SHARED_LIBWEBP=ON
+    -DUSE_SHARED_PIXMAN=ON
     -DUSE_SHARED_TINYXML=ON
-    -DUSE_SHARED_GTEST=ON
-    -DUSE_SHARED_ALLEGRO4=ON
-    -DENABLE_UPDATER=OFF
+    -DUSE_SHARED_ZLIB=ON
+    -DWITH_DESKTOP_INTEGRATION=ON
+    -DWITH_WEBP_SUPPORT=ON
   '';
 
-  NIX_LDFLAGS = "-lX11";
+  enableParallelBuilding = true;
 
-  meta = {
-    description = "Animated sprite editor & pixel art tool";
+  meta = with stdenv.lib; {
     homepage = https://www.aseprite.org/;
-    license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.linux;
+    description = "Animated sprite editor & pixel art tool";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/editors/aseprite/default.nix
+++ b/pkgs/applications/editors/aseprite/default.nix
@@ -53,9 +53,16 @@ stdenv.mkDerivation rec {
     "-DENABLE_TAR=OFF"
   ];
 
-  postInstall = lib.optionalString unfree ''
+  postInstall = ''
+    # Install desktop icons.
+    src="$out/share/aseprite/data/icons"
+    for size in 16 32 48 64; do
+      dst="$out"/share/icons/hicolor/"$size"x"$size"
+      install -Dm644 "$src"/ase"$size".png "$dst"/apps/aseprite.png
+      install -Dm644 "$src"/doc"$size".png "$dst"/mimetypes/aseprite.png
+    done
     # Delete unneeded artifacts of bundled libraries.
-    rm -rf $out/include $out/lib
+    rm -rf "$out"/include "$out"/lib
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13494,9 +13494,7 @@ with pkgs;
 
   atom = callPackage ../applications/editors/atom { };
 
-  aseprite = callPackage ../applications/editors/aseprite {
-    giflib = giflib_4_1;
-  };
+  aseprite = callPackage ../applications/editors/aseprite { };
 
   astroid = callPackage ../applications/networking/mailreaders/astroid { };
 


### PR DESCRIPTION
###### Motivation for this change

- Do not use system allegro, because bundled allegro has important fixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).