### PR TITLE
assh: init at 2.6.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -662,4 +662,5 @@
   zoomulator = "Kim Simmons <zoomulator@gmail.com>";
   zraexy = "David Mell <zraexy@gmail.com>";
   zx2c4 = "Jason A. Donenfeld <Jason@zx2c4.com>";
+  zzamboni = "Diego Zamboni <diego@zzamboni.org>";
 }

--- a/pkgs/tools/networking/assh/default.nix
+++ b/pkgs/tools/networking/assh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, openssh, makeWrapper }:
 
 buildGoPackage rec {
   name = "assh-${version}";
@@ -7,8 +7,13 @@ buildGoPackage rec {
   goPackagePath = "github.com/moul/advanced-ssh-config";
   subPackages = [ "cmd/assh" ];
 
+  nativeBuildInputs = [ makeWrapper ];
+
   postInstall = stdenv.lib.optionalString (stdenv.isDarwin) ''
     install_name_tool -delete_rpath $out/lib $bin/bin/assh
+  '' + ''
+    wrapProgram "$bin/bin/assh" \
+      --prefix PATH : ${openssh}/bin
   '';
 
   src = fetchFromGitHub {

--- a/pkgs/tools/networking/assh/default.nix
+++ b/pkgs/tools/networking/assh/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "assh-${version}";
+  version = "2.6.0";
+
+  goPackagePath = "github.com/moul/advanced-ssh-config";
+  subPackages = [ "cmd/assh" ];
+
+  postInstall = stdenv.lib.optionalString (stdenv.isDarwin) ''
+    install_name_tool -delete_rpath $out/lib $bin/bin/assh
+  '';
+
+  src = fetchFromGitHub {
+    repo = "advanced-ssh-config";
+    owner = "moul";
+    rev = "v${version}";
+    sha256 = "1vv98dz5822k51xklnmky0lwfjw8nc6ryvn8lmv9n63ppwh9s2s6";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Advanced SSH config - Regex, aliases, gateways, includes and dynamic hosts";
+    homepage = https://github.com/moul/advanced-ssh-config;
+    license = licenses.mit;
+    maintainers = with maintainers; [ zzamboni ];
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1234,6 +1234,8 @@ with pkgs;
 
   autossh = callPackage ../tools/networking/autossh { };
 
+  assh = callPackage ../tools/networking/assh { };
+
   asynk = callPackage ../tools/networking/asynk { };
 
   bacula = callPackage ../tools/backup/bacula { };


### PR DESCRIPTION
Powerful wrapper around ssh.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

