### PR TITLE
spideroak: fix crash due to zlib version mismatch

### DIFF
--- a/pkgs/applications/networking/spideroak/default.nix
+++ b/pkgs/applications/networking/spideroak/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, makeWrapper, glib
 , fontconfig, patchelf, libXext, libX11
-, freetype, libXrender
+, freetype, libXrender, zlib
 }:
 
 let
@@ -17,7 +17,7 @@ let
     else throw "Spideroak client for: ${stdenv.system} not supported!";
 
   ldpath = stdenv.lib.makeLibraryPath [
-    glib fontconfig libXext libX11 freetype libXrender
+    glib fontconfig libXext libX11 freetype libXrender zlib
   ];
 
   version = "6.0.1";
@@ -42,6 +42,8 @@ in stdenv.mkDerivation {
     rm "$out/usr/bin/SpiderOakONE"
     rmdir $out/usr/bin || true
     mv $out/usr/share $out/
+
+    rm -f $out/opt/SpiderOakONE/lib/libz*
 
     patchelf --set-interpreter ${stdenv.glibc.out}/lib/${interpreter} \
       "$out/opt/SpiderOakONE/lib/SpiderOakONE"


### PR DESCRIPTION
Fixes #23960

###### Motivation for this change

spideroak crashes on startup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

