### PR TITLE
aiohttp-cors: 0.5.1 -> 0.5.3

### DIFF
--- a/pkgs/applications/networking/gns3/server.nix
+++ b/pkgs/applications/networking/gns3/server.nix
@@ -1,22 +1,25 @@
-{ stdenv, python34Packages, fetchFromGitHub }:
+{ stdenv, python3Packages, fetchFromGitHub }:
 
-python34Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "gns3-server";
-  version = "2.0.3";
-
-  broken = true;
+  version = "2.1.0rc1";
 
   src = fetchFromGitHub {
     owner = "GNS3";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1c7mzj1r2zh90a7vs3s17jakfp9s43b8nnj29rpamqxvl3qhbdy7";
+    sha256 = "181689fpjxq4hy2lyxk4zciqhgnhj5srvb4xsxdlbf68n89fj2zf";
   };
 
-  propagatedBuildInputs = with python34Packages; [
-    aiohttp jinja2 psutil zipstream aiohttp-cors raven jsonschema
+  propagatedBuildInputs = with python3Packages; [
+    aiohttp jinja2 psutil zipstream aiohttp-cors raven jsonschema yarl typing
+    prompt_toolkit
   ];
+
+  postPatch = ''
+    sed -i 's/yarl>=0.11,<0.12/yarl/g' requirements.txt
+  '';
 
   # Requires network access
   doCheck = false;

--- a/pkgs/applications/networking/gns3/server.nix
+++ b/pkgs/applications/networking/gns3/server.nix
@@ -5,6 +5,8 @@ python34Packages.buildPythonPackage rec {
   pname = "gns3-server";
   version = "2.0.3";
 
+  broken = true;
+
   src = fetchFromGitHub {
     owner = "GNS3";
     repo = pname;

--- a/pkgs/development/python-modules/aiohttp/cors.nix
+++ b/pkgs/development/python-modules/aiohttp/cors.nix
@@ -1,0 +1,24 @@
+{lib, stdenv, buildPythonPackage, fetchPypi, pythonOlder, typing, aiohttp }:
+
+buildPythonPackage rec {
+  pname = "aiohttp-cors";
+  version = "0.5.3";
+  name = "${pname}-${version}";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "11b51mhr7wjfiikvj3nc5s8c7miin2zdhl3yrzcga4mbpkj892in";
+  };
+
+  # Requires network access
+  doCheck = false;
+
+  propagatedBuildInputs = [ aiohttp ]
+  ++ lib.optional (pythonOlder "3.5") typing;
+
+  meta = with lib; {
+    description = "CORS support for aiohttp";
+    homepage = "https://github.com/aio-libs/aiohttp-cors";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -323,30 +323,7 @@ in {
 
   aiohttp = callPackage ../development/python-modules/aiohttp { };
 
-  aiohttp-cors = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "aiohttp-cors";
-    # 0.5.3 is the current version but gns3-server requires 0.5.1
-    version = "0.5.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/${pname}/${name}.tar.gz";
-      sha256 = "0szma27ri25fq4nwwvs36myddggw3jz4pyzmq63yz4xpw0jjdxck";
-    };
-
-    # Requires network access
-    doCheck = false;
-
-    propagatedBuildInputs = with self; [ aiohttp ]
-      ++ optional (pythonOlder "3.5") typing;
-
-    meta = {
-      description = "CORS support for aiohttp";
-      homepage = "https://github.com/aio-libs/aiohttp-cors";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ primeos ];
-    };
-  };
+  aiohttp-cors = callPackage ../development/python-modules/aiohttp/cors.nix { };
 
   alabaster = callPackage ../development/python-modules/alabaster {};
 


### PR DESCRIPTION
###### Motivation for this change
Fixes build failures for aiohttp-cors. Introduces new problems. Marking gns3server as broken because of https://github.com/GNS3/gns3-server/issues/1054. Hopefully 2.1 will ship soon so we can fix gns3server. Without rolling back aiohttp, we can't make gns3server work. 

Related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

