### PR TITLE
zuki-themes: 3.24.2017-06-26 -> 3.24-2

### DIFF
--- a/pkgs/misc/themes/zuki/default.nix
+++ b/pkgs/misc/themes/zuki/default.nix
@@ -1,27 +1,14 @@
-{ stdenv, fetchFromGitHub, gnome3, gdk_pixbuf, gtk_engines, gtk-engine-murrine }:
+{ stdenv, fetchFromGitHub, gdk_pixbuf, gtk_engines, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
   name = "zuki-themes-${version}";
-  version = "${gnome3.version}.${date}";
-  date = {
-    "3.20" = "2017-05-03";
-    "3.22" = "2017-04-23";
-    "3.24" = "2017-06-26";
-  }."${gnome3.version}";
+  version = "3.24-2";
 
   src = fetchFromGitHub {
     owner = "lassekongo83";
     repo = "zuki-themes";
-    rev = {
-      "3.20" = "ce7ae498df7d5c81acaf48ed957b9f828356d58c";
-      "3.22" = "e97f2c3cf75b5205bc5ecd6072696327169fde5d";
-      "3.24" = "d25e0a2fb6e08ad107d8bb627451433362f2a830";
-    }."${gnome3.version}";
-    sha256 = {
-      "3.20" = "0na81q9mc8kwn9m04kkcchrdr67087dqf3q155imhjgqrxjhh3w4";
-      "3.22" = "195v0d2sgqh92c104xqm00p68yxp6kzp5mzx8q7s36bdv9p972q4";
-      "3.24" = "0z5swi5aah3s4yinfglh491qydxgjkqwf6zxyz7k9c1d7lrvj3ww";
-    }."${gnome3.version}";
+    rev = "v${version}";
+    sha256 = "1js92qq1zi3iq40nl6n0m52hhhn9ql9i7y8ycg8vw3w0v8xyb4km";
   };
 
   buildInputs = [ gdk_pixbuf gtk_engines gtk-engine-murrine ];


### PR DESCRIPTION
###### Motivation for this change

- Update to version 3.24-2, released on 2017 Aug 3

- Remove versions for GNOME 3.22 and 3.20. The version for 3.24 should
  work with them as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).