### PR TITLE
neofetch: 3.2.0 -> 3.3.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -304,7 +304,7 @@
   kiloreux = "Kiloreux Emperex <kiloreux@gmail.com>";
   kkallio = "Karn Kallio <tierpluspluslists@gmail.com>";
   knedlsepp = "Josef Kemetmüller <josef.kemetmueller@gmail.com>";
-  konimex = "Muhammad Herdiansyah <herdiansyah@openmailbox.org>";
+  konimex = "Muhammad Herdiansyah <herdiansyah@netc.eu>";
   koral = "Koral <koral@mailoo.org>";
   kovirobi = "Kovacsics Robert <kovirobi@gmail.com>";
   kragniz = "Louis Taylor <louis@kragniz.eu>";

--- a/pkgs/tools/misc/neofetch/default.nix
+++ b/pkgs/tools/misc/neofetch/default.nix
@@ -2,25 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "neofetch-${version}";
-  version = "3.2.0";
+  version = "3.3.0";
   src = fetchFromGitHub {
     owner = "dylanaraps";
     repo = "neofetch";
     rev = version;
-    sha256 = "1skkclvkqayqsbywja2fhv18l4rn9kg2da6bkip82zrwd713akl3";
+    sha256 = "1f1hvd635wv81qg802jdi0yggi4631w9nlznipaxkvk4y1zpdq5j";
   };
-
-  # This patch is only needed so that Neofetch 3.2.0 can look for
-  # configuration file, w3m directory (for fetching images) and ASCII
-  # directory properly. It won't be needed in subsequent releases.
-  patches = [
-    (fetchpatch {
-      name = "nixos.patch";
-      url = "https://github.com/konimex/neofetch/releases/download/3.2.0/nixos.patch";
-      sha256 = "0c6vsa74bxq6qlgbv3rrkhzkpvnq4304s6y2r1bl0sachyakaljy";
-    })
-  ];
-
 
   dontBuild = true;
 


### PR DESCRIPTION
###### Motivation for this change

Also included: Maintainer email change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

