### PR TITLE
mysqlBackup service: Grant privileges to backup user

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1709.xml
+++ b/nixos/doc/manual/release-notes/rl-1709.xml
@@ -289,6 +289,46 @@ FLUSH PRIVILEGES;
       in them being reloaded.
     </para>
   </listitem>
+
+  <listitem>
+    <para>
+      <literal>services.mysqlBackup</literal> now works by default
+      without any user setup, including for users other than
+      <literal>mysql</literal>.
+    </para>
+
+    <para>
+      By default, the <literal>mysql</literal> user is no longer the
+      user which performs the backup. Instead a system account
+      <literal>mysqlbackup</literal> is used.
+    </para>
+
+    <para>
+      The <literal>mysqlBackup</literal> service is also now using
+      systemd timers instead of <literal>cron</literal>.
+    </para>
+
+    <para>
+      Therefore, the <literal>services.mysqlBackup.period</literal>
+      option no longer exists, and has been replaced with
+      <literal>services.mysqlBackup.calendar</literal>, which is in
+      the format of <link
+      xlink:href="https://www.freedesktop.org/software/systemd/man/systemd.time.html#Calendar%20Events">systemd.time(7)</link>.
+    </para>
+
+    <para>
+      If you expect to be sent an e-mail when the backup fails,
+      consider using a script which monitors the systemd journal for
+      errors. Regretfully, at present there is no built-in
+      functionality for this.
+    </para>
+
+    <para>
+      You can check that backups still work by running
+      <command>systemctl start mysql-backup</command> then
+      <command>systemctl status mysql-backup</command>.
+    </para>
+  </listitem>
 </itemizedlist>
 
 <para>Other notable improvements:</para>

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -283,6 +283,7 @@ in rec {
   tests.mumble = callTest tests/mumble.nix {};
   tests.munin = callTest tests/munin.nix {};
   tests.mysql = callTest tests/mysql.nix {};
+  tests.mysqlBackup = callTest tests/mysql-backup.nix {};
   tests.mysqlReplication = callTest tests/mysql-replication.nix {};
   tests.nat.firewall = callTest tests/nat.nix { withFirewall = true; };
   tests.nat.firewall-conntrack = callTest tests/nat.nix { withFirewall = true; withConntrackHelpers = true; };

--- a/nixos/tests/mysql-backup.nix
+++ b/nixos/tests/mysql-backup.nix
@@ -1,0 +1,42 @@
+# Test whether mysqlBackup option works
+import ./make-test.nix ({ pkgs, ... } : {
+  name = "mysql-backup";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ rvl ];
+  };
+
+  nodes = {
+    master = { config, pkgs, ... }: {
+      services.mysql = {
+        enable = true;
+        initialDatabases = [ { name = "testdb"; schema = ./testdb.sql; } ];
+        package = pkgs.mysql;
+      };
+
+      services.mysqlBackup = {
+        enable = true;
+        databases = [ "doesnotexist" "testdb" ];
+      };
+    };
+  };
+
+  testScript =
+    '' startAll;
+
+       # Need to have mysql started so that it can be populated with data.
+       $master->waitForUnit("mysql.service");
+
+       # Wait for testdb to be populated.
+       $master->sleep(10);
+
+       # Do a backup and wait for it to finish.
+       $master->startJob("mysql-backup.service");
+       $master->waitForJob("mysql-backup.service");
+
+       # Check that data appears in backup
+       $master->succeed("${pkgs.gzip}/bin/zcat /var/backup/mysql/testdb.gz | grep hello");
+
+       # Check that a failed backup is logged
+       $master->succeed("journalctl -u mysql-backup.service | grep 'fail.*doesnotexist' > /dev/null");
+    '';
+})

--- a/nixos/tests/testdb.sql
+++ b/nixos/tests/testdb.sql
@@ -8,3 +8,4 @@ insert into tests values (1, 'a');
 insert into tests values (2, 'b');
 insert into tests values (3, 'c');
 insert into tests values (4, 'd');
+insert into tests values (5, 'hello');


### PR DESCRIPTION
Grants enough privileges to the configured user so that it can run `mysqldump`.

Uses the new declarative users options.

Resolves #24728.

/cc @davidak @florianjacob @fadenb 


###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
