### PR TITLE
racket: 6.10 -> 6.10.1

### DIFF
--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -33,11 +33,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "racket-${version}";
-  version = "6.10";
+  version = "6.10.1";
 
   src = fetchurl {
     url = "http://mirror.racket-lang.org/installers/${version}/${name}-src.tgz";
-    sha256 = "1mqnyj3bawad12dygsb11f2dbnkjp7q6d7ra714rqyw8mxix5ws0";
+    sha256 = "0v3z6x277lq1y7wkqdf6mj3826z5vq0yadygspx9h4r0f1dnmafc";
   };
 
   FONTCONFIG_FILE = fontsConf;


### PR DESCRIPTION
###### Motivation for this change
Update the `racket`-package to it's latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

