### PR TITLE
watson-ruby: init at 1.6.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -197,8 +197,8 @@
   exlevan = "Alexey Levan <exlevan@gmail.com>";
   expipiplus1 = "Joe Hermaszewski <nix@monoid.al>";
   fadenb = "Tristan Helmich <tristan.helmich+nixos@gmail.com>";
-  fare = "Francois-Rene Rideau <fahree@gmail.com>";
   falsifian = "James Cook <james.cook@utoronto.ca>";
+  fare = "Francois-Rene Rideau <fahree@gmail.com>";
   florianjacob = "Florian Jacob <projects+nixos@florianjacob.de>";
   flosse = "Markus Kohlhase <mail@markus-kohlhase.de>";
   fluffynukeit = "Daniel Austin <dan@fluffynukeit.com>";
@@ -290,12 +290,12 @@
   jonafato = "Jon Banafato <jon@jonafato.com>";
   jpierre03 = "Jean-Pierre PRUNARET <nix@prunetwork.fr>";
   jpotier = "Martin Potier <jpo.contributes.to.nixos@marvid.fr>";
-  jyp = "Jean-Philippe Bernardy <jeanphilippe.bernardy@gmail.com>";
   jraygauthier = "Raymond Gauthier <jraygauthier@gmail.com>";
   jtojnar = "Jan Tojnar <jtojnar@gmail.com>";
   juliendehos = "Julien Dehos <dehos@lisic.univ-littoral.fr>";
   jwiegley = "John Wiegley <johnw@newartisans.com>";
   jwilberding = "Jordan Wilberding <jwilberding@afiniate.com>";
+  jyp = "Jean-Philippe Bernardy <jeanphilippe.bernardy@gmail.com>";
   jzellner = "Jeff Zellner <jeffz@eml.cc>";
   kaiha = "Kai Harries <kai.harries@gmail.com>";
   kamilchm = "Kamil Chmielewski <kamil.chm@gmail.com>";
@@ -335,6 +335,7 @@
   lovek323 = "Jason O'Conal <jason@oconal.id.au>";
   lowfatcomputing = "Andreas Wagner <andreas.wagner@lowfatcomputing.org>";
   lsix = "Lancelot SIX <lsix@lancelotsix.com>";
+  ltavard = "Laure Tavard <laure.tavard@univ-grenoble-alpes.fr>";
   lucas8 = "Luc Chabassier <luc.linux@mailoo.org>";
   ludo = "Ludovic Courtès <ludo@gnu.org>";
   lufia = "Kyohei Kadota <lufia@lufia.org>";
@@ -580,10 +581,9 @@
   taku0 = "Takuo Yonezawa <mxxouy6x3m_github@tatapa.org>";
   tari = "Peter Marheine <peter@taricorp.net>";
   tavyc = "Octavian Cerna <octavian.cerna@gmail.com>";
-  ltavard = "Laure Tavard <laure.tavard@univ-grenoble-alpes.fr>";
   teh = "Tom Hunger <tehunger@gmail.com>";
-  teto = "Matthieu Coudron <mcoudron@hotmail.com>";
   telotortium = "Robert Irelan <rirelan@gmail.com>";
+  teto = "Matthieu Coudron <mcoudron@hotmail.com>";
   thall = "Niclas Thall <niclas.thall@gmail.com>";
   thammers = "Tobias Hammerschmidt <jawr@gmx.de>";
   the-kenny = "Moritz Ulrich <moritz@tarn-vedra.de>";
@@ -612,6 +612,7 @@
   #urkud = "Yury G. Kudryashov <urkud+nix@ya.ru>"; inactive since 2012
   uwap = "uwap <me@uwap.name>";
   vaibhavsagar = "Vaibhav Sagar <vaibhavsagar@gmail.com>";
+  valeriangalliat = "Valérian Galliat <val@codejam.info>";
   vandenoever = "Jos van den Oever <jos@vandenoever.info>";
   vanschelven = "Klaas van Schelven <klaas@vanschelven.com>";
   vanzef = "Ivan Solyankin <vanzef@gmail.com>";
@@ -628,7 +629,6 @@
   vlstill = "Vladimír Štill <xstill@fi.muni.cz>";
   vmandela = "Venkateswara Rao Mandela <venkat.mandela@gmail.com>";
   vmchale = "Vanessa McHale <tmchale@wisc.edu>";
