### PR TITLE
Xinetd

### DIFF
--- a/nixos/modules/services/networking/xinetd.nix
+++ b/nixos/modules/services/networking/xinetd.nix
@@ -16,6 +16,7 @@ let
         ${cfg.extraDefaults}
       }
 
+      ${concatMapStrings makeInternalService cfg.internalServices}
       ${concatMapStrings makeService cfg.services}
     '';
 
@@ -35,6 +36,148 @@ let
         ${srv.extraConfig}
       }
     '';
+
+  internalServices = {
+    echo = ''
+# description: An xinetd internal service which echo's characters back to
+# clients.
+# This is the tcp version.
+service echo
+{
+	disable		= no
+	type		= INTERNAL
+	id		= echo-stream
+	socket_type	= stream
+	protocol	= tcp
+	user		= root
+	wait		= no
+}
+# This is the udp version.
+service echo
+{
+	disable		= no
+	type		= INTERNAL
+	id		= echo-dgram
+	socket_type	= dgram
+	protocol	= udp
+	user		= root
+	wait		= yes
+}
+    '';
+    chargen = ''
+# description: An xinetd internal service which generate characters.  The
+# xinetd internal service which continuously generates characters until the
+# connection is dropped.  The characters look something like this:
+# !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefg
+# This is the tcp version.
+service chargen
+{
+	disable		= no
+	type		= INTERNAL
+	id		= chargen-stream
+	socket_type	= stream
+	protocol	= tcp
+	user		= root
+	wait		= no
+}
+
+# This is the udp version.
+service chargen
+{
+	disable		= no
+	type		= INTERNAL
+	id		= chargen-dgram
+	socket_type	= dgram
+	protocol	= udp
+	user		= root
+	wait		= yes
+}
+    '';
+    discard = ''
+# description: An RFC 863 discard server.
+# This is the tcp version.
+service discard
+{
+	disable		= no
+	type		= INTERNAL
+	id		= discard-stream
+	socket_type	= stream
+	protocol	= tcp
+	user		= root
+	wait		= no
+}
+
+# This is the udp version.
+service discard
+{
+	disable		= no
+	type		= INTERNAL
+	id		= discard-dgram
+	socket_type	= dgram
+	protocol	= udp
+	user		= root
+	wait		= yes
+}
+    '';
+    daytime = ''
+# description: An internal xinetd service which gets the current system time
+# then prints it out in a format like this: "Wed Nov 13 22:30:27 EST 2002".
+# This is the tcp version.
+service daytime
+{
+	disable		= no
+	type		= INTERNAL
+	id		= daytime-stream
+	socket_type	= stream
+	protocol	= tcp
+	user		= root
+	wait		= no
+}
+
+# This is the udp version.
+service daytime
+{
+	disable		= no
+	type		= INTERNAL
+	id		= daytime-dgram
+	socket_type	= dgram
+	protocol	= udp
+	user		= root
+	wait		= yes
+}
+    '';
+    time = ''
+# description: An RFC 868 time server. This protocol provides a
+# site-independent, machine readable date and time. The Time service sends back
+# to the originating source the time in seconds since midnight on January first
+# 1900.
+# This is the tcp version.
+service time
+{
+	disable		= no
+	type		= INTERNAL
+	id		= time-stream
+	socket_type	= stream
+	protocol	= tcp
+	user		= root
+	wait		= no
+}
+
+# This is the udp version.
+service time
+{
+	disable		= no
+	type		= INTERNAL
+	id		= time-dgram
+	socket_type	= dgram
+	protocol	= udp
+	user		= root
+	wait		= yes
+}
+    '';
+      };
+
+  makeInternalService = srv: internalServices.${srv} ;
 
 in
 
@@ -57,6 +200,16 @@ in
       description = ''
         Additional configuration lines added to the default section of xinetd's configuration.
       '';
+    };
+
+    services.xinetd.internalServices = mkOption {
+      default = [];
+      description = ''
+        A list of internal services provided by xinetd. Example:
+        ["echo" "chargen" "discard" "daytime" "time"]
+      '';
+
+      type = with types; listOf str;
     };
 
     services.xinetd.services = mkOption {


### PR DESCRIPTION
###### Motivation for this change

xinetd has internal services that some legacy software uses, and that I enable at home.

###### Things done

I actually tested my renaming xinetd to MYxinetd and importing using imports in my configuration.nix.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
