### PR TITLE
nixos/zfs: import encrypted datasets by default for zfsUnstable

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -140,6 +140,17 @@ in
           this once.
         '';
       };
+
+      requestEncryptionCredentials = mkOption {
+        type = types.bool;
+        default = config.boot.zfs.enableUnstable;
+        description = ''
+          Request encryption keys or passwords for all encrypted datasets on import.
+
+          Dataset encryption is only supported in zfsUnstable at the moment.
+        '';
+      };
+
     };
 
     services.zfs.autoSnapshot = {
@@ -263,6 +274,10 @@ in
           assertion = !cfgZfs.forceImportAll || cfgZfs.forceImportRoot;
           message = "If you enable boot.zfs.forceImportAll, you must also enable boot.zfs.forceImportRoot";
         }
+        {
+          assertion = cfgZfs.requestEncryptionCredentials -> cfgZfs.enableUnstable;
+          message = "This feature is only available for zfs unstable. Set the NixOS option boot.zfs.enableUnstable.";
+        }
       ];
 
       boot = {
@@ -306,6 +321,9 @@ in
             done
             echo
             if [[ -n "$msg" ]]; then echo "$msg"; fi
+            ${lib.optionalString cfgZfs.requestEncryptionCredentials ''
+              zfs load-key -a
+            ''}
         '') rootPools));
       };
 

--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -68,8 +68,8 @@ in
     };
 
     splUnstable = common {
-      version = "2017-08-11";
-      rev = "9df9692637aeee416f509c7f39655beb2d35b549";
-      sha256 = "1dggf6xqgk2f7vccv6cgvr8krj7h9f921szp1j2qbxnnq41m37mi";
+      version = "2017-09-26";
+      rev = "e8474f9ad3b3d23c3277535c4f53f8fd1e6cbd74";
+      sha256 = "1hydfhmngpq31gxkxipqxnin74l760d1ia202h12vsgix9sp32h7";
     };
 }

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -157,10 +157,10 @@ in {
     incompatibleKernelVersion = null;
 
     # this package should point to a version / git revision compatible with the latest kernel release
-    version = "2017-09-12";
+    version = "2017-09-26";
 
-    rev = "ded8f06a3cfee60b3a8ea5309e9c4d0e567ed3b5";
-    sha256 = "0yn4fg4a00hpflmmr0jbbhfb921nygpw2xbbjy35abl57k6zk375";
+    rev = "7e98073379353a05498ac5a2f1a5df2a2257d6b0";
+    sha256 = "1hydfhmngpq31gxkxipqxnin74l760d1ia202h12vsgix9sp32h7";
     isUnstable = true;
 
     extraPatches = [


### PR DESCRIPTION
###### Motivation for this change

Already works like a charm but needs more documentation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

