### PR TITLE
pydub 0.16.7 -> 0.20.0

### DIFF
--- a/pkgs/development/python-modules/pydub/default.nix
+++ b/pkgs/development/python-modules/pydub/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, scipy, ffmpeg-full }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "pydub";
+  version = "0.20.0";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hqsvvph6ks4kxj0m2q1xvl5bllqmpk78rlqpqhh79schl344xkv";
+  };
+
+  patches = [
+    ./pyaudioop-python3.patch
+  ];
+
+  checkInputs = [ scipy ffmpeg-full ];
+
+  meta = with stdenv.lib; {
+    description = "Manipulate audio with a simple and easy high level interface.";
+    homepage    = "http://pydub.com/";
+    license     = licenses.mit;
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/pydub/pyaudioop-python3.patch
+++ b/pkgs/development/python-modules/pydub/pyaudioop-python3.patch
@@ -1,0 +1,46 @@
+diff --git i/pydub/pyaudioop.py w/pydub/pyaudioop.py
+index 8f8f017..aa6bb8c 100644
+--- i/pydub/pyaudioop.py
++++ w/pydub/pyaudioop.py
+@@ -1,4 +1,4 @@
+-import __builtin__
++import builtins
+ import math
+ import struct
+ from fractions import gcd
+@@ -79,7 +79,7 @@ def _get_minval(size, signed=True):
+ def _get_clipfn(size, signed=True):
+     maxval = _get_maxval(size, signed)
+     minval = _get_minval(size, signed)
+-    return lambda val: __builtin__.max(min(val, maxval), minval)
++    return lambda val: builtins.max(min(val, maxval), minval)
+ 
+ 
+ def _overflow(val, size, signed=True):
+@@ -109,7 +109,7 @@ def max(cp, size):
+     if len(cp) == 0:
+         return 0
+ 
+-    return __builtin__.max(abs(sample) for sample in _get_samples(cp, size))
++    return builtins.max(abs(sample) for sample in _get_samples(cp, size))
+ 
+ 
+ def minmax(cp, size):
+@@ -117,8 +117,8 @@ def minmax(cp, size):
+ 
+     max_sample, min_sample = 0, 0
+     for sample in _get_samples(cp, size):
+-        max_sample = __builtin__.max(sample, max_sample)
+-        min_sample = __builtin__.min(sample, min_sample)
++        max_sample = builtins.max(sample, max_sample)
++        min_sample = builtins.min(sample, min_sample)
+ 
+     return min_sample, max_sample
+ 
+@@ -542,4 +542,4 @@ def lin2adpcm(cp, size, state):
+ 
+ 
+ def adpcm2lin(cp, size, state):
+-    raise NotImplementedError()
+\ No newline at end of file
++    raise NotImplementedError()

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3852,22 +3852,7 @@ in {
     };
   };
 
-  pydub = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "pydub";
-    version = "0.16.7";
-    src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/05/e0/8d2496c8ef1d7f2c8ff625be3849f550da42809b862879a8fb137c6baa11/${name}.tar.gz";
-      sha256 = "10rmbvsld5fni9wsvb7la8lblrglsnzd2l1159rcxqf6b8k441dx";
-    };
-
-    meta = {
-      description = "Manipulate audio with a simple and easy high level interface.";
-      homepage    = "http://pydub.com/";
-      license     = licenses.mit;
-      platforms   = platforms.all;
-    };
-  };
+  pydub = callPackage ../development/python-modules/pydub {};
 
   pyjade = buildPythonPackage rec {
     name = "${pname}-${version}";


### PR DESCRIPTION
###### Motivation for this change
fixes build failures.

related to #28643

Had to disable tests because pyaudioop test module hard codes __builtins__ which breaks on python 3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

