### PR TITLE
ttwatch: init at 2017-04-20

### DIFF
--- a/pkgs/tools/misc/ttwatch/default.nix
+++ b/pkgs/tools/misc/ttwatch/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, cmake, perl, openssl, curl, libusb1 }:
+
+stdenv.mkDerivation rec {
+  name = "ttwatch-${version}";
+  version = "2017-04-20";
+
+  src = fetchFromGitHub {
+    owner = "ryanbinns";
+    repo = "ttwatch";
+    rev = "f07a12712ed331f1530db3846828641eb0e2f5c5";
+    sha256 = "0y27bldmp6w02pjhr2cmy9g6n23vi0q26pil3rd7vbg4qjahxz27";
+  };
+
+  nativeBuildInputs = [ cmake perl ];
+  buildInputs = [ openssl curl libusb1 ];
+
+  preFixup = ''
+    chmod +x $out/bin/ttbin2mysports
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/ryanbinns/ttwatch;
+    description = "Linux TomTom GPS Watch Utilities";
+    maintainers = with maintainers; [ dotlambda ];
+    license = licenses.mit;
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4896,6 +4896,8 @@ with pkgs;
 
   ttmkfdir = callPackage ../tools/misc/ttmkfdir { };
 
+  ttwatch = callPackage ../tools/misc/ttwatch { };
+
   udunits = callPackage ../development/libraries/udunits { };
 
   uemacs = callPackage ../applications/editors/uemacs { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

