### PR TITLE
falkon: init at 2.1.2.1

### DIFF
--- a/pkgs/applications/networking/browsers/falkon/default.nix
+++ b/pkgs/applications/networking/browsers/falkon/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, lib, fetchFromGitHub, cmake, extra-cmake-modules, pkgconfig, qmake
+, libpthreadstubs, libxcb, libXdmcp, qtsvg, qttools, qtwebengine, qtx11extras, kwallet, openssl }:
+
+stdenv.mkDerivation rec {
+  # Last qupvilla release is 2.1.2 so we add the .1 although it isn't actually a
+  # release but it is basically 2.1.2 with the falkon name
+  name = "falkon-${version}.1";
+  version = "2.1.2";
+
+  src = fetchFromGitHub {
+    owner  = "KDE";
+    repo   = "falkon";
+    rev    = "eecaf2e9d6b572a7f7d2e6dc324e3d79b61c31db";
+    sha256 = "01r5aw10jd0qz7xvad0cqzjbnsj7vwblh54wbq4x1m6xbkp6xcgy";
+  };
+
+  preConfigure = ''
+    export NONBLOCK_JS_DIALOGS=true
+    export KDE_INTEGRATION=true
+    export GNOME_INTEGRATION=false
+    export FALKON_PREFIX=$out
+  '';
+
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [
+    libpthreadstubs libxcb libXdmcp
+    kwallet
+    qtsvg qtwebengine qtx11extras
+  ];
+
+  nativeBuildInputs = [ cmake extra-cmake-modules pkgconfig qmake qttools ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "QtWebEngine based cross-platform web browser";
+    homepage    = https://community.kde.org/Incubator/Projects/Falkon;
+    license     = licenses.gpl3;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15962,6 +15962,8 @@ with pkgs;
     gst-plugins-bad = null;
   };
 
+  falkon = libsForQt5.callPackage ../applications/networking/browsers/falkon { };
+
   qutebrowser = libsForQt5.callPackage ../applications/networking/browsers/qutebrowser {
     inherit (python3Packages) buildPythonApplication pyqt5 jinja2 pygments pyyaml pypeg2 cssutils pyopengl;
     inherit (gst_all_1) gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav;


### PR DESCRIPTION
###### Motivation for this change

Falkon is the new name for ```qupzilla```.

The version here is QupZila 2.1.2 + a few more commits from upstream that turn it into Falkon.

Please note that there is an issue with qtwebengine and nouveau causing it to crash when using nouveau:
https://bugs.launchpad.net/oxide/+bug/1499419 but it works with intel graphics.

This is not falkon/qupzilla related!

Further to #29488, @disassembler 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

