### PR TITLE
ferm: 2.3.1 -> 2.4.1

### DIFF
--- a/pkgs/tools/networking/ferm/default.nix
+++ b/pkgs/tools/networking/ferm/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, makeWrapper, perl, ebtables, ipset, iptables }:
 
 stdenv.mkDerivation rec {
-  version = "2.3.1";
+  version = "2.4.1";
   name = "ferm-${version}";
 
   src = fetchurl {
-    url = "http://ferm.foo-projects.org/download/2.3/ferm-${version}.tar.gz";
-    sha256 = "1scdnd2jk4787jyr6fxav2598g0x7hjic5b8bj77j8s0hki48m4a";
+    url = "http://ferm.foo-projects.org/download/2.4/ferm-${version}.tar.xz";
+    sha256 = "1fv8wk513yysp4q0i65rl2m0hg2lxwwgk9ppprsca1xcxrdpsvwa";
   };
 
   buildInputs = [ perl ipset ebtables iptables makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Updated to newer version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

