### PR TITLE
lib, treewide: Add `*Platform.extensions` and use it where possible

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -28,6 +28,15 @@ rec {
         else if final.isLinux  then "glibc"
         # TODO(@Ericson2314) think more about other operating systems
         else                        "native/impure";
+      extensions = {
+        sharedLibrary =
+          /**/ if final.isDarwin  then ".dylib"
+          else if final.isWindows then ".dll"
+          else                         ".so";
+        executable =
+          /**/ if final.isWindows then ".exe"
+          else                         "";
+      };
     } // mapAttrs (n: v: v final.parsed) inspect.predicates
       // args;
   in final;

--- a/pkgs/applications/networking/cluster/mesos/default.nix
+++ b/pkgs/applications/networking/cluster/mesos/default.nix
@@ -8,7 +8,6 @@
 
 let
   mavenRepo = import ./mesos-deps.nix { inherit stdenv curl; };
-  soext = if stdenv.system == "x86_64-darwin" then "dylib" else "so";
   # `tar -z` requires gzip on $PATH, so wrap tar.
   # At some point, we should try to patch mesos so we add gzip to the PATH when
   # tar is invoked. I think that only needs to be done here:
@@ -193,7 +192,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/share/java
     cp src/java/target/mesos-*.jar $out/share/java
 
-    MESOS_NATIVE_JAVA_LIBRARY=$out/lib/libmesos.${soext}
+    MESOS_NATIVE_JAVA_LIBRARY=$out/lib/libmesos${stdenv.hostPlatform.extensions.sharedLibrary}
 
     mkdir -p $out/nix-support
     touch $out/nix-support/setup-hook

--- a/pkgs/development/compilers/llvm/3.9/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.9/llvm.nix
@@ -26,7 +26,6 @@ assert (hostPlatform != buildPlatform) -> !enableSharedLibraries;
 
 let
   src = fetch "llvm" "1vi9sf7rx1q04wj479rsvxayb6z740iaz3qniwp266fgp5a07n8z";
-  shlib = if stdenv.isDarwin then "dylib" else "so";
 
   # Used when creating a version-suffixed symlink of libLLVM.dylib
   shortVersion = with stdenv.lib;
