### PR TITLE
top-level: Remove useless abstractions

### DIFF
--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
 
   inherit (common) version src postPatch hardeningDisable enableParallelBuilding meta;
 
-  buildInputs = [ ncurses pkgconfig ]
+  nativeBuildInputs = [ gettext pkgconfig ];
+  buildInputs = [ ncurses ]
     ++ stdenv.lib.optionals hostPlatform.isDarwin [ Carbon Cocoa ];
-  nativeBuildInputs = [ gettext ];
 
   configureFlags = [
     "--enable-multibyte"

--- a/pkgs/development/compilers/emscripten-fastcomp/default.nix
+++ b/pkgs/development/compilers/emscripten-fastcomp/default.nix
@@ -4,10 +4,14 @@ let
 
   self = {
     emscriptenfastcomp-unwrapped = callPackage ./emscripten-fastcomp.nix {};
-    emscriptenfastcomp-wrapped = wrapCCWith stdenv.cc.libc ''
-      # hardening flags break WASM support
-      cat > $out/nix-support/add-hardening.sh
-    '' self.emscriptenfastcomp-unwrapped;
+    emscriptenfastcomp-wrapped = wrapCCWith {
+      cc = self.emscriptenfastcomp-unwrapped;
+      libc = stdenv.cc.libc;
+      extraBuildCommands = ''
+        # hardening flags break WASM support
+        cat > $out/nix-support/add-hardening.sh
+      '';
+    };
     emscriptenfastcomp = symlinkJoin {
       name = "emscriptenfastcomp";
       paths = [ self.emscriptenfastcomp-wrapped self.emscriptenfastcomp-unwrapped ];

--- a/pkgs/os-specific/gnu/default.nix
+++ b/pkgs/os-specific/gnu/default.nix
@@ -3,14 +3,21 @@
 args@{ fetchgit, stdenv, autoconf, automake, automake111x, libtool
 , texinfo, glibcCross, hurdPartedCross, libuuid, samba
 , gccCrossStageStatic, gccCrossStageFinal
-, forcedNativePackages, forceSystem, newScope, platform, config
+, forceSystem, newScope, platform, config
 , targetPlatform, buildPlatform
-, overrides ? {} }:
+, overrides ? {}
+, buildPackages, pkgs
+}:
 
 with args;
 
 let
   callPackage = newScope gnu;
+
+  forcedNativePackages =
+    if stdenv.hostPlatform == stdenv.buildPlatform
+    then pkgs
+    else buildPackages;
 
   gnu = {
     hurdCross = forcedNativePackages.callPackage ./hurd {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29,8 +29,6 @@ with pkgs;
 
   callPackage_i686 = pkgsi686Linux.callPackage;
 
-  forcedNativePackages = if hostPlatform == buildPlatform then pkgs else buildPackages;
-
   # A stdenv capable of building 32-bit binaries.  On x86_64-linux,
   # it uses GCC compiled with multilib support; on i686-linux, it's
   # just the plain stdenv.
@@ -5428,34 +5426,27 @@ with pkgs;
       else if targetPlatform.libc == "libSystem" then darwin.xcode
       else null;
     in wrapCCCross {
-      cc = forcedNativePackages.gcc.cc.override {
+      cc = gcc.cc.override {
         crossStageStatic = true;
         langCC = false;
         libcCross = libcCross1;
         enableShared = false;
         # Why is this needed?
-        inherit (forcedNativePackages) binutils;
       };
       libc = libcCross1;
-      inherit (forcedNativePackages) binutils;
   };
 
   # Only needed for mingw builds
   gccCrossMingw2 = assert targetPlatform != buildPlatform; wrapCCCross {
     cc = gccCrossStageStatic.gcc;
     libc = windows.mingw_headers2;
-    inherit (forcedNativePackages) binutils;
   };
 
   gccCrossStageFinal = assert targetPlatform != buildPlatform; wrapCCCross {
-    cc = forcedNativePackages.gcc.cc.override {
+    cc = gcc.cc.override {
       crossStageStatic = false;
-
-      # Why is this needed?
-      inherit (forcedNativePackages) binutils;
     };
     libc = libcCross;
-    inherit (forcedNativePackages) binutils;
   };
 
   gcc45 = lowPrio (wrapCC (callPackage ../development/compilers/gcc/4.5 {
@@ -6232,7 +6223,7 @@ with pkgs;
   wrapCCCross =
     {cc, libc, binutils, name ? "gcc-cross-wrapper"}:
 
-    forcedNativePackages.ccWrapperFun {
+    ccWrapperFun {
       nativeTools = false;
       nativeLibc = false;
       noLibc = (libc == null);
@@ -7334,7 +7325,7 @@ with pkgs;
      cross_renaming: we should make all programs use pkgconfig as
      nativeBuildInput after the renaming.
      */
-  pkgconfig = forcedNativePackages.callPackage ../development/tools/misc/pkgconfig {
+  pkgconfig = callPackage ../development/tools/misc/pkgconfig {
     fetchurl = fetchurlBoot;
   };
   pkgconfigUpstream = lowPrio (pkgconfig.override { vanilla = true; });


### PR DESCRIPTION
###### Motivation for this change

1. `forcedNativePackages` is not needed if splicing and `buildPackages` is used correctly.

2. `wrapCCCross` is not needed now that `gcc-cross-wrapper` has been removed in lieu of a generalized `cc-wrapper`.

The vim change is good practice, and needed to get the perfect hash diff :).

###### Things done

All tested native and cross hashes are preserved. (!)