### PR TITLE
monero: 0.10.3.1 -> 0.11.0.0

### DIFF
--- a/pkgs/applications/misc/monero/default.nix
+++ b/pkgs/applications/misc/monero/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, boost, miniupnpc, openssl, pkgconfig, unbound }:
 
 let
-  version = "0.10.3.1";
+  version = "0.11.0.0";
 in
 stdenv.mkDerivation {
   name = "monero-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     owner = "monero-project";
     repo = "monero";
     rev = "v${version}";
-    sha256 = "1x6qjqijdbjyfb0dcjn46gp38hkb419skxansf9w2cjf58c2055n";
+    sha256 = "041xxk9gznfpgn8f07m7sddr74cwm1sdyf9i85k10ndja87xc6y4";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
@@ -30,7 +30,6 @@ stdenv.mkDerivation {
         bin/monerod \
         bin/monero-blockchain-export \
         bin/monero-blockchain-import \
-        bin/monero-utils-deserialize \
         bin/monero-wallet-cli \
         bin/monero-wallet-rpc
   '';


### PR DESCRIPTION
###### Motivation for this change

After a recent hardfork in Monero, old clients are no longer compatible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

