### PR TITLE
emacs: 25.2 -> 25.3

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -26,12 +26,12 @@ let
 in
 stdenv.mkDerivation rec {
   name = "emacs-${version}${versionModifier}";
-  version = "25.2";
+  version = "25.3";
   versionModifier = "";
 
   src = fetchurl {
     url = "mirror://gnu/emacs/${name}.tar.xz";
-    sha256 = "1ykkq0xl28ljdg61bm6gzy04ww86ajms98gix72qg6cpr6a53dar";
+    sha256 = "02y00y9q42g1iqgz5qhmsja75hwxd88yrn9zp14lanay0zkwafi5";
   };
 
   patches = (lib.optional stdenv.isDarwin ./at-fdcwd.patch);


### PR DESCRIPTION
###### Motivation for this change
https://lists.gnu.org/archive/html/emacs-devel/2017-09/msg00211.html

> This is an emergency release to fix a security vulnerability in Emacs.
>
> Enriched Text mode has its support for decoding 'x-display' disabled.
> This feature allows saving 'display' properties as part of text.
> Emacs 'display' properties support evaluation of arbitrary Lisp forms
> as part of instantiating the property, so decoding 'x-display' is
> vulnerable to executing arbitrary malicious Lisp code included in the
> text (e.g., sent as part of an email message).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

