### PR TITLE
updating jetbrains channels; made unknown channel error non-fatal

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -372,15 +372,15 @@ in
 
   rider = buildRider rec {
     name = "rider-${version}";
-    version = "171.4456.1432"; /* updated by script */
+    version = "171.4456.3271"; /* updated by script */
     description = "A cross-platform .NET IDE based on the IntelliJ platform and ReSharper";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
-      url = "https://download.jetbrains.com/resharper/Rider-RC-${version}.tar.gz";
-      sha256 = "37bad69cdfcc4f297b2500a7bb673af7ef8f1fd45baa4eb2fa388d2c4bcb41ee"; /* updated by script */
+      url = "https://download.jetbrains.com/resharper/JetBrains.Rider-${version}.tar.gz";
+      sha256 = "2979efedd0ada257191d928aafa682af299c536ad0cc47fe764fb4038f493d5d"; /* updated by script */
     };
     wmClass = "jetbrains-rider";
-    update-channel = "rider_2017_1_eap";
+    update-channel = "rider_2017_2_eap";
   };
 
   ruby-mine = buildRubyMine rec {

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -216,12 +216,12 @@ in
 
   clion = buildClion rec {
     name = "clion-${version}";
-    version = "2017.2.1"; /* updated by script */
+    version = "2017.2.2"; /* updated by script */
     description  = "C/C++ IDE. New. Intelligent. Cross-platform";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/cpp/CLion-${version}.tar.gz";
-      sha256 = "acd3d09a37a3fa922a85a48635d1b230d559ea68917e2e7895caf16460d50c13"; /* updated by script */
+      sha256 = "a019cd2469ecda7d93f3cd7ad3b8e349f374425783f6b4a54181907f6264d6e6"; /* updated by script */
     };
     wmClass = "jetbrains-clion";
     update-channel = "CLion_Release"; # channel's id as in http://www.jetbrains.com/updates/updates.xml
@@ -242,12 +242,12 @@ in
 
   gogland = buildGogland rec {
     name = "gogland-${version}";
-    version = "172.3757.46"; /* updated by script */
+    version = "172.3968.45"; /* updated by script */
     description = "Up and Coming Go IDE";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/go/${name}.tar.gz";
-      sha256 = "0d6b710edc434ed5d5ea5c4734b9026e2caeba7e74a027c1eb6fd837c5d4f4fd"; /* updated by script */
+      sha256 = "dccf09e21aced1ed13afdc7537fb0d3add8bd1a03e74df68b99e04429178695a"; /* updated by script */
     };
     wmClass = "jetbrains-gogland";
     update-channel = "gogland_1.0_EAP";
@@ -268,12 +268,12 @@ in
 
   idea-community = buildIdea rec {
     name = "idea-community-${version}";
-    version = "2017.2.2"; /* updated by script */
+    version = "2017.2.4"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
-      sha256 = "c719af3d538bef23d061ef62d4acbf503198ff62322a3c0c5b3c38ab7ac36c4f"; /* updated by script */
+      sha256 = "6abf1e9a26e59504e355221ad3f72c558c9dcc348a298748f6d79cb5dec7369d"; /* updated by script */
     };
     wmClass = "jetbrains-idea-ce";
     update-channel = "IDEA_Release";
@@ -307,12 +307,12 @@ in
 
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
-    version = "2017.2.2"; /* updated by script */
+    version = "2017.2.4"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIU-${version}-no-jdk.tar.gz";
-      sha256 = "b8eb9d612800cc896eb6b6fbefbf9f49d92d2350ae1c3c4598e5e12bf93be401"; /* updated by script */
+      sha256 = "15a4799ffde294d0f2fce0b735bbfe370e3d0327380a0efc45905241729898e3"; /* updated by script */
     };
     wmClass = "jetbrains-idea";
     update-channel = "IDEA_Release";
