### PR TITLE
alacritty: Install desktop icon

### DIFF
--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -47,16 +47,24 @@ buildRustPackage rec {
   ] ++ rpathLibs;
 
   patchPhase = ''
+    runHook prePatch
+
     substituteInPlace copypasta/src/x11.rs \
       --replace Command::new\(\"xclip\"\) Command::new\(\"${xclip}/bin/xclip\"\)
+
+    runHook postPatch
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     for f in $(find target/release -maxdepth 1 -type f); do
       cp $f $out/bin
     done;
     patchelf --set-rpath "${stdenv.lib.makeLibraryPath rpathLibs}" $out/bin/alacritty
+
+    runHook postInstall
   '';
 
   dontPatchELF = true;

--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -64,6 +64,9 @@ buildRustPackage rec {
     done;
     patchelf --set-rpath "${stdenv.lib.makeLibraryPath rpathLibs}" $out/bin/alacritty
 
+    mkdir -p $out/share/applications
+    cp Alacritty.desktop $out/share/applications/alacritty.desktop
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
### Motivation

Two unrelated changes:

- Install the `.desktop` file provided by alacritty
- Run the pre- and post-hooks for overridden phases. (This is a little pedantic on my part. There are obscure errors one can get from missing hooks. None of them affect alacritty yet. I'm not sure they ever will, but I figured better to deal with it while I'm already looking at it.)

### Testing
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

