### PR TITLE
logilab_common: 0.63.2 -> 1.4.1

### DIFF
--- a/pkgs/development/python-modules/logilab/common.nix
+++ b/pkgs/development/python-modules/logilab/common.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, unittest2, six }:
+
+buildPythonPackage rec {
+  pname = "logilab-common";
+  version = "1.4.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "02in5555iak50gzn35bnnha9s85idmh0wwxaxz13v81z5krn077d";
+  };
+
+  propagatedBuildInputs = [ unittest2 six ];
+
+  # package supports 3.x but tests require egenix-mx-base which is python 2.x only
+  # and is not currently in nixos
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Python packages and modules used by Logilab ";
+    homepage = https://www.logilab.org/project/logilab-common;
+    license = licenses.lgpl;
+  };
+}

--- a/pkgs/development/python-modules/logilab/constraint.nix
+++ b/pkgs/development/python-modules/logilab/constraint.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, logilab_common, six }:
+
+buildPythonPackage rec {
+  pname = "logilab-constraint";
+  version = "0.6.0";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1n0xim4ij1n4yvyqqvyc0wllhjs22szglsd5av0j8k2qmck4njcg";
+  };
+
+  propagatedBuildInputs = [
+    logilab_common six
+  ];
+
+
+  meta = with stdenv.lib; {
+    description = "logilab-database provides some classes to make unified access to different";
+    homepage = "http://www.logilab.org/project/logilab-database";
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11464,25 +11464,7 @@ in {
     propagatedBuildInputs = with self; [ unittest2 six ];
   };
 
-  logilab-constraint = buildPythonPackage rec {
-    name = "logilab-constraint-${version}";
-    version = "0.6.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/l/logilab-constraint/${name}.tar.gz";
-      sha256 = "1n0xim4ij1n4yvyqqvyc0wllhjs22szglsd5av0j8k2qmck4njcg";
-    };
-
-    propagatedBuildInputs = with self; [
-      logilab_common six
-    ];
-
-    meta = with stdenv.lib; {
-      description = "logilab-database provides some classes to make unified access to different";
-      homepage = "http://www.logilab.org/project/logilab-database";
-    };
-  };
-
+  logilab-constraint = callPackage ../development/python-modules/logilab/constraint.nix {};
 
   lxml = buildPythonPackage ( rec {
     name = "lxml-3.8.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11453,16 +11453,7 @@ in {
     };
   };
 
-  logilab_common = buildPythonPackage rec {
-    name = "logilab-common-0.63.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/l/logilab-common/${name}.tar.gz";
-      sha256 = "1rr81zlmlgdma3s75i5c1l8q2m25v4ac41i9pniik4mhkc6a0fv0";
-    };
-
-    propagatedBuildInputs = with self; [ unittest2 six ];
-  };
+  logilab_common = callPackage ../development/python-modules/logilab/common.nix {};
 
   logilab-constraint = callPackage ../development/python-modules/logilab/constraint.nix {};
 


### PR DESCRIPTION
###### Motivation for this change
fixes logilab_constraint build.

related to #28643

Attempted to get tests working, but tests require a library not in nixos that hasn't been updated for python 3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

