### PR TITLE
ghcjsHEAD: bump ghcjs shims

### DIFF
--- a/pkgs/development/compilers/ghcjs/head_shims.nix
+++ b/pkgs/development/compilers/ghcjs/head_shims.nix
@@ -2,6 +2,6 @@
 fetchFromGitHub {
   owner = "ghcjs";
   repo = "shims";
-  rev = "f67394c559ac921a768b12f141499119563b8bf3";
-  sha256 = "1lz86qmkxkfch1yk9a62admw7jsd34sqcrskgpq28hbhjpgzf1lv";
+  rev = "85395dce971e23a39e5f93af4ed139ca36d4e448";
+  sha256 = "1kqgik75jx681s1kjx1s7dryigr3m940c3zb9vy0r3psxrw6sf2g";
 }


### PR DESCRIPTION
There have been a few fixes so it makes sense to update this.