### PR TITLE
zfsUnstable: init at 2017-09-12 (encryption support)

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -192,7 +192,6 @@ with lib;
       "Set the option `services.xserver.displayManager.sddm.package' instead.")
     (mkRemovedOptionModule [ "fonts" "fontconfig" "forceAutohint" ] "")
     (mkRemovedOptionModule [ "fonts" "fontconfig" "renderMonoTTFAsBitmap" ] "")
-    (mkRemovedOptionModule [ "boot" "zfs" "enableUnstable" ] "0.7.0 is now the default")
 
     # ZSH
     (mkRenamedOptionModule [ "programs" "zsh" "enableSyntaxHighlighting" ] [ "programs" "zsh" "syntaxHighlighting" "enable" ])

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -24,7 +24,11 @@ let
 
   kernel = config.boot.kernelPackages;
 
-  packages = {
+  packages = if config.boot.zfs.enableUnstable then {
+    spl = kernel.splUnstable;
+    zfs = kernel.zfsUnstable;
+    zfsUser = pkgs.zfsUnstable;
+  } else {
     spl = kernel.spl;
     zfs = kernel.zfs;
     zfsUser = pkgs.zfs;
@@ -58,6 +62,19 @@ in
 
   options = {
     boot.zfs = {
+      enableUnstable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Use the unstable zfs package. This might be an option, if the latest
+          kernel is not yet supported by a published release of ZFS. Enabling
+          this option will install a development version of ZFS on Linux. The
+          version will have already passed an extensive test suite, but it is
+          more likely to hit an undiscovered bug compared to running a released
+          version of ZFS on Linux.
+          '';
+      };
+
       extraPools = mkOption {
         type = types.listOf types.str;
         default = [];

--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -10,53 +10,66 @@ with stdenv.lib;
 let
   buildKernel = any (n: n == configFile) [ "kernel" "all" ];
   buildUser = any (n: n == configFile) [ "user" "all" ];
+  common = { version
+    , sha256
+    , rev ? "spl-${version}"
+    } @ args : stdenv.mkDerivation rec {
+      name = "spl-${configFile}-${version}${optionalString buildKernel "-${kernel.version}"}";
+
+      src = fetchFromGitHub {
+        owner = "zfsonlinux";
+        repo = "spl";
+        inherit rev sha256;
+      };
+
+      patches = [ ./const.patch ./install_prefix.patch ];
+
+      nativeBuildInputs = [ autoreconfHook ];
+
+      hardeningDisable = [ "pic" ];
+
+      preConfigure = ''
+        substituteInPlace ./module/spl/spl-generic.c --replace /usr/bin/hostid hostid
+        substituteInPlace ./module/spl/spl-generic.c --replace "PATH=/sbin:/usr/sbin:/bin:/usr/bin" "PATH=${coreutils}:${gawk}:/bin"
+        substituteInPlace ./module/splat/splat-vnode.c --replace "PATH=/sbin:/usr/sbin:/bin:/usr/bin" "PATH=${coreutils}:/bin"
+        substituteInPlace ./module/splat/splat-linux.c --replace "PATH=/sbin:/usr/sbin:/bin:/usr/bin" "PATH=${coreutils}:/bin"
+      '';
+
+      configureFlags = [
+        "--with-config=${configFile}"
+      ] ++ optionals buildKernel [
+        "--with-linux=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
+        "--with-linux-obj=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+      ];
+
+      enableParallelBuilding = true;
+
+      meta = {
+        description = "Kernel module driver for solaris porting layer (needed by in-kernel zfs)";
+
+        longDescription = ''
+          This kernel module is a porting layer for ZFS to work inside the linux
+          kernel.
+        '';
+
+        homepage = http://zfsonlinux.org/;
+        platforms = platforms.linux;
+        license = licenses.gpl2Plus;
+        maintainers = with maintainers; [ jcumming wizeman wkennington fpletz globin ];
+      };
+  };
 in
   assert any (n: n == configFile) [ "kernel" "user" "all" ];
   assert buildKernel -> kernel != null;
-stdenv.mkDerivation rec {
-  name = "spl-${configFile}-${version}${optionalString buildKernel "-${kernel.version}"}";
-  version = "0.7.1";
+{
+    splStable = common {
+      version = "0.7.1";
+      sha256 = "0m8qhbdd8n40lbd91s30q4lrw8g169sha0410c8rwk2d5qfaxv9n";
+    };
 
-  src = fetchFromGitHub {
-    owner = "zfsonlinux";
-    repo = "spl";
-    rev = "spl-${version}";
-    sha256 = "0m8qhbdd8n40lbd91s30q4lrw8g169sha0410c8rwk2d5qfaxv9n";
-  };
-
-  patches = [ ./const.patch ./install_prefix.patch ];
-
-  nativeBuildInputs = [ autoreconfHook ];
-
-  hardeningDisable = [ "pic" ];
-
-  preConfigure = ''
-    substituteInPlace ./module/spl/spl-generic.c --replace /usr/bin/hostid hostid
-    substituteInPlace ./module/spl/spl-generic.c --replace "PATH=/sbin:/usr/sbin:/bin:/usr/bin" "PATH=${coreutils}:${gawk}:/bin"
-    substituteInPlace ./module/splat/splat-vnode.c --replace "PATH=/sbin:/usr/sbin:/bin:/usr/bin" "PATH=${coreutils}:/bin"
-    substituteInPlace ./module/splat/splat-linux.c --replace "PATH=/sbin:/usr/sbin:/bin:/usr/bin" "PATH=${coreutils}:/bin"
-  '';
-
-  configureFlags = [
-    "--with-config=${configFile}"
-  ] ++ optionals buildKernel [
-    "--with-linux=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
-    "--with-linux-obj=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-  ];
-
-  enableParallelBuilding = true;
-
-  meta = {
-    description = "Kernel module driver for solaris porting layer (needed by in-kernel zfs)";
-
-    longDescription = ''
-      This kernel module is a porting layer for ZFS to work inside the linux
-      kernel.
-    '';
-
-    homepage = http://zfsonlinux.org/;
-    platforms = platforms.linux;
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ jcumming wizeman wkennington fpletz globin ];
-  };
+    splUnstable = common {
+      version = "2017-08-11";
+      rev = "9df9692637aeee416f509c7f39655beb2d35b549";
+      sha256 = "1dggf6xqgk2f7vccv6cgvr8krj7h9f921szp1j2qbxnnq41m37mi";
+    };
 }

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -13,112 +13,163 @@ let
   buildKernel = any (n: n == configFile) [ "kernel" "all" ];
   buildUser = any (n: n == configFile) [ "user" "all" ];
 
-in stdenv.mkDerivation rec {
-  name = "zfs-${configFile}-${version}${optionalString buildKernel "-${kernel.version}"}";
-  version = "0.7.1";
+  common = { version
+    , sha256
+    , extraPatches
+    , spl
+    , rev ? "zfs-${version}"
+    , isUnstable ? false
+    , incompatibleKernelVersion ? null } @ args:
+    if buildKernel &&
+      (incompatibleKernelVersion != null) &&
+        versionAtLeast kernel.version incompatibleKernelVersion then
+       throw ''
+         Linux v${kernel.version} is not yet supported by zfsonlinux v${version}.
+         ${stdenv.lib.optional (!isUnstable) "Try zfsUnstable or set the NixOS option boot.zfs.enableUnstable."}
+       ''
+    else stdenv.mkDerivation rec {
+      name = "zfs-${configFile}-${version}${optionalString buildKernel "-${kernel.version}"}";
 
-  src = fetchFromGitHub {
-    owner = "zfsonlinux";
-    repo = "zfs";
-    rev = "zfs-${version}";
+      src = fetchFromGitHub {
+        owner = "zfsonlinux";
+        repo = "zfs";
+        inherit rev sha256;
+      };
+
+      patches = extraPatches;
+
+      buildInputs = [ autoreconfHook nukeReferences ]
+        ++ optionals buildKernel [ spl ]
+        ++ optionals buildUser [ zlib libuuid python attr ];
+
+      # for zdb to get the rpath to libgcc_s, needed for pthread_cancel to work
+      NIX_CFLAGS_LINK = "-lgcc_s";
+
+      hardeningDisable = [ "pic" ];
+
+      preConfigure = ''
+        substituteInPlace ./module/zfs/zfs_ctldir.c   --replace "umount -t zfs"           "${utillinux}/bin/umount -t zfs"
+        substituteInPlace ./module/zfs/zfs_ctldir.c   --replace "mount -t zfs"            "${utillinux}/bin/mount -t zfs"
+        substituteInPlace ./lib/libzfs/libzfs_mount.c --replace "/bin/umount"             "${utillinux}/bin/umount"
+        substituteInPlace ./lib/libzfs/libzfs_mount.c --replace "/bin/mount"              "${utillinux}/bin/mount"
+        substituteInPlace ./cmd/ztest/ztest.c         --replace "/usr/sbin/ztest"         "$out/sbin/ztest"
+        substituteInPlace ./cmd/ztest/ztest.c         --replace "/usr/sbin/zdb"           "$out/sbin/zdb"
+        substituteInPlace ./config/user-systemd.m4    --replace "/usr/lib/modules-load.d" "$out/etc/modules-load.d"
+        substituteInPlace ./config/zfs-build.m4       --replace "\$sysconfdir/init.d"     "$out/etc/init.d"
+        substituteInPlace ./etc/zfs/Makefile.am       --replace "\$(sysconfdir)"          "$out/etc"
+        substituteInPlace ./cmd/zed/Makefile.am       --replace "\$(sysconfdir)"          "$out/etc"
+        substituteInPlace ./module/Makefile.in        --replace "/bin/cp"                 "cp"
+        substituteInPlace ./etc/systemd/system/zfs-share.service.in \
+          --replace "@bindir@/rm " "${coreutils}/bin/rm "
+
+        for f in ./udev/rules.d/*
+        do
+          substituteInPlace "$f" --replace "/lib/udev/vdev_id" "$out/lib/udev/vdev_id"
+        done
+
+        ./autogen.sh
+      '';
+
+      configureFlags = [
+        "--with-config=${configFile}"
+        ] ++ optionals buildUser [
+        "--with-dracutdir=$(out)/lib/dracut"
+        "--with-udevdir=$(out)/lib/udev"
+        "--with-systemdunitdir=$(out)/etc/systemd/system"
+        "--with-systemdpresetdir=$(out)/etc/systemd/system-preset"
+        "--with-mounthelperdir=$(out)/bin"
+        "--sysconfdir=/etc"
+        "--localstatedir=/var"
+        "--enable-systemd"
+        ] ++ optionals buildKernel [
+        "--with-spl=${spl}/libexec/spl"
+        "--with-linux=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
+        "--with-linux-obj=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+      ];
+
+      enableParallelBuilding = true;
+
+      installFlags = [
+        "sysconfdir=\${out}/etc"
+        "DEFAULT_INITCONF_DIR=\${out}/default"
+      ];
+
+      postInstall = ''
+        # Prevent kernel modules from depending on the Linux -dev output.
+        nuke-refs $(find $out -name "*.ko")
+      '' + optionalString buildUser ''
+        # Remove provided services as they are buggy
+        rm $out/etc/systemd/system/zfs-import-*.service
+
+        sed -i '/zfs-import-scan.service/d' $out/etc/systemd/system/*
+
+        for i in $out/etc/systemd/system/*; do
+        substituteInPlace $i --replace "zfs-import-cache.service" "zfs-import.target"
+        done
+
+        # Fix pkgconfig.
+        ln -s ../share/pkgconfig $out/lib/pkgconfig
+
+        # Remove tests because they add a runtime dependency on gcc
+        rm -rf $out/share/zfs/zfs-tests
+      '';
+
+      outputs = [ "out" ] ++ optionals buildUser [ "lib" "dev" ];
+
+      meta = {
+        description = "ZFS Filesystem Linux Kernel module";
+        longDescription = ''
+          ZFS is a filesystem that combines a logical volume manager with a
+          Copy-On-Write filesystem with data integrity detection and repair,
+          snapshotting, cloning, block devices, deduplication, and more.
+        '';
+        home = http://zfsonlinux.org/;
+        license = licenses.cddl;
+        platforms = platforms.linux;
+        maintainers = with maintainers; [ jcumming wizeman wkennington fpletz globin ];
+      };
+    };
+in {
+  # also check if kernel version constraints in
+  # ./nixos/modules/tasks/filesystems/zfs.nix needs
+  # to be adapted
+  zfsStable = common {
+    # comment/uncomment if breaking kernel versions are known
+    incompatibleKernelVersion = null;
+
+    # this package should point to the latest release.
+    version = "0.7.1";
+
     sha256 = "0czal6lpl8igrhwmqh5jcgx07rlcgnrfg6ywzf681vsyh3gaxj9n";
+
+    extraPatches = [
+      (fetchpatch {
+        url = "https://github.com/Mic92/zfs/compare/zfs-0.7.0-rc3...nixos-zfs-0.7.0-rc3.patch";
+        sha256 = "1vlw98v8xvi8qapzl1jwm69qmfslwnbg3ry1lmacndaxnyckkvhh";
+      })
+    ];
+
+    inherit spl;
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/Mic92/zfs/compare/zfs-0.7.0-rc3...nixos-zfs-0.7.0-rc3.patch";
-      sha256 = "1vlw98v8xvi8qapzl1jwm69qmfslwnbg3ry1lmacndaxnyckkvhh";
-    })
-  ];
+  zfsUnstable = common {
+    # comment/uncomment if breaking kernel versions are known
+    incompatibleKernelVersion = null;
 
-  buildInputs = [ autoreconfHook nukeReferences ]
-  ++ optionals buildKernel [ spl ]
-  ++ optionals buildUser [ zlib libuuid python attr ];
+    # this package should point to a version / git revision compatible with the latest kernel release
+    version = "2017-09-12";
 
-  # for zdb to get the rpath to libgcc_s, needed for pthread_cancel to work
-  NIX_CFLAGS_LINK = "-lgcc_s";
+    rev = "ded8f06a3cfee60b3a8ea5309e9c4d0e567ed3b5";
+    sha256 = "0yn4fg4a00hpflmmr0jbbhfb921nygpw2xbbjy35abl57k6zk375";
+    isUnstable = true;
 
-  hardeningDisable = [ "pic" ];
+    extraPatches = [
+      (fetchpatch {
+        url = "https://github.com/Mic92/zfs/compare/ded8f06a3cfee...nixos-zfs-2017-09-12.patch";
+        sha256 = "033wf4jn0h0kp0h47ai98rywnkv5jwvf3xwym30phnaf8xxdx8aj";
+      })
+    ];
 
-  preConfigure = ''
-    substituteInPlace ./module/zfs/zfs_ctldir.c   --replace "umount -t zfs"           "${utillinux}/bin/umount -t zfs"
-    substituteInPlace ./module/zfs/zfs_ctldir.c   --replace "mount -t zfs"            "${utillinux}/bin/mount -t zfs"
-    substituteInPlace ./lib/libzfs/libzfs_mount.c --replace "/bin/umount"             "${utillinux}/bin/umount"
-    substituteInPlace ./lib/libzfs/libzfs_mount.c --replace "/bin/mount"              "${utillinux}/bin/mount"
-    substituteInPlace ./cmd/ztest/ztest.c         --replace "/usr/sbin/ztest"         "$out/sbin/ztest"
-    substituteInPlace ./cmd/ztest/ztest.c         --replace "/usr/sbin/zdb"           "$out/sbin/zdb"
-    substituteInPlace ./config/user-systemd.m4    --replace "/usr/lib/modules-load.d" "$out/etc/modules-load.d"
-    substituteInPlace ./config/zfs-build.m4       --replace "\$sysconfdir/init.d"     "$out/etc/init.d"
-    substituteInPlace ./etc/zfs/Makefile.am       --replace "\$(sysconfdir)"          "$out/etc"
-    substituteInPlace ./cmd/zed/Makefile.am       --replace "\$(sysconfdir)"          "$out/etc"
-    substituteInPlace ./module/Makefile.in        --replace "/bin/cp"                 "cp"
-    substituteInPlace ./etc/systemd/system/zfs-share.service.in \
-      --replace "@bindir@/rm " "${coreutils}/bin/rm "
-
-    for f in ./udev/rules.d/*
-    do
-      substituteInPlace "$f" --replace "/lib/udev/vdev_id" "$out/lib/udev/vdev_id"
-    done
-
-    ./autogen.sh
-  '';
-
-  configureFlags = [
-    "--with-config=${configFile}"
-    ] ++ optionals buildUser [
-    "--with-dracutdir=$(out)/lib/dracut"
-    "--with-udevdir=$(out)/lib/udev"
-    "--with-systemdunitdir=$(out)/etc/systemd/system"
-    "--with-systemdpresetdir=$(out)/etc/systemd/system-preset"
-    "--with-mounthelperdir=$(out)/bin"
-    "--sysconfdir=/etc"
-    "--localstatedir=/var"
-    "--enable-systemd"
-    ] ++ optionals buildKernel [
-    "--with-spl=${spl}/libexec/spl"
-    "--with-linux=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
-    "--with-linux-obj=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-  ];
-
-  enableParallelBuilding = true;
-
-  installFlags = [
-    "sysconfdir=\${out}/etc"
-    "DEFAULT_INITCONF_DIR=\${out}/default"
-  ];
-
-  postInstall = ''
-    # Prevent kernel modules from depending on the Linux -dev output.
-    nuke-refs $(find $out -name "*.ko")
-  '' + optionalString buildUser ''
-    # Remove provided services as they are buggy
-    rm $out/etc/systemd/system/zfs-import-*.service
-
-    sed -i '/zfs-import-scan.service/d' $out/etc/systemd/system/*
-
-    for i in $out/etc/systemd/system/*; do
-    substituteInPlace $i --replace "zfs-import-cache.service" "zfs-import.target"
-    done
-
-    # Fix pkgconfig.
-    ln -s ../share/pkgconfig $out/lib/pkgconfig
-
-    # Remove tests because they add a runtime dependency on gcc
-    rm -rf $out/share/zfs/zfs-tests
-  '';
-
-  outputs = [ "out" ] ++ optionals buildUser [ "lib" "dev" ];
-
-  meta = {
-    description = "ZFS Filesystem Linux Kernel module";
-    longDescription = ''
-      ZFS is a filesystem that combines a logical volume manager with a
-      Copy-On-Write filesystem with data integrity detection and repair,
-      snapshotting, cloning, block devices, deduplication, and more.
-    '';
-    homepage = http://zfsonlinux.org/;
-    license = licenses.cddl;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ jcumming wizeman wkennington fpletz globin ];
+    spl = splUnstable;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12411,10 +12411,12 @@ with pkgs;
 
     sch_cake = callPackage ../os-specific/linux/sch_cake { };
 
-    spl = callPackage ../os-specific/linux/spl {
+    inherit (callPackage ../os-specific/linux/spl {
       configFile = "kernel";
       inherit kernel;
-    };
+    }) splStable splUnstable;
+
+    spl = splStable;
 
     sysdig = callPackage ../os-specific/linux/sysdig {};
 
@@ -12438,10 +12440,12 @@ with pkgs;
 
     x86_energy_perf_policy = callPackage ../os-specific/linux/x86_energy_perf_policy { };
 
-    zfs = callPackage ../os-specific/linux/zfs {
+    inherit (callPackage ../os-specific/linux/zfs {
       configFile = "kernel";
       inherit kernel spl;
-    };
+     }) zfsStable zfsUnstable;
+
+     zfs = zfsStable;
   });
 
   # The current default kernel / kernel modules.
@@ -12739,9 +12743,9 @@ with pkgs;
 
   statifier = callPackage ../os-specific/linux/statifier { };
 
-  spl = callPackage ../os-specific/linux/spl {
+  inherit (callPackage ../os-specific/linux/spl {
     configFile = "user";
-  };
+  }) splStable splUnstable;
 
   sysdig = callPackage ../os-specific/linux/sysdig {
     kernel = null;
@@ -12945,9 +12949,11 @@ with pkgs;
 
   zd1211fw = callPackage ../os-specific/linux/firmware/zd1211 { };
 
-  zfs = callPackage ../os-specific/linux/zfs {
+  inherit (callPackage ../os-specific/linux/zfs {
     configFile = "user";
-  };
+  }) zfsStable zfsUnstable;
+
+  zfs = zfsStable;
 
   ### DATA
 


### PR DESCRIPTION
###### Motivation for this change

I add this to be able to test upcomming zfs encryption support.
Currently it builds and run on my machine, but I have not yet tested importing of an encrypted pool yet.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

