### PR TITLE
nixos/mysql: declarative users & databases

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -30,6 +30,10 @@ let
       master-password = ${cfg.replication.masterPassword}
       master-port = ${toString cfg.replication.masterPort}
     ''}
+    ${optionalString (cfg.ensureUsers != [])
+    ''
+      plugin-load-add = auth_socket.so
+    ''}
     ${cfg.extraOptions}
   '';
 
@@ -121,6 +125,46 @@ in
       initialScript = mkOption {
         default = null;
         description = "A file containing SQL statements to be executed on the first startup. Can be used for granting certain permissions on the database";
+      };
+
+      ensureDatabases = mkOption {
+        default = [];
+        description = ''
+          Ensures that the specified databases exist.
+          This option will never delete existing databases, especially not when the value of this
+          option is changed. This means that databases created once through this option or
+          otherwise have to be removed manually.
+        '';
+        example = [
+          "nextcloud"
+          "piwik"
+        ];
+      };
+
+      ensureUsers = mkOption {
+        default = [];
+        description = ''
+          Ensures that the specified users exist and have at least the ensured permissions.
+          The MySQL users will be identified using Unix socket authentication. This authenticates the Unix user with the
+          same name only, and that without the need for a password.
+          This option will never delete existing users or remove permissions, especially not when the value of this
+          option is changed. This means that users created and permissions assigned once through this option or
+          otherwise have to be removed manually.
+        '';
+        example = [
+          {
+            name = "nextcloud";
+            ensurePermissions = {
+              "nextcloud.*" = "ALL PRIVILEGES";
+            };
+          }
+          {
+            name = "backup";
+            ensurePermissions = {
+              "*.*" = "SELECT, LOCK TABLES";
+            };
+          }
+        ];
       };
 
       # FIXME: remove this option; it's a really bad idea.
@@ -305,6 +349,24 @@ in
 
               rm /tmp/mysql_init
             fi
+
+            ${optionalString (cfg.ensureDatabases != []) ''
+              (
+              ${concatMapStrings (database: ''
+                echo "CREATE DATABASE IF NOT EXISTS ${database};"
+              '') cfg.ensureDatabases}
+              ) | ${mysql}/bin/mysql -u root -N
+            ''}
+
+            ${concatMapStrings (user:
+              ''
+                ( echo "CREATE USER IF NOT EXISTS '${user.name}'@'localhost' IDENTIFIED WITH ${if mysql == pkgs.mariadb then "unix_socket" else "auth_socket"};"
+                  ${concatStringsSep "\n" (mapAttrsToList (database: permission: ''
+                  echo "GRANT ${permission} ON ${database} TO '${user.name}'@'localhost';"
+                  '') user.ensurePermissions)}
+                ) | ${mysql}/bin/mysql -u root -N
+              '') cfg.ensureUsers}
+
           ''; # */
       };
 


### PR DESCRIPTION
using Unix socket authentication, ensured on every rebuild.

###### Motivation for this change
I want to be able to declaratively manage the MySQL / MariaDB databases and users I need for the standard web apps like wordpress, nextcloud, piwik et cetera. This can be used by end users as well as package maintainer.

This helps #29031 by allowing to easily create a MySQL user for backing up, with reduced permissions.

This goes in the direction of and could supersede #6963 , but with scope reduced to local, Unix socket authenticated users.

I tried to circumvent the issue of un-synchronized state between nix configuration and actual databases by calling this **ensure**Databases / **ensure**Users and making it clear that this only ensures the databases and users are *there*, but does nothing to delete or rename databases and users or to reduce permissions that were once given. This will be up to the user, to prevent e.g. accidental deletion of databases and generally breaking things.

(Also, I don't even know how the state of which databases existed before and after rebuilds could be diffed and updated accordingly.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

