### PR TITLE
gollum service: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -301,6 +301,7 @@
   ./services/misc/gitlab.nix
   ./services/misc/gitolite.nix
   ./services/misc/gogs.nix
+  ./services/misc/gollum.nix
   ./services/misc/gpsd.nix
   #./services/misc/ihaskell.nix
   ./services/misc/irkerd.nix

--- a/nixos/modules/services/misc/gollum.nix
+++ b/nixos/modules/services/misc/gollum.nix
@@ -1,0 +1,92 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.gollum;
+in
+
+{
+  options.services.gollum = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable the Gollum service.";
+    };
+
+    address = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      description = "IP address on which the web server will listen.";
+    };
+
+    port = mkOption {
+      type = types.int;
+      default = 4567;
+      description = "Port on which the web server will run.";
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Content of the configuration file";
+    };
+
+    branch = mkOption {
+      type = types.str;
+      default = "master";
+      example = "develop";
+      description = "Git branch to serve";
+    };
+
+    stateDir = mkOption {
+      type = types.path;
+      default = "/var/lib/gollum";
+      description = "Specifies the path of the repository directory. If it does not exist, Gollum will create it on startup.";
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    users.users.gollum = {
+      group = config.users.users.gollum.name;
+      description = "Gollum user";
+      createHome = false;
+    };
+
+    users.groups.gollum = { };
+
+    systemd.services.gollum = {
+      description = "Gollum wiki";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.git ];
+
+      preStart = let
+          userName = config.users.users.gollum.name;
+          groupName = config.users.groups.gollum.name;
+        in ''
+        # All of this is safe to be run on an existing repo
+        mkdir -p ${cfg.stateDir}
+        git init ${cfg.stateDir}
+        chmod 755 ${cfg.stateDir}
+        chown -R ${userName}:${groupName} ${cfg.stateDir}
+      '';
+
+      serviceConfig = {
+        User = config.users.extraUsers.gollum.name;
+        Group = config.users.extraGroups.gollum.name;
+        PermissionsStartOnly = true;
+        ExecStart = ''
+          ${pkgs.gollum}/bin/gollum \
+            --port ${toString cfg.port} \
+            --host ${cfg.address} \
+            --config ${builtins.toFile "gollum-config.rb" cfg.extraConfig} \
+            --ref ${cfg.branch} \
+            ${cfg.stateDir}
+        '';
+      };
+    };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

This introduces the already packaged `gollum` package as a nixos module. Example config:

```
  services.gollum = {
    enable = true;
    port = 12486;
  };
```

I mainly copied code from the `gitit` module (which I used before `gollum`). As `gitit` is commented out for quite some time, it may be that I used some outdated coding conventions. Also I'm not that familiar with `systemd` services. Feedback is welcome.

As I use `gollum` personally, I will continue to add features to it and will do maintenance. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

