### PR TITLE
Use patchelfUnstable in chromium/plugins.nix

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -1,6 +1,10 @@
 { stdenv
 , jshon
+, glib
+, nspr
+, nss
 , fetchzip
+, patchelfUnstable
 , enablePepperFlash ? false
 , enableWideVine ? false
 
@@ -45,6 +49,8 @@ let
 
     src = upstream-info.binary;
 
+    nativeBuildInputs = [ patchelfUnstable ];
+
     phases = [ "unpackPhase" "patchPhase" "installPhase" "checkPhase" ];
 
     unpackCmd = let
@@ -66,7 +72,7 @@ let
     patchPhase = ''
       for sofile in libwidevinecdm.so libwidevinecdmadapter.so; do
         chmod +x "$sofile"
-        patchelf --set-rpath "${mkrpath [ stdenv.cc.cc ]}" "$sofile"
+        patchelf --set-rpath "${mkrpath [ stdenv.cc.cc glib nspr nss ]}" "$sofile"
       done
 
       patchelf --set-rpath "$out/lib:${mkrpath [ stdenv.cc.cc ]}" \
@@ -102,6 +108,8 @@ let
       sha256 = "005sxx3ll18c6idy1db2gb47chd9c5mf83qac0vyvljsrlc7430c";
       stripRoot = false;
     };
+
+    nativeBuildInputs = [ patchelfUnstable ];
 
     patchPhase = ''
       chmod +x libpepflashplayer.so

--- a/pkgs/development/tools/misc/patchelf/unstable.nix
+++ b/pkgs/development/tools/misc/patchelf/unstable.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  name = "patchelf-0.10-pre-20160920";
+  name = "patchelf-0.10-pre-20170217";
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "patchelf";
-    rev = "327d80443672c397970738f9e216a7e86cbf3ad7";
-    sha256 = "0nghzywda4jrj70gvn4dnrzasafgdp0basj04wfir1smvsi047zr";
+    rev = "c1f89c077e44a495c62ed0dcfaeca21510df93ef";
+    sha256 = "07vx75f2r1bh58qj4b6bl27v39srs2rfr1jrif7syspfhkn4qzw4";
   };
 
   setupHook = [ ./setup-hook.sh ];


### PR DESCRIPTION
###### Motivation for this change

(Kind of) solves #22333.

Thanks to this change, the system builds correctly, but `chromium` itself, with WideVine plugin, segfaults. That’s a step forward, I think and someone can take if from here.

