### PR TITLE
fcitx-engines.rime: init at 0.3.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -384,7 +384,6 @@
   mikefaille = "Michaël Faille <michael@faille.io>";
   miltador = "Vasiliy Solovey <miltador@yandex.ua>";
   mimadrid = "Miguel Madrid <mimadrid@ucm.es>";
-  mingchuan = "Ming Chuan <ming@culpring.com>";
   mirdhyn = "Merlin Gaillard <mirdhyn@gmail.com>";
   mirrexagon = "Andrew Abbott <mirrexagon@mirrexagon.com>";
   mjanczyk = "Marcin Janczyk <m@dragonvr.pl>";
@@ -550,6 +549,7 @@
   shell = "Shell Turner <cam.turn@gmail.com>";
   shlevy = "Shea Levy <shea@shealevy.com>";
   siddharthist = "Langston Barrett <langston.barrett@gmail.com>";
+  sifmelcara = "Ming Chuan <ming@culpring.com>";
   sigma = "Yann Hodique <yann.hodique@gmail.com>";
   simonvandel = "Simon Vandel Sillesen <simon.vandel@gmail.com>";
   sivteck = "Sivaram Balakrishnan <sivaram1992@gmail.com>";

--- a/pkgs/applications/misc/pcmanx-gtk2/default.nix
+++ b/pkgs/applications/misc/pcmanx-gtk2/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     homepage = http://pcman.ptt.cc;
     license = licenses.gpl2;
     description = "Telnet BBS browser with GTK+ interface";
