### PR TITLE
s-tui: init at 0.6.0

### DIFF
--- a/pkgs/tools/system/s-tui/default.nix
+++ b/pkgs/tools/system/s-tui/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, pythonPackages }:
+
+pythonPackages.buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "s-tui";
+  version = "0.6.2";
+
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "0fijk26sm51bnxf7plzd1fn2k4f8mdqd7j9zqc3d8zri7228vik2";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [
+    urwid
+    psutil
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://amanusk.github.io/s-tui/;
+    descrption = "Stress-Terminal UI monitoring tool";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ infinisil ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4195,6 +4195,8 @@ with pkgs;
 
   rzip = callPackage ../tools/compression/rzip { };
 
+  s-tui = callPackage ../tools/system/s-tui { };
+
   s3backer = callPackage ../tools/filesystems/s3backer { };
 
   s3fs = callPackage ../tools/filesystems/s3fs { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

