### PR TITLE
[WIP] qxt: fixing build with gcc6

### DIFF
--- a/pkgs/development/libraries/qxt/default.nix
+++ b/pkgs/development/libraries/qxt/default.nix
@@ -11,7 +11,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ qt4 which ];
 
-  patchPhase = ''
+  patches = [
+    ./gcc6.patch
+  ];
+
+  preConfigure = ''
     patchShebangs configure
     substituteInPlace configure --replace "/bin/pwd" "${coreutils}/bin/pwd"
   '';

--- a/pkgs/development/libraries/qxt/gcc6.patch
+++ b/pkgs/development/libraries/qxt/gcc6.patch
@@ -1,0 +1,13 @@
+diff --git i/src/core/qxtslotjob.cpp w/src/core/qxtslotjob.cpp
+index eee4597..9387f19 100644
+--- i/src/core/qxtslotjob.cpp
++++ w/src/core/qxtslotjob.cpp
+@@ -174,7 +174,7 @@ This uses QxtSignalWaiter so it will _not_ block your current thread.
+ 
+ QVariant QxtFuture::delayedResult(int msec)
+ {
+-    if (!waiter->wait(msec, false))
++    if (!waiter->wait(msec, NULL))
+         return QVariant();
+     return job->result();
+ }


### PR DESCRIPTION
###### Motivation for this change
fixes build with gcc6

related to #28643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

