### PR TITLE
flashplayer: 26.0.0.151 -> 27.0.0.130 [Critical security fixes]

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -94,12 +94,12 @@ let
 
   flash = stdenv.mkDerivation rec {
     name = "flashplayer-ppapi-${version}";
-    version = "26.0.0.151";
+    version = "27.0.0.130";
 
     src = fetchzip {
       url = "https://fpdownload.adobe.com/pub/flashplayer/pdc/"
           + "${version}/flash_player_ppapi_linux.x86_64.tar.gz";
-      sha256 = "0l15k2ws3256zyvbfx66j8p1liqv4k2m8hhw2jz8nzza7q6il35p";
+      sha256 = "005sxx3ll18c6idy1db2gb47chd9c5mf83qac0vyvljsrlc7430c";
       stripRoot = false;
     };
 

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
@@ -73,25 +73,25 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-${version}";
-  version = "26.0.0.151";
+  version = "27.0.0.130";
 
   src = fetchurl {
     url =
       if debug then
-        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/26/flash_player_npapi_linux_debug.${arch}.tar.gz"
+        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/27/flash_player_npapi_linux_debug.${arch}.tar.gz"
       else
         "https://fpdownload.adobe.com/get/flashplayer/pdc/${version}/flash_player_npapi_linux.${arch}.tar.gz";
     sha256 =
       if debug then
         if arch == "x86_64" then
-          "0dlgardgrd8a18b48b0l6xk68dqi39yndv05phrypsxzr00p23q8"
+          "1sj06x4kfwxi9cnc8adjkxk6p81acl39l2idnyqb429l2s84d1d9"
         else
-          "0dbvsww4v6hlqn4yhdmzs335inim5iq0ym998x8zpavilqq51y0d"
+          "0f9vzdn523m408sw76r32zqf7d86l2mhcfsszbfh2bixg8p2cxzz"
       else
         if arch == "x86_64" then
-          "1yywffslh5px15w62wck1rnlp317jr6a334r409q7hxqc3x90z8l"
+          "0qkdabcnqfpbfsbs8ssms9xk2pqvps6fbasvcyvhnywclra25ggc"
         else
-          "1f1czbx14nvgr1qlzcp03nhj6c55wra8l6f4bsig691n3hfpb6hp";
+          "0qkwkc6s4ganja4b2jsz4yff0bziirvbzxg0wyf648hqlb3bw5a6";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
@@ -55,19 +55,19 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-standalone-${version}";
-  version = "26.0.0.151";
+  version = "27.0.0.130";
 
   src = fetchurl {
     url =
       if debug then
-        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/26/flash_player_sa_linux_debug.x86_64.tar.gz"
+        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/27/flash_player_sa_linux_debug.x86_64.tar.gz"
       else
-        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/26/flash_player_sa_linux.x86_64.tar.gz";
+        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/27/flash_player_sa_linux.x86_64.tar.gz";
     sha256 =
       if debug then
-        "0pfb217bg0v9hq0cbyndhmhkba16nhz2rasl7kk4ppxcfcjhr5pb"
+        "0gqm90j8czjnzar3ia65msd18kydjhgq5l9iv1difgm8lqji5ii0"
       else
-        "0a9ayylkpjprad1al7ddplxrpymd181a9gmw9hhk78s11v2zvwn8";
+        "1agplangzlrp326dhz3xcvi6i325a644ggrh8g0cmgq9nfcpssnb";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

- Critical security fixes
- Bug fixes
- Other improvements

https://helpx.adobe.com/flash-player/release-note/fp_27_air_27_release_notes.html
https://helpx.adobe.com/security/products/flash-player/apsb17-28.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

- Built packages
  - `nix-env -i -f . -A pkgs.flashplayer`
  - `nix-build -I nixpkgs=. -A pkgsi686Linux.flashplayer`
  - `nix-build -I nixpkgs=. -E "(import <nixpkgs> {}).flashplayer.override { debug = true; }"`
  - `nix-build -I nixpkgs=. -E "(import <nixpkgs> {}).pkgsi686Linux.flashplayer.override { debug = true; }"`
  - `nix-build -I nixpkgs=. -A pkgs.flashplayer-standalone`
  - `nix-build -I nixpkgs=. -A pkgs.flashplayer-standalone-debugger`
  - `nix-build -I nixpkgs=. -E "(import <nixpkgs> {}).chromium.override { enablePepperFlash = true; }"`
- Played a video with Firefox (x86_64)
- Played a video with Chromium (x86_64)
- Played a video with flashplayer-standalone and flashplayer-standalone-debugger (x86_64).
- Checked the version with Firefox (x86_64) http://www.adobe.com/software/flash/about/
- Checked the version with Chromium (x86_64) http://www.adobe.com/software/flash/about/
- Checked the version with with flashplayer-standalone and flashplayer-standalone-debugger (x86_64).

---