@@ -124,7 +123,7 @@ in stdenv.mkDerivation rec {
   postInstall = ""
   + stdenv.lib.optionalString (enableSharedLibraries) ''
     moveToOutput "lib/libLLVM-*" "$lib"
-    moveToOutput "lib/libLLVM.${shlib}" "$lib"
+    moveToOutput "lib/libLLVM${stdenv.hostPlatform.extensions.sharedLibrary}" "$lib"
     substituteInPlace "$out/lib/cmake/llvm/LLVMExports-release.cmake" \
       --replace "\''${_IMPORT_PREFIX}/lib/libLLVM-" "$lib/lib/libLLVM-"
   ''

--- a/pkgs/development/compilers/llvm/4/llvm.nix
+++ b/pkgs/development/compilers/llvm/4/llvm.nix
@@ -23,7 +23,6 @@
 
 let
   src = fetch "llvm" "0l9bf7kdwhlj0kq1hawpyxhna1062z3h7qcz2y8nfl9dz2qksy6s";
-  shlib = if stdenv.isDarwin then "dylib" else "so";
 
   # Used when creating a version-suffixed symlink of libLLVM.dylib
   shortVersion = with stdenv.lib;
@@ -115,7 +114,7 @@ in stdenv.mkDerivation rec {
   ''
   + stdenv.lib.optionalString enableSharedLibraries ''
     moveToOutput "lib/libLLVM-*" "$lib"
-    moveToOutput "lib/libLLVM.${shlib}" "$lib"
+    moveToOutput "lib/libLLVM${stdenv.hostPlatform.extensions.sharedLibrary}" "$lib"
     substituteInPlace "$out/lib/cmake/llvm/LLVMExports-${if debugVersion then "debug" else "release"}.cmake" \
       --replace "\''${_IMPORT_PREFIX}/lib/libLLVM-" "$lib/lib/libLLVM-"
   ''

--- a/pkgs/development/libraries/armadillo/default.nix
+++ b/pkgs/development/libraries/armadillo/default.nix
@@ -12,10 +12,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ openblasCompat superlu hdf5 ];
 
-  cmakeFlags = let
-    libSuff = if stdenv.isDarwin then "dylib" else "so";
-  in [
-    "-DLAPACK_LIBRARY=${openblasCompat}/lib/libopenblas.${libSuff}"
+  cmakeFlags = [
+    "-DLAPACK_LIBRARY=${openblasCompat}/lib/libopenblas${stdenv.hostPlatform.extensions.sharedLibrary}"
     "-DDETECT_HDF5=ON"
   ];
 

--- a/pkgs/development/libraries/libhdhomerun/default.nix
+++ b/pkgs/development/libraries/libhdhomerun/default.nix
@@ -14,11 +14,9 @@ stdenv.mkDerivation {
     substituteInPlace Makefile --replace "-arch i386" ""
   '';
 
-  installPhase = let
-    libSuff = if stdenv.isDarwin then "dylib" else "so";
-  in ''
+  installPhase = ''
     mkdir -p $out/{bin,lib,include/hdhomerun}
-    install -Dm444 libhdhomerun.${libSuff} $out/lib
+    install -Dm444 libhdhomerun${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib
     install -Dm555 hdhomerun_config $out/bin
     cp *.h $out/include/hdhomerun
   '';

--- a/pkgs/development/libraries/libsvm/default.nix
+++ b/pkgs/development/libraries/libsvm/default.nix
@@ -15,11 +15,11 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = let
-    libSuff = if stdenv.isDarwin then "dylib" else "so";
+    libSuff = stdenv.hostPlatform.extensions.sharedLibrary;
   in ''
     mkdir -p $out/lib $out/bin $out/include;
-    cp libsvm.so.2 $out/lib/libsvm.2.${libSuff};
-    ln -s $out/lib/libsvm.2.${libSuff} $out/lib/libsvm.${libSuff};
+    cp libsvm.so.2 $out/lib/libsvm.2${libSuff};
+    ln -s $out/lib/libsvm.2${libSuff} $out/lib/libsvm${libSuff};
     cp svm-scale svm-train svm-predict $out/bin;
     cp svm.h $out/include;
   '';

--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -7,7 +7,7 @@ let
   name = "suitesparse-${version}";
 
   int_t = if openblas.blas64 then "int64_t" else "int32_t";
-  SHLIB_EXT = if stdenv.isDarwin then "dylib" else "so";
+  SHLIB_EXT = stdenv.hostPlatform.extensions.sharedLibrary;
 in
 stdenv.mkDerivation {
   inherit name;
@@ -64,10 +64,10 @@ stdenv.mkDerivation {
         for i in "$out"/lib/lib*.a; do
           ar -x $i
         done
-        ${if enableCuda then cudatoolkit else stdenv.cc.outPath}/bin/${if enableCuda then "nvcc" else "cc"} *.o ${if stdenv.isDarwin then "-dynamiclib" else "--shared"} -o "$out/lib/libsuitesparse.${SHLIB_EXT}" -lopenblas ${stdenv.lib.optionalString enableCuda "-lcublas"}
+        ${if enableCuda then cudatoolkit else stdenv.cc.outPath}/bin/${if enableCuda then "nvcc" else "cc"} *.o ${if stdenv.isDarwin then "-dynamiclib" else "--shared"} -o "$out/lib/libsuitesparse${SHLIB_EXT}" -lopenblas ${stdenv.lib.optionalString enableCuda "-lcublas"}
     )
     for i in umfpack cholmod amd camd colamd spqr; do
-      ln -s libsuitesparse.${SHLIB_EXT} "$out"/lib/lib$i.${SHLIB_EXT}
+      ln -s libsuitesparse${SHLIB_EXT} "$out"/lib/lib$i${SHLIB_EXT}
     done
 
     # Install documentation

--- a/pkgs/development/libraries/tbb/default.nix
+++ b/pkgs/development/libraries/tbb/default.nix
@@ -1,8 +1,5 @@
 { stdenv, fetchurl }:
 
-let
-  SHLIB_EXT = if stdenv.isDarwin then "dylib" else "so";
-in
 stdenv.mkDerivation {
   name = "tbb-4.4-u2";
 
@@ -16,7 +13,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out/{lib,share/doc}
-    cp "build/"*release*"/"*${SHLIB_EXT}* $out/lib/
+    cp "build/"*release*"/"*${stdenv.hostPlatform.extensions.sharedLibrary}* $out/lib/
     mv include $out/
     rm $out/include/index.html
     mv doc/html $out/share/doc/tbb

--- a/pkgs/development/libraries/tinyxml/2.6.2.nix
+++ b/pkgs/development/libraries/tinyxml/2.6.2.nix
@@ -2,7 +2,7 @@
 
 let
   version = "2.6.2";
-  SHLIB_EXT = if stdenv.isDarwin then "dylib" else "so";
+  SHLIB_EXT = stdenv.hostPlatform.extensions.sharedLibrary;
 in stdenv.mkDerivation {
   name = "tinyxml-${version}";
 
@@ -38,7 +38,7 @@ in stdenv.mkDerivation {
     # build the lib as a shared library
     ''${CXX} -Wall -O2 -shared -fpic tinyxml.cpp \
     tinyxmlerror.cpp tinyxmlparser.cpp      \
-    tinystr.cpp -o libtinyxml.${SHLIB_EXT}
+    tinystr.cpp -o libtinyxml${SHLIB_EXT}
   '';
 
   doCheck = true;
@@ -55,7 +55,7 @@ in stdenv.mkDerivation {
     mkdir -pv $out/lib/pkgconfig/
     mkdir -pv $out/share/doc/tinyxml/
 
-    cp -v libtinyxml.${SHLIB_EXT} $out/lib/
+    cp -v libtinyxml${SHLIB_EXT} $out/lib/
     cp -v *.h $out/include/
 
     substituteInPlace tinyxml.pc --replace "@out@" "$out"

--- a/pkgs/development/python-modules/Wand/default.nix
+++ b/pkgs/development/python-modules/Wand/default.nix
@@ -7,12 +7,12 @@
 , psutil
 , memory_profiler
 , pytest_xdist
-, sharedLibraryExtension
 }:
 
 let
-  magick_wand_library = "${imagemagick}/lib/libMagickWand-6.Q16${sharedLibraryExtension}";
-  imagemagick_library = "${imagemagick}/lib/libMagickCore-6.Q16${sharedLibraryExtension}";
+  soext = stdenv.hostPlatform.extensions.sharedLibrary;
+  magick_wand_library = "${imagemagick}/lib/libMagickWand-6.Q16${soext}";
+  imagemagick_library = "${imagemagick}/lib/libMagickCore-6.Q16${soext}";
 in buildPythonPackage rec {
   pname = "Wand";
   version = "0.4.4";

--- a/pkgs/development/python-modules/shapely/default.nix
+++ b/pkgs/development/python-modules/shapely/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi
-, geos, glibcLocales, pytest, cython, sharedLibraryExtension
+, geos, glibcLocales, pytest, cython
 , numpy
 }:
 
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   patchPhase = let
     libc = if stdenv.isDarwin then "libc.dylib" else "libc.so.6";
   in ''
-    sed -i "s|_lgeos = load_dll('geos_c', fallbacks=.*)|_lgeos = load_dll('geos_c', fallbacks=['${geos}/lib/libgeos_c${sharedLibraryExtension}'])|" shapely/geos.py
+    sed -i "s|_lgeos = load_dll('geos_c', fallbacks=.*)|_lgeos = load_dll('geos_c', fallbacks=['${geos}/lib/libgeos_c${stdenv.hostPlatform.extensions.sharedLibrary}'])|" shapely/geos.py
     sed -i "s|free = load_dll('c').free|free = load_dll('c', fallbacks=['${stdenv.cc.libc}/lib/${stdenv.cc.libc}']).free|" shapely/geos.py
   '';
 

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -194,7 +194,7 @@ in
   rbnacl = spec: {
     postInstall = ''
     sed -i $(cat $out/nix-support/gem-meta/install-path)/lib/rbnacl.rb -e "2a \
-    RBNACL_LIBSODIUM_GEM_LIB_PATH = '${libsodium.out}/lib/libsodium.${if stdenv.isDarwin then "dylib" else "so"}'
+    RBNACL_LIBSODIUM_GEM_LIB_PATH = '${libsodium.out}/lib/libsodium${stdenv.hostPlatform.extensions.sharedLibrary}'
     "
     '';
   };

--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -1,9 +1,5 @@
 { stdenv }:
 
-let
-  shlib = if stdenv.isDarwin then "dylib" else "so";
-in
-
 stdenv.mkDerivation {
   name = "cc-wrapper-test";
 
@@ -34,7 +30,12 @@ stdenv.mkDerivation {
 
     printf "checking whether compiler uses NIX_LDFLAGS... " >&2
     mkdir -p foo/lib
-    $CC -shared ${stdenv.lib.optionalString stdenv.isDarwin "-Wl,-install_name,@rpath/libfoo.dylib"} -DVALUE=42 -o foo/lib/libfoo.${shlib} ${./foo.c}
+    $CC -shared \
+      ${stdenv.lib.optionalString stdenv.isDarwin "-Wl,-install_name,@rpath/libfoo.dylib"} \
+      -DVALUE=42 \
+      -o foo/lib/libfoo${stdenv.hostPlatform.extensions.sharedLibrary} \
+      ${./foo.c}
+
     NIX_LDFLAGS="-L$NIX_BUILD_TOP/foo/lib -rpath $NIX_BUILD_TOP/foo/lib" $CC -lfoo -o ldflags-check ${./ldflags-main.c}
     ./ldflags-check
 

--- a/pkgs/test/stdenv-inputs/default.nix
+++ b/pkgs/test/stdenv-inputs/default.nix
@@ -1,8 +1,6 @@
 { stdenv }:
 
 let
-  shlib = if stdenv.isDarwin then "dylib" else "so";
-
   foo = stdenv.mkDerivation {
     name = "foo-test";
 
@@ -13,7 +11,10 @@ let
       $CC -o $out/bin/foo ${./cc-main.c}
       chmod +x $out/bin/foo
       cp ${./foo.c} $out/include/foo.h
-      $CC -shared ${stdenv.lib.optionalString stdenv.isDarwin "-Wl,-install_name,$out/lib/libfoo.dylib"} -o $out/lib/libfoo.${shlib} ${./foo.c}
+      $CC -shared \
+        ${stdenv.lib.optionalString stdenv.isDarwin "-Wl,-install_name,$out/lib/libfoo.dylib"} \
+        -o $out/lib/libfoo${stdenv.hostPlatform.extensions.sharedLibrary} \
+        ${./foo.c}
     '';
   };
 
@@ -28,7 +29,10 @@ let
       $CC -o $out/bin/bar ${./cc-main.c}
       chmod +x $out/bin/bar
       cp ${./bar.c} $dev/include/bar.h
-      $CC -shared ${stdenv.lib.optionalString stdenv.isDarwin "-Wl,-install_name,$dev/lib/libbar.dylib"} -o $dev/lib/libbar.${shlib} ${./bar.c}
+      $CC -shared \
+        ${stdenv.lib.optionalString stdenv.isDarwin "-Wl,-install_name,$dev/lib/libbar.dylib"} \
+        -o $dev/lib/libbar${stdenv.hostPlatform.extensions.sharedLibrary} \
+        ${./bar.c}
     '';
   };
 in

--- a/pkgs/tools/networking/eggdrop/default.nix
+++ b/pkgs/tools/networking/eggdrop/default.nix
@@ -1,9 +1,5 @@
 { stdenv, fetchFromGitHub, tcl }:
 
-let
-  shlib = if stdenv.isDarwin then "dylib" else "so";
-in
-
 stdenv.mkDerivation rec {
   name = "eggdrop-${version}";
   version = "1.6.21-nix1";
@@ -29,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--with-tcllib=${tcl}/lib/lib${tcl.libPrefix}.${shlib}"
+    "--with-tcllib=${tcl}/lib/lib${tcl.libPrefix}${stdenv.hostPlatform.extensions.sharedLibrary}"
     "--with-tclinc=${tcl}/include/tcl.h"
   ];
 

--- a/pkgs/tools/security/yara/default.nix
+++ b/pkgs/tools/security/yara/default.nix
@@ -17,20 +17,16 @@ stdenv.mkDerivation rec {
 
   # FIXME: this is probably not the right way to make it work
   # make[2]: *** No rule to make target 'libyara/.libs/libyara.a', needed by 'yara'.  Stop.
-  dynamic_library_extension = ""
-    + stdenv.lib.optionalString stdenv.isLinux "so"
-    + stdenv.lib.optionalString stdenv.isDarwin "dylib"
-  ;
   prePatch = ''
     cat >staticlibrary.patch <<EOF
     --- a/Makefile.am 2015-11-01 11:39:12.000000000 +0100
     +++ b/Makefile.am 2015-11-01 11:45:32.000000000 +0100
     @@ -12 +12 @@
     -yara_LDADD = libyara/.libs/libyara.a
-    +yara_LDADD = libyara/.libs/libyara.${dynamic_library_extension}
+    +yara_LDADD = libyara/.libs/libyara${stdenv.hostPlatform.extensions.sharedLibrary}
     @@ -15 +15 @@
     -yarac_LDADD = libyara/.libs/libyara.a
-    +yarac_LDADD = libyara/.libs/libyara.${dynamic_library_extension}
+    +yarac_LDADD = libyara/.libs/libyara${stdenv.hostPlatform.extensions.sharedLibrary}
     EOF
   '';
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Keeping track of platform-specific extensions in a more organized manner.

###### Things done

Eval is currently broken on master, so testing is more difficult than it should be.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

