### PR TITLE
Marionette: disable for python 3

### DIFF
--- a/pkgs/development/python-modules/marionette-harness/default.nix
+++ b/pkgs/development/python-modules/marionette-harness/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy3k
 , mozprofile
 , mozversion
 , moztest
@@ -15,6 +16,7 @@ buildPythonPackage rec {
   pname = "marionette-harness";
   version = "4.1.0";
   name = "${pname}-${version}";
+  disabled = isPy3k;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/marionette-harness/marionette_driver.nix
+++ b/pkgs/development/python-modules/marionette-harness/marionette_driver.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy3k
 , mozversion
 , mozrunner
 }:
@@ -10,6 +11,7 @@ buildPythonPackage rec {
   pname = "marionette_driver";
   version = "2.3.0";
   name = "${pname}-${version}";
+  disabled = isPy3k;
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change

Pypi page only lists python 2.7 support and the mozilla dependencies are python 2.7 only.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

