### PR TITLE
texworks: init at 0.6.2

### DIFF
--- a/pkgs/applications/editors/texworks/default.nix
+++ b/pkgs/applications/editors/texworks/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig
+, qt5, libsForQt5, hunspell
+, withLua ? true, lua
+, withPython ? true, python }:
+
+stdenv.mkDerivation rec {
+  name = "texworks-${version}";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "TeXworks";
+    repo = "texworks";
+    rev = "release-${version}";
+    sha256 = "0kj4pq5h4vs2wwg6cazxjlv83x6cwdfsa76winfkdddaqzpdklsj";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ qt5.qtscript libsForQt5.poppler hunspell lua python ]
+                ++ lib.optional withLua lua
+                ++ lib.optional withPython python;
+
+  cmakeFlags = lib.optional withLua "-DWITH_LUA=ON"
+               ++ lib.optional withPython "-DWITH_PYTHON=ON";
+
+  meta = with stdenv.lib; {
+    description = "Simple TeX front-end program inspired by TeXShop";
+    homepage = http://www.tug.org/texworks/;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ dotlambda ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4552,6 +4552,8 @@ with pkgs;
 
   textadept = callPackage ../applications/editors/textadept { };
 
+  texworks = callPackage ../applications/editors/texworks { };
+
   thc-hydra = callPackage ../tools/security/thc-hydra { };
 
   thefuck = callPackage ../tools/misc/thefuck { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

