### PR TITLE
oslo-config: fix build

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     "--with-png=${libpng.dev}"      # optional
     "--with-poppler=${poppler.dev}" # optional
     "--with-libz=${zlib.dev}"       # optional
-    "--with-pg=${postgresql}/bin/pg_config"
+    "--with-pg=${postgresql.dev}/bin/pg_config"
     "--with-mysql=${mysql.lib.dev}/bin/mysql_config"
     "--with-geotiff=${libgeotiff}"
     "--with-sqlite3=${sqlite.dev}"

--- a/pkgs/development/python-modules/hupper/default.nix
+++ b/pkgs/development/python-modules/hupper/default.nix
@@ -1,0 +1,20 @@
+{ buildPythonPackage, fetchPypi, python
+, pytest, pytestcov, watchdog, mock
+}:
+
+buildPythonPackage rec {
+  pname = "hupper";
+  version = "1.0";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "02lj6kgaf9xpr0binxwac3gpdhljglyj9fr78s165jc7qd7mifdg";
+  };
+
+  checkPhase = ''
+    py.test
+  '';
+
+  checkInputs = [ pytest pytestcov watchdog mock ];
+}

--- a/pkgs/development/python-modules/keystoneauth1/default.nix
+++ b/pkgs/development/python-modules/keystoneauth1/default.nix
@@ -6,20 +6,21 @@
 
 buildPythonPackage rec {
   pname = "keystoneauth1";
-  version = "3.1.0";
+  version = "3.2.0";
   name = "${pname}-${version}";
   disabled = isPyPy; # a test fails
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e5abfa8bbe866d52ca56afbe528d15214a60033cc1dc9804478cae7424f0f8fb";
+    sha256 = "0rg3harfyvai34lrjiqnl1crmvswjvj8nsviasnz4b9pcvp3d03n";
   };
 
   buildInputs = [ pbr testtools testresources testrepository mock
                   pep8 fixtures mox3 requests-mock ];
-  propagatedBuildInputs = [ iso8601 requests six stevedore
-                            webob oslo-config ];
+  propagatedBuildInputs = [ iso8601 requests six stevedore webob ];
 
+  # oslo_config is required but would create a circular dependency
+  doCheck = false;
   postPatch = ''
     sed -i 's@python@${python.interpreter}@' .testr.conf
     substituteInPlace requirements.txt --replace "argparse" ""

--- a/pkgs/development/python-modules/keystoneauth1/default.nix
+++ b/pkgs/development/python-modules/keystoneauth1/default.nix
@@ -2,6 +2,7 @@
 , pbr, testtools, testresources, testrepository, mock
 , pep8, fixtures, mox3, requests-mock
 , iso8601, requests, six, stevedore, webob, oslo-config
