### PR TITLE
mpi4py: disabling tests

### DIFF
--- a/pkgs/development/python-modules/mpi4py/tests.patch
+++ b/pkgs/development/python-modules/mpi4py/tests.patch
@@ -1,0 +1,13 @@
+diff --git i/test/test_dl.py w/test/test_dl.py
+index a3211a3..9d25569 100644
+--- i/test/test_dl.py
++++ w/test/test_dl.py
+@@ -12,7 +12,7 @@ class TestDL(unittest.TestCase):
+         if sys.platform == 'darwin':
+             libm = 'libm.dylib'
+         else:
+-            libm = 'libm.so'
++            libm = 'libm.so.6'
+ 
+         handle = dl.dlopen(libm, dl.RTLD_LOCAL|dl.RTLD_LAZY)
+         self.assertTrue(handle != 0)


### PR DESCRIPTION
###### Motivation for this change
disabling tests. Timing out because mpi processes can't communicate with each other.

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

