### PR TITLE
abcm2ps: init at 8.13.15

### DIFF
--- a/pkgs/tools/audio/abcm2ps/default.nix
+++ b/pkgs/tools/audio/abcm2ps/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, pkgconfig, which, freetype, pango }:
+
+stdenv.mkDerivation rec {
+  name = "abcm2ps-${version}";
+  version = "8.13.15";
+
+  src = fetchFromGitHub {
+    owner = "leesavide";
+    repo = "abcm2ps";
+    rev = "v${version}";
+    sha256 = "04j1s4ycd8siidj7xn7s0vwm5sj0qrhqr5qzpila2g8kjc4ldxml";
+  };
+
+  patchPhase = ''
+    chmod +x configure
+  '';
+
+  configureFlags = [
+    "--INSTALL=install"
+  ];
+
+  buildInputs = [ which pkgconfig freetype pango ];
+
+  meta = with stdenv.lib; {
+    homepage = http://moinejf.free.fr/;
+    license = licenses.gpl3;
+    description = "abcm2ps is a command line program which converts ABC to music sheet in PostScript or SVG format";
+    maintainers = [ maintainers.dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -362,6 +362,8 @@ with pkgs;
 
   a2ps = callPackage ../tools/text/a2ps { };
 
+  abcm2ps = callPackage ../tools/audio/abcm2ps { };
+
   abcmidi = callPackage ../tools/audio/abcmidi { };
 
   abduco = callPackage ../tools/misc/abduco { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

