### PR TITLE
xonsh: fix typo ("xnosh") in "enable" description

### DIFF
--- a/nixos/modules/programs/xonsh.nix
+++ b/nixos/modules/programs/xonsh.nix
@@ -21,7 +21,7 @@ in
       enable = mkOption {
         default = false;
         description = ''
-          Whether to configure xnosh as an interactive shell.
+          Whether to configure xonsh as an interactive shell.
         '';
         type = types.bool;
       };


### PR DESCRIPTION
###### Motivation for this change

That's most likely a typo. It seems to have been around at least since 760da3e3f39b43c113797456dcdbe8ad6cfb466c.

###### Things done

(I've done none of these, as I've edited the file online on the GitHub website. As only the description is concerned, I'm pretty sure this change can't break anything, unless I haven't understood at all how NixOS packages work.)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

