### PR TITLE
arelle: 2017-06-01 -> 2017-08-24

### DIFF
--- a/pkgs/development/python-modules/arelle/default.nix
+++ b/pkgs/development/python-modules/arelle/default.nix
@@ -1,27 +1,27 @@
 { gui ? true,
   buildPythonPackage, fetchFromGitHub, lib,
   sphinx_1_2, lxml, isodate, numpy, pytest,
-  tkinter ? null, py3to2,
+  tkinter ? null, py3to2, isPy3k,
   ... }:
 
-let
+buildPythonPackage rec {
+  name = "arelle-${version}${lib.optionalString (!gui) "-headless"}";
+  version = "2017-08-24";
+
+  disabled = !isPy3k;
+
   # Releases are published at http://arelle.org/download/ but sadly no
   # tags are published on github.
-  version = "2017-06-01";
-
   src = fetchFromGitHub {
     owner = "Arelle";
     repo = "Arelle";
-    rev = "c883f843d55bb48f03a15afceb4cc823cd4601bd";
-    sha256 = "1h48qdj0anv541rd3kna8bmcwfrl1l3yw76wsx8p6hx5prbmzg4v";
+    rev = "cb24e35d57b562a864ae3dd4542c4d9fcf3865fe";
+    sha256 = "1sbvhb3xlfnyvf1xj9dxwpcrfiaf7ikkdwvvap7aaxfxgiz85ip2";
   };
-
-in
-
-buildPythonPackage {
-  name = "arelle-${version}${lib.optionalString (!gui) "-headless"}";
-  inherit src;
   outputs = ["out" "doc"];
+  patches = [
+    ./tests.patch
+  ];
   postPatch = "rm testParser2.py";
   buildInputs = [
     sphinx_1_2
@@ -45,6 +45,8 @@ buildPythonPackage {
   postBuild = ''
     (cd apidocs && make html && cp -r _build $doc)
     '';
+
+  doCheck = if gui then true else false;
 
   meta = {
     description = "An open source facility for XBRL, the eXtensible Business Reporting Language supporting various standards, exposed through a python or REST API" + lib.optionalString gui " and a graphical user interface";

--- a/pkgs/development/python-modules/arelle/tests.patch
+++ b/pkgs/development/python-modules/arelle/tests.patch
@@ -1,0 +1,32 @@
+diff --git c/arelle/CntlrProfiler.py i/arelle/CntlrProfiler.py
+index a64bb1b..dc0299d 100644
+--- c/arelle/CntlrProfiler.py
++++ i/arelle/CntlrProfiler.py
+@@ -1,5 +1,6 @@
+ 
+-import Cntlr, ModelManager, FileSource, time
++from arelle import Cntlr, ModelManager, FileSource
++import time
+ from optparse import OptionParser
+ import cProfile
+ import gettext
+diff --git c/arelle/ValidateFilingText.py i/arelle/ValidateFilingText.py
+index 12dbbbb..c0e98c3 100644
+--- c/arelle/ValidateFilingText.py
++++ i/arelle/ValidateFilingText.py
+@@ -16,7 +16,7 @@ XMLdeclaration = re.compile(r"<\?xml.*\?>", re.DOTALL)
+ XMLpattern = re.compile(r".*(<|&lt;|&#x3C;|&#60;)[A-Za-z_]+[A-Za-z0-9_:]*[^>]*(/>|>|&gt;|/&gt;).*", re.DOTALL)
+ CDATApattern = re.compile(r"<!\[CDATA\[(.+)\]\]")
+ #EFM table 5-1 and all &xxx; patterns
+-docCheckPattern = re.compile(r"&\w+;|[^0-9A-Za-z`~!@#$%&\*\(\)\.\-+ \[\]\{\}\|\\:;\"'<>,_?/=\t\n\r\m\f]") # won't match &#nnn;
++docCheckPattern = re.compile(r"&\w+;|[^0-9A-Za-z`~!@#$%&\*\(\)\.\-+ \[\]\{\}\|\\:;\"'<>,_?/=\t\n\r\f]") # won't match &#nnn;
+ namedEntityPattern = re.compile("&[_A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]"
+                                 r"[_\-\.:" 
+                                 "\xB7A-Za-z0-9\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u0300-\u036F\u203F-\u2040]*;")
+@@ -904,4 +904,4 @@ def referencedFiles(modelXbrl, localFilesOnly=True):
+     # footnote or other elements
+     for elt in modelXbrl.modelDocument.xmlRootElement.iter("{http://www.w3.org/1999/xhtml}a", "{http://www.w3.org/1999/xhtml}img"):
+         addReferencedFile(elt, elt)
+-    return referencedFiles
+\ No newline at end of file
++    return referencedFiles


### PR DESCRIPTION
###### Motivation for this change
fixes tests for python 3.6.

Remove \m from regex (not supported anymore)

Also, implicitly specify from arelle import in Cntlr in CntlrProfiler.py

arelle released a new release for RedHat on 2017-08-24, so I'm considering code from that date a stable release.

tests break on headless expecting tkinter library, so tests are only ran on when gui == true.

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

