### PR TITLE
ws4py: add git to checkInputs

### DIFF
--- a/pkgs/development/python-modules/ws4py/default.nix
+++ b/pkgs/development/python-modules/ws4py/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest, mock, git, asyncio
+, cherrypy, gevent, tornado }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "ws4py";
+  version = "0.4.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0zr3254ky6r7q15l3dhdczfa8i723055zdkqssjifsgcwvirriks";
+  };
+
+  checkInputs = [ pytest mock git ];
+  propagatedBuildInputs = [ asyncio cherrypy gevent tornado ];
+
+  checkPhase = ''
+    pytest test
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://ws4py.readthedocs.org;
+    description = "A WebSocket package for Python";
+    maintainers = with maintainers; [ rickynils ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -24545,29 +24545,7 @@ EOF
     };
   };
 
-  ws4py = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "ws4py";
-    version = "0.4.2";
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "0zr3254ky6r7q15l3dhdczfa8i723055zdkqssjifsgcwvirriks";
-    };
-
-    buildInputs = with self; [ pytest mock ];
-    propagatedBuildInputs = with self; [ asyncio cherrypy gevent tornado ];
-
-    checkPhase = ''
-      pytest test
-    '';
-
-    meta = {
-      homepage = https://ws4py.readthedocs.org;
-      description = "A WebSocket package for Python";
-      maintainers = with maintainers; [ rickynils ];
-    };
-  };
+  ws4py = callPackage ../development/python-modules/ws4py {};
 
   gdata = buildPythonPackage rec {
     name = "gdata-${version}";


### PR DESCRIPTION
###### Motivation for this change
moves ws4py to python-modules and moves buildInputs to checkInputs.

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

