### PR TITLE
erlang: introduce "no X" variation

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6295,7 +6295,7 @@ with pkgs;
 
   inherit (beam.interpreters)
     erlang erlangR17 erlangR18 erlangR19 erlangR20
-    erlang_odbc erlang_javac erlang_odbc_javac erlang_basho_R16B02
+    erlang_odbc erlang_javac erlang_odbc_javac erlang_nox erlang_basho_R16B02
     elixir elixir_1_5 elixir_1_4 elixir_1_3
     lfe lfe_1_2;
 

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -6,11 +6,12 @@ rec {
   # Each
   interpreters = rec {
 
-    # R18 is the default version.
+    # R19 is the default version.
     erlang = erlangR19; # The main switch to change default Erlang version.
     erlang_odbc = erlangR19_odbc;
     erlang_javac = erlangR19_javac;
     erlang_odbc_javac = erlangR19_odbc_javac;
+    erlang_nox = erlangR19_nox;
 
     # These are standard Erlang versions, using the generic builder.
     erlangR16 = lib.callErlang ../development/interpreters/erlang/R16.nix {};
@@ -21,6 +22,7 @@ rec {
     erlangR17_odbc_javac = erlangR17.override {
       javacSupport = true; odbcSupport = true;
     };
+    erlangR17_nox = erlangR17.override { wxSupport = false; };
     erlangR18 = lib.callErlang ../development/interpreters/erlang/R18.nix {
       wxGTK = wxGTK30;
     };
@@ -29,6 +31,7 @@ rec {
     erlangR18_odbc_javac = erlangR18.override {
       javacSupport = true; odbcSupport = true;
     };
+    erlangR18_nox = erlangR18.override { wxSupport = false; };
     erlangR19 = lib.callErlang ../development/interpreters/erlang/R19.nix {
       wxGTK = wxGTK30;
     };
@@ -37,6 +40,7 @@ rec {
     erlangR19_odbc_javac = erlangR19.override {
       javacSupport = true; odbcSupport = true;
     };
+    erlangR19_nox = erlangR19.override { wxSupport = false; };
     erlangR20 = lib.callErlang ../development/interpreters/erlang/R20.nix {
       wxGTK = wxGTK30;
     };
@@ -45,6 +49,7 @@ rec {
     erlangR20_odbc_javac = erlangR20.override {
       javacSupport = true; odbcSupport = true;
     };
+    erlangR20_nox = erlangR20.override { wxSupport = false; };
 
     # Bash fork, using custom builder.
     erlang_basho_R16B02 = lib.callErlang ../development/interpreters/erlang/R16B02-8-basho.nix {


### PR DESCRIPTION
###### Motivation for this change

Erlang pulls in a lot of X dependencies by default. This "_nox" variation reduces the size of the default R18 closure from 465mb to 306mb.

Further to #29518 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

