### PR TITLE
piwik: 3.0.4 -> 3.1.0

### DIFF
--- a/pkgs/servers/web-apps/piwik/default.nix
+++ b/pkgs/servers/web-apps/piwik/default.nix
@@ -2,29 +2,20 @@
 
 stdenv.mkDerivation rec {
   name = "piwik-${version}";
-  version = "3.0.4";
+  version = "3.1.0";
 
   src = fetchurl {
     url = "https://builds.piwik.org/${name}.tar.gz";
-    sha512 = "2i0vydr073ynv7wcn078zxhvywdv85c648hympkzicdd746g995878py9006m96iwkmk4q664wn3f8jnfqsl1jd9f26alz1nssizbn9";
+    sha512 = "175300ibf0lg4xnyn5v47czi3vd6i7yqf1im3br4975f6k7w8q22m2mk2mi006795js5q52x48g4sc7wb47wac7wbla8wp98al48gfb";
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
-  # regarding the PIWIK_USER_PATH substitutes:
-  #   looks like this is just a bug / confusion of the directories, and nobody has tested this.
-  #   PR at https://github.com/piwik/piwik/pull/11661
   # regarding the 127.0.0.1 substitute:
   #   This replaces the default value of the database server field.
   #   unix socket authentication only works with localhost,
   #   but password-based SQL authentication works with both.
   postPatch = ''
-    substituteInPlace core/AssetManager/UIAssetFetcher.php \
-      --replace "return PIWIK_USER_PATH;" "return PIWIK_DOCUMENT_ROOT;"
-    substituteInPlace core/AssetManager/UIAssetMerger/StylesheetUIAssetMerger.php \
-      --replace "setImportDir(PIWIK_USER_PATH);" "setImportDir(PIWIK_DOCUMENT_ROOT);"
-    substituteInPlace core/AssetManager/UIAssetMerger/StylesheetUIAssetMerger.php \
-      --replace "\$absolutePath = PIWIK_USER_PATH" "\$absolutePath = PIWIK_DOCUMENT_ROOT"
     substituteInPlace plugins/Installation/FormDatabaseSetup.php \
       --replace "=> '127.0.0.1'," "=> 'localhost',"
     cp ${./bootstrap.php} bootstrap.php


### PR DESCRIPTION
###### Motivation for this change
Upgrade fixes security vulnerabilities.
Besides, my patch for Nix was merged upstream and therefore could be removed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

