### PR TITLE
python-cffi: fix test failures when using clang

### DIFF
--- a/pkgs/development/python-modules/cffi/default.nix
+++ b/pkgs/development/python-modules/cffi/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, isPyPy, fetchPypi, libffi, pycparser, pytest }:
+{ stdenv, buildPythonPackage, isPyPy, fetchPypi, libffi, pycparser, pytest }:
 
 if isPyPy then null else buildPythonPackage rec {
   pname = "cffi";
@@ -13,15 +13,14 @@ if isPyPy then null else buildPythonPackage rec {
   propagatedBuildInputs = [ libffi pycparser ];
   buildInputs = [ pytest ];
 
-  patchPhase = ''
-    substituteInPlace testing/cffi0/test_ownlib.py --replace "gcc" "cc"
-  '';
+  # The tests use -Werror but with python3.6 clang detects some unreachable code.
+  NIX_CFLAGS_COMPILE = stdenv.lib.optional stdenv.cc.isClang "-Wno-unreachable-code";
 
   checkPhase = ''
     py.test
   '';
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     maintainers = with maintainers; [ domenkozar ];
     homepage = https://cffi.readthedocs.org/;
     license = with licenses; [ mit ];


### PR DESCRIPTION
###### Motivation for this change

Should unblock nixpkgs-unstable, since nox depends on cffi.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
