### PR TITLE
caddy: 0.10.7 -> 0.10.9

### DIFF
--- a/pkgs/servers/caddy/default.nix
+++ b/pkgs/servers/caddy/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub, fetchpatch }:
 
 buildGoPackage rec {
   name = "caddy-${version}";
-  version = "0.10.7";
+  version = "0.10.9";
 
   goPackagePath = "github.com/mholt/caddy";
 
@@ -12,8 +12,18 @@ buildGoPackage rec {
     owner = "mholt";
     repo = "caddy";
     rev = "v${version}";
-    sha256 = "1sn959l2cq6pallmngwf1hrjk7qrsfb5wsqbv15xnczl22lvwf13";
+    sha256 = "1shry7dqcbb5d3hp9xz5l3jx9a6i18wssz3m28kpjf3cks427v55";
   };
+
+  patches = [
+    # This header was added in 0.10.9 and was since reverted but no new release made
+    # remove this patch when updating to next release
+    (fetchpatch {
+      url = "https://github.com/mholt/caddy/commit/d267b62fe9fdd008f13774afc72d95335934d133.patch";
+      name = "revert-sponsors-header.patch";
+      sha256 = "192g23kzkrwgif7ii9c70mh1a25gwhm1l1mzyqm9i0d3jifsfc2j";
+    })
+  ];
 
   buildFlagsArray = ''
     -ldflags=


### PR DESCRIPTION
###### Motivation for this change
Upstream version update. 
Fixes some issues related to certificate renewal, adding support for quic backends.

There was a hugely controversial change in this release: a header advertising the sponsors of Caddy.
This change has since been reverted upstream but no new release was made because of the change.

I chose to apply this patch and added a comment to the next person who updates this package to remove it. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