-    maintainers = [ maintainers.mingchuan ];
+    maintainers = [ maintainers.sifmelcara ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/data/misc/brise/default.nix
+++ b/pkgs/data/misc/brise/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, librime }:
+
+stdenv.mkDerivation rec {
+  name = "brise-unstable-2017-09-16";
+
+  src = fetchFromGitHub {
+    owner = "rime";
+    repo = "brise";
+    rev = "1cfb0fe1d3a4190ce5d034f141941156dd271e80";
+    sha256 = "1l13j3cfwida0ycl874fizz2jwjvlxid589a1iciqa9y25k21ql7";
+  };
+
+  buildInputs = [ librime ];
+
+  postPatch = ''
+    patchShebangs scripts/*
+  '';
+
+  # we need to use fetchFromGitHub to fetch sub-packages before we 'make',
+  # since nix won't allow networking during 'make'
+  preBuild = import ./fetchPackages.nix fetchFromGitHub;
+
+  makeFlags = [ "BRISE_BUILD_BINARIES=yes" "PREFIX=$(out)" ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Rime Schema Repository";
+    longDescription = ''
+      This software is a collection of data packages used by Rime
+      to support various Chinese input methods, including those based on
+      modern dialects or historical diasystems of the Chinese language.
+    '';
+    homepage = http://rime.im;
+    # Note that individual packages in this collection
+    # may be released under different licenses
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = [ maintainers.mingchuan ];
+  };
+}

--- a/pkgs/data/misc/brise/default.nix
+++ b/pkgs/data/misc/brise/default.nix
@@ -36,6 +36,6 @@ stdenv.mkDerivation rec {
     # may be released under different licenses
     license = licenses.gpl3;
     platforms = platforms.all;
-    maintainers = [ maintainers.mingchuan ];
+    maintainers = [ maintainers.sifmelcara ];
   };
 }

--- a/pkgs/data/misc/brise/fetchPackages.nix
+++ b/pkgs/data/misc/brise/fetchPackages.nix
@@ -1,0 +1,130 @@
+fetchFromGitHub:
+# generated using https://gist.github.com/sifmelcara/895c71f99500b9d56d68e9a866b58821
+''
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-array";
+  rev = "9ca2b725ae52c9b3185213e3555df1f9d4f1c53f";
+  sha256 = "0x3sifdpdivr8ssynjhc4g1zfl6h9hm9nh9p9zb9wkh1ky9z7kha";
+}} array
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-bopomofo";
+  rev = "7046ffe42b46915947117f80d901fb9a6e19c1a7";
+  sha256 = "09w8jl2dlgp72k49x0l2jiaqb359v576kai4xww6cljgr24ng8pl";
+}} bopomofo
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-cangjie";
+  rev = "64242be99c1e6793c9f40fef296a81d07a84e976";
+  sha256 = "0v5sk8zrm5p5gg8lszqm0imj9jswjlnfq87nw6m9pg5h5al230ja";
+}} cangjie
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-combo-pinyin";
+  rev = "97a7dc4670e0f90ad28e7d67c1543f4f0adc531d";
+  sha256 = "0y8iyvq7z6xj3lk2ppk4ggz297wn1r2xxbv53f2710jc7gyzf04q";
+}} combo-pinyin
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-double-pinyin";
+  rev = "1b75af4239897fd1e4c99d625b62093e66baff14";
+  sha256 = "0p54qx5a6rr55hl997kdcfxjczd9lcddrc5xsy7nhlfyc6108s2v";
+}} double-pinyin
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-emoji";
+  rev = "7e527056fe055237fee59463e0d445f3909aaf0c";
+  sha256 = "04d35n254viw29yyjf3ml7xljmi63sqgg870swlbi5bikcx7n9jf";
+}} emoji
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-essay";
+  rev = "595e35756d16d57d09405e243302b65b4384b5b4";
+  sha256 = "10kqhvrz8x17b2pf6x2x2znz5y6cj05c4rgwi1f0xhxiyrgjw9gm";
+}} essay
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-ipa";
+  rev = "9e02f8a02e9febb7b2df25f6906881a1df934811";
+  sha256 = "1g4v4j1gnv1qspfz88liwj1aa4gaa3aax0x2cif4vxicsm7w372m";
+}} ipa
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-jyutping";
+  rev = "3cc76e6e15cc05f1f94b89e750c21f87ce8fc0e4";
+  sha256 = "1yggz0yb84z8810s2gmsxkm9lh57fdzddx5v2rb5mqcwnimsd6ap";
+}} jyutping
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-luna-pinyin";
+  rev = "da00c3a6f932f094666e98a09f6ce9c7d74c334c";
+  sha256 = "0q3g1hj9bay5865h3pz7gv46d7wfka1jdxnddxcbp4zn7gjpsd48";
+}} luna-pinyin
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-middle-chinese";
+  rev = "6f9731bac8f289f77d35f1090159f1937e38c1f7";
+  sha256 = "0xd9iwk4j5043gfmp7rb57hbarfm6sxr32wiasi6p3c5g355zn89";
+}} middle-chinese
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-pinyin-simp";
+  rev = "38c08403c22845f7e2965c1d7a1514b41755d7dc";
+  sha256 = "1c0cqljx3d93w27y2flxyqcfd3rd9fvixbw6mxgfjzdb3s42bn8h";
+}} pinyin-simp
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-prelude";
+  rev = "120c2aa73b1b5e1bce904901bf13f506295004a5";
+  sha256 = "1aah9z58gkqrc18zadsq598ybj8ra22bgka3gma2jmi3rls2znq4";
+}} prelude
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-quick";
+  rev = "638abf270e121bc2bfc6029a14ee85a3f4c2188b";
+  sha256 = "0l1pma0yxrypnb5cq7jiczy0wa42kdqsc1brqkkccdnp08pa1p1m";
+}} quick
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-scj";
+  rev = "6b74ce14be0464bf076d7adc40aea4b120f233ec";
+  sha256 = "0lr92knr41mlqd1s0g2lh2h2qr8xka1s46x7iv4d6ghjf0id4gz6";
+}} scj
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-soutzoe";
+  rev = "3ab93d1b9ca9ca7cf17ff32bb4418b7a095afc3c";
+  sha256 = "1glbvgzx4psasq23511k8ymd7mf1pqvm3z18nzszhs00iif66s3m";
+}} soutzoe
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-stenotype";
+  rev = "766f22565f83f5c63c0ea195c936779ec6ae824d";
+  sha256 = "0jsvfq7xim99zs5imyk7rpknlaimk6nlxy38fmfxa1r843781mfd";
+}} stenotype
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-stroke";
+  rev = "e048967a4c1b956575828f1a20e565efed4b1137";
+  sha256 = "10asdz5bj12pnji7afzls6jd9dn2v90l2dgdjf0jfp2kfzd6pxnl";
+}} stroke
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-terra-pinyin";
+  rev = "e303507e728def38739f5761c50722eae1f06dd5";
+  sha256 = "1krbmx2iq3zw4q1x4aa9c72b9xgrnjrhyxa4h5hnq5l29p9qms4d";
+}} terra-pinyin
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-wubi";
+  rev = "97b7d9f93378e98fd11167bd80d54c40e67076aa";
+  sha256 = "1cdpbqqkqjbizja0w3f7a826a5bxb39nlf9qf2130x9havmkc89z";
+}} wubi
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-wugniu";
+  rev = "de40b29f8218cc852bf82b315c7070f1d50bda02";
+  sha256 = "1m7miwsqpy49cgqd1bl7z5lkkirj3lc2bdwd1zqfg5zbgfwn0rp8";
+}} wugniu
+''

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation rec {
     description = "A compiled language with Ruby like syntax and type inference";
     homepage = https://crystal-lang.org/;
     license = stdenv.lib.licenses.asl20;
-    maintainers = with stdenv.lib.maintainers; [ mingchuan ];
+    maintainers = with stdenv.lib.maintainers; [ sifmelcara ];
     platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/development/libraries/librime/default.nix
+++ b/pkgs/development/libraries/librime/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     homepage    = http://rime.im/;
     description = "Rime Input Method Engine, the core library";
     license     = licenses.bsd3;
-    maintainers = with maintainers; [ mingchuan ];
+    maintainers = with maintainers; [ sifmelcara ];
     platforms   = platforms.all;
   };
 }

--- a/pkgs/development/libraries/librime/default.nix
+++ b/pkgs/development/libraries/librime/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, cmake, boost, glog, leveldb, marisa, opencc,
+  libyamlcpp, gmock }:
+
+stdenv.mkDerivation rec {
+  name = "librime-${version}";
+  version = "1.2.9";
+
+  src = fetchFromGitHub {
+    owner = "rime";
+    repo = "librime";
+    rev = "rime-${version}";
+    sha256 = "14jgnfm61ynm086x9v7wfmv2p14h0qp8lq4d2jqm21n821jsraj6";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ boost glog leveldb marisa opencc libyamlcpp gmock ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage    = http://rime.im/;
+    description = "Rime Input Method Engine, the core library";
+    license     = licenses.bsd3;
+    maintainers = with maintainers; [ mingchuan ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/marisa/default.nix
+++ b/pkgs/development/libraries/marisa/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     homepage    = https://code.google.com/p/marisa-trie/;
     description = "Static and space-efficient trie data structure library";
     license     = licenses.bsd3;
-    maintainers = with maintainers; [ mingchuan ];
+    maintainers = with maintainers; [ sifmelcara ];
     platforms   = platforms.all;
   };
 }

--- a/pkgs/development/libraries/marisa/default.nix
+++ b/pkgs/development/libraries/marisa/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "marisa-${version}";
+  version = "0.2.4";
+
+  src = fetchurl {
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/marisa-trie/marisa-${version}.tar.gz";
+    sha256 = "1cwzf8hr348zihkiy0qckx0n6rxg7sy113xhbslb1irw1pvs99v7";
+  };
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage    = https://code.google.com/p/marisa-trie/;
+    description = "Static and space-efficient trie data structure library";
+    license     = licenses.bsd3;
+    maintainers = with maintainers; [ mingchuan ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/development/tools/build-managers/shards/default.nix
+++ b/pkgs/development/tools/build-managers/shards/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     homepage = https://crystal-lang.org/;
     license = licenses.asl20;
     description = "Dependency manager for the Crystal language";
-    maintainers = with maintainers; [ mingchuan ];
+    maintainers = with maintainers; [ sifmelcara ];
     platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-rime/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-rime/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, cmake, pkgconfig, fcitx, librime, brise, hicolor_icon_theme }:
+
+stdenv.mkDerivation rec {
+  name = "fcitx-rime-${version}";
+  version = "0.3.2";
+
+  src = fetchurl {
+    url = "https://download.fcitx-im.org/fcitx-rime/${name}.tar.xz";
+    sha256 = "0bd8snfa6jr8dhnm0s0z021iryh5pbaf7p15rhkgbigw2pssczpr";
+  };
+
+  buildInputs = [ cmake pkgconfig fcitx librime brise hicolor_icon_theme ];
+
+  # cmake cannont automatically find our nonstandard brise install location
+  cmakeFlags = [ "-DRIME_DATA_DIR=${brise}/share/rime-data" ];
+
+  preInstall = ''
+    substituteInPlace src/cmake_install.cmake \
+       --replace ${fcitx} $out
+    substituteInPlace data/cmake_install.cmake \
+       --replace ${fcitx} $out
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    isFcitxEngine = true;
+    homepage      = https://github.com/fcitx/fcitx-rime;
+    downloadPage  = https://download.fcitx-im.org/fcitx-rime/;
+    description   = "Rime support for Fcitx";
+    license       = licenses.gpl2;
+    platforms     = platforms.linux;
+    maintainers   = with maintainers; [ mingchuan ];
+  };
+}

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-rime/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-rime/default.nix
@@ -30,6 +30,6 @@ stdenv.mkDerivation rec {
     description   = "Rime support for Fcitx";
     license       = licenses.gpl2;
     platforms     = platforms.linux;
-    maintainers   = with maintainers; [ mingchuan ];
+    maintainers   = with maintainers; [ sifmelcara ];
   };
 }

--- a/pkgs/tools/text/opencc/default.nix
+++ b/pkgs/tools/text/opencc/default.nix
@@ -9,9 +9,13 @@ stdenv.mkDerivation {
 
   buildInputs = [ cmake python ];
 
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=OFF"
+  makeFlags = [
+    # let intermediate tools find intermediate library
+    "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(CURDIR)/src"
   ];
+
+  # Parallel building occasionaly fails with: Error copying file "/tmp/nix-build-opencc-1.0.5.drv-0/OpenCC-ver.1.0.5/build/src/libopencc.so.1.0.0" to "/tmp/nix-build-opencc-1.0.5.drv-0/OpenCC-ver.1.0.5/build/src/tools".
+  enableParallelBuilding = false;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/BYVoid/OpenCC;

--- a/pkgs/tools/text/opencc/default.nix
+++ b/pkgs/tools/text/opencc/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
       phrase-level conversion, variant conversion and regional idioms among Mainland China,
       Taiwan and Hong kong.
     '';
-    maintainers = [ maintainers.mingchuan ];
+    maintainers = [ maintainers.sifmelcara ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1953,6 +1953,8 @@ with pkgs;
 
     unikey = callPackage ../tools/inputmethods/fcitx-engines/fcitx-unikey { };
 
+    rime = callPackage ../tools/inputmethods/fcitx-engines/fcitx-rime { };
+
     m17n = callPackage ../tools/inputmethods/fcitx-engines/fcitx-m17n { };
 
     mozc = callPackage ../tools/inputmethods/fcitx-engines/fcitx-mozc rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9218,6 +9218,8 @@ with pkgs;
 
   librevisa = callPackage ../development/libraries/librevisa { };
 
+  librime = callPackage ../development/libraries/librime {};
+
   libsamplerate = callPackage ../development/libraries/libsamplerate {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices Carbon CoreServices;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13082,6 +13082,8 @@ with pkgs;
 
   bgnet = callPackage ../data/documentation/bgnet { };
 
+  brise = callPackage ../data/misc/brise { };
+
   inherit (kdeFrameworks) breeze-icons;
 
   cacert = callPackage ../data/misc/cacert { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9748,6 +9748,8 @@ with pkgs;
 
   mapnik = callPackage ../development/libraries/mapnik { };
 
+  marisa = callPackage ../development/libraries/marisa {};
+
   matio = callPackage ../development/libraries/matio { };
 
   mbedtls = callPackage ../development/libraries/mbedtls { };


### PR DESCRIPTION
###### Motivation for this change

Add fcitx support for [Rime](http://rime.im/) input method and Rime's dependencies.

About the `brise` package: This package provides data for many variants of Chinese input methods. Since it will try to download data from GitHub (if data do not already exists), we need to fetch those dialect's data manually.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
