### PR TITLE
nixcloud.email: a simple yet powerful abstraction for a basic mailser…

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -265,6 +265,7 @@
   ./services/mail/opendkim.nix
   ./services/mail/opensmtpd.nix
   ./services/mail/postfix.nix
+  ./services/mail/nixcloud-email.nix
   ./services/mail/postsrsd.nix
   ./services/mail/postgrey.nix
   ./services/mail/spamassassin.nix

--- a/nixos/modules/services/mail/nixcloud-email.nix
+++ b/nixos/modules/services/mail/nixcloud-email.nix
@@ -1,0 +1,359 @@
+{ config, pkgs, lib, options, ... } @ toplevel:
+with lib;
+
+let
+  cfg = config.nixcloud.email;
+in
+{
+  imports = [ ./virtual-mail-users.nix ];
+  options = {
+    nixcloud.email = mkOption {
+      default = {};
+      description = ''
+        nixcloud.email simplifies mailserver hosting by providing a minimal abstraction with useful defaults.
+      '';
+      type = types.submodule ({ config, ... } : {
+        config._module.args.toplevel = toplevel;
+        options = {
+          enable = mkOption {
+            default = false;
+            description = ''
+              nixcloud.io email abstraction, optimized for simple usage yet supporting complex features.
+            '';
+          };
+          ipAddress = mkOption {
+            example = "1.2.3.4";
+            description = ''
+              The IPv4 address used for the email service.
+            '';
+          };
+          ip6Address = mkOption {
+            example = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
+            description = ''
+              The IPv6 address used for the email service. Note: You need to set the reverse PTR correctly or you can't send emails to gmail.com for instance.
+            '';
+          };
+          domains = mkOption {
+            type = types.listOf (types.str);
+            example = [ "example.com" ];
+            description = ''
+              The domains for which the mailserver is responsible.
+            '';
+          };
+          hostname = mkOption {
+            type = types.str;
+            example = "mail.example.com";
+            default = toplevel.config.networking.hostName;
+            description = ''
+              The domain the MX record points to and hostname needs not be listed in domains. Used by Postfix and ACME.
+            '';
+          };
+          enableSpamassassin = mkOption {
+            type = types.bool;
+            default = true;
+            description = ''
+              SpamAssassin is the #1 Open Source anti-spam platform giving system administrators a filter to classify email and block spam (unsolicited bulk email).
+            '';
+          };
+          enableGreylisting = mkOption {
+            type = types.bool;
+            default = true;
+            description = ''
+              Enable the Postfix policy server implementing greylisting developed by David Schweikert.
+            '';
+          };
+          enableMailQuota = mkOption {
+            type = types.bool;
+            default = true;
+            description = ''
+              Dovecot2 mail quotas - https://wiki2.dovecot.org/Quota
+            '';
+          };
+          enableDKIM = mkOption {
+            type = types.bool;
+            default = true;
+            description = ''
+              A community effort to develop and maintain a C library for producing DKIM-aware applications and an open source milter for providing DKIM servicei (http://opendkim.org/). 
+            '';
+          };
+          enableACME= mkOption {
+            type = types.bool;
+            default = true;
+            description = ''
+              Let’s Encrypt uses the ACME protocol to verify that you control a given domain name and to issue you a certificate.
+            '';
+          };
+          users = mkOption {
+            type = types.listOf (types.submodule (import ./virtual-mail-submodule.nix));
+            example = [ { name = "js"; domain = "nixcloud.io"; password="qwertz"; } ];
+            default = [];
+            description = "A list of virtual mail users for which the password is managed via this abstraction";
+          };
+        };
+      });
+    };
+  };
+
+  config = mkIf (config.nixcloud.email.enable == true)
+    (mkMerge [ 
+
+      ({ 
+        networking = {
+          firewall = {
+            allowPing = true;
+            allowedTCPPorts = [
+              25               # master (postfix)
+              143              # imap (dovecot)
+              587              # dovecot (submission)
+              993              # imaps (dovecot)
+              4190             # sieve
+            ];
+          };
+        };
+      })
+
+
+      ({
+        services.mailUsers.users = cfg.users; 
+      })
+      
+      (mkIf cfg.enableSpamassassin {
+        services.spamassassin = {
+          enable = true;
+          #debug = true;
+          config = ''
+            #rewrite_header Subject [***** SPAM _SCORE_ *****]
+            required_score          5.0
+            use_bayes               1
+            bayes_auto_learn        1
+            add_header all Status _YESNO_, score=_SCORE_ required=_REQD_ tests=_TESTS_ autolearn=_AUTOLEARN_ version=_VERSION_
+          '';
+        };
+      })
+
+      (mkIf cfg.enableACME { 
+        networking = {
+          firewall = {
+            allowedTCPPorts = [
+              80
+            ];
+          };
+        };
+
+        services.nginx = {
+          enable = true;
+          virtualHosts.mail= {
+            default = true;
+            enableACME = true;
+            #serverName = "mail.nix.lt";
+            serverName = cfg.hostname;
+            # FIXME eventually we want to run these commands after a cert update
+            #acmePostRun =
+            #  systemctl restart httpd.service;
+            #  systemctl restart postfix.service;
+            #  systemctl restart dovecot2.service;
+            #'';
+          };
+        };
+      })
+
+      (mkIf cfg.enableDKIM {
+        users.users.postfix.extraGroups = [ "opendkim" ];
+        services.opendkim = {
+          enable = true;
+          selector = "mail";
+          keyPath = "/var/lib/dkim/keys/";
+          #domains = "csl:nix.lt";
+          domains = "csl:${lib.concatStringsSep "," cfg.domains}";
+          configFile = pkgs.writeText "opendkim.conf" ''
+            UMask 0002
+          '';
+        };
+      })
+
+      (mkIf cfg.enableGreylisting {
+        services.postgrey = {
+          enable = true;
+        };
+      })
+
+      # for sending emails (optional)
+      { 
+        services.postfix = {
+          enable = true;
+          enableHeaderChecks = true;
+          masterConfig = {
+            smtp_inet = {
+              args = [ "-o" "content_filter=spamassassin" "-o" "smtp_bind_address=${cfg.ipAddress}" "-o" "smtp_bind_address6=${cfg.ip6Address}"];
+            };
+            spamassassin = {
+              command = "pipe";
+              args = [ "user=spamd" "argv=${pkgs.spamassassin}/bin/spamc" "-f" "-e" "/run/wrappers/bin/sendmail" "-oi" "-f" ''''${sender}'' ''''${recipient}'' ];
+              privileged = true;
+            };
+          };
+          setSendmail = true;
+          hostname = cfg.hostname;
+          destination = [
+            "localhost"
+          ];
+          enableSubmission=true;
+          submissionOptions = {
+            "smtpd_tls_security_level" = "encrypt";
+            "smtpd_sasl_auth_enable" = "yes";
+            "smtpd_client_restrictions" = "permit_sasl_authenticated,reject";
+            "smtpd_sasl_type" = "dovecot";
+            "smtpd_sasl_path" = "private/auth";
+          };
+
+          config = {
+            smtpd_tls_auth_only = true;
+            message_size_limit = "100480000";
+            mailbox_size_limit = "1004800000";
+            virtual_mailbox_domains = cfg.domains;
+            virtual_transport = "lmtp:unix:private/lmtp-dovecot";
+
+            smtpd_sasl_auth_enable = true;
+            smtpd_sasl_security_options = "noanonymous";
+            broken_sasl_auth_clients = true;
+ 
+            smtpd_relay_restrictions = [
+              "reject_non_fqdn_recipient"
+              "reject_unknown_recipient_domain"
+              "permit_mynetworks"
+              "permit_sasl_authenticated"
+              "reject_unauth_destination"
+            ];
+            smtpd_client_restrictions = [
+              "permit_mynetworks"
+              "permit_sasl_authenticated"
+              "reject_unknown_client_hostname" # reject reverse PTR not matching hostname
+            ];
+            smtpd_helo_required = "yes";
+            smtpd_helo_restrictions = [
+              "permit_mynetworks"
+              # with this three lines i can't send emails from mac os x computers and ipads...
+              # Fehler beim Senden der Nachricht: Der Mail-Server antwortete:
+              # 4.7.1 <RoswithsMini572.fritz.box>: Helo command rejected: Host not found.
+              #  Bitte überprüfen Sie die E-Mail-Adresse des Empfängers "rs@dune2.de" und wiederholen Sie den Vorgang.
+              #"reject_invalid_helo_hostname"
+              #"reject_non_fqdn_helo_hostname"
+              #"reject_unknown_helo_hostname"
+            ];
+
+            # Add some security
+            smtpd_recipient_restrictions = [
+              "reject_unknown_sender_domain"    # prevents spam
+              "reject_unknown_recipient_domain" # prevents spam
+              "reject_unauth_pipelining"        # prevent bulk mail spam
+              "permit_sasl_authenticated"
+              "permit_mynetworks"
+              "reject_unauth_destination"
+              "check_policy_service inet:localhost:12340" # quota
+              "check_policy_service unix:/var/run/postgrey.sock" # postgrey
+            ] ++ (if cfg.enableGreylisting then [ "check_policy_service unix:/var/run/postgrey.sock" ] else []); # postgrey
+            smtpd_milters = [ "unix:/run/opendkim/opendkim.sock" ]; # [ "inet:localhost:12301" ];
+            non_smtpd_milters = [ "unix:/run/opendkim/opendkim.sock" ]; # [ "inet:localhost:12301" ];
+            smtpd_tls_received_header = true;
+          };
+        } // optionalAttrs (cfg.enableACME) {
+          sslCert = "/var/lib/acme/${cfg.hostname}/fullchain.pem";
+          sslKey = "/var/lib/acme/${cfg.hostname}/key.pem";
+        };
+
+        services.dovecot2 = {
+          enable = true;
+          enableImap = true;
+          enableLmtp = true;
+          enablePAM = false;
+          enableQuota = true;
+          mailLocation = "maildir:/var/lib/virtualMail/%d/users/%n/mail";
+
+          mailUser = "virtualMail";
+          mailGroup = "virtualMail";
+
+
+          # refactor this into services.dovecot2 mkOption -> mailuser & mailgroup
+          # sieve shall be a mkOption in dovecot2
+          modules = [ pkgs.dovecot_pigeonhole ];
+
+          protocols = [ "sieve" ];
+
+          sieveScripts = {
+            before = pkgs.writeText "before.sieve" ''
+              require ["fileinto", "reject", "envelope", "mailbox", "reject"];
+              
+              if header :contains "X-Spam-Flag" "YES" {
+                fileinto :create "Spam";
+                stop;
+              }
+            '';
+          };
+
+          mailboxes = [
+            { name = "Trash";
+              auto = "create";
+              specialUse = "Trash";
+            }
+
+            { name = "Drafts";
+              auto = "create";
+              specialUse = "Drafts";
+            }
+
+            { name = "Sent";
+              auto = "create";
+              specialUse = "Sent";
+            }
+
+            { name = "Spam";
+              auto = "create";
+              specialUse = "Junk";
+            }
+          ];
+
+          extraConfig = ''
+            mail_home = /var/lib/virtualMail/%d/users/%n/
+
+            passdb {
+              driver = passwd-file
+              args = username_format=%n ${config.services.mailUsers.virtualMailEnv}/%d
+            }
+
+            userdb {
+              driver = static
+              args = uid=${config.services.dovecot2.mailUser} gid=${config.services.dovecot2.mailGroup}
+            }
+
+            service auth {
+              unix_listener /var/lib/postfix/queue/private/auth {
+                mode = 0660
+                user = postfix
+                group = postfix        
+              }
+            }
+
+            service lmtp {
+              unix_listener /var/lib/postfix/queue/private/lmtp-dovecot {
+                mode = 0660
+                user = postfix
+                group = postfix
+              }
+            }
+
+            protocol lmtp {
+              mail_plugins = $mail_plugins sieve
+            }
+
+            plugin sieve {
+              sieve = /var/lib/virtualMail/%d/users/%n/sieve.active
+              sieve_dir = /var/lib/virtualMail/%d/users/%n/sieve
+            }
+          '';
+        } // optionalAttrs (cfg.enableACME) { 
+            sslServerCert = "/var/lib/acme/${cfg.hostname}/fullchain.pem";
+            sslServerKey = "/var/lib/acme/${cfg.hostname}/key.pem";
+        }; 
+      }
+    ]);
+}

