### PR TITLE
mba6x_bl: 2016-04-22 -> 2016-12-08

### DIFF
--- a/pkgs/os-specific/linux/mba6x_bl/default.nix
+++ b/pkgs/os-specific/linux/mba6x_bl/default.nix
@@ -1,23 +1,16 @@
 { fetchFromGitHub, kernel, stdenv }:
 
-with stdenv.lib;
-
-let pkgName = "mba6x_bl";
-in
-
 stdenv.mkDerivation rec {
-  name = "${pkgName}-${version}";
-  version = "2016-04-22";
+  name = "mba6x_bl-2016-12-08";
 
   src = fetchFromGitHub {
     owner = "patjak";
-    repo = pkgName;
-    rev = "d05c125efe182376ddab30d486994ec00e144650";
-    sha256 = "15h90z3ijq4lv37nmx70xqggcvn21vr7mki2psk1jyj88in3j3xn";
+    repo = "mba6x_bl";
+    rev = "b96aafd30c18200b4ad1f6eb995bc19200f60c47";
+    sha256 = "10payvfxahazdxisch4wm29fhl8y07ki72q4c78sl4rn73sj6yjq";
   };
 
   enableParallelBuilding = true;
-
   hardeningDisable = [ "pic" ];
 
   makeFlags = [
@@ -25,7 +18,7 @@ stdenv.mkDerivation rec {
     "INSTALL_MOD_PATH=$(out)"
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "MacBook Air 6,1 and 6,2 (mid 2013) backlight driver";
     homepage = https://github.com/patjak/mba6x_bl;
     license = licenses.gpl2;


### PR DESCRIPTION
###### Motivation for this change

New version of `mba6x_bl` module demotes errors that are always present on system boot on some MacBook Air laptops: https://github.com/patjak/mba6x_bl/commit/055d50de05cbfee6f215ad6c1aba8e4ff4308429

The module doesn't have any releases, only master branch commits.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

