### PR TITLE
Revert "kdeFrameworks: 5.37 -> 5.38"

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.38/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.37/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/ktexteditor.nix
+++ b/pkgs/development/libraries/kde-frameworks/ktexteditor.nix
@@ -2,7 +2,7 @@
   mkDerivation, lib, copyPathsToStore,
   extra-cmake-modules, perl,
   karchive, kconfig, kguiaddons, ki18n, kiconthemes, kio, kparts, libgit2,
-  qtscript, qtxmlpatterns, sonnet, syntax-highlighting, qtquickcontrols
+  qtscript, qtxmlpatterns, sonnet, syntax-highlighting
 }:
 
 mkDerivation {
@@ -11,7 +11,7 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules perl ];
   buildInputs = [
     karchive kconfig kguiaddons ki18n kiconthemes kio libgit2 qtscript
-    qtxmlpatterns sonnet syntax-highlighting qtquickcontrols
+    qtxmlpatterns sonnet syntax-highlighting
   ];
   propagatedBuildInputs = [ kparts ];
 }

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,603 +3,603 @@
 
 {
   attica = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/attica-5.38.0.tar.xz";
-      sha256 = "12smdcd7lcyjqiw0bsk3lwivrl6cvmiqv5cqaw0gz8flhvk29w96";
-      name = "attica-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/attica-5.37.0.tar.xz";
+      sha256 = "13jqk4w9crh8pca6n9334l1gb8bmwf86pa36k0mfh5j19dq72g2p";
+      name = "attica-5.37.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/baloo-5.38.0.tar.xz";
-      sha256 = "14522akyxg36lclfblp65xai95i9hiydqjhkmfkadjbq82wm9s9i";
-      name = "baloo-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/baloo-5.37.0.tar.xz";
+      sha256 = "19sl07lhjrri40vfi8wl6azgmg08lgfb98xx110j6spjbbbnww79";
+      name = "baloo-5.37.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/bluez-qt-5.38.0.tar.xz";
-      sha256 = "0hanmygp4smbvczxn4dj997z3bln32p017z0r26z89m2p0b2ylwv";
-      name = "bluez-qt-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/bluez-qt-5.37.0.tar.xz";
+      sha256 = "1x6nj7vsn0sp9rckzkcbl6fwm7qzj5w98w2qys1fndb1spl7av8s";
+      name = "bluez-qt-5.37.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/breeze-icons-5.38.0.tar.xz";
-      sha256 = "09afi6c4h31ycs6aa85lqbmn392zi532zf8fp7ll43xxjv9isac9";
-      name = "breeze-icons-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/breeze-icons-5.37.0.tar.xz";
+      sha256 = "17nr2phd0nxyx49igvl170ksikapgc4365z26pw0dmmw41llcbxw";
+      name = "breeze-icons-5.37.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/extra-cmake-modules-5.38.0.tar.xz";
-      sha256 = "0ci3vdzdbcrbnxpqvf4hcwcrzz1ijhifp8b99wh3k53rinnai231";
-      name = "extra-cmake-modules-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/extra-cmake-modules-5.37.0.tar.xz";
+      sha256 = "1jr7nmhh4kyz1g454qkldfhimfjvvylqa19zna5iak08bkq8q696";
+      name = "extra-cmake-modules-5.37.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/frameworkintegration-5.38.0.tar.xz";
-      sha256 = "0w1n3czgsnnmaqwypy3mpci8s4ppv9030zxw7ka7rsvwgkpqijq8";
-      name = "frameworkintegration-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/frameworkintegration-5.37.0.tar.xz";
+      sha256 = "0pcy3hjqbahbx65yxz5bl0h2ah4y3fb7mq3pj1rrp2cpp92s135a";
+      name = "frameworkintegration-5.37.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kactivities-5.38.0.tar.xz";
-      sha256 = "0grm0cilc80g5ih2hqhwgwm35mlfnrs343j6ixkd9s0mflv2b798";
-      name = "kactivities-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kactivities-5.37.0.tar.xz";
+      sha256 = "005xvzp10kvwcsl2w6ghcqgqnr2rdvv9w61i4y44y25vcb85g26v";
+      name = "kactivities-5.37.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kactivities-stats-5.38.0.tar.xz";
-      sha256 = "0s57iz04n3m4fpqrqflda6vpk4l1mnf0nyz1iyza382fb375afd2";
-      name = "kactivities-stats-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kactivities-stats-5.37.0.tar.xz";
+      sha256 = "09zsdzf77palmww7x3dzinl0hxrm4z0q0yc2fmf0d7z6cfl695y2";
+      name = "kactivities-stats-5.37.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kapidox-5.38.0.tar.xz";
-      sha256 = "1j4k75lhqdnsxmgyvblla0627qvgabxivw6limfdb3rdpmqdxj76";
-      name = "kapidox-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kapidox-5.37.0.tar.xz";
+      sha256 = "1xwkaamifxjghv158rwslndfd9z70rm9ixnp1mmkgw8radwsqg5v";
+      name = "kapidox-5.37.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/karchive-5.38.0.tar.xz";
-      sha256 = "0n5nxd3v9ljjff0r6k4xrvy5hj057b7c7jzcq258harl359d8m4k";
-      name = "karchive-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/karchive-5.37.0.tar.xz";
+      sha256 = "1599lql0kcx705313bfvbazr7rayr6vsiwrpiq6iwljzc7lli1im";
+      name = "karchive-5.37.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kauth-5.38.0.tar.xz";
-      sha256 = "12nyfbilz4v4b2i5x191iph3jj4lcpw7z1rh0xrv5y1v7dczk6i7";
-      name = "kauth-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kauth-5.37.0.tar.xz";
+      sha256 = "0ciz28bvbvxlv0iz0cgs31x2m1czkki21ypzqj8rg2ix8jw2p65w";
+      name = "kauth-5.37.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kbookmarks-5.38.0.tar.xz";
-      sha256 = "0s230mcwmrg0qpz42sg804m96j2xpnwj4bdp0mfv08x3jasqpbrq";
-      name = "kbookmarks-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kbookmarks-5.37.0.tar.xz";
+      sha256 = "0l6rkj0b7hk2wg6dypj1dkl8pcd1vx89gaiixbhkd3vf7jp46n41";
+      name = "kbookmarks-5.37.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kcmutils-5.38.0.tar.xz";
-      sha256 = "0n6f2xvl5v8fwfxpdl6la1hb01dh4h1pcdrf05nn60v0rqg9f58b";
-      name = "kcmutils-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kcmutils-5.37.0.tar.xz";
+      sha256 = "1ik1505f16swsmvrv62dacis33f1ccnmkw3zbhb84vbrbqyskvzx";
+      name = "kcmutils-5.37.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kcodecs-5.38.0.tar.xz";
-      sha256 = "0cnxhaj5jk7f3j9q4hzphc3nm3vdaqwy9xab5d4nvn1kv8vjv8ii";
-      name = "kcodecs-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kcodecs-5.37.0.tar.xz";
+      sha256 = "0kmk97b5vbnyb3xjxwmg3l47aka8mkf50g4p7wvr096qwplffbva";
+      name = "kcodecs-5.37.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kcompletion-5.38.0.tar.xz";
-      sha256 = "0f955w67wrk15rdmglrk7k0xc5i6kah12bpb078xhzlyfackg52w";
-      name = "kcompletion-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kcompletion-5.37.0.tar.xz";
+      sha256 = "0qhjkqmd1jjy50hlzsdxwgnjwpfdrz3njl5n88h3nzp83yjv1ljz";
+      name = "kcompletion-5.37.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kconfig-5.38.0.tar.xz";
-      sha256 = "0fi428dsr6qpa9336wcfic6hyix6l2p9s135w00qzdwhdkr4lx3r";
-      name = "kconfig-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kconfig-5.37.0.tar.xz";
+      sha256 = "1f0y2gmwy05b17clr7vg1zp18l1z0fd757v02ha7cwd64yznyr5d";
+      name = "kconfig-5.37.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kconfigwidgets-5.38.0.tar.xz";
-      sha256 = "0w319d94wxn90dbbdfw5zrn2ddnv9vb7wldkpvvycq7yxrhsfw0x";
-      name = "kconfigwidgets-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kconfigwidgets-5.37.0.tar.xz";
+      sha256 = "001d1nj8q6xpl71rwm15rnvy5ajyxpvknvf4ic7p5pbik3021bs6";
+      name = "kconfigwidgets-5.37.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kcoreaddons-5.38.0.tar.xz";
-      sha256 = "1m3mn9fhllwcidzji2l26k5yxzrqkbyjdly04nh3s5rf823dvqwv";
-      name = "kcoreaddons-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kcoreaddons-5.37.0.tar.xz";
+      sha256 = "0a45sz11d7b2d8sbr9z57mv337nbhd94fiqk3issw470n0y46g3y";
+      name = "kcoreaddons-5.37.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kcrash-5.38.0.tar.xz";
-      sha256 = "1a8hvyhwa112wx4ldadlrxpyda6qpial387j07dr1jq1cnzr0p11";
-      name = "kcrash-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kcrash-5.37.0.tar.xz";
+      sha256 = "16k2pwf3s3adgayd9vq7kk8c5gnq9g6wra4psrvs3a3c5k5am5y0";
+      name = "kcrash-5.37.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kdbusaddons-5.38.0.tar.xz";
-      sha256 = "1mw9sl82y2aj7l2xj1skrbxbyv55br60h6f61r4f1mqcaxaqj7qw";
-      name = "kdbusaddons-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kdbusaddons-5.37.0.tar.xz";
+      sha256 = "0745arkp4wnpwyhjq02h7lfac049cmlg5qwhf96i7ss0w54vch4i";
+      name = "kdbusaddons-5.37.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kdeclarative-5.38.0.tar.xz";
-      sha256 = "1966sxzhdkzi2lwg5ixhrx0yg10plbvn9lsjgnj9crghaajsnf4b";
-      name = "kdeclarative-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kdeclarative-5.37.0.tar.xz";
+      sha256 = "1ish46m2dpnpqjnf8g660clcg7ky65w11cbk2m79pwyhqvhxgggj";
+      name = "kdeclarative-5.37.0.tar.xz";
     };
   };
   kded = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kded-5.38.0.tar.xz";
