### PR TITLE
gocode: 20170530 -> 20170903

### DIFF
--- a/pkgs/development/tools/gocode/default.nix
+++ b/pkgs/development/tools/gocode/default.nix
@@ -2,8 +2,8 @@
 
 buildGoPackage rec {
   name = "gocode-${version}";
-  version = "20170530-${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "f1eef9a6ba005abb145d7b58fdd225e83a3c6a05";
+  version = "20170903-${stdenv.lib.strings.substring 0 7 rev}";
+  rev = "c7fddb39ecbc9ebd1ebe7d2a3af473ed0fffffa1";
 
   goPackagePath = "github.com/nsf/gocode";
 
@@ -15,6 +15,6 @@ buildGoPackage rec {
   src = fetchgit {
     inherit rev;
     url = "https://github.com/nsf/gocode";
-    sha256 = "1hkr46ikrprx203i2yr6xds1bzxggblh7bg026m2cda6dxgpnsgw";
+    sha256 = "0qx8pq38faig41xkl1a4hrgp3ziyjyn6g53vn5wj7cdgm5kk67nb";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Updated the software to the latest version to get around this issue: https://github.com/nsf/gocode/issues/466

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

