### PR TITLE
Python 3.4 and 3.5: support LD_LIBRARY_PATH

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.4/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.4/default.nix
@@ -66,6 +66,7 @@ in stdenv.mkDerivation {
 
   patches = [
     ./no-ldconfig.patch
+    ./ld_library_path.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/interpreters/python/cpython/3.4/ld_library_path.patch
+++ b/pkgs/development/interpreters/python/cpython/3.4/ld_library_path.patch
@@ -1,0 +1,51 @@
+From 85991e0d7f0e631240f3f6233bd65d1128a66dec Mon Sep 17 00:00:00 2001
+From: Frederik Rietdijk <fridh@fridh.nl>
+Date: Thu, 14 Sep 2017 10:00:31 +0200
+Subject: [PATCH] ctypes.util: support LD_LIBRARY_PATH
+
+Backports support for LD_LIBRARY_PATH from 3.6
+---
+ Lib/ctypes/util.py | 26 +++++++++++++++++++++++++-
+ 1 file changed, 25 insertions(+), 1 deletion(-)
+
+diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
+index 780cd5d21b..d7ac15070f 100644
+--- a/Lib/ctypes/util.py
++++ b/Lib/ctypes/util.py
+@@ -181,8 +181,32 @@ elif os.name == "posix":
+         def _findSoname_ldconfig(name):
+             return None
+ 
++        def _findLib_ld(name):
++            # See issue #9998 for why this is needed
++            expr = r'[^\(\)\s]*lib%s\.[^\(\)\s]*' % re.escape(name)
++            cmd = ['ld', '-t']
++            libpath = os.environ.get('LD_LIBRARY_PATH')
++            if libpath:
++                for d in libpath.split(':'):
++                    cmd.extend(['-L', d])
++            cmd.extend(['-o', os.devnull, '-l%s' % name])
++            result = None
++            try:
++                p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
++                                     stderr=subprocess.PIPE,
++                                     universal_newlines=True)
++                out, _ = p.communicate()
++                res = re.search(expr, os.fsdecode(out))
++                if res:
++                    result = res.group(0)
++            except Exception as e:
++                pass  # result will be None
++            return result
++
+         def find_library(name):
+-            return _findSoname_ldconfig(name) or _get_soname(_findLib_gcc(name))
++            # See issue #9998
++            return _findSoname_ldconfig(name) or \
++                   _get_soname(_findLib_gcc(name) or _findLib_ld(name))
+ 
+ ################################################################
+ # test code
+-- 
+2.14.1
+

--- a/pkgs/development/interpreters/python/cpython/3.5/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.5/default.nix
@@ -66,6 +66,7 @@ in stdenv.mkDerivation {
 
   patches = [
     ./no-ldconfig.patch
+    ./ld_library_path.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/interpreters/python/cpython/3.5/ld_library_path.patch
+++ b/pkgs/development/interpreters/python/cpython/3.5/ld_library_path.patch
@@ -1,0 +1,51 @@
+From 918201682127ed8a270a4bd1a448b490019e4ada Mon Sep 17 00:00:00 2001
+From: Frederik Rietdijk <fridh@fridh.nl>
+Date: Thu, 14 Sep 2017 10:00:31 +0200
+Subject: [PATCH] ctypes.util: support LD_LIBRARY_PATH
+
+Backports support for LD_LIBRARY_PATH from 3.6
+---
+ Lib/ctypes/util.py | 26 +++++++++++++++++++++++++-
+ 1 file changed, 25 insertions(+), 1 deletion(-)
+
+diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
+index e9957d7951..9926f6c881 100644
+--- a/Lib/ctypes/util.py
++++ b/Lib/ctypes/util.py
+@@ -219,8 +219,32 @@ elif os.name == "posix":
+         def _findSoname_ldconfig(name):
+             return None
+ 
++        def _findLib_ld(name):
++            # See issue #9998 for why this is needed
++            expr = r'[^\(\)\s]*lib%s\.[^\(\)\s]*' % re.escape(name)
++            cmd = ['ld', '-t']
++            libpath = os.environ.get('LD_LIBRARY_PATH')
++            if libpath:
++                for d in libpath.split(':'):
++                    cmd.extend(['-L', d])
++            cmd.extend(['-o', os.devnull, '-l%s' % name])
++            result = None
++            try:
++                p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
++                                     stderr=subprocess.PIPE,
++                                     universal_newlines=True)
++                out, _ = p.communicate()
++                res = re.search(expr, os.fsdecode(out))
++                if res:
++                    result = res.group(0)
++            except Exception as e:
++                pass  # result will be None
++            return result
++
+         def find_library(name):
+-            return _findSoname_ldconfig(name) or _get_soname(_findLib_gcc(name))
++            # See issue #9998
++            return _findSoname_ldconfig(name) or \
++                   _get_soname(_findLib_gcc(name) or _findLib_ld(name))
+ 
+ ################################################################
+ # test code
+-- 
+2.14.1
+


### PR DESCRIPTION
###### Motivation for this change

Support for `LD_LIBRARY_PATH` was added to Python 3.6, fixes #29154.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