@@ -320,12 +320,12 @@ in
 
   phpstorm = buildPhpStorm rec {
     name = "phpstorm-${version}";
-    version = "2017.2.1"; /* updated by script */
+    version = "2017.2.3"; /* updated by script */
     description = "Professional IDE for Web and PHP developers";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webide/PhpStorm-${version}.tar.gz";
-      sha256 = "2f1af9ef6e9cda25a809a19a25f2d4fbaef00edf9d1d5a195572ab5e04e71e5e"; /* updated by script */
+      sha256 = "ee2fb52218a4d81d72d1fbab84ff9cc905695b6c2bafb5747daea8ee1487e782"; /* updated by script */
     };
     wmClass = "jetbrains-phpstorm";
     update-channel = "PS2017.2";
@@ -346,12 +346,12 @@ in
 
   pycharm-community = buildPycharm rec {
     name = "pycharm-community-${version}";
-    version = "2017.2.2"; /* updated by script */
+    version = "2017.2.3"; /* updated by script */
     description = "PyCharm Community Edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "4eacc9bf512406bebf71546ccb4b6c14ea8e06748fd76be6ca409ea1955e1f53"; /* updated by script */
+      sha256 = "e8562938c2ede32a1c1036391942190144cd9f0927bd49b6b3ddf5f7a01c33aa"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm-ce";
     update-channel = "PyCharm_Release";
@@ -359,12 +359,12 @@ in
 
   pycharm-professional = buildPycharm rec {
     name = "pycharm-professional-${version}";
-    version = "2017.2.2"; /* updated by script */
+    version = "2017.2.3"; /* updated by script */
     description = "PyCharm Professional Edition";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "21aedfd189115fcfee0e8c8df88eccbd8f19b998667af3c55ce5d56d4eaa37a9"; /* updated by script */
+      sha256 = "3e6f1cd48c08363353b2d2777a581cb60bebd6c538b325767c11d02395376945"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm";
     update-channel = "PyCharm_Release";
@@ -424,12 +424,12 @@ in
 
   webstorm = buildWebStorm rec {
     name = "webstorm-${version}";
-    version = "2017.2.2"; /* updated by script */
+    version = "2017.2.4"; /* updated by script */
     description = "Professional IDE for Web and JavaScript development";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webstorm/WebStorm-${version}.tar.gz";
-      sha256 = "d6b7b103f8543e25d2602657f12d029856529895af6354e1a0875ed40bd05180"; /* updated by script */
+      sha256 = "c0aa4f21bdb2bed8a2fe1b1a831ac7ace625695ce2cfc0d3a88ea8ecf572a2b5"; /* updated by script */
     };
     wmClass = "jetbrains-webstorm";
     update-channel = "WS_Release";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -320,12 +320,12 @@ in
 
   phpstorm = buildPhpStorm rec {
     name = "phpstorm-${version}";
-    version = "2017.2.3"; /* updated by script */
+    version = "2017.2.4"; /* updated by script */
     description = "Professional IDE for Web and PHP developers";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webide/PhpStorm-${version}.tar.gz";
-      sha256 = "ee2fb52218a4d81d72d1fbab84ff9cc905695b6c2bafb5747daea8ee1487e782"; /* updated by script */
+      sha256 = "7ee7afac677dd62d67d70f9fbf2e634ccf06bd80d8750babd0e78b1679e9c342"; /* updated by script */
     };
     wmClass = "jetbrains-phpstorm";
     update-channel = "PS2017.2";
@@ -372,7 +372,7 @@ in
 
   rider = buildRider rec {
     name = "rider-${version}";
-    version = "171.4456.3271"; /* updated by script */
+    version = "2017.2-171.4456.3271"; /* updated by script */
     description = "A cross-platform .NET IDE based on the IntelliJ platform and ReSharper";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {

--- a/pkgs/applications/editors/jetbrains/update.pl
+++ b/pkgs/applications/editors/jetbrains/update.pl
@@ -66,14 +66,15 @@ sub update_nix_block {
         $url =~ s/\$\{version\}/$latest_versions{$channel}/;
         die "$url still has some interpolation" if $url =~ /\$/;
         my ($sha256) = get("$url.sha256") =~ /^([0-9a-f]{64})/;
+        my $version_string = $latest_versions{$channel};
         unless ( $sha256 ) {
           my $full_version = $latest_versions{"full1_" . $channel};
-          my $last_version_try = $latest_versions{$channel};
-          $url =~ s/$last_version_try/$full_version/;
+          $url =~ s/$version_string/$full_version/;
 	  ($sha256) = get("$url.sha256") =~ /^([0-9a-f]{64})/;
+	  $version_string = $full_version;
         }
         die "invalid sha256 in $url.sha256" unless $sha256;
-        $block =~ s#version\s*=\s*"([^"]+)".+$#version = "$latest_versions{$channel}"; /* updated by script */#m;
+        $block =~ s#version\s*=\s*"([^"]+)".+$#version = "$version_string"; /* updated by script */#m;
         $block =~ s#sha256\s*=\s*"([^"]+)".+$#sha256 = "$sha256"; /* updated by script */#m;
       }
     }

--- a/pkgs/applications/editors/jetbrains/update.pl
+++ b/pkgs/applications/editors/jetbrains/update.pl
@@ -54,26 +54,27 @@ sub update_nix_block {
       my ($version) = $block =~ /version\s*=\s*"([^"]+)"/;
       die "no version in $block" unless $version;
       if ($version eq $latest_versions{$channel}) {
-	print("$channel is up to date at $version\n");
-      } else {
-	print("updating $channel: $version -> $latest_versions{$channel}\n");
-	my ($url) = $block =~ /url\s*=\s*"([^"]+)"/;
-	# try to interpret some nix
-	my ($name) = $block =~ /name\s*=\s*"([^"]+)"/;
-	$name =~ s/\$\{version\}/$latest_versions{$channel}/;
-	$url =~ s/\$\{name\}/$name/;
-	$url =~ s/\$\{version\}/$latest_versions{$channel}/;
-	die "$url still has some interpolation" if $url =~ /\$/;
-	my ($sha256) = get("$url.sha256") =~ /^([0-9a-f]{64})/;
-	unless ( $sha256 ) {
-	    my $full_version = $latest_versions{"full1_" . $channel};
-	    my $last_version_try = $latest_versions{$channel};
-            $url =~ s/$last_version_try/$full_version/;
-	}
-	($sha256) = get("$url.sha256") =~ /^([0-9a-f]{64})/;
+        print("$channel is up to date at $version\n");
+      }
+      else {
+        print("updating $channel: $version -> $latest_versions{$channel}\n");
+        my ($url) = $block =~ /url\s*=\s*"([^"]+)"/;
+        # try to interpret some nix
+        my ($name) = $block =~ /name\s*=\s*"([^"]+)"/;
+        $name =~ s/\$\{version\}/$latest_versions{$channel}/;
+        $url =~ s/\$\{name\}/$name/;
+        $url =~ s/\$\{version\}/$latest_versions{$channel}/;
+        die "$url still has some interpolation" if $url =~ /\$/;
+        my ($sha256) = get("$url.sha256") =~ /^([0-9a-f]{64})/;
+        unless ( $sha256 ) {
+          my $full_version = $latest_versions{"full1_" . $channel};
+          my $last_version_try = $latest_versions{$channel};
+          $url =~ s/$last_version_try/$full_version/;
+	  ($sha256) = get("$url.sha256") =~ /^([0-9a-f]{64})/;
+        }
         die "invalid sha256 in $url.sha256" unless $sha256;
