### PR TITLE
(pass): Add tomb plugin

### DIFF
--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -4,7 +4,7 @@
 
 , xclip ? null, xdotool ? null, dmenu ? null
 , x11Support ? !stdenv.isDarwin
-, tomb
+, tombPluginSupport ? false, tomb
 }:
 
 with lib;
@@ -18,14 +18,19 @@ let
     owner  = "roddhjav";
     repo   = "pass-${p.name}";
     inherit (p) rev sha256;
-  })) [
+  }))
+  ([
     { name = "import";
-      rev = "491935bd275f29ceac2b876b3a288011d1ce31e7"; sha256 = "02mbh05ab8h7kc30hz718d1d1vkjz43b96c7p0xnd92610d2q66q"; }
+      rev = "491935bd275f29ceac2b876b3a288011d1ce31e7";
+      sha256 = "02mbh05ab8h7kc30hz718d1d1vkjz43b96c7p0xnd92610d2q66q"; }
     { name = "update";
-      rev = "cf576c9036fd18efb9ed29e0e9f811207b556fde"; sha256 = "1hhbrg6a2walrvla6q4cd3pgrqbcrf9brzjkb748735shxfn52hd"; }
-    { name = "tomb";
-      rev = "3368134898a42c1b758fabac625ec240e125c6be"; sha256 = "0qqmxfg4w3r088qhlkhs44036mya82vjflsjjhw2hk8y0wd2i6ds"; }
-  ];
+      rev = "cf576c9036fd18efb9ed29e0e9f811207b556fde";
+      sha256 = "1hhbrg6a2walrvla6q4cd3pgrqbcrf9brzjkb748735shxfn52hd"; }
+    ] ++ stdenv.lib.optional tombPluginSupport {
+      name = "tomb";
+      rev = "3368134898a42c1b758fabac625ec240e125c6be";
+      sha256 = "0qqmxfg4w3r088qhlkhs44036mya82vjflsjjhw2hk8y0wd2i6ds"; }
+  );
 
 in stdenv.mkDerivation rec {
   version = "1.7.1";
@@ -69,8 +74,8 @@ in stdenv.mkDerivation rec {
     tree
     which
     qrencode
-    tomb
-  ] ++ stdenv.lib.optional stdenv.isLinux procps
+  ] ++ optional tombPluginSupport tomb
+    ++ optional stdenv.isLinux procps
     ++ ifEnable x11Support [ dmenu xclip xdotool ]);
 
   postFixup = ''

--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -4,6 +4,7 @@
 
 , xclip ? null, xdotool ? null, dmenu ? null
 , x11Support ? !stdenv.isDarwin
+, tomb
 }:
 
 with lib;
@@ -18,8 +19,12 @@ let
     repo   = "pass-${p.name}";
     inherit (p) rev sha256;
   })) [
-    { name = "import"; rev = "491935bd275f29ceac2b876b3a288011d1ce31e7"; sha256 = "02mbh05ab8h7kc30hz718d1d1vkjz43b96c7p0xnd92610d2q66q"; }
-    { name = "update"; rev = "cf576c9036fd18efb9ed29e0e9f811207b556fde"; sha256 = "1hhbrg6a2walrvla6q4cd3pgrqbcrf9brzjkb748735shxfn52hd"; }
+    { name = "import";
+      rev = "491935bd275f29ceac2b876b3a288011d1ce31e7"; sha256 = "02mbh05ab8h7kc30hz718d1d1vkjz43b96c7p0xnd92610d2q66q"; }
+    { name = "update";
+      rev = "cf576c9036fd18efb9ed29e0e9f811207b556fde"; sha256 = "1hhbrg6a2walrvla6q4cd3pgrqbcrf9brzjkb748735shxfn52hd"; }
+    { name = "tomb";
+      rev = "3368134898a42c1b758fabac625ec240e125c6be"; sha256 = "0qqmxfg4w3r088qhlkhs44036mya82vjflsjjhw2hk8y0wd2i6ds"; }
   ];
 
 in stdenv.mkDerivation rec {
@@ -64,6 +69,7 @@ in stdenv.mkDerivation rec {
     tree
     which
     qrencode
+    tomb
   ] ++ stdenv.lib.optional stdenv.isLinux procps
     ++ ifEnable x11Support [ dmenu xclip xdotool ]);
 


### PR DESCRIPTION
###### Motivation for this change
Add the pass-tomb plugin to pass. 

###### Things done
Import tomb and add the tomb plugin

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

