### PR TITLE
Python-kivy: init at 1.10.0

### DIFF
--- a/pkgs/development/python-modules/kivy/default.nix
+++ b/pkgs/development/python-modules/kivy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, maintainers, platforms, licenses, pkgs, self }:
+{ stdenv, buildPythonPackage, fetchPypi, maintainers, platforms, licenses, pkgs, self }:
 
 # From the 1.10.0 documentation:
 # "This version of Kivy requires at least Cython version 0.23, and has been
@@ -12,10 +12,12 @@ assert stdenv.lib.versionAtLeast self.cython.version "0.23";
 # assert stdenv.lib.versionOlder self.cython.version "0.25.3";
 
 buildPythonPackage rec {
-  name = "Kivy-1.10.0";
+  pname = "Kivy";
+  version = "1.10.0";
+  name = "${pname}-${version}";
 
-  src = pkgs.fetchurl {
-    url = "mirror://pypi/k/kivy/${name}.tar.gz";
+  src = fetchPypi {
+    inherit pname version;
     sha256 = "1394zh6kvf7k5d8vlzxcsfcailr3q59xwg9b1n7qaf25bvyq1h98";
   };
 
@@ -48,6 +50,7 @@ buildPythonPackage rec {
     # https://kivy.org/docs/installation/installation-linux.html
 
     pkgs.mesa
+    pkgs.mtdev
 
     pkgs.SDL2
     pkgs.SDL2_image
@@ -69,7 +72,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = with self; [
     pillow
-    pkgs.mtdev
     ] ;
 
   # We're not currently running tests, because there are 38 errors and 1 failure

--- a/pkgs/development/python-modules/kivy/default.nix
+++ b/pkgs/development/python-modules/kivy/default.nix
@@ -1,0 +1,99 @@
+{ stdenv, buildPythonPackage, maintainers, platforms, licenses, pkgs, self }:
+
+# From the 1.10.0 documentation:
+# "This version of Kivy requires at least Cython version 0.23, and has been
+# tested through 0.25.2. Later versions may work, but as they have not been
+# tested there is no guarantee."
+
+assert stdenv.lib.versionAtLeast self.cython.version "0.23";
+
+# Rather than depending on a specific older version of Cython, we accept the
+# off-chance of breakage:
+# assert stdenv.lib.versionOlder self.cython.version "0.25.3";
+
+buildPythonPackage rec {
+  name = "Kivy-1.10.0";
+
+  src = pkgs.fetchurl {
+    url = "mirror://pypi/k/kivy/${name}.tar.gz";
+    sha256 = "1394zh6kvf7k5d8vlzxcsfcailr3q59xwg9b1n7qaf25bvyq1h98";
+  };
+
+  # setup.py invokes git on build but we're fetching a tarball, so
+  # can't retrieve git version. We remove the git-invocation from setup.py
+  # This patch can presumably be removed on the next version of Kivy, because the problem
+  # was addressed in https://github.com/kivy/kivy/issues/5365
+  patches = [
+    ./setup.py.patch
+  ];
+
+  buildInputs = with self; [
+    pkgconfig
+    cython
+
+    kivygarden  # See https://github.com/kivy/kivy/issues/5367 suggestion I-2
+    requests  # See https://github.com/kivy/kivy/issues/5367 suggestion I-3
+    docutils # See https://github.com/kivy/kivy/issues/5367 question Q-5
+    pygments # See https://github.com/kivy/kivy/issues/5367 question Q-6
+
+    # nose  # needed for tests (which are currently disabled)
+
+    # The setup below is, as much as I can figure out how to make it, an attempt
+    # to create a "canonical full install" of Kivy on linux, as allued to in
+    # https://github.com/kivy/kivy/issues/5367 question Q-7
+
+    # Some sources to reconstruct such a thing are:
+    # .travis.yml (which contains the actual build instructions for CI)
+    # https://kivy.org/docs/installation/installation.html
+    # https://kivy.org/docs/installation/installation-linux.html
+
+    pkgs.mesa
+
+    pkgs.SDL2
+    pkgs.SDL2_image
+    pkgs.SDL2_ttf
+    pkgs.SDL2_mixer
+
+    # NOTE: The degree to which gstreamer actually works is unclear
+    pkgs.gst_all_1.gstreamer
+    pkgs.gst_all_1.gst-plugins-base
+    pkgs.gst_all_1.gst-plugins-good
+    pkgs.gst_all_1.gst-plugins-bad
+
+    # Not done yet:
+    # "Camera is also unclear in the cross-platform sense, though for a
+    # canonical linux configuration the answer is probably opencv. SDL2 for
+    # image provider qualifies as "canonical", though it is my impression that
+    # ffpyplayer has wider and better format support."
+    ];
+
+  propagatedBuildInputs = with self; [
+    pillow
+    pkgs.mtdev
+    ] ;
+
+  # We're not currently running tests, because there are 38 errors and 1 failure
+  # This number may be reduced somewhat once https://github.com/kivy/kivy/issues/5373 is fixed
+
+  # KIVY_NO_CONFIG is needed, because otherwise tests attempt to write to the non-existing $HOME
+  # checkPhase = ''
+  #   export KIVY_NO_CONFIG=1
+  #   nosetests
+  # '';
+
+  doCheck = false;
+
+  postPatch = ''
+   substituteInPlace kivy/lib/mtdev.py \
+     --replace "LoadLibrary('libmtdev.so.1')" "LoadLibrary('${pkgs.mtdev}/lib/libmtdev.so.1')"
+  '';
+
+  meta = {
+    description = "A software library for rapid development of hardware-accelerated multitouch applications.";
+    homepage    = "https://pypi.python.org/pypi/kivy";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ vanschelven ];
+    platforms   = platforms.unix;  # I can only test linux; in principle other platforms are supported
+  };
+
+}

--- a/pkgs/development/python-modules/kivy/kivy-garden.nix
+++ b/pkgs/development/python-modules/kivy/kivy-garden.nix
@@ -1,0 +1,25 @@
+# The sole reason for this package is that it is a (questionable) dependency of Kivy
+{ buildPythonPackage, fetchPypi, maintainers, platforms, licenses, pkgs, self }:
+
+buildPythonPackage rec {
+  pname = "kivy-garden";
+  version = "0.1.4";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wkcpr2zc1q5jb0bi7v2dgc0vs5h1y7j42mviyh764j2i0kz8mn2";
+  };
+
+  buildInputs = with self; [ ];
+  propagatedBuildInputs = with self; [ requests ];
+
+  meta = {
+    description = "The kivy garden installation script, split into its own package for convenient use in buildozer.";
+
+    homepage    = "https://pypi.python.org/pypi/kivy-garden";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ vanschelven ];
+    platforms   = platforms.unix;  # Can only test linux; in principle other platforms are supported
+  };
+}

