### PR TITLE
pythonPackages.textacy: init at 0.4.1

### DIFF
--- a/pkgs/applications/audio/mopidy-gmusic/default.nix
+++ b/pkgs/applications/audio/mopidy-gmusic/default.nix
@@ -13,7 +13,7 @@ pythonPackages.buildPythonApplication rec {
     mopidy
     pythonPackages.requests
     pythonPackages.gmusicapi
-    pythonPackages.cachetools
+    pythonPackages.cachetools_1
   ];
 
   doCheck = false;

--- a/pkgs/development/python-modules/cachetools/1.nix
+++ b/pkgs/development/python-modules/cachetools/1.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPyPy }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "cachetools";
+  version = "1.1.3";
+  disabled = isPyPy;  # a test fails
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0js7qx5pa8ibr8487lcf0x3a7w0xml0wa17snd6hjs0857kqhn20";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/tkem/cachetools";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/cachetools/default.nix
+++ b/pkgs/development/python-modules/cachetools/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPyPy }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "cachetools";
+  version = "2.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0pdw2fr29pxlyn1g5fhdrrqbpn0iw062nv716ngdqvdx7hnizq7d";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Extensible memoizing collections and decorators";
+    homepage = "https://github.com/tkem/cachetools";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/cld2-cffi/default.nix
+++ b/pkgs/development/python-modules/cld2-cffi/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchPypi, six, cffi, nose }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "cld2-cffi";
+  version = "0.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0rvcdx4fdh5yk4d2nlddq1q1r2r0xqp86hpmbdn447pdcj1r8a9s";
+  };
+
+  propagatedBuildInputs = [ six cffi ];
+  checkInputs = [ nose ];
+
+  # gcc doesn't approve of this code, so disable -Werror
+  NIX_CFLAGS_COMPILE = "-w";
+
+  checkPhase = "nosetests -v";
+
+  meta = with stdenv.lib; {
+    description = "CFFI bindings around Google Chromium's embedded compact language detection library (CLD2)";
+    homepage = "https://github.com/GregBowyer/cld2-cffi";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rvl ];
+  };
+}

--- a/pkgs/development/python-modules/ijson/default.nix
+++ b/pkgs/development/python-modules/ijson/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "ijson";
+  version = "2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0x7l9k2dvxzd5mjgiq15nl9b0sxcqy1cqaz744bjwkz4z5mrypzg";
+  };
+
+  doCheck = false; # something about yajl
+
+  meta = with stdenv.lib; {
+    description = "Iterative JSON parser with a standard Python iterator interface";
+    homepage = "https://github.com/isagalaev/ijson";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ rvl ];
+  };
+}

--- a/pkgs/development/python-modules/pyemd/default.nix
+++ b/pkgs/development/python-modules/pyemd/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, numpy, cython }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "pyemd";
+  version = "0.4.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "13y06y7r1697cv4r430g45fxs40i2yk9xn0dk9nqlrpddw3a0mr4";
+  };
+
+  propagatedBuildInputs = [ numpy ];
+  buildInputs = [ cython ];
+
+  meta = with stdenv.lib; {
+    description = "A Python wrapper for Ofir Pele and Michael Werman's implementation of the Earth Mover's Distance";
+    homepage = http://github.com/wmayner/pyemd;
+    license = licenses.mit;
+    maintainers = with maintainers; [ rvl ];
+  };
+}

--- a/pkgs/development/python-modules/pyphen/default.nix
+++ b/pkgs/development/python-modules/pyphen/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "Pyphen";
+  version = "0.9.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1mqb5jrigxipxzp1d8nbwkq0cfjw77pnn6hc4mp1yd2mn059mymb";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Pure Python module to hyphenate text";
+    homepage = "https://github.com/Kozea/Pyphen";
+    license = with licenses; [gpl2 lgpl21 mpl20];
+    maintainers = with maintainers; [ rvl ];
+  };
+}

