### PR TITLE
abcMIDI: init at 2017.06.10

### DIFF
--- a/pkgs/tools/audio/abcmidi/default.nix
+++ b/pkgs/tools/audio/abcmidi/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "abcMIDI-${version}";
+  version = "2017.06.10";
+  src = fetchFromGitHub {
+    owner = "leesavide";
+    repo = "abcmidi";
+    rev = name;
+    sha256 = "0y92m3mj63vvy79ksq4z5hgkz6w50drg9a4bmbk6jylny0l0bdpy";
+  };
+
+  # There is also a file called "makefile" which seems to be preferred by the standard build phase
+  makefile = "Makefile";
+  
+  meta = with stdenv.lib; {
+    homepage = http://abc.sourceforge.net/abcMIDI/;
+    license = licenses.gpl2Plus;
+    description = "abc <-> MIDI conversion utilities";
+    maintainers = [ maintainers.dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -362,6 +362,8 @@ with pkgs;
 
   a2ps = callPackage ../tools/text/a2ps { };
 
+  abcmidi = callPackage ../tools/audio/abcmidi { };
+
   abduco = callPackage ../tools/misc/abduco { };
 
   acbuild = callPackage ../applications/misc/acbuild { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