-  valeriangalliat = "Valérian Galliat <val@codejam.info>";
   volhovm = "Mikhail Volkhov <volhovm.cs@gmail.com>";
   volth = "Jaroslavas Pocepko <jaroslavas@volth.com>";
   vozz = "Oliver Hunt <oliver.huntuk@gmail.com>";

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -508,6 +508,7 @@
   robberer = "Longrin Wischnewski <robberer@freakmail.de>";
   robbinch = "Robbin C. <robbinch33@gmail.com>";
   roberth = "Robert Hensing <nixpkgs@roberthensing.nl>";
+  robertodr = "Roberto Di Remigio <roberto.diremigio@gmail.com>";
   robgssp = "Rob Glossop <robgssp@gmail.com>";
   roblabla = "Robin Lambertz <robinlambertz+dev@gmail.com>";
   roconnor = "Russell O'Connor <roconnor@theorem.ca>";

--- a/pkgs/development/tools/misc/watson-ruby/Gemfile
+++ b/pkgs/development/tools/misc/watson-ruby/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'watson-ruby'

--- a/pkgs/development/tools/misc/watson-ruby/Gemfile.lock
+++ b/pkgs/development/tools/misc/watson-ruby/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    json (2.1.0)
+    watson-ruby (1.6.3)
+      json
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  watson-ruby
+
+BUNDLED WITH
+   1.14.4

--- a/pkgs/development/tools/misc/watson-ruby/default.nix
+++ b/pkgs/development/tools/misc/watson-ruby/default.nix
@@ -1,0 +1,18 @@
+{ lib, bundlerEnv, ruby }:
+
+bundlerEnv rec {
+  name = "watson-ruby-${version}";
+
+  version = (import ./gemset.nix).watson-ruby.version;
+  inherit ruby;
+  # expects Gemfile, Gemfile.lock and gemset.nix in the same directory
+  gemdir = ./.;
+
+  meta = with lib; {
+    description = "An inline issue manager";
+    homepage    = http://goosecode.com/watson/;
+    license     = with licenses; mit;
+    maintainers = with maintainers; [ robertodr ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/misc/watson-ruby/default.nix
+++ b/pkgs/development/tools/misc/watson-ruby/default.nix
@@ -1,14 +1,25 @@
-{ lib, bundlerEnv, ruby }:
+{ stdenv, bundlerEnv, ruby }:
 
-bundlerEnv rec {
+
+stdenv.mkDerivation rec {
   name = "watson-ruby-${version}";
-
   version = (import ./gemset.nix).watson-ruby.version;
-  inherit ruby;
-  # expects Gemfile, Gemfile.lock and gemset.nix in the same directory
-  gemdir = ./.;
 
-  meta = with lib; {
+  env = bundlerEnv rec {
+    name = "watson-ruby-gems-${version}";
+    inherit ruby;
+    # expects Gemfile, Gemfile.lock and gemset.nix in the same directory
+    gemdir = ./.;
+  };
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    ln -s ${env}/bin/watson $out/bin/watson
+  '';
+
+  meta = with stdenv.lib; {
     description = "An inline issue manager";
     homepage    = http://goosecode.com/watson/;
     license     = with licenses; mit;

--- a/pkgs/development/tools/misc/watson-ruby/gemset.nix
+++ b/pkgs/development/tools/misc/watson-ruby/gemset.nix
@@ -1,0 +1,18 @@
+{
+  json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01v6jjpvh3gnq6sgllpfqahlgxzj50ailwhj9b3cd20hi2dx0vxp";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+  watson-ruby = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1d5m29nr0i030q8ygmbapwri5ndcg2q6lf8a15bk79lfcp9xyj9w";
+      type = "gem";
+    };
+    version = "1.6.3";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7574,6 +7574,8 @@ with pkgs;
     pythonPackages = python3Packages;
   };
 
+  watson-ruby = callPackage ../development/tools/misc/watson-ruby {};
+
   xc3sprog = callPackage ../development/tools/misc/xc3sprog { };
 
   xcbuild  = callPackage ../development/tools/xcbuild/wrapper.nix {


### PR DESCRIPTION
###### Motivation for this change
Package the inline issue manager [Watson](http://goosecode.com/watson/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

