### PR TITLE
arelle: enable only on python 3.4 (merge as necessary)

### DIFF
--- a/pkgs/development/python-modules/arelle/default.nix
+++ b/pkgs/development/python-modules/arelle/default.nix
@@ -1,14 +1,14 @@
 { gui ? true,
   buildPythonPackage, fetchFromGitHub, lib,
   sphinx_1_2, lxml, isodate, numpy, pytest,
-  tkinter ? null, py3to2, isPy3k,
+  tkinter ? null, py3to2, isPy34,
   ... }:
 
 buildPythonPackage rec {
   name = "arelle-${version}${lib.optionalString (!gui) "-headless"}";
   version = "2017-08-24";
 
-  disabled = !isPy3k;
+  disabled = !isPy34;
 
   # Releases are published at http://arelle.org/download/ but sadly no
   # tags are published on github.


### PR DESCRIPTION
###### Motivation for this change

Python 3.4 is the version suggested by arelle.org
On other versions, the build fails, so this PR disables those.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

