### PR TITLE
gmime3: init; notmuch: use gmime3

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, fixDarwinDylibNames, gdb
+{ fetchurl, stdenv, fixDarwinDylibNames
 , pkgconfig, gnupg
 , xapian, gmime, talloc, zlib
 , doxygen, perl
@@ -6,8 +6,10 @@
 , bash-completion
 , emacs
 , ruby
-, which, dtach, openssl, bash
+, which, dtach, openssl, bash, gdb, man
 }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   version = "0.25";
@@ -32,19 +34,11 @@ stdenv.mkDerivation rec {
     emacs  # (optional) to byte compile emacs code
     ruby  # (optional) ruby bindings
     which dtach openssl bash  # test dependencies
-    ]
-    ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames
-    ++ stdenv.lib.optional (!stdenv.isDarwin) gdb;
+  ]
+  ++ optional stdenv.isDarwin fixDarwinDylibNames
+  ++ optionals (!stdenv.isDarwin) [ gdb man ]; # test dependencies
 
-  doCheck = !stdenv.isDarwin;
-  checkTarget = "test";
-
-  patchPhase = ''
-    # XXX: disabling few tests since i have no idea how to make them pass for now
-    rm -f test/T010-help-test.sh \
-          test/T350-crypto.sh \
-          test/T355-smime.sh
-
+  postPatch = ''
     find test -type f -exec \
       sed -i \
         -e "1s|#!/usr/bin/env bash|#!${bash}/bin/bash|" \
@@ -65,7 +59,9 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  preFixup = stdenv.lib.optionalString stdenv.isDarwin ''
+  makeFlags = "V=1";
+
+  preFixup = optionalString stdenv.isDarwin ''
     set -e
 
     die() {
@@ -92,12 +88,16 @@ stdenv.mkDerivation rec {
     install_name_tool -change "$badname" "$goodname" "$prg"
   '';
 
+  doCheck = !stdenv.isDarwin && (versionAtLeast gmime.version "3.0");
+  checkTarget = "test V=1";
+
   postInstall = ''
     make install-man
   '';
+
   dontGzipMan = true; # already compressed
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "Mail indexer";
     homepage    = https://notmuchmail.org/;
     license     = licenses.gpl3;

--- a/pkgs/development/libraries/gmime/2.nix
+++ b/pkgs/development/libraries/gmime/2.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchurl, pkgconfig, glib, zlib, libgpgerror, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
-  name = "gmime-2.6.23";
+  version = "2.6.23";
+  name = "gmime-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gmime/2.6/${name}.tar.xz";

--- a/pkgs/development/libraries/gmime/2.nix
+++ b/pkgs/development/libraries/gmime/2.nix
@@ -16,10 +16,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/jstedfast/gmime/;
     description = "A C/C++ library for creating, editing and parsing MIME messages and structures";
-    maintainers = [ stdenv.lib.maintainers.chaoflow ];
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ chaoflow ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/gmime/3.nix
+++ b/pkgs/development/libraries/gmime/3.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, pkgconfig, glib, zlib, gpgme, libidn, gobjectIntrospection }:
+
+stdenv.mkDerivation rec {
+  name = "gmime-3.0.1";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gmime/3.0/${name}.tar.xz";
+    sha256 = "001y93b8mq9alzkvli6vfh3pzdcn5c5iy206ml23lzhhhvm5k162";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ pkgconfig gobjectIntrospection ];
+  propagatedBuildInputs = [ glib zlib gpgme libidn ];
+  configureFlags = [ "--enable-introspection=yes" ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/jstedfast/gmime/;
+    description = "A C/C++ library for creating, editing and parsing MIME messages and structures";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ chaoflow ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/gmime/3.nix
+++ b/pkgs/development/libraries/gmime/3.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchurl, pkgconfig, glib, zlib, gpgme, libidn, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
-  name = "gmime-3.0.1";
+  version = "3.0.1";
+  name = "gmime-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gmime/3.0/${name}.tar.xz";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8187,7 +8187,9 @@ with pkgs;
 
   glui = callPackage ../development/libraries/glui {};
 
-  gmime = callPackage ../development/libraries/gmime { };
+  gmime2 = callPackage ../development/libraries/gmime/2.nix { };
+  gmime3 = callPackage ../development/libraries/gmime/3.nix { };
+  gmime = gmime2;
 
   gmm = callPackage ../development/libraries/gmm { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15580,7 +15580,9 @@ with pkgs;
 
   notepadqq = libsForQt56.callPackage ../applications/editors/notepadqq { };
 
-  notmuch = callPackage ../applications/networking/mailreaders/notmuch { };
+  notmuch = callPackage ../applications/networking/mailreaders/notmuch {
+    gmime = gmime3;
+  };
 
   notmuch-mutt = callPackage ../applications/networking/mailreaders/notmuch/mutt.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
A merge of my changes, and #28796 that passes all tests and is tested to work for a couple of weeks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

