### PR TITLE
universal-ctags: generate manpage

### DIFF
--- a/pkgs/development/tools/misc/universal-ctags/default.nix
+++ b/pkgs/development/tools/misc/universal-ctags/default.nix
@@ -2,20 +2,17 @@
 
 stdenv.mkDerivation rec {
   name = "universal-ctags-${version}";
-  version = "2017-01-08";
+  version = "2017-09-22";
 
   src = fetchFromGitHub {
     owner = "universal-ctags";
     repo = "ctags";
-    rev = "9668032d8715265ca5b4ff16eb2efa8f1c450883";
-    sha256 = "0nwcf5mh3ba0g23zw7ym73pgpfdass412k2fy67ryr9vnc709jkj";
+    rev = "b9537289952cc7b26526aaff3094599d714d1729";
+    sha256 = "1kbw9ycl2ddzpfs1v4rbqa4gdhw4inrisf4awyaxb7zxfxmbzk1g";
   };
 
   nativeBuildInputs = [ pythonPackages.docutils ];
   buildInputs = [ autoreconfHook pkgconfig ];
-
-  # remove when https://github.com/universal-ctags/ctags/pull/1267 is merged
-  patches = [ ./sed-test.patch ];
 
   autoreconfPhase = ''
     ./autogen.sh --tmpdir

--- a/pkgs/development/tools/misc/universal-ctags/default.nix
+++ b/pkgs/development/tools/misc/universal-ctags/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, perl }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, perl, pythonPackages }:
 
 stdenv.mkDerivation rec {
   name = "universal-ctags-${version}";
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0nwcf5mh3ba0g23zw7ym73pgpfdass412k2fy67ryr9vnc709jkj";
   };
 
+  nativeBuildInputs = [ pythonPackages.docutils ];
   buildInputs = [ autoreconfHook pkgconfig ];
 
   # remove when https://github.com/universal-ctags/ctags/pull/1267 is merged


### PR DESCRIPTION
###### Motivation for this change
ctags is a complex program with lots of flags, manpage is really helpful

###### Things done
The manpage is generated via the rst2man utility present in python.docutils. Add it as a nativeBuildInput dependancy.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

