### PR TITLE
oraclejdk: add version 9

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk9-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk9-linux.nix
@@ -1,0 +1,175 @@
+{ swingSupport ? true
+, stdenv
+, requireFile
+, makeWrapper
+, unzip
+, file
+, xorg ? null
+, packageType ? "JDK" # JDK, JRE, or ServerJRE
+, pluginSupport ? true
+, installjce ? false
+, glib
+, libxml2
+, ffmpeg_2
+, libxslt
+, mesa_noglu
+, freetype
+, fontconfig
+, gtk2
+, pango
+, cairo
+, alsaLib
+, atk
+, gdk_pixbuf
+, zlib
+, elfutils
+, setJavaClassPath
+}:
+
+assert stdenv.system == "x86_64-linux";
+assert swingSupport -> xorg != null;
+
+let
+  version = "9";
+
+  downloadUrlBase = http://www.oracle.com/technetwork/java/javase/downloads;
+
+  jce =
+    if installjce then
+      requireFile {
+        name = "jce_policy-8.zip";
+        url = "${downloadUrlBase}/jce8-download-2133166.html";
+        sha256 = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";
+      }
+    else
+      "";
+
+  rSubPaths = [
+    "lib/jli"
+    "lib/server"
+    "lib"
+  ];
+
+in
+
+let result = stdenv.mkDerivation rec {
+  name = if packageType == "JDK"       then "oraclejdk-${version}"
+    else if packageType == "JRE"       then "oraclejre-${version}"
+    else if packageType == "ServerJRE" then "oracleserverjre-${version}"
+    else abort "unknown package Type ${packageType}";
+
+  src =
+    if packageType == "JDK" then
+      requireFile {
+        name = "jdk-${version}_linux-x64_bin.tar.gz";
+        url =  "${downloadUrlBase}/jdk9-downloads-3848520.html";
+        sha256 = "0vbgy7h9h089l3xh6sl57v57g28x1djyiigqs4z6gh7wahx7hv8w";
+      }
+    else if packageType == "JRE" then
+      requireFile {
+        name = "jre-${version}_linux-x64_bin.tar.gz";
+        url = "${downloadUrlBase}/jre9-downloads-3848532.html";
+        sha256 = "18i4jjb6sby67xg5ql6dkk3ja1nackbb23g1bnp522450nclpxdb";
+      }
+    else if packageType == "ServerJRE" then
+      requireFile {
+        name = "serverjre-${version}_linux-x64_bin.tar.gz";
+        url = "${downloadUrlBase}/server-jre9-downloads-3848530.html";
+        sha256 = "01bxi7lx13lhlpbifw93b6r7a9bayiykw8kzwlyyqi8pz3pw8c5h";
+      }
+    else abort "unknown package Type ${packageType}";
+
+  nativeBuildInputs = [ file ]
+    ++ stdenv.lib.optional installjce unzip;
+
+  buildInputs = [ makeWrapper ];
+
+  # See: https://github.com/NixOS/patchelf/issues/10
+  dontStrip = 1;
+
+  installPhase = ''
+    cd ..
+
+    # Set PaX markings
+    exes=$(file $sourceRoot/bin/* 2> /dev/null | grep -E 'ELF.*(executable|shared object)' | sed -e 's/: .*$//')
+    for file in $exes; do
+      paxmark m "$file"
+      # On x86 for heap sizes over 700MB disable SEGMEXEC and PAGEEXEC as well.
+      ${stdenv.lib.optionalString stdenv.isi686 ''paxmark msp "$file"''}
+    done
+
+    mv $sourceRoot $out
+
+    shopt -s extglob
+    for file in $out/*
+    do
+      if test -f $file ; then
+        rm $file
+      fi
+    done
+
+    if test -n "${jce}"; then
+      unzip ${jce}
+      cp -v UnlimitedJCEPolicy*/*.jar $out/lib/security
+    fi
+
+    if test -z "$pluginSupport"; then
+      rm -f $out/bin/javaws
+    fi
+
+    mkdir $out/lib/plugins
+    ln -s $out/lib/libnpjp2.so $out/lib/plugins
+
+    # for backward compatibility
+    ln -s $out $out/jre
+
+    mkdir -p $out/nix-support
+    printWords ${setJavaClassPath} > $out/nix-support/propagated-native-build-inputs
+
+    # Set JAVA_HOME automatically.
+    cat <<EOF >> $out/nix-support/setup-hook
+    if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
+    EOF
+  '';
+
+  postFixup = ''
+    rpath+="''${rpath:+:}${stdenv.lib.concatStringsSep ":" (map (a: "$out/${a}") rSubPaths)}"
+
+    # set all the dynamic linkers
+    find $out -type f -perm -0100 \
+        -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "$rpath" {} \;
+
+    find $out -name "*.so" -exec patchelf --set-rpath "$rpath" {} \;
+
+    # Oracle Java Mission Control needs to know where libgtk-x11 and related is
+    if test -x $out/bin/jmc; then
+      wrapProgram "$out/bin/jmc" \
+          --suffix-each LD_LIBRARY_PATH ':' "$rpath"
+    fi
+  '';
+
+  /**
+   * libXt is only needed on amd64
+   */
+  libraries =
+    [stdenv.cc.libc glib libxml2 ffmpeg_2 libxslt mesa_noglu xorg.libXxf86vm alsaLib fontconfig freetype pango gtk2 cairo gdk_pixbuf atk zlib elfutils] ++
+    (if swingSupport then [xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXp xorg.libXt xorg.libXrender stdenv.cc.cc] else []);
+
+  rpath = stdenv.lib.strings.makeLibraryPath libraries;
+
+  passthru.mozillaPlugin = "/lib/plugins";
+
+  passthru.jre = result; # FIXME: use multiple outputs or return actual JRE package
+
+  passthru.home = result;
+
+  # for backward compatibility
+  passthru.architecture = "";
+
+  meta = with stdenv.lib; {
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ]; # some inherit jre.meta.platforms
+  };
+
+}; in result

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5874,11 +5874,17 @@ with pkgs;
 
   oraclejdk8psu = pkgs.oraclejdk8psu_distro true false;
 