-	$block =~ s#version\s*=\s*"([^"]+)".+$#version = "$latest_versions{$channel}"; /* updated by script */#m;
-	$block =~ s#sha256\s*=\s*"([^"]+)".+$#sha256 = "$sha256"; /* updated by script */#m;
+        $block =~ s#version\s*=\s*"([^"]+)".+$#version = "$latest_versions{$channel}"; /* updated by script */#m;
+        $block =~ s#sha256\s*=\s*"([^"]+)".+$#sha256 = "$sha256"; /* updated by script */#m;
       }
     }
     else {

--- a/pkgs/applications/editors/jetbrains/update.pl
+++ b/pkgs/applications/editors/jetbrains/update.pl
@@ -44,26 +44,31 @@ sub update_nix_block {
   my ($block) = @_;
   my ($channel) = $block =~ /update-channel\s*=\s*"([^"]+)"/;
   if ($channel) {
-    die "unknown update-channel $channel" unless $latest_versions{$channel};
-    my ($version) = $block =~ /version\s*=\s*"([^"]+)"/;
-    die "no version in $block" unless $version;
-    if ($version eq $latest_versions{$channel}) {
-      print("$channel is up to date at $version\n");
-    } else {
-      print("updating $channel: $version -> $latest_versions{$channel}\n");
-      my ($url) = $block =~ /url\s*=\s*"([^"]+)"/;
-      # try to interpret some nix
-      my ($name) = $block =~ /name\s*=\s*"([^"]+)"/;
-      $name =~ s/\$\{version\}/$latest_versions{$channel}/;
-      $url =~ s/\$\{name\}/$name/;
-      $url =~ s/\$\{version\}/$latest_versions{$channel}/;
-      die "$url still has some interpolation" if $url =~ /\$/;
+      print "channel is $channel\n";
+    if ($latest_versions{$channel}) {
+      my ($version) = $block =~ /version\s*=\s*"([^"]+)"/;
+      die "no version in $block" unless $version;
+      if ($version eq $latest_versions{$channel}) {
+	print("$channel is up to date at $version\n");
+      } else {
+	print("updating $channel: $version -> $latest_versions{$channel}\n");
+	my ($url) = $block =~ /url\s*=\s*"([^"]+)"/;
+	# try to interpret some nix
+	my ($name) = $block =~ /name\s*=\s*"([^"]+)"/;
+	$name =~ s/\$\{version\}/$latest_versions{$channel}/;
+	$url =~ s/\$\{name\}/$name/;
+	$url =~ s/\$\{version\}/$latest_versions{$channel}/;
+	die "$url still has some interpolation" if $url =~ /\$/;
 
