### PR TITLE
glibc: Grab the right linux headers when build != host

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -1,10 +1,12 @@
 /* Build configuration used to build glibc, Info files, and locale
    information.  */
 
-{ stdenv, lib, fetchurl
-, gd ? null, libpng ? null
+{ stdenv, lib
 , buildPlatform, hostPlatform
 , buildPackages
+, fetchurl
+, linuxHeaders ? null
+, gd ? null, libpng ? null
 }:
 
 { name
@@ -17,7 +19,6 @@
 } @ args:
 
 let
-  inherit (buildPackages) linuxHeaders;
   version = "2.25";
   patchSuffix = "-49";
   sha256 = "067bd9bb3390e79aa45911537d13c3721f1d9d3769931a30c2681bfee66f23a0";


### PR DESCRIPTION
###### Motivation for this change

In #28519 / 791ce593ce065cf074edf1509ff52ebc69136d9e I made `linuxHeaders` be used from the stage stage, as it would be if it were a library containing headers and code. I forgot to update glibc, however, so it was incorrectly using headers for the build platform, not host platform.

This fixes that, basically reverting a small portion of changes I made a few months ago in 25edc476fd9fe1bd8bedf571d218ba4f27fb5a27 and its parent.

###### Things done

No native hashes are changed.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS, built aarch64 toolchain
   - [ ] ~macOS~ someday!
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

