### PR TITLE
qt-5/qtbase-setup-hook.sh: attempt to make directories only if needed

### DIFF
--- a/pkgs/development/libraries/qt-5/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/qtbase-setup-hook.sh
@@ -123,7 +123,7 @@ if [ -z "$NIX_QT5_TMP" ]; then
 
     mkdir -p "$NIX_QT5_TMP/nix-support"
     for subdir in bin include lib mkspecs share; do
-        mkdir "$NIX_QT5_TMP/$subdir"
+        mkdir -p "$NIX_QT5_TMP/$subdir"
         echo "$subdir/" >> "$NIX_QT5_TMP/nix-support/qt-inputs"
     done
 


### PR DESCRIPTION
Resolves #29589.

So I haven't actually tested this but I'm assuming it will work. @teto could you test? However, I don't actually know if this is a sub-optimal solution though, because maybe there's a reason you've decided to not already do this? If so, feel free to disregard and close this PR. 

cc @ttuegel from `git blame`.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

