### PR TITLE
CONTRIBUTING.md: mention that the meta.license and meta.maintainers attributes must be set

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,11 +32,13 @@ under the terms of [COPYING](../COPYING), which is an MIT-like license.
     The old config generation system used impure shell scripts and could break in specific circumstances (see #1234).
 
 * `meta.description` should:
-  * Be capitalized
-  * Not start with the package name
-  * Not have a dot at the end
+  * Be capitalized.
+  * Not start with the package name.
+  * Not have a period at the end.
+* `meta.license` must be set and fit the upstream license.
+* `meta.maintainers` must be set.
 
-See the nixpkgs manual for more details on how to [Submit changes to nixpkgs](https://nixos.org/nixpkgs/manual/#chap-submitting-changes).
+See the nixpkgs manual for more details on [standard meta-attributes](https://nixos.org/nixpkgs/manual/#sec-standard-meta-attributes) and on how to [submit changes to nixpkgs](https://nixos.org/nixpkgs/manual/#chap-submitting-changes).
 
 ## Writing good commit messages
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,6 +36,7 @@ under the terms of [COPYING](../COPYING), which is an MIT-like license.
   * Not start with the package name.
   * Not have a period at the end.
 * `meta.license` must be set and fit the upstream license.
+  * If there is no upstream license, `meta.license` should default to `stdenv.lib.licenses.unfree`.
 * `meta.maintainers` must be set.
 
 See the nixpkgs manual for more details on [standard meta-attributes](https://nixos.org/nixpkgs/manual/#sec-standard-meta-attributes) and on how to [submit changes to nixpkgs](https://nixos.org/nixpkgs/manual/#chap-submitting-changes).


### PR DESCRIPTION
###### Motivation for this change

So I've been reviewing a few PRs recently and I found that it's actually fairly common for these attributes to be left out (for PRs adding new packages). I know that CONTRIBUTING.md already has a link to the nixpkgs manual which mentions these attributes, but I felt that maybe these two lines could be added to CONTRIBUTING.md directly as well, seeing as though people seem to omit them from time to time?

The manual does say that a maintainer must be set, but I don't think the manual explicitly mentions that a license attribute *must* be set. However, even if the manual doesn't say a license must be set, I believe it's good form to require it for all packages (hence the line about `meta.license`), thoughts? For example, even if a package does not have a license, it can just be assumed to be nonfree (because I believe that's legally the case in basically all parts of the world?), and therefore have a license attribute `stdenv.lib.licenses.unfree`.

Just to clarify, obviously `meta` attributes are optional, but I'm talking about when a package is to be added to this nixpkgs repository.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

