### PR TITLE
Revert "haskell infra, ghc: Slight cleanup"

### DIFF
--- a/pkgs/development/compilers/ghc/6.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/6.10.2-binary.nix
@@ -1,29 +1,24 @@
-{ stdenv
-, fetchurl, perl
-, libedit, ncurses5, gmp
-}:
-
-# Prebuilt only does native
-assert stdenv.targetPlatform == stdenv.hostPlatform;
+{stdenv, lib, fetchurl, perl, libedit, ncurses5, gmp}:
 
 stdenv.mkDerivation rec {
   version = "6.10.2";
 
   name = "ghc-${version}-binary";
 
-  src = {
-      "i686-linux" = fetchurl {
+  src =
+    if stdenv.system == "i686-linux" then
+      fetchurl {
         # This binary requires libedit.so.0 (rather than libedit.so.2).
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
         sha256 = "1fw0zr2qshlpk8s0d16k27zcv5263nqdg2xds5ymw8ff6qz9rz9b";
-      };
-      "x86_64-linux" = fetchurl {
+      }
+    else if stdenv.system == "x86_64-linux" then
+      fetchurl {
         # Idem.
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
         sha256 = "1rd2j7lmcfsm2rdfb5g6q0l8dz3sxadk5m3d2f69d4a6g4p4h7jj";
-      };
-    }.${stdenv.hostPlatform.system}
-      or (throw "cannot bootstrap GHC on this platform");
+      }
+    else throw "cannot bootstrap GHC on this platform";
 
   buildInputs = [perl];
 
@@ -42,17 +37,17 @@ stdenv.mkDerivation rec {
      '' +
     # On Linux, use patchelf to modify the executables so that they can
     # find editline/gmp.
-    stdenv.lib.optionalString stdenv.hostPlatform.isLinux ''
+    (if stdenv.isLinux then ''
       find . -type f -perm -0100 \
           -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
           --set-rpath "${lib.makeLibraryPath [ libedit ncurses5 gmp ]}" {} \;
       for prog in ld ar gcc strip ranlib; do
         find . -name "setup-config" -exec sed -i "s@/usr/bin/$prog@$(type -p $prog)@g" {} \;
       done
-     '';
+     '' else "");
 
   configurePhase = ''
-    ./configure --prefix=$out --with-gmp-libraries=${stdenv.lib.getLib gmp}/lib --with-gmp-includes=${stdenv.lib.getDev gmp}/include
+    ./configure --prefix=$out --with-gmp-libraries=${lib.getLib gmp}/lib --with-gmp-includes=${lib.getDev gmp}/include
   '';
 
   # Stripping combined with patchelf breaks the executables (they die
@@ -67,7 +62,7 @@ stdenv.mkDerivation rec {
   # and create some wrapper scripts that set DYLD_FRAMEWORK_PATH so
   # that the executables work with no special setup.
   postInstall =
-    stdenv.lib.optionalString stdenv.hostPlatform.isDarwin
+    (if stdenv.isDarwin then
       ''
         mkdir -p $out/frameworks/GMP.framework/Versions/A
         ln -s ${gmp.out}/lib/libgmp.dylib $out/frameworks/GMP.framework/GMP
@@ -84,7 +79,7 @@ stdenv.mkDerivation rec {
             echo \"DYLD_FRAMEWORK_PATH=$out/frameworks exec $out/bin-orig/$i -framework-path $out/frameworks \\\"\\$@\\\"\" >> $out/bin/$i
             chmod +x $out/bin/$i
         done
-      ''
+      '' else "")
     +
       ''
         # bah, the passing gmp doesn't work, so let's add it to the final package.conf in a quick but dirty way

--- a/pkgs/development/compilers/ghc/6.10.4.nix
+++ b/pkgs/development/compilers/ghc/6.10.4.nix
@@ -1,8 +1,5 @@
 {stdenv, fetchurl, libedit, ghc, perl, gmp, ncurses}:
 
-# TODO(@Ericson2314): Cross compilation support
-assert stdenv.targetPlatform == stdenv.hostPlatform;
-
 stdenv.mkDerivation rec {
   version = "6.10.4";
 
@@ -24,8 +21,6 @@ stdenv.mkDerivation rec {
   ];
 
   NIX_CFLAGS_COMPILE = "-fomit-frame-pointer";
-
-  passthru = { prefix = ""; };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/6.12.3.nix
+++ b/pkgs/development/compilers/ghc/6.12.3.nix
@@ -1,8 +1,5 @@
 {stdenv, fetchurl, ghc, perl, gmp, ncurses}:
 
-# TODO(@Ericson2314): Cross compilation support
-assert stdenv.targetPlatform == stdenv.hostPlatform;
-
 stdenv.mkDerivation rec {
   version = "6.12.3";
 
@@ -35,8 +32,6 @@ stdenv.mkDerivation rec {
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
   stripDebugFlags=["-S" "--keep-file-symbols"];
-
-  passthru = { prefix = ""; };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/7.0.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.0.4-binary.nix
@@ -1,35 +1,32 @@
-{ stdenv
-, fetchurl, perl
-, ncurses5, gmp, libiconv
-}:
-
-# Prebuilt only does native
-assert stdenv.targetPlatform == stdenv.hostPlatform;
+{stdenv, fetchurl, perl, ncurses5, gmp, libiconv}:
 
 stdenv.mkDerivation rec {
   version = "7.0.4";
 
   name = "ghc-${version}-binary";
 
-  src = {
-      "i686-linux" = fetchurl {
+  src =
+    if stdenv.system == "i686-linux" then
+      fetchurl {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
         sha256 = "0mfnihiyjl06f5w1yrjp36sw9g67g2ymg5sdl0g23h1pab99jx63";
-      };
-      "x86_64-linux" = fetchurl {
+      }
+    else if stdenv.system == "x86_64-linux" then
+      fetchurl {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
         sha256 = "0mc4rhqcxz427wq4zgffmnn0d2yjqvy6af4x9mha283p1gdj5q99";
-      };
-      "i686-darwin" = fetchurl {
+      }
+    else if stdenv.system == "i686-darwin" then
+      fetchurl {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-apple-darwin.tar.bz2";
         sha256 = "0qj45hslrrr8zfks8m1jcb3awwx9rh35ndnpfmb0gwb6j7azq5n3";
-      };
-      "x86_64-darwin" = fetchurl {
+      }
+    else if stdenv.system == "x86_64-darwin" then
+      fetchurl {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.bz2";
         sha256 = "1m2ml88p1swf4dnv2vq8hz4drcp46n3ahpfi05wh01ajkf8hnn3l";
-      };
-    }.${stdenv.hostPlatform.system}
-      or (throw "cannot bootstrap GHC on this platform");
+      }
+    else throw "cannot bootstrap GHC on this platform";
 
   buildInputs = [perl];
 

--- a/pkgs/development/compilers/ghc/7.0.4.nix
+++ b/pkgs/development/compilers/ghc/7.0.4.nix
@@ -1,8 +1,5 @@
 { stdenv, fetchurl, ghc, perl, gmp, ncurses, libiconv }:
 
-# TODO(@Ericson2314): Cross compilation support
-assert stdenv.targetPlatform == stdenv.hostPlatform;
-
 stdenv.mkDerivation rec {
   version = "7.0.4";
   name = "ghc-${version}";
@@ -44,8 +41,6 @@ stdenv.mkDerivation rec {
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
   stripDebugFlags=["-S" "--keep-file-symbols"];
-
-  passthru = { prefix = ""; };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/7.10.2.nix
+++ b/pkgs/development/compilers/ghc/7.10.2.nix
@@ -1,27 +1,13 @@
-{ stdenv, __targetPackages
-, buildPlatform, hostPlatform, targetPlatform
+{ stdenv, fetchurl, fetchpatch, bootPkgs, perl, ncurses, libiconv, binutils, coreutils
+, libxml2, libxslt, docbook_xsl, docbook_xml_dtd_45, docbook_xml_dtd_42, hscolour
 
-# build-tools
-, bootPkgs, hscolour
-, binutils, coreutils, fetchurl, fetchpatch, perl
-, docbook_xsl, docbook_xml_dtd_45, docbook_xml_dtd_42, libxml2, libxslt
-
-, ncurses, libiconv
-
-, # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
-  enableIntegerSimple ? false, gmp ? null
+, enableIntegerSimple ? false, gmp
 }:
-
-assert !enableIntegerSimple -> gmp != null;
 
 let
   inherit (bootPkgs) ghc;
-
-  # TODO(@Ericson2314) Make unconditional
-  prefix = stdenv.lib.optionalString
-    (targetPlatform != hostPlatform)
-    "${targetPlatform.config}-";
 
   buildMK = ''
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
@@ -41,7 +27,7 @@ in
 
 stdenv.mkDerivation rec {
   version = "7.10.2";
-  name = "${prefix}ghc-${version}";
+  name = "ghc-${version}";
 
   src = fetchurl {
     url = "https://downloads.haskell.org/~ghc/7.10.2/${name}-src.tar.xz";
@@ -78,7 +64,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     # Install the bash completion file.
-    install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/${prefix}ghc
+    install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/ghc
 
     # Patch scripts to include "readelf" and "cat" in $PATH.
     for i in "$out/bin/"*; do
@@ -89,7 +75,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    inherit bootPkgs prefix;
+    inherit bootPkgs;
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -1,27 +1,13 @@
-{ stdenv, __targetPackages
-, buildPlatform, hostPlatform, targetPlatform
+{ stdenv, fetchurl, fetchpatch, bootPkgs, perl, ncurses, libiconv, binutils, coreutils
+, libxml2, libxslt, docbook_xsl, docbook_xml_dtd_45, docbook_xml_dtd_42, hscolour
 
-# build-tools
-, bootPkgs, hscolour
-, binutils, coreutils, fetchurl, fetchpatch, perl
-, docbook_xsl, docbook_xml_dtd_45, docbook_xml_dtd_42, libxml2, libxslt
-
-, ncurses, libiconv
-
-, # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
-  enableIntegerSimple ? false, gmp ? null
+, enableIntegerSimple ? false, gmp
 }:
-
-assert !enableIntegerSimple -> gmp != null;
 
 let
   inherit (bootPkgs) ghc;
-
-  # TODO(@Ericson2314) Make unconditional
-  prefix = stdenv.lib.optionalString
-    (targetPlatform != hostPlatform)
-    "${targetPlatform.config}-";
 
   docFixes = fetchurl {
     url = "https://downloads.haskell.org/~ghc/7.10.3/ghc-7.10.3a.patch";
@@ -32,7 +18,7 @@ in
 
 stdenv.mkDerivation rec {
   version = "7.10.3";
-  name = "${prefix}ghc-${version}";
+  name = "ghc-${version}";
 
   src = fetchurl {
     url = "https://downloads.haskell.org/~ghc/${version}/${name}-src.tar.xz";
@@ -76,7 +62,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     # Install the bash completion file.
-    install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/${prefix}ghc
+    install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/ghc
 
     # Patch scripts to include "readelf" and "cat" in $PATH.
     for i in "$out/bin/"*; do
@@ -87,7 +73,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    inherit bootPkgs prefix;
+    inherit bootPkgs;
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/7.2.2.nix
+++ b/pkgs/development/compilers/ghc/7.2.2.nix
@@ -2,11 +2,8 @@
 
   # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
-, enableIntegerSimple ? false, gmp ? null
+, enableIntegerSimple ? false, gmp
 }:
-
-# TODO(@Ericson2314): Cross compilation support
-assert stdenv.targetPlatform == stdenv.hostPlatform;
 
 stdenv.mkDerivation rec {
   version = "7.2.2";
@@ -53,8 +50,6 @@ stdenv.mkDerivation rec {
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
   stripDebugFlags=["-S" "--keep-file-symbols"];
-
-  passthru = { prefix = ""; };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/7.4.2-binary.nix
+++ b/pkgs/development/compilers/ghc/7.4.2-binary.nix
@@ -1,35 +1,32 @@
-{ stdenv
-, fetchurl, perl, makeWrapper
-, ncurses5, gmp, libiconv
-}:
-
-# Prebuilt only does native
-assert stdenv.targetPlatform == stdenv.hostPlatform;
+{stdenv, fetchurl, perl, ncurses5, gmp, libiconv, makeWrapper}:
 
 stdenv.mkDerivation rec {
   version = "7.4.2";
 
   name = "ghc-${version}-binary";
 
-  src = {
-      "i686-linux" = fetchurl {
+  src =
+    if stdenv.system == "i686-linux" then
+      fetchurl {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
         sha256 = "0gny7knhss0w0d9r6jm1gghrcb8kqjvj94bb7hxf9syrk4fxlcxi";
-      };
-      "x86_64-linux" = fetchurl {
+      }
+    else if stdenv.system == "x86_64-linux" then
+      fetchurl {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
         sha256 = "043jabd0lh6n1zlqhysngbpvlsdznsa2mmsj08jyqgahw9sjb5ns";
-      };
-      "i686-darwin" =  fetchurl {
+      }
+    else if stdenv.system == "i686-darwin" then
+      fetchurl {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-apple-darwin.tar.bz2";
         sha256 = "1vrbs3pzki37hzym1f1nh07lrqh066z3ypvm81fwlikfsvk4djc0";
-      };
-      "x86_64-darwin" = fetchurl {
+      }
+    else if stdenv.system == "x86_64-darwin" then
+      fetchurl {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.bz2";
         sha256 = "1imzqc0slpg0r6p40n5a9m18cbcm0m86z8dgyhfxcckksw54mzwf";
-      };
-    }.${stdenv.hostPlatform.system}
-      or (throw "cannot bootstrap GHC on this platform");
+      }
+    else throw "cannot bootstrap GHC on this platform";
 
   buildInputs = [perl];
 

--- a/pkgs/development/compilers/ghc/7.4.2.nix
+++ b/pkgs/development/compilers/ghc/7.4.2.nix
@@ -1,13 +1,9 @@
 { stdenv, fetchurl, ghc, perl, ncurses, libiconv
 
-, # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
-  enableIntegerSimple ? false, gmp ? null
+, enableIntegerSimple ? false, gmp
 }:
-
-# TODO(@Ericson2314): Cross compilation support
-assert stdenv.targetPlatform == stdenv.hostPlatform;
-assert !enableIntegerSimple -> gmp != null;
 
 stdenv.mkDerivation rec {
   version = "7.4.2";
@@ -55,8 +51,6 @@ stdenv.mkDerivation rec {
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
   stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!stdenv.isDarwin) "--keep-file-symbols";
-
-  passthru = { prefix = ""; };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/7.6.3.nix
+++ b/pkgs/development/compilers/ghc/7.6.3.nix
@@ -1,13 +1,9 @@
 { stdenv, fetchurl, ghc, perl, ncurses, binutils, libiconv
 
-, # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
-  enableIntegerSimple ? false, gmp ? null
+, enableIntegerSimple ? false, gmp
 }:
-
-# TODO(@Ericson2314): Cross compilation support
-assert stdenv.targetPlatform == stdenv.hostPlatform;
-assert !enableIntegerSimple -> gmp != null;
 
 let
   # The "-Wa,--noexecstack" options might be needed only with GNU ld (as opposed
@@ -81,8 +77,6 @@ in stdenv.mkDerivation rec {
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
   stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!stdenv.isDarwin) "--keep-file-symbols";
-
-  passthru = { prefix = ""; };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/7.8.3.nix
+++ b/pkgs/development/compilers/ghc/7.8.3.nix
@@ -1,13 +1,9 @@
 { stdenv, fetchurl, ghc, perl, ncurses, libiconv
 
-, # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
-  enableIntegerSimple ? false, gmp ? null
+, enableIntegerSimple ? false, gmp
 }:
-
-# TODO(@Ericson2314): Cross compilation support
-assert stdenv.targetPlatform == stdenv.hostPlatform;
-assert !enableIntegerSimple -> gmp != null;
 
 stdenv.mkDerivation rec {
   version = "7.8.3";
@@ -52,8 +48,6 @@ stdenv.mkDerivation rec {
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
   stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!stdenv.isDarwin) "--keep-file-symbols";
-
-  passthru = { prefix = ""; };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/7.8.4.nix
+++ b/pkgs/development/compilers/ghc/7.8.4.nix
@@ -1,13 +1,9 @@
 { stdenv, fetchurl, ghc, perl, ncurses, libiconv
 
-, # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
-  enableIntegerSimple ? false, gmp ? null
+, enableIntegerSimple ? false, gmp
 }:
-
-# TODO(@Ericson2314): Cross compilation support
-assert stdenv.targetPlatform == stdenv.hostPlatform;
-assert !enableIntegerSimple -> gmp != null;
 
 stdenv.mkDerivation (rec {
   version = "7.8.4";
@@ -52,8 +48,6 @@ stdenv.mkDerivation (rec {
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
   stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!stdenv.isDarwin) "--keep-file-symbols";
-
-  passthru = { prefix = ""; };
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -1,30 +1,18 @@
-{ stdenv, __targetPackages
-, buildPlatform, hostPlatform, targetPlatform
+{ stdenv, lib, fetchurl, fetchpatch, bootPkgs, perl, ncurses, libiconv, binutils, coreutils
+, hscolour, patchutils, sphinx
 
-# build-tools
-, bootPkgs, hscolour
-, binutils, coreutils, fetchurl, fetchpatch, patchutils, perl, sphinx
-
-, libiconv, ncurses
-
-, # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
-  enableIntegerSimple ? false, gmp ? null
+, enableIntegerSimple ? false, gmp
+, cross ? null
 }:
-
-assert !enableIntegerSimple -> gmp != null;
 
 let
   inherit (bootPkgs) ghc;
-
-  # TODO(@Ericson2314) Make unconditional
-  prefix = stdenv.lib.optionalString
-    (targetPlatform != hostPlatform)
-    "${targetPlatform.config}-";
 in
 stdenv.mkDerivation rec {
   version = "8.0.2";
-  name = "${prefix}ghc-${version}";
+  name = "ghc-${version}";
 
   src = fetchurl {
     url = "https://downloads.haskell.org/~ghc/8.0.2/${name}-src.tar.xz";
@@ -59,20 +47,19 @@ stdenv.mkDerivation rec {
     "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
   ] ++ stdenv.lib.optional stdenv.isDarwin [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
-  ] ++ stdenv.lib.optionals (targetPlatform.isDarwin && targetPlatform.isAarch64) [
+  ] ++
     # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
-    "--disable-large-address-space"
-  ];
+    lib.optional (cross.config or null == "aarch64-apple-darwin14") "--disable-large-address-space";
 
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
   stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!stdenv.isDarwin) "--keep-file-symbols";
 
   postInstall = ''
-    paxmark m $out/lib/${name}/bin/${if targetPlatform != hostPlatform then "ghc" else "{ghc,haddock}"}
+    paxmark m $out/lib/${name}/bin/{ghc,haddock}
 
     # Install the bash completion file.
-    install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/${prefix}ghc
+    install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/ghc
 
     # Patch scripts to include "readelf" and "cat" in $PATH.
     for i in "$out/bin/"*; do
@@ -83,7 +70,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    inherit bootPkgs prefix;
+    inherit bootPkgs;
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/8.2.1.nix
+++ b/pkgs/development/compilers/ghc/8.2.1.nix
@@ -1,30 +1,16 @@
-{ stdenv, __targetPackages
-, buildPlatform, hostPlatform, targetPlatform
-, selfPkgs, cross ? null
+{ stdenv, lib, fetchurl, bootPkgs, perl, ncurses, libiconv, binutils, coreutils
+, autoconf, automake, happy, alex, python3, sphinx, hscolour
+, buildPlatform, targetPlatform , selfPkgs, cross ? null
 
-# build-tools
-, bootPkgs, alex, happy, hscolour
-, autoconf, automake, binutils, coreutils, fetchurl, perl, python3, sphinx
-
-, libiconv ? null, ncurses
-
-, # If enabled, GHC will be build with the GPL-free but slower integer-simple
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
-  enableIntegerSimple ? false, gmp ? null
+, enableIntegerSimple ? false, gmp
 }:
-
-assert !enableIntegerSimple -> gmp != null;
 
 let
   inherit (bootPkgs) ghc;
-
   version = "8.2.1";
 
-  # TODO(@Ericson2314) Make unconditional
-  prefix = stdenv.lib.optionalString
-    (targetPlatform != hostPlatform)
-    "${targetPlatform.config}-";
-  
   commonBuildInputs = [ alex autoconf automake ghc happy hscolour perl python3 sphinx ];
   commonPreConfigure =  ''
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
@@ -35,10 +21,9 @@ let
   '' + stdenv.lib.optionalString enableIntegerSimple ''
     echo "INTEGER_LIBRARY=integer-simple" > mk/build.mk
   '';
-in
-stdenv.mkDerivation (rec {
+in stdenv.mkDerivation (rec {
   inherit version;
-  name = "${prefix}ghc-${version}";
+  name = "ghc-${version}";
 
   src = fetchurl {
     url = "https://downloads.haskell.org/~ghc/${version}/${name}-src.tar.xz";
@@ -67,17 +52,15 @@ stdenv.mkDerivation (rec {
 
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
-  stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!targetPlatform.isDarwin) "--keep-file-symbols";
+  stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!stdenv.isDarwin) "--keep-file-symbols";
 
   checkTarget = "test";
 
-  # zsh and other shells are smart about `{ghc}` but bash isn't, and doesn't
-  # treat that as a unary `{x,y,z,..}` repetition.
   postInstall = ''
-    paxmark m $out/lib/${name}/bin/${if targetPlatform != hostPlatform then "ghc" else "{ghc,haddock}"}
+    paxmark m $out/lib/${name}/bin/{ghc,haddock}
 
     # Install the bash completion file.
-    install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/${prefix}ghc
+    install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/ghc
 
     # Patch scripts to include "readelf" and "cat" in $PATH.
     for i in "$out/bin/"*; do
@@ -90,7 +73,7 @@ stdenv.mkDerivation (rec {
   outputs = [ "out" "doc" ];
 
   passthru = {
-    inherit bootPkgs prefix;
+    inherit bootPkgs;
   } // stdenv.lib.optionalAttrs (targetPlatform != buildPlatform) {
     crossCompiler = selfPkgs.ghc.override {
       cross = targetPlatform;
@@ -122,7 +105,7 @@ stdenv.mkDerivation (rec {
     "--enable-bootstrap-with-devel-snapshot"
   ] ++
     # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
-    stdenv.lib.optional (cross.config or null == "aarch64-apple-darwin14") "--disable-large-address-space";
+    lib.optional (cross.config or null == "aarch64-apple-darwin14") "--disable-large-address-space";
 
   buildInputs = commonBuildInputs ++ [ stdenv.ccCross stdenv.binutils ];
 

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -1,33 +1,20 @@
-{ stdenv, __targetPackages
-, buildPlatform, hostPlatform, targetPlatform
+{ stdenv, lib, fetchgit, bootPkgs, perl, ncurses, libiconv, binutils, coreutils
+, autoconf, automake, happy, alex, python3, buildPlatform, targetPlatform
 , selfPkgs, cross ? null
 
-# build-tools
-, bootPkgs, alex, happy
-, autoconf, automake, binutils, coreutils, fetchgit, perl, python3
-
-, libiconv ? null, ncurses
-
-, # If enabled, GHC will be build with the GPL-free but slower integer-simple
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
-  enableIntegerSimple ? false, gmp ? null
-
+, enableIntegerSimple ? false, gmp
 , version ? "8.3.20170808"
 }:
-
-assert !enableIntegerSimple -> gmp != null;
 
 let
   inherit (bootPkgs) ghc;
 
+  commonBuildInputs = [ ghc perl autoconf automake happy alex python3 ];
+
   rev = "14457cf6a50f708eecece8f286f08687791d51f7";
 
-  # TODO(@Ericson2314) Make unconditional
-  prefix = stdenv.lib.optionalString
-    (targetPlatform != hostPlatform)
-    "${targetPlatform.config}-";
-
-  commonBuildInputs = [ ghc perl autoconf automake happy alex python3 ];
   commonPreConfigure =  ''
     echo ${version} >VERSION
     echo ${rev} >GIT_COMMIT_ID
@@ -40,8 +27,7 @@ let
   '' + stdenv.lib.optionalString enableIntegerSimple ''
     echo "INTEGER_LIBRARY=integer-simple" > mk/build.mk
   '';
-in
-stdenv.mkDerivation (rec {
+in stdenv.mkDerivation (rec {
   inherit version rev;
   name = "ghc-${version}";
 
@@ -71,17 +57,15 @@ stdenv.mkDerivation (rec {
 
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
-  stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!targetPlatform.isDarwin) "--keep-file-symbols";
+  stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!stdenv.isDarwin) "--keep-file-symbols";
 
   checkTarget = "test";
 
-  # zsh and other shells are smart about `{ghc}` but bash isn't, and doesn't
-  # treat that as a unary `{x,y,z,..}` repetition.
   postInstall = ''
-    paxmark m $out/lib/${name}/bin/${if targetPlatform != hostPlatform then "ghc" else "{ghc,haddock}"}
+    paxmark m $out/lib/${name}/bin/{ghc,haddock}
 
     # Install the bash completion file.
-    install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/${prefix}ghc
+    install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/ghc
 
     # Patch scripts to include "readelf" and "cat" in $PATH.
     for i in "$out/bin/"*; do
@@ -94,7 +78,7 @@ stdenv.mkDerivation (rec {
   outputs = [ "out" "doc" ];
 
   passthru = {
-    inherit bootPkgs prefix;
+    inherit bootPkgs;
   } // stdenv.lib.optionalAttrs (targetPlatform != buildPlatform) {
     crossCompiler = selfPkgs.ghc.override {
       cross = targetPlatform;
@@ -126,7 +110,7 @@ stdenv.mkDerivation (rec {
     "--enable-bootstrap-with-devel-snapshot"
   ] ++
     # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
-    stdenv.lib.optional (cross.config or null == "aarch64-apple-darwin14") "--disable-large-address-space";
+    lib.optional (cross.config or null == "aarch64-apple-darwin14") "--disable-large-address-space";
 
   buildInputs = commonBuildInputs;
 

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -36,8 +36,9 @@ let
   isHaLVM       = ghc.isHaLVM or false;
   ghc761OrLater = isGhcjs || isHaLVM || lib.versionOlder "7.6.1" ghc.version;
   packageDBFlag = if ghc761OrLater then "--global-package-db" else "--global-conf";
-  ghcCommand'    = if isGhcjs then "ghcjs" else "ghc";
-  ghcCommand = "${ghc.prefix}${ghcCommand'}";
+  ghcCommand'   = if isGhcjs then "ghcjs" else "ghc";
+  crossPrefix = if (ghc.cross or null) != null then "${ghc.cross.config}-" else "";
+  ghcCommand = "${crossPrefix}${ghcCommand'}";
   ghcCommandCaps= lib.toUpper ghcCommand';
   libDir        = if isHaLVM then "$out/lib/HaLVM-${ghc.version}" else "$out/lib/${ghcCommand}-${ghc.version}";
   docDir        = "$out/share/doc/ghc/html";

--- a/pkgs/os-specific/darwin/ghc-standalone-archive/default.nix
+++ b/pkgs/os-specific/darwin/ghc-standalone-archive/default.nix
@@ -2,7 +2,8 @@
 { haskellPackages, src, deps ? p : [], name }: let
   inherit (haskellPackages) ghc ghcWithPackages;
   with-env = ghcWithPackages deps;
-  ghcName = "${ghc.prefix}ghc";
+  crossPrefix = if (ghc.cross or null) != null then "${ghc.cross.config}-" else "";
+  ghcName = "${crossPrefix}ghc";
 in runCommand name { buildInputs = [ with-env cctools ]; } ''
   mkdir -p $out/lib
   mkdir -p $out/include


### PR DESCRIPTION
Reverts NixOS/nixpkgs#29424. Please don't merge extensive changes like that without giving me any chance to comment. I am not happy about some of the modifications, particularly the random reformatting of code that serves no purpose but makes diffs with previous versions or branches more extensive than necessary and hard to read.