### PR TITLE
[WIP] ghcjsHEAD: possibly fix template-haskell issue

### DIFF
--- a/pkgs/development/compilers/ghcjs/head.nix
+++ b/pkgs/development/compilers/ghcjs/head.nix
@@ -8,17 +8,17 @@ bootPkgs.callPackage ./base.nix {
   ghcjsSrc = fetchFromGitHub {
     # TODO: switch back to the regular ghcjs repo
     # when https://github.com/ghcjs/ghcjs/pull/573 is merged.
-    owner = "k0001";
+    owner = "basvandijk";
     repo = "ghcjs";
-    rev = "600015e085a28da601b65a41c513d4a458fcd184";
-    sha256 = "01kirrg0fnfwhllvwgfqjiwzwj4yv4lyig87x61n9jp6y5shzjdx";
+    rev = "f743ca7bfee006412376f42c247af1e0a98de95a";
+    sha256 = "1ixzrj5bg4ig0a8f6w11774sqp9sqlkdb0jyvmc5q37aq01w7wm5";
   };
   ghcjsBootSrc = fetchgit {
     # TODO: switch back to git://github.com/ghcjs/ghcjs-boot.git
     # when https://github.com/ghcjs/ghcjs-boot/pull/41 is merged.
     url = git://github.com/basvandijk/ghcjs-boot.git;
-    rev = "19a3b157ecb807c2224daffda5baecc92b76af35";
-    sha256 = "16sgr8vfr1nx5ljnk8gckgjk70zpa67ix4dbr9aizkwyz41ilfrb";
+    rev = "8020b2a9be585e958050c0a2c9144961bc8fad38";
+    sha256 = "1n6xmcn6dwp1lsalyr84gqbx41qycisx5dxdxmw4wdh0v2pclqrq";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Building a Haskell package with GHCJS that uses Template Haskell sometimes results in a:

```
hPutBuf: resource vanished (Broken pipe)
```

See: https://github.com/ghcjs/ghcjs/issues/607

The latest commit on the ghc-8.0 branch of the ghcjs repo can potentially fix this.

Since https://github.com/ghcjs/ghcjs/pull/573 is still not merged I rebased that PR on the latest ghc-8.0 branch. I also rebased ghcjs-boot.
