### PR TITLE
jetbrains-jdk

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchurl, file, glib, libxml2, libav_0_8, ffmpeg, libxslt, mesa_noglu,
+ xorg, alsaLib, fontconfig, freetype, pango, gtk2, cairo, gdk_pixbuf, atk }:
+
+let
+  version = "152b970.2";
+  architecture = "amd64";
+  rSubPaths = [
+    "lib/${architecture}/jli"
+    "lib/${architecture}/server"
+    "lib/${architecture}/xawt"
+    "lib/${architecture}"
+  ];
+  libraries =
+    [stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg libxslt mesa_noglu xorg.libXxf86vm alsaLib fontconfig freetype pango gtk2 cairo gdk_pixbuf atk] ++
+    [xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXp xorg.libXt xorg.libXrender stdenv.cc.cc];
+
+in
+
+let jbsdk = stdenv.mkDerivation {
+  name = "jbsdk-${version}";
+  src = fetchurl {
+    url = "https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbsdk8u${version}_linux_x64.tar.gz";
+    sha256 = "0i2cqjfab91kr618z88nb5g9yg60j5z08wjl0nlvcmpvg2z6va0m";
+  };
+  nativeBuildInputs = [ file ];
+
+  unpackCmd = "mkdir jdk; pushd jdk; tar -xzf $src; popd";
+
+  installPhase = ''
+    cd ..
+
+    exes=$(file $sourceRoot/bin/* $sourceRoot/jre/bin/* 2> /dev/null | grep -E 'ELF.*(executable|shared object)' | sed -e 's/: .*$//')
+    for file in $exes; do
+      paxmark m "$file"
+    done
+
+    mv $sourceRoot $out
+    jrePath=$out/jre
+  '';
+
+  postFixup = ''
+    rpath+="''${rpath:+:}${stdenv.lib.concatStringsSep ":" (map (a: "$jrePath/${a}") rSubPaths)}"
+    find $out -type f -perm -0100 \
+        -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "$rpath" {} \;
+    find $out -name "*.so" -exec patchelf --set-rpath "$rpath" {} \;
+  '';
+
+
+  rpath = stdenv.lib.strings.makeLibraryPath libraries;
+
+  passthru.home = jbsdk;
+}; in jbsdk

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14603,7 +14603,12 @@ with pkgs;
     libart = pkgs.gnome2.libart_lgpl;
   };
 
-  jetbrains = recurseIntoAttrs (callPackages ../applications/editors/jetbrains { androidsdk = androidsdk_extras; });
+  jetbrains = (recurseIntoAttrs (callPackages ../applications/editors/jetbrains {
+    jdk = jetbrains.jdk;
+    androidsdk = androidsdk_extras;
+  }) // {
+    jdk = callPackage ../development/compilers/jetbrains-jdk {  };
+  });
 
   libquvi = callPackage ../applications/video/quvi/library.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Adds Jetbrains OpenJDK fork with patches aimed for a better experience when using Jetbrains's products. Original commit is the jbsdk expression from @matklad (your handle is a funny spelling of foodlover in Swedish :) from Issue #23115 and then I've added another with some minor style fixes. This PR also changes the default JDK for the jetbrains attrset and as such fixes #29151. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

