### PR TITLE
HPLIP: Fix PostScript printers, installed utilities

### DIFF
--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -88,6 +88,7 @@ pythonPackages.buildPythonApplication {
 
   preConfigure = ''
     export configureFlags="$configureFlags
+      --with-hpppddir=$out/share/cups/model/HP
       --with-cupsfilterdir=$out/lib/cups/filter
       --with-cupsbackenddir=$out/lib/cups/backend
       --with-icondir=$out/share/applications

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -61,10 +61,9 @@ pythonPackages.buildPythonApplication {
 
   nativeBuildInputs = [
     pkgconfig
-    makeWrapper
   ];
 
-  propagatedBuildInputs = with pythonPackages; [
+  pythonPath = with pythonPackages; [
     dbus
     pillow
     pygobject2
@@ -73,6 +72,8 @@ pythonPackages.buildPythonApplication {
   ] ++ stdenv.lib.optionals qtSupport [
     pyqt4
   ];
+
+  makeWrapperArgs = [ ''--prefix PATH : "${nettools}/bin"'' ];
 
   prePatch = ''
     # HPLIP hardcodes absolute paths everywhere. Nuke from orbit.
@@ -145,10 +146,30 @@ pythonPackages.buildPythonApplication {
     rm $out/etc/udev/rules.d/56-hpmud.rules
   '';
 
-  postFixup = ''
-    wrapProgram $out/lib/cups/filter/hpps \
-      --prefix PATH : "${nettools}/bin"
+  # The installed executables are just symlinks into $out/share/hplip,
+  # but wrapPythonPrograms ignores symlinks. We cannot replace the Python
+  # modules in $out/share/hplip with wrapper scripts because they import
+  # each other as libraries. Instead, we emulate wrapPythonPrograms by
+  # 1. Calling patchPythonProgram on the original script in $out/share/hplip
+  # 2. Making our own wrapper pointing directly to the original script.
+  dontWrapPythonPrograms = true;
+  preFixup = ''
+    buildPythonPath "$out $pythonPath"
 
+    for bin in $out/bin/*; do
+      py=$(readlink -m $bin)
+      rm $bin
+      echo "patching \`$py'..."
+      patchPythonScript "$py"
+      echo "wrapping \`$bin'..."
+      makeWrapper "$py" "$bin" \
+          --prefix PATH ':' "$program_PATH" \
+          --set PYTHONNOUSERSITE "true" \
+          $makeWrapperArgs
+    done
+  '';
+
+  postFixup = ''
     substituteInPlace $out/etc/hp/hplip.conf --replace /usr $out
   '' + stdenv.lib.optionalString (!withPlugin) ''
     # A udev rule to notify users that they need the binary plugin.


### PR DESCRIPTION
### Motivation

This PR fixes two bugs:

1. The PPDs for PostScript-based printers are not installed where CUPS can find them, so the drivers for all such printers (most enterprise models) are missing.
2. None of the installed utilities work because `wrapPythonPrograms` ignores symlinks! We cannot wrap the symlink targets, either, so we must emulate it ourselves.


### Testing

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