-      sha256 = "0xsjzj5jx4wsrq5fnbv6raqlr11shz20p2mvypf5wfvq2c1vb5lb";
-      name = "kded-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kded-5.37.0.tar.xz";
+      sha256 = "162s5qx2qb0bi889f8jjvd3ci31azd8iwp25i04vwi0lzglwb8gy";
+      name = "kded-5.37.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/portingAids/kdelibs4support-5.38.0.tar.xz";
-      sha256 = "06vlgziy212pwm4z9r8rbfa9ziwx3nkihy9b25m13gbh60baqapp";
-      name = "kdelibs4support-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/portingAids/kdelibs4support-5.37.0.tar.xz";
+      sha256 = "1zz100m1sqfmg3ni7023b99qn79jhdd2ryw6534axl5zgn0sglh9";
+      name = "kdelibs4support-5.37.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kdesignerplugin-5.38.0.tar.xz";
-      sha256 = "0rivjxgsxvsgk24lnzsqpzqr7m1i1faqnbby3rnkw2059z28l0y6";
-      name = "kdesignerplugin-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kdesignerplugin-5.37.0.tar.xz";
+      sha256 = "1197003bqcdpsyn6faasr2nhaadh7ryg92vjpqim78af3vwinsdw";
+      name = "kdesignerplugin-5.37.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kdesu-5.38.0.tar.xz";
-      sha256 = "1c9j2zih7r0jph41kzxnxpri9snphm1k4w4rs1q6zawwz8a5kcr5";
-      name = "kdesu-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kdesu-5.37.0.tar.xz";
+      sha256 = "1qfhkzk6l9rfdyiad8y6k30zlhziz3q2dxvxkmnghxmkg98yhdza";
+      name = "kdesu-5.37.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kdewebkit-5.38.0.tar.xz";
-      sha256 = "1cncbjkgrbrnvwx3izjqh9hqiw9bg6aqaq09f8bdryvr8537b0zf";
-      name = "kdewebkit-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kdewebkit-5.37.0.tar.xz";
+      sha256 = "1ph3a50wix42hmsbc9jbfxla172aihjx9yzp9rza09j1a7va3hg1";
+      name = "kdewebkit-5.37.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kdnssd-5.38.0.tar.xz";
-      sha256 = "101gygxrq2m3yfz6j0ldspib3pm3jjvqz505j3h15zj59qcwqw0x";
-      name = "kdnssd-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kdnssd-5.37.0.tar.xz";
+      sha256 = "03rd6znn2qwndn4m3bb03slwyic06ry535rawgyh06lfps0fcc5z";
+      name = "kdnssd-5.37.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kdoctools-5.38.0.tar.xz";
-      sha256 = "0fbv7i1930rl496psny7nfiixvsnaq535h1zggwkwv6i9dh7wpy9";
-      name = "kdoctools-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kdoctools-5.37.0.tar.xz";
+      sha256 = "0gbc5qqim6262hvkl9pf6rynnblxb3hsw3c4ars03ip7n761y0zl";
+      name = "kdoctools-5.37.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kemoticons-5.38.0.tar.xz";
-      sha256 = "1c0991yd8jx2diy5ynl11h5qqyapn1dsir2gy04y8m90h944vdd5";
-      name = "kemoticons-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kemoticons-5.37.0.tar.xz";
+      sha256 = "1cx978s1dm3v1jh4aymncxs44iizdqp174dqg9m5mf043fcvvinq";
+      name = "kemoticons-5.37.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kfilemetadata-5.38.0.tar.xz";
-      sha256 = "1815r9lx99h9kzbk67bfk41jya3y2hsi112fsgpv3m4mg028pklm";
-      name = "kfilemetadata-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kfilemetadata-5.37.0.tar.xz";
+      sha256 = "17mbm6pdi6ac61kj2qzxf7y3rbxhxg9rwqr7qy766gh3img2vq8p";
+      name = "kfilemetadata-5.37.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kglobalaccel-5.38.0.tar.xz";
-      sha256 = "1rxmghm302ndn6qgrdgl1fccyi57bq8a0273p6wy8vs5pn2902ms";
-      name = "kglobalaccel-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kglobalaccel-5.37.0.tar.xz";
+      sha256 = "1d84q3r6q5n2lclym9a9m1brfqnq3p3dykfpzvhcba3bjxh3cdsb";
+      name = "kglobalaccel-5.37.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kguiaddons-5.38.0.tar.xz";
-      sha256 = "1jks0hwn665hlypl0qfhi5r0prqzrg1gv4skc88zp1kgx05kb9h1";
-      name = "kguiaddons-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kguiaddons-5.37.0.tar.xz";
+      sha256 = "13g6nlw8fk135i6z3f8ichy8whxd6v4rycg80dlvm25h66rg6vn5";
+      name = "kguiaddons-5.37.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/portingAids/khtml-5.38.0.tar.xz";
-      sha256 = "0fa61va3dbwml40y4scxks223swlb8vf5730wr7rijl91lz1adgy";
-      name = "khtml-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/portingAids/khtml-5.37.0.tar.xz";
+      sha256 = "1n0mx2xy9n5ffhvh58z3kn61aa7dhppsrwgxk697pybqy1h45ah2";
+      name = "khtml-5.37.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/ki18n-5.38.0.tar.xz";
-      sha256 = "0z9arj2s4fn04vavl6ad3avl1p5yr3mgr2n802lmvy2wlqicy314";
-      name = "ki18n-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/ki18n-5.37.0.tar.xz";
+      sha256 = "1c1sy4pbhlwsajs2972brdmma5val72gkil6k0a0f58nfvvg952d";
+      name = "ki18n-5.37.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kiconthemes-5.38.0.tar.xz";
-      sha256 = "01xa30r2cx312vbmz2c3x8vvna1cqb6fx91cjp4aivp9q4jwaz9a";
-      name = "kiconthemes-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kiconthemes-5.37.0.tar.xz";
+      sha256 = "1j7mgfsvxa24nf1d9xyn2jv9y9j523vghsvsm73x8d3ijibchfxq";
+      name = "kiconthemes-5.37.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kidletime-5.38.0.tar.xz";
-      sha256 = "1i91w9hcb2k5n9qz8q7k2z44z9ss7r9i2zsg9vnl8am7dqqhmlsv";
-      name = "kidletime-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kidletime-5.37.0.tar.xz";
+      sha256 = "01m4q3l2yq83f2dpbv6jry7cjkj6bqdgfpy5b8byaf1gf9w2firs";
+      name = "kidletime-5.37.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kimageformats-5.38.0.tar.xz";
-      sha256 = "0q78shcwgczdm5ylhbp9fnq70w3hqzkbynp2vpyyg5pjaam8xjlp";
-      name = "kimageformats-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kimageformats-5.37.0.tar.xz";
+      sha256 = "1knha6wjzjs0vnkljwpfinzg3hg2jyh9c07ifqvd47cprl96ickg";
+      name = "kimageformats-5.37.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kinit-5.38.0.tar.xz";
-      sha256 = "0k4i0zrwkz088vjkk7d7whwhkrjvqqhdigspzf58d1laryiy0jdf";
-      name = "kinit-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kinit-5.37.0.tar.xz";
+      sha256 = "0b7dyy4hqyf6wk7gg2l23ldnji2zl8vzyj5wd5qh4yi7rdl6js5r";
+      name = "kinit-5.37.0.tar.xz";
     };
   };
   kio = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kio-5.38.0.tar.xz";
