### PR TITLE
vcstool: init at 0.1.31

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -541,6 +541,7 @@
   siddharthist = "Langston Barrett <langston.barrett@gmail.com>";
   sigma = "Yann Hodique <yann.hodique@gmail.com>";
   simonvandel = "Simon Vandel Sillesen <simon.vandel@gmail.com>";
+  sivteck = "Sivaram Balakrishnan <sivaram1992@gmail.com>";
   sjagoe = "Simon Jagoe <simon@simonjagoe.com>";
   sjmackenzie = "Stewart Mackenzie <setori88@gmail.com>";
   sjourdois = "Stéphane ‘kwisatz’ Jourdois <sjourdois@gmail.com>";

--- a/pkgs/development/tools/vcstool/default.nix
+++ b/pkgs/development/tools/vcstool/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, python3Packages
+, git, bazaar, subversion }:
+
+with python3Packages;
+
+buildPythonApplication rec {
+  name = "${pname}-${version}";
+  pname = "vcstool";
+  version = "0.1.31";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0n2zkvy2km9ky9lljf1mq5nqyqi5qqzfy2a6sgkjg2grvsk7abxc";
+  };
+
+  propagatedBuildInputs = [ pyyaml ];
+
+  makeWrapperArgs = ["--prefix" "PATH" ":" "${stdenv.lib.makeBinPath [ git bazaar subversion ]}"];
+
+  doCheck = false; # requires network
+
+  meta = with stdenv.lib; {
+    description = "Provides a command line tool to invoke vcs commands on multiple repositories";
+    homepage = https://github.com/dirk-thomas/vcstool;
+    license = licenses.asl20;
+    maintainer = with maintainers; [ sivteck ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4744,6 +4744,8 @@ with pkgs;
     inherit (perlPackages) ShellCommand TestMost;
   };
 
+  vcstool = callPackage ../development/tools/vcstool { };
+
   verilator = callPackage ../applications/science/electronics/verilator {};
 
   verilog = callPackage ../applications/science/electronics/verilog {};


### PR DESCRIPTION
Adds vcstool application. Initial work to get ROS2 packages on
Nix

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