--- a/pkgs/development/python-modules/spacy/models.json
+++ b/pkgs/development/python-modules/spacy/models.json
@@ -1,0 +1,42 @@
+[{
+  "pname": "es_core_web_md",
+  "version": "1.0.0",
+  "sha256": "0ikyakdhnj6rrfpr8k83695d1gd3z9n60a245hwwchv94jmr7r6s",
+  "license": "cc-by-sa-40"
+},
+{
+  "pname": "fr_depvec_web_lg",
+  "version": "1.0.0",
+  "sha256": "0nxmdszs1s5by2874cz37azrmwamh1ngdsiylffkfihzq6s8bhka",
+  "license": "cc-by-nc-sa-40"
+},
+{
+  "pname": "en_core_web_md",
+  "version": "1.2.1",
+  "sha256": "12prr4hcbfdaky9rcna1y1ykr417jkhkks2r8l06g8fb7am3pvp3",
+  "license": "cc-by-sa-40"
+},
+{
+  "pname": "en_depent_web_md",
+  "version": "1.2.1",
+  "sha256": "0giyr35q5lpp5drpcamyvb5gsjnhj62mk3ndfr49nm1s6d5f6m52",
+  "license": "cc-by-sa-40"
+},
+{
+  "pname": "en_core_web_sm",
+  "version": "1.2.0",
+  "sha256": "0vc4l77dcwa9lmzyqdci8ikjc0m2rhasl2zvyba547vf76qb0528",
+  "license": "cc-by-sa-40"
+},
+{
+  "pname": "de_core_news_md",
+  "version": "1.0.0",
+  "sha256": "072jz2rdi1nckny7k16avp86vjg4didfdsw816kfl9zwr88iny6g",
+  "license": "cc-by-sa-40"
+},
+{
+  "pname": "en_vectors_glove_md",
+  "version": "1.0.0",
+  "sha256": "1jbr27xnh5fdww8yphpvk2brfnzb174wfnxkzdqwv3iyi02zsin6",
+  "license": "cc-by-sa-40"
+}]

--- a/pkgs/development/python-modules/spacy/models.nix
+++ b/pkgs/development/python-modules/spacy/models.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchurl, spacy }:
+let
+  buildModelPackage = { pname, version, sha256, license }: buildPythonPackage {
+    name = "${pname}-${version}";
+    inherit pname version;
+
+    src = fetchurl {
+      url = "https://github.com/explosion/spacy-models/releases/download/${pname}-${version}/${pname}-${version}.tar.gz";
+      inherit sha256;
+    };
+
+    propagatedBuildInputs = [ spacy ];
+
+    meta = with stdenv.lib; {
+      description = "Models for the spaCy NLP library";
+      homepage    = "https://github.com/explosion/spacy-models";
+      license     = licenses."${license}";
+      maintainers = with maintainers; [ rvl ];
+    };
+  };
+
+  makeModelSet = models: with pkgs.lib; listToAttrs (map (m: nameValuePair m.pname (buildModelPackage m)) models);
+
+in makeModelSet (pkgs.lib.importJSON ./models.json)
+
+# cat models.json | jq -r '.[] | @uri "https://github.com/explosion/spacy-models/releases/download/\(.pname)-\(.version)/\(.pname)-\(.version).tar.gz"' | xargs -n1 nix-prefetch-url

--- a/pkgs/development/python-modules/textacy/default.nix
+++ b/pkgs/development/python-modules/textacy/default.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, buildPythonPackage
+, isPy27
+, fetchPypi
+, cachetools
+, cld2-cffi
+, cython
+, cytoolz
+, ftfy
+, ijson
+, matplotlib
+, networkx
+, numpy
+, pyemd
+, pyphen
+, python-Levenshtein
+, requests
+, scikitlearn
+, scipy
+, spacy
+, tqdm
+, unidecode
+}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "textacy";
+  version = "0.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04wf3a7zgzz83nmgkh488wkl50zm9yfdpv3sl12sm2zj685plqcz";
+  };
+
+  disabled = isPy27; # 2.7 requires backports.csv
+
+  propagatedBuildInputs = [
+    cachetools
+    cld2-cffi
+    cytoolz
+    ftfy
+    ijson
+    matplotlib
+    networkx
+    numpy
+    pyemd
+    pyphen
+    python-Levenshtein
+    requests
+    scikitlearn
+    scipy
+    spacy
+    tqdm
+    unidecode
+  ];
+
+  doCheck = false;  # tests want to download data files
+
+  meta = with stdenv.lib; {
+    description = "Higher-level text processing, built on spaCy";
+    homepage = "http://textacy.readthedocs.io/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rvl ];
+  };
+}

--- a/pkgs/development/python-modules/unidecode/default.nix
+++ b/pkgs/development/python-modules/unidecode/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, glibcLocales }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "Unidecode";
+  version = "0.04.21";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0lfhp9c5xrbpjvbpr12ji52g1lx04404bzzdg6pvabhzisw6l2i8";
+  };
+
+  LC_ALL="en_US.UTF-8";
+
+  buildInputs = [ glibcLocales ];
+
+  meta = with stdenv.lib; {
+    homepage = http://pypi.python.org/pypi/Unidecode/;
+    description = "ASCII transliterations of Unicode text";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ domenkozar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27277,6 +27277,8 @@ EOF
 
   spacy = callPackage ../development/python-modules/spacy { };
 
+  textacy = callPackage ../development/python-modules/textacy { };
+
   pyemd  = callPackage ../development/python-modules/pyemd { };
 
   behave = callPackage ../development/python-modules/behave { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -24149,26 +24149,7 @@ EOF
   };
 
 
-  unidecode = buildPythonPackage rec {
-    name = "Unidecode-0.04.18";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/U/Unidecode/${name}.tar.gz";
-      sha256 = "12hhblqy1ajvidm38im4171x4arg83pfmziyn53nizp29p3m14gi";
-    };
-
-    LC_ALL="en_US.UTF-8";
-
-    buildInputs = [ pkgs.glibcLocales ];
-
-    meta = {
-      homepage = http://pypi.python.org/pypi/Unidecode/;
-      description = "ASCII transliterations of Unicode text";
-      license = licenses.gpl2;
-      maintainers = with maintainers; [ domenkozar ];
-    };
-  };
-
+  unidecode = callPackage ../development/python-modules/unidecode {};
 
   pyusb = buildPythonPackage rec {
     name = "pyusb-1.0.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14289,7 +14289,7 @@ in {
        oslo-serialization oslo-utils iso8601 oslo-log oslo-i18n webob
      ];
      buildInputs = with self; [
-       oslo-middleware cachetools oslo-service futurist anyjson oslosphinx
+       oslo-middleware cachetools_1 oslo-service futurist anyjson oslosphinx
        testtools oslotest
      ];
 
