### PR TITLE
tests: add initrd-network-ssh test

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -258,6 +258,7 @@ in rec {
   tests.hibernate = callTest tests/hibernate.nix {};
   tests.hound = callTest tests/hound.nix {};
   tests.i3wm = callTest tests/i3wm.nix {};
+  tests.initrd-network-ssh = callTest tests/initrd-network-ssh.nix {};
   tests.installer = callSubTests tests/installer.nix {};
   tests.influxdb = callTest tests/influxdb.nix {};
   tests.ipv6 = callTest tests/ipv6.nix {};

--- a/nixos/tests/initrd-network-ssh.nix
+++ b/nixos/tests/initrd-network-ssh.nix
@@ -1,0 +1,74 @@
+import ./make-test.nix ({ pkgs, lib, ... }:
+
+let
+  keys = pkgs.runCommand "gen-keys" {
+    outputs = [ "out" "dbPub" "dbPriv" "sshPub" "sshPriv" ];
+    buildInputs = with pkgs; [ dropbear openssh ];
+  }
+  ''
+    touch $out
+    dropbearkey -t rsa -f $dbPriv -s 4096 | sed -n 2p > $dbPub
+    ssh-keygen -q -t rsa -b 4096 -N "" -f client
+    mv client $sshPriv
+    mv client.pub $sshPub
+  '';
+
+in {
+  name = "initrd-network-ssh";
+  meta = with lib.maintainers; {
+    maintainers = [ willibutz ];
+  };
+
+  nodes = with lib; rec {
+    server =
+      { config, pkgs, ... }:
+      {
+        boot.kernelParams = [
+          "ip=${
+            (head config.networking.interfaces.eth1.ip4).address
+          }:::255.255.255.0::eth1:none"
+        ];
+        boot.initrd.network = {
+          enable = true;
+          ssh = {
+            enable = true;
+            authorizedKeys = [ "${readFile keys.sshPub}" ];
+            port = 22;
+            hostRSAKey = keys.dbPriv;
+          };
+        };
+        boot.initrd.preLVMCommands = ''
+          while true; do
+            if [ -f fnord ]; then
+              poweroff
+            fi
+            sleep 1
+          done
+        '';
+      };
+
+    client =
+      { config, pkgs, ... }:
+      {
+        environment.etc.knownHosts = {
+          text = concatStrings [
+            "server,"
+            "${toString (head (splitString " " (
+              toString (elemAt (splitString "\n" config.networking.extraHosts) 2)
+            )))} "
+            "${readFile keys.dbPub}"
+          ];
+        };
+      };
+  };
+
+  testScript = ''
+    startAll;
+    $client->waitForUnit("network.target");
+    $client->copyFileFromHost("${keys.sshPriv}","/etc/sshKey");
+    $client->succeed("chmod 0600 /etc/sshKey");
+    $client->waitUntilSucceeds("ping -c 1 server");
+    $client->succeed("ssh -i /etc/sshKey -o UserKnownHostsFile=/etc/knownHosts server 'touch /fnord'");
+    $client->shutdown;
+  '';
+})


### PR DESCRIPTION
starts two VMs:
- one with dropbear listening from initrd,
  waiting for a file
- another connecting via ssh, creating the file

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

