### PR TITLE
networking.defaultMailServer.authPassFile: allow types.path

### DIFF
--- a/nixos/modules/programs/ssmtp.nix
+++ b/nixos/modules/programs/ssmtp.nix
@@ -103,9 +103,9 @@ in
       };
 
       authPassFile = mkOption {
-        type = types.nullOr types.str;
+        type = types.nullOr (types.either types.str types.path);
         default = null;
-        example = "/run/keys/ssmtp-authpass";
+        example = /home/user/locally-stored-pass-file;
         description = ''
           Path to a file that contains the password used for SMTP auth. The file
           should not contain a trailing newline, if the password does not contain one.


### PR DESCRIPTION
###### Motivation for this change

`types.path` is semantically correct when providing file path values.
However `networking.defaultMailServer.authPassFile` only allows strings and null ATM.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

