### PR TITLE
numix-icon-theme-square: 2016-11-23 -> 17-09-13

### DIFF
--- a/pkgs/data/icons/numix-icon-theme-square/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-square/default.nix
@@ -1,17 +1,15 @@
 { stdenv, fetchFromGitHub, numix-icon-theme }:
 
 stdenv.mkDerivation rec {
-  version = "2016-11-23";
-
-  package-name = "numix-icon-theme-square";
-
   name = "${package-name}-${version}";
+  package-name = "numix-icon-theme-square";
+  version = "17-09-13";
 
   src = fetchFromGitHub {
     owner = "numixproject";
     repo = package-name;
-    rev = "1c30eb02aea3d95c49f95c212702b56e93ac9043";
-    sha256 = "1d2car4dsh1dnim9jlakm035ydqd1f115cagm6zm8gwa5w9annag";
+    rev = version;
+    sha256 = "1grpm902hiid561fbp9y1rb9z21y8d1krjgxgs7j8qnpx380sd5x";
   };
 
   buildInputs = [ numix-icon-theme ];


### PR DESCRIPTION
###### Motivation for this change

Update to version 17-09-13

[Release](https://github.com/numixproject/numix-icon-theme-square/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).