+, pyyaml, betamax, oauthlib
 }:
 
 buildPythonPackage rec {
@@ -15,12 +16,20 @@ buildPythonPackage rec {
     sha256 = "0rg3harfyvai34lrjiqnl1crmvswjvj8nsviasnz4b9pcvp3d03n";
   };
 
-  buildInputs = [ pbr testtools testresources testrepository mock
-                  pep8 fixtures mox3 requests-mock ];
+  buildInputs = [ pbr  ];
+  checkInputs = [ pyyaml betamax oauthlib testtools testresources
+                  testrepository mock pep8 fixtures mox3 requests-mock ];
   propagatedBuildInputs = [ iso8601 requests six stevedore webob ];
 
-  # oslo_config is required but would create a circular dependency
-  doCheck = false;
+  doCheck = true;
+  # 1. oslo-config
+  # 2. oslo-utils
+  # 3. requests-kerberos
+  preCheck = ''
+    rm keystoneauth1/tests/unit/loading/test_{session,conf,adapter}.py
+    rm keystoneauth1/tests/unit/access/test_v{2,3}_access.py
+    rm keystoneauth1/tests/unit/extras/kerberos/test_fedkerb_loading.py
+  '';
   postPatch = ''
     sed -i 's@python@${python.interpreter}@' .testr.conf
     substituteInPlace requirements.txt --replace "argparse" ""

--- a/pkgs/development/python-modules/oslo-config/default.nix
+++ b/pkgs/development/python-modules/oslo-config/default.nix
@@ -1,16 +1,17 @@
-{ buildPythonPackage, fetchPypi, pbr, six, netaddr, stevedore, mock }:
+{ buildPythonPackage, fetchPypi, pbr, six, netaddr, stevedore, mock,
+debtcollector, rfc3986, pyyaml, oslo-i18n }:
 
 buildPythonPackage rec {
   pname = "oslo.config";
-  version = "4.11.0";
+  version = "4.12.0";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1be8aaba466a3449fdb21ee8f7025b0d3d252c8c7568b8d5d05ceff58617cd05";
+    sha256 = "1pa9lajsadyq47bmxx12dxlcmnqsqlgnb55hwqas26lgnb2073dx";
   };
 
-  propagatedBuildInputs = [ pbr six netaddr stevedore ];
+  propagatedBuildInputs = [ pbr six netaddr stevedore debtcollector rfc3986 pyyaml oslo-i18n ];
   buildInputs = [ mock ];
 
   # TODO: circular import on oslo-i18n
@@ -20,6 +21,4 @@ buildPythonPackage rec {
     substituteInPlace requirements.txt --replace "argparse" ""
   '';
 
-  # Requires a bunch of new packages
-  meta.broken = true;
 }

--- a/pkgs/development/python-modules/oslo-config/default.nix
+++ b/pkgs/development/python-modules/oslo-config/default.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, fetchPypi, pbr, six, netaddr, stevedore, mock,
+{ lib, buildPythonPackage, fetchPypi, pbr, six, netaddr, stevedore, mock,
 debtcollector, rfc3986, pyyaml, oslo-i18n }:
 
 buildPythonPackage rec {
@@ -20,5 +20,13 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace requirements.txt --replace "argparse" ""
   '';
+
+  meta = with lib; {
+    description = "Oslo Configuration API";
+    homepage = "https://docs.openstack.org/oslo.config/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ makefu ];
+  };
+
 
 }

--- a/pkgs/development/python-modules/plaster-pastedeploy/default.nix
+++ b/pkgs/development/python-modules/plaster-pastedeploy/default.nix
@@ -1,0 +1,22 @@
+{ buildPythonPackage, fetchPypi, python
+, plaster, PasteDeploy
+, pytest, pytestcov
+}:
+
+buildPythonPackage rec {
+  pname = "plaster_pastedeploy";
+  version = "0.4.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1lrbkya5birfmg9gnfcnsa9id28klmjcqbm33rcg69pv9sfld4jv";
+  };
+
+  checkPhase = ''
+    py.test
+  '';
+
+  propagatedBuildInputs = [ plaster PasteDeploy ];
+  checkInputs = [ pytest pytestcov ];
+}

--- a/pkgs/development/python-modules/plaster/default.nix
+++ b/pkgs/development/python-modules/plaster/default.nix
@@ -1,0 +1,20 @@
+{ buildPythonPackage, fetchPypi, python
+, pytest, pytestcov
+}:
+
+buildPythonPackage rec {
+  pname = "plaster";
+  version = "0.5";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0z48pis4qyhyqj3ia82r04diaa153dw66wrpbly06hdzvhw8j0ia";
+  };
+
+  checkPhase = ''
+    py.test
+  '';
+
+  checkInputs = [ pytest pytestcov ];
+}

--- a/pkgs/development/python-modules/requestsexceptions/default.nix
+++ b/pkgs/development/python-modules/requestsexceptions/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, pbr }:
+
+buildPythonPackage rec {
+  pname = "requestsexceptions";
+  version = "1.3.0";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gim00vi7vfq16y8b9m1vpy01grqvrdrbh88jb98qx6n6sk1n54g";
+  };
+
+  propagatedBuildInputs = [ pbr ];
+
+  # upstream hacking package is not required for functional testing
+  patchPhase = ''
+    sed -i '/^hacking/d' test-requirements.txt
+  '';
+
+  meta = with lib; {
+    description = "Import exceptions from potentially bundled packages in requests.";
+    homepage = "https://pypi.python.org/pypi/requestsexceptions";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ makefu ];
+    patforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/sqlalchemy-migrate/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-migrate/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     sha256 = "0ld2bihp9kmf57ykgzrfgxs4j9kxlw79sgdj9sfn47snw3izb2p6";
   };
 
