### PR TITLE
gnome-doc-utils: fix build for store paths containing '+' character

### DIFF
--- a/pkgs/development/tools/documentation/gnome-doc-utils/default.nix
+++ b/pkgs/development/tools/documentation/gnome-doc-utils/default.nix
@@ -10,8 +10,14 @@ python2Packages.buildPythonApplication {
     sha256 = "19n4x25ndzngaciiyd8dd6s2mf9gv6nv3wv27ggns2smm7zkj1nb";
   };
 
+  nativeBuildInputs = [ intltool pkgconfig ];
+  buildInputs = [ libxslt ];
+
   configureFlags = "--disable-scrollkeeper";
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libxslt intltool ];
+
+  preBuild = ''
+    substituteInPlace xml2po/xml2po/Makefile --replace '-e "s+^#!.*python.*+#!$(PYTHON)+"' '-e "s\"^#!.*python.*\"#!$(PYTHON)\""'
+  '';
+
   propagatedBuildInputs = [ libxml2Python ];
 }


### PR DESCRIPTION
###### Motivation for this change

https://bugzilla.gnome.org/show_bug.cgi?id=787606

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

this is a mass-rebuild