-      sha256 = "15qmr2ghrj7pgqxrgpvhdp9g5vaap9mzlmry6ayph75m1afb4fpl";
-      name = "kio-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kio-5.37.0.tar.xz";
+      sha256 = "0nxchbhs8p2d4243dyp7qa65g1p6r3ic2h6dz7w0aa0qzsy8wi29";
+      name = "kio-5.37.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kirigami2-5.38.0.tar.xz";
-      sha256 = "18k41j5ijmgmzgl2rv4ac0bnxlax3505zi1nmqm8bkdpznhfr13c";
-      name = "kirigami2-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kirigami2-5.37.0.tar.xz";
+      sha256 = "1z42rsi8nzshrbv8m8vxkay4dq46kggglhgxbbgg2q00y8gjq9dd";
+      name = "kirigami2-5.37.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kitemmodels-5.38.0.tar.xz";
-      sha256 = "0s20in4jjd2pvv9bn79lvgqqlf806hw014icp51f5hfknrhpdyjc";
-      name = "kitemmodels-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kitemmodels-5.37.0.tar.xz";
+      sha256 = "1nlpzzp4m0ghfz1p2hrwn4lbhjhxc8b8q8kbzqbh9hmwmimbzzrr";
+      name = "kitemmodels-5.37.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kitemviews-5.38.0.tar.xz";
-      sha256 = "0ldi8qzs2sbhz8l57nshjrnwhjl9mhw90kcqw71cldp41wm0pps6";
-      name = "kitemviews-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kitemviews-5.37.0.tar.xz";
+      sha256 = "17r7vnlyiiifhrz4gb4fifshn1jb4c67lhadczi8d301rzk7wwsm";
+      name = "kitemviews-5.37.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kjobwidgets-5.38.0.tar.xz";
-      sha256 = "0vp6nc73c9788nrib742k9nzqbx4m8m77ipqh9dnnkx4ggrhsd55";
-      name = "kjobwidgets-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kjobwidgets-5.37.0.tar.xz";
+      sha256 = "1162dxhpspd7p1735npp0amrxr5b0j467f5651k2rv6mvqfmqr4b";
+      name = "kjobwidgets-5.37.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/portingAids/kjs-5.38.0.tar.xz";
-      sha256 = "0diw580k5kyv60bqhnxhqinlrn0b3p3n89iy0kdgjgnr6197fwy1";
-      name = "kjs-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/portingAids/kjs-5.37.0.tar.xz";
+      sha256 = "046hy8ji4i6p2xp5gnqa8dk82sv6sbh4xg67y79i82bbi97dvq9b";
+      name = "kjs-5.37.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/portingAids/kjsembed-5.38.0.tar.xz";
-      sha256 = "0nb07n54208gnmag7h3dhc8hri2s83ln1c9wq6c0xw7jchaz9z8a";
-      name = "kjsembed-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/portingAids/kjsembed-5.37.0.tar.xz";
+      sha256 = "0w2wk5azf1b45db58qj0cdc1l056x9s1xcd09ibavx5xmdvq6br0";
+      name = "kjsembed-5.37.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/portingAids/kmediaplayer-5.38.0.tar.xz";
-      sha256 = "1qb2g8j871gf38i2dk2j9ags848fa3kqdjl3l4924hf28az0g736";
-      name = "kmediaplayer-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/portingAids/kmediaplayer-5.37.0.tar.xz";
+      sha256 = "0fqxrkcwwzg11zsax9q169lisnfp9jsqg4ccd6xvv8kpkz3g04jp";
+      name = "kmediaplayer-5.37.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/knewstuff-5.38.0.tar.xz";
-      sha256 = "1l4cmfcsljg7v5l6341fxcp7c7i615l8351l941dwcmw4yng0lj0";
-      name = "knewstuff-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/knewstuff-5.37.0.tar.xz";
+      sha256 = "1scnxhxx4g8j4wml6x8i5v00rpaxyzzcm7vqbra2axbql5d8g8ny";
+      name = "knewstuff-5.37.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/knotifications-5.38.0.tar.xz";
-      sha256 = "1jvmv2hi3dbf0bd2b61l9s5lb1dx2rjl9z7pw1fb5j20910k6zgd";
-      name = "knotifications-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/knotifications-5.37.0.tar.xz";
+      sha256 = "0gvv6jal7n4m3y30ragjlyhghq3y2782d422im9klxqzlgdgvkb6";
+      name = "knotifications-5.37.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/knotifyconfig-5.38.0.tar.xz";
-      sha256 = "05hgglm6ypbaplxr43632zh5fmgsz6543110169k9fbjnczyhcyk";
-      name = "knotifyconfig-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/knotifyconfig-5.37.0.tar.xz";
+      sha256 = "14kjckynszv8015p17j578l3knmkmw25d8r8ks4wavgj3db9bik5";
+      name = "knotifyconfig-5.37.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kpackage-5.38.0.tar.xz";
-      sha256 = "0v4j3kqgg52rlmdxmd98aqw0hk7i2xqsw9mhhxfs9c7vm1x05sxn";
-      name = "kpackage-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kpackage-5.37.0.tar.xz";
+      sha256 = "1ikf55q2pk8vm70pqm7rmakja309zjh9z1lg0xqslq1pqd6xki7s";
+      name = "kpackage-5.37.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kparts-5.38.0.tar.xz";
-      sha256 = "19ba749pwnb7xvmr7lryn6z53zb49hqn0xq4j9fmbic95nh039zp";
-      name = "kparts-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kparts-5.37.0.tar.xz";
+      sha256 = "0jrd8idkz8nhkda2rwgf8rysqngiv4r5ajmrzp2kfz1pr91a6l5h";
+      name = "kparts-5.37.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kpeople-5.38.0.tar.xz";
-      sha256 = "0yd29436bgfw6jjjr9n38hx8561mrlgl5vynci6ng9bx1jflay0x";
-      name = "kpeople-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kpeople-5.37.0.tar.xz";
+      sha256 = "1qgp4wqp985ac1m9wakpsvk3c2driwkwrjkc3aic7dyr1p456qsf";
+      name = "kpeople-5.37.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kplotting-5.38.0.tar.xz";
-      sha256 = "1hvfqm6i5fsyssb51w3yybsil8h9cbqgd2n8k0wnz99m8xifzn72";
-      name = "kplotting-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kplotting-5.37.0.tar.xz";
+      sha256 = "0k4s0qvhjm9h1bmg16l32g4bsdrp2jrcila4dgzvrb56447px0zw";
+      name = "kplotting-5.37.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kpty-5.38.0.tar.xz";
-      sha256 = "0cgh8hixrplgc280652jlvk8ibcddmjvflwb0gjawd9iq7lcb66y";
-      name = "kpty-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kpty-5.37.0.tar.xz";
+      sha256 = "0wb873r1ycgi11s0qx3lhvz54703yz5sax6fb6wdmri5c05gzd5a";
+      name = "kpty-5.37.0.tar.xz";
     };
   };
   kross = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/portingAids/kross-5.38.0.tar.xz";
