### PR TITLE
Fix build of python3Packages.spacy

### DIFF
--- a/pkgs/development/python-modules/ftfy/default.nix
+++ b/pkgs/development/python-modules/ftfy/default.nix
@@ -10,11 +10,12 @@
 buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "ftfy";
-  version = "5.1.1";
+  # latest is 5.1.1, buy spaCy requires 4.4.3
+  version = "4.4.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "67a29a2fad5f72aec2d8a0a7084e4f499ed040455133ee96b1c458609fc29e78";        
+    sha256 = "152xdb56rhs1q4r0ck1n557sbphw7zq18r75a7kkd159ckdnc01w";
   };
 
   propagatedBuildInputs = [ html5lib wcwidth];
@@ -38,6 +39,6 @@ buildPythonPackage rec {
     description = "Given Unicode text, make its representation consistent and possibly less broken.";
     homepage = https://github.com/LuminosoInsight/python-ftfy/tree/master/tests;
     license = licenses.mit;
-    maintainers = with maintainers; [ sdll ];    
+    maintainers = with maintainers; [ sdll ];
     };
 }


### PR DESCRIPTION
###### Motivation for this change

ftfy package was added for spaCy and is only used by spaCy.

This change downgrades its version to meet the bounds specified by spaCy (>=4.4.2,<5.0.0).

Relevant to #28643.

###### Things done


- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change -- built `python3Packages.spacy`
- [X] Tested execution of all binary files -- `./result/bin/ftfy`
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


/cc @sdll @FRidh
