### PR TITLE
networkmanager_openvpn: 1.2.8 -> 1.8.0

### DIFF
--- a/pkgs/tools/networking/network-manager/openvpn.nix
+++ b/pkgs/tools/networking/network-manager/openvpn.nix
@@ -4,12 +4,12 @@
 stdenv.mkDerivation rec {
   name    = "${pname}${if withGnome then "-gnome" else ""}-${version}";
   pname   = "NetworkManager-openvpn";
-  major   = "1.2";
-  version = "${major}.8";
+  major   = "1.8";
+  version = "${major}.0";
 
   src = fetchurl {
     url    = "mirror://gnome/sources/${pname}/${major}/${pname}-${version}.tar.xz";
-    sha256 = "0m06sg2rnz764psvpsrx0pvll11nfn9hypgbp3s6vna8y83l02ry";
+    sha256 = "1973n89g66a3jfx8r45a811fga4kadh6r1w35cb25cz1mlii2vhn";
   };
 
   buildInputs = [ openvpn networkmanager libsecret ]


### PR DESCRIPTION
###### Motivation for this change

Update `networkmanager_openvpn`.

Depends on https://github.com/NixOS/nixpkgs/pull/29375 (probably).

###### Things done

Update `networkmanager_openvpn`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