@@ -14298,20 +14298,8 @@ in {
      };
    };
 
-   cachetools = buildPythonPackage rec {
-     name = "cachetools-${version}";
-     version = "1.1.3";
-     disabled = isPyPy;  # a test fails
-
-     src = pkgs.fetchurl {
-       url = "mirror://pypi/c/cachetools/${name}.tar.gz";
-       sha256 = "0js7qx5pa8ibr8487lcf0x3a7w0xml0wa17snd6hjs0857kqhn20";
-     };
-
-     meta = with stdenv.lib; {
-       homepage = "https://github.com/tkem/cachetools";
-     };
-   };
+   cachetools_1 = callPackage ../development/python-modules/cachetools/1.nix {};
+   cachetools = callPackage ../development/python-modules/cachetools {};
 
    futurist = buildPythonPackage rec {
      name = "futurist-${version}";
@@ -14347,7 +14335,7 @@ in {
     propagatedBuildInputs = with self; [
       pbr oslo-config oslo-context oslo-log oslo-utils oslo-serialization
       oslo-i18n stevedore six eventlet greenlet webob pyyaml kombu_3 trollius
-      aioeventlet cachetools oslo-middleware futurist redis oslo-service
+      aioeventlet cachetools_1 oslo-middleware futurist redis oslo-service
       eventlet pyzmq
     ];
 
@@ -14754,7 +14742,7 @@ in {
     };
 
     propagatedBuildInputs = with self; [
-      pbr futures enum34 debtcollector cachetools oslo-serialization oslo-utils
+      pbr futures enum34 debtcollector cachetools_1 oslo-serialization oslo-utils
       jsonschema monotonic stevedore networkx futurist pbr automaton fasteners
     ];
     buildInputs = with self; [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27277,6 +27277,8 @@ EOF
 
   spacy = callPackage ../development/python-modules/spacy { };
 
+  spacy_models = callPackage ../development/python-modules/spacy/models.nix { };
+
   textacy = callPackage ../development/python-modules/textacy { };
 
   pyemd  = callPackage ../development/python-modules/pyemd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7431,6 +7431,8 @@ in {
     inherit pythonOlder;
   };
 
+  pyphen = callPackage ../development/python-modules/pyphen {};
+
   pypoppler = buildPythonPackage rec {
     name = "pypoppler-${version}";
     version = "0.12.2";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2696,6 +2696,8 @@ in {
     };
   };
 
+  cld2-cffi = callPackage ../development/python-modules/cld2-cffi {};
+
   clf = buildPythonPackage rec {
     name = "clf-${version}";
     version = "0.5.2";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27277,6 +27277,8 @@ EOF
 
   spacy = callPackage ../development/python-modules/spacy { };
 
+  pyemd  = callPackage ../development/python-modules/pyemd { };
+
   behave = callPackage ../development/python-modules/behave { };
 
   pyhamcrest = callPackage ../development/python-modules/pyhamcrest { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6323,6 +6323,8 @@ in {
     };
   };
 
+  ijson = callPackage ../development/python-modules/ijson/default.nix {};
+
   imagesize = buildPythonPackage rec {
     name = "imagesize-${version}";
     version = "0.7.0";


### PR DESCRIPTION
#### Motivation for this change

Natural language processing with Python under Nix.

* This change adds the textacy python package and its dependencies.
* Versions have been tweaked on some dependencies where necessary.
* Finally, this change also adds python package derivations for the language model datasets required for many NLP functions.

###### Datasets

The language data models can't be downloaded in the way described by the spaCy docs because their download script is a wrapper around `pip install`. The data files total a couple GB and need enough `/tmp` space to assemble. I'm assuming that because the derivations exist under an attrset, they won't be automatically built by Hydra (good).

#### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` -- didn't use nox but have tested build of `mopidy-gmusic`, but not the "oslo" packages because they are already marked broken.
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @sdll