### PR TITLE
nixos/gitolite: use group 'gitolite' instead of 'nogroup'

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -426,7 +426,7 @@
       teamspeak = 124;
       influxdb = 125;
       nsd = 126;
-      #gitolite = 127; # unused
+      gitolite = 127;
       znc = 128;
       polipo = 129;
       mopidy = 130;

--- a/nixos/modules/services/misc/gitolite.nix
+++ b/nixos/modules/services/misc/gitolite.nix
@@ -85,6 +85,14 @@ in
           Gitolite user account. This is the username of the gitolite endpoint.
         '';
       };
+
+      group = mkOption {
+        type = types.str;
+        default = "gitolite";
+        description = ''
+          Primary group of the Gitolite user account.
+        '';
+      };
     };
   };
 
@@ -121,8 +129,10 @@ in
       home            = cfg.dataDir;
       createHome      = true;
       uid             = config.ids.uids.gitolite;
+      group           = cfg.group;
       useDefaultShell = true;
     };
+    users.extraGroups."${cfg.group}".gid = config.ids.gids.gitolite;
 
     systemd.services."gitolite-init" = {
       description = "Gitolite initialization";


### PR DESCRIPTION
###### Motivation for this change
Having files (git repositories) owned by 'nogroup' is a bad idea.

###### Things done

I built a NixOS system with this patch applied. /var/lib/gitolite is now owned by "gitolite" instead of "nogroup".

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

