### PR TITLE
encrypted devices: add label set assertion

### DIFF
--- a/nixos/modules/tasks/encrypted-devices.nix
+++ b/nixos/modules/tasks/encrypted-devices.nix
@@ -56,6 +56,13 @@ in
   };
 
   config = mkIf anyEncrypted {
+    assertions = map (dev: {
+      assertion = dev.label != null;
+      message = ''
+        The filesystem for ${dev.mountPoint} has encrypted.enable set to true, but no encrypted.label set
+      '';
+    }) encDevs;
+
     boot.initrd = {
       luks = {
         devices =


### PR DESCRIPTION
###### Motivation for this change
rnhmjoj on IRC found this issue. Now an assertion gets throws when `encrypted.enable` is set, but `encrypted.label` isn't.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

