### PR TITLE
nixpkgs: add stdenv tests to unstable and darwin-tested

### DIFF
--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -38,13 +38,31 @@ let
           meta.description = "Release-critical builds for the Nixpkgs darwin channel";
           constituents =
             [ jobs.tarball
-              jobs.stdenv.x86_64-darwin
-              jobs.ghc.x86_64-darwin
               jobs.cabal2nix.x86_64-darwin
-              jobs.ruby.x86_64-darwin
-              jobs.python.x86_64-darwin
-              jobs.rustc.x86_64-darwin
+              jobs.emacs.x86_64-darwin
+              jobs.ghc.x86_64-darwin
+              jobs.git.x86_64-darwin
               jobs.go.x86_64-darwin
+              jobs.mysql.x86_64-darwin
+              jobs.nix-repl.x86_64-darwin
+              jobs.nix.x86_64-darwin
+              jobs.nox.x86_64-darwin
+              jobs.openssh.x86_64-darwin
+              jobs.openssl.x86_64-darwin
+              jobs.postgresql.x86_64-darwin
+              jobs.python.x86_64-darwin
+              jobs.python3.x86_64-darwin
+              jobs.ruby.x86_64-darwin
+              jobs.rustc.x86_64-darwin
+              jobs.stdenv.x86_64-darwin
+              jobs.vim.x86_64-darwin
+
+              jobs.tests.cc-wrapper.x86_64-darwin
+              jobs.tests.cc-wrapper-clang.x86_64-darwin
+              jobs.tests.cc-wrapper-libcxx.x86_64-darwin
+              jobs.tests.cc-wrapper-clang-39.x86_64-darwin
+              jobs.tests.cc-wrapper-libcxx-39.x86_64-darwin
+              jobs.tests.stdenv-inputs.x86_64-darwin
               jobs.tests.macOSSierraShared.x86_64-darwin
             ];
         };
@@ -76,6 +94,20 @@ let
               jobs.git.x86_64-darwin
               jobs.mysql.x86_64-darwin
               jobs.vim.x86_64-darwin
+
+              jobs.tests.cc-wrapper.x86_64-linux
+              jobs.tests.cc-wrapper.x86_64-darwin
+              jobs.tests.cc-wrapper-clang.x86_64-linux
+              jobs.tests.cc-wrapper-clang.x86_64-darwin
+              jobs.tests.cc-wrapper-libcxx.x86_64-linux
+              jobs.tests.cc-wrapper-libcxx.x86_64-darwin
+              jobs.tests.cc-wrapper-clang-39.x86_64-linux
+              jobs.tests.cc-wrapper-clang-39.x86_64-darwin
+              jobs.tests.cc-wrapper-libcxx-39.x86_64-linux
+              jobs.tests.cc-wrapper-libcxx-39.x86_64-darwin
+              jobs.tests.stdenv-inputs.x86_64-linux
+              jobs.tests.stdenv-inputs.x86_64-darwin
+              jobs.tests.macOSSierraShared.x86_64-darwin
             ] ++ lib.collect lib.isDerivation jobs.stdenvBootstrapTools;
         };
 


### PR DESCRIPTION
###### Motivation for this change

Block nixpkgs channels when the stdenv tests fail.
Also added some more packages to the darwin-tested job, since it's pretty minimal right now.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

