### PR TITLE
Bcolz init at 1.1.2

### DIFF
--- a/pkgs/development/python-modules/bcolz/default.nix
+++ b/pkgs/development/python-modules/bcolz/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, numpy, mock, setuptools_scm, cython, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "bcolz";
+  version = "1.1.2";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ws0b9p1r4gcxic7fm8clm2q2ily3bd6i4giczw4s6gv5ilk7ds2";
+  };
+
+  doCheck = !isPy3k;
+
+  buildInputs = [ setuptools_scm cython ];
+  propagatedBuildInputs = [ numpy mock ];
+
+  meta = with stdenv.lib; {
+    description = "A columnar data container that can be compressed";
+    homepage = "https://github.com/Blosc/bcolz";
+    maintainers = with maintainers; [ gabesoft ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3677,6 +3677,7 @@ in {
     };
   };
 
+  bcolz = callPackage ../development/python-modules/bcolz { };
 
   pbkdf2 = buildPythonPackage rec {
     name = "pbkdf2-1.3";


### PR DESCRIPTION
###### Motivation for this change
Added the [bcolz](https://github.com/Blosc/bcolz) package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

