### PR TITLE
dyn: 1.5.0 -> 1.6.3

### DIFF
--- a/pkgs/development/python-modules/dyn/default.nix
+++ b/pkgs/development/python-modules/dyn/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest, pytestcov, mock, pytestpep8
+, pytest_xdist, covCore, glibcLocales }:
+
+buildPythonPackage rec {
+  pname = "dyn";
+  version = "1.6.3";
+  name  = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1xq90fliix5nbv934s3wf2pahmx6m2b9y0kqwn192c76qh7xlzib";
+  };
+
+  buildInputs = [ glibcLocales ];
+
+  checkInputs = [
+    pytest
+    pytestcov
+    mock
+    pytestpep8
+    pytest_xdist
+    covCore
+  ];
+  # Disable checks because they are not stateless and require internet access.
+  doCheck = false;
+
+  LC_ALL="en_US.UTF-8";
+
+  meta = with stdenv.lib; {
+    description = "Dynect dns lib";
+    homepage = "http://dyn.readthedocs.org/en/latest/intro.html";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5178,33 +5178,7 @@ in {
     inherit (pkgs) fetchFromGitHub bluez;
   };
 
-  dyn = buildPythonPackage rec {
-    version = "1.5.0";
-    name = "dyn-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/dyn/${name}.tar.gz";
-      sha256 = "dc4b4b2a5d9d26f683230fd822641b39494df5fcbfa716281d126ea6425dd4c3";
-    };
-
-    buildInputs = with self; [
-      pytest
-      pytestcov
-      mock
-      pytestpep8
-      pytest_xdist
-      covCore
-      pkgs.glibcLocales
-    ];
-
-    LC_ALL="en_US.UTF-8";
-
-    meta = {
-      description = "Dynect dns lib";
-      homepage = "http://dyn.readthedocs.org/en/latest/intro.html";
-      license = licenses.bsd3;
-    };
-  };
+  dyn = callPackage ../development/python-modules/dyn { };
 
   easydict = callPackage ../development/python-modules/easydict { };
 


### PR DESCRIPTION
###### Motivation for this change
fixes build failures. Disables checks requiring internet access.

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

