### PR TITLE
nixos/nfs: allow setting the path to krb5.keytab

### DIFF
--- a/nixos/modules/tasks/filesystems/nfs.nix
+++ b/nixos/modules/tasks/filesystems/nfs.nix
@@ -85,8 +85,14 @@ in
         enable = mkDefault false;
       };
 
+    systemd.services.auth-rpcgss-module =
+      {
+        unitConfig.ConditionPathExists = [ "" "/etc/krb5.keytab" ];
+      };
+
     systemd.services.rpc-gssd =
       { restartTriggers = [ nfsConfFile ];
+        unitConfig.ConditionPathExists = [ "" "/etc/krb5.keytab" ];
       };
 
     systemd.services.rpc-statd =

--- a/pkgs/os-specific/linux/nfs-utils/default.nix
+++ b/pkgs/os-specific/linux/nfs-utils/default.nix
@@ -39,7 +39,7 @@ in stdenv.mkDerivation rec {
       sed -i "s,^PATH=.*,PATH=$out/bin:${statdPath}," utils/statd/start-statd
 
       configureFlags="--with-start-statd=$out/bin/start-statd $configureFlags"
-      
+
       substituteInPlace systemd/nfs-utils.service \
         --replace "/bin/true" "${coreutils}/bin/true"
 


### PR DESCRIPTION
###### Motivation for this change

Currently the `rpc-gssd.service` has a `ConditionPathExists` clause that can
never be met, because it's looking for stateful data inside `/nix/store`.

`auth-rpcgss-module.service` also only starts if this file exists.

Fixes NixOS/nixpkgs#29509.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

- Added an argument `keytabPath` to the `nfs-utils` expression, which defaults to `/etc/krb5.keytab` (the path that nfs-utils uses by default)
- Added a `keytabPath` configuration option at `services.nfs.keytabPath` which is passed to the `nfs-utils` expression.

At first I tried setting `systemd.services.rpc-gssd.unitConfig.ConditionPathExists = /etc/krb5.keytab;`, but it didn't work.

I'm not sure this is the best way to do it but it seems to work for me.

---

