### PR TITLE
include-what-you-use: 0.6 -> 0.8

### DIFF
--- a/pkgs/development/tools/analysis/include-what-you-use/default.nix
+++ b/pkgs/development/tools/analysis/include-what-you-use/default.nix
@@ -3,14 +3,14 @@
 stdenv.mkDerivation rec {
   name = "include-what-you-use-${version}";
   # Also bump llvmPackages in all-packages.nix to the supported version!
-  version = "0.6";
+  version = "0.8";
 
   src = fetchurl {
-    sha256 = "0n3z4pfbby0rl338irbs4yvcmjfnza82xg9a8r9amyl0bkfasbxb";
+    sha256 = "0r6n5gqicl0f9c8jrphq40kc2cis952gmnkm3643m3jwad0mn33d";
     url = "${meta.homepage}/downloads/${name}.src.tar.gz";
   };
 
-  buildInputs = with llvmPackages; [ clang llvm ];
+  buildInputs = with llvmPackages; [ clang-unwrapped llvm ];
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [ "-DIWYU_LLVM_ROOT_PATH=${llvmPackages.clang-unwrapped}" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7131,7 +7131,7 @@ with pkgs;
   };
 
   include-what-you-use = callPackage ../development/tools/analysis/include-what-you-use {
-    llvmPackages = llvmPackages_38;
+    llvmPackages = llvmPackages_4;
   };
 
   indent = callPackage ../development/tools/misc/indent { };


### PR DESCRIPTION
###### Motivation for this change

`clang` has to be replaced with `clang-unwrapped` after https://github.com/NixOS/nixpkgs/commit/907222098acbbf68d3c565c6cbd9bad36e0255a8 which introduced `libstdc++-hook.sh` incompatible with gcc. (CC @LnL7)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
