### PR TITLE
odp-dpdk: fix a typo

### DIFF
--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    make install-runtime install-sdk DESTDIR=$out prefix= includedir=/include datadir=/
+    make install-runtime DESTDIR=$out prefix= includedir=/include datadir=/
     make install-sdk DESTDIR=$out prefix= includedir=/include datadir=/
     make install-kmod DESTDIR=$kmod
   '';


### PR DESCRIPTION
(cherry picked from commit 4ac8529dd40e11ab14c039ecb5f14b2a85d3b2df)

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