+  oraclejdk9 = pkgs.oraclejdk9distro "JDK" false;
+
   oraclejre = lowPrio (pkgs.jdkdistro false false);
 
   oraclejre8 = lowPrio (pkgs.oraclejdk8distro false false);
 
   oraclejre8psu = lowPrio (pkgs.oraclejdk8psu_distro false false);
+
+  oraclejre9 = lowPrio (pkgs.oraclejdk9distro "JRE" false);
+
+  oracleserverjre9 = lowPrio (pkgs.oraclejdk9distro "ServerJRE" false);
 
   jrePlugin = jre8Plugin;
 
@@ -5894,12 +5900,17 @@ with pkgs;
   oraclejdk8distro = installjdk: pluginSupport:
     assert supportsJDK;
     (if pluginSupport then appendToName "with-plugin" else x: x)
-      (callPackage ../development/compilers/oraclejdk/jdk8cpu-linux.nix { inherit installjdk; });
+      (callPackage ../development/compilers/oraclejdk/jdk8cpu-linux.nix { inherit installjdk pluginSupport; });
 
   oraclejdk8psu_distro = installjdk: pluginSupport:
     assert supportsJDK;
     (if pluginSupport then appendToName "with-plugin" else x: x)
-      (callPackage ../development/compilers/oraclejdk/jdk8psu-linux.nix { inherit installjdk; });
+      (callPackage ../development/compilers/oraclejdk/jdk8psu-linux.nix { inherit installjdk pluginSupport; });
+
+  oraclejdk9distro = packageType: pluginSupport:
+    assert supportsJDK;
+    (if pluginSupport then appendToName "with-plugin" else x: x)
+      (callPackage ../development/compilers/oraclejdk/jdk9-linux.nix { inherit packageType pluginSupport; });
 
   jikes = callPackage ../development/compilers/jikes { };
 


### PR DESCRIPTION
###### Motivation for this change

See [the releaes notes](http://www.oracle.com/technetwork/java/javase/9-relnotes-3622618.html).

Oracle JDK 9 does not seems to contain `jre` directory, so `oraclejre9` package now uses a dedicated archive file.

There is no 32-bit version nor arm version yet. So I didn't make `oraclejdk9` the default version for `oraclejdk` package. If Oracle releases them, I will update the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Sample code for testing: https://github.com/taku0/JavaSample

---
