### PR TITLE
Add pim-data-exporter

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -145,7 +145,7 @@ let
       okteta = callPackage ./okteta.nix {};
       okular = callPackage ./okular.nix {};
       pimcommon = callPackage ./pimcommon.nix {};
-	  pim-data-exporter = callPackage ./pim-data-exporter.nix {};
+      pim-data-exporter = callPackage ./pim-data-exporter.nix {};
       pim-sieve-editor = callPackage ./pim-sieve-editor.nix {};
       print-manager = callPackage ./print-manager.nix {};
       spectacle = callPackage ./spectacle.nix {};

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -145,6 +145,7 @@ let
       okteta = callPackage ./okteta.nix {};
       okular = callPackage ./okular.nix {};
       pimcommon = callPackage ./pimcommon.nix {};
+	  pim-data-exporter = callPackage ./pim-data-exporter.nix {};
       pim-sieve-editor = callPackage ./pim-sieve-editor.nix {};
       print-manager = callPackage ./print-manager.nix {};
       spectacle = callPackage ./spectacle.nix {};

--- a/pkgs/applications/kde/pim-data-exporter.nix
+++ b/pkgs/applications/kde/pim-data-exporter.nix
@@ -1,0 +1,22 @@
+{
+  mkDerivation, lib, kdepimTeam,
+  extra-cmake-modules, kdoctools,
+  akonadi, kcmutils, kcrash, kdbusaddons, kidentitymanagement, kldap,
+  kmailtransport, knewstuff, knotifications, knotifyconfig, kparts, kross, ktexteditor,
+  kwallet, libkdepim, libkleo, pimcommon, qttools,
+  karchive, mailcommon, messagelib, pim-data-exporter
+}:
+
+mkDerivation {
+  name = "pim-data-exporter";
+  meta = {
+    license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
+    maintainers = kdepimTeam;
+  };
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [
+    akonadi kcmutils kcrash kdbusaddons kidentitymanagement kldap kmailtransport
+    knewstuff knotifications knotifyconfig kparts kross ktexteditor kwallet libkdepim
+    libkleo pimcommon qttools karchive mailcommon messagelib
+  ];
+}


### PR DESCRIPTION
###### Motivation for this change
The KDE app pim-data-exporter wasn't listed before, and I needed to copy my config from another machine. Figured other people might find this useful.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

