### PR TITLE
aspellWithDicts: use a single env

### DIFF
--- a/pkgs/development/libraries/aspell/aspell-with-dicts.nix
+++ b/pkgs/development/libraries/aspell/aspell-with-dicts.nix
@@ -4,8 +4,7 @@
 { aspell
 , aspellDicts
 , makeWrapper
-, symlinkJoin
-, runCommand
+, buildEnv
 }:
 
 f:
@@ -14,22 +13,20 @@ let
   # Dictionaries we want
   dicts = f aspellDicts;
 
-  # A tree containing the dictionaries
-  dictEnv = symlinkJoin {
-    name = "aspell-dicts";
-    paths = dicts;
-  };
-
-in runCommand "aspell-env" {
+in buildEnv {
+  name = "aspell-env";
   buildInputs = [ makeWrapper ];
-} ''
-  # Construct wrappers in /bin
-  mkdir -p $out/bin
-  pushd "${aspell}/bin"
-  for prg in *; do
-    if [ -f "$prg" ]; then
-      makeWrapper "${aspell}/bin/$prg" "$out/bin/$prg" --set ASPELL_CONF "dict-dir ${dictEnv}/lib/aspell"
-    fi
-  done
-  popd
-''
+  paths = [ aspell ] ++ dicts;
+  postBuild = ''
+    # Construct wrappers in /bin
+    unlink "$out/bin"
+    mkdir -p "$out/bin"
+    pushd "${aspell}/bin"
+    for prg in *; do
+      if [ -f "$prg" ]; then
+        makeWrapper "${aspell}/bin/$prg" "$out/bin/$prg" --set ASPELL_CONF "dict-dir $out/lib/aspell"
+      fi
+    done
+    popd
+  '';
+}


### PR DESCRIPTION
In c0cf19608faf447d4b78f77ff36a770462b19a22 the function
`aspellWithDicts` was introduced, that allows to build a derivation
consisting of aspell and specified dictionaries. In
96457d26dded05bcba8e9fbb9bf0255596654aab a fix was included to properly
find the dictionaries.

Issue #29429 describes that, while the current method works for the
aspell binary, it does not in case of the API.

This commit rewrites the wrapper into a single derivation, create a
single tree of symbolic references to both the binary and the
dictionaries so that its possible to find the dictionaries with the API.
Furthermore, the binary is wrapped so it can still find the dictionaries
as well.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

