### PR TITLE
Updated afewmail homepage

### DIFF
--- a/pkgs/development/python-modules/afew/default.nix
+++ b/pkgs/development/python-modules/afew/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/teythoon/afew;
+    homepage = https://github.com/afewmail/afew;
     description = "An initial tagging script for notmuch mail";
     maintainers = with maintainers; [ garbas ];
   };


### PR DESCRIPTION
###### Motivation for this change

The project moved a while ago. The original homepage might be outdated.

###### Things done

No checks have been performed since this is informational only.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

