### PR TITLE
esptool: 1.3 -> 2.1

### DIFF
--- a/pkgs/tools/misc/esptool/default.nix
+++ b/pkgs/tools/misc/esptool/default.nix
@@ -1,19 +1,18 @@
-{ stdenv, fetchFromGitHub, python3 }:
+{ stdenv, fetchFromGitHub, python3, openssl }:
 
 python3.pkgs.buildPythonApplication rec {
   name = "esptool-${version}";
-  version = "1.3";
+  version = "2.1";
 
   src = fetchFromGitHub {
     owner = "espressif";
     repo = "esptool";
     rev = "v${version}";
-    sha256 = "0112fybkz4259gyvhcs18wa6938jp6w7clk66kpd0d1dg70lz1h6";
+    sha256 = "137p0kcscly95qpjzgx1yxm8k2wf5y9v3srvlhp2ajniirgv8ijv";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [ pyserial ];
-
-  doCheck = false; # FIXME: requires packaging some new deps
+  buildInputs = with python3.pkgs; [ flake8 ];
+  propagatedBuildInputs = with python3.pkgs; [ pyserial pyaes ecdsa openssl ];
 
   meta = with stdenv.lib; {
     description = "ESP8266 and ESP32 serial bootloader utility";


### PR DESCRIPTION
###### Motivation for this change
New version available which adds support for the ESP32.
Now, the tests using `flake8` are also enabled.
I even tested the upload of some binaries to a real-world ESP8266.

If you want, I can also refactor the derivation to use `fetchPypi` and call it in `python-packages.nix` instead of `all-packages.nix`. Just let me know if that's desired.

@dezgeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

