### PR TITLE
emscriptenfastcomp: move wrap magic to own file, use newScope

### DIFF
--- a/pkgs/development/compilers/emscripten-fastcomp/default.nix
+++ b/pkgs/development/compilers/emscripten-fastcomp/default.nix
@@ -1,54 +1,22 @@
-{ stdenv, fetchFromGitHub, cmake, python, ... }:
-
+{ newScope, stdenv, wrapCC, wrapCCWith, symlinkJoin }:
 let
-  rev = "1.37.16";
-  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
-in
-stdenv.mkDerivation rec {
-  name = "emscripten-fastcomp-${rev}";
+  callPackage = newScope (self // {inherit stdenv;});
 
-  src = fetchFromGitHub {
-    owner = "kripken";
-    repo = "emscripten-fastcomp";
-    sha256 = "0wj9sc0gciaiidcjv6wb0qn6ks06xds7q34351masc7qpvd217by";
-    inherit rev;
+  self = {
+    emscriptenfastcomp-unwrapped = callPackage ./emscripten-fastcomp.nix {};
+    emscriptenfastcomp-wrapped = wrapCCWith stdenv.cc.libc ''
+      # hardening flags break WASM support
+      cat > $out/nix-support/add-hardening.sh
+    '' self.emscriptenfastcomp-unwrapped;
+    emscriptenfastcomp = symlinkJoin {
+      name = "emscriptenfastcomp";
+      paths = [ self.emscriptenfastcomp-wrapped self.emscriptenfastcomp-unwrapped ];
+      preferLocalBuild = false;
+      allowSubstitutes = true;
+      postBuild = ''
+        # replace unwrapped clang-3.9 binary by wrapper
+        ln -sf $out/bin/clang $out/bin/clang-[0-9]*
+      '';
+    };
   };
-
-  srcFL = fetchFromGitHub {
-    owner = "kripken";
-    repo = "emscripten-fastcomp-clang";
-    sha256 = "1akdgxzxhzjbhp4d14ajcrp9jrf39x004a726ly2gynqc185l4j7";
-    inherit rev;
-  };
-
-  nativeBuildInputs = [ cmake python ];
-  preConfigure = ''
-    cp -Lr ${srcFL} tools/clang
-    chmod +w -R tools/clang
-  '';
-  cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
-    "-DLLVM_TARGETS_TO_BUILD='X86;JSBackend'"
-    "-DLLVM_INCLUDE_EXAMPLES=OFF"
-    "-DLLVM_INCLUDE_TESTS=OFF"
-    # "-DCLANG_INCLUDE_EXAMPLES=OFF"
-    "-DCLANG_INCLUDE_TESTS=OFF"
-  ] ++ (stdenv.lib.optional stdenv.isLinux
-    # necessary for clang to find crtend.o
-    "-DGCC_INSTALL_PREFIX=${gcc}"
-  );
-  enableParallelBuilding = true;
-
-  passthru = {
-    isClang = true;
-    inherit gcc;
-  };
-
-  meta = with stdenv.lib; {
-    homepage = https://github.com/kripken/emscripten-fastcomp;
-    description = "Emscripten LLVM";
-    platforms = platforms.all;
-    maintainers = with maintainers; [ qknight matthewbauer ];
-    license = stdenv.lib.licenses.ncsa;
-  };
-}
+in self

--- a/pkgs/development/compilers/emscripten-fastcomp/emscripten-fastcomp.nix
+++ b/pkgs/development/compilers/emscripten-fastcomp/emscripten-fastcomp.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchFromGitHub, cmake, python, ... }:
+
+let
+  rev = "1.37.16";
+  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
+in
+stdenv.mkDerivation rec {
+  name = "emscripten-fastcomp-${rev}";
+
+  src = fetchFromGitHub {
+    owner = "kripken";
+    repo = "emscripten-fastcomp";
+    sha256 = "0wj9sc0gciaiidcjv6wb0qn6ks06xds7q34351masc7qpvd217by";
+    inherit rev;
+  };
+
+  srcFL = fetchFromGitHub {
+    owner = "kripken";
+    repo = "emscripten-fastcomp-clang";
+    sha256 = "1akdgxzxhzjbhp4d14ajcrp9jrf39x004a726ly2gynqc185l4j7";
+    inherit rev;
+  };
+
+  nativeBuildInputs = [ cmake python ];
+  preConfigure = ''
+    cp -Lr ${srcFL} tools/clang
+    chmod +w -R tools/clang
+  '';
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DLLVM_TARGETS_TO_BUILD='X86;JSBackend'"
+    "-DLLVM_INCLUDE_EXAMPLES=OFF"
+    "-DLLVM_INCLUDE_TESTS=OFF"
+    # "-DCLANG_INCLUDE_EXAMPLES=OFF"
+    "-DCLANG_INCLUDE_TESTS=OFF"
+  ] ++ (stdenv.lib.optional stdenv.isLinux
+    # necessary for clang to find crtend.o
+    "-DGCC_INSTALL_PREFIX=${gcc}"
+  );
+  enableParallelBuilding = true;
+
+  passthru = {
+    isClang = true;
+    inherit gcc;
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/kripken/emscripten-fastcomp;
+    description = "Emscripten LLVM";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ qknight matthewbauer ];
+    license = stdenv.lib.licenses.ncsa;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1816,21 +1816,9 @@ with pkgs;
 
   emscripten = callPackage ../development/compilers/emscripten { };
 
-  emscriptenfastcomp-unwrapped = callPackage ../development/compilers/emscripten-fastcomp { };
-  emscriptenfastcomp-wrapped = wrapCCWith stdenv.cc.libc ''
-    # hardening flags break WASM support
-    cat > $out/nix-support/add-hardening.sh
-  '' emscriptenfastcomp-unwrapped;
-  emscriptenfastcomp = symlinkJoin {
-    name = "emscriptenfastcomp";
-    paths = [ emscriptenfastcomp-wrapped emscriptenfastcomp-unwrapped ];
-    preferLocalBuild = false;
-    allowSubstitutes = true;
-    postBuild = ''
-      # replace unwrapped clang-3.9 binary by wrapper
-      ln -sf $out/bin/clang $out/bin/clang-[0-9]*
-    '';
-  };
+  emscriptenfastcompPackages = callPackage ../development/compilers/emscripten-fastcomp { };
+
+  emscriptenfastcomp = emscriptenfastcompPackages.emscriptenfastcomp;
 
   emscriptenPackages = recurseIntoAttrs (callPackage ./emscripten-packages.nix { });
 


### PR DESCRIPTION
###### Motivation for this change

Having the wrap magic in the `top-level` broke the following script for me:

```
nix-instantiate --eval --json --strict maintainers/scripts/find-tarballs.nix --arg expr 'builtins.removeAttrs ((import pkgs/top-level/release.nix { scrubJobs = false; supportedSystems = [ "x86_64-linux" "x86_64-darwin" ]; })) ["unstable" "tarball" "darwin-unstable" ]'
```

I moved it to its own file, similiar to the llvm/clang packages. Please verify :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

