### PR TITLE
Add modules for tinydns and dnscache from djbdns

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -518,6 +518,7 @@
   ./services/networking/tcpcrypt.nix
   ./services/networking/teamspeak3.nix
   ./services/networking/tinc.nix
+  ./services/networking/tinydns.nix
   ./services/networking/tftpd.nix
   ./services/networking/tox-bootstrapd.nix
   ./services/networking/toxvpn.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -419,6 +419,7 @@
   ./services/networking/ddclient.nix
   ./services/networking/dhcpcd.nix
   ./services/networking/dhcpd.nix
+  ./services/networking/dnscache.nix
   ./services/networking/dnschain.nix
   ./services/networking/dnscrypt-proxy.nix
   ./services/networking/dnscrypt-wrapper.nix

--- a/nixos/modules/services/networking/dnscache.nix
+++ b/nixos/modules/services/networking/dnscache.nix
@@ -1,0 +1,86 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.dnscache;
+
+  dnscache-root = pkgs.runCommand "dnscache-root" {} ''
+    mkdir -p $out/{servers,ip}
+
+    ${concatMapStrings (ip: ''
+      echo > "$out/ip/"${lib.escapeShellArg ip}
+    '') cfg.clientIps}
+
+    ${concatStrings (mapAttrsToList (host: ips: ''
+      ${concatMapStrings (ip: ''
+        echo ${lib.escapeShellArg ip} > "$out/servers/"${lib.escapeShellArg host}
+      '') ips}
+    '') cfg.domainServers)}
+
+    # djbdns contains an outdated list of root servers;
+    # if one was not provided in config, provide a current list
+    if [ ! -e servers/@ ]; then
+      awk '/^.?.ROOT-SERVERS.NET/ { print $4 }' ${pkgs.dns-root-data}/root.hints > $out/servers/@
+    fi
+  '';
+
+in {
+
+  ###### interface
+
+  options = {
+    services.dnscache = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Whether to run the dnscache caching dns server";
+      };
+
+      ip = mkOption {
+        default = "0.0.0.0";
+        type = types.str;
+        description = "IP address on which to listen for connections";
+      };
+
+      clientIps = mkOption {
+        default = [ "127.0.0.1" ];
+        type = types.listOf types.str;
+        description = "client IP addresses (or prefixes) from which to accept connections";
+        example = ["192.168" "172.23.75.82"];
+      };
+
+      domainServers = mkOption {
+        default = { };
+        type = types.attrsOf (types.listOf types.str);
+        description = "table of {hostname: server} pairs to use as authoritative servers for hosts (and subhosts)";
+        example = {
+          "example.com" = ["8.8.8.8" "8.8.4.4"];
+        };
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf config.services.dnscache.enable {
+    environment.systemPackages = [ pkgs.djbdns ];
+    users.extraUsers.dnscache = {};
+
+    systemd.services.dnscache = {
+      description = "djbdns dnscache server";
+      wantedBy = [ "multi-user.target" ];
+      path = with pkgs; [ bash daemontools djbdns ];
+      preStart = ''
+        rm -rf /var/lib/dnscache
+        dnscache-conf dnscache dnscache /var/lib/dnscache ${config.services.dnscache.ip}
+        rm -rf /var/lib/dnscache/root
+        ln -sf ${dnscache-root} /var/lib/dnscache/root
+      '';
+      script = ''
+        cd /var/lib/dnscache/
+        exec ./run
+      '';
+    };
+  };
+}

--- a/nixos/modules/services/networking/tinydns.nix
+++ b/nixos/modules/services/networking/tinydns.nix
@@ -1,0 +1,53 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  ###### interface
+
+  options = {
+    services.tinydns = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Whether to run the tinydns dns server";
+      };
+
+      data = mkOption {
+        type = types.lines;
+        description = "The DNS data to serve, in the format described by tinydns-data(8)";
+      };
+
+      ip = mkOption {
+        default = "0.0.0.0";
+        type = types.str;
+        description = "IP address on which to listen for connections";
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf config.services.tinydns.enable {
+    environment.systemPackages = [ pkgs.djbdns ];
+
+    users.extraUsers.tinydns = {};
+
+    systemd.services.tinydns = {
+      description = "djbdns tinydns server";
+      wantedBy = [ "multi-user.target" ];
+      path = with pkgs; [ daemontools djbdns ];
+      preStart = ''
+        rm -rf /var/lib/tinydns
+        tinydns-conf tinydns tinydns /var/lib/tinydns ${config.services.tinydns.ip}
+        cd /var/lib/tinydns/root/
+        ln -sf ${pkgs.writeText "tinydns-data" config.services.tinydns.data} data
+        tinydns-data
+      '';
+      script = ''
+        cd /var/lib/tinydns
+        exec ./run
+      '';
+    };
+  };
+}

--- a/nixos/modules/services/networking/tinydns.nix
+++ b/nixos/modules/services/networking/tinydns.nix
@@ -15,6 +15,7 @@ with lib;
 
       data = mkOption {
         type = types.lines;
+        default = "";
         description = "The DNS data to serve, in the format described by tinydns-data(8)";
       };
 

--- a/pkgs/tools/networking/djbdns/default.nix
+++ b/pkgs/tools/networking/djbdns/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, glibc } :
+
+let
+  version = "1.05";
+
+  manSrc = fetchurl {
+    url = "http://smarden.org/pape/djb/manpages/djbdns-${version}-man-20031023.tar.gz";
+    sha256 = "0sg51gjy6j1hnrra406q1qhf5kvk1m00y8qqhs6r0a699gqmh75s";
+  };
+
+in
+
+stdenv.mkDerivation {
+  name = "djbdns-${version}";
+
+  src = fetchurl {
+    url = "https://cr.yp.to/djbdns/djbdns-${version}.tar.gz";
+    sha256 = "0j3baf92vkczr5fxww7rp1b7gmczxmmgrqc8w2dy7kgk09m85k9w";
+  };
+
+  patches = [ ./hier.patch ];
+
+  postPatch = ''
+    echo gcc -O2 -include ${glibc.dev}/include/errno.h > conf-cc
+    echo $out > conf-home
+    sed -i "s|/etc/dnsroots.global|$out/etc/dnsroots.global|" dnscache-conf.c
+  '';
+
+  installPhase = ''
+    mkdir -pv $out/etc;
+    make setup
+    cd $out;
+    tar xzvf ${manSrc};
+    for n in 1 5 8; do
+      mkdir -p man/man$n;
+      mv -iv djbdns-man/*.$n man/man$n;
+    done;
+    rm -rv djbdns-man;
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A collection of Domain Name System tools";
+    longDescription = "Includes software for all the fundamental DNS operations: DNS cache: finding addresses of Internet hosts; DNS server: publishing addresses of Internet hosts; and DNS client: talking to a DNS cache.";
+    homepage = https://cr.yp.to/djbdns.html;
+    license = licenses.publicDomain;
+    maintainers = with maintainers; [ jerith666 ];
+  };
+}

--- a/pkgs/tools/networking/djbdns/hier.patch
+++ b/pkgs/tools/networking/djbdns/hier.patch
@@ -1,0 +1,15 @@
+--- a/hier.c	2016-04-19 21:22:21.992192405 -0400
++++ b/hier.c	2016-04-19 21:22:33.160229778 -0400
+@@ -2,9 +2,9 @@
+ 
+ void hier()
+ {
+-  c("/","etc","dnsroots.global",-1,-1,0644);
++  c(auto_home,"etc","dnsroots.global",-1,-1,0644);
+ 
+-  h(auto_home,-1,-1,02755);
+-  d(auto_home,"bin",-1,-1,02755);
++  h(auto_home,-1,-1,0755);
++  d(auto_home,"bin",-1,-1,0755);
+ 
+   c(auto_home,"bin","dnscache-conf",-1,-1,0755);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1645,6 +1645,8 @@ with pkgs;
 
   dev86 = callPackage ../development/compilers/dev86 { };
 
+  djbdns = callPackage ../tools/networking/djbdns { };
+
   dnscrypt-proxy = callPackage ../tools/networking/dnscrypt-proxy { };
 
   dnscrypt-wrapper = callPackage ../tools/networking/dnscrypt-wrapper { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).