--- a/pkgs/development/python-modules/kivy/setup.py.patch
+++ b/pkgs/development/python-modules/kivy/setup.py.patch
@@ -1,0 +1,16 @@
+--- Kivy-1.10.0/setup.py	2017-05-07 17:24:57.000000000 +0200
++++ setup.py	2017-09-04 14:27:13.222721223 +0200
+@@ -42,12 +42,7 @@
+ def get_version(filename='kivy/version.py'):
+     VERSION = kivy.__version__
+     DATE = datetime.utcnow().strftime('%Y%m%d')
+-    try:
+-        GIT_REVISION = check_output(
+-            ['git', 'rev-parse', 'HEAD']
+-        ).strip().decode('ascii')
+-    except CalledProcessError:
+-        GIT_REVISION = "Unknown"
++    GIT_REVISION = "Unknown"
+ 
+     cnt = (
+         "# THIS FILE IS GENERATED FROM KIVY SETUP.PY\n"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11176,6 +11176,29 @@ in {
 
   keyring = callPackage ../development/python-modules/keyring { };
 
+  kivy = callPackage ../development/python-modules/kivy { inherit stdenv buildPythonPackage maintainers platforms licenses pkgs self ; };
+
+  kivygarden = buildPythonPackage rec {
+    # The sole reason for this package is that it is a (questionable) dependency of Kivy
+    name = "kivy-garden-0.1.4";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/k/kivy-garden/${name}.tar.gz";
+      sha256 = "0wkcpr2zc1q5jb0bi7v2dgc0vs5h1y7j42mviyh764j2i0kz8mn2";
+    };
+
+    buildInputs = with self; [ requests ];
+
+    meta = {
+      description = "The kivy garden installation script, split into its own package for convenient use in buildozer.";
+
+      homepage    = "https://pypi.python.org/pypi/kivy-garden";
+      license     = licenses.mit;
+      maintainers = with maintainers; [ vanschelven ];
+      platforms   = platforms.unix;  # Can only test linux; in principle other platforms are supported
+    };
+  };
+
   klaus = buildPythonPackage rec {
     version = "0.9.1";
     name = "klaus-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11176,28 +11176,9 @@ in {
 
   keyring = callPackage ../development/python-modules/keyring { };
 
-  kivy = callPackage ../development/python-modules/kivy { inherit stdenv buildPythonPackage maintainers platforms licenses pkgs self ; };
+  kivy = callPackage ../development/python-modules/kivy { inherit stdenv buildPythonPackage fetchPypi maintainers platforms licenses pkgs self ; };
 
-  kivygarden = buildPythonPackage rec {
-    # The sole reason for this package is that it is a (questionable) dependency of Kivy
-    name = "kivy-garden-0.1.4";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/k/kivy-garden/${name}.tar.gz";
-      sha256 = "0wkcpr2zc1q5jb0bi7v2dgc0vs5h1y7j42mviyh764j2i0kz8mn2";
-    };
-
-    buildInputs = with self; [ requests ];
-
-    meta = {
-      description = "The kivy garden installation script, split into its own package for convenient use in buildozer.";
-
-      homepage    = "https://pypi.python.org/pypi/kivy-garden";
-      license     = licenses.mit;
-      maintainers = with maintainers; [ vanschelven ];
-      platforms   = platforms.unix;  # Can only test linux; in principle other platforms are supported
-    };
-  };
+  kivygarden = callPackage ../development/python-modules/kivy/kivy-garden.nix { inherit buildPythonPackage fetchPypi maintainers platforms licenses pkgs self ; };
 
   klaus = buildPythonPackage rec {
     version = "0.9.1";


### PR DESCRIPTION
###### Motivation for this change

Kivy is an Open source Python library for rapid development of applications
that make use of innovative user interfaces, such as multi-touch apps.

Most of Kivy's dependencies are optional, so defining a good "default" set of useful dependencies was a bit of a challenge. The present set of dependencies works well for me, but more dependencies, or even options for configuring the package, may be required in the future.

There is also some discussion at https://github.com/kivy/kivy/issues/5367

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