-      my ($sha256) = get("$url.sha256") =~ /^([0-9a-f]{64})/;
-      die "invalid sha256 in $url.sha256" unless $sha256;
+	my ($sha256) = get("$url.sha256") =~ /^([0-9a-f]{64})/;
+	die "invalid sha256 in $url.sha256" unless $sha256;
 
-      $block =~ s#version\s*=\s*"([^"]+)".+$#version = "$latest_versions{$channel}"; /* updated by script */#m;
-      $block =~ s#sha256\s*=\s*"([^"]+)".+$#sha256 = "$sha256"; /* updated by script */#m;
+	$block =~ s#version\s*=\s*"([^"]+)".+$#version = "$latest_versions{$channel}"; /* updated by script */#m;
+	$block =~ s#sha256\s*=\s*"([^"]+)".+$#sha256 = "$sha256"; /* updated by script */#m;
+      }
+    }
+    else {
+      warn "unknown update-channel $channel";
     }
   }
   return $block;

--- a/pkgs/applications/editors/jetbrains/update.pl
+++ b/pkgs/applications/editors/jetbrains/update.pl
@@ -70,8 +70,8 @@ sub update_nix_block {
         unless ( $sha256 ) {
           my $full_version = $latest_versions{"full1_" . $channel};
           $url =~ s/$version_string/$full_version/;
-	  ($sha256) = get("$url.sha256") =~ /^([0-9a-f]{64})/;
-	  $version_string = $full_version;
+          ($sha256) = get("$url.sha256") =~ /^([0-9a-f]{64})/;
+          $version_string = $full_version;
         }
         die "invalid sha256 in $url.sha256" unless $sha256;
         $block =~ s#version\s*=\s*"([^"]+)".+$#version = "$version_string"; /* updated by script */#m;


### PR DESCRIPTION
###### Motivation for this change

Needed to update Jetbrains channels; newer builds are available from JetBrains, some older builds are not.

###### Things done

1. Changed update.pl for the case when an existing channel no longer appears as a JetBrains channel. This should not prevent updates to existing channels that do not have a problem.
2. Added support for new download URL format as introduced for channel rider_2017_2_eap.
3. Ran update.pl

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