```
Received signal 11 SEGV_MAPERR 7f81d066a868
#0 0x55a7355dd695 base::debug::StackTrace::StackTrace()
#1 0x55a7355ddab9 base::debug::(anonymous namespace)::StackDumpSignalHandler()
#2 0x7f804f53e840 <unknown>
#3 0x7f804f756986 _dl_relocate_object
#4 0x7f804f75e8a9 dl_open_worker
#5 0x7f8048446d31 __GI__dl_catch_error
#6 0x7f804f75e0a7 _dl_open
#7 0x7f804f329f66 dlopen_doit
#8 0x7f8048446d31 __GI__dl_catch_error
#9 0x7f804f32a569 _dlerror_run
#10 0x7f804f329ff1 __dlopen_check
#11 0x55a7356194ca base::LoadNativeLibraryWithOptions()
#12 0x55a735619396 base::LoadNativeLibrary()
#13 0x55a733fed671 content::PreloadPepperPlugins()
#14 0x55a733feddd5 content::ZygoteMain()
#15 0x55a7351e6dc7 content::RunZygote()
#16 0x55a7351e755f content::ContentMainRunnerImpl::Run()
#17 0x55a7351f29e2 service_manager::Main()
#18 0x55a7351e6031 content::ContentMain()
#19 0x55a733ad2143 ChromeMain
#20 0x7f8048348530 __libc_start_main
#21 0x55a733ad1faa _start
  r8: 00007f8048332ef8  r9: 00007f804f95b500 r10: 00007f80483bf140 r11: 00007f804f95b500
 r12: 000000001532e800 r13: 00007f8034966af0 r14: cde800001532e800 r15: 0000256ed93c7300
  di: 00007f803496a868  si: 0000256ed9369e00  bp: 00007fffd72f36f0  bx: 00007f803497d840
  dx: 00007f804f96dc80  ax: 00000000cde80000  cx: 0000000000000000  sp: 00007fffd72f35c0
  ip: 00007f804f756986 efl: 0000000000010206 cgf: 002b000000000033 erf: 0000000000000004
 trp: 000000000000000e msk: 0000000000000000 cr2: 00007f81d066a868
[end of stack trace]
Calling _exit(1). Core file will not be generated.
[16341:16341:0921/142607.149640:FATAL:zygote_host_impl_linux.cc(196)] Check failed: ReceiveFixedMessage(fds[0], kZygoteHelloMessage, sizeof(kZygoteHelloMessage), &real_pid). 
#0 0x559e92cb2695 base::debug::StackTrace::StackTrace()
#1 0x559e92ccd1b5 logging::LogMessage::~LogMessage()
#2 0x559e91b35813 content::ZygoteHostImpl::LaunchZygote()
#3 0x559e91b345f4 content::ZygoteCommunication::Init()
#4 0x559e91b34c2c content::CreateGenericZygote()
#5 0x559e9174b7e4 content::BrowserMainLoop::EarlyInitialization()
#6 0x559e9174f0e4 content::BrowserMainRunnerImpl::Initialize()
#7 0x559e91747504 content::BrowserMain()
#8 0x559e928bc55f content::ContentMainRunnerImpl::Run()
#9 0x559e928c79e2 service_manager::Main()
#10 0x559e928bb031 content::ContentMain()
#11 0x559e911a7143 ChromeMain
#12 0x7f5bd3bfb530 __libc_start_main
#13 0x559e911a6faa _start

Received signal 6
#0 0x559e92cb2695 base::debug::StackTrace::StackTrace()
#1 0x559e92cb2ab9 base::debug::(anonymous namespace)::StackDumpSignalHandler()
#2 0x7f5bdadf1840 <unknown>
#3 0x7f5bd3c0e384 __GI_raise
#4 0x7f5bd3c0f7ea __GI_abort
#5 0x559e92cb2325 base::debug::BreakDebugger()
#6 0x559e92ccd299 logging::LogMessage::~LogMessage()
#7 0x559e91b35813 content::ZygoteHostImpl::LaunchZygote()
#8 0x559e91b345f4 content::ZygoteCommunication::Init()
#9 0x559e91b34c2c content::CreateGenericZygote()
#10 0x559e9174b7e4 content::BrowserMainLoop::EarlyInitialization()
#11 0x559e9174f0e4 content::BrowserMainRunnerImpl::Initialize()
#12 0x559e91747504 content::BrowserMain()
#13 0x559e928bc55f content::ContentMainRunnerImpl::Run()
#14 0x559e928c79e2 service_manager::Main()
#15 0x559e928bb031 content::ContentMain()
#16 0x559e911a7143 ChromeMain
#17 0x7f5bd3bfb530 __libc_start_main
#18 0x559e911a6faa _start
  r8: 0000000000000000  r9: 00007fff458f6b90 r10: 0000000000000008 r11: 0000000000000246
 r12: 00007fff458f6e90 r13: 00000000000000ae r14: 00007fff458f6ec0 r15: 00007fff458f7540
  di: 0000000000000002  si: 00007fff458f6b90  bp: 00007fff458f70b0  bx: 00007fff458f7630
  dx: 0000000000000000  ax: 0000000000000000  cx: 00007f5bd3c0e384  sp: 00007fff458f6c08
  ip: 00007f5bd3c0e384 efl: 0000000000000246 cgf: 002b000000000033 erf: 0000000000000000
 trp: 0000000000000000 msk: 0000000000000000 cr2: 0000000000000000
[end of stack trace]
Calling _exit(1). Core file will not be generated.
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

