### PR TITLE
giv: 20150811-git (broken) -> 0.9.26

### DIFF
--- a/pkgs/applications/graphics/giv/build.patch
+++ b/pkgs/applications/graphics/giv/build.patch
@@ -2,16 +2,21 @@ Get the environment propagated to scons forked childs, and correct the dicom plu
 a typedef of size_t that failed at least on x86_64-linux.
 
 diff --git a/SConstruct b/SConstruct
-index 16eccd9..603e931 100644
+index 9e752d6..f93f27f 100644
 --- a/SConstruct
 +++ b/SConstruct
-@@ -7,8 +7,7 @@ else:
-     cppflags = ['-O2']
-     variant = 'Release'
+@@ -9,13 +9,7 @@ else:
+ 
+ commit_id = os.popen('git rev-parse HEAD').read().replace('\n','')
  
 -env = Environment(LIBPATH=[],
--                  CPPFLAGS = cppflags)
+-                  CPPFLAGS = cppflags + ['-Wno-deprecated-declarations',
+-                                         '-Wno-reorder',
+-                                         '-Wno-unused-but-set-variable',
+-                                         '-Wno-unused-function'],
+-                  CXXFLAGS=['-std=c++1y']
+-                  )
 +env = Environment(ENV = os.environ)
  
  env['SBOX'] = False
- 
+ env['COMMITIDSHORT'] = commit_id[0:6]

--- a/pkgs/applications/graphics/giv/default.nix
+++ b/pkgs/applications/graphics/giv/default.nix
@@ -2,13 +2,14 @@
   pcre, cfitsio, perl, gob2, vala_0_23, libtiff, json_glib }:
 
 stdenv.mkDerivation rec {
-  name = "giv-20150811-git";
+  name = "giv-${version}";
+  version = "0.9.26";
 
   src = fetchFromGitHub {
     owner = "dov";
     repo = "giv";
-    rev = "64648bfbbf10ec4a9adfbc939c96c7d1dbdce57a";
-    sha256 = "1sz2n7jbmg3g97bs613xxjpzqbsl5rvpg6v7g3x3ycyd35r8vsfp";
+    rev = "v${version}";
+    sha256 = "1sfm8j3hvqij6z3h8xz724d7hjqqbzljl2a6pp4yjpnnrxksnic2";
   };
 
   hardeningDisable = [ "format" ];


### PR DESCRIPTION
###### Motivation for this change

#28643

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
