### PR TITLE
nifticlib: init at 2.0.0

### DIFF
--- a/pkgs/development/libraries/science/biology/nifticlib/default.nix
+++ b/pkgs/development/libraries/science/biology/nifticlib/default.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation rec {
   name  = "${pname}-${pversion}";
 
   src = fetchurl {
-    url    = "https://downloads.sourceforge.net/project/niftilib/${pname}/${pname}_2_0_0/${name}.tar.gz";
-    sha256 = "a3e988e6a32ec57833056f6b09f940c69e79829028da121ff2c5c6f7f94a7f88";
+    url    = "mirror://sourceforge/project/niftilib/${pname}/${pname}_2_0_0/${name}.tar.gz";
+    sha256 = "123z9bwzgin5y8gi5ni8j217k7n683whjsvg0lrpii9flgk8isd3";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/science/biology/nifticlib/default.nix
+++ b/pkgs/development/libraries/science/biology/nifticlib/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, cmake, zlib }:
+
+stdenv.mkDerivation rec {
+  pname    = "nifticlib";
+  pversion = "2.0.0";
+  name  = "${pname}-${pversion}";
+
+  src = fetchurl {
+    url    = "https://downloads.sourceforge.net/project/niftilib/${pname}/${pname}_2_0_0/${name}.tar.gz";
+    sha256 = "a3e988e6a32ec57833056f6b09f940c69e79829028da121ff2c5c6f7f94a7f88";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ zlib ];
+
+  checkPhase = "ctest";
+
+  meta = with stdenv.lib; {
+    homepage = https://sourceforge.net/projects/niftilib;
+    description = "Medical imaging format C API";
+    maintainers = with maintainers; [ bcdarwin ];
+    platforms = platforms.linux;
+    license = licenses.publicDomain;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9761,6 +9761,8 @@ with pkgs;
 
   ndpi = callPackage ../development/libraries/ndpi { };
 
+  nifticlib = callPackage ../development/libraries/science/biology/nifticlib { };
+
   notify-sharp = callPackage ../development/libraries/notify-sharp { };
 
   ncurses5 = callPackage ../development/libraries/ncurses { abiVersion = "5"; };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

