### PR TITLE
mgba: 0.5.2 -> 0.6.0

### DIFF
--- a/pkgs/misc/emulators/mgba/default.nix
+++ b/pkgs/misc/emulators/mgba/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "mgba-${version}";
-  version = "0.5.2";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "mgba-emu";
     repo = "mgba";
     rev = version;
-    sha256 = "1cpxiwzbywnjs3lrqa3bc9bj68plypx0br3lssd6p68c4wh01fyp";
+    sha256 = "1kzb6zj2lxfaiyfq9h7q26fh7xh1ggybmh5pin5rcgs7jyygrsjb";
   };
 
   nativeBuildInputs = [ pkgconfig cmake ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

