### PR TITLE
travis-ci: don’t merge prs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ matrix:
           before_script:
               - sudo mount -o remount,exec,size=2G,mode=755 /run/user
           env:
-            - TARGETS='nox pr'
+            - TARGETS=nox
         - os: osx
           osx_image: xcode7.3
           env:
-            - TARGETS='nox pr'
+            - TARGETS=nox
 env:
     global:
         - GITHUB_TOKEN=5edaaf1017f691ed34e7f80878f8f5fbd071603f

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,22 +13,22 @@ script:
   - ./maintainers/scripts/travis-nox-review-pr.sh $TARGETS
 
 matrix:
+    fast_finish: true
+    allow_failures:
+        - env: TARGETS=nox
     include:
         - os: linux
           sudo: required
-          env:
-            - TARGETS='nixpkgs-verify nixpkgs-manual nixpkgs-tarball nixpkgs-unstable nixos-options'
+          env: TARGETS='nixpkgs-verify nixpkgs-manual nixpkgs-tarball nixpkgs-unstable nixos-options'
         - os: linux
           sudo: required
           dist: trusty
           before_script:
               - sudo mount -o remount,exec,size=2G,mode=755 /run/user
-          env:
-            - TARGETS=nox
+          env: TARGETS=nox
         - os: osx
           osx_image: xcode7.3
-          env:
-            - TARGETS=nox
+          env: TARGETS=nox
 
 git:
     depth: 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ matrix:
           osx_image: xcode7.3
           env:
             - TARGETS=nox
+
+git:
+    depth: 2
+
 env:
     global:
         - GITHUB_TOKEN=5edaaf1017f691ed34e7f80878f8f5fbd071603f

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,28 +5,30 @@ sudo: true
 # ..as per:  https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
 # Nixpkgs PR tests OOM with 4G: https://github.com/NixOS/nixpkgs/issues/24200
 
+script:
+  - if [ "$TRAVIS_PULL_REQUEST" != false ]; then
+      git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/head;
+      git checkout -qf FETCH_HEAD;
+    fi
+  - ./maintainers/scripts/travis-nox-review-pr.sh $TARGETS
+
 matrix:
     include:
         - os: linux
           sudo: required
-          script:
-              - ./maintainers/scripts/travis-nox-review-pr.sh nixpkgs-verify nixpkgs-manual nixpkgs-tarball nixpkgs-unstable
-              - ./maintainers/scripts/travis-nox-review-pr.sh nixos-options nixos-manual
           env:
-            - BUILD_TYPE="Test Nixpkgs evaluation & NixOS manual build"
+            - TARGETS='nixpkgs-verify nixpkgs-manual nixpkgs-tarball nixpkgs-unstable nixos-options'
         - os: linux
           sudo: required
           dist: trusty
           before_script:
               - sudo mount -o remount,exec,size=2G,mode=755 /run/user
-          script: ./maintainers/scripts/travis-nox-review-pr.sh nox pr
           env:
-            - BUILD_TYPE="Build affected packages (Linux)"
+            - TARGETS='nox pr'
         - os: osx
           osx_image: xcode7.3
-          script: ./maintainers/scripts/travis-nox-review-pr.sh nox pr
           env:
-            - BUILD_TYPE="Build affected packages (macOS)"
+            - TARGETS='nox pr'
 env:
     global:
         - GITHUB_TOKEN=5edaaf1017f691ed34e7f80878f8f5fbd071603f

--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -68,7 +68,8 @@ while test -n "$1"; do
                     token="--token $GITHUB_TOKEN"
                 fi
 
-                nix-shell --packages nox --run "nox-review pr --slug $TRAVIS_REPO_SLUG $token $TRAVIS_PULL_REQUEST"
+                nix-shell --packages nox \
+                          --run "nox-review pr --no-merge --slug $TRAVIS_REPO_SLUG $token $TRAVIS_PULL_REQUEST"
             fi
             ;;
 

--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -53,7 +53,7 @@ while test -n "$1"; do
         nox)
             # build nox (+ a basic nix-shell env) silently so it's not in the
             # log
-            nix-shell -p nox stdenv --command true
+            nix-build '<nixpkgs>' -A nox > /dev/null
 
             args=""
             if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then

--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -11,49 +11,51 @@ while test -n "$1"; do
         nixpkgs-verify)
             echo "=== Verifying that nixpkgs evaluates..."
 
-            nix-env --file $TRAVIS_BUILD_DIR --query --available --json > /dev/null
+            nix-env -f. -qa --json > /dev/null
             ;;
 
         nixos-options)
             echo "=== Checking NixOS options"
 
-            nix-build $TRAVIS_BUILD_DIR/nixos/release.nix --attr options --show-trace
+            nix-build nixos/release.nix -A options --show-trace -Q
             ;;
 
         nixos-manual)
             echo "=== Checking NixOS manuals"
 
-            nix-build $TRAVIS_BUILD_DIR/nixos/release.nix --attr manual --show-trace
+            nix-build nixos/release.nix -A manual --show-trace -Q
             ;;
 
         nixpkgs-manual)
             echo "=== Checking nixpkgs manuals"
 
-            nix-build $TRAVIS_BUILD_DIR/pkgs/top-level/release.nix --attr manual --show-trace
+            nix-build pkgs/top-level/release.nix -A manual --show-trace -Q
             ;;
 
         nixpkgs-tarball)
             echo "=== Checking nixpkgs tarball creation"
 