--- a/nixos/modules/services/mail/virtual-mail-submodule.nix
+++ b/nixos/modules/services/mail/virtual-mail-submodule.nix
@@ -1,0 +1,54 @@
+{ config, pkgs, lib, ... }:
+with lib;
+{
+  options = {
+    name = mkOption {
+      type = types.str;
+      example = "postmaster";
+      description = "'name' is the part before the @ in the email address";
+    };
+
+    password = mkOption {
+      type = types.str;
+      example = ''
+        #{ name = "js"; domain = "lastlog.de"; aliases = [ "joachim@lastlog.de" ]; password = "{SHA256-CRYPT}$5$/CHK3ckfRJloONnq$X/16jK2NPTiZpBZZ1XVpHhPXyxPy1p0QtUNeUFrYav5"; }
+        { name = "anton"; domain = "lastlog.de"; aliases = [ "joachim@mail.lastlog.de" ]; password = "{PLAIN}hallo"; }
+
+      '';
+      description = ''
+        You can generate passwords like this:
+          doveadm pw -s sha256-crypt
+          Enter new password:
+          Retype new password:
+          {SHA256-CRYPT}$5$/CHK3ckfRJloONnq$X/16jK2NPTiZpBZZ1XVpHhPXyxPy1p0QtUNeUFrYav5
+      '';
+    };
+
+    domain = mkOption {
+      type = types.str;
+      example = "nixcloud.io";
+      description = "The domain of your mailservice you want to operate dovecot2 on";
+    };
+
+    aliases = mkOption {
+      type = types.listOf types.str;
+      example = [ "myalias@mydomain.tld" "auchich@mydomain.tld" ];
+      description = "A list of email addresses which are all aliases to the virtual mail user in 'name'";
+      default = [];
+    };
+
+    quota = mkOption {
+      type = types.str;
+      default = "";
+      example = "10G";
+      description = "Quota limit for the user in bytes. Supports suffixes b, k, M, G, T and %.";
+    };
+
+    catchallFor = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = [ "catchall.mymail.com" "example.mail" ];
+      description = "All domains that are catchall domains for which this user receives all emails.";
+    };
+  };
+}

