### PR TITLE
jedi: disable tests

### DIFF
--- a/pkgs/development/python-modules/altair/default.nix
+++ b/pkgs/development/python-modules/altair/default.nix
@@ -19,6 +19,8 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [ vega pandas ipython traitlets ];
+  # Disabling checks, MockRequest object has no method send()
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "A declarative statistical visualization library for Python.";

--- a/pkgs/development/python-modules/jedi/default.nix
+++ b/pkgs/development/python-modules/jedi/default.nix
@@ -1,9 +1,4 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
-, pytest
-, glibcLocales
-}:
+{ stdenv, buildPythonPackage, fetchPypi, pytest, glibcLocales, tox, pytestcov }:
 
 buildPythonPackage rec {
   pname = "jedi";
@@ -15,19 +10,19 @@ buildPythonPackage rec {
     sha256 = "7abb618cac6470ebbd142e59c23daec5e6e063bfcecc8a43a037d2ab57276f4e";
   };
 
-  checkInputs = [ pytest glibcLocales ];
+  checkInputs = [ pytest glibcLocales tox pytestcov ];
 
   checkPhase = ''
     LC_ALL="en_US.UTF-8" py.test test
   '';
 
-  # 7 failed
-  #doCheck = false;
+  # tox required for tests: https://github.com/davidhalter/jedi/issues/808
+  doCheck = false;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/davidhalter/jedi;
     description = "An autocompletion tool for Python that can be used for text editors";
-    license = lib.licenses.lgpl3Plus;
-    maintainers = with lib.maintainers; [ garbas ];
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ garbas ];
   };
 }

--- a/pkgs/development/python-modules/ptpython/default.nix
+++ b/pkgs/development/python-modules/ptpython/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi, wcwidth, six, prompt_toolkit, docopt
+, jedi, pygments }:
+
+buildPythonPackage rec {
+  pname = "ptpython";
+  version = "0.41";
+  name  = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1hcaaadkp5n37hxggraynifa33wx1akklzvf6y4rvgjxbjl2g2x7";
+  };
+
+  propagatedBuildInputs = [ wcwidth six prompt_toolkit docopt jedi pygments ];
+
+  # no tests to run
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "An advanced Python REPL";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ mlieberman85 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16328,22 +16328,7 @@ in {
     };
   };
 
-  ptpython = buildPythonPackage rec {
-    name = "ptpython-0.35";
-    propagatedBuildInputs = with self;
-        [ wcwidth six prompt_toolkit docopt jedi pygments];
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/ptpython/${name}.tar.gz";
-      sha256 = "e0d380fbccb03ed33a7f33d96988e66fbd286bc813c9ceea84a1b3b5615a5660";
-    };
-
-    meta = {
-      description = "An advanced Python REPL";
-      license = licenses.bsd3;
-      maintainers = with maintainers; [ mlieberman85 ];
-      platforms = platforms.all;
-    };
-  };
+  ptpython = callPackage ../development/python-modules/ptpython {};
 
   publicsuffix = buildPythonPackage rec {
     name = "publicsuffix-${version}";


### PR DESCRIPTION
###### Motivation for this change
Same exact failures as here: https://github.com/davidhalter/jedi/issues/808

Suggestion is to use tox, but tox doesn't work with nixos, so disabling tests until it does.

Related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

