### PR TITLE
tint2: 0.14.6 -> 15.1

### DIFF
--- a/pkgs/applications/misc/tint2/default.nix
+++ b/pkgs/applications/misc/tint2/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchFromGitLab, pkgconfig, cmake, gettext, cairo, pango, pcre
-, glib , imlib2, gtk2, libXinerama , libXrender, libXcomposite, libXdamage
-, libX11 , libXrandr, librsvg, libpthreadstubs , libXdmcp
-, libstartup_notification , hicolor_icon_theme, wrapGAppsHook
+, glib, imlib2, gtk2, libXinerama, libXrender, libXcomposite, libXdamage
+, libX11, libXrandr, librsvg, libpthreadstubs, libXdmcp
+, libstartup_notification, hicolor_icon_theme, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
   name = "tint2-${version}";
-  version = "0.14.6";
+  version = "15.1";
 
   src = fetchFromGitLab {
     owner = "o9000";
     repo = "tint2";
     rev = version;
-    sha256 = "0v7i8araj85cbl45icinvmsz5741cx2ybjgkx72m3xfcb9fqg69l";
+    sha256 = "16mpvknibbqy0vjgkwig7g8i6rivm14ipd7ixvqydgcj7wibn0b7";
   };
 
   enableParallelBuilding = true;
@@ -23,11 +23,8 @@ stdenv.mkDerivation rec {
     libXcomposite libXdamage libX11 libXrandr librsvg libpthreadstubs
     libXdmcp libstartup_notification hicolor_icon_theme ];
 
-  preConfigure = ''
+  postPatch = ''
     substituteInPlace CMakeLists.txt --replace /etc $out/etc
-  '';
-
-  prePatch = ''
     for f in ./src/launcher/apps-common.c \
              ./src/launcher/icon-theme-common.c \
              ./themes/*tint2rc


### PR DESCRIPTION
###### Motivation for this change

Update to version 15.1

[ChangeLog](https://gitlab.com/o9000/tint2/blob/15.1/ChangeLog)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).