### PR TITLE
nixos/gitolite: add enableGitAnnex option

### DIFF
--- a/nixos/modules/services/misc/gitolite.nix
+++ b/nixos/modules/services/misc/gitolite.nix
@@ -41,6 +41,15 @@ in
         '';
       };
 
+      enableGitAnnex = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable git-annex support. Uses the <literal>extraGitoliteRc</literal> option
+          to apply the necessary configuration.
+        '';
+      };
+
       commonHooks = mkOption {
         type = types.listOf types.path;
         default = [];
@@ -75,6 +84,8 @@ in
           will need to take any customizations you may have in
           <literal>~/.gitolite.rc</literal>, convert them to appropriate Perl
           statements, add them to this option, and remove the file.
+
+          See also the <literal>enableGitAnnex</literal> option.
         '';
       };
 
@@ -116,6 +127,11 @@ in
         ''} >>"$out/gitolite.rc"
       '';
   in {
+    services.gitolite.extraGitoliteRc = optionalString cfg.enableGitAnnex ''
+      # Enable git-annex support:
+      push( @{$RC{ENABLE}}, 'git-annex-shell ua');
+    '';
+
     users.extraUsers.${cfg.user} = {
       description     = "Gitolite user";
       home            = cfg.dataDir;
@@ -188,6 +204,7 @@ in
         '';
     };
 
-    environment.systemPackages = [ pkgs.gitolite pkgs.git ];
+    environment.systemPackages = [ pkgs.gitolite pkgs.git ]
+        ++ optional cfg.enableGitAnnex pkgs.gitAndTools.git-annex;
   });
 }


### PR DESCRIPTION
###### Motivation for this change

This allows to easily enable support for `git-annex` in the `gitolite` service.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

