### PR TITLE
arelle: add py3to2 as a buildInput

### DIFF
--- a/pkgs/development/python-modules/arelle/default.nix
+++ b/pkgs/development/python-modules/arelle/default.nix
@@ -1,7 +1,7 @@
 { gui ? true,
   buildPythonPackage, fetchFromGitHub, lib,
   sphinx_1_2, lxml, isodate, numpy, pytest,
-  tkinter ? null,
+  tkinter ? null, py3to2,
   ... }:
 
 let
@@ -26,6 +26,7 @@ buildPythonPackage {
   buildInputs = [
     sphinx_1_2
     pytest
+    py3to2
   ];
   propagatedBuildInputs = [
     lxml

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -101,7 +101,7 @@ in {
 
   py3to2 = callPackage ../development/python-modules/3to2 { };
   # Left for backwards compatibility
-  "3to2" = callPackage ../development/python-modules/3to2 { };
+  "3to2" = self.py3to2;
 
   aenum = callPackage ../development/python-modules/aenum { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -99,6 +99,8 @@ in {
 
   acoustics = callPackage ../development/python-modules/acoustics { };
 
+  py3to2 = callPackage ../development/python-modules/3to2 { };
+  # Left for backwards compatibility
   "3to2" = callPackage ../development/python-modules/3to2 { };
 
   aenum = callPackage ../development/python-modules/aenum { };


### PR DESCRIPTION
###### Motivation for this change
adds py3to2 as buildInput so build works.

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

