### PR TITLE
btfs: 2.13 -> 2.17

### DIFF
--- a/pkgs/os-specific/linux/btfs/default.nix
+++ b/pkgs/os-specific/linux/btfs/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "btfs-${version}";
-  version = "2.13";
+  version = "2.17";
 
   src = fetchFromGitHub {
     owner  = "johang";
     repo   = "btfs";
     rev    = "v${version}";
-    sha256 = "1nd021xbxrikd8p0w9816xjwlrs9m1nc6954q23qxfw2jbmszlk2";
+    sha256 = "0v0mypwnx832f7vg52wmiw0lyz7rrkhqsgi7zc261ak1gfaw4nwd";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change
- [x] Tested compilation of all pkgs that depend on this change (none)
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

