### PR TITLE
go: fix tests and impurity

### DIFF
--- a/pkgs/development/compilers/go/1.9.nix
+++ b/pkgs/development/compilers/go/1.9.nix
@@ -118,6 +118,15 @@ stdenv.mkDerivation rec {
       ./ssl-cert-file-1.9.patch
       ./creds-test.patch
       ./remove-test-pie-1.9.patch
+
+      (fetchpatch {
+        url = "https://github.com/golang/go/commit/29415eb2b92e78481897c4161ba99f5b09fa6102.patch";
+        sha256 = "01jkm4b2dazzjnfla7rdd0w2clzplga3zza6ybpmkjkk3i4bp73d";
+      })
+      (fetchpatch {
+        url = "https://github.com/golang/go/commit/27e80f7c4d8001598367e15a1617fa524bd0fb11.patch";
+        sha256 = "1250nrc79jwcagkjqffn5srn78isykvjhvmqhwipwyqb99q85wcz";
+      })
     ];
 
   postPatch = optionalString stdenv.isDarwin ''
@@ -171,11 +180,11 @@ stdenv.mkDerivation rec {
   disallowedReferences = [ go_bootstrap ];
 
   meta = with stdenv.lib; {
-    branch = "1.8";
+    branch = "1.9";
     homepage = http://golang.org/;
     description = "The Go Programming language";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ cstrahan wkennington ];
+    maintainers = with maintainers; [ cstrahan orivej wkennington ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/tools/networking/envoy/default.nix
+++ b/pkgs/tools/networking/envoy/default.nix
@@ -299,5 +299,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     platforms = platforms.linux;
     maintainers = with maintainers; [ cstrahan ];
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

- The first patch fixes unreliability of Go 1.9 tests. (https://github.com/golang/go/issues/21559)
- The second patch fixes unexpected dependency of packages built with Go `plugin` package on the `go` derivation. (https://github.com/golang/go/issues/21825)

I expect the patches to ship with Go 1.9.1. They are necessary to switch `buildGoPackage` to 1.9 in #29173.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  (`envoy` fails to build before and after this change)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
