### PR TITLE
awesome-slugify: fixes tests

### DIFF
--- a/pkgs/development/python-modules/awesome-slugify/default.nix
+++ b/pkgs/development/python-modules/awesome-slugify/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildPythonPackage, fetchPypi, unidecode, regex, python }:
+
+buildPythonPackage rec {
+  pname = "awesome-slugify";
+  version = "1.6.5";
+  name  = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wgxrhr8s5vk2xmcz9s1z1aml4ppawmhkbggl9rp94c747xc7pmv";
+  };
+
+  patches = [
+    ./slugify_filename_test.patch # fixes broken test by new unidecode
+  ];
+
+  propagatedBuildInputs = [ unidecode regex ];
+
+  checkPhase = ''
+      ${python.interpreter} -m unittest discover
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/dimka665/awesome-slugify";
+    description = "Python flexible slugify function";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/development/python-modules/awesome-slugify/slugify_filename_test.patch
+++ b/pkgs/development/python-modules/awesome-slugify/slugify_filename_test.patch
@@ -1,0 +1,13 @@
+diff --git i/slugify/tests.py w/slugify/tests.py
+index 4c9fa1c..3e14328 100644
+--- i/slugify/tests.py
++++ w/slugify/tests.py
+@@ -57,7 +57,7 @@ class PredefinedSlugifyTestCase(unittest.TestCase):
+         self.assertEqual(slugify_url('The Über article'), 'uber-article')
+ 
+     def test_slugify_filename(self):
+-        self.assertEqual(slugify_filename(u'Дrаft №2.txt'), u'Draft_2.txt')
++        self.assertEqual(slugify_filename(u'Дrаft №2.txt'), u'Draft_No._2.txt')
+ 
+ 
+ class ToLowerTestCase(unittest.TestCase):

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -741,29 +741,7 @@ in {
 
   python-slugify = callPackage ../development/python-modules/python-slugify { };
 
-  awesome-slugify = buildPythonPackage rec {
-    name = "awesome-slugify-${version}";
-    version = "1.6.5";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/awesome-slugify/${name}.tar.gz";
-      sha256 = "0wgxrhr8s5vk2xmcz9s1z1aml4ppawmhkbggl9rp94c747xc7pmv";
-    };
-
-    propagatedBuildInputs = with self; [ unidecode regex ];
-
-    checkPhase = ''
-      ${python.interpreter} -m unittest discover
-    '';
-
-    meta = with stdenv.lib; {
-      homepage = "https://github.com/dimka665/awesome-slugify";
-      description = "Python flexible slugify function";
-      license = licenses.gpl3;
-      platforms = platforms.all;
-      maintainers = with maintainers; [ abbradar ];
-    };
-  };
+  awesome-slugify = callPackage ../development/python-modules/awesome-slugify {};
 
   noise = buildPythonPackage rec {
     name = "noise-${version}";


### PR DESCRIPTION
###### Motivation for this change
unidecode was fixed in 151d0fde19

Updated PR to just fix awesome-slugify tests that break because of newer unidecode version in #29334

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