--- a/nixos/modules/services/mail/virtual-mail-users.nix
+++ b/nixos/modules/services/mail/virtual-mail-users.nix
@@ -1,0 +1,44 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let 
+  userOptions = import ./virtual-mail-submodule.nix;
+  virtualMailEnv = pkgs.buildEnv {
+    name = "virtualMail-env";
+    paths = [];
+    postBuild = let
+      quotaRule = q: if q == "" then "" else "userdb_quota_rule=*";
+      bytes = q: if q == "" then "" else "bytes=${q}";
+      passwdLine = { name, domain, password, quota, ... }: { domain = "${domain}"; line = name + ":" + password + ":::::${quotaRule quota}:${bytes quota}"; }; 
+      lines = map passwdLine config.services.mailUsers.users;
+      domains = catAttrs "domain" lines;
+      values = domain: catAttrs "line" (filter (x: x.domain == domain) lines);
+      fileContent = domain: concatStringsSep "\n" (values domain);
+      lnDomainFile = domain: "ln -sf ${pkgs.writeText domain (fileContent domain)} $out/${domain}";
+    in concatStringsSep " && " (map lnDomainFile domains);
+  };
+
+in {
+  options.services.mailUsers = {
+    users = mkOption {
+      type = types.listOf (types.submodule userOptions);
+      example = [ { name = "js"; domain = "nixcloud.io"; password="qwertz"; } ];
+      default = [];
+      description = "A list of virtual mail users for which the password is managed via this abstraction";
+    };
+    virtualMailEnv = mkOption {
+      default = virtualMailEnv;
+      description = "Passwords are stored in the nix store and this virtual environment is a directory with those";
+    };
+  };
+
+  config = {
+    services.postfix.virtual = concatStringsSep "\n" (flatten (map (x: map (alias: alias + " " + x.name + "@" + x.domain) x.aliases) config.services.mailUsers.users
+                             ++ map (user: map (d: "@${d} ${user.name}@${user.domain}") user.catchallFor) config.services.mailUsers.users));
+    users.groups.virtualMail = { members = [ "dovecot2" ];};
+    users.users.virtualMail = {
+      home = "/var/lib/virtualMail";
+      createHome = true;
+    };
+  };
+}


