### PR TITLE
qupzilla: init at 2.1.2

### DIFF
--- a/pkgs/applications/networking/browsers/qupzilla/default.nix
+++ b/pkgs/applications/networking/browsers/qupzilla/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, qt5 }:
+
+stdenv.mkDerivation rec {
+  name = "qupzilla";
+  version = "2.1.2";
+
+
+  src = fetchFromGitHub {
+    owner = "QupZilla";
+    repo = "qupzilla";
+    rev = "v${version}";
+    sha256 = "06s50hynnmb3k42a0a5jg6ql58wv19cskvnzmcmi46wcm676shgy";
+  };
+
+  patchPhase = ''
+    sed -i 's,d_prefix = .*,d_prefix = '$out',' src/defines.pri
+  '';
+
+  nativeBuildInputs = with qt5; [ qmake ];
+  buildInputs = with qt5; [ full qtwebengine qtx11extras ];
+
+  meta = with stdenv.lib; {
+    inherit (qt5.qtbase.meta) platforms;
+    homepage = https://github.com/QupZilla/qupzilla;
+    description = "Cross-platform Qt web browser";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ disassembler ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15963,6 +15963,8 @@ with pkgs;
     gst-plugins-bad = null;
   };
 
+  qupzilla = libsForQt5.callPackage ../applications/networking/browsers/qupzilla {};
+
   qutebrowser = libsForQt5.callPackage ../applications/networking/browsers/qutebrowser {
     inherit (python3Packages) buildPythonApplication pyqt5 jinja2 pygments pyyaml pypeg2 cssutils pyopengl;
     inherit (gst_all_1) gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav;


### PR DESCRIPTION
###### Motivation for this change
Adds qupzilla web browser.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

