### PR TITLE
[WIP] paths-from-graph.pl: generate the hash of the store path

### DIFF
--- a/pkgs/build-support/kernel/paths-from-graph.pl
+++ b/pkgs/build-support/kernel/paths-from-graph.pl
@@ -70,7 +70,8 @@ elsif ($ENV{"printRegistration"} eq "1") {
     # --hash-given' / `nix-store --load-db'.
     foreach my $storePath (sort (keys %storePaths)) {
         print "$storePath\n";
-        print "0000000000000000000000000000000000000000000000000000000000000000\n"; # !!! fix
+        my $nixHash = "nix-hash --type sha256 " . $storePath;
+        print `$nixHash`;
         print "0\n"; # !!! fix	
         print "\n"; # don't care about preserving the deriver
         print scalar(@{$refs{$storePath}}), "\n";


### PR DESCRIPTION
Try to fix #29264 

Since I don't perl, I have written this poc to see if it solves my issue. And it does.
With the PR #28561 : 
```
 nix-build ./ -A dockerTools.examples.nix && docker load -i result && docker run --rm nix nix-store --verify-path $(nix-build ./ -A glibc)

```

Note this also increase the compute time of the graph since we have to hash the whole content.