### PR TITLE
awesome: specify version

### DIFF
--- a/pkgs/applications/window-managers/awesome/default.nix
+++ b/pkgs/applications/window-managers/awesome/default.nix
@@ -39,6 +39,7 @@ with luaPackages; stdenv.mkDerivation rec {
                   xcbutilxrm ];
 
   #cmakeFlags = "-DGENERATE_MANPAGES=ON";
+  cmakeFlags = "-DOVERRIDE_VERSION=${version}";
 
   LD_LIBRARY_PATH = "${stdenv.lib.makeLibraryPath [ cairo pango gobjectIntrospection ]}";
   GI_TYPELIB_PATH = "${pango.out}/lib/girepository-1.0";


### PR DESCRIPTION
By default, awesome will use "devel" as a version name
(or `git describe`). This has led to awesome always
showing "devel" for its version.

Some extensions depend on version information to figure
out what features they can use.

This change overrides the version for the build from the
derivations' `version` attribute.

###### Motivation for this change

See above. The first occurrence of an extension that depended on
awesome's version detection: https://github.com/deficient/calendar/pull/3

###### Things done

- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @ndowens 