### PR TITLE
clepy: 0.3.20 -> 0.3.23

### DIFF
--- a/pkgs/development/python-modules/clepy/default.nix
+++ b/pkgs/development/python-modules/clepy/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, decorator, mock, nose }:
+
+buildPythonPackage rec {
+  pname = "clepy";
+  version = "0.3.23";
+  name  = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "14rbijbgkw3vxfbcdd1j4ff9qlk7drdd461bb4fznabjqvqd1r5d";
+  };
+
+  buildInputs = [ decorator nose mock ];
+  # no tests in module causing this bug https://github.com/pypa/setuptools/issues/613
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = http://code.google.com/p/clepy/;
+    description = "Utilities created by the Cleveland Python users group";
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2802,22 +2802,7 @@ in {
 
   cligj = callPackage ../development/python-modules/cligj { };
 
-  clepy = buildPythonPackage rec {
-    name = "clepy-0.3.20";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/clepy/${name}.tar.gz";
-      sha256 = "16vibfxms5z4ld8gbkra6dkhqm2cc3jnn0fwp7mw70nlwxnmm51c";
-    };
-
-    buildInputs = with self; [ self.mock self.nose self.decorator ];
-
-    meta = {
-      homepage = http://code.google.com/p/clepy/;
-      description = "Utilities created by the Cleveland Python users group";
-    };
-  };
-
+  clepy = callPackage ../development/python-modules/clepy { };
 
   clientform = buildPythonPackage (rec {
     name = "clientform-0.2.10";


### PR DESCRIPTION
###### Motivation for this change
Fixes build failures.

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

