### PR TITLE
bitlbee-facebook: 1.1.1 -> 1.1.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/bitlbee-facebook/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-facebook/default.nix
@@ -3,13 +3,13 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "bitlbee-facebook-${version}";
-  version = "1.1.1";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     rev = "v${version}";
-    owner = "jgeboski";
+    owner = "bitlbee";
     repo = "bitlbee-facebook";
-    sha256 = "08ibjqqcrmq1a5nmj8z93rjrdabi0yy2a70p31xalnfrh200m24c";
+    sha256 = "0kz2sc10iq01vn0hvf06bcdc1rsxz1j77z3mw55slf3j08xr07in";
   };
 
   nativeBuildInputs = [ autoconf automake libtool pkgconfig ];
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "The Facebook protocol plugin for bitlbee";
 
-    homepage = https://github.com/jgeboski/bitlbee-facebook;
+    homepage = https://github.com/bitlbee/bitlbee-facebook;
     license = licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
   };


### PR DESCRIPTION
Fixes login failures due to Facebook protocol changes.


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

