### PR TITLE
Fix the automatic override for networking.nameservers when services.bind is enabled.

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -194,7 +194,7 @@ in
       {
         # Don't silently ignore the users nameserver configuration.
         assertion =  hasLocalResolver -> cfg.nameservers == null;
-        message = "Can't specify nameservers when Bind or Dnsmasq local resolver is enabled";
+        message = "Can't specify networking.nameservers when Bind or Dnsmasq localResolver is enabled";
       }
     ];
 

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -190,6 +190,14 @@ in
 
   config = {
 
+    assertions = [
+      {
+        # Don't silently ignore the users nameserver configuration.
+        assertion =  hasLocalResolver -> cfg.nameservers == null;
+        message = "Can't specify nameservers when Bind or Dnsmasq local resolver is enabled";
+      }
+    ];
+
     environment.etc =
       { # /etc/services: TCP/UDP port assignments.
         "services".source = pkgs.iana-etc + "/etc/services";

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -192,14 +192,6 @@ in
 
   config = {
 
-    assertions = [
-      {
-        # Setting nameservers is mutually exclusive with running bind or dnsmasq as local resolver."
-        assertion =  hasLocalResolver -> cfg.nameservers == [];
-        message = "Can't specify networking.nameservers when bind.resolveLocalQueries or dnsmasq.resolveLocalQueries is set to true";
-      }
-    ];
-
     environment.etc =
       { # /etc/services: TCP/UDP port assignments.
         "services".source = pkgs.iana-etc + "/etc/services";

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -9,7 +9,7 @@ let
   cfg = config.networking;
   dnsmasqResolve = config.services.dnsmasq.enable &&
                    config.services.dnsmasq.resolveLocalQueries;
-  hasLocalResolver = config.services.bind.enable || dnsmasqResolve;
+  hasLocalResolver = cfg.nameservers == [] && ( config.services.bind.enable || dnsmasqResolve );
 
   resolvconfOptions = cfg.resolvconfOptions
     ++ optional cfg.dnsSingleRequest "single-request"
@@ -189,14 +189,6 @@ in
   };
 
   config = {
-
-    assertions = [
-      {
-        # Don't silently ignore the users nameserver configuration.
-        assertion =  hasLocalResolver -> cfg.nameservers == null;
-        message = "Can't specify networking.nameservers when Bind or Dnsmasq localResolver is enabled";
-      }
-    ];
 
     environment.etc =
       { # /etc/services: TCP/UDP port assignments.

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -151,6 +151,15 @@ in
         ";
       };
 
+      resolveLocalQueries = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether dnsmasq should resolve local queries (i.e. add 127.0.0.1 to
+          /etc/resolv.conf, overriding networking.nameserver).
+        '';
+      };
+
     };
 
   };

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -155,7 +155,7 @@ in
         type = types.bool;
         default = true;
         description = ''
-          Whether dnsmasq should resolve local queries (i.e. add 127.0.0.1 to
+          Whether bind should resolve local queries (i.e. add 127.0.0.1 to
           /etc/resolv.conf, overriding networking.nameserver).
         '';
       };

--- a/nixos/modules/services/networking/dnsmasq.nix
+++ b/nixos/modules/services/networking/dnsmasq.nix
@@ -42,7 +42,7 @@ in
         default = true;
         description = ''
           Whether dnsmasq should resolve local queries (i.e. add 127.0.0.1 to
-          /etc/resolv.conf).
+          /etc/resolv.conf overriding networking.nameservers).
         '';
       };
 

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -102,7 +102,7 @@ let
               ''
                 # Set the static DNS configuration, if given.
                 ${pkgs.openresolv}/sbin/resolvconf -m 1 -a static <<EOF
-                ${optionalString (cfg.nameservers != [] && cfg.domain != null) ''
+                ${optionalString (cfg.domain != null) ''
                   domain ${cfg.domain}
                 ''}
                 ${optionalString (cfg.search != []) ("search " + concatStringsSep " " cfg.search)}


### PR DESCRIPTION
###### Motivation for this change

The Nixos-networking code assumes that when `services.bind` is enabled it means it runs in local resolver mode. This is not always true as I run Bind in master mode to host a domain and I point `networking.nameservers` to an external name server.

What happens is that my system cannot run Bind in master mode and resolve names at a remote name server.

###### Things done

This PR changes the Nixos networking configurator to check for a new attribute `resolveLocalQueries` to services.bind. It defaults to `true` to keep the existing behaviour of setting 127.0.0.1 as nameserver in /etc/resolv.conf

When that flag is set to false, it doesn't set the resolver and the standard behaviour applies. I.e.: If `networking.nameservers` is set, choose that, otherwise let resolveconf handle DHCP. etc.

See for more discussion my previous PR: https://github.com/NixOS/nixpkgs/pull/29205

Closes #29202


- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux

