### PR TITLE
roswell: init at version 17.9.10.82

### DIFF
--- a/pkgs/development/tools/misc/roswell/default.nix
+++ b/pkgs/development/tools/misc/roswell/default.nix
@@ -1,0 +1,62 @@
+{ autoconf
+, automake
+, bash
+, buildFHSUserEnv
+, curl
+, fetchFromGitHub
+, stdenv
+, writeTextFile
+}:
+
+let
+  product = "roswell";
+  version = "17.9.10.82";
+
+  roswell = stdenv.mkDerivation rec {
+    name = "${product}-${version}";
+
+    src = fetchFromGitHub {
+      owner = product;
+      repo = product;
+      rev = "v${version}";
+      sha256 = "1064lj5hy70j7nkf46h7pg5yvksgaj3k9aha7gp09hd826857q4m";
+    };
+
+    preConfigure = ''
+      sh bootstrap
+    '';
+
+    buildInputs = [ curl ];
+
+    nativeBuildInputs = [ autoconf automake ];
+
+    meta = with stdenv.lib; {
+      homepage = https://github.com/roswell/roswell;
+      description = "Lisp installer and launcher for major environments that just works";
+      license = licenses.mit;
+      platforms = platforms.all;
+    };
+  };
+
+  fhsEnv = buildFHSUserEnv {
+    name = "${product}-${version}-fhs-env";
+
+    targetPkgs = pkgs: (with pkgs; [ bash gnumake stdenv.cc ]);
+  };
+
+in
+  if !stdenv.isDarwin then
+    writeTextFile {
+      name = "${product}-${version}";
+
+      executable = true;
+
+      destination = "/bin/ros";
+
+      text = ''
+        #!${fhsEnv}/bin/${fhsEnv.name}
+        ${roswell}/bin/ros $@
+      '';
+    }
+  else
+    roswell

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7380,6 +7380,8 @@ with pkgs;
 
   rolespec = callPackage ../development/tools/misc/rolespec { };
 
+  roswell = callPackage ../development/tools/misc/roswell { };
+
   rr = callPackage ../development/tools/analysis/rr { };
 
   saleae-logic = callPackage ../development/tools/misc/saleae-logic { };


### PR DESCRIPTION
###### Motivation for this change

Roswell is a popular Common Lisp tool, it should be part of nixpkgs.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

