### PR TITLE
Coq: Homotopy Type Theory

### DIFF
--- a/pkgs/development/coq-modules/HoTT/default.nix
+++ b/pkgs/development/coq-modules/HoTT/default.nix
@@ -1,0 +1,59 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, coq }:
+
+if !stdenv.lib.versionAtLeast coq.coq-version "8.6"
+then throw "This version of HoTT requires Coq 8.6"
+else stdenv.mkDerivation rec {
+  name = "coq${coq.coq-version}-HoTT-${version}";
+  version = "20170921";
+
+  src = fetchFromGitHub {
+    owner = "HoTT";
+    repo = "HoTT";
+    rev = "e3557740a699167e6adb1a65855509d55a392fa1";
+    sha256 = "0zwfp8g62b50vmmbb2kmskj3v6w7qx1pbf43yw0hr7asdz2zbx5v";
+  };
+
+  buildInputs = [ autoconf automake coq ];
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    patchShebangs ./autogen.sh
+    ./autogen.sh
+
+    mkdir -p "$out/bin"
+  '';
+
+  configureFlags = [
+    "--bindir=$(out)/bin"
+  ];
+
+  patchPhase = ''
+    patchShebangs etc
+    patchShebangs hoqc hoqchk hoqdep hoqide hoqtop
+  '';
+
+  postBuild = ''
+    patchShebangs hoq-config
+  '';
+
+  # Currently, all the scripts like hoqc and hoqtop assume that the *.vo files are
+  # either (1) in the same directory as the scripts, or (2) in /usr/share/hott.
+  # We fulfill (1), which means that these files are only accessible via hoqtop,
+  # hoqc, etc and not via coqtop, coqc, etc.
+  postInstall = ''
+    mv $out/share/hott/* "$out/bin"
+    rmdir $out/share/hott
+    rmdir $out/share
+  '';
+
+  installFlags = [
+    "COQBIN=${coq}/bin"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = http://homotopytypetheory.org/;
+    description = "Homotopy type theory";
+    maintainers = with maintainers; [ siddharthist ];
+    platforms = coq.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18324,6 +18324,7 @@ with pkgs;
     dpdgraph = callPackage ../development/coq-modules/dpdgraph {};
     flocq = callPackage ../development/coq-modules/flocq {};
     heq = callPackage ../development/coq-modules/heq {};
+    HoTT = callPackage ../development/coq-modules/HoTT {};
     interval = callPackage ../development/coq-modules/interval {};
     mathcomp = callPackage ../development/coq-modules/mathcomp { };
     paco = callPackage ../development/coq-modules/paco {};


### PR DESCRIPTION
###### Motivation for this change
I'm writing my undergraduate thesis on Homotopy Type Theory 😄 But honestly, users of HoTT are becoming a larger and larger share of Coq users in general.   

There's an issue with this package: because HoTT replaces the Coq standard library, it's difficult to use with vanilla `coqc`, `coqtop`, and related binaries. It provides its own (`hoqc`, `hoqtop`, etc.), but they expect to be in the same directory as the compiled *.vo files or for said files to be at `/usr/share/hott`. I've simply dropped the *.vo files into `bin`. I'm also open to symlinking them from a more standard directory. 

Another issue is that the current version might not work with older versions of Coq. Is there a way to prevent it from building with e.g. `coq_8_4`?

You can test the build by running
```
nix-build -A coqPackages_8_6.HoTT
```
and then
```
./result/bin/hoqtop
```
and typing
```
Require Import HoTT.Categories.Category
```
You should get no error message, as opposed to when typing `foo` and getting
```
Coq < Require Import foo.
Toplevel input, characters 15-18:
> Require Import foo.
>                ^^^
Error: Unable to locate library foo.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

