### PR TITLE
cc-wrapper: Use stdenvNoCC to build

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -5,15 +5,15 @@
 # script that sets up the right environment variables so that the
 # compiler and the linker just "work".
 
-{ name ? "", stdenv, nativeTools, noLibc ? false, nativeLibc, nativePrefix ? ""
-, cc ? null, libc ? null, binutils ? null, coreutils ? null, shell ? stdenv.shell
+{ name ? "", stdenvNoCC, nativeTools, noLibc ? false, nativeLibc, nativePrefix ? ""
+, cc ? null, libc ? null, binutils ? null, coreutils ? null, shell ? stdenvNoCC.shell
 , zlib ? null, extraPackages ? [], extraBuildCommands ? ""
 , isGNU ? false, isClang ? cc.isClang or false, gnugrep ? null
 , buildPackages ? {}
 , useMacosReexportHack ? false
 }:
 
-with stdenv.lib;
+with stdenvNoCC.lib;
 
 assert nativeTools -> nativePrefix != "";
 assert !nativeTools ->
@@ -25,6 +25,7 @@ assert (noLibc || nativeLibc) == (libc == null);
 assert cc.langVhdl or false -> zlib != null;
 
 let
+  stdenv = stdenvNoCC;
   inherit (stdenv) hostPlatform targetPlatform;
 
   # Prefix for binaries. Customarily ends with a dash separator.

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -77,7 +77,7 @@ in rec {
 
         cc = if isNull last then "/dev/null" else import ../../build-support/cc-wrapper {
           inherit shell;
-          inherit (last) stdenv;
+          inherit (last) stdenvNoCC;
 
           nativeTools  = false;
           nativeLibc   = false;
@@ -324,7 +324,7 @@ in rec {
     shell       = "${pkgs.bash}/bin/bash";
 
     cc = lib.callPackageWith {} ../../build-support/cc-wrapper {
-      inherit (pkgs) stdenv;
+      inherit (pkgs) stdenvNoCC;
       inherit shell;
       nativeTools = false;
       nativeLibc  = false;

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -77,7 +77,7 @@ let inherit (localSystem) system; in
         nativeTools  = true;
         nativePrefix = "/usr";
         nativeLibc   = true;
-        inherit (prevStage) stdenv;
+        stdenvNoCC = prevStage.stdenv;
         cc           = {
           name    = "clang-9.9.9";
           cc      = "/usr";

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -84,7 +84,7 @@ let
           libc = prevStage.glibc;
           inherit (prevStage) binutils coreutils gnugrep;
           name = name;
-          stdenv = prevStage.ccWrapperStdenv;
+          stdenvNoCC = prevStage.ccWrapperStdenv;
         };
 
         extraAttrs = {
@@ -244,7 +244,7 @@ in
         };
         cc = prevStage.gcc-unwrapped;
         libc = self.glibc;
-        inherit (self) stdenv binutils coreutils gnugrep;
+        inherit (self) stdenvNoCC binutils coreutils gnugrep;
         name = "";
         shell = self.bash + "/bin/bash";
       };

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -117,6 +117,7 @@ in
       cc = null;
       fetchurl = null;
     };
+    stdenvNoCC = stdenv;
 
     cc = import ../../build-support/cc-wrapper {
       name = "cc-native";
@@ -126,7 +127,7 @@ in
         "i686-solaris" = "/usr/gnu";
         "x86_64-solaris" = "/opt/local/gcc47";
       }.${system} or "/usr";
-      inherit stdenv;
+      inherit stdenvNoCC;
     };
 
     fetchurl = import ../../build-support/fetchurl {

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -1,5 +1,5 @@
 { lib
-, crossSystem, config
+, crossSystem, config, overlays
 , bootStages
 , ...
 }:
@@ -7,9 +7,7 @@
 assert crossSystem == null;
 
 bootStages ++ [
-  (prevStage: let
-    inherit (prevStage) stdenv;
-  in {
+  (prevStage: {
     inherit config overlays;
 
     stdenv = import ../generic rec {
@@ -27,10 +25,9 @@ bootStages ++ [
 
       cc = import ../../build-support/cc-wrapper {
         nativeTools = false;
-        nativePrefix = stdenv.lib.optionalString hostPlatform.isSunOS "/usr";
+        nativePrefix = lib.optionalString hostPlatform.isSunOS "/usr";
         nativeLibc = true;
-        inherit stdenv;
-        inherit (prevStage) binutils coreutils gnugrep;
+        inherit (prevStage) stdenvNoCC binutils coreutils gnugrep;
         cc = prevStage.gcc.cc;
         isGNU = true;
         shell = prevStage.bash + "/bin/sh";
@@ -38,7 +35,7 @@ bootStages ++ [
 
       shell = prevStage.bash + "/bin/sh";
 
-      fetchurlBoot = stdenv.fetchurlBoot;
+      fetchurlBoot = prevStage.stdenv.fetchurlBoot;
 
       overrides = self: super: {
         inherit cc;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6207,11 +6207,11 @@ with pkgs;
 
   wla-dx = callPackage ../development/compilers/wla-dx { };
 
-  wrapCCWith = { name ? "", cc, libc, extraBuildCommands ? "" }: ccWrapperFun {
+  wrapCCWith = { name ? "", cc, libc, extraBuildCommands ? "" }: ccWrapperFun rec {
     nativeTools = targetPlatform == hostPlatform && stdenv.cc.nativeTools or false;
     nativeLibc = targetPlatform == hostPlatform && stdenv.cc.nativeLibc or false;
     nativePrefix = stdenv.cc.nativePrefix or "";
-    noLibc = (libc == null);
+    noLibc = !nativeLibc && (libc == null);
 
     isGNU = cc.isGNU or false;
     isClang = cc.isClang or false;


### PR DESCRIPTION
###### Motivation for this change

cc-wrapper may wrap a C compiler, but it doesn't need one to build itself. (c.f. expand-response-params is a separate derivation.) This helps avoid cycles on the cross stuff, in addition to removing a useless dependency edge.

I could have been super careful with overrides in the stdenv to avoid the mass rebuild, but I don't think it's worth it. [If all goes well, we'll merge this with the other PRs in https://github.com/NixOS/nixpkgs/projects/8, so they'll be a mas-rebuild anyways.]

###### Things done

Building stdenv as part of other things. PR has more commits than it should because it depends on other PRs.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

