### PR TITLE
pkgs/telepresence: init at 0.65

### DIFF
--- a/pkgs/tools/networking/telepresence/default.nix
+++ b/pkgs/tools/networking/telepresence/default.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, fetchgit, fetchFromGitHub, makeWrapper, git
+, python3, sshfs-fuse, torsocks, sshuttle, conntrack_tools }:
+
+let
+  sshuttle-telepresence = lib.overrideDerivation sshuttle (p: {
+    src = fetchgit {
+      url = "https://github.com/datawire/sshuttle.git";
+      rev = "8f881d131a0d5cb203c5a530d233996077f1da1e";
+      sha256 = "0c760xhblz5mpcn5ddqpvivvgn0ixqbhpjsy50dkhgn6lymrx9bx";
+      leaveDotGit = true;
+    };
+
+    buildInputs = p.buildInputs ++ [ git ];
+    postPatch = "rm sshuttle/tests/client/test_methods_nat.py";
+    postInstall = "mv $out/bin/sshuttle $out/bin/sshuttle-telepresence";
+  });
+in stdenv.mkDerivation rec {
+  pname = "telepresence";
+  version = "0.65";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "datawire";
+    repo = "telepresence";
+    rev = version;
+    sha256 = "01hwaybhdmfzmyzvwdx19nc5px2grf4k1vbbj9jdmsh5pmzfrby4";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  phases = ["unpackPhase" "installPhase"];
+
+  installPhase = ''
+    mkdir -p $out/libexec $out/bin
+    cp cli/telepresence $out/libexec/telepresence
+
+    makeWrapper $out/libexec/telepresence $out/bin/telepresence \
+      --prefix PATH : ${lib.makeBinPath [python3 sshfs-fuse torsocks conntrack_tools sshuttle-telepresence]}
+  '';
+
+  meta = {
+    homepage = https://www.telepresence.io/;
+    description = "Local development against a remote Kubernetes or OpenShift cluster";
+    license = with lib.licenses; [ asl20 ];
+    maintainers = with lib.maintainers; [ offline ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4524,6 +4524,8 @@ with pkgs;
 
   telegraf = callPackage ../servers/monitoring/telegraf { };
 
+  telepresence = callPackage ../tools/networking/telepresence { };
+
   texmacs = callPackage ../applications/editors/texmacs {
     tex = texlive.combined.scheme-small;
     extraFonts = true;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [ONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

