### PR TITLE
piwik: 3.1.0 -> 3.1.1

### DIFF
--- a/pkgs/servers/web-apps/piwik/default.nix
+++ b/pkgs/servers/web-apps/piwik/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "piwik-${version}";
-  version = "3.1.0";
+  version = "3.1.1";
 
   src = fetchurl {
     url = "https://builds.piwik.org/${name}.tar.gz";
-    sha512 = "175300ibf0lg4xnyn5v47czi3vd6i7yqf1im3br4975f6k7w8q22m2mk2mi006795js5q52x48g4sc7wb47wac7wbla8wp98al48gfb";
+    sha512 = "2mqzk12959j9xqb9cqz8np35zcs1313zjx9pikbjw9z9mfcqgv0ccvrnl2ymmwll333drr9qaxs54n0mkk66xbhz04nmzmib0kp9k8h";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
Fixing regression introduced in 3.1.0 and other bugs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