### PR DESCRIPTION
## Motivation for this change

at nixcloud we refactored postfix, dkim, spamassassin, dovecot2 into a simple abstraction called `nixcloud.email` and also maintain that abstraction.

WARNING: we introduce a new namespace: `nixcloud.email` instead of `services.email` since we take responsibility for the changes. we are working on automated testing for this infrastructure as well and will upload this until the end of the year. this probably needs some discussion.

we are using this abstraction on lastlog.de already and it works fine except:

* dkim signatures can't be verified for some reason
* per user quotas don't work and we can't see why yet

we have a bunch of nice features:

* virtualMail user abstraction
* easy way to assign passwords for mail users declaratively
* optional greylisting
* optional spamassassin
* explicit ipv4/ipv6 support 
* sieve filters working
* automated ACME (for example: mail.lastlog.de)
* helpful defaults to communicate with gmail and others
* catchall

upcoming features:

* spamassassin automated learning
* DNS automation
* nagios tests
* CI tests (using a nix file)

## WARNING
please do not merge this until these two PRs have been merged:

* https://github.com/NixOS/nixpkgs/pull/29364
* https://github.com/NixOS/nixpkgs/pull/29365

we already transformed postfix and spamassassin, see this PR:

* https://github.com/NixOS/nixpkgs/pull/27276
* https://github.com/NixOS/nixpkgs/pull/26470

other mission critical todos:

* https://github.com/NixOS/nixpkgs/issues/29414
* https://github.com/NixOS/nixpkgs/issues/29466

## example configuration

    let
      ipAddress = "8.19.10.3";
      ipv6Address = "201:48:11:403::1:1";
    in
    ...
      nixcloud.email= {
        enable = true;
        domains = [ "lastlog.de" "dune2.de" ];
        ipAddress = ipAddress;
        ip6Address = ipv6Address;
        hostname = "mail.lastlog.de";
        users = [
          # see https://wiki.dovecot.org/Authentication/PasswordSchemes
          { name = "js"; domain = "lastlog.de"; password = "{SHA256-CRYPT}$<<<removed by qknight>>>"; }
          { name = "foo1"; domain = "dune2.de"; password = "{PLAIN}asdfasdfasdfasdf"; }
        ];
      };

# thanks

many thanks to @uwap and @aszlig for their help with these patches!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

