### PR TITLE
nixos/tinc: Fix tinc cli wrapper for tinc 1.0

### DIFF
--- a/nixos/modules/services/networking/tinc.nix
+++ b/nixos/modules/services/networking/tinc.nix
@@ -199,8 +199,10 @@ in
         buildInputs = [ pkgs.makeWrapper ];
         buildCommand = ''
           mkdir -p $out/bin
-          ${concatStringsSep "\n" (mapAttrsToList (network: data: ''
-              makeWrapper ${data.package}/bin/tinc "$out/bin/tinc.${network}" --add-flags "--pidfile=/run/tinc.${network}.pid"
+          ${concatStringsSep "\n" (mapAttrsToList (network: data:
+            optionalString (versionAtLeast data.package.version "1.1pre") ''
+              makeWrapper ${data.package}/bin/tinc "$out/bin/tinc.${network}" \
+                --add-flags "--pidfile=/run/tinc.${network}.pid"
             '') cfg.networks)}
         '';
       };


### PR DESCRIPTION
tinc 1.0 only has the `tincd` executable, while tinc 1.1 has `tinc`.

###### Motivation for this change
When using stable tinc instead of the (default) pre-release, the nixos/tinc module currently breaks on master as well as the 17.09 branch. I try to fix that with this patch. The issue was introduced in 00512470ec241949148b61e1c120fa76d685cf9a

@volth Could you take a look?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

