### PR TITLE
autoreconfHook: Simplify by avoiding `findInputs`

### DIFF
--- a/pkgs/build-support/setup-hooks/autoreconf.sh
+++ b/pkgs/build-support/setup-hooks/autoreconf.sh
@@ -1,9 +1,5 @@
 preConfigurePhases+=" autoreconfPhase"
 
-for i in @autoconf@ @automake@ @libtool@ @gettext@; do
-    findInputs $i nativePkgs propagated-native-build-inputs
-done
-
 autoreconfPhase() {
     runHook preAutoreconf
     autoreconf ${autoreconfFlags:---install --force --verbose}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -69,7 +69,7 @@ with pkgs;
   ### BUILD SUPPORT
 
   autoreconfHook = makeSetupHook
-    { substitutions = { inherit autoconf automake gettext libtool; }; }
+    { deps = [ autoconf automake gettext libtool ]; }
     ../build-support/setup-hooks/autoreconf.sh;
 
   ensureNewerSourcesHook = { year }: makeSetupHook {}


### PR DESCRIPTION
###### Motivation for this change

`findInputs` is a stdenv/setup helper we should strive not to call elsewhere. Using normal deps is more idiomatic anyways.

###### Things done

I've tested this change as part of https://hydra.mayflower.de/jobset/mayflower/hydra-jobs-cross-rewrite in the past.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

