### PR TITLE
singular: use gcc5 to fix build

### DIFF
--- a/pkgs/applications/science/math/singular/default.nix
+++ b/pkgs/applications/science/math/singular/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gmp, bison, perl, autoconf, ncurses, readline, coreutils, pkgconfig
+{ stdenv, fetchurl, gmp, bison, perl, autoconf, ncurses, readline, coreutils, gcc5, pkgconfig
 , asLibsingular ? false
 }:
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ gmp perl ncurses readline ];
-  nativeBuildInputs = [ autoconf bison pkgconfig ];
+  nativeBuildInputs = [ autoconf bison gcc5 pkgconfig ];
 
   preConfigure = ''
     find . -exec sed -e 's@/bin/rm@${coreutils}&@g' -i '{}' ';'


### PR DESCRIPTION
###### Motivation for this change

#28643

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

