### PR TITLE
zulu: init 9.0.0.15

### DIFF
--- a/pkgs/development/compilers/zulu/8.nix
+++ b/pkgs/development/compilers/zulu/8.nix
@@ -1,14 +1,14 @@
 { stdenv, lib, fetchurl, unzip, makeWrapper, setJavaClassPath
 , zulu, glib, libxml2, libav_0_8, ffmpeg, libxslt, mesa_noglu, alsaLib
-, fontconfig, freetype, gnome2, cairo, gdk_pixbuf, atk, xorg, zlib
+, fontconfig, freetype, gnome2, cairo, gdk_pixbuf, atk, xorg
 , swingSupport ? true }:
 
 let
-  version = "9.0.0.15";
-  openjdk = "9.0.0";
+  version = "8.21.0.1";
+  openjdk = "8.0.131";
 
-  sha256_linux = "0s9vr135yhdnxqds4hfafyrlh33j6g78v6l1v0ap2y6yqgabh9qi";
-  sha256_darwin = "104w1msrwijf8dv3n65hjinp7i47z6ygzjipdzqriqam2zljxn4b";
+  sha256_linux = "0cr1wvk1ifdq69ia8sr6171yzciba8l5x7dszwa5g2v0vmmqq88p";
+  sha256_darwin = "0xq9bdzbdq8wq48gj6j56bw30l2iafz6sy1wdhrf92n9bnz5qmw7";
 
   platform = if stdenv.isDarwin then "macosx" else "linux";
   hash = if stdenv.isDarwin then sha256_darwin else sha256_linux;
@@ -17,7 +17,7 @@ let
   libraries = [
     stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg libxslt mesa_noglu
     xorg.libXxf86vm alsaLib fontconfig freetype gnome2.pango
-    gnome2.gtk cairo gdk_pixbuf atk zlib
+    gnome2.gtk cairo gdk_pixbuf atk
   ] ++ (lib.optionals swingSupport (with xorg; [
     xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXp
     xorg.libXt xorg.libXrender stdenv.cc.cc
@@ -39,9 +39,12 @@ in stdenv.mkDerivation rec {
     mkdir -p $out
     cp -r ./* "$out/"
 
-    rpath=$rpath''${rpath:+:}$out/lib/jli
-    rpath=$rpath''${rpath:+:}$out/lib/server
-    rpath=$rpath''${rpath:+:}$out/lib
+    jrePath="$out/jre"
+
+    rpath=$rpath''${rpath:+:}$jrePath/lib/amd64/jli
+    rpath=$rpath''${rpath:+:}$jrePath/lib/amd64/server
+    rpath=$rpath''${rpath:+:}$jrePath/lib/amd64/xawt
+    rpath=$rpath''${rpath:+:}$jrePath/lib/amd64
 
     # set all the dynamic linkers
     find $out -type f -perm -0100 \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6244,8 +6244,9 @@ with pkgs;
 
   yosys = callPackage ../development/compilers/yosys { };
 
-  zulu = callPackage ../development/compilers/zulu { };
-
+  zulu8 = callPackage ../development/compilers/zulu/8.nix { };
+  zulu9 = callPackage ../development/compilers/zulu { };
+  zulu = zulu9;
 
   ### DEVELOPMENT / INTERPRETERS
 


### PR DESCRIPTION
###### Motivation for this change
JDK 9 release today

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I threw this into an `sbt` build of mine and everything built fine.

I am unable to test the Darwin version but it should work fine...

Pinging @copumpkin @rbvermaa to try Darwin.
We may also want to point `openjdk` on Darwin at this (Does anybody know why we have two derivations for Zulu 1.8.x - `openjdk-darwin` and `zulu`? Both claim to work on Darwin, only one on Linux...)