### PR TITLE
adapta-gtk-theme: 3.91.2.10 -> 3.91.2.147

### DIFF
--- a/pkgs/misc/themes/adapta/default.nix
+++ b/pkgs/misc/themes/adapta/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "adapta-gtk-theme-${version}";
-  version = "3.91.2.10";
+  version = "3.91.2.147";
 
   src = fetchFromGitHub {
     owner = "tista500";
     repo = "Adapta";
     rev = version;
-    sha256 = "0bp5fnxgrrrs0ajqw2lbhbarbpvzvajnvcjip6fkl9aa76gz9czy";
+    sha256 = "1sv4s8rcc40v4lanapdqanlqf1l60rbc5wd7h73l5cigbqxxgda9";
   };
 
   preferLocalBuild = true;


### PR DESCRIPTION
###### Motivation for this change

Update to version 3.91.2.147.

[Releases](https://github.com/adapta-project/adapta-gtk-theme/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).