### PR TITLE
freeswitch: fix build

### DIFF
--- a/pkgs/servers/sip/freeswitch/default.nix
+++ b/pkgs/servers/sip/freeswitch/default.nix
@@ -9,7 +9,11 @@ stdenv.mkDerivation rec {
     url = "http://files.freeswitch.org/freeswitch-releases/${name}.tar.bz2";
     sha256 = "071g7229shr9srwzspx29fcx3ccj3rwakkydpc4vdf1q3lldd2ld";
   };
-  postPatch = "patchShebangs libs/libvpx/build/make/rtcd.pl";
+  postPatch = ''
+    patchShebangs     libs/libvpx/build/make/rtcd.pl
+    substituteInPlace libs/libvpx/build/make/configure.sh \
+      --replace AS=\''${AS} AS=yasm
+  '';
 
   buildInputs = [
     openssl ncurses curl pkgconfig gnutls readline perl libjpeg


### PR DESCRIPTION
###### Motivation for this change

The latest build seems to be picking up `as` instead of `yasm`for its assembler
Forcing it to use `yasm` fixes the build.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
