### PR TITLE
nextcloud-client: miscellaneous fixes

### DIFF
--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -14,9 +14,15 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig cmake ];
   buildInputs = [ qtbase qtwebkit qtkeychain sqlite ];
 
-  preConfigure = ''
-    cmakeFlagsArray+=("-UCMAKE_INSTALL_LIBDIR" "-DOEM_THEME_DIR=$(realpath ./nextcloudtheme)" "../client")
-  '';
+  dontUseCmakeBuildDir = true;
+
+  cmakeDir = "client";
+
+  cmakeFlags = [
+    "-UCMAKE_INSTALL_LIBDIR"
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DOEM_THEME_DIR=${src}/nextcloudtheme"
+  ];
 
   meta = with stdenv.lib; {
     description = "Nextcloud themed desktop client";

--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ qtbase qtwebkit qtkeychain sqlite ]
     ++ stdenv.lib.optional stdenv.isLinux inotify-tools;
 
+  enableParallelBuilding = true;
+
   dontUseCmakeBuildDir = true;
 
   cmakeDir = "client";

--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchgit, cmake, pkgconfig, qtbase, qtwebkit, qtkeychain, sqlite }:
+{ stdenv, fetchgit, cmake, pkgconfig, qtbase, qtwebkit, qtkeychain, sqlite
+, inotify-tools }:
 
 stdenv.mkDerivation rec {
   name = "nextcloud-client-${version}";
@@ -12,7 +13,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig cmake ];
-  buildInputs = [ qtbase qtwebkit qtkeychain sqlite ];
+  buildInputs = [ qtbase qtwebkit qtkeychain sqlite ]
+    ++ stdenv.lib.optional stdenv.isLinux inotify-tools;
 
   dontUseCmakeBuildDir = true;
 
@@ -22,6 +24,9 @@ stdenv.mkDerivation rec {
     "-UCMAKE_INSTALL_LIBDIR"
     "-DCMAKE_BUILD_TYPE=Release"
     "-DOEM_THEME_DIR=${src}/nextcloudtheme"
+  ] ++ stdenv.lib.optionals stdenv.isLinux [
+    "-DINOTIFY_LIBRARY=${inotify-tools}/lib/libinotifytools.so"
+    "-DINOTIFY_INCLUDE_DIR=${inotify-tools}/include"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

I've been maintaining a version of this [outside of nixpkgs](https://github.com/eqyiel/nixos-config/blob/0096911831147821e709e0c07e46ebe09810c12b/pkgs/nextcloud-client/default.nix) for a while and since this is a thing now I would like to contribute the difference to this expression.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

- enabled parallel building
- use existing cmake* attrs rather than manipulating cmake flags in preConfigure
- use inotify for more efficient monitoring of file changes
- provide gnome-keyring integration when built with `withGnomeKeying = true;`

I'm not sure if adding `gnome_keyring` to `LD_LIBRARY_PATH` is the correct way to go about this, but it's what worked for me.

@caugner thanks for your work on this package.

---

