### PR TITLE
[wip] jupyter_console: 5.0.0 -> 5.1.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6966,12 +6966,12 @@ in {
   };
 
   jupyter_console = buildPythonPackage rec {
-    version = "5.0.0";
+    version = "5.1.0";
     name = "jupyter_console-${version}";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/j/jupyter_console/${name}.tar.gz";
-      sha256 = "7ddfc8cc49921b0ed852500928922e637f9188358c94b5c76339a5a8f9ac4c11";
+      sha256 = "1myg8fs7ffvy3jm3pvx86xgzpkwa68csh3v9sply22q7zr6sxd6h";
     };
 
     buildInputs = with self; [ nose ];


### PR DESCRIPTION
###### Motivation for this change
Upon running jupyter-console I would get
`ImportError: No module named 'IPython.utils.warn'`

Now I get 
```
/nix/store/g8prw6jy2yvrww8kfmsdyzja66dbm0sl-python3-3.6.2/bin/python3.6m: No module named ipykernel_launcher
Traceback (most recent call last):
  File "/nix/store/p6h97chmra4158ph14ahabynbbyg22wn-python3.6-jupyter_console-5.1.0/lib/python3.6/site-packages/jupyter_console/ptshell.py", line 321, in init_kernel_info
    reply = self.client.get_shell_msg(timeout=1)
  File "/nix/store/qn7a9ria8s2kza9mfjaz4pa7fmrm4fjm-python3.6-jupyter_client-5.1.0/lib/python3.6/site-packages/jupyter_client/client.py", line 77, in get_shell_msg
    return self.shell_channel.get_msg(*args, **kwargs)
  File "/nix/store/qn7a9ria8s2kza9mfjaz4pa7fmrm4fjm-python3.6-jupyter_client-5.1.0/lib/python3.6/site-packages/jupyter_client/blocking/channels.py", line 57, in get_msg
    raise Empty
queue.Empty
```
so still a WIP


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