-      sha256 = "1dccg214cqpyn3nninalpknglfmchz2k1fk4rlgq53wf4n6w23b7";
-      name = "kross-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/portingAids/kross-5.37.0.tar.xz";
+      sha256 = "06pk6f6v82pd7x9rsmkhkp5r9sgcbrc503lqckl8d7argbb7j4k1";
+      name = "kross-5.37.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/krunner-5.38.0.tar.xz";
-      sha256 = "16fhl5zm8scyxk83mpkavvzkn23qgzcblg315jy6klr5bz9jxgcm";
-      name = "krunner-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/krunner-5.37.0.tar.xz";
+      sha256 = "171qbhr1yszl2gcffm47p5wiwj71w9yhvk6srhvfpiwfyh61a4ld";
+      name = "krunner-5.37.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kservice-5.38.0.tar.xz";
-      sha256 = "0zaamvxhfx4xdy2m8spyhi0hdv6p0fn5hqn9pyi5l8xdixnwjc9d";
-      name = "kservice-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kservice-5.37.0.tar.xz";
+      sha256 = "1zxs5yzd3rmy33vsip4c4igk9g38kzaggw8c29sxmgr8vgdrnvhr";
+      name = "kservice-5.37.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/ktexteditor-5.38.0.tar.xz";
-      sha256 = "195ygv1j4wfvly31g22wxz9sshhqyi1yyf2mv1v63d9ci88v7rri";
-      name = "ktexteditor-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/ktexteditor-5.37.0.tar.xz";
+      sha256 = "0y04s1nwkf0np6iymjxf0jssin28qw2901kpb3iw8gd52ni5rrks";
+      name = "ktexteditor-5.37.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/ktextwidgets-5.38.0.tar.xz";
-      sha256 = "120jxab8w1vhqcckda51r0x2pmfb2qd2h6inhivl72c4m5x89w7f";
-      name = "ktextwidgets-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/ktextwidgets-5.37.0.tar.xz";
+      sha256 = "1p8ns75sbnapm6ds16hx36q9vlnz9phgy28rx0gm1ckxqvm4yzr5";
+      name = "ktextwidgets-5.37.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kunitconversion-5.38.0.tar.xz";
-      sha256 = "10k0xfb11r7l1bdnlanqgdwwx8wrs8bmnswb2y85xxr7wwsqnlvc";
-      name = "kunitconversion-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kunitconversion-5.37.0.tar.xz";
+      sha256 = "1qvq61sbv9naj5ndi5xjwx7ami0xa6bqiajr912kbbbp2257cjsi";
+      name = "kunitconversion-5.37.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kwallet-5.38.0.tar.xz";
-      sha256 = "1qysdj4nmkxywj7bzqdc78ifnqjnkrz9qbp4a49acpng2y4zw1nw";
-      name = "kwallet-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kwallet-5.37.0.tar.xz";
+      sha256 = "1l7jl3y0rzx2whnbp6w5p6kg71vwyccp2nwxxgcxr6541m0nihsz";
+      name = "kwallet-5.37.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kwayland-5.38.0.tar.xz";
-      sha256 = "0gd58nvyc39waj7vv2c68r59qqpv0jppm95548j2p924w48syjj0";
-      name = "kwayland-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kwayland-5.37.0.tar.xz";
+      sha256 = "0d4c8l8k38pgj73kzlf1hsq52w31wy9wgpwph1bv0cq5yn2rjiyr";
+      name = "kwayland-5.37.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kwidgetsaddons-5.38.0.tar.xz";
-      sha256 = "1yh48qxdqz3rk020wr897vkzsi4nhh37lxbg6211xrlirn0lzvj5";
-      name = "kwidgetsaddons-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kwidgetsaddons-5.37.0.tar.xz";
+      sha256 = "1jmk377r1h4is2il7chh6bq8wbj21psf4b1yiw84iivg38vlpid4";
+      name = "kwidgetsaddons-5.37.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kwindowsystem-5.38.0.tar.xz";
-      sha256 = "02xrin8lshvqkw12d0692z40h3g61f4crh28jcmi5zqlaxiyn5ic";
-      name = "kwindowsystem-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kwindowsystem-5.37.0.tar.xz";
+      sha256 = "0pd2n0j5pdv1x7wf4mwcpimnah73g6l0xidhqbpg37p829jix2k2";
+      name = "kwindowsystem-5.37.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kxmlgui-5.38.0.tar.xz";
-      sha256 = "12cmyhm05nkr9xj7cpnqihrlndfqn1kjkzhcn1ywj20y1gd3mxv4";
-      name = "kxmlgui-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kxmlgui-5.37.0.tar.xz";
+      sha256 = "0jrvjlxkg9knj61b2gj2w6l96jlmww9kn4ij808ir35365x3cdg2";
+      name = "kxmlgui-5.37.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/kxmlrpcclient-5.38.0.tar.xz";
-      sha256 = "0g9ah59h8vq68yg4pfdbqx44xrs856wrr181rsdbsizj0qj3hyaa";
-      name = "kxmlrpcclient-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/kxmlrpcclient-5.37.0.tar.xz";
+      sha256 = "1jn9v86dpfx43qcdcsp6lpnga9q6aa5vxjkkg4wg0wbxmw4w9gvq";
+      name = "kxmlrpcclient-5.37.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/modemmanager-qt-5.38.0.tar.xz";
-      sha256 = "18ham8lrxblywc634n49237js5y5k6qgjf5zrjc8gzapn934l89w";
-      name = "modemmanager-qt-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/modemmanager-qt-5.37.0.tar.xz";
+      sha256 = "1fqf43kvj1v1mcdlbfxbh6sh3ycvg35aml2ywh2a684iz4qzq1aq";
+      name = "modemmanager-qt-5.37.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/networkmanager-qt-5.38.0.tar.xz";
-      sha256 = "10d28nrkppmmfl9pwq2hkrvi461acf29djdzala4l37mp4dwvbf8";
-      name = "networkmanager-qt-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/networkmanager-qt-5.37.0.tar.xz";
+      sha256 = "01px9n97gyvyyfg3dp1k7dik9fprgx9i28hg8wjr2rb5dlr99jd1";
+      name = "networkmanager-qt-5.37.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/oxygen-icons5-5.38.0.tar.xz";
-      sha256 = "0fk97r3br5myqpnfalz67l5hkamxc5vc5swa68wpg1xih6jc3iid";
-      name = "oxygen-icons5-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/oxygen-icons5-5.37.0.tar.xz";
+      sha256 = "1rns7n93f83qp5q11a7r5y87y0hvc0q95ar57cqy0fxsqrg4614h";
+      name = "oxygen-icons5-5.37.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/plasma-framework-5.38.0.tar.xz";
-      sha256 = "1dvhqfi34v44h0wj0m68k477hmx53x9zsf4mh03xq164w1yz68sg";
-      name = "plasma-framework-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/plasma-framework-5.37.0.tar.xz";
+      sha256 = "0kamvxfzrbx3msn0cp3k20clqchz9jg5wlazz3h6p6zmrk5v16bh";
+      name = "plasma-framework-5.37.0.tar.xz";
     };
   };
   prison = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/prison-5.38.0.tar.xz";
