### PR TITLE
ghc prebuilt: Normalize style without changing hashes

### DIFF
--- a/pkgs/development/compilers/ghc/6.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/6.10.2-binary.nix
@@ -1,24 +1,26 @@
-{stdenv, lib, fetchurl, perl, libedit, ncurses5, gmp}:
+{ stdenv
+, fetchurl, perl
+, libedit, ncurses5, gmp
+}:
 
 stdenv.mkDerivation rec {
   version = "6.10.2";
 
   name = "ghc-${version}-binary";
 
-  src =
-    if stdenv.system == "i686-linux" then
-      fetchurl {
+  src = fetchurl ({
+      "i686-linux" = {
         # This binary requires libedit.so.0 (rather than libedit.so.2).
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
         sha256 = "1fw0zr2qshlpk8s0d16k27zcv5263nqdg2xds5ymw8ff6qz9rz9b";
-      }
-    else if stdenv.system == "x86_64-linux" then
-      fetchurl {
+      };
+      "x86_64-linux" = {
         # Idem.
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
         sha256 = "1rd2j7lmcfsm2rdfb5g6q0l8dz3sxadk5m3d2f69d4a6g4p4h7jj";
-      }
-    else throw "cannot bootstrap GHC on this platform";
+      };
+    }.${stdenv.hostPlatform.system}
+      or (throw "cannot bootstrap GHC on this platform"));
 
   buildInputs = [perl];
 
@@ -37,17 +39,17 @@ stdenv.mkDerivation rec {
      '' +
     # On Linux, use patchelf to modify the executables so that they can
     # find editline/gmp.
-    (if stdenv.isLinux then ''
+    stdenv.lib.optionalString stdenv.hostPlatform.isLinux ''
       find . -type f -perm -0100 \
           -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          --set-rpath "${lib.makeLibraryPath [ libedit ncurses5 gmp ]}" {} \;
+          --set-rpath "${stdenv.lib.makeLibraryPath [ libedit ncurses5 gmp ]}" {} \;
       for prog in ld ar gcc strip ranlib; do
         find . -name "setup-config" -exec sed -i "s@/usr/bin/$prog@$(type -p $prog)@g" {} \;
       done
-     '' else "");
+     '';
 
   configurePhase = ''
-    ./configure --prefix=$out --with-gmp-libraries=${lib.getLib gmp}/lib --with-gmp-includes=${lib.getDev gmp}/include
+    ./configure --prefix=$out --with-gmp-libraries=${stdenv.lib.getLib gmp}/lib --with-gmp-includes=${stdenv.lib.getDev gmp}/include
   '';
 
   # Stripping combined with patchelf breaks the executables (they die

--- a/pkgs/development/compilers/ghc/6.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/6.10.2-binary.nix
@@ -9,18 +9,18 @@ stdenv.mkDerivation rec {
   name = "ghc-${version}-binary";
 
   src = fetchurl ({
-      "i686-linux" = {
-        # This binary requires libedit.so.0 (rather than libedit.so.2).
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
-        sha256 = "1fw0zr2qshlpk8s0d16k27zcv5263nqdg2xds5ymw8ff6qz9rz9b";
-      };
-      "x86_64-linux" = {
-        # Idem.
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
-        sha256 = "1rd2j7lmcfsm2rdfb5g6q0l8dz3sxadk5m3d2f69d4a6g4p4h7jj";
-      };
-    }.${stdenv.hostPlatform.system}
-      or (throw "cannot bootstrap GHC on this platform"));
+    "i686-linux" = {
+      # This binary requires libedit.so.0 (rather than libedit.so.2).
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
+      sha256 = "1fw0zr2qshlpk8s0d16k27zcv5263nqdg2xds5ymw8ff6qz9rz9b";
+    };
+    "x86_64-linux" = {
+      # Idem.
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
+      sha256 = "1rd2j7lmcfsm2rdfb5g6q0l8dz3sxadk5m3d2f69d4a6g4p4h7jj";
+    };
+  }.${stdenv.hostPlatform.system}
+    or (throw "cannot bootstrap GHC on this platform"));
 
   buildInputs = [perl];
 
@@ -29,14 +29,14 @@ stdenv.mkDerivation rec {
     # first. The GHC Cabal build system makes use of strip by default and
     # has hardcoded paths to /usr/bin/strip in many places. We replace
     # those below, making them point to our dummy script.
-     ''
+    ''
       mkdir "$TMP/bin"
       for i in strip; do
         echo '#! ${stdenv.shell}' > "$TMP/bin/$i"
         chmod +x "$TMP/bin/$i"
       done
       PATH="$TMP/bin:$PATH"
-     '' +
+    '' +
     # On Linux, use patchelf to modify the executables so that they can
     # find editline/gmp.
     stdenv.lib.optionalString stdenv.hostPlatform.isLinux ''
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
       for prog in ld ar gcc strip ranlib; do
         find . -name "setup-config" -exec sed -i "s@/usr/bin/$prog@$(type -p $prog)@g" {} \;
       done
-     '';
+    '';
 
   configurePhase = ''
     ./configure --prefix=$out --with-gmp-libraries=${stdenv.lib.getLib gmp}/lib --with-gmp-includes=${stdenv.lib.getDev gmp}/include
@@ -60,22 +60,21 @@ stdenv.mkDerivation rec {
   # calls install-strip ...
   dontBuild = true;
 
-  postInstall =
-      ''
-        # bah, the passing gmp doesn't work, so let's add it to the final package.conf in a quick but dirty way
-        sed -i "s@^\(.*pkgName = PackageName \"rts\".*\libraryDirs = \\[\)\(.*\)@\\1\"${gmp.out}/lib\",\2@" $out/lib/ghc-${version}/package.conf
+  postInstall = ''
+    # bah, the passing gmp doesn't work, so let's add it to the final package.conf in a quick but dirty way
+    sed -i "s@^\(.*pkgName = PackageName \"rts\".*\libraryDirs = \\[\)\(.*\)@\\1\"${gmp.out}/lib\",\2@" $out/lib/ghc-${version}/package.conf
 
-        # Sanity check, can ghc create executables?
-        cd $TMP
-        mkdir test-ghc; cd test-ghc
-        cat > main.hs << EOF
-          module Main where
-          main = putStrLn "yes"
-        EOF
-        $out/bin/ghc --make main.hs
-        echo compilation ok
-        [ $(./main) == "yes" ]
-      '';
+    # Sanity check, can ghc create executables?
+    cd $TMP
+    mkdir test-ghc; cd test-ghc
+    cat > main.hs << EOF
+      module Main where
+      main = putStrLn "yes"
+    EOF
+    $out/bin/ghc --make main.hs
+    echo compilation ok
+    [ $(./main) == "yes" ]
+  '';
 
   meta = {
     homepage = http://haskell.org/ghc;

--- a/pkgs/development/compilers/ghc/6.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/6.10.2-binary.nix
@@ -58,29 +58,7 @@ stdenv.mkDerivation rec {
   # calls install-strip ...
   dontBuild = true;
 
-  # The binaries for Darwin use frameworks, so fake those frameworks,
-  # and create some wrapper scripts that set DYLD_FRAMEWORK_PATH so
-  # that the executables work with no special setup.
   postInstall =
-    (if stdenv.isDarwin then
-      ''
-        mkdir -p $out/frameworks/GMP.framework/Versions/A
-        ln -s ${gmp.out}/lib/libgmp.dylib $out/frameworks/GMP.framework/GMP
-        ln -s ${gmp.out}/lib/libgmp.dylib $out/frameworks/GMP.framework/Versions/A/GMP
-        # !!! fix this
-        mkdir -p $out/frameworks/GNUeditline.framework/Versions/A
-        ln -s ${libedit}/lib/libeditline.dylib $out/frameworks/GNUeditline.framework/GNUeditline
-        ln -s ${libedit}/lib/libeditline.dylib $out/frameworks/GNUeditline.framework/Versions/A/GNUeditline
-
-        mv $out/bin $out/bin-orig
-        mkdir $out/bin
-        for i in $(cd $out/bin-orig && ls); do
-            echo \"#! $SHELL -e\" >> $out/bin/$i
-            echo \"DYLD_FRAMEWORK_PATH=$out/frameworks exec $out/bin-orig/$i -framework-path $out/frameworks \\\"\\$@\\\"\" >> $out/bin/$i
-            chmod +x $out/bin/$i
-        done
-      '' else "")
-    +
       ''
         # bah, the passing gmp doesn't work, so let's add it to the final package.conf in a quick but dirty way
         sed -i "s@^\(.*pkgName = PackageName \"rts\".*\libraryDirs = \\[\)\(.*\)@\\1\"${gmp.out}/lib\",\2@" $out/lib/ghc-${version}/package.conf

--- a/pkgs/development/compilers/ghc/7.0.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.0.4-binary.nix
@@ -9,24 +9,24 @@ stdenv.mkDerivation rec {
   name = "ghc-${version}-binary";
 
   src = fetchurl ({
-      "i686-linux" = {
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
-        sha256 = "0mfnihiyjl06f5w1yrjp36sw9g67g2ymg5sdl0g23h1pab99jx63";
-      };
-      "x86_64-linux" = {
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
-        sha256 = "0mc4rhqcxz427wq4zgffmnn0d2yjqvy6af4x9mha283p1gdj5q99";
-      };
-      "i686-darwin" = {
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-apple-darwin.tar.bz2";
-        sha256 = "0qj45hslrrr8zfks8m1jcb3awwx9rh35ndnpfmb0gwb6j7azq5n3";
-      };
-      "x86_64-darwin" = {
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.bz2";
-        sha256 = "1m2ml88p1swf4dnv2vq8hz4drcp46n3ahpfi05wh01ajkf8hnn3l";
-      };
-    }.${stdenv.hostPlatform.system}
-      or (throw "cannot bootstrap GHC on this platform"));
+    "i686-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
+      sha256 = "0mfnihiyjl06f5w1yrjp36sw9g67g2ymg5sdl0g23h1pab99jx63";
+    };
+    "x86_64-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
+      sha256 = "0mc4rhqcxz427wq4zgffmnn0d2yjqvy6af4x9mha283p1gdj5q99";
+    };
+    "i686-darwin" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-apple-darwin.tar.bz2";
+      sha256 = "0qj45hslrrr8zfks8m1jcb3awwx9rh35ndnpfmb0gwb6j7azq5n3";
+    };
+    "x86_64-darwin" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.bz2";
+      sha256 = "1m2ml88p1swf4dnv2vq8hz4drcp46n3ahpfi05wh01ajkf8hnn3l";
+    };
+  }.${stdenv.hostPlatform.system}
+    or (throw "cannot bootstrap GHC on this platform"));
 
   buildInputs = [perl];
 
@@ -41,22 +41,22 @@ stdenv.mkDerivation rec {
     # first. The GHC Cabal build system makes use of strip by default and
     # has hardcoded paths to /usr/bin/strip in many places. We replace
     # those below, making them point to our dummy script.
-     ''
+    ''
       mkdir "$TMP/bin"
       for i in strip; do
         echo '#! ${stdenv.shell}' > "$TMP/bin/$i"
         chmod +x "$TMP/bin/$i"
       done
       PATH="$TMP/bin:$PATH"
-     '' +
+    '' +
     # We have to patch the GMP paths for the integer-gmp package.
-     ''
+    ''
       find . -name integer-gmp.buildinfo \
           -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${gmp.out}/lib@" {} \;
-     '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    '' + stdenv.lib.optionalString stdenv.isDarwin ''
       find . -name base.buildinfo \
           -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${libiconv}/lib@" {} \;
-     '' +
+    '' +
     # On Linux, use patchelf to modify the executables so that they can
     # find editline/gmp.
     stdenv.lib.optionalString stdenv.isLinux ''
@@ -68,24 +68,24 @@ stdenv.mkDerivation rec {
       for prog in ld ar gcc strip ranlib; do
         find . -name "setup-config" -exec sed -i "s@/usr/bin/$prog@$(type -p $prog)@g" {} \;
       done
-     '' + stdenv.lib.optionalString stdenv.isDarwin ''
-       # not enough room in the object files for the full path to libiconv :(
-       fix () {
-         install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $1
-       }
+    '' + stdenv.lib.optionalString stdenv.isDarwin ''
+      # not enough room in the object files for the full path to libiconv :(
+      fix () {
+        install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $1
+      }
 
-       ln -s ${libiconv}/lib/libiconv.dylib ghc-${version}/utils/ghc-pwd/dist/build/tmp
-       ln -s ${libiconv}/lib/libiconv.dylib ghc-${version}/utils/hpc/dist/build/tmp
-       ln -s ${libiconv}/lib/libiconv.dylib ghc-${version}/ghc/stage2/build/tmp
+      ln -s ${libiconv}/lib/libiconv.dylib ghc-${version}/utils/ghc-pwd/dist/build/tmp
+      ln -s ${libiconv}/lib/libiconv.dylib ghc-${version}/utils/hpc/dist/build/tmp
+      ln -s ${libiconv}/lib/libiconv.dylib ghc-${version}/ghc/stage2/build/tmp
 
-       for file in ghc-cabal ghc-pwd ghc-stage2 ghc-pkg haddock hsc2hs hpc; do
-         fix $(find . -type f -name $file)
-       done
+      for file in ghc-cabal ghc-pwd ghc-stage2 ghc-pkg haddock hsc2hs hpc; do
+        fix $(find . -type f -name $file)
+      done
 
-       for file in $(find . -name setup-config); do
-         substituteInPlace $file --replace /usr/bin/ranlib "$(type -P ranlib)"
-       done
-     '';
+      for file in $(find . -name setup-config); do
+        substituteInPlace $file --replace /usr/bin/ranlib "$(type -P ranlib)"
+      done
+    '';
 
   configurePhase = ''
     ./configure --prefix=$out \
@@ -101,19 +101,18 @@ stdenv.mkDerivation rec {
   # calls install-strip ...
   dontBuild = true;
 
-  postInstall =
-      ''
-        # Sanity check, can ghc create executables?
-        cd $TMP
-        mkdir test-ghc; cd test-ghc
-        cat > main.hs << EOF
-          module Main where
-          main = putStrLn "yes"
-        EOF
-        $out/bin/ghc --make main.hs
-        echo compilation ok
-        [ $(./main) == "yes" ]
-      '';
+  postInstall = ''
+    # Sanity check, can ghc create executables?
+    cd $TMP
+    mkdir test-ghc; cd test-ghc
+    cat > main.hs << EOF
+      module Main where
+      main = putStrLn "yes"
+    EOF
+    $out/bin/ghc --make main.hs
+    echo compilation ok
+    [ $(./main) == "yes" ]
+  '';
 
   meta.license = stdenv.lib.licenses.bsd3;
   meta.platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin"];

--- a/pkgs/development/compilers/ghc/7.0.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.0.4-binary.nix
@@ -74,9 +74,9 @@ stdenv.mkDerivation rec {
          install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $1
        }
 
-       ln -s ${libiconv}/lib/libiconv.dylib ghc-7.0.4/utils/ghc-pwd/dist/build/tmp
-       ln -s ${libiconv}/lib/libiconv.dylib ghc-7.0.4/utils/hpc/dist/build/tmp
-       ln -s ${libiconv}/lib/libiconv.dylib ghc-7.0.4/ghc/stage2/build/tmp
+       ln -s ${libiconv}/lib/libiconv.dylib ghc-${version}/utils/ghc-pwd/dist/build/tmp
+       ln -s ${libiconv}/lib/libiconv.dylib ghc-${version}/utils/hpc/dist/build/tmp
+       ln -s ${libiconv}/lib/libiconv.dylib ghc-${version}/ghc/stage2/build/tmp
 
        for file in ghc-cabal ghc-pwd ghc-stage2 ghc-pkg haddock hsc2hs hpc; do
          fix $(find . -type f -name $file)

--- a/pkgs/development/compilers/ghc/7.0.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.0.4-binary.nix
@@ -1,32 +1,32 @@
-{stdenv, fetchurl, perl, ncurses5, gmp, libiconv}:
+{ stdenv
+, fetchurl, perl
+, ncurses5, gmp, libiconv
+}:
 
 stdenv.mkDerivation rec {
   version = "7.0.4";
 
   name = "ghc-${version}-binary";
 
-  src =
-    if stdenv.system == "i686-linux" then
-      fetchurl {
+  src = fetchurl ({
+      "i686-linux" = {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
         sha256 = "0mfnihiyjl06f5w1yrjp36sw9g67g2ymg5sdl0g23h1pab99jx63";
-      }
-    else if stdenv.system == "x86_64-linux" then
-      fetchurl {
+      };
+      "x86_64-linux" = {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
         sha256 = "0mc4rhqcxz427wq4zgffmnn0d2yjqvy6af4x9mha283p1gdj5q99";
-      }
-    else if stdenv.system == "i686-darwin" then
-      fetchurl {
+      };
+      "i686-darwin" = {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-apple-darwin.tar.bz2";
         sha256 = "0qj45hslrrr8zfks8m1jcb3awwx9rh35ndnpfmb0gwb6j7azq5n3";
-      }
-    else if stdenv.system == "x86_64-darwin" then
-      fetchurl {
+      };
+      "x86_64-darwin" = {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.bz2";
         sha256 = "1m2ml88p1swf4dnv2vq8hz4drcp46n3ahpfi05wh01ajkf8hnn3l";
-      }
-    else throw "cannot bootstrap GHC on this platform";
+      };
+    }.${stdenv.hostPlatform.system}
+      or (throw "cannot bootstrap GHC on this platform"));
 
   buildInputs = [perl];
 

--- a/pkgs/development/compilers/ghc/7.4.2-binary.nix
+++ b/pkgs/development/compilers/ghc/7.4.2-binary.nix
@@ -79,9 +79,9 @@ stdenv.mkDerivation rec {
          install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $1
        }
 
-       ln -s ${libiconv}/lib/libiconv.dylib ghc-7.4.2/utils/ghc-pwd/dist-install/build/tmp
-       ln -s ${libiconv}/lib/libiconv.dylib ghc-7.4.2/utils/hpc/dist-install/build/tmp
-       ln -s ${libiconv}/lib/libiconv.dylib ghc-7.4.2/ghc/stage2/build/tmp
+       ln -s ${libiconv}/lib/libiconv.dylib ghc-${version}/utils/ghc-pwd/dist-install/build/tmp
+       ln -s ${libiconv}/lib/libiconv.dylib ghc-${version}/utils/hpc/dist-install/build/tmp
+       ln -s ${libiconv}/lib/libiconv.dylib ghc-${version}/ghc/stage2/build/tmp
 
        for file in ghc-cabal ghc-pwd ghc-stage2 ghc-pkg haddock hsc2hs hpc; do
          fix $(find . -type f -name $file)
@@ -107,10 +107,10 @@ stdenv.mkDerivation rec {
   dontBuild = true;
 
   preInstall = stdenv.lib.optionalString stdenv.isDarwin ''
-    mkdir -p $out/lib/ghc-7.4.2
+    mkdir -p $out/lib/ghc-${version}
     mkdir -p $out/bin
     ln -s ${libiconv}/lib/libiconv.dylib $out/bin
-    ln -s ${libiconv}/lib/libiconv.dylib $out/lib/ghc-7.4.2/libiconv.dylib
+    ln -s ${libiconv}/lib/libiconv.dylib $out/lib/ghc-${version}/libiconv.dylib
     ln -s ${libiconv}/lib/libiconv.dylib utils/ghc-cabal/dist-install/build/tmp
   '';
 

--- a/pkgs/development/compilers/ghc/7.4.2-binary.nix
+++ b/pkgs/development/compilers/ghc/7.4.2-binary.nix
@@ -1,32 +1,32 @@
-{stdenv, fetchurl, perl, ncurses5, gmp, libiconv, makeWrapper}:
+{ stdenv
+, fetchurl, perl, makeWrapper
+, ncurses5, gmp, libiconv
+}:
 
 stdenv.mkDerivation rec {
   version = "7.4.2";
 
   name = "ghc-${version}-binary";
 
-  src =
-    if stdenv.system == "i686-linux" then
-      fetchurl {
+  src = fetchurl ({
+      "i686-linux" = {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
         sha256 = "0gny7knhss0w0d9r6jm1gghrcb8kqjvj94bb7hxf9syrk4fxlcxi";
-      }
-    else if stdenv.system == "x86_64-linux" then
-      fetchurl {
+      };
+      "x86_64-linux" = {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
         sha256 = "043jabd0lh6n1zlqhysngbpvlsdznsa2mmsj08jyqgahw9sjb5ns";
-      }
-    else if stdenv.system == "i686-darwin" then
-      fetchurl {
+      };
+      "i686-darwin" = {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-apple-darwin.tar.bz2";
         sha256 = "1vrbs3pzki37hzym1f1nh07lrqh066z3ypvm81fwlikfsvk4djc0";
-      }
-    else if stdenv.system == "x86_64-darwin" then
-      fetchurl {
+      };
+      "x86_64-darwin" = {
         url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.bz2";
         sha256 = "1imzqc0slpg0r6p40n5a9m18cbcm0m86z8dgyhfxcckksw54mzwf";
-      }
-    else throw "cannot bootstrap GHC on this platform";
+      };
+    }.${stdenv.hostPlatform.system}
+      or (throw "cannot bootstrap GHC on this platform"));
 
   buildInputs = [perl];
 


### PR DESCRIPTION
###### Motivation for this change

This is the first part of https://github.com/NixOS/nixpkgs/pull/29688. Merging to master, and probably back-porting, so future work is easier to port between ghc and nixpkgs versions with, e.g.
```bash
git diff pkgs/develop/compiler/ghc/foo | sed 's/-a.b.c/v-x.y.z/' | git apply -3
```

###### Things done

No hashes are changed.

---

