### PR TITLE
xmlsec: enable deprecated headers required by lasso

### DIFF
--- a/pkgs/development/libraries/xmlsec/default.nix
+++ b/pkgs/development/libraries/xmlsec/default.nix
@@ -16,6 +16,10 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   doCheck = true;
 
+  # enable deprecated soap headers required by lasso
+  # https://dev.entrouvert.org/issues/18771
+  configureFlags = [ "--enable-soap" ];
+
   # otherwise libxmlsec1-gnutls.so won't find libgcrypt.so, after #909
   NIX_LDFLAGS = [ "-lgcrypt" ];
 


### PR DESCRIPTION
###### Motivation for this change

+ lasso broke due to recently deprecated soap headers in the latest xmlsec
+ this PR reenables it back
+  upstream bug filed https://dev.entrouvert.org/issues/18771

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
