### PR TITLE
[RDY] fcitx: fix keyboard not found

### DIFF
--- a/pkgs/development/libraries/libpinyin/default.nix
+++ b/pkgs/development/libraries/libpinyin/default.nix
@@ -6,7 +6,6 @@ let
     sha256 = "0qqk30nflj07zjhs231c95ln4yj4ipzwxxiwrxazrg4hb8bhypqq";
   };
 in
-
 stdenv.mkDerivation rec {
   name = "libpinyin-${version}";
   version = "2.1.91";

--- a/pkgs/development/libraries/libpinyin/default.nix
+++ b/pkgs/development/libraries/libpinyin/default.nix
@@ -2,14 +2,14 @@
 
 let
   modelData = fetchurl {
-    url    = "mirror://sourceforge/libpinyin/models/model12.text.tar.gz";
-    sha256 = "1fijhhnjgj8bj1xr5pp7c4qxf11cqybgfqg7v36l3x780d84hfnd";
+    url    = "mirror://sourceforge/libpinyin/models/model14.text.tar.gz";
+    sha256 = "0qqk30nflj07zjhs231c95ln4yj4ipzwxxiwrxazrg4hb8bhypqq";
   };
 in
 
 stdenv.mkDerivation rec {
   name = "libpinyin-${version}";
-  version = "1.6.0";
+  version = "2.1.91";
 
   nativeBuildInputs = [ autoreconfHook glib db pkgconfig ];
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     owner  = "libpinyin";
     repo   = "libpinyin";
     rev    = version;
-    sha256 = "0k40a7wfp8zj9d426afv0am5sr3m2i2p309fq0vf8qrb050hj17f";
+    sha256 = "0jbvn65p3zh0573hh27aasd3qly5anyfi8jnps2dxi0my09wbrq3";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchurl, cmake, pkgconfig, fcitx, gettext, libpinyin, glib, pcre, dbus, qt4 }:
+{ stdenv, fetchurl, cmake, pkgconfig, fcitx, gettext, libpinyin, glib, pcre, dbus, qtwebengine, qtbase, fcitx-qt5 }:
 
 stdenv.mkDerivation rec {
   name = "fcitx-libpinyin-${version}";
-  version = "0.3.91";
+  version = "0.5.3";
 
   src = fetchurl {
     url = "http://download.fcitx-im.org/fcitx-libpinyin/${name}.tar.xz";
-    sha256 = "19h0p1s8bkw24v7x6v19fg7dqpz2kkjlvvrqhypi5bkkvfswf7xn";
+    sha256 = "196c229ckib3xvafkk4n3n3jk9rpksfcjsbbwka6a9k2f34qrjj6";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake fcitx gettext libpinyin glib pcre dbus qt4 ];
+  nativeBuildInputs = [ pkgconfig  ];
+  buildInputs = [ fcitx-qt5 qtbase qtwebengine.dev cmake fcitx gettext libpinyin glib pcre dbus ];
 
   preInstall = ''
     substituteInPlace src/cmake_install.cmake \
@@ -24,13 +24,14 @@ stdenv.mkDerivation rec {
   '';
 
   preBuild = let
+    ZHUYIN_DATA_FILE_NAME = "model.text.20161206.tar.gz";
     store_path = fetchurl {
-      url = https://download.fcitx-im.org/data/model.text.20130308.tar.gz;
-      sha256 = "0s8sazix29z1ilxmkw2f0bv6i349awd89ibylf9ixy615s1vb5a5";
+      url = "https://download.fcitx-im.org/data/${ZHUYIN_DATA_FILE_NAME}";
+      sha256 = "017p11si1b7bkwx36xaybq5a9icq1pd7x1jbymqw92akfgjj8w2w";
     };
   in
     ''
-      cp -rv ${store_path} $NIX_BUILD_TOP/$name/data/model.text.20130308.tar.gz
+      cp -rv ${store_path} $NIX_BUILD_TOP/$name/data/${ZHUYIN_DATA_FILE_NAME}
     '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "fcitx-qt5-${version}";
-  version = "1.1.0";
+  version = "1.2.1";
 
   src = fetchurl {
     url = "http://download.fcitx-im.org/fcitx-qt5/${name}.tar.xz";
-    sha256 = "0r8c5k0qin3mz2p1mdciip6my0x58662sx5z50zs4c5pkdg21qwv";
+    sha256 = "0z8ax0dxk88byic41mfaiahjdv1k8ciwn97xfjkkgr4ijgscdr8c";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules pkgconfig ];
@@ -16,10 +16,12 @@ stdenv.mkDerivation rec {
   preInstall = ''
     substituteInPlace platforminputcontext/cmake_install.cmake \
       --replace ${qtbase.out} $out
+    substituteInPlace quickphrase-editor/cmake_install.cmake \
+      --replace ${fcitx} $out
   '';
 
   meta = with stdenv.lib; {
-    homepage    = "https://github.com/fcitx/fcitx-qt5";
+    homepage    = http://github.com/fcitx/fcitx-qt5;
     description = "Qt5 IM Module for Fcitx";
     license     = licenses.gpl2;
     platforms   = platforms.linux;

--- a/pkgs/tools/inputmethods/fcitx/unwrapped.nix
+++ b/pkgs/tools/inputmethods/fcitx/unwrapped.nix
@@ -2,27 +2,75 @@
 , libxml2, enchant, isocodes, icu, libpthreadstubs
 , pango, cairo, libxkbfile, libXau, libXdmcp, libxkbcommon
 , dbus, gtk2, gtk3, qt4, extra-cmake-modules
+, xkeyboard_config, pcre, libuuid, curl, cacert
+, withPinyin ? true
+, fetchFromGitHub
 }:
 
+let
+  # releases at http://download.fcitx-im.org/fcitx/${name}_dict.tar.xz
+  # contains all data but if we want to compile from source, we need to
+  # fetch them ourselves
+  # to update the urls and where to unpack these, look into the
+  # src/module/*/data/CMakeLists.txt files
+  # fcitx_download tgt_name url output)
+  dicts = let SPELL_EN_DICT_VER="20121020"; in fetchurl {
+      url = "http://download.fcitx-im.org/data/en_dict-${SPELL_EN_DICT_VER}.tar.gz";
+      sha256 = "1svcb97sq7nrywp5f2ws57cqvlic8j6p811d9ngflplj8xw5sjn4";
+  };
+  table = fetchurl {
+      url = http://download.fcitx-im.org/data/table.tar.gz;
+      sha256 = "1dw7mgbaidv3vqy0sh8dbfv8631d2zwv5mlb7npf69a1f8y0b5k1";
+  };
+  pystroke-data = let PY_STROKE_VER="20121124"; in fetchurl {
+      url = "http://download.fcitx-im.org/data/py_stroke-${PY_STROKE_VER}.tar.gz";
+      sha256 = "0j72ckmza5d671n2zg0psg7z9iils4gyxz7jgkk54fd4pyljiccf";
+  };
+  pytable-data = let PY_TABLE_VER="20121124"; in fetchurl {
+      url = "http://download.fcitx-im.org/data/py_table-${PY_TABLE_VER}.tar.gz";
+      sha256 = "011cg7wssssm6hm564cwkrrnck2zj5rxi7p9z5akvhg6gp4nl522";
+  };
+  pinyin-data = fetchurl {
+      url = http://download.fcitx-im.org/data/pinyin.tar.gz;
+      sha256 = "1qfq5dy4czvd1lvdnxzyaiir9x8b1m46jjny11y0i33m9ar2jf2q";
+  };
+in
 stdenv.mkDerivation rec {
   name = "fcitx-${version}";
-  version = "4.2.9.1";
+  version = "4.2.9.5";
 
-  src = fetchurl {
-    url    = "http://download.fcitx-im.org/fcitx/${name}_dict.tar.xz";
-    sha256 = "0xvcmm4yi7kagf55d0yl3ql5ssbkm9410fwbz3kd988pchichdsk";
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = "fcitx";
+    rev = version;
+    sha256 = "0rv69bacdvblka85dakz4ldpznrgwj59nqcccp5mkkn1rab4zh1r";
   };
+
+  # put data at the correct locations else cmake tries to fetch them,
+  # which fails in sandboxed mode
+  prePatch = ''
+    cp ${dicts} src/module/spell/dict/$(stripHash ${dicts})
+    cp ${table} src/im/table/data/$(stripHash ${table})
+  ''
+  + stdenv.lib.optionalString withPinyin ''
+    cp ${pystroke-data} src/module/pinyin-enhance/data/$(stripHash ${pystroke-data})
+    cp ${pytable-data} src/module/pinyin-enhance/data/$(stripHash ${pytable-data})
+    cp ${pinyin-data} src/im/pinyin/data/$(stripHash ${pinyin-data})
+  ''
+  ;
 
   postPatch = ''
     substituteInPlace src/frontend/qt/CMakeLists.txt \
       --replace $\{QT_PLUGINS_DIR} $out/lib/qt4/plugins
+
+    patchShebangs cmake/
   '';
 
-  nativeBuildInputs = [ cmake extra-cmake-modules intltool pkgconfig ];
+  nativeBuildInputs = [ cmake extra-cmake-modules intltool pkgconfig pcre ];
 
   buildInputs = [
-    enchant gettext isocodes icu libpthreadstubs libXau libXdmcp libxkbfile
-    libxkbcommon libxml2 dbus cairo gtk2 gtk3 pango qt4
+    xkeyboard_config enchant gettext isocodes icu libpthreadstubs libXau libXdmcp libxkbfile
+    libxkbcommon libxml2 dbus cairo gtk2 gtk3 pango qt4 libuuid
   ];
 
   cmakeFlags = ''
@@ -33,10 +81,15 @@ stdenv.mkDerivation rec {
     -DENABLE_OPENCC=OFF
     -DENABLE_PRESAGE=OFF
     -DENABLE_XDGAUTOSTART=OFF
-  '';
+    -DENABLE_PINYIN=${if withPinyin then "ON" else "OFF"}
+    -DENABLE_TABLE=ON
+    -DENABLE_SPELL=ON
+    -DENABLE_QT_GUI=ON
+    -DXKB_RULES_XML_FILE='${xkeyboard_config}/share/X11/xkb/rules/evdev.xml'
+    '';
 
   meta = with stdenv.lib; {
-    homepage    = "https://github.com/fcitx/fcitx";
+    homepage    = http://github.com/fcitx/fcitx;
     description = "A Flexible Input Method Framework";
     license     = licenses.gpl2;
     platforms   = platforms.linux;

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-libpinyin/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   name = "ibus-libpinyin-${version}";
-  version = "1.8.0";
+  version = "1.9.2";
 
   src = fetchFromGitHub {
     owner  = "libpinyin";
     repo   = "ibus-libpinyin";
     rev    = version;
-    sha256 = "1d85kzlhav0ay798i88yqyrjbkv3y7w2aiadpmcjgscyd5ccsnnz";
+    sha256 = "067w926gcf0kwwn71yshhjmyzkad0qsdm1dsi2xwz1j633qd4xlb";
   };
 
   buildInputs = [ ibus glib sqlite libpinyin python3 gtk3 db ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2105,7 +2105,7 @@ with pkgs;
 
     cloudpinyin = callPackage ../tools/inputmethods/fcitx-engines/fcitx-cloudpinyin { };
 
-    libpinyin = callPackage ../tools/inputmethods/fcitx-engines/fcitx-libpinyin { };
+    libpinyin = libsForQt5.callPackage ../tools/inputmethods/fcitx-engines/fcitx-libpinyin { };
 
     skk = callPackage ../tools/inputmethods/fcitx-engines/fcitx-skk { };
   };


### PR DESCRIPTION
###### Motivation for this change

NixOs defeats the fcitx discovery function responsible for finding evdev.xml & co. See https://groups.google.com/forum/#!topic/nix-devel/-_yLnqkMVj0 and
https://github.com/fcitx/fcitx/issues/357
Fcitx author kindly patched his project to make the discovery more reliable.

###### Things done
xkeyboard_config is now a mandatory nativeBuildInput so I enabled that. There is no new release yet so I changed the version to master (I should pin it to a specific revision else the sha is going to be outdated).

I opened the PR so that people can get a fix for fcitx but right now I am puzzled because while
`nix-shell -A fcitx '<nixpkgs>'` followed by a genericBuild compiles just fine, when it is done via 
`sudo LANG=C nixos-rebuild switch` then I have this error:

```
:71:5: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
     write(ofd, &wcount, sizeof(uint32_t));
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 64%] Linking C executable comp-spell-dict
[ 64%] Built target comp-spell-dict
Scanning dependencies of target spell-en-download
CMake Error at /dev/stdin:1 (le):
  Unknown CMake command "le".
```

I am not sure how to debug that.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

