### PR TITLE
vcstool: init at 0.1.31

### DIFF
--- a/pkgs/development/tools/vcstool/default.nix
+++ b/pkgs/development/tools/vcstool/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, python35Packages }:
+
+  python35Packages.buildPythonApplication rec {
+    name = "vcstool";
+    version = "0.1.31";
+    #no tests
+    doCheck = false;
+
+    propagatedBuildInputs = with python35Packages; [ pyyaml ];
+    src = fetchurl {
+        url = "mirror://pypi/v/vcstool/${name}-${version}.tar.gz";
+        sha256 = "0n2zkvy2km9ky9lljf1mq5nqyqi5qqzfy2a6sgkjg2grvsk7abxc";
+    };
+
+    meta = with stdenv.lib; {
+        description = "Provides a command line tool to invoke vcs commands on multiple repositories";
+        homepage = "https://github.com/dirk-thomas/vcstool";
+        license = licenses.bsd3;
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4744,6 +4744,8 @@ with pkgs;
     inherit (perlPackages) ShellCommand TestMost;
   };
 
+  vcstool = callPackage ../development/tools/vcstool { };
+
   verilator = callPackage ../applications/science/electronics/verilator {};
 
   verilog = callPackage ../applications/science/electronics/verilog {};


### PR DESCRIPTION
Adds vcstool application. Initial work to get ROS2 packages on
Nix

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

