### PR TITLE
poezio-git: init at 0.11-44-gc88459c

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15805,6 +15805,7 @@ with pkgs;
   pmenu = callPackage ../applications/misc/pmenu { };
 
   poezio = python3Packages.poezio;
+  poezio-git = python3Packages.poezio-git;
 
   pommed = callPackage ../os-specific/linux/pommed {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25773,6 +25773,36 @@ EOF
     };
   };
 
+  poezio-git = buildPythonApplication rec {
+    name = "poezio-${version}";
+    version = "0.11-44-gc88459c";
+    src = pkgs.fetchgit {
+      url = "git://git.poez.io/poezio/";
+      rev = "v${version}";
+      sha256 = "0zhf84c6mk3zf1xpx2kd89ax05k4ngw5v51w99jdfxllfg74k2xi";
+    };
+
+    disabled = pythonOlder "3.4";
+
+    buildInputs = with self; [ pytest ];
+    propagatedBuildInputs = with self ; [ aiodns slixmpp pyinotify potr mpd2 ];
+
+    patches = [
+      ../development/python-modules/poezio/fix_gnupg_import.patch
+    ];
+
+    checkPhase = ''
+      py.test
+    '';
+
+    meta = {
+      description = "Free console XMPP client";
+      homepage = http://poez.io;
+      license = licenses.mit;
+      maintainers = with maintainers; [ lsix woffs ];
+    };
+  };
+
   potr = buildPythonPackage rec {
     version = "1.0.1";
     name = "potr-${version}";


### PR DESCRIPTION
###### Motivation for this change

make a more recent version of poezio available

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

