### PR TITLE
google-drive-ocamlfuse: 0.6.17 -> 0.6.21

### DIFF
--- a/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
+++ b/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
@@ -1,16 +1,20 @@
-{ stdenv, fetchurl, zlib
+{ stdenv, fetchFromGitHub, zlib
 , ocaml, ocamlbuild, ocamlfuse, findlib, gapi_ocaml, ocaml_sqlite3, camlidl }:
 
 stdenv.mkDerivation rec {
-  name    = "google-drive-ocamlfuse-${version}";
-  version = "0.6.17";
+  name = "google-drive-ocamlfuse-${version}";
+  version = "0.6.21";
 
-  src = fetchurl {
-    url = "https://forge.ocamlcore.org/frs/download.php/1674/${name}.tar.gz";
-    sha256 = "1ldja7080pnjaibrbdvfqwakp4mac8yw1lkb95f7lgldmy96lxas";
+  src = fetchFromGitHub {
+    owner = "astrada";
+    repo = "google-drive-ocamlfuse";
+    rev = "v${version}";
+    sha256 = "14qvhz18pzxdgxk5vcs024ajbkxccfwc9p3z5r6vfkc9mm851v59";
   };
 
-  buildInputs = [ zlib ocaml ocamlbuild ocamlfuse findlib gapi_ocaml ocaml_sqlite3 camlidl];
+  nativeBuildInputs = [ ocamlbuild ];
+
+  buildInputs = [ zlib ocaml ocamlfuse findlib gapi_ocaml ocaml_sqlite3 camlidl ];
 
   configurePhase = "ocaml setup.ml -configure --prefix \"$out\"";
   buildPhase = "ocaml setup.ml -build";


### PR DESCRIPTION
###### Motivation for this change

Update to version [0.6.21](https://github.com/astrada/google-drive-ocamlfuse/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).