### PR TITLE
fuse3: 3.1.1 -> 3.2.0

### DIFF
--- a/pkgs/os-specific/linux/fuse/default.nix
+++ b/pkgs/os-specific/linux/fuse/default.nix
@@ -13,8 +13,8 @@ in {
   };
 
   fuse_3 = mkFuse {
-    version = "3.1.1";
-    sha256Hash = "14mazl2i55fp4vjphwgcmk3mp2x3mhqwh9nci0rd0jl5lhpdmpq6";
+    version = "3.2.0";
+    sha256Hash = "0bfpwkfamg4rcbq1s7v5rblpisqq73z6d5j3dxypgqll07hfg51x";
     maintainers = [ maintainers.primeos ];
   };
 }

--- a/pkgs/os-specific/linux/fuse/fuse3-install.patch
+++ b/pkgs/os-specific/linux/fuse/fuse3-install.patch
@@ -1,0 +1,24 @@
+--- a/util/install_helper.sh	1970-01-01 01:00:01.000000000 +0100
++++ b/util/install_helper.sh	2017-09-21 23:43:50.703942577 +0200
+@@ -11,19 +11,11 @@
+ udevrulesdir="$3"
+ prefix="${MESON_INSTALL_DESTDIR_PREFIX}"
+ 
+-chown root:root "${prefix}/${bindir}/fusermount3"
+-chmod u+s "${prefix}/${bindir}/fusermount3"
+-
+-if test ! -e "${DESTDIR}/dev/fuse"; then
+-    mkdir -p "${DESTDIR}/dev"
+-    mknod "${DESTDIR}/dev/fuse" -m 0666 c 10 229
+-fi
+-
+ install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \
+-        "${DESTDIR}/${udevrulesdir}/99-fuse3.rules"
++        "${prefix}/${udevrulesdir}/99-fuse.rules"
+ 
+ install -D -m 755 "${MESON_SOURCE_ROOT}/util/init_script" \
+-        "${DESTDIR}/etc/init.d/fuse3"
++        "${prefix}/etc/init.d/fuse3"
+ 
+ if test -x /usr/sbin/update-rc.d && test -z "${DESTDIR}"; then
+     /usr/sbin/update-rc.d fuse3 start 34 S . start 41 0 6 . || /bin/true

--- a/pkgs/os-specific/linux/fuse/fuse3-install_man.patch
+++ b/pkgs/os-specific/linux/fuse/fuse3-install_man.patch
@@ -1,0 +1,8 @@
+--- a/doc/meson.build	1970-01-01 01:00:01.000000000 +0100
++++ b/doc/meson.build	2017-09-22 01:53:01.859190506 +0200
+@@ -1,5 +1,4 @@
+ # Attention, emacs, please use -*- mode: python -*-
+ # (even though this isn't actually Python code)
+ 
+-install_man('fusermount3.1', 'mount.fuse.8')
+ 

--- a/pkgs/os-specific/linux/fuse/fuse3-no-udev.patch
+++ b/pkgs/os-specific/linux/fuse/fuse3-no-udev.patch
@@ -1,0 +1,12 @@
++++ b/util/meson.build	2017-09-23 20:59:31.555392297 +0200
+--- a/util/meson.build	2017-09-23 20:59:58.333180437 +0200
+@@ -18,8 +18,7 @@
+            install: true,
+            install_dir: get_option('sbindir'))
+ 
+-udev = dependency('udev')
+-udevrulesdir = join_paths(udev.get_pkgconfig_variable('udevdir'), 'rules.d')
++udevrulesdir = 'etc/udev/rules.d'
+ 
+ meson.add_install_script('install_helper.sh', get_option('sysconfdir'),
+                          get_option('bindir'), udevrulesdir)


### PR DESCRIPTION
Open questions:
- [x] drop the dependency on `udev` (seems only relevant for `udevrulesdir` which we don't need anyway)?
```
udev = dependency('udev')
udevrulesdir = join_paths(udev.get_pkgconfig_variable('udevdir'), 'rules.d')
```
- [x] UTF-8 support? Meson throws a warning but it shouldn't cause any problems ([Debian discussion](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=873831)).
  - Shouldn't be relevant for this PR (should be changed for meson/stdenv).

FYI:
- File list diff:
```
--- /nix/store/nbd7vdqc8bdy6g2flzpmf2ygpwcw0bn1-fuse-3.1.1
+++ /nix/store/rh4cxwhd1ga9yxmnh9nmyjzz281j3w72-fuse-3.2.0
├── file list
│ @@ -1,26 +1,27 @@
│  bin
│  bin/fusermount3
│  bin/mount.fuse
│  etc
│ +etc/init.d
│ +etc/init.d/fuse3
│  etc/udev
│  etc/udev/rules.d
│  etc/udev/rules.d/99-fuse.rules
│  include
│  include/fuse3
│  include/fuse3/cuse_lowlevel.h
│  include/fuse3/fuse.h
│  include/fuse3/fuse_common.h
│  include/fuse3/fuse_lowlevel.h
│  include/fuse3/fuse_opt.h
│  lib
│ -lib/libfuse3.la
│  lib/libfuse3.so
│  lib/libfuse3.so.3
│ -lib/libfuse3.so.3.1.1
│ +lib/libfuse3.so.3.2.0
│  lib/pkgconfig
│  lib/pkgconfig/fuse3.pc
│  sbin
│  share
│  share/man
│  share/man/man1
│  share/man/man1/fusermount3.1.gz
```
- Date from `install_man`:
```
├── share
│ ├── man
│ │ ├── man1
│ │ │ ├── fusermount3.1.gz
│ │ │ │ ├── metadata
│ │ │ │ │ @@ -1 +1 @@
│ │ │ │ │ -gzip compressed data, from Unix
│ │ │ │ │ +gzip compressed data, last modified: Thu Sep 21 21:58:10 2017, max compression
│ │ ├── man8
│ │ │ ├── mount.fuse.8.gz
│ │ │ │ ├── metadata
│ │ │ │ │ @@ -1 +1 @@
│ │ │ │ │ -gzip compressed data, from Unix
│ │ │ │ │ +gzip compressed data, last modified: Thu Sep 21 21:58:10 2017, max compression
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

