### PR TITLE
ants: bump version and fix sandboxed build

### DIFF
--- a/pkgs/applications/science/biology/ants/default.nix
+++ b/pkgs/applications/science/biology/ants/default.nix
@@ -2,23 +2,26 @@
 
 stdenv.mkDerivation rec {
   _name    = "ANTs";
-  _version = "2.1.0";
+  _version = "2.2.0";
   name  = "${_name}-${_version}";
 
   src = fetchFromGitHub {
-    owner  = "stnava";
+    owner  = "ANTsX";
     repo   = "ANTs";
-    rev    = "4e02aa76621698e3513330dd9e863e22917e14b7";
-    sha256 = "0gyys1lf69bl3569cskxc8r5llwcr0dsyzvlby5skhfpsyw0dh8r";
+    rev    = "37ad4e20be3a5ecd26c2e4e41b49e778a0246c3d";
+    sha256 = "1hrdwv3m9xh3yf7l0rm2ggxc2xzckfb8srs88g485ibfszx7i03q";
   };
 
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [ itk vtk ];
 
-  cmakeFlags = [ "-DANTS_SUPERBUILD=FALSE" "-DUSE_VTK=TRUE" ];
+  cmakeFlags = [ "-DANTS_SUPERBUILD=FALSE" "-DUSE_VTK=TRUE"
+                 # as cmake otherwise tries to download test data:
+                 "-DBUILD_TESTING=FALSE" ];
+
+  enableParallelBuilding = true;
 
   checkPhase = "ctest";
-  doCheck = false;
 
   postInstall = ''
     for file in $out/bin/*; do
@@ -27,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/stnava/ANTs;
+    homepage = https://github.com/ANTxS/ANTs;
     description = "Advanced normalization toolkit for medical image registration and other processing";
     maintainers = with maintainers; [ bcdarwin ];
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

- fix sandboxed build failure;
- bump version

for 17.09 release (#28643)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

