### PR TITLE
wrapGAppsHook: Correct `wrapProgram` invocations

### DIFF
--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook.sh
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook.sh
@@ -35,10 +35,16 @@ wrapGAppsHook() {
     gappsWrapperArgs+=(--prefix $v : "$dummy")
   done
 
-  if [ -z "$dontWrapGApps" ]; then
-    for i in $prefix/bin/* $prefix/libexec/*; do
-      echo "Wrapping app $i"
-      wrapProgram "$i" "${gappsWrapperArgs[@]}"
+  if [[ -z "$dontWrapGApps" ]]; then
+    targetDirs=( "${prefix}/bin" "${prefix}/libexec" )
+    for targetDir in "${targetDirs[@]}"; do
+      if [[ -d "${targetDir}" ]]; then
+        find "${targetDir}" -type f -executable -print0 \
+          | while IFS= read -r -d '' file; do
+          echo "Wrapping program ${file}"
+          wrapProgram "${file}" "${gappsWrapperArgs[@]}"
+        done
+      fi
     done
   fi
 }


### PR DESCRIPTION
Cherry-picked from 2cd342cfb361cfa6413e6612028997079c2fa9ed
###### Motivation for this change
fixes issue #25756 for 17.03, which has not been backported yet

original commit message below
-----------------------------------------
This change fixes several defects in the way `wrapGAppsHook` selected
the executable to wrap.

Previously, it would wrap any top-level files in the target `/bin` and
`/libexec` directories, including directories and non-executable
files.  In addition, it failed to wrap files in subdirectories.

Now, it uses `find` to iterate over these directory hierarchies,
selecting only executable files for wrapping.

###### Things done

Cherry-picked commit, built emacs and tried out hexl-mode, which workds now.  ~Have not tested any other build~. Also built a firefox, seemed to work fine.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

