### PR TITLE
cairo: 1.14.10 -> 1.15.8

### DIFF
--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, fetchFromGitHub, fetchpatch, pkgconfig, libiconv
-, libintlOrEmpty, expat, zlib, libpng, pixman, fontconfig, freetype, xorg
+{ stdenv, fetchgit, fetchpatch, pkgconfig, libiconv, libintlOrEmpty, expat
+, zlib, libpng, pixman, fontconfig, freetype, xorg
 , gobjectSupport ? true, glib
 , xcbSupport ? true # no longer experimental since 1.12
 , glSupport ? true, mesa_noglu ? null # mesa is no longer a big dependency
@@ -12,11 +12,14 @@ assert glSupport -> mesa_noglu != null;
 let inherit (stdenv.lib) optional optionals; in
 
 stdenv.mkDerivation rec {
-  name = "cairo-1.14.10";
+  pname = "cairo";
+  version = "1.15.8";
+  name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "http://cairographics.org/releases/${name}.tar.xz";
-    sha256 = "02banr0wxckq62nbhc3mqidfdh2q956i2r7w2hd9bjgjb238g1vy";
+  src = fetchgit {
+    url = "https://anongit.freedesktop.org/git/${pname}";
+    rev = version;
+    sha256 = "0fi68c72b2vi7f07mflikn8dga622492rhlv5sx500glsn1svy1j";
   };
 
   patches = [
@@ -99,6 +102,8 @@ stdenv.mkDerivation rec {
     homepage = http://cairographics.org/;
 
     license = with licenses; [ lgpl2Plus mpl10 ];
+
+    maintainers = with maintainers; [ vyp ];
 
     platforms = platforms.all;
   };


### PR DESCRIPTION
###### Motivation for this change

Emojis

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

<details>
<summary>This doesn't build, not sure why.. any ideas?</summary>

```
$ nix-build -A cairo -K
these derivations will be built:
  /nix/store/d096bg77p22zv5ciffk199vqqsq7y8x8-cairo.drv
  /nix/store/am09rq9myssrq114n02kkd4697g2rv29-cairo-1.15.8.drv
building path(s) ‘/nix/store/xma5yxnyzz5shd89fam8gi6j4zs8la3l-cairo’
exporting https://anongit.freedesktop.org/git/cairo (rev 1.15.8) into /nix/store/xma5yxnyzz5shd89fam8gi6j4zs8la3l-cairo
Initialized empty Git repository in /nix/store/xma5yxnyzz5shd89fam8gi6j4zs8la3l-cairo/.git/
remote: Counting objects: 3202, done.
remote: Compressing objects: 100% (3134/3134), done.
remote: Total 3202 (delta 383), reused 2125 (delta 59)
Receiving objects: 100% (3202/3202), 31.75 MiB | 259.00 KiB/s, done.
Resolving deltas: 100% (383/383), done.
From https://anongit.freedesktop.org/git/cairo
 * tag               1.15.8     -> FETCH_HEAD
Switched to a new branch 'fetchgit'
removing `.git'...
building path(s) ‘/nix/store/3v7d3mzxmdydp7b70sjk21zkn00msbm7-cairo-1.15.8-dev’, ‘/nix/store/b93yalsc4g5qlfm8033vbs0l6cma96hi-cairo-1.15.8-devdoc’, ‘/nix/store/v91gv17s6lv82yhbabw9d3vj0rg28yzc-cairo-1.15.8’
unpacking sources
unpacking source archive /nix/store/xma5yxnyzz5shd89fam8gi6j4zs8la3l-cairo
source root is cairo
patching sources
applying patch /nix/store/hrvsw11xgc50zix0djc19gi8kds3234s-cairo-CVE-2016-9082.patch
patching file boilerplate/cairo-boilerplate.c
patching file src/cairo-image-compositor.c
patching file src/cairo-image-surface-private.h
patching file src/cairo-mesh-pattern-rasterizer.c
patching file src/cairo-png.c
patching file src/cairo-script-surface.c
configuring
no configure script, doing nothing
building
no Makefile, doing nothing
glibPreInstallPhase
installing
install flags: install pkgconfigdir=/nix/store/3v7d3mzxmdydp7b70sjk21zkn00msbm7-cairo-1.15.8-dev/lib/pkgconfig m4datadir=/nix/store/3v7d3mzxmdydp7b70sjk21zkn00msbm7-cairo-1.15.8-dev/share/aclocal aclocaldir=/nix/store/3v7d3mzxmdydp7b70sjk21zkn00msbm7-cairo-1.15.8-dev/share/aclocal gsettingsschemadir=/nix/store/v91gv17s6lv82yhbabw9d3vj0rg28yzc-cairo-1.15.8/share/gsettings-schemas/cairo-1.15.8/glib-2.0/schemas/
make: *** No rule to make target 'install'.  Stop.
note: keeping build directory ‘/tmp/nix-build-cairo-1.15.8.drv-0’
builder for ‘/nix/store/am09rq9myssrq114n02kkd4697g2rv29-cairo-1.15.8.drv’ failed with exit code 2
error: build of ‘/nix/store/am09rq9myssrq114n02kkd4697g2rv29-cairo-1.15.8.drv’ failed
```
</details>