### PR TITLE
playbar2: init at 2.5

### DIFF
--- a/pkgs/applications/audio/playbar2/default.nix
+++ b/pkgs/applications/audio/playbar2/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, cmake
+, extra-cmake-modules
+, plasma-framework
+, kwindowsystem
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  name = "playbar2-${version}";
+  version = "2.5";
+
+  src = fetchFromGitHub {
+    owner = "audoban";
+    repo = "PlayBar2";
+    rev = "v${version}";
+    sha256 = "0iv2m4flgaz2r0k7f6l0ca8p6cw8j8j2gin1gci2pg3l5g5khbch";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    plasma-framework
+    kwindowsystem
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Mpris2 Client for Plasma5";
+    homepage = https://github.com/audoban/PlayBar2;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ pjones ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3889,6 +3889,8 @@ with pkgs;
 
   platinum-searcher = callPackage ../tools/text/platinum-searcher { };
 
+  playbar2 = libsForQt5.callPackage ../applications/audio/playbar2 { };
+
   plex = callPackage ../servers/plex { enablePlexPass = config.plex.enablePlexPass or false; };
 
   ploticus = callPackage ../tools/graphics/ploticus {


### PR DESCRIPTION
###### Motivation for this change

Add package `playbar2`

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

