### PR TITLE
jscoverage: fix build with gcc6

### DIFF
--- a/pkgs/development/tools/misc/jscoverage/default.nix
+++ b/pkgs/development/tools/misc/jscoverage/default.nix
@@ -8,6 +8,10 @@ stdenv.mkDerivation rec {
     sha256 = "c45f051cec18c10352f15f9844f47e37e8d121d5fd16680e2dd0f3b4420eb7f4";
   };
 
+  patches = [
+    ./jsfalse_to_null.patch
+  ];
+
   buildInputs = [ autoconf makedepend perl python unzip zip ];
 
   # It works without MOZ_FIX_LINK_PATHS, circumventing an impurity

--- a/pkgs/development/tools/misc/jscoverage/jsfalse_to_null.patch
+++ b/pkgs/development/tools/misc/jscoverage/jsfalse_to_null.patch
@@ -1,0 +1,26 @@
+diff --git i/js/jsstr.cpp w/js/jsstr.cpp
+index e662bf1..b18597e 100644
+--- i/js/jsstr.cpp
++++ w/js/jsstr.cpp
+@@ -3040,7 +3040,7 @@ js_InitStringClass(JSContext *cx, JSObject *obj)
+                                  JSVAL_VOID, NULL, NULL,
+                                  JSPROP_READONLY | JSPROP_PERMANENT | JSPROP_SHARED, 0, 0,
+                                  NULL)) {
+-        return JS_FALSE;
++        return NULL;
+     }
+ 
+     return proto;
+diff --git i/js/jsxml.cpp w/js/jsxml.cpp
+index 5621ede..e00c97d 100644
+--- i/js/jsxml.cpp
++++ w/js/jsxml.cpp
+@@ -303,7 +303,7 @@ NewXMLNamespace(JSContext *cx, JSString *prefix, JSString *uri, JSBool declared)
+ 
+     obj = js_NewObject(cx, &js_NamespaceClass.base, NULL, NULL);
+     if (!obj)
+-        return JS_FALSE;
++        return NULL;
+     JS_ASSERT(JSVAL_IS_VOID(obj->fslots[JSSLOT_PREFIX]));
+     JS_ASSERT(JSVAL_IS_VOID(obj->fslots[JSSLOT_URI]));
+     JS_ASSERT(JSVAL_IS_VOID(obj->fslots[JSSLOT_DECLARED]));


### PR DESCRIPTION
###### Motivation for this change
fixes build.

Related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

