### PR TITLE
stdenv: Provide a way for full `set -x` debugging

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -1,4 +1,3 @@
-
 <chapter xmlns="http://docbook.org/ns/docbook"
          xmlns:xlink="http://www.w3.org/1999/xlink"
          xml:id="chap-stdenv">
@@ -188,11 +187,13 @@ genericBuild
 
   <varlistentry>
     <term><varname>NIX_DEBUG</varname></term>
-    <listitem><para>If set, <literal>stdenv</literal> will print some
-    debug information during the build.  In particular, the
-    <command>gcc</command> and <command>ld</command> wrapper scripts
-    will print out the complete command line passed to the wrapped
-    tools.</para></listitem>
+    <listitem><para>
+      A natural number indicating how much information to log.
+      If set to 1 or higher, <literal>stdenv</literal> will print moderate debug information during the build.
+      In particular, the <command>gcc</command> and <command>ld</command> wrapper scripts will print out the complete command line passed to the wrapped tools.
+      If set to 6 or higher, the <literal>stdenv</literal> setup script will be run with <literal>set -x</literal> tracing.
+      If set to 7 or higher, the <command>gcc</command> and <command>ld</command> wrapper scripts will also be run with <literal>set -x</literal> tracing.
+    </para></listitem>
   </varlistentry>
 
 </variablelist>

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -16,14 +16,14 @@ do
   hardeningDisableMap[$flag]=1
 done
 
-if [[ -n "${NIX_DEBUG:-}" ]]; then
+if (( "${NIX_DEBUG:-0}" >= 1 )); then
   printf 'HARDENING: disabled flags:' >&2
   (( "${#hardeningDisableMap[@]}" )) && printf ' %q' "${!hardeningDisableMap[@]}" >&2
   echo >&2
 fi
 
 if [[ -z "${hardeningDisableMap[all]:-}" ]]; then
-  if [[ -n "${NIX_DEBUG:-}" ]]; then
+  if (( "${NIX_DEBUG:-0}" >= 1 )); then
     echo 'HARDENING: Is active (not completely disabled with "all" flag)' >&2;
   fi
   for flag in "${hardeningFlags[@]}"
@@ -31,40 +31,40 @@ if [[ -z "${hardeningDisableMap[all]:-}" ]]; then
     if [[ -z "${hardeningDisableMap[$flag]:-}" ]]; then
       case $flag in
         fortify)
-          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling fortify >&2; fi
+          if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling fortify >&2; fi
           hardeningCFlags+=('-O2' '-D_FORTIFY_SOURCE=2')
           ;;
         stackprotector)
-          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling stackprotector >&2; fi
+          if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling stackprotector >&2; fi
           hardeningCFlags+=('-fstack-protector-strong' '--param' 'ssp-buffer-size=4')
           ;;
         pie)
-          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling CFlags -fPIE >&2; fi
+          if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling CFlags -fPIE >&2; fi
           hardeningCFlags+=('-fPIE')
           if [[ ! ("$*" =~ " -shared " || "$*" =~ " -static ") ]]; then
-            if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling LDFlags -pie >&2; fi
+            if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling LDFlags -pie >&2; fi
             hardeningCFlags+=('-pie')
             hardeningLDFlags+=('-pie')
           fi
           ;;
         pic)
-          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling pic >&2; fi
+          if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling pic >&2; fi
           hardeningCFlags+=('-fPIC')
           ;;
         strictoverflow)
-          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling strictoverflow >&2; fi
+          if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling strictoverflow >&2; fi
           hardeningCFlags+=('-fno-strict-overflow')
           ;;
         format)
-          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling format >&2; fi
+          if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling format >&2; fi
           hardeningCFlags+=('-Wformat' '-Wformat-security' '-Werror=format-security')
           ;;
         relro)
-          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling relro >&2; fi
+          if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling relro >&2; fi
           hardeningLDFlags+=('-z' 'relro')
           ;;
         bindnow)
-          if [[ -n "${NIX_DEBUG:-}" ]]; then echo HARDENING: enabling bindnow >&2; fi
+          if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling bindnow >&2; fi
           hardeningLDFlags+=('-z' 'now')
           ;;
         *)

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -2,6 +2,10 @@
 set -eu -o pipefail
 shopt -s nullglob
 
+if (( "${NIX_DEBUG:-0}" >= 7 )); then
+    set -x
+fi
+
 path_backup="$PATH"
 
 # That @-vars are substituted separately from bash evaluation makes

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -161,7 +161,7 @@ if [ "$*" = -v ]; then
 fi
 
 # Optionally print debug info.
-if [ -n "${NIX_DEBUG:-}" ]; then
+if (( "${NIX_DEBUG:-0}" >= 1 )); then
     # Old bash workaround, see ld-wrapper for explanation.
     echo "extra flags before to @prog@:" >&2
     printf "  %q\n" ${extraBefore+"${extraBefore[@]}"}  >&2

--- a/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
@@ -2,6 +2,10 @@
 set -eu -o pipefail
 shopt -s nullglob
 
+if (( "${NIX_DEBUG:-0}" >= 7 )); then
+    set -x
+fi
+
 # N.B. Gnat is not used during bootstrapping, so we don't need to
 # worry about the old bash empty array `set -u` workarounds.
 

