### PR TITLE
ocamlPackages.merlin: 2.5.4 -> to 3.0.2

### DIFF
--- a/pkgs/development/tools/ocaml/merlin/default.nix
+++ b/pkgs/development/tools/ocaml/merlin/default.nix
@@ -4,15 +4,7 @@
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.00";
 
 let
-  version = if lib.versionOlder (lib.getVersion ocaml) "4.02.0"
-  then
-    "2.3.1"
-  else
-    "2.5.4";
-  hashes = {
-    "2.3.1" = "192jamcc7rmvadlqqsjkzsl6hlgwhg9my1qc89fxh1lmd4qdsrpn";
-    "2.5.4" = "101vk16c5wayd51s8w0mvy99bk7q3gm2gz8i8616wa1lmyszjknh";
-  };
+  version = "3.0.2";
 in
 
 stdenv.mkDerivation {
@@ -20,8 +12,8 @@ stdenv.mkDerivation {
   name = "merlin-${version}";
 
   src = fetchzip {
-    url = "https://github.com/the-lambda-church/merlin/archive/v${version}.tar.gz";
-    sha256 = hashes."${version}";
+    url = "https://github.com/ocaml/merlin/archive/v${version}.tar.gz";
+    sha256 = "0lcgafs5ip8vhvrp1d7yv6mzjsirmayd83cj4wwq6zxcrl7yv4x8";
   };
 
   buildInputs = [ ocaml findlib yojson ]


### PR DESCRIPTION
###### Motivation for this change

The versions of Merlin available are incompatible with the emacs merlin layer.

###### Things done

Merlin updated to 3.0.2

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
