### PR TITLE
ld-wrapper: Use .dylib not .so on Darwin

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -386,6 +386,8 @@ stdenv.mkDerivation {
   # for substitution in utils.sh
   expandResponseParams = "${expand-response-params}/bin/expand-response-params";
 
+  slext = targetPlatform.extensions.sharedLibrary;
+
   crossAttrs = {
     shell = shell.crossDrv + shell.crossDrv.shellPath;
   };

--- a/pkgs/build-support/cc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-wrapper.sh
@@ -85,10 +85,10 @@ if [ "$NIX_@infixSalt@_DONT_SET_RPATH" != 1 ] || [ "$NIX_@infixSalt@_SET_BUILD_I
                 libDirs+=("$p")
                 ;;
             -l)
-                libs["lib${p}.so"]=1
+                libs["lib${p}@slext@"]=1
                 ;;
             -dynamic-linker | -plugin)
-                # Ignore this argument, or it will match *.so and be added to rpath.
+                # Ignore this argument, or it will match *@slext@ and be added to rpath.
                 ;;
             *)
                 case "$p" in
@@ -96,9 +96,9 @@ if [ "$NIX_@infixSalt@_DONT_SET_RPATH" != 1 ] || [ "$NIX_@infixSalt@_SET_BUILD_I
                         libDirs+=("${p:2}")
                         ;;
                     -l?*)
-                        libs["lib${p:2}.so"]=1
+                        libs["lib${p:2}@slext@"]=1
                         ;;
-                    "${NIX_STORE:-}"/*.so | "${NIX_STORE:-}"/*.so.*)
+                    "${NIX_STORE:-}"/*@slext@ | "${NIX_STORE:-}"/*@slext@.*)
                         # This is a direct reference to a shared library.
                         libDirs+=("${p%/*}")
                         libs["${p##*/}"]=1


### PR DESCRIPTION
###### Motivation for this change

ld-wrapper in a few places assumes the extension of a dynamic lib. This makes it accurate on Darwin.

My sierra hack will use this. That I'd like to back-port to 17.09, so this should be too.

###### Things done

We could be relying on ld-wrapper not working correctly as intended in myriad ways. Best to test this one pretty well.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @orivej 