### PR TITLE
nixos/gogs: Fix module when no passwords provided

### DIFF
--- a/nixos/modules/services/misc/gogs.nix
+++ b/nixos/modules/services/misc/gogs.nix
@@ -257,7 +257,7 @@ in
         in the Nix store. Use database.passwordFile instead.'';
 
     # Create database passwordFile default when password is configured.
-    services.gogs.database.passwordFile = mkIf (cfg.database.password != "")
+    services.gogs.database.passwordFile =
       (mkDefault (toString (pkgs.writeTextFile {
         name = "gogs-database-password";
         text = cfg.database.password;


### PR DESCRIPTION
Please use this instead of #27950. It should also be cherry-picked to release-17.09.

###### Motivation for this change

If neither database.password or database.passwordFile were provided, it would try and fail to coerce null to a string.

This fixes the situation where there is no password for the database.


###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @jgertm @schneefux @NeQuissimus @fpletz 
