### PR TITLE
elk: 5.5.2 -> 5.6.1

### DIFF
--- a/pkgs/development/tools/misc/kibana/5.x.nix
+++ b/pkgs/development/tools/misc/kibana/5.x.nix
@@ -11,9 +11,9 @@ let
   elasticArch = archOverrides."${arch}" or arch;
   plat = elemAt info 1;
   shas = {
-    "x86_64-linux"  = "0nmx7r6i54x7pii4ryh3wzzbwvnmcb3f1hn6ch96r24xi4v9m1sb";
-    "i686-linux"    = "0am6wmbcsh7zxzdrl1q9jbjrb7y4apvi6sr70j61xcx07pbickpp";
-    "x86_64-darwin" = "0kjnlzsz4i2fca3jgfsr1kknqzaypb0r78a7cxz2m7daj3bmpvpl";
+    "x86_64-linux"  = "02dhhp16pmkrpi2dfrca9qzz1q7jrxhaw6l3cfflgxx77hz0hlnw";
+    "i686-linux"    = "1h1zr342dq7nngvzpf9pn9mvwsi7aksa3qjyqpcc4yvbmmyrlk0m";
+    "x86_64-darwin" = "0van8cnir6s520crc20bf2clbkf822c3ylpk7iiq7da8hwvsypp9";
   };
 in stdenv.mkDerivation rec {
   name = "kibana-${version}";

--- a/pkgs/misc/logging/beats/default.nix
+++ b/pkgs/misc/logging/beats/default.nix
@@ -8,7 +8,7 @@ let beat = package : extraArgs : buildGoPackage (rec {
         owner = "elastic";
         repo = "beats";
         rev = "v${version}";
-        sha256 = "0vzjlgc0sym3kh6nflf2iyy2k3gxd7zwq8ma0cd7kpf42vxwhvqy";
+        sha256 = "1lbdi4c0y4bfkmim9q98ravknv4yw0dl3z57c3w5aqhi2sx0w23h";
       };
 
       goPackagePath = "github.com/elastic/beats";

--- a/pkgs/servers/search/elasticsearch/5.x.nix
+++ b/pkgs/servers/search/elasticsearch/5.x.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/elasticsearch/${name}.tar.gz";
-    sha256 = "1wavcqhwx4nj5v1ba8136009asnhrnhpm87zdsbxlvifqz0f4w08";
+    sha256 = "0pvi6akicg0i3bz3lbc6k9rznxw7d25flg9wbs2dyxv8i2rrqvq0";
   };
 
   patches = [ ./es-home-5.x.patch ./es-classpath-5.x.patch ];

--- a/pkgs/tools/misc/logstash/5.x.nix
+++ b/pkgs/tools/misc/logstash/5.x.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/logstash/${name}.tar.gz";
-    sha256 = "04nrw7ikcjp02cmwvaa1swj0b66l91n9d8qbdicsa023js4mp14m";
+    sha256 = "11qg8i0svsccr1wd0yj0ivfzpza2hd68221g38v88shvj0bb737f";
   };
 
   dontBuild         = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1840,7 +1840,7 @@ with pkgs;
   evemu = callPackage ../tools/system/evemu { };
 
   # The latest version used by elasticsearch, logstash, kibana and the the beats from elastic.
-  elk5Version = "5.5.2";
+  elk5Version = "5.6.1";
 
   elasticsearch = callPackage ../servers/search/elasticsearch { };
   elasticsearch2 = callPackage ../servers/search/elasticsearch/2.x.nix { };


### PR DESCRIPTION
Release notes:

* https://www.elastic.co/guide/en/elasticsearch/reference/5.6/release-notes-5.6.1.html
* https://www.elastic.co/guide/en/logstash/5.6/logstash-5-6-1.html
* https://www.elastic.co/guide/en/kibana/current/release-notes-5.6.1.html

The following succeeds: `nix-build nixos/release.nix -A tests.elk`
