### PR TITLE
radicale_infcloud: init

### DIFF
--- a/pkgs/development/python-modules/radicale_infcloud/default.nix
+++ b/pkgs/development/python-modules/radicale_infcloud/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, buildPythonPackage }:
+
+buildPythonPackage rec {
+  pname = "radicale_infcloud";
+  name = "${pname}-${version}";
+  version = "2017-07-27";
+
+  src = fetchFromGitHub {
+    owner = "Unrud";
+    repo = "RadicaleInfCloud";
+    rev = "972757bf4c6be8b966ee063e3741ced29ba8169f";
+    sha256 = "1c9ql9nv8kwi791akwzd19dcqzd916i7yxzbnrismzw4f5bhgzsk";
+  };
+
+  doCheck = false; # Tries to import radicale, circular dependency
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/Unrud/RadicaleInfCloud/;
+    description = "Integrate InfCloud into Radicale's web interface";
+    license = with licenses; [ agpl3 gpl3 ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ aneeshusa ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18346,6 +18346,8 @@ in {
     };
   };
 
+  radicale_infcloud = callPackage ../development/python-modules/radicale_infcloud {};
+
   recaptcha_client = buildPythonPackage rec {
     name = "recaptcha-client-1.0.6";
 


### PR DESCRIPTION
###### Motivation for this change

Package https://github.com/Unrud/RadicaleInfCloud for use with Radicale.

Possibly of interest to @Infinisil as the other radicale maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).