### PR TITLE
testssl.sh: init at 2.9.5-1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -190,6 +190,7 @@
   erikryb = "Erik Rybakken <erik.rybakken@math.ntnu.no>";
   ertes = "Ertugrul Söylemez <esz@posteo.de>";
   ethercrow = "Dmitry Ivanov <ethercrow@gmail.com>";
+  etu = "Elis Hirwing <elis@hirwing.se>";
   exi = "Reno Reckling <nixos@reckling.org>";
   exlevan = "Alexey Levan <exlevan@gmail.com>";
   expipiplus1 = "Joe Hermaszewski <nix@monoid.al>";

--- a/pkgs/applications/networking/testssl/default.nix
+++ b/pkgs/applications/networking/testssl/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, pkgs }:
+
+stdenv.mkDerivation rec {
+  version = "2.9.5-1";
+  name = "testssl.sh-${version}";
+
+  src = fetchFromGitHub {
+    owner = "drwetter";
+    repo = "testssl.sh";
+    rev = "v${version}";
+    sha256 = "0hz6g685jwl0c0jrdca746425xpwiwc8lnlc2gigga5hkcq8qzl9";
+  };
+
+  nativeBuildInputs = with pkgs; [
+    makeWrapper
+  ];
+
+  patches = [ ./testssl.patch ];
+
+  pwdBinPath = "${stdenv.lib.makeBinPath (with pkgs; [ coreutils ])}/pwd";
+  opensslBinPath = "${stdenv.lib.makeBinPath (with pkgs; [ openssl ])}/openssl";
+  postPatch = ''
+    sed -i -e "s|/bin/pwd|${pwdBinPath}|g"                                     \
+           -e "s|TESTSSL_INSTALL_DIR:-\"\"|TESTSSL_INSTALL_DIR:-\"$out\"|g"    \
+           -e "s|OPENSSL:-\"\"|OPENSSL:-\"${opensslBinPath}\"|g" \
+           testssl.sh
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/etc
+    cp -r etc/ $out/
+    cp testssl.sh $out/bin/testssl.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "CLI tool to check a server's TLS/SSL capabilities";
+    longDescription = ''
+      CLI tool which checks a server's service on any port for the support of
+      TLS/SSL ciphers, protocols as well as recent cryptographic flaws and more.
+    '';
+    homepage = https://testssl.sh/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.etu ];
+  };
+}

--- a/pkgs/applications/networking/testssl/testssl.patch
+++ b/pkgs/applications/networking/testssl/testssl.patch
@@ -1,0 +1,10 @@
+--- testssl/testssl.sh	2017-09-24 16:53:29.395263437 +0200
++++ testssl-new/testssl.sh	2017-09-24 16:53:41.221154492 +0200
+@@ -165,6 +165,7 @@
+ # following variables make use of $ENV, e.g. OPENSSL=<myprivate_path_to_openssl> ./testssl.sh <host>
+ # 0 means (normally) true here. Some of the variables are also accessible with a command line switch, see --help
+ declare -x OPENSSL OPENSSL_TIMEOUT
++OPENSSL=${OPENSSL:-""}
+ FAST_SOCKET=${FAST_SOCKET:-false}       # EXPERIMENTAL feature to accelerate sockets -- DO NOT USE it for production
+ COLOR=${COLOR:-2}                       # 2: Full color, 1: b/w+positioning, 0: no ESC at all
+ COLORBLIND=${COLORBLIND:-false}         # if true, swap blue and green in the output

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16549,6 +16549,8 @@ with pkgs;
 
   twmn = libsForQt5.callPackage ../applications/misc/twmn { };
 
+  testssl = callPackage ../applications/networking/testssl { };
+
   umurmur = callPackage ../applications/networking/umurmur { };
 
   unigine-valley = callPackage ../applications/graphics/unigine-valley { };


### PR DESCRIPTION
###### Motivation for this change
Add testssl.sh which is a nice utility for testing TLS/SSL capabilities of servers without having to use any kind of web-service. It's very useful for testing setups of services before deployment and such.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

