### PR TITLE
coreutils: remove conflicting _FORTIFY_SOURCE definition

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -76,8 +76,6 @@ stdenv.mkDerivation rec {
   NIX_LDFLAGS = optionalString selinuxSupport "-lsepol";
   FORCE_UNSAFE_CONFIGURE = optionalString hostPlatform.isSunOS "1";
 
-  makeFlags = optionalString hostPlatform.isDarwin "CFLAGS=-D_FORTIFY_SOURCE=0";
-
   # Works around a bug with 8.26:
   # Makefile:3440: *** Recursive variable 'INSTALL' references itself (eventually).  Stop.
   preInstall = optionalString (hostPlatform != buildPlatform) ''


### PR DESCRIPTION
Originally this was introduced in 055e646b ('coreutils: Guard against compiler not supporting __builtin_stpncpy_chk') four years ago. Right now this doesn't seem to serve any purpose and it conflicts with the hardening flags:

    <command line>:2:9: warning: '_FORTIFY_SOURCE' macro redefined [-Wmacro-redefined]
    #define _FORTIFY_SOURCE 2
            ^
    <command line>:1:9: note: previous definition is here
    #define _FORTIFY_SOURCE 0
            ^
    1 warning generated.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] macOS
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

