### PR TITLE
treewide: Do not limit hardenging because gcc 4.9 in bootstrap

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -69,9 +69,6 @@ let
 
     enableParallelBuilding = true;
 
-    # FIXME needs gcc 4.9 in bootstrap tools
-    hardeningDisable = [ "stackprotector" ];
-
     preConfigure =
       ''
         configureFlags="$configureFlags -Dprefix=$out -Dman1dir=$out/share/man/man1 -Dman3dir=$out/share/man/man3"

--- a/pkgs/development/libraries/cloog/0.18.0.nix
+++ b/pkgs/development/libraries/cloog/0.18.0.nix
@@ -18,9 +18,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "stackprotector" ];
-
   meta = {
     description = "Library that generates loops for scanning polyhedra";
 

--- a/pkgs/development/libraries/gmp/5.1.x.nix
+++ b/pkgs/development/libraries/gmp/5.1.x.nix
@@ -18,9 +18,6 @@ let self = stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ m4 ];
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "format" "stackprotector" ];
-
   patches = if stdenv.isDarwin then [ ./need-size-t.patch ] else null;
 
   configureFlags =

--- a/pkgs/development/libraries/isl/0.14.1.nix
+++ b/pkgs/development/libraries/isl/0.14.1.nix
@@ -12,9 +12,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "stackprotector" ];
-
   meta = {
     homepage = http://www.kotnet.org/~skimo/isl/;
     license = stdenv.lib.licenses.lgpl21;

--- a/pkgs/development/libraries/libelf/default.nix
+++ b/pkgs/development/libraries/libelf/default.nix
@@ -17,9 +17,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "stackprotector" ];
-
   # Libelf's custom NLS macros fail to determine the catalog file extension on
   # Darwin, so disable NLS for now.
   # FIXME: Eventually make Gettext a build input on all platforms.

--- a/pkgs/development/libraries/libmpc/default.nix
+++ b/pkgs/development/libraries/libmpc/default.nix
@@ -20,9 +20,6 @@ stdenv.mkDerivation rec {
 
   doCheck = hostPlatform == buildPlatform;
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "stackprotector" ];
-
   meta = {
     description = "Library for multiprecision complex arithmetic with exact rounding";
 

--- a/pkgs/development/libraries/mpfr/default.nix
+++ b/pkgs/development/libraries/mpfr/default.nix
@@ -17,9 +17,6 @@ stdenv.mkDerivation rec {
   # mpfr.h requires gmp.h
   propagatedBuildInputs = [ gmp ];
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "stackprotector" ];
-
   configureFlags =
     stdenv.lib.optional hostPlatform.isSunOS "--disable-thread-safe" ++
     stdenv.lib.optional hostPlatform.is64bit "--with-pic";

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -29,9 +29,6 @@ stdenv.mkDerivation rec {
   setOutputFlags = false;
   outputDoc = "dev"; # single tiny man3 page
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "stackprotector" ];
-
   configureFlags = stdenv.lib.optional (!static) "--shared";
 
   postInstall = ''

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -61,9 +61,6 @@ stdenv.mkDerivation rec {
 
   inherit noSysDirs;
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "stackprotector" ];
-
   preConfigure = ''
     # Clear the default library search path.
     if test "$noSysDirs" = "1"; then

--- a/pkgs/development/tools/misc/gnum4/default.nix
+++ b/pkgs/development/tools/misc/gnum4/default.nix
@@ -15,9 +15,6 @@ stdenv.mkDerivation rec {
   # Upstream is aware of it; it may be in the next release.
   patches = [ ./s_isdir.patch ] ++ stdenv.lib.optional hostPlatform.isDarwin stdenv.secure-format-patch;
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "stackprotector" ];
-
   meta = {
     homepage = http://www.gnu.org/software/m4/;
     description = "GNU M4, a macro processor";

--- a/pkgs/development/tools/misc/patchelf/default.nix
+++ b/pkgs/development/tools/misc/patchelf/default.nix
@@ -10,9 +10,6 @@ stdenv.mkDerivation rec {
 
   setupHook = [ ./setup-hook.sh ];
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "stackprotector" ];
-
   #doCheck = true; # problems when loading libc.so.6
 
   meta = {

--- a/pkgs/development/tools/misc/texinfo/6.3.nix
+++ b/pkgs/development/tools/misc/texinfo/6.3.nix
@@ -17,9 +17,6 @@ stdenv.mkDerivation rec {
 
   configureFlags = stdenv.lib.optional stdenv.isSunOS "AWK=${gawk}/bin/awk";
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "stackprotector" ];
-
   preInstall = ''
     installFlags="TEXMF=$out/texmf-dist";
     installTargets="install install-tex";

--- a/pkgs/development/tools/parsing/bison/3.x.nix
+++ b/pkgs/development/tools/parsing/bison/3.x.nix
@@ -13,9 +13,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ m4 perl ] ++ stdenv.lib.optional stdenv.isSunOS help2man;
   propagatedBuildInputs = [ m4 ];
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "stackprotector" ];
-
   meta = {
     homepage = http://www.gnu.org/software/bison/;
     description = "Yacc-compatible parser generator";

--- a/pkgs/os-specific/linux/paxctl/default.nix
+++ b/pkgs/os-specific/linux/paxctl/default.nix
@@ -18,9 +18,6 @@ stdenv.mkDerivation rec {
     "MANDIR=share/man/man1"
   ];
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "stackprotector" ];
-
   setupHook = ./setup-hook.sh;
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -17,9 +17,6 @@ stdenv.mkDerivation rec {
 
   postInstall = "rm -rf $out/share/doc";
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "stackprotector" ];
-
   meta = with stdenv.lib; {
     homepage = http://tukaani.org/xz/;
     description = "XZ, general-purpose data compression software, successor of LZMA";

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -21,9 +21,6 @@ stdenv.mkDerivation rec {
     sha256 = "0r8c1bgm68kl70j1lgd0rv12iykw6143k4m9a56xip9rc2hv25qi";
   };
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "stackprotector" ];
-
   patches = optional hostPlatform.isCygwin ./coreutils-8.23-4.cygwin.patch;
 
   # The test tends to fail on btrfs and maybe other unusual filesystems.

--- a/pkgs/tools/system/which/default.nix
+++ b/pkgs/tools/system/which/default.nix
@@ -8,9 +8,6 @@ stdenv.mkDerivation rec {
     sha256 = "1bgafvy3ypbhhfznwjv1lxmd6mci3x1byilnnkc7gcr486wlb8pl";
   };
 
-  # FIXME needs gcc 4.9 in bootstrap tools
-  hardeningDisable = [ "stackprotector" ];
-
   meta = with stdenv.lib; {
     homepage = http://ftp.gnu.org/gnu/which/;
     platforms = platforms.all;


### PR DESCRIPTION
###### Motivation for this change

GCC in Bootstrap tools has since been bumped

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