--- a/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
@@ -109,7 +109,7 @@ fi
 #fi
 
 # Optionally print debug info.
-if [ -n "${NIX_DEBUG:-}" ]; then
+if (( "${NIX_DEBUG:-0}" >= 1 )); then
     echo "extra flags before to @prog@:" >&2
     printf "  %q\n" "${extraBefore[@]}"  >&2
     echo "original flags to @prog@:" >&2

--- a/pkgs/build-support/cc-wrapper/gnatlink-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnatlink-wrapper.sh
@@ -2,6 +2,10 @@
 set -eu -o pipefail
 shopt -s nullglob
 
+if (( "${NIX_DEBUG:-0}" >= 7 )); then
+    set -x
+fi
+
 # N.B. Gnat is not used during bootstrapping, so we don't need to
 # worry about the old bash empty array `set -u` workarounds.
 

--- a/pkgs/build-support/cc-wrapper/gnatlink-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnatlink-wrapper.sh
@@ -24,7 +24,7 @@ extraBefore=()
 #export NIX_@infixSalt@_LDFLAGS_SET=1
 
 # Optionally print debug info.
-if [ -n "${NIX_DEBUG:-}" ]; then
+if (( "${NIX_DEBUG:-0}" >= 1 )); then
     echo "extra flags before to @prog@:" >&2
     printf "  %q\n" "${extraBefore[@]}"  >&2
     echo "original flags to @prog@:" >&2

--- a/pkgs/build-support/cc-wrapper/ld-solaris-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-solaris-wrapper.sh
@@ -2,6 +2,10 @@
 set -eu -o pipefail
 shopt -s nullglob
 
+if (( "${NIX_DEBUG:-0}" >= 7 )); then
+    set -x
+fi
+
 declare -a args=("$@")
 # I've also tried adding -z direct and -z lazyload, but it gave too many problems with C++ exceptions :'(
 # Also made sure libgcc would not be lazy-loaded, as suggested here: https://www.illumos.org/issues/2534#note-3

--- a/pkgs/build-support/cc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-wrapper.sh
@@ -2,6 +2,10 @@
 set -eu -o pipefail
 shopt -s nullglob
 
+if (( "${NIX_DEBUG:-0}" >= 7 )); then
+    set -x
+fi
+
 path_backup="$PATH"
 
 # phase separation makes this look useless

--- a/pkgs/build-support/cc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-wrapper.sh
@@ -156,7 +156,7 @@ fi
 
 
 # Optionally print debug info.
-if [ -n "${NIX_DEBUG:-}" ]; then
+if (( "${NIX_DEBUG:-0}" >= 1 )); then
     # Old bash workaround, see above.
     echo "extra flags before to @prog@:" >&2
     printf "  %q\n" ${extraBefore+"${extraBefore[@]}"}  >&2

--- a/pkgs/build-support/cc-wrapper/utils.sh
+++ b/pkgs/build-support/cc-wrapper/utils.sh
@@ -1,5 +1,5 @@
 skip () {
-    if [ -n "${NIX_DEBUG:-}" ]; then
+    if (( "${NIX_DEBUG:-0}" >= 1 )); then
         echo "skipping impure path $1" >&2
     fi
 }

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1,6 +1,10 @@
 set -eu
 set -o pipefail
 
+if (( "${NIX_DEBUG:-0}" >= 6 )); then
+    set -x
+fi
+
 : ${outputs:=out}
 
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -269,7 +269,7 @@ for i in $initialPath; do
     addToSearchPath PATH "$i/bin"
 done
 
-if [ "${NIX_DEBUG:-}" = 1 ]; then
+if (( "${NIX_DEBUG:-0}" >= 1 )); then
     echo "initial path: $PATH"
 fi
 
@@ -429,7 +429,7 @@ fi
 
 
 PATH="${_PATH-}${_PATH:+${PATH:+:}}$PATH"
-if [ "${NIX_DEBUG:-}" = 1 ]; then
+if (( "${NIX_DEBUG:-0}" >= 1 )); then
     echo "final path: $PATH"
 fi
 
@@ -539,7 +539,7 @@ substituteAll() {
     local -a args=()
 
     for varName in $(awk 'BEGIN { for (v in ENVIRON) if (v ~ /^[a-z][a-zA-Z0-9_]*$/) print v }'); do
-        if [ "${NIX_DEBUG:-}" = "1" ]; then
+        if (( "${NIX_DEBUG:-0}" >= 1 )); then
             printf "@%s@ -> %q\n" "${varName}" "${!varName}"
         fi
         args+=("--subst-var" "$varName")


### PR DESCRIPTION
###### Motivation for this change

I need `set -x` all the time, and have been resorting to fairly ugly hacks to get it. @domenkozar needs it to. Re-purposing `NIX_DEBUG` as a "log-level"-style debugger seemed like a pretty non-intrusive way to achieve this.

###### Things done

I won't bother rebuilding the world just for this. But I'll be rebasing my https://github.com/NixOS/nixpkgs/pull/26805 on top of it.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

N.B. I often rebase my PRs on top of each other---they either depend or it's easier to chain rebase if the history is already linear-- \-and this one landed on https://github.com/NixOS/nixpkgs/pull/29610. Just look the last 4 commits.

CC @orivej