### PR TITLE
go-ethereum: 1.6.7 -> 1.7.0

### DIFF
--- a/pkgs/applications/altcoins/go-ethereum.nix
+++ b/pkgs/applications/altcoins/go-ethereum.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "go-ethereum-${version}";
-  version = "1.6.7";
+  version = "1.7.0";
   goPackagePath = "github.com/ethereum/go-ethereum";
 
   # Fixes Cgo related build failures (see https://github.com/NixOS/nixpkgs/issues/25959 )
@@ -12,7 +12,7 @@ buildGoPackage rec {
     owner = "ethereum";
     repo = "go-ethereum";
     rev = "v${version}";
-    sha256 = "19cq0pmif4y33v34jzvam4mcszl8vf2saf2gzfz01l4x1iv4hf1r";
+    sha256 = "0ybjaiyrfb320rab6a5r9iiqvkrcd8b2qvixzx0kjmc4a7l1q5zh";
   };
 
   # Fix cyclic referencing on Darwin
@@ -23,9 +23,10 @@ buildGoPackage rec {
     done
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://ethereum.github.io/go-ethereum/;
     description = "Official golang implementation of the Ethereum protocol";
-    license = with lib.licenses; [ lgpl3 gpl3 ];
+    license = with licenses; [ lgpl3 gpl3 ];
+    maintainers = [ maintainers.adisbladis ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Upstream update

Also added myself as maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

