### PR TITLE
trackballs: 1.1.4 (broken) -> 1.2.3

### DIFF
--- a/pkgs/games/trackballs/default.nix
+++ b/pkgs/games/trackballs/default.nix
@@ -1,35 +1,22 @@
-{ stdenv, fetchurl, SDL, mesa, SDL_ttf, gettext, zlib, SDL_mixer, SDL_image, guile
-, debug ? false }:
+{ stdenv, fetchFromGitHub, cmake, SDL2, SDL2_ttf, gettext, zlib, SDL2_mixer, SDL2_image, guile, mesa }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "trackballs-1.1.4";
-  
-  src = fetchurl {
-    url = mirror://sourceforge/trackballs/trackballs-1.1.4.tar.gz;
-    sha256 = "19ilnif59sxa8xmfisk90wngrd11pj8s86ixzypv8krm4znbm7a5";
+  name = "trackballs-${version}";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "trackballs";
+    repo = "trackballs";
+    rev = "v${version}";
+    sha256 = "13f28frni7fkalxx4wqvmkzz7ba3d8pic9f9sd2z9wa6gbjs9zrf";
   };
 
-  buildInputs = [ zlib mesa SDL SDL_ttf SDL_mixer SDL_image guile gettext ];
-
-  hardeningDisable = [ "format" ];
-
-  CFLAGS = optionalString debug "-g -O0";
-  CXXFLAGS = CFLAGS;
-  dontStrip = debug;
-  postUnpack = optionalString debug
-    "mkdir -p $out/src; cp -R * $out/src ; cd $out/src";
-
-  NIX_CFLAGS_COMPILE = "-iquote ${SDL.dev}/include/SDL";
-  configureFlags = optionalString debug "--enable-debug";
-
-  patchPhase = ''
-    sed -i -e 's/images icons music/images music/' share/Makefile.in
-  '';
+  buildInputs = [ cmake zlib SDL2 SDL2_ttf SDL2_mixer SDL2_image guile gettext mesa ];
 
   meta = {
-    homepage = http://trackballs.sourceforge.net/;
+    homepage = https://trackballs.github.io/;
     description = "3D Marble Madness clone";
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17752,10 +17752,7 @@ with pkgs;
 
   tome4 = callPackage ../games/tome4 { };
 
-  trackballs = callPackage ../games/trackballs {
-    debug = false;
-    guile = guile_1_8;
-  };
+  trackballs = callPackage ../games/trackballs { };
 
   tremulous = callPackage ../games/tremulous { };
 


### PR DESCRIPTION
###### Motivation for this change

#28643

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).