### PR TITLE
ocamlfuse: 2.7-3 -> 2.7.1cvs5

### DIFF
--- a/pkgs/development/ocaml-modules/ocamlfuse/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlfuse/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, ocaml, camlidl, fuse, findlib }:
 
 stdenv.mkDerivation rec {
-  name = "ocamlfuse-2.7-3";
+  name = "ocamlfuse-2.7.1cvs5";
   src = fetchFromGitHub {
     owner = "astrada";
     repo = "ocamlfuse";
-    rev = "a085349685758668854499ce6c1fc00c83a5c23b";
-    sha256 = "1pyml2ay5wab1blwpzrv1r6lnycm000jk6aar8i9fkdnh15sa6c3";
+    rev = "v2.7.1_cvs5";
+    sha256 = "01ayw2hzpxan95kncbxh9isj9g149cs8scq3xim1vy8bz085wb0m";
   };
 
   buildInputs = [ocaml findlib];
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://sourceforge.net/projects/ocamlfuse;
+    description = "OCaml bindings for FUSE";
     license = stdenv.lib.licenses.gpl2;
-    description = "ocaml binding for fuse";
-    maintainers = with stdenv.lib.maintainers; [ bennofs ];
     platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ bennofs ];
   };
 }

--- a/pkgs/development/ocaml-modules/ocamlfuse/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlfuse/default.nix
@@ -1,11 +1,13 @@
 { stdenv, fetchFromGitHub, ocaml, camlidl, fuse, findlib }:
 
 stdenv.mkDerivation rec {
-  name = "ocamlfuse-2.7.1cvs5";
+  name = "ocamlfuse-${version}";
+  version = "2.7.1_cvs5";
+
   src = fetchFromGitHub {
     owner = "astrada";
     repo = "ocamlfuse";
-    rev = "v2.7.1_cvs5";
+    rev = "v${version}";
     sha256 = "01ayw2hzpxan95kncbxh9isj9g149cs8scq3xim1vy8bz085wb0m";
   };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).