### PR TITLE
ephem: init at 3.7.6.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -107,6 +107,7 @@
   choochootrain = "Hurshal Patel <hurshal@imap.cc>";
   chris-martin = "Chris Martin <ch.martin@gmail.com>";
   chrisjefferson = "Christopher Jefferson <chris@bubblescope.net>";
+  chrisrosset = "Christopher Rosset <chris@rosset.org.uk>";
   christopherpoole = "Christopher Mark Poole <mail@christopherpoole.net>";
   ciil = "Simon Lackerbauer <simon@lackerbauer.com>";
   ckampka = "Christian Kampka <christian@kampka.net>";

--- a/pkgs/development/python-modules/ephem/default.nix
+++ b/pkgs/development/python-modules/ephem/default.nix
@@ -19,6 +19,6 @@ buildPythonPackage rec {
     description = "Compute positions of the planets and stars";
     homepage = https://pypi.python.org/pypi/ephem/;
     license = licenses.lgpl3;
-    maintainers = with stdenv.lib.maintainers; [ chrisrosset ];
+    maintainers = with maintainers; [ chrisrosset ];
   };
 }

--- a/pkgs/development/python-modules/ephem/default.nix
+++ b/pkgs/development/python-modules/ephem/default.nix
@@ -1,4 +1,5 @@
-{ lib, buildPythonPackage, python, fetchPypi }:
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k
+, glibcLocales, pytest }:
 
 buildPythonPackage rec {
   pname = "ephem";
@@ -10,12 +11,19 @@ buildPythonPackage rec {
     sha256 = "7a4c82b1def2893e02aec0394f108d24adb17bd7b0ca6f4bc78eb7120c0212ac";
   };
 
+  patchFlags = "-p0";
+  checkInputs = [ pytest glibcLocales ];
+  # JPLTest uses assets not distributed in package
+  checkPhase = ''
+    LC_ALL="en_US.UTF-8" py.test --pyargs ephem.tests -k "not JPLTest"
+  '';
+
   # Unfortunately, the tests are broken for Python 3 in 3.7.6.0. They have been
   # fixed in https://github.com/brandon-rhodes/pyephem/commit/c8633854e2d251a198b0f701d0528b508baa2411
   # but there has not been a new release since then.
-  doCheck = false;
+  doCheck = !isPy3k;
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "Compute positions of the planets and stars";
     homepage = https://pypi.python.org/pypi/ephem/;
     license = licenses.lgpl3;

--- a/pkgs/development/python-modules/ephem/default.nix
+++ b/pkgs/development/python-modules/ephem/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, python, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "ephem";
+  name = "${pname}-${version}";
+  version = "3.7.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7a4c82b1def2893e02aec0394f108d24adb17bd7b0ca6f4bc78eb7120c0212ac";
+  };
+
+  # Unfortunately, the tests are broken for Python 3 in 3.7.6.0. They have been
+  # fixed in https://github.com/brandon-rhodes/pyephem/commit/c8633854e2d251a198b0f701d0528b508baa2411
+  # but there has not been a new release since then.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Compute positions of the planets and stars";
+    homepage = https://pypi.python.org/pypi/ephem/;
+    license = licenses.lgpl3;
+    maintainers = with stdenv.lib.maintainers; [ chrisrosset ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26694,6 +26694,7 @@ EOF
 
   parse-type = callPackage ../development/python-modules/parse-type { };
 
+  ephem = callPackage ../development/python-modules/ephem { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

Added [`ephem`](https://pypi.python.org/pypi/ephem/) - useful for Python programs dealing with astronomy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

