### PR TITLE
spideroak: 6.0.1 -> 6.1.9

### DIFF
--- a/pkgs/applications/networking/spideroak/default.nix
+++ b/pkgs/applications/networking/spideroak/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, makeWrapper, glib
-, fontconfig, patchelf, libXext, libX11
-, freetype, libXrender, zlib
+{ stdenv, fetchurl, makeWrapper, patchelf
+, fontconfig, freetype, glib, libICE, libSM
+, libX11, libXext, libXrender, zlib
 }:
 
 let
@@ -12,15 +12,16 @@ let
     else if stdenv.system == "i686-linux" then "ld-linux.so.2"
     else throw "Spideroak client for: ${stdenv.system} not supported!";
 
-  sha256 = if stdenv.system == "x86_64-linux" then "88fd785647def79ee36621fa2a8a5bea73c513de03103f068dd10bc25f3cf356"
-    else if stdenv.system == "i686-linux" then "8c23271291f40aa144bbf38ceb3cc2a05bed00759c87a65bd798cf8bb289d07a"
+  sha256 = if stdenv.system == "x86_64-linux" then "0k87rn4aj0v79rz9jvwspnwzmh031ih0y74ra88nc8kl8j6b6gjm"
+    else if stdenv.system == "i686-linux" then "1wbxfikj8f7rx26asswqrfp9vpk8w5941s21y1pnaff2gcac8m3z"
     else throw "Spideroak client for: ${stdenv.system} not supported!";
 
   ldpath = stdenv.lib.makeLibraryPath [
-    glib fontconfig libXext libX11 freetype libXrender zlib
+    fontconfig freetype glib libICE libSM
+    libX11 libXext libXrender zlib
   ];
 
-  version = "6.0.1";
+  version = "6.1.9";
 
 in stdenv.mkDerivation {
   name = "spideroak-${version}";


### PR DESCRIPTION
###### Motivation for this change

New upstream version available

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I will rebase this PR if #29481 is accepted and merged, since it includes the commit from that PR.