### PR TITLE
libuv: 1.14.1 and nodejs 8.5.0

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -2,14 +2,14 @@
 , ApplicationServices, CoreServices }:
 
 stdenv.mkDerivation rec {
-  version = "1.13.1";
+  version = "1.14.1";
   name = "libuv-${version}";
 
   src = fetchFromGitHub {
     owner = "libuv";
     repo = "libuv";
     rev = "v${version}";
-    sha256 = "0k348kgdphha1w4cw78zngq3gqcrhcn0az7k0k4w2bgmdf4ip8z8";
+    sha256 = "1121qvnvpcabq1bl2k41jq8r2hn2x123csiaf7s9vrq66bbxgfdx";
   };
 
   postPatch = let

--- a/pkgs/development/web/nodejs/v8.nix
+++ b/pkgs/development/web/nodejs/v8.nix
@@ -10,11 +10,11 @@ let
   baseName = if enableNpm then "nodejs" else "nodejs-slim";
 in
   stdenv.mkDerivation (nodejs // rec {
-    version = "8.4.0";
+    version = "8.5.0";
     name = "${baseName}-${version}";
     src = fetchurl {
       url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
-      sha256 = "0qgkccsldpdrjxwwq78z94hsqz6qivmi4n2738iiginw06hs4njx";
+      sha256 = "0g2wyy9zdjzm9c0vbjn8bn49s1b2c7r2iwdfc4dpx7h4wpcfbkg1";
     };
 
     patches = stdenv.lib.optionals stdenv.isDarwin [ ./no-xcode-v7.patch ];


### PR DESCRIPTION
###### Motivation for this change

Nodejs 8.5.0 requires the latest version of libuv 1.14.1.

[libuv changelog](https://github.com/libuv/libuv/blob/eaf25ae3eb8fe567b8be15614996b112dbf5c11b/ChangeLog)
[nodejs release notes](https://nodejs.org/en/blog/release/v8.5.0/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

