### PR TITLE
mwlib: fix build using older odfpy

### DIFF
--- a/pkgs/development/python-modules/mwlib/default.nix
+++ b/pkgs/development/python-modules/mwlib/default.nix
@@ -1,0 +1,80 @@
+{ stdenv, buildPythonPackage, fetchurl, fetchPypi, isPy3k, apipkg, bottle, gevent
+, lxml, pillow, py, pyPdf, qserve, roman, simplejson, sqlite3dbm, timelib, pytest }:
+
+let
+  pyparsing = buildPythonPackage rec {
+    pname = "pyparsing";
+    version = "1.5.7";
+    name  = "${pname}-${version}";
+    disabled = isPy3k;
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "17z7ws076z977sclj628fvwrp8y9j2rvdjcsq42v129n1gwi8vk4";
+    };
+    meta = with stdenv.lib; {
+      homepage = http://pyparsing.wikispaces.com/;
+      description = "An alternative approach to creating and executing simple grammars, vs. the traditional lex/yacc approach, or the use of regular expressions";
+    };
+  };
+  odfpy = buildPythonPackage rec {
+    pname = "odfpy";
+    version = "0.9.6";
+    disabled = isPy3k;
+    name  = "${pname}-${version}";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "14880cb34kidqhr4svp374dwcsk5mmlzwi8asxvyvmycy5lzjn74";
+    };
+    doCheck = false;
+    meta = with stdenv.lib; {
+      description = "Python API and tools to manipulate OpenDocument files";
+      homepage = "https://joinup.ec.europa.eu/software/odfpy/home";
+      license = lib.licenses.asl20;
+    };
+  };
+in buildPythonPackage rec {
+  pname = "mwlib";
+  version = "0.15.15";
+  name  = "${pname}-${version}";
+  disabled = isPy3k;
+
+  src = fetchurl {
+    url = "http://pypi.pediapress.com/packages/mirror/${name}.tar.gz";
+    sha256 = "1dnmnkc21zdfaypskbpvkwl0wpkpn0nagj1fc338w64mbxrk8ny7";
+  };
+
+
+  propagatedBuildInputs = [
+      apipkg
+      bottle
+      gevent
+      lxml
+      odfpy
+      pillow
+      py
+      pyPdf
+      pyparsing
+      qserve
+      roman
+      simplejson
+      sqlite3dbm
+      timelib
+  ];
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  # Tests are in build directory but we need extension modules that are in $out
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Library for parsing MediaWiki articles and converting them to different output formats";
+    homepage = "http://pediapress.com/code/";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/odfpy/0.9.6.nix
+++ b/pkgs/development/python-modules/odfpy/0.9.6.nix
@@ -1,0 +1,23 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "odfpy";
+  version = "0.9.6";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "14880cb34kidqhr4svp374dwcsk5mmlzwi8asxvyvmycy5lzjn74";
+  };
+
+  doCheck = false;
+
+  meta = {
+    description = "Python API and tools to manipulate OpenDocument files";
+    homepage = "https://joinup.ec.europa.eu/software/odfpy/home";
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6872,61 +6872,8 @@ in {
     };
   };
 
-  mwlib = let
-    pyparsing = buildPythonPackage rec {
-      name = "pyparsing-1.5.7";
-      disabled = isPy3k;
+  mwlib = callPackage ../development/python-modules/mwlib {};
 
-      src = pkgs.fetchurl {
-        url = "mirror://pypi/p/pyparsing/${name}.tar.gz";
-        sha256 = "646e14f90b3689b005c19ac9b6b390c9a39bf976481849993e277d7380e6e79f";
-      };
-      meta = {
-        homepage = http://pyparsing.wikispaces.com/;
-        description = "An alternative approach to creating and executing simple grammars, vs. the traditional lex/yacc approach, or the use of regular expressions";
-      };
-    };
-  in buildPythonPackage rec {
-    version = "0.15.15";
-    name = "mwlib-${version}";
-
-    src = pkgs.fetchurl {
-      url = "http://pypi.pediapress.com/packages/mirror/${name}.tar.gz";
-      sha256 = "1dnmnkc21zdfaypskbpvkwl0wpkpn0nagj1fc338w64mbxrk8ny7";
-    };
-
-    propagatedBuildInputs = with self; [
-        apipkg
-        bottle
-        gevent
-        lxml
-        odfpy
-        pillow
-        py
-        pyPdf
-        pyparsing
-        qserve
-        roman
-        simplejson
-        sqlite3dbm
-        timelib
-    ];
-
-    checkInputs = with self; [ pytest ];
-
-    checkPhase = ''
-      py.test
-    '';
-
-    # Tests are in build directory but we need extension modules that are in $out
-    doCheck = false;
-
-    meta = {
-      description = "Library for parsing MediaWiki articles and converting them to different output formats";
-      homepage = "http://pediapress.com/code/";
-      license = licenses.bsd3;
-    };
-  };
 
   mwlib-ext = buildPythonPackage rec {
     version = "0.13.2";


### PR DESCRIPTION
###### Motivation for this change
This may end up being just pulled out of nixpkgs or marked broken, but this is a fix that gets the build working.

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

