### PR TITLE
matterbridge: fix src hash

### DIFF
--- a/pkgs/servers/matterbridge/default.nix
+++ b/pkgs/servers/matterbridge/default.nix
@@ -8,7 +8,7 @@ buildGoPackage rec {
 
   src = fetchurl {
     url = "https://github.com/42wim/matterbridge/archive/v${version}.tar.gz";
-    sha256 = "0nn3929wyjdpkk8azp6wd6mkcg8h0jb1fjxm6jmb74xvdknrzv3k";
+    sha256 = "1br3rf500jdklzpxg1lkagglvmqshhligfkhndi8plg9hmzpd8qp";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
I used the wrong source hash because of some kind of metadata problem.
See https://github.com/NixOS/nixpkgs/pull/28892#issuecomment-330344570
for details.

cc @joachifm 