### PR TITLE
containerd: 0.2.9 -> 1.0.1

### DIFF
--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -1,23 +1,38 @@
 { stdenv, lib, fetchFromGitHub, removeReferencesTo
-, go, libapparmor, apparmor-parser, libseccomp }:
+, go, libapparmor, apparmor-parser, libseccomp, btrfs-progs }:
 
 with lib;
 
 stdenv.mkDerivation rec {
   name = "containerd-${version}";
-  version = "0.2.9";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "containerd";
     repo = "containerd";
     rev = "v${version}";
-    sha256 = "0rix0mv203fn3rcxmpqdpb54l1a0paqplg2xgldpd943qi1rm552";
+    sha256 = "0kfafqi66yp4qy738pl11f050hfrx9m4kc670qpx7fmf9ii7q6p2";
   };
 
-  buildInputs = [ removeReferencesTo go ];
+  hardeningDisable = [ "fortify" ];
+
+  buildInputs = [ removeReferencesTo go btrfs-progs ];
+  buildFlags = "VERSION=v${version}";
+
+  BUILDTAGS = []
+    ++ optional (btrfs-progs == null) "no_btrfs";
+
+  preConfigure = ''
+    # Extract the source
+    cd "$NIX_BUILD_TOP"
+    mkdir -p "go/src/github.com/containerd"
+    mv "$sourceRoot" "go/src/github.com/containerd/containerd"
+    export GOPATH=$NIX_BUILD_TOP/go:$GOPATH
+'';
 
   preBuild = ''
-    ln -s $(pwd) vendor/src/github.com/containerd/containerd
+    cd go/src/github.com/containerd/containerd
+    patchShebangs .
   '';
 
   installPhase = ''


### PR DESCRIPTION
Update containerd to its latest beta. (Probably would need tests like the docker one 👼 I'll look into it)

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

The diff between containerd 0.2.x and 1.0.0 is huge (1.x is way more feature complete). Also, fixing `containerd --version` on 1.x 👼

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

