### PR TITLE
aspcud: add darwin platform support

### DIFF
--- a/pkgs/tools/misc/aspcud/default.nix
+++ b/pkgs/tools/misc/aspcud/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Solver for package problems in CUDF format using ASP";
     homepage = http://potasssco.sourceforge.net/;
-    platforms = platforms.linux;
+    platforms = platforms.all;
     maintainers = [ maintainers.hakuch ];
     license = licenses.gpl3Plus;
   };


### PR DESCRIPTION
This works because `gringo` now builds on Darwin.

###### Motivation for this change

See #29251 for information on `aspcud` and its relation to `opam` on Darwin. I will follow up with the applicable OPAM changes after this PR Is merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
