### PR TITLE
arelle: enable only on python 3.4 DON'T MERGE

### DIFF
--- a/pkgs/development/python-modules/arelle/default.nix
+++ b/pkgs/development/python-modules/arelle/default.nix
@@ -1,5 +1,6 @@
 { gui ? true,
   buildPythonPackage, fetchFromGitHub, lib,
+  isPy34,
   sphinx_1_2, lxml, isodate, numpy, pytest,
   tkinter ? null, py3to2,
   ... }:
@@ -20,6 +21,10 @@ in
 
 buildPythonPackage {
   name = "arelle-${version}${lib.optionalString (!gui) "-headless"}";
+  # Python 3.4 is the 'officially supported' version,
+  # see http://arelle.org/download/
+  # Python 2.7 seems feasible, but did not work out of the box.
+  disabled = !isPy34;
   inherit src;
   outputs = ["out" "doc"];
   postPatch = "rm testParser2.py";


### PR DESCRIPTION
###### Motivation for this change

Python 3.4 is the version suggested by arelle.org
On other versions, the build fails, so this PR disables those.

Equivalent pr for release-17.09: #29420

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

