### PR TITLE
audit: Remove openldap dependency

### DIFF
--- a/pkgs/os-specific/linux/audit/default.nix
+++ b/pkgs/os-specific/linux/audit/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchurl, openldap
-, enablePython ? false, python ? null
+{
+  stdenv, fetchurl,
+  enablePython ? false, python ? null,
 }:
 
 assert enablePython -> python != null;
@@ -12,24 +13,18 @@ stdenv.mkDerivation rec {
     sha256 = "1vvqw5xgirap0jdmajw7l3pq563aycvy3hlqvj3k2cac8i4jbqlq";
   };
 
-  outputs = [ "bin" "dev" "out" "man" "plugins" ];
+  outputs = [ "bin" "dev" "out" "man" ];
 
-  buildInputs = [ openldap ]
-            ++ stdenv.lib.optional enablePython python;
+  buildInputs = stdenv.lib.optional enablePython python;
 
-  configureFlags = ''
-    ${if enablePython then "--with-python" else "--without-python"}
-  '';
+  configureFlags = [
+    # z/OS plugin is not useful on Linux,
+    # and pulls in an extra openldap dependency otherwise
+    "--disable-zos-remote"
+    (if enablePython then "--with-python" else "--without-python")
+  ];
 
   enableParallelBuilding = true;
-
-  postInstall =
-    ''
-      # Move the z/OS plugin to a separate output to prevent an
-      # openldap runtime dependency in audit.bin.
-      mkdir -p $plugins/bin
-      mv $bin/sbin/audispd-zos-remote $plugins/bin/
-    '';
 
   meta = {
     description = "Audit Library";


### PR DESCRIPTION
###### Motivation for this change

The openldap dependency is only used for the audisp z/OS plugin.
This is not useful on Linux, so always disable this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).