### PR TITLE
client-ip-echo: init at 0.1.0.1

### DIFF
--- a/pkgs/servers/misc/client-ip-echo/client-ip-echo.nix
+++ b/pkgs/servers/misc/client-ip-echo/client-ip-echo.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, fetchFromGitHub, base, bytestring, network, stdenv }:
+mkDerivation {
+  pname = "client-ip-echo";
+  version = "0.1.0.1";
+  src = fetchFromGitHub {
+    owner = "jerith666";
+    repo = "client-ip-echo";
+    rev = "f6e3e115a1e61a387cf79956ead36d7ac25a2901";
+    sha256 = "0irxcaiwxxn4ggd2dbya1mvpnyfanx0x06whp8ccrha141cafwqp";
+  };
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [ base bytestring network ];
+  description = "accepts TCP connections and echoes the client's IP address back to it";
+  license = stdenv.lib.licenses.lgpl3;
+}

--- a/pkgs/servers/misc/client-ip-echo/default.nix
+++ b/pkgs/servers/misc/client-ip-echo/default.nix
@@ -1,0 +1,2 @@
+{ pkgs }:
+pkgs.haskellPackages.callPackage ./client-ip-echo.nix { }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1488,6 +1488,8 @@ with pkgs;
 
   clex = callPackage ../tools/misc/clex { };
 
+  client-ip-echo = callPackage ../servers/misc/client-ip-echo { };
+
   cloc = callPackage ../tools/misc/cloc {
     inherit (perlPackages) perl AlgorithmDiff RegexpCommon;
   };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).