-  checkInputs = [ unittest2 scripttest pytz pylint  mock testtools ];
+  checkInputs = [ unittest2 scripttest pytz pylint mock testtools tempest-lib ];
   propagatedBuildInputs = [ pbr tempita decorator sqlalchemy six sqlparse ];
 
   checkPhase = ''
@@ -27,8 +27,7 @@ buildPythonPackage rec {
     ${python.interpreter} setup.py test
   '';
 
-  # Tests require tempest-lib which requires the broken oslo-config
-  doCheck = false;
+  doCheck = true;
 
   meta = with stdenv.lib; {
     homepage = http://code.google.com/p/sqlalchemy-migrate/;

--- a/pkgs/development/python-modules/sqlalchemy-migrate/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-migrate/default.nix
@@ -33,5 +33,6 @@ buildPythonPackage rec {
     homepage = http://code.google.com/p/sqlalchemy-migrate/;
     description = "Schema migration tools for SQLAlchemy";
     license = licenses.asl20;
+    maintainers = with maintainers; [ makefu ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6061,6 +6061,8 @@ in {
 
   };
 
+  hupper = callPackage ../development/python-modules/hupper {};
+
   hovercraft = buildPythonPackage rec {
     disabled = ! isPy3k;
     name = "hovercraft-${version}";
@@ -7049,6 +7051,10 @@ in {
 
   phpserialize = callPackage ../development/python-modules/phpserialize { };
 
+  plaster = callPackage ../development/python-modules/plaster {};
+
+  plaster-pastedeploy = callPackage ../development/python-modules/plaster-pastedeploy {};
+
   plotly = callPackage ../development/python-modules/plotly { };
 
   podcastparser = callPackage ../development/python-modules/podcastparser { };
@@ -7327,11 +7333,13 @@ in {
   };
 
   pyramid = buildPythonPackage rec {
-    name = "pyramid-1.7";
+    pname = "pyramid";
+    version = "1.9.1";
+    name = "${pname}-${version}";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pyramid/${name}.tar.gz";
-      sha256 = "161qacv7qqln3q02kcqll0q2mmaypm701hn1llwdwnkaywkb3xi6";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "0dhbzc4q0vsnv3aihy728aczg56xs6h9s1rmvr096q4lb6yln3w4";
     };
 
     buildInputs = with self; [
@@ -7340,6 +7348,9 @@ in {
       webtest
       zope_component
       zope_interface
+      plaster
+      plaster-pastedeploy
+      hupper
     ] ++ optional isPy26 unittest2;
 
     propagatedBuildInputs = with self; [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8856,18 +8856,21 @@ in {
   };
 
   eventlet = buildPythonPackage rec {
-    name = "eventlet-0.17.4";
+    pname = "eventlet";
+    version = "0.20.0";
+    name = "${pname}-${version}";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/e/eventlet/${name}.tar.gz";
-      sha256 = "0vam0qfm8p5jkpp2cv12r5bnpnv902ld7q074h7x5y5g9rqyj8c7";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "15bq5ybbigxnp5xwkps53zyhlg15lmcnq3ny2dppj0r0bylcs5rf";
     };
 
     buildInputs = with self; [ nose httplib2 pyopenssl  ];
 
     doCheck = false;  # too much transient errors to bother
 
-    propagatedBuildInputs = optionals (!isPyPy) [ self.greenlet ];
+    propagatedBuildInputs = optionals (!isPyPy) [ self.greenlet ] ++
+      (with self; [ enum-compat ]) ;
 
     meta = {
       homepage = http://pypi.python.org/pypi/eventlet/;
@@ -12623,13 +12626,15 @@ in {
   };
 
   monotonic = buildPythonPackage rec {
-    name = "monotonic-0.4";
+    pname = "monotonic";
+    version = "1.3";
+    name = "${pname}-${version}";
 
     __propagatedImpureHostDeps = stdenv.lib.optional stdenv.isDarwin "/usr/lib/libc.dylib";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/m/monotonic/${name}.tar.gz";
-      sha256 = "1diab6hfh3jpa1f0scpqaqrawk4g97ss4v7gkn2yw8znvdm6abw5";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "06vw7jwq96106plhlc5vz1v1xvjismdgw9wjyzvzf0ylglnrwiib";
     };
 
     patchPhase = optionalString stdenv.isLinux ''
@@ -13846,12 +13851,13 @@ in {
   };
 
   oslo-serialization = buildPythonPackage rec {
-    name = "oslo.serialization-${version}";
-    version = "1.10.0";
+    pname = "oslo.serialization";
+    version = "2.20.0";
+    name = "${pname}-${version}";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/o/oslo.serialization/${name}.tar.gz";
-      sha256 = "15k8aql2rx5jzv3hfvmd48vsyw172qa64bs3fmsyx25p37zyfy8a";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "00j8hn8f0shk4anzb6zwn8w1sfxcil9a3jgxljwalq6ma2rzp9pw";
     };
 
     patchPhase = ''
@@ -13893,12 +13899,13 @@ in {
 
 
   oslo-utils = buildPythonPackage rec {
-    name = "oslo.utils-${version}";
-    version = "2.6.0";
+    pname = "oslo.utils";
+    version = "3.29.0";
+    name = "${pname}-${version}";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/o/oslo.utils/${name}.tar.gz";
-      sha256 = "1prgi03nxkcykyja821qkycsqlnpyzw17mpvj8qf3pjmgb9gv1fy";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "0l90ijw96czjd6z8bw88983rsnq5753iw86rhk1wi064w4rs19ig";
     };
 
     propagatedBuildInputs = with self; [ pbr Babel six iso8601 pytz netaddr netifaces
@@ -14254,12 +14261,14 @@ in {
 
 
   oslo-service = buildPythonPackage rec {
-    name = "oslo.service-${version}";
-    version = "0.10.0";
+    pname = "oslo.service";
+    version = "1.26.0";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/o/oslo.service/oslo.service-0.10.0.tar.gz";
-      sha256 = "1pcnimc2a50arcgq355ad9lramf6y1yv974swgfj6w90v5c6p9gz";
+    name = "${pname}-${version}";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "083q7z6nrska5fq12vnd70blphxscd7ivca2d78jk84d99h0m5n5";
     };
 
     propagatedBuildInputs = with self; [
@@ -14267,16 +14276,15 @@ in {
       oslo-concurrency wrapt eventlet six oslo-serialization greenlet paste
       oslo-config monotonic iso8601 oslo-log pytz routes msgpack
       oslo-i18n argparse oslo-utils pbr enum34 netaddr stevedore netifaces
-      pyinotify webob retrying pyinotify ];
+      pyinotify webob retrying pyinotify oslo-log ];
     buildInputs = with self; [
       oslosphinx oslotest pkgs.procps mock mox3 fixtures subunit testrepository
       testtools testscenarios
     ];
 
-    # failing tests
-    preCheck = ''
-      rm oslo_service/tests/test_service.py
-    '';
+    ## cannot import eventlet due to:
+    # _proto_tcp = socket.getprotobyname('tcp')
+    doCheck = false;
 
     meta = with stdenv.lib; {
       homepage = "http://wiki.openstack.org/wiki/Oslo#oslo.service";
@@ -14721,13 +14729,14 @@ in {
 
 
   oslo-concurrency = buildPythonPackage rec {
-   name = "oslo-concurrency-${version}";
-   version = "2.7.0";
+    pname = "oslo.concurrency";
+    version = "3.22.0";
+    name = "${pname}-${version}";
 
-   src = pkgs.fetchurl {
-     url = "mirror://pypi/o/oslo.concurrency/oslo.concurrency-2.7.0.tar.gz";
-     sha256 = "1yp8c87yi6fx1qbq4y1xkx47iiifg7jqzpcghivhxqra8vna185d";
-   };
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "0nh1ycc2s6w05g5w63bsmmda0gw7qsrwlax3as8a0piai99z4m51";
+    };
 
    propagatedBuildInputs = with self; [
      oslo-i18n argparse six wrapt oslo-utils pbr enum34 Babel netaddr monotonic
@@ -14735,8 +14744,8 @@ in {
      eventlet
    ];
    buildInputs = with self; [
-     oslosphinx fixtures futures coverage oslotest
-   ];
+     oslosphinx fixtures coverage oslotest
+   ] ++ (optional (!isPy3k) futures);
 
    # too much magic in tests
    doCheck = false;
@@ -14816,16 +14825,17 @@ in {
   olefile = callPackage ../development/python-modules/olefile { };
 
   oslo-log = buildPythonPackage rec {
-    name = "oslo.log-${version}";
-    version = "1.12.1";
+    name = "${pname}-${version}";
+    pname = "oslo.log";
+    version = "3.31.0";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/o/oslo.log/${name}.tar.gz";
-      sha256 = "10x596r19zjla5n1bf04j5vncx0c9gpc5wc2jlmgjbl3cyx3vgsv";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "1w08cl98n8592pvb2gw01mqlwi8nnnpg1zy10mvj6xdpvfk2yqzz";
     };
 
     propagatedBuildInputs = with self; [
-      pbr Babel six iso8601 debtcollector
+      pbr Babel six iso8601 debtcollector dateutil
       oslo-utils oslo-i18n oslo-config oslo-serialization oslo-context
     ] ++ stdenv.lib.optional stdenv.isLinux pyinotify;
     buildInputs = with self; [ oslotest oslosphinx ];
@@ -14835,12 +14845,13 @@ in {
   };
 
   oslo-context = buildPythonPackage rec {
-    name = "oslo.context-${version}";
-    version = "0.7.0";
+    name = "${pname}-${version}";
+    pname = "oslo.context";
+    version = "2.18.1";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/o/oslo.context/${name}.tar.gz";
-      sha256 = "18fmg9dhgngshk63wfb3ddrgx5br8jxkk3x30z40741mslp1fdjy";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "1sc7qrwffsm15m91c17k0xiglv6bxh9sbksvxvrrgja82m57mgh6";
     };
 
     propagatedBuildInputs = with self; [ pbr Babel ];
@@ -19050,14 +19061,16 @@ in {
   ropper = callPackage ../development/python-modules/ropper { };
 
   routes = buildPythonPackage rec {
-    name = "routes-1.12.3";
+    pname = "Routes";
+    version = "2.4.1";
+    name = "${pname}-${version}";
 
-    src = pkgs.fetchurl {
-      url = mirror://pypi/R/Routes/Routes-1.12.3.tar.gz;
-      sha256 = "eacc0dfb7c883374e698cebaa01a740d8c78d364b6e7f3df0312de042f77aa36";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "1zamff3m0kc4vyfniyhxpkkcqv1rrgnmh37ykxv34nna1ws47vi6";
     };
 
-    propagatedBuildInputs = with self; [ paste webtest ];
+    propagatedBuildInputs = with self; [ paste webtest repoze_lru ];
 
     meta = {
       description = "A Python re-implementation of the Rails routes system for mapping URLs to application actions";
@@ -22492,15 +22505,16 @@ EOF
   };
 
   webob = buildPythonPackage rec {
-    version = "1.4.1";
-    name = "webob-${version}";
+    pname = "WebOb";
+    version = "1.7.3";
+    name = "${pname}-${version}";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/W/WebOb/WebOb-${version}.tar.gz";
-      sha256 = "1nz9m6ijf46wfn33zfza13c0k1n4kjnmn3icdlrlgz5yj21vky0j";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "10vjp2rvqiyvw157fk3sy7yds1gknzw97z4gk0qv1raskx5s2p76";
     };
 
-    propagatedBuildInputs = with self; [ nose ];
+    propagatedBuildInputs = with self; [ nose pytest ];
 
     meta = {
       description = "WSGI request and response object";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2606,11 +2606,13 @@ in {
     # https://github.com/celery/celery/pull/3736#issuecomment-274155454 from upstream
     patches = [ ../development/python-modules/celery/fix_endless_python3.6_loop_logger_isa.patch ];
 
-    ## importing of eventlet fails because of:
-    # _proto_tcp = socket.getprotobyname('tcp')
-    ## raises an exception in the sandbox
+    # make /etc/protocols accessible to fix socket.getprotobyname('tcp') in sandbox
     preCheck = ''
-      rm ./t/unit/concurrency/test_eventlet.py
+      export NIX_REDIRECTS=/etc/protocols=${pkgs.iana-etc}/etc/protocols \
+        LD_PRELOAD=${pkgs.libredirect}/lib/libredirect.so
+    '';
+    postCheck = ''
+      unset NIX_REDIRECTS LD_PRELOAD
     '';
 
     buildInputs = with self; [ pytest case ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1313,11 +1313,11 @@ in {
   };
 
   betamax = buildPythonPackage rec {
-    name = "betamax-0.6.0";
+    name = "betamax-0.8.0";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/b/betamax/${name}.tar.gz";
-      sha256 = "0vw4d53jbbb2kdl7l891h8iyxklqcd6ldvgcyhw9hl40ljdhv1wz";
+      sha256 = "18f8v5gng3j773jlbbzx4rg1i4y2zw3m2l1zpmbvp8bh5a2q1i42";
     };
 
     propagatedBuildInputs = [ self.requests ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2606,6 +2606,13 @@ in {
     # https://github.com/celery/celery/pull/3736#issuecomment-274155454 from upstream
     patches = [ ../development/python-modules/celery/fix_endless_python3.6_loop_logger_isa.patch ];
 
+    ## importing of eventlet fails because of:
+    # _proto_tcp = socket.getprotobyname('tcp')
+    ## raises an exception in the sandbox
+    preCheck = ''
+      rm ./t/unit/concurrency/test_eventlet.py
+    '';
+
     buildInputs = with self; [ pytest case ];
     propagatedBuildInputs = with self; [ kombu billiard pytz anyjson amqp eventlet ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14852,14 +14852,14 @@ in {
 
   oslo-i18n = buildPythonPackage rec {
     name = "oslo.i18n-${version}";
-    version = "2.7.0";
+    version = "3.18.0";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/o/oslo.i18n/${name}.tar.gz";
-      sha256 = "11jgcvj36g97awh7fpar4xxgwrvzfahq6rw7xxqac32ia790ylcz";
+      sha256 = "19w6wil588fgppc7d42fqkrjs0y81ap62svzbij8hlb3w2d4a91n";
     };
 
-    propagatedBuildInputs = with self; [ pbr Babel six oslo-config ];
+    propagatedBuildInputs = with self; [ pbr Babel six ];
     buildInputs = with self; [ mock coverage oslotest ];
     patchPhase = ''
       sed -i 's@python@${python.interpreter}@' .testr.conf
@@ -14870,11 +14870,11 @@ in {
 
   oslotest = buildPythonPackage rec {
     name = "oslotest-${version}";
-    version = "1.12.0";
+    version = "2.18.0";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/o/oslotest/${name}.tar.gz";
-      sha256 = "17i92hymw1dwmmb5yv90m2gam2x21mc960q1pr7bly93x49h8666";
+      sha256 = "0a0zhpb4yp7g6d290jk7a4pfci4ciwhsrqzhbwbl2szi50gp7km1";
     };
 
     patchPhase = ''
@@ -14882,27 +14882,26 @@ in {
     '';
 
     propagatedBuildInputs = with self; [ pbr fixtures subunit six testrepository
-      testscenarios testtools mock mox3 oslo-config os-client-config ];
+      os-client-config debtcollector testscenarios testtools mock mox3 os-client-config ];
   };
 
   os-client-config = buildPythonPackage rec {
     name = "os-client-config-${version}";
-    version = "1.8.1";
+    version = "1.28.0";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/o/os-client-config/${name}.tar.gz";
-      sha256 = "10hz4yp594mi1p7v1pvgsmx5w2rnb9y8d0jvb2lfv03ljnwzv8jz";
+      sha256 = "1f7q384b9drp3fqcg0w8aihv9k4idaay8vr3an187zjpgbx9rgp5";
     };
 
-    buildInputs = with self; [ pbr testtools testscenarios testrepository fixtures ];
-    propagatedBuildInputs = with self; [ appdirs pyyaml keystoneauth1 ];
+    # requires oslotest but is a dependency of that package ...
+    doCheck = false;
+
+    buildInputs = with self; [ pbr testtools testscenarios testrepository fixtures jsonschema ];
+    propagatedBuildInputs = with self; [ appdirs pyyaml keystoneauth1 requestsexceptions ];
 
     patchPhase = ''
       sed -i 's@python@${python.interpreter}@' .testr.conf
-    '';
-    # TODO: circular import on oslotest
-    preCheck = ''
-      rm os_client_config/tests/{test_config,test_cloud_config,test_environ}.py
     '';
   };
 
@@ -14927,16 +14926,20 @@ in {
 
   mox3 = buildPythonPackage rec {
     name = "mox3-${version}";
-    version = "0.11.0";
+    version = "0.23.0";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/m/mox3/${name}.tar.gz";
-      sha256 = "09dkgki21v5zqrx575h1aazxsq5akkv0a90z644bk1ry9a4zg1pn";
+      sha256 = "0q26sg0jasday52a7y0cch13l0ssjvr4yqnvswqxsinj1lv5ld88";
     };
 
     patchPhase = ''
       sed -i 's@python@${python.interpreter}@' .testr.conf
     '';
+
+    #  FAIL: mox3.tests.test_mox.RegexTest.testReprWithFlags
+    #  ValueError: cannot use LOCALE flag with a str pattern
+    doCheck = !isPy36;
 
     buildInputs = with self; [ subunit testrepository testtools six ];
     propagatedBuildInputs = with self; [ pbr fixtures ];
@@ -14944,21 +14947,21 @@ in {
 
   debtcollector = buildPythonPackage rec {
     name = "debtcollector-${version}";
-    version = "0.9.0";
+    version = "1.17.0";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/d/debtcollector/${name}.tar.gz";
-      sha256 = "1mvdxdrnwlgfqg26s5himkjq6f06r2khlrignx36kkbyaix6j9xb";
+      sha256 = "0rh47fd5kgjcdv9dxr7xf0x308cvfic3h2zk03ifvb4pdc5kbqvi";
     };
     patchPhase = ''
       sed -i 's@python@${python.interpreter}@' .testr.conf
     '';
 
     buildInputs = with self; [ pbr ];
-    propagatedBuildInputs = with self; [ wrapt Babel six doc8 ];
+    propagatedBuildInputs = with self; [ wrapt Babel six doc8 ] ++
+                              (optional (isPy26 || isPy27) funcsigs);
     checkInputs = with self; [ pbr Babel six wrapt testtools testscenarios
-       testrepository subunit coverage oslotest ];
-    doCheck = false; # oslo is broken
+                               testrepository subunit coverage ];
   };
 
   doc8 = callPackage ../development/python-modules/doc8 { };
@@ -18362,6 +18365,8 @@ in {
       maintainer = maintainers.fridh;
     };
   };
+
+  requestsexceptions = callPackage ../development/python-modules/requestsexceptions {};
 
   requests_ntlm = callPackage ../development/python-modules/requests_ntlm { };
 


### PR DESCRIPTION
Also updated the following dependencies:
keystoneauth1: 3.1.0 -> 3.2.0
  needed to disable test due to circular dependencies towards oslo-config
oslo-i18n: 2.7.0 -> 3.18.0
  update required to not have oslo-config as a build dependency
oslotest: 1.12.0 -> 2.18.0
os-client-config: 1.8.1 -> 1.28.0
  needed to disable testing due to circular dependency with oslotest
mox3: 0.11.0 -> 0.23.0
  for py36: needed to disable testing due to LOCALE flag ValueError
debtcollector: 0.9.0 -> 1.17.0

*update*:
oslo-service: 0.10.0 -> 1.26.0
  needs to disable tests due to network errors when importing eventlet
  for tests ( socket.getprotobyname('tcp') -> no such protocol )
eventlet: 0.17.4 -> 0.20.0
  cannot update to 0.21.0 due to version pinning ( < 0.21.0 ) of oslo-service
monotonic: 0.4 -> 1.3
oslo-serialization: 1.10.0 -> 2.20.0
oslo-utils: 2.6.0 -> 3.29.0
oslo-concurrency: 2.7.0 -> 3.22.0
oslo-log: 1.12.1 -> 3.31.0
oslo-context: 0.7.0 -> 2.18.1
routes: 1.12.3 -> 2.4.1
webob: 1.4.1 -> 1.7.3

extra packages:
requestsexceptions: init at 1.3.0
  removed `hacking` reference in `test-dependencies.txt` as it is not a test dependency

###### Motivation for this change

oslo-config broke (and never got fixed) with the update introduced in d58e1f1c7b3e955d3ee1194ea96c574338b47b97 . It got marked as broken 67651d80bc8baaf09ab91fec8ea423e09107ed8f and is now in the process of being deleted via the PR to remove *all things openstack* #29491 .
oslo-config however is a dependency for a number of different other packages. My main reason to have working tests it in nixpkgs is for sqlalchemy_migrate ( -> tempest-lib -> oslo-config ).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

