### PR TITLE
systemd-vconsole-setup: remove workaround

### DIFF
--- a/nixos/modules/tasks/kbd.nix
+++ b/nixos/modules/tasks/kbd.nix
@@ -98,22 +98,11 @@ in
           '') config.i18n.consoleColors}
         '';
 
-        /* XXX: systemd-vconsole-setup needs a "main" terminal. By default
-         * /dev/tty0 is used which wouldn't work when the service is restarted
-         * from X11. We set this to /dev/tty1; not ideal because it may also be
-         * owned by X11 or something else.
-         *
-         * See #22470.
-         */
         systemd.services."systemd-vconsole-setup" =
           { wantedBy = [ "sysinit.target" ];
             before = [ "display-manager.service" ];
             after = [ "systemd-udev-settle.service" ];
             restartTriggers = [ vconsoleConf kbdEnv ];
-            serviceConfig.ExecStart = [
-              ""
-              "${pkgs.systemd}/lib/systemd/systemd-vconsole-setup /dev/tty1"
-            ];
           };
       }
 


### PR DESCRIPTION
###### Motivation for this change
It's no longer needed since systemd-vconsole-setup enumerates all ttys until it finds a suitable one since systemd v234. The workaround did not work with gdm.

Should fix #22470

CC @abbradar 

###### Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Tested whether running `systemd-vconsole-setup` without any arguments works with gdm
---

