### PR TITLE
netdata: 1.5.0 -> 1.7.0

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, autoreconfHook, zlib, pkgconfig, libuuid }:
 
 stdenv.mkDerivation rec{
-  version = "1.5.0";
+  version = "1.7.0";
   name = "netdata-${version}";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "firehol";
     repo = "netdata";
-    sha256 = "1nsv0s11ai1kvig9xr4cz2f2lalvilpbfjpd8fdfqk9fak690zhz";
+    sha256 = "1fv01jnbgwbafsxavlji90zdqizn8m4nfg9ivc4sbi05j036bg6n";
   };
 
   buildInputs = [ autoreconfHook zlib pkgconfig libuuid ];

--- a/pkgs/tools/system/netdata/web_access.patch
+++ b/pkgs/tools/system/netdata/web_access.patch
@@ -1,7 +1,7 @@
 --- a/src/web_client.c.orig
 +++ b/src/web_client.c
-@@ -331,7 +331,7 @@
-         buffer_sprintf(w->response.data, "File '%s' does not exist, or is not accessible.", webfilename);
+@@ -302,7 +302,7 @@
+         buffer_strcat_htmlescape(w->response.data, webfilename);
          return 404;
      }
 -
@@ -9,8 +9,8 @@
      // check if the file is owned by expected user
      if(stat.st_uid != web_files_uid()) {
          error("%llu: File '%s' is owned by user %u (expected user %u). Access Denied.", w->id, webfilename, stat.st_uid, web_files_uid());
-@@ -345,7 +345,7 @@
-         buffer_sprintf(w->response.data, "Access to file '%s' is not permitted.", webfilename);
+@@ -320,7 +320,7 @@
+         buffer_strcat_htmlescape(w->response.data, webfilename);
          return 403;
      }
 -


### PR DESCRIPTION
Updates netdata. Lots of improvements:

https://github.com/firehol/netdata/releases/tag/v1.6.0
https://github.com/firehol/netdata/releases/tag/v1.7.0

I have updated the web_access.patch but not changed its functionality.
I'm not sure it's needed anymore though, when I compiled without the patch Netdata still seemed to work fine with the NixOS service module. It's not clear to me what's supposedly broken without this patch. If the previous authors could explain or verify that would be great.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).