### PR TITLE
python.pkgs.python-gnupg: disable failing test test_search_keys

### DIFF
--- a/pkgs/development/python-modules/python-gnupg/default.nix
+++ b/pkgs/development/python-modules/python-gnupg/default.nix
@@ -17,7 +17,8 @@ buildPythonPackage rec {
     substituteInPlace gnupg.py \
     --replace "gpgbinary='gpg'" "gpgbinary='${gnupg1}/bin/gpg'"
     substituteInPlace test_gnupg.py \
-    --replace "gpgbinary=GPGBINARY" "gpgbinary='${gnupg1}/bin/gpg'"
+    --replace "gpgbinary=GPGBINARY" "gpgbinary='${gnupg1}/bin/gpg'" \
+    --replace "test_search_keys" "disabled__test_search_keys"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Reading the code, it's hard to see how this test was *ever* supposed to
pass. interestingly, peeking across the fence, guix have disabled this test
too for the same reason.

note that tests don't actually run *at all* on py27 but that's a problem
for another day

###### Motivation for this change

Fix hydra build of `python-gnupg` on py36

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

