### PR TITLE
radsecproxy: init at 1.6.9

### DIFF
--- a/pkgs/tools/networking/radsecproxy/default.nix
+++ b/pkgs/tools/networking/radsecproxy/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, openssl }:
+
+stdenv.mkDerivation rec {
+
+  name = "radsecproxy-${version}";
+  version = "1.6.9";
+
+  src = fetchurl {
+    url = "https://software.nordu.net/radsecproxy/radsecproxy-${version}.tar.xz";
+    sha256 = "6f2c7030236c222782c9ac2c52778baa63540a1865b75a7a6d8c1280ce6ad816";
+  };
+
+  buildInputs = [ openssl ];
+
+  configureFlags = [
+     "--with-ssl=${openssl.dev}"
+     "--sysconfdir=/etc"
+     "--localstatedir=/var"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://software.nordu.net/radsecproxy/;
+    description = "A generic RADIUS proxy that supports both UDP and TLS (RadSec) RADIUS transports.";
+    license = licenses.bsd;
+    maintainers = with maintainers; [ sargon ];
+    platforms = with platforms; linux;
+  };
+
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4058,6 +4058,8 @@ with pkgs;
 
   radeon-profile = libsForQt5.callPackage ../tools/misc/radeon-profile { };
 
+  radsecproxy = callPackage ../tools/networking/radsecproxy { };
+
   radvd = callPackage ../tools/networking/radvd { };
 
   rainbowstream = pythonPackages.rainbowstream;


### PR DESCRIPTION
###### Motivation for this change
Missing package. Specially useful in combination with freeradius, e.g. for eduroam setups.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