-      sha256 = "0prj3z6s3aighmk4qarfljca7j9cy7ypvgh8rv5di3jb2v4nbg4m";
-      name = "prison-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/prison-5.37.0.tar.xz";
+      sha256 = "1icsirwfh7zscm8x9g2gp7aqzhs81ahhjflwjcwpz9bh0r9f1wb7";
+      name = "prison-5.37.0.tar.xz";
     };
   };
   solid = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/solid-5.38.0.tar.xz";
-      sha256 = "1b3c5drx4m1x4ai0ziz0yan16a5s3ghf0py37mb92qyimq586lhh";
-      name = "solid-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/solid-5.37.0.tar.xz";
+      sha256 = "1gb9gnp1a11q5abl97b7sq1if2rqcrcs0f33sakpxf1z9y0ppg8l";
+      name = "solid-5.37.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/sonnet-5.38.0.tar.xz";
-      sha256 = "1355p88swnk828gsbnm3v4gryffnwbzjcdq49k8jwywzb65bnwxa";
-      name = "sonnet-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/sonnet-5.37.0.tar.xz";
+      sha256 = "0sb6i464riadgb2q73nj0vy6xavr2m1sszrvghr20nj7i64f3kk0";
+      name = "sonnet-5.37.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/syntax-highlighting-5.38.0.tar.xz";
-      sha256 = "101ng0l3jfg8x9bns9z38jk3iayijwcb299kf860vfy0nki8gf6l";
-      name = "syntax-highlighting-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/syntax-highlighting-5.37.0.tar.xz";
+      sha256 = "1l56pb84z7sy0qq8xkd5w5v5418bm9n4qds0vd39ch655d47bl72";
+      name = "syntax-highlighting-5.37.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.38.0";
+    version = "5.37.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.38/threadweaver-5.38.0.tar.xz";
-      sha256 = "1d89l9lknc1q25cz9r8iwc1a102q788mj01ghnl6ydss65rclvfv";
-      name = "threadweaver-5.38.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.37/threadweaver-5.37.0.tar.xz";
+      sha256 = "1hb3721r1zbbyj211886sfkcxk18k0rsdhcg9ssagx10f29rpxx4";
+      name = "threadweaver-5.37.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
Reverts NixOS/nixpkgs#29277.

Upstream documented a [show-stopping bug](https://bugs.kde.org/show_bug.cgi?id=384597) and recommends we do not release based on Frameworks 5.38 yet.