### PR TITLE
moto: 0.4.25 -> 0.4.31

### DIFF
--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildPythonPackage, fetchPypi, jinja2, werkzeug, flask, requests, pytz
+, six, boto, httpretty, xmltodict, nose, sure, boto3, freezegun, dateutil }:
+
+buildPythonPackage rec {
+  pname = "moto";
+  version = "0.4.31";
+  name    = "moto-${version}";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "19s8hfz4mzzzdksa0ddlvrga5mxdaqahk89p5l29a5id8127shr8";
+  };
+
+  propagatedBuildInputs = [
+    boto
+    dateutil
+    flask
+    httpretty
+    jinja2
+    pytz
+    werkzeug
+    requests
+    six
+    xmltodict
+  ];
+
+  checkInputs = [ boto3 nose sure freezegun ];
+
+  checkPhase = "nosetests";
+
+  # TODO: make this true; I think lots of the tests want network access but we can probably run the others
+  doCheck = false;
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12332,27 +12332,7 @@ in {
 
   moretools = callPackage ../development/python-modules/moretools { };
 
-  moto = buildPythonPackage rec {
-    version = "0.4.25";
-    name    = "moto-${version}";
-    src = pkgs.fetchurl {
-      url    = "http://pypi.python.org/packages/df/9e/0b22ac0abf61711c86ae75a0548825e19cc123b522ff3508cbc43924969d/moto-0.4.25.tar.gz";
-      sha256 = "1gqm7h6bm5xkspd07bnjwdr2q6cvpxkayx0hkgk8fhkawbg0fqq7";
-    };
-
-    propagatedBuildInputs = with self; [
-      # Main dependencies
-      jinja2 werkzeug flask requests six boto httpretty xmltodict
-      # For tests
-      nose sure boto3 freezegun
-    ];
-
-    checkPhase = "nosetests";
-
-    # TODO: make this true; I think lots of the tests want network access but we can probably run the others
-    doCheck = false;
-  };
-
+  moto = callPackage ../development/python-modules/moto {};
 
   mox = buildPythonPackage rec {
     name = "mox-0.5.3";


### PR DESCRIPTION
###### Motivation for this change
Fixes gensim by adding required build dependency of moto.
Also upgrades moto to 0.4.31. 1.x is out now, but it breaks compatibility so I think we should stick with 0.4.31 for 17.09 release.

related to #28643 

Looking at this further, gensim doesn't need moto, it depends on smart_open, which requires moto, so I rebased and pulled out the gensim commit. This fixes both the gensim and smart_open builds that were failing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

