### PR TITLE
timescaledb: init at 0.5.0

### DIFF
--- a/pkgs/servers/sql/postgresql/timescaledb/default.nix
+++ b/pkgs/servers/sql/postgresql/timescaledb/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "timescaledb-${version}";
-  version = "0.4.2";
+  version = "0.5.0";
 
   buildInputs = [ postgresql ];
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "timescale";
     repo = "timescaledb";
     rev = version;
-    sha256 = "0rwcd7wg3kv343b02330nlpqfm6jj5g0d2pkr1pc78cq8prhxx39";
+    sha256 = "01swgjw563c42azxsg55ry7cyiipxkcvfrxmw71jil5dxl3s0fkz";
   };
 
   installPhase = ''

--- a/pkgs/servers/sql/postgresql/timescaledb/default.nix
+++ b/pkgs/servers/sql/postgresql/timescaledb/default.nix
@@ -1,5 +1,11 @@
 { stdenv, fetchFromGitHub, postgresql }:
 
+# # To enable on NixOS:
+# config.services.postgresql = {
+#   extraPlugins = [ pkgs.timescaledb ];
+#   extraConfig = "shared_preload_libraries = 'timescaledb'";
+# }
+
 stdenv.mkDerivation rec {
   name = "timescaledb-${version}";
   version = "0.5.0";
@@ -21,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "TimescaleDB scales PostgreSQL for time-series data via automatic partitioning across time and space";
+    description = "Scales PostgreSQL for time-series data via automatic partitioning across time and space";
     homepage = https://www.timescale.com/;
     maintainers = with maintainers; [ volth ];
     platforms = platforms.linux;

--- a/pkgs/servers/sql/postgresql/timescaledb/default.nix
+++ b/pkgs/servers/sql/postgresql/timescaledb/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, postgresql }:
+
+stdenv.mkDerivation rec {
+  name = "timescaledb-${version}";
+  version = "0.4.2";
+
+  buildInputs = [ postgresql ];
+
+  src = fetchFromGitHub {
+    owner = "timescale";
+    repo = "timescaledb";
+    rev = version;
+    sha256 = "0rwcd7wg3kv343b02330nlpqfm6jj5g0d2pkr1pc78cq8prhxx39";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D timescaledb.so                  -t $out/lib
+    install -D timescaledb.control             -t $out/share/extension
+    install -D sql/timescaledb--${version}.sql -t $out/share/extension
+  '';
+
+  meta = with stdenv.lib; {
+    description = "TimescaleDB scales PostgreSQL for time-series data via automatic partitioning across time and space";
+    homepage = https://www.timescale.com/;
+    maintainers = with maintainers; [ volth ];
+    platforms = platforms.linux;
+    license = licenses.postgresql;
+  };
+}

--- a/pkgs/servers/sql/postgresql/timescaledb/default.nix
+++ b/pkgs/servers/sql/postgresql/timescaledb/default.nix
@@ -15,9 +15,9 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    install -D timescaledb.so                  -t $out/lib
-    install -D timescaledb.control             -t $out/share/extension
-    install -D sql/timescaledb--${version}.sql -t $out/share/extension
+    install -D timescaledb.so      -t $out/lib
+    install -D timescaledb.control -t $out/share/extension
+    cp -dpR    sql/*                  $out/share/extension/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16492,6 +16492,8 @@ with pkgs;
 
   timbreid = callPackage ../applications/audio/pd-plugins/timbreid { };
 
+  timescaledb = callPackage ../servers/sql/postgresql/timescaledb {};
+
   timewarrior = callPackage ../applications/misc/timewarrior { };
 
   timidity = callPackage ../tools/misc/timidity { };


### PR DESCRIPTION
PostgreSQL extension for time-series data

Requires PostgreSQL 9.6.x

To enable on NixOS:
```
config.services.postgresql = {
  extraPlugins = [ pkgs.timescaledb ];
  extraConfig = "shared_preload_libraries = 'timescaledb'";
}
```