### PR TITLE
pythonPackages.pomegranate: init at 0.7.7

### DIFF
--- a/pkgs/development/python-modules/pomegranate/default.nix
+++ b/pkgs/development/python-modules/pomegranate/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, pythonPackages, fetchFromGitHub }:
+
+pythonPackages.buildPythonPackage rec {
+  pname = "pomegranate";
+  version = "0.7.7";
+  name  = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    repo = "pomegranate";
+    owner = "jmschrei";
+    rev = version;
+    sha256 = "07zkg9jxjql00ppmkc4wsm2xidx58xnkmbbqaqv8jmh67y80yx75";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ numpy scipy cython networkx joblib ];
+
+  buildInputs = [ pythonPackages.nose ];
+
+  meta = with stdenv.lib; {
+    description = "Probabilistic and graphical models for Python, implemented in cython for speed";
+    homepage = https://github.com/jmschrei/pomegranate;
+    license = licenses.mit;
+    maintainers = with maintainers; [ rybern ];
+  };
+}

--- a/pkgs/development/python-modules/pomegranate/default.nix
+++ b/pkgs/development/python-modules/pomegranate/default.nix
@@ -1,20 +1,18 @@
-{ stdenv, pythonPackages, fetchFromGitHub }:
+{ stdenv, buildPythonPackage, fetchPypi, numpy, scipy, cython, networkx, joblib, nose }:
 
-pythonPackages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "pomegranate";
   version = "0.7.7";
   name  = "${pname}-${version}";
 
-  src = fetchFromGitHub {
-    repo = "pomegranate";
-    owner = "jmschrei";
-    rev = version;
-    sha256 = "07zkg9jxjql00ppmkc4wsm2xidx58xnkmbbqaqv8jmh67y80yx75";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b5b7a6256778fc4097ee77caec28ec845ec1fee3d701f3f26f83860b2d45c453";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ numpy scipy cython networkx joblib ];
+  propagatedBuildInputs = [ numpy scipy cython networkx joblib ];
 
-  buildInputs = [ pythonPackages.nose ];
+  checkInputs = [ nose ];
 
   meta = with stdenv.lib; {
     description = "Probabilistic and graphical models for Python, implemented in cython for speed";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7285,6 +7285,8 @@ in {
 
   podcastparser = callPackage ../development/python-modules/podcastparser { };
 
+  pomegranate = callPackage ../development/python-modules/pomegranate { };
+
   poppler-qt4 = buildPythonPackage rec {
     name = "poppler-qt4-${version}";
     version = "0.18.1";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

