### PR TITLE
pythonPackages.pafy: 0.5.2 -> 0.5.3.1

### DIFF
--- a/pkgs/development/python-modules/pafy/default.nix
+++ b/pkgs/development/python-modules/pafy/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, youtube-dl, fetchurl }:
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "pafy";
+  version = "0.5.3.1";
+
+  src = fetchurl {
+    url = "mirror://pypi/p/pafy/${name}.tar.gz";
+    sha256 = "1a7dxi95m1043rxx1r5x3ngb66nwlq6aqcasyqqjzmmmjps4zrim";
+  };
+
+  # No tests included in archive
+  doCheck = false;
+
+  propagatedBuildInputs = [ youtube-dl ];
+
+  meta = with lib; {
+    description = "A library to download YouTube content and retrieve metadata";
+    homepage = http://np1.github.io/pafy/;
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ odi ];
+  };
+}
+

--- a/pkgs/development/python-modules/pafy/default.nix
+++ b/pkgs/development/python-modules/pafy/default.nix
@@ -1,11 +1,11 @@
-{ lib, buildPythonPackage, youtube-dl, fetchurl }:
+{ lib, buildPythonPackage, youtube-dl, fetchPypi }:
 buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "pafy";
   version = "0.5.3.1";
 
-  src = fetchurl {
-    url = "mirror://pypi/p/pafy/${name}.tar.gz";
+  src = fetchPypi {
+    inherit pname version;
     sha256 = "1a7dxi95m1043rxx1r5x3ngb66nwlq6aqcasyqqjzmmmjps4zrim";
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25833,27 +25833,7 @@ EOF
     };
   };
 
-  pafy = buildPythonPackage rec {
-    name = "pafy-${version}";
-    version = "0.5.3.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pafy/${name}.tar.gz";
-      sha256 = "1a7dxi95m1043rxx1r5x3ngb66nwlq6aqcasyqqjzmmmjps4zrim";
-    };
-
-    # No tests included in archive
-    doCheck = false;
-
-    propagatedBuildInputs = with self; [ youtube-dl ];
-
-    meta = with stdenv.lib; {
-      description = "A library to download YouTube content and retrieve metadata";
-      homepage = http://np1.github.io/pafy/;
-      license = licenses.lgpl3Plus;
-      maintainers = with maintainers; [ odi ];
-    };
-  };
+  pafy = callPackage ../development/python-modules/pafy { };
 
   suds = buildPythonPackage rec {
     name = "suds-0.4";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25835,11 +25835,11 @@ EOF
 
   pafy = buildPythonPackage rec {
     name = "pafy-${version}";
-    version = "0.5.2";
+    version = "0.5.3.1";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/p/pafy/${name}.tar.gz";
-      sha256 = "1ckvrypyvb7jbqlgwdz0y337ajagjv7dgxyns326nqwypn1wpq0i";
+      sha256 = "1a7dxi95m1043rxx1r5x3ngb66nwlq6aqcasyqqjzmmmjps4zrim";
     };
 
     # No tests included in archive


### PR DESCRIPTION
###### Motivation for this change

Fix `mpsyt` which was no longer working

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

