### PR TITLE
llvm: init 5.0

### DIFF
--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -1,0 +1,97 @@
+{ stdenv, fetch, cmake, libxml2, libedit, llvm, version, release_version, clang-tools-extra_src, python
+, fixDarwinDylibNames
+, enableManpages ? false
+}:
+
+let
+  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
+  self = stdenv.mkDerivation {
+    name = "clang-${version}";
+
+    unpackPhase = ''
+      unpackFile ${fetch "cfe" "0w09s8fn3lkn6i04nj0cisgp821r815fk5b5fjn97xrd371277q1"}
+      mv cfe-${version}* clang
+      sourceRoot=$PWD/clang
+      unpackFile ${clang-tools-extra_src}
+      mv clang-tools-extra-* $sourceRoot/tools/extra
+    '';
+
+    nativeBuildInputs = [ cmake python ]
+      ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
+
+    buildInputs = [ libedit libxml2 llvm ]
+      ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
+
+    cmakeFlags = [
+      "-DCMAKE_CXX_FLAGS=-std=c++11"
+    ] ++ stdenv.lib.optionals enableManpages [
+      "-DCLANG_INCLUDE_DOCS=ON"
+      "-DLLVM_ENABLE_SPHINX=ON"
+      "-DSPHINX_OUTPUT_MAN=ON"
+      "-DSPHINX_OUTPUT_HTML=OFF"
+      "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
+    ]
+    # Maybe with compiler-rt this won't be needed?
+    ++ stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}"
+    ++ stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include";
+
+    patches = [ ./purity.patch ];
+
+    postBuild = stdenv.lib.optionalString enableManpages ''
+      cmake --build . --target docs-clang-man
+    '';
+
+    postPatch = ''
+      sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' \
+             -e 's/Args.hasArg(options::OPT_nostdlibinc)/true/' \
+             lib/Driver/ToolChains/*.cpp
+
+      # Patch for standalone doc building
+      sed -i '1s,^,find_package(Sphinx REQUIRED)\n,' docs/CMakeLists.txt
+    '';
+
+    outputs = [ "out" "python" ]
+      ++ stdenv.lib.optional enableManpages "man";
+
+    # Clang expects to find LLVMgold in its own prefix
+    # Clang expects to find sanitizer libraries in its own prefix
+    postInstall = ''
+      ln -sv ${llvm}/lib/LLVMgold.so $out/lib
+      ln -sv ${llvm}/lib/clang/${release_version}/lib $out/lib/clang/${release_version}/
+      ln -sv $out/bin/clang $out/bin/cpp
+
+      mkdir -p $python/bin $python/share/clang/
+      mv $out/bin/{git-clang-format,scan-view} $python/bin
+      if [ -e $out/bin/set-xcode-analyzer ]; then
+        mv $out/bin/set-xcode-analyzer $python/bin
+      fi
+      mv $out/share/clang/*.py $python/share/clang
+
+      rm $out/bin/c-index-test
+    ''
+    + stdenv.lib.optionalString enableManpages ''
+      # Manually install clang manpage
+      cp docs/man/*.1 $out/share/man/man1/
+
+      # Move it and other man pages to 'man' output
+      moveToOutput "share/man" "$man"
+    '';
+
+    enableParallelBuilding = true;
+
+    passthru = {
+      lib = self; # compatibility with gcc, so that `stdenv.cc.cc.lib` works on both
+      isClang = true;
+      inherit llvm;
+    } // stdenv.lib.optionalAttrs stdenv.isLinux {
+      inherit gcc;
+    };
+
+    meta = {
+      description = "A c, c++, objective-c, and objective-c++ frontend for the llvm compiler";
+      homepage    = http://llvm.org/;
+      license     = stdenv.lib.licenses.ncsa;
+      platforms   = stdenv.lib.platforms.all;
+    };
+  };
+in self

--- a/pkgs/development/compilers/llvm/5/clang/purity.patch
+++ b/pkgs/development/compilers/llvm/5/clang/purity.patch
@@ -1,0 +1,30 @@
+From 4add81bba40dcec62c4ea4481be8e35ac53e89d8 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Thu, 18 May 2017 11:56:12 -0500
+Subject: [PATCH] "purity" patch for 5.0
+
+---
+ lib/Driver/ToolChains/Gnu.cpp | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/lib/Driver/ToolChains/Gnu.cpp b/lib/Driver/ToolChains/Gnu.cpp
+index fe3c0191bb..c6a482bece 100644
+--- a/lib/Driver/ToolChains/Gnu.cpp
++++ b/lib/Driver/ToolChains/Gnu.cpp
+@@ -494,13 +494,6 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+   if (!Args.hasArg(options::OPT_static)) {
+     if (Args.hasArg(options::OPT_rdynamic))
+       CmdArgs.push_back("-export-dynamic");
+-
+-    if (!Args.hasArg(options::OPT_shared)) {
+-      const std::string Loader =
+-          D.DyldPrefix + ToolChain.getDynamicLinker(Args);
+-      CmdArgs.push_back("-dynamic-linker");
+-      CmdArgs.push_back(Args.MakeArgString(Loader));
+-    }
+   }
+ 
+   CmdArgs.push_back("-o");
+-- 
+2.11.0
+

--- a/pkgs/development/compilers/llvm/5/compiler-rt-codesign.patch
+++ b/pkgs/development/compilers/llvm/5/compiler-rt-codesign.patch
@@ -1,0 +1,155 @@
+From 3dec5f3475a26aeb4678627795c4b67c6b7b4785 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Tue, 19 Sep 2017 13:13:06 -0500
+Subject: [PATCH] remove codesign use on Apple, disable ios sim testing that
+ needs it
+
+---
+ cmake/Modules/AddCompilerRT.cmake |  8 ------
+ test/asan/CMakeLists.txt          | 52 ---------------------------------------
+ test/tsan/CMakeLists.txt          | 47 -----------------------------------
+ 3 files changed, 107 deletions(-)
+
+diff --git a/cmake/Modules/AddCompilerRT.cmake b/cmake/Modules/AddCompilerRT.cmake
+index bc5fb9ff7..b64eb4246 100644
+--- a/cmake/Modules/AddCompilerRT.cmake
++++ b/cmake/Modules/AddCompilerRT.cmake
+@@ -210,14 +210,6 @@ function(add_compiler_rt_runtime name type)
+         set_target_properties(${libname} PROPERTIES IMPORT_PREFIX "")
+         set_target_properties(${libname} PROPERTIES IMPORT_SUFFIX ".lib")
+       endif()
+-      if(APPLE)
+-        # Ad-hoc sign the dylibs
+-        add_custom_command(TARGET ${libname}
+-          POST_BUILD  
+-          COMMAND codesign --sign - $<TARGET_FILE:${libname}>
+-          WORKING_DIRECTORY ${COMPILER_RT_LIBRARY_OUTPUT_DIR}
+-        )
+-      endif()
+     endif()
+     install(TARGETS ${libname}
+       ARCHIVE DESTINATION ${COMPILER_RT_LIBRARY_INSTALL_DIR}
+diff --git a/test/asan/CMakeLists.txt b/test/asan/CMakeLists.txt
+index 8bfc15b5c..f23d0f71a 100644
+--- a/test/asan/CMakeLists.txt
++++ b/test/asan/CMakeLists.txt
+@@ -83,58 +83,6 @@ foreach(arch ${ASAN_TEST_ARCH})
+   endif()
+ endforeach()
+ 
+-# iOS and iOS simulator test suites
+-# These are not added into "check-all", in order to run these tests, use
+-# "check-asan-iossim-x86_64" and similar. They also require that an extra env
+-# variable to select which iOS device or simulator to use, e.g.:
+-# SANITIZER_IOSSIM_TEST_DEVICE_IDENTIFIER="iPhone 6"
+-if(APPLE)
+-  set(EXCLUDE_FROM_ALL ON)
+-
+-  set(ASAN_TEST_TARGET_CC ${COMPILER_RT_TEST_COMPILER})
+-  set(ASAN_TEST_IOS "1")
+-  pythonize_bool(ASAN_TEST_IOS)
+-  set(ASAN_TEST_DYNAMIC True)
+-
+-  foreach(arch ${DARWIN_iossim_ARCHS})
+-    set(ASAN_TEST_IOSSIM "1")
+-    pythonize_bool(ASAN_TEST_IOSSIM)
+-    set(ASAN_TEST_TARGET_ARCH ${arch})
+-    set(ASAN_TEST_TARGET_CFLAGS "-arch ${arch} -isysroot ${DARWIN_iossim_SYSROOT} ${COMPILER_RT_TEST_COMPILER_CFLAGS}")
+-    set(ASAN_TEST_CONFIG_SUFFIX "-${arch}-iossim")
+-    get_bits_for_arch(${arch} ASAN_TEST_BITS)
+-    string(TOUPPER ${arch} ARCH_UPPER_CASE)
+-    set(CONFIG_NAME "IOSSim${ARCH_UPPER_CASE}Config")
+-    configure_lit_site_cfg(
+-      ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
+-      ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg
+-      )
+-    add_lit_testsuite(check-asan-iossim-${arch} "AddressSanitizer iOS Simulator ${arch} tests"
+-      ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/
+-      DEPENDS ${ASAN_TEST_DEPS})
+-  endforeach()
+-
+-  foreach (arch ${DARWIN_ios_ARCHS})
+-    set(ASAN_TEST_IOSSIM "0")
+-    pythonize_bool(ASAN_TEST_IOSSIM)
+-    set(ASAN_TEST_TARGET_ARCH ${arch})
+-    set(ASAN_TEST_TARGET_CFLAGS "-arch ${arch} -isysroot ${DARWIN_ios_SYSROOT} ${COMPILER_RT_TEST_COMPILER_CFLAGS}")
+-    set(ASAN_TEST_CONFIG_SUFFIX "-${arch}-ios")
+-    get_bits_for_arch(${arch} ASAN_TEST_BITS)
+-    string(TOUPPER ${arch} ARCH_UPPER_CASE)
+-    set(CONFIG_NAME "IOS${ARCH_UPPER_CASE}Config")
+-    configure_lit_site_cfg(
+-      ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
+-      ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg
+-      )
+-    add_lit_testsuite(check-asan-ios-${arch} "AddressSanitizer iOS ${arch} tests"
+-      ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/
+-      DEPENDS ${ASAN_TEST_DEPS})
+-  endforeach()
+-
+-  set(EXCLUDE_FROM_ALL OFF)
+-endif()
+-
+ # Add unit tests.
+ if(COMPILER_RT_INCLUDE_TESTS)
+   set(ASAN_TEST_DYNAMIC False)
+diff --git a/test/tsan/CMakeLists.txt b/test/tsan/CMakeLists.txt
+index a68908612..cde0accb5 100644
+--- a/test/tsan/CMakeLists.txt
++++ b/test/tsan/CMakeLists.txt
+@@ -42,53 +42,6 @@ foreach(arch ${TSAN_TEST_ARCH})
+   list(APPEND TSAN_TESTSUITES ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME})
+ endforeach()
+ 
+-# iOS and iOS simulator test suites
+-# These are not added into "check-all", in order to run these tests, use
+-# "check-tsan-iossim-x86_64" and similar. They also require an extra environment
+-# variable to select which iOS device or simulator to use, e.g.:
+-# SANITIZER_IOSSIM_TEST_DEVICE_IDENTIFIER="iPhone 6"
+-if(APPLE)
+-  set(EXCLUDE_FROM_ALL ON)
+-
+-  set(TSAN_TEST_TARGET_CC ${COMPILER_RT_TEST_COMPILER})
+-  set(TSAN_TEST_IOS "1")
+-  pythonize_bool(TSAN_TEST_IOS)
+-
+-  set(arch "x86_64")
+-  set(TSAN_TEST_IOSSIM "1")
+-  pythonize_bool(TSAN_TEST_IOSSIM)
+-  set(TSAN_TEST_TARGET_ARCH ${arch})
+-  set(TSAN_TEST_TARGET_CFLAGS "-arch ${arch} -isysroot ${DARWIN_iossim_SYSROOT} ${COMPILER_RT_TEST_COMPILER_CFLAGS}")
+-  set(TSAN_TEST_CONFIG_SUFFIX "-${arch}-iossim")
+-  string(TOUPPER ${arch} ARCH_UPPER_CASE)
+-  set(CONFIG_NAME "IOSSim${ARCH_UPPER_CASE}Config")
+-  configure_lit_site_cfg(
+-    ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
+-    ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg
+-    )
+-  add_lit_testsuite(check-tsan-iossim-${arch} "ThreadSanitizer iOS Simulator ${arch} tests"
+-    ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/
+-    DEPENDS ${TSAN_TEST_DEPS})
+-
+-  set(arch "arm64")
+-  set(TSAN_TEST_IOSSIM "0")
+-  pythonize_bool(TSAN_TEST_IOSSIM)
+-  set(TSAN_TEST_TARGET_ARCH ${arch})
+-  set(TSAN_TEST_TARGET_CFLAGS "-arch ${arch} -isysroot ${DARWIN_ios_SYSROOT} ${COMPILER_RT_TEST_COMPILER_CFLAGS}")
+-  set(TSAN_TEST_CONFIG_SUFFIX "-${arch}-ios")
+-  string(TOUPPER ${arch} ARCH_UPPER_CASE)
+-  set(CONFIG_NAME "IOS${ARCH_UPPER_CASE}Config")
+-  configure_lit_site_cfg(
+-    ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
+-    ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg
+-    )
+-  add_lit_testsuite(check-tsan-ios-${arch} "ThreadSanitizer iOS Simulator ${arch} tests"
+-    ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/
+-    DEPENDS ${TSAN_TEST_DEPS})
+-
+-  set(EXCLUDE_FROM_ALL OFF)
+-endif()
+-
+ if(COMPILER_RT_INCLUDE_TESTS)
+   configure_lit_site_cfg(
+     ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.site.cfg.in
+-- 
+2.14.1
+

--- a/pkgs/development/compilers/llvm/5/default.nix
+++ b/pkgs/development/compilers/llvm/5/default.nix
@@ -1,0 +1,81 @@
+{ lowPrio, newScope, stdenv, targetPlatform, cmake, libstdcxxHook
+, libxml2, python2, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun
+, darwin
+}:
+
+let
+  callPackage = newScope (self // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
+
+  release_version = "5.0.0";
+  version = release_version; # differentiating these is important for rc's
+
+  fetch = name: sha256: fetchurl {
+    url = "http://llvm.org/releases/${release_version}/${name}-${version}.src.tar.xz";
+    inherit sha256;
+  };
+
+  compiler-rt_src = fetch "compiler-rt" "1cy0y389zxn7mk8vffqvfirk9bbcbc8ziwc1nf1a8d118rk55bfm";
+  clang-tools-extra_src = fetch "clang-tools-extra" "1ikkv6k8cfgpjqlm24iqz52i5nyafzsc4dyikzzyb9n4b6wpil47";
+
+  # Add man output without introducing extra dependencies.
+  overrideManOutput = drv:
+    let drv-manpages = drv.override { enableManpages = true; }; in
+    drv // { man = drv-manpages.man; /*outputs = drv.outputs ++ ["man"];*/ };
+
+  llvm = callPackage ./llvm.nix {
+    inherit compiler-rt_src stdenv;
+  };
+
+  clang-unwrapped = callPackage ./clang {
+    inherit clang-tools-extra_src stdenv;
+  };
+
+  self = {
+    llvm = overrideManOutput llvm;
+    clang-unwrapped = overrideManOutput clang-unwrapped;
+
+    llvm-manpages = lowPrio self.llvm.man;
+    clang-manpages = lowPrio self.clang-unwrapped.man;
+
+    clang = if stdenv.cc.isGNU then self.libstdcxxClang else self.libcxxClang;
+
+    libstdcxxClang = ccWrapperFun {
+      cc = self.clang-unwrapped;
+      /* FIXME is this right? */
+      inherit (stdenv.cc) libc nativeTools nativeLibc;
+      extraPackages = [ libstdcxxHook ];
+    };
+
+    libcxxClang = ccWrapperFun {
+      cc = self.clang-unwrapped;
+      /* FIXME is this right? */
+      inherit (stdenv.cc) libc nativeTools nativeLibc;
+      extraPackages = [ self.libcxx self.libcxxabi ];
+    };
+
+    stdenv = stdenv.override (drv: {
+      allowedRequisites = null;
+      cc = self.clang;
+      # Don't include the libc++ and libc++abi from the original stdenv.
+      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
+    });
+
+    libcxxStdenv = stdenv.override (drv: {
+      allowedRequisites = null;
+      cc = self.libcxxClang;
+      # Don't include the libc++ and libc++abi from the original stdenv.
+      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
+    });
+
+    lld = callPackage ./lld.nix {};
+
+    lldb = callPackage ./lldb.nix {};
+
+    libcxx = callPackage ./libc++ {};
+
+    libcxxabi = callPackage ./libc++abi.nix {};
+
+    openmp = callPackage ./openmp.nix {};
+  };
+
+in self

--- a/pkgs/development/compilers/llvm/5/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/5/libc++/default.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, fetch, cmake, llvm, libcxxabi, fixDarwinDylibNames, version }:
+
+stdenv.mkDerivation rec {
+  name = "libc++-${version}";
+
+  src = fetch "libcxx" "1cf953msb0vwgjjrapw06950dnsdb2ps305czkn0vvr1k8g9irga";
+
+  postUnpack = ''
+    unpackFile ${libcxxabi.src}
+    export LIBCXXABI_INCLUDE_DIR="$PWD/$(ls -d libcxxabi-${version}*)/include"
+  '';
+
+  prePatch = ''
+    substituteInPlace lib/CMakeLists.txt --replace "/usr/lib/libc++" "\''${LIBCXX_LIBCXXABI_LIB_PATH}/libc++"
+  '';
+
+  preConfigure = ''
+    # Get headers from the cxxabi source so we can see private headers not installed by the cxxabi package
+    cmakeFlagsArray=($cmakeFlagsArray -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$LIBCXXABI_INCLUDE_DIR")
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
+
+  cmakeFlags = [
+    "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
+    "-DLIBCXX_LIBCPPABI_VERSION=2"
+    "-DLIBCXX_CXX_ABI=libcxxabi"
+  ];
+
+  enableParallelBuilding = true;
+
+  linkCxxAbi = stdenv.isLinux;
+
+  setupHook = ./setup-hook.sh;
+
+  meta = {
+    homepage = http://libcxx.llvm.org/;
+    description = "A new implementation of the C++ standard library, targeting C++11";
+    license = with stdenv.lib.licenses; [ ncsa mit ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/llvm/5/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/5/libc++/setup-hook.sh
@@ -1,0 +1,3 @@
+linkCxxAbi="@linkCxxAbi@"
+export NIX_CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/5/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/5/libc++abi.nix
@@ -1,0 +1,47 @@
+{ stdenv, cmake, fetch, libcxx, libunwind, llvm, version }:
+
+stdenv.mkDerivation {
+  name = "libc++abi-${version}";
+
+  src = fetch "libcxxabi" "04c9dfmrr8diih73x0wq99dk9xb99mg0bvsnbhx5q912xg3ihs8p";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;
+
+  postUnpack = ''
+    unpackFile ${libcxx.src}
+    unpackFile ${llvm.src}
+    export cmakeFlags="-DLLVM_PATH=$PWD/$(ls -d llvm-*) -DLIBCXXABI_LIBCXX_PATH=$PWD/$(ls -d libcxx-*)"
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    export TRIPLE=x86_64-apple-darwin
+  '';
+
+  installPhase = if stdenv.isDarwin
+    then ''
+      for file in lib/*.dylib; do
+        # this should be done in CMake, but having trouble figuring out
+        # the magic combination of necessary CMake variables
+        # if you fancy a try, take a look at
+        # http://www.cmake.org/Wiki/CMake_RPATH_handling
+        install_name_tool -id $out/$file $file
+      done
+      make install
+      install -d 755 $out/include
+      install -m 644 ../include/*.h $out/include
+    ''
+    else ''
+      install -d -m 755 $out/include $out/lib
+      install -m 644 lib/libc++abi.so.1.0 $out/lib
+      install -m 644 ../include/cxxabi.h $out/include
+      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
+      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
+    '';
+
+  meta = {
+    homepage = http://libcxxabi.llvm.org/;
+    description = "A new implementation of low level support for a standard C++ library";
+    license = with stdenv.lib.licenses; [ ncsa mit ];
+    maintainers = with stdenv.lib.maintainers; [ vlstill ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/llvm/5/lld.nix
+++ b/pkgs/development/compilers/llvm/5/lld.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, fetch
+, cmake
+, zlib
+, llvm
+, python
+, version
+}:
+
+stdenv.mkDerivation {
+  name = "lld-${version}";
+
+  src = fetch "lld" "15rqsmfw0jlsri7hszbs8l0j7v1030cy9xvvdb245397llh7k6ir";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ llvm ];
+
+  outputs = [ "out" "dev" ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    moveToOutput include "$dev"
+    moveToOutput lib "$dev"
+  '';
+
+  meta = {
+    description = "The LLVM Linker";
+    homepage    = http://lld.llvm.org/;
+    license     = stdenv.lib.licenses.ncsa;
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/compilers/llvm/5/lldb.nix
+++ b/pkgs/development/compilers/llvm/5/lldb.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, fetch
+, cmake
+, zlib
+, ncurses
+, swig
+, which
+, libedit
+, libxml2
+, llvm
+, clang-unwrapped
+, python
+, version
+, darwin
+}:
+
+stdenv.mkDerivation {
+  name = "lldb-${version}";
+
+  src = fetch "lldb" "0zcbav39srf6awv9znvzr7nqdrj704i8da3wdgc8362y20rcm860";
+
+  postPatch = ''
+    # Fix up various paths that assume llvm and clang are installed in the same place
+    sed -i 's,".*ClangConfig.cmake","${clang-unwrapped}/lib/cmake/clang/ClangConfig.cmake",' \
+      cmake/modules/LLDBStandalone.cmake
+    sed -i 's,".*tools/clang/include","${clang-unwrapped}/include",' \
+      cmake/modules/LLDBStandalone.cmake
+    sed -i 's,"$.LLVM_LIBRARY_DIR.",${llvm}/lib ${clang-unwrapped}/lib,' \
+      cmake/modules/LLDBStandalone.cmake
+  '';
+
+  nativeBuildInputs = [ cmake python which swig ];
+  buildInputs = [ ncurses zlib libedit libxml2 llvm ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.libobjc darwin.apple_sdk.libs.xpc darwin.apple_sdk.frameworks.Foundation darwin.bootstrap_cmds darwin.apple_sdk.frameworks.Carbon darwin.apple_sdk.frameworks.Cocoa ];
+
+  CXXFLAGS = "-fno-rtti";
+  hardeningDisable = [ "format" ];
+
+  cmakeFlags = [
+    "-DLLDB_CODESIGN_IDENTITY=" # codesigning makes nondeterministic
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A next-generation high-performance debugger";
+    homepage    = http://llvm.org/;
+    license     = licenses.ncsa;
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/development/compilers/llvm/5/llvm-outputs.patch
+++ b/pkgs/development/compilers/llvm/5/llvm-outputs.patch
@@ -1,0 +1,26 @@
+diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.cpp
+index 94d426b..37f7794 100644
+--- a/tools/llvm-config/llvm-config.cpp
++++ b/tools/llvm-config/llvm-config.cpp
+@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+     ActiveIncludeOption = "-I" + ActiveIncludeDir;
+   }
+ 
++  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  if (!IsInDevelopmentTree) {
++    bool WantShared = true;
++    for (int i = 1; i < argc; ++i) {
++      StringRef Arg = argv[i];
++      if (Arg == "--link-shared")
++        WantShared = true;
++      else if (Arg == "--link-static")
++        WantShared = false; // the last one wins
++    }
++
++    if (WantShared)
++      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++  }
++
+   /// We only use `shared library` mode in cases where the static library form
+   /// of the components provided are not available; note however that this is
+   /// skipped if we're run from within the build dir. However, once installed,

--- a/pkgs/development/compilers/llvm/5/llvm.nix
+++ b/pkgs/development/compilers/llvm/5/llvm.nix
@@ -1,0 +1,153 @@
+{ stdenv
+, fetch
+, fetchpatch
+, perl
+, groff
+, cmake
+, python
+, libffi
+, binutils
+, libxml2
+, valgrind
+, ncurses
+, version
+, release_version
+, zlib
+, compiler-rt_src
+, libcxxabi
+, debugVersion ? false
+, enableManpages ? false
+, enableSharedLibraries ? true
+, darwin
+}:
+
+let
+  src = fetch "llvm" "1nin64vz21hyng6jr19knxipvggaqlkl2l9jpd5czbc4c2pcnpg3";
+
+  # Used when creating a version-suffixed symlink of libLLVM.dylib
+  shortVersion = with stdenv.lib;
+    concatStringsSep "." (take 2 (splitString "." release_version));
+in stdenv.mkDerivation rec {
+  name = "llvm-${version}";
+
+  unpackPhase = ''
+    unpackFile ${src}
+    mv llvm-${version}* llvm
+    sourceRoot=$PWD/llvm
+    unpackFile ${compiler-rt_src}
+    mv compiler-rt-* $sourceRoot/projects/compiler-rt
+  '';
+
+  outputs = [ "out" ]
+    ++ stdenv.lib.optional enableSharedLibraries "lib"
+    ++ stdenv.lib.optional enableManpages "man";
+
+  nativeBuildInputs = [ perl groff cmake python ]
+    ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
+
+  buildInputs = [ libxml2 libffi ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ libcxxabi ];
+
+  propagatedBuildInputs = [ ncurses zlib ];
+
+  # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
+  # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra
+  # can build this. If we didn't do it, basically the entire nixpkgs on Darwin would have an unfree dependency and we'd
+  # get no binary cache for the entire platform. If you really find yourself wanting the TSAN, make this controllable by
+  # a flag and turn the flag off during the stdenv build.
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace ./projects/compiler-rt/cmake/config-ix.cmake \
+      --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
+  ''
+  # Patch llvm-config to return correct library path based on --link-{shared,static}.
+  + stdenv.lib.optionalString (enableSharedLibraries) ''
+    substitute '${./llvm-outputs.patch}' ./llvm-outputs.patch --subst-var lib
+    patch -p1 < ./llvm-outputs.patch
+  '' + ''
+    # FileSystem permissions tests fail with various special bits
+    substituteInPlace unittests/Support/CMakeLists.txt \
+      --replace "Path.cpp" ""
+    rm unittests/Support/Path.cpp
+
+    # Revert compiler-rt commit that makes codesign mandatory
+    patch -p1 -i ${./compiler-rt-codesign.patch} -d projects/compiler-rt
+  '';
+
+  # hacky fix: created binaries need to be run before installation
+  preBuild = ''
+    mkdir -p $out/
+    ln -sv $PWD/lib $out
+  '';
+
+  cmakeFlags = with stdenv; [
+    "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"
+    "-DLLVM_INSTALL_UTILS=ON"  # Needed by rustc
+    "-DLLVM_BUILD_TESTS=ON"
+    "-DLLVM_ENABLE_FFI=ON"
+    "-DLLVM_ENABLE_RTTI=ON"
+    "-DCOMPILER_RT_INCLUDE_TESTS=OFF" # FIXME: requires clang source code
+  ]
+  ++ stdenv.lib.optional enableSharedLibraries
+    "-DLLVM_LINK_LLVM_DYLIB=ON"
+  ++ stdenv.lib.optionals enableManpages [
+    "-DLLVM_BUILD_DOCS=ON"
+    "-DLLVM_ENABLE_SPHINX=ON"
+    "-DSPHINX_OUTPUT_MAN=ON"
+    "-DSPHINX_OUTPUT_HTML=OFF"
+    "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
+  ]
+  ++ stdenv.lib.optional (!isDarwin)
+    "-DLLVM_BINUTILS_INCDIR=${stdenv.lib.getDev binutils}/include"
+  ++ stdenv.lib.optionals (isDarwin) [
+    "-DLLVM_ENABLE_LIBCXX=ON"
+    "-DCAN_TARGET_i386=false"
+  ];
+
+  postBuild = ''
+    rm -fR $out
+
+    paxmark m bin/{lli,llvm-rtdyld}
+    paxmark m unittests/ExecutionEngine/MCJIT/MCJITTests
+    paxmark m unittests/ExecutionEngine/Orc/OrcJITTests
+    paxmark m unittests/Support/SupportTests
+    paxmark m bin/lli-child-target
+  '';
+
+  preCheck = ''
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
+  '';
+
+  postInstall = stdenv.lib.optionalString enableManpages ''
+    moveToOutput "share/man" "$man"
+  ''
+  + stdenv.lib.optionalString enableSharedLibraries ''
+    moveToOutput "lib/libLLVM-*" "$lib"
+    moveToOutput "lib/libLLVM${stdenv.hostPlatform.extensions.sharedLibrary}" "$lib"
+    substituteInPlace "$out/lib/cmake/llvm/LLVMExports-${if debugVersion then "debug" else "release"}.cmake" \
+      --replace "\''${_IMPORT_PREFIX}/lib/libLLVM-" "$lib/lib/libLLVM-"
+  ''
+  + stdenv.lib.optionalString (stdenv.isDarwin && enableSharedLibraries) ''
+    substituteInPlace "$out/lib/cmake/llvm/LLVMExports-${if debugVersion then "debug" else "release"}.cmake" \
+      --replace "\''${_IMPORT_PREFIX}/lib/libLLVM.dylib" "$lib/lib/libLLVM.dylib"
+    install_name_tool -id $lib/lib/libLLVM.dylib $lib/lib/libLLVM.dylib
+    install_name_tool -change @rpath/libLLVM.dylib $lib/lib/libLLVM.dylib $out/bin/llvm-config
+    ln -s $lib/lib/libLLVM.dylib $lib/lib/libLLVM-${shortVersion}.dylib
+    ln -s $lib/lib/libLLVM.dylib $lib/lib/libLLVM-${release_version}.dylib
+  '';
+
+  doCheck = stdenv.isLinux && (!stdenv.isi686);
+
+  checkTarget = "check-all";
+
+  enableParallelBuilding = true;
+
+  passthru.src = src;
+
+  meta = {
+    description = "Collection of modular and reusable compiler and toolchain technologies";
+    homepage    = http://llvm.org/;
+    license     = stdenv.lib.licenses.ncsa;
+    maintainers = with stdenv.lib.maintainers; [ lovek323 raskin viric dtzWill ];
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/compilers/llvm/5/openmp.nix
+++ b/pkgs/development/compilers/llvm/5/openmp.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, fetch
+, cmake
+, zlib
+, llvm
+, perl
+, version
+}:
+
+stdenv.mkDerivation {
+  name = "openmp-${version}";
+
+  src = fetch "openmp" "1igplg89bl6k6r9q88hnpcznq3g9lb79w7bix025lwp00ldhivy0";
+
+  nativeBuildInputs = [ cmake perl ];
+  buildInputs = [ llvm ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Components required to build an executable OpenMP program";
+    homepage    = http://openmp.llvm.org/;
+    license     = stdenv.lib.licenses.mit;
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5297,6 +5297,7 @@ with pkgs;
     useMacosReexportHack = true;
   };
 
+  clang_5  = llvmPackages_5.clang;
   clang_4  = llvmPackages_4.clang;
   clang_39 = llvmPackages_39.clang;
   clang_38 = llvmPackages_38.clang;
@@ -5916,13 +5917,17 @@ with pkgs;
 
   lizardfs = callPackage ../tools/filesystems/lizardfs { };
 
-  lld = llvmPackages_4.lld;
+  lld = llvmPackages.lld;
+  lld_4 = llvmPackages_4.lld;
+  lld_5 = llvmPackages_5.lld;
 
   lldb = llvmPackages.lldb;
   lldb_4 = llvmPackages_4.lldb;
+  lldb_5 = llvmPackages_5.lldb;
 
   llvm = llvmPackages.llvm;
 
+  llvm_5  = llvmPackages_5.llvm;
   llvm_4  = llvmPackages_4.llvm;
   llvm_39 = llvmPackages_39.llvm;
   llvm_38 = llvmPackages_38.llvm;
@@ -5963,6 +5968,10 @@ with pkgs;
     libxml2 = libxml2.override { pythonSupport = false; };
     python2 = callPackage ../development/interpreters/python/cpython/2.7/boot.nix { inherit (darwin) CF configd; };
   });
+
+  llvmPackages_5 = callPackage ../development/compilers/llvm/5 {
+    inherit (stdenvAdapters) overrideCC;
+  };
 
   manticore = callPackage ../development/compilers/manticore { };
 
@@ -19440,6 +19449,8 @@ with pkgs;
     cc-wrapper-libcxx = callPackage ../test/cc-wrapper { stdenv = llvmPackages.libcxxStdenv; };
     cc-wrapper-clang-39 = callPackage ../test/cc-wrapper { stdenv = llvmPackages_39.stdenv; };
     cc-wrapper-libcxx-39 = callPackage ../test/cc-wrapper { stdenv = llvmPackages_39.libcxxStdenv; };
+    cc-wrapper-clang-5 = callPackage ../test/cc-wrapper { stdenv = llvmPackages_5.stdenv; };
+    cc-wrapper-libcxx-5 = callPackage ../test/cc-wrapper { stdenv = llvmPackages_5.libcxxStdenv; };
     stdenv-inputs = callPackage ../test/stdenv-inputs { };
 
     macOSSierraShared = callPackage ../test/macos-sierra-shared {};


### PR DESCRIPTION
###### Motivation for this change

New stable LLVM!

This does not change the default version anywhere, just makes the new version available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This should (and will be) squashed, postponing that until testing sorts out things like Darwin fixes that will require re-squashing anyway.