### PR TITLE
stdenv: Also splice unlisted default "out" output

### DIFF
--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -43,8 +43,9 @@ let
           // (lib.optionalAttrs (buildPkgs ? ${name}) { nativeDrv = buildValue; })
           // (lib.optionalAttrs (runPkgs ? ${name}) { crossDrv = runValue; });
         # Get the set of outputs of a derivation
-        getOutputs = value:
-          lib.genAttrs (value.outputs or []) (output: value.${output});
+        getOutputs = value: lib.genAttrs
+          (value.outputs or (lib.optional (value ? out) "out"))
+          (output: value.${output});
       in
         # Certain *Cross derivations will fail assertions, but we need their
         # nativeDrv. We are assuming anything that fails to evaluate is an


### PR DESCRIPTION
###### Motivation for this change

Otherwise, some cross builds will use the wrong type of dep.
   
###### Things done

This won't affect native builds, and perhaps no extant cross builds either.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