-            nix-build $TRAVIS_BUILD_DIR/pkgs/top-level/release.nix --attr tarball --show-trace
+            nix-build pkgs/top-level/release.nix -A tarball --show-trace -Q
             ;;
 
         nixpkgs-unstable)
             echo "=== Checking nixpkgs unstable job"
 
-            nix-instantiate $TRAVIS_BUILD_DIR/pkgs/top-level/release.nix --attr unstable --show-trace
+            nix-instantiate pkgs/top-level/release.nix -A unstable \
+                                                       --show-trace -Q
             ;;
 
         nixpkgs-lint)
             echo "=== Checking nixpkgs lint"
 
-            nix-shell --packages nixpkgs-lint --run "nixpkgs-lint -f $TRAVIS_BUILD_DIR"
+            nix-shell -p nixpkgs-lint \
+                      --run "nixpkgs-lint -f $TRAVIS_BUILD_DIR"
             ;;
 
         nox)
             # build nox (+ a basic nix-shell env) silently so it's not in the
             # log
-            nix-build '<nixpkgs>' -A nox > /dev/null
+            nix-build '<nixpkgs>' -A nox -Q > /dev/null
 
             args=""
             if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then

--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -55,7 +55,7 @@ while test -n "$1"; do
         nox)
             # build nox (+ a basic nix-shell env) silently so it's not in the
             # log
-            nix-build '<nixpkgs>' -A nox -Q > /dev/null
+            nix-build '<nixpkgs>' -A nox -Q > /dev/null 2>&1
 
             args=""
             if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then

--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -51,26 +51,25 @@ while test -n "$1"; do
             ;;
 
         nox)
-            echo "=== Fetching Nox from binary cache"
-
-            # build nox (+ a basic nix-shell env) silently so it's not in the log
+            # build nox (+ a basic nix-shell env) silently so it's not in the
+            # log
             nix-shell -p nox stdenv --command true
-            ;;
 
-        pr)
+            args=""
             if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-                echo "=== No pull request found"
+                echo "=== Build $TRAVIS_BRANCH branch"
+                args="wip --against $TRAVIS_BRANCH^"
             else
                 echo "=== Building pull request #$TRAVIS_PULL_REQUEST"
 
-                token=""
+                args="pr --no-merge --slug $TRAVIS_REPO_SLUG"
                 if [ -n "$GITHUB_TOKEN" ]; then
-                    token="--token $GITHUB_TOKEN"
+                    args="$args --token $GITHUB_TOKEN"
                 fi
-
-                nix-shell --packages nox \
-                          --run "nox-review pr --no-merge --slug $TRAVIS_REPO_SLUG $token $TRAVIS_PULL_REQUEST"
+                args="$args $TRAVIS_PULL_REQUEST"
             fi
+
+            nix-shell -p nox --run "nox-review $args"
             ;;
 
         *)


### PR DESCRIPTION
Travis has a frustrating habit of wanting to merge PRs into master. This is
fine when Nixpkgs is working 100% but that means that when master is failing
the PR is also failing (even though the PR author has literally no control over
master). This is a solution that I think will work out better for everybody.

First, ```nox-review pr``` has a new option called ```--no-merge```  that will mean that
nox-review won’t try to merge PRs into master. Note that Nox was updated in
94400c0. To prevent Travis from breaking, please verify that this is in
nixpkgs-unstable. You can verify with,

```sh
rev=$(git ls-remote https://github.com/nixos/nixpkgs-channels refs/heads/nixpkgs-unstable | awk '{print $1}')
if git merge-base --is-ancestor 94400c0 $rev; then
  echo ok to merge
else
  echo do not merge
fi
```

Second, the Travis CI script will now check out the HEAD commit of the PR (which
the author can actually change) instead of the MERGE commit.

Together, these changes should mean that PR authors are only responsible for
their own HEADs. This may solve some potential problems but also means PR
authors should start carrying about what is actually in HEAD. Basically, you
should branching off of a working version of Nixpkgs. This should probably be a
commit of something that has gone through Hydra testing like ```nixpkgs-17.09-darwin``` or
```nixos-17.09```. At the very least you should branch off of nixpkgs-unstable unless
you absolutely need something that has been touched since then! (in that case
just branch off of the latest working commit). Basic idea, do NOT blindly branch
off of nixpkgs/master!

This is a preliminary note I’ve made that should probably be included somewhere.
I’ll probably make a mailing list request. Note to PR authors:

> For Travis CI to succeed, you need to pay attention to what Nixpkgs commit you
branched off of. Because Nixpkgs is huge, Travis CI needs the binary cache to be
available, so you need to make sure your base commit has entered the binary
cache. It is recommended that you use nixpkgs-unstable or nixos-unstable as a
base.

The following commands will set this up for you,

```shell
git remote add https://github.com/nixos/nixpkgs-channels nixpkgs-channels
git fetch nixpkgs-channels nixpkgs-unstable
```

and to create a new branch,
```shell
git checkout -b YOUR_BRANCH_NAME nixpkgs-channels/nixpkgs-unstable
```

or if you have already create a branch,
```shell
git rebase nixpkgs-channels/nixpkgs-unstable
```

> Make sure you still merge into nixpkgs master! If there are merge conflicts with
master, you will still need to resolve them.

Testing for Travis is always difficult so I really can't know how well this works until this PR is opened.