### PR TITLE
impressive: fixes and improvements

### DIFF
--- a/pkgs/applications/office/impressive/default.nix
+++ b/pkgs/applications/office/impressive/default.nix
@@ -1,12 +1,12 @@
-{ fetchurl, stdenv, python2Packages, makeWrapper, lib
-, xpdf, mesa, SDL, freeglut }:
+{ fetchurl, stdenv, python2, makeWrapper, lib
+, mesa, SDL, freeglut, ghostscript, pdftk, dejavu_fonts }:
 
 let
-  inherit (python2Packages) python pyopengl pygame setuptools pillow;
   version = "0.11.1";
+  pythonEnv = python2.withPackages (ps: with ps; [pyopengl pygame pillow]);
 in stdenv.mkDerivation {
     # This project was formerly known as KeyJNote.
-    # See http://keyj.s2000.ws/?p=77 for details.
+    # See http://keyj.emphy.de/apple-lawsuit/ for details.
 
     name = "impressive-${version}";
 
@@ -15,37 +15,26 @@ in stdenv.mkDerivation {
       sha256 = "0b3rmy6acp2vmf5nill3aknxvr9a5aawk1vnphkah61anxp62gsr";
     };
 
-    # Note: We need to have `setuptools' in the path to be able to use
-    # PyOpenGL.
-    buildInputs = [ makeWrapper xpdf pillow pyopengl pygame ];
+    buildInputs = [ makeWrapper pythonEnv ];
 
     configurePhase = ''
+      # Let's fail at build time if the library we're substituting in doesn't
+      # exist/isn't marked as executable
+      test -x ${SDL}/lib/libSDL.so
       sed -i "impressive.py" \
-          -e 's|^#!/usr/bin/env.*$|#!${python}/bin/python|g'
+          -e '/^__website__/a SDL_LIBRARY = "${SDL}/lib/libSDL.so"' \
+          -e 's/sdl = CDLL.*/sdl = CDLL(SDL_LIBRARY)/' \
+          -e 's^FontPath =.*/usr/.*$^FontPath = ["${dejavu_fonts}/share/fonts", ""]^'
     '';
 
     installPhase = ''
-      mkdir -p "$out/bin" "$out/share/doc/impressive"
+      mkdir -p "$out/bin" "$out/share/doc/impressive" "$out/share/man/man1"
       mv impressive.py "$out/bin/impressive"
-      mv * "$out/share/doc/impressive"
+      mv impressive.1 "$out/share/man/man1"
+      mv changelog.txt impressive.html license.txt "$out/share/doc/impressive"
 
-      # XXX: We have to reiterate PyOpenGL's dependencies here.
-      #
-      # `setuptools' must be in the Python path as it's used by
-      # PyOpenGL.
-      #
-      # We set $LIBRARY_PATH (no `LD_'!) so that ctypes can find
-      # `libGL.so', which it does by running `gcc', which in turn
-      # honors $LIBRARY_PATH.  See
-      # http://python.net/crew/theller/ctypes/reference.html#id1 .
       wrapProgram "$out/bin/impressive" \
-         --prefix PATH ":" "${xpdf}/bin" \
-         --prefix PYTHONPATH ":" \
-                  ${lib.concatStringsSep ":"
-                     (map (path:
-                            path + "/lib/${python.libPrefix}/site-packages")
-                          [ pillow pyopengl pygame setuptools ])} \
-         --prefix LIBRARY_PATH ":" "${lib.makeLibraryPath [ mesa freeglut SDL ]}"
+         --prefix PATH ":" "${ghostscript}/bin:${pdftk}/bin"
     '';
 
     meta = {
@@ -73,7 +62,7 @@ in stdenv.mkDerivation {
 
       license = stdenv.lib.licenses.gpl2;
 
-      maintainers = [ ];
+      maintainers = with lib.maintainers; [ lheckemann ];
       platforms = stdenv.lib.platforms.mesaPlatforms;
     };
   }


### PR DESCRIPTION
###### Motivation for this change
- Fix finding SDL (would previously fail unless gcc was in environment) (fixes #23980)
- Use ghostscript rather than xpdf for rendering as it has a slightly
  smaller closure
- Fix broken link for reasoning behind name change
- Add self to maintainers
- Add reference to DejaVu fonts so it can always find the OSD fonts
- Install manpage into correct location

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @FRidh 