### PR TITLE
rabbitmq_server: 3.6.6 -> 3.6.10

### DIFF
--- a/pkgs/servers/amqp/rabbitmq-server/default.nix
+++ b/pkgs/servers/amqp/rabbitmq-server/default.nix
@@ -7,11 +7,11 @@
 stdenv.mkDerivation rec {
   name = "rabbitmq-server-${version}";
 
-  version = "3.6.6";
+  version = "3.6.10";
 
   src = fetchurl {
-    url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_6_6/rabbitmq-server-3.6.6.tar.xz";
-    sha256 = "13mpnyfxd026w525rsnkcw0f8bcrkbzl7k9g8pnqmm3zyny8jmir";
+    url = "https://www.rabbitmq.com/releases/rabbitmq-server/v${version}/${name}.tar.xz";
+    sha256 = "0k1rhg1a51201b1hp6vaf4fk48hqz7m9hw55b8xnnyz2ld88jiqg";
   };
 
   buildInputs =
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   postInstall =
     ''
       echo 'PATH=${erlang}/bin:''${PATH:+:}$PATH' >> $out/sbin/rabbitmq-env
-    ''; # */
+    '';
 
   meta = {
     homepage = http://www.rabbitmq.com/;


### PR DESCRIPTION
###### Motivation for this change

3.6.6 has some known vulnerabilities: https://pivotal.io/security/cve-2017-4965
3.6.10 was the latest when the change was made at Zalora. I realize there are 3.6.11 and 3.6.12 now, but it'll take a while for another round of updating and testing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

