### PR TITLE
salt: 2016.11.5 -> 2017.7.1

### DIFF
--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -8,12 +8,12 @@
 
 python2Packages.buildPythonApplication rec {
   pname = "salt";
-  version = "2016.11.5";
+  version = "2017.7.1";
   name = "${pname}-${version}";
 
   src = python2Packages.fetchPypi {
     inherit pname version;
-    sha256 = "1gpq6s87vy782z4b5h6s7zwndcxnllbdr2wldxr9hyp4lfj2f55q";
+    sha256 = "079kymgxyzhf47dd42l7f42jp45gx5im4k3g31bj25p1s0aq91py";
   };
 
   propagatedBuildInputs = with python2Packages; [


### PR DESCRIPTION
###### Motivation for this change

* Version bump to latest: `2017.7.1`

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

