### PR TITLE
Remove Profpatsch from the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,9 +26,9 @@ doc/languages-frameworks/python.md      @FRidh
 # Haskell
 pkgs/development/compilers/ghc                       @peti
 pkgs/development/haskell-modules                     @peti
-pkgs/development/haskell-modules/default.nix         @Profpatsch @peti
-pkgs/development/haskell-modules/generic-builder.nix @Profpatsch @peti
-pkgs/development/haskell-modules/hoogle.nix          @Profpatsch @peti
+pkgs/development/haskell-modules/default.nix         @peti
+pkgs/development/haskell-modules/generic-builder.nix @peti
+pkgs/development/haskell-modules/hoogle.nix          @peti
 
 # R
 pkgs/applications/science/math/R @peti


### PR DESCRIPTION
Since CODEOWNERS shall be interpreted as actual ownership (and not just a
mentionbot replacement), I will remove myself again.