### PR TITLE
Add new top-level package set for headless packages

### DIFF
--- a/nixos/modules/config/no-x-libs.nix
+++ b/nixos/modules/config/no-x-libs.nix
@@ -26,16 +26,6 @@ with lib;
 
     fonts.fontconfig.enable = false;
 
-    nixpkgs.config.packageOverrides = pkgs: {
-      dbus = pkgs.dbus.override { x11Support = false; };
-      networkmanager_fortisslvpn = pkgs.networkmanager_fortisslvpn.override { withGnome = false; };
-      networkmanager_l2tp = pkgs.networkmanager_l2tp.override { withGnome = false; };
-      networkmanager_openconnect = pkgs.networkmanager_openconnect.override { withGnome = false; };
-      networkmanager_openvpn = pkgs.networkmanager_openvpn.override { withGnome = false; };
-      networkmanager_pptp = pkgs.networkmanager_pptp.override { withGnome = false; };
-      networkmanager_vpnc = pkgs.networkmanager_vpnc.override { withGnome = false; };
-      networkmanager_iodine = pkgs.networkmanager_iodine.override { withGnome = false; };
-      pinentry = pkgs.pinentry.override { gtk2 = null; qt4 = null; };
-    };
+    nixpkgs.overlays = [ pkgs.headless-overlay ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -355,6 +355,10 @@ with pkgs;
 
   iconConvTools = callPackage ../build-support/icon-conv-tools {};
 
+  ### OVERLAYS (n.b.: don't add to these without consulting the community; they can be expensive)
+
+  headless-overlay = import ./headless.nix;
+  headless = lib.lowPrioSet (recurseIntoAttrs (import path { overlays = [ headless-overlay ]; }));
 
   ### TOOLS
 

--- a/pkgs/top-level/headless.nix
+++ b/pkgs/top-level/headless.nix
@@ -1,0 +1,20 @@
+# The goal for this package set is to run without cruft you wouldn't need on a headless server/VM.
+# Typical things one might want to disable here are audio support, HID device support, graphical
+# support, and so on. If that seems like a lot of concerns rolled into one, this is a trade-off:
+# the more individual knobs we add, the more the combinatorics of building all these packages and
+# maintaining all the various combinations, which is both a drain on Hydra and on maintainer time.
+# This set seems like a reasonably common use case that was worth representing.
+# See https://github.com/NixOS/nixpkgs/issues/29135 and https://github.com/NixOS/nixpkgs/issues/12877
+# for more discussion on the pros and cons of these.
+
+self: super: {
+  dbus = super.dbus.override { x11Support = false; };
+  networkmanager_fortisslvpn = super.networkmanager_fortisslvpn.override { withGnome = false; };
+  networkmanager_l2tp = super.networkmanager_l2tp.override { withGnome = false; };
+  networkmanager_openconnect = super.networkmanager_openconnect.override { withGnome = false; };
+  networkmanager_openvpn = super.networkmanager_openvpn.override { withGnome = false; };
+  networkmanager_pptp = super.networkmanager_pptp.override { withGnome = false; };
+  networkmanager_vpnc = super.networkmanager_vpnc.override { withGnome = false; };
+  networkmanager_iodine = super.networkmanager_iodine.override { withGnome = false; };
+  pinentry = super.pinentry.override { gtk2 = null; qt4 = null; };
+}


### PR DESCRIPTION
The package set itself is currnetly fairly small and taken from the no-x-libs.nix module that we already had.

Should address https://github.com/NixOS/nixpkgs/issues/29135. Ideally I'd prefer to move towards something more like #12877 but that seemed like a much bigger bite, and this could always move to using that once implemented.

cc @edolstra @vcunat 

P.S: I'm feeling pretty good about the branch name I picked. Anyone enjoy Harry Potter?