### PR TITLE
libxmlxx: move glibmm to propagatedBuildInputs

### DIFF
--- a/pkgs/development/libraries/libxmlxx/default.nix
+++ b/pkgs/development/libraries/libxmlxx/default.nix
@@ -12,9 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig perl ];
 
-  buildInputs = [ glibmm ];
-
-  propagatedBuildInputs = [ libxml2 ];
+  propagatedBuildInputs = [ libxml2 glibmm ];
 
   meta = with stdenv.lib; {
     homepage = http://libxmlplusplus.sourceforge.net/;


### PR DESCRIPTION
###### Motivation for this change
Was helping someone on IRC debug why adding libxmlxx to buildInputs didn't work with pkgconfig. pkgconfig output it was missing glibmm. This pull requests moves that dependency to propagatedBuildInputs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

