### PR TITLE
WIP: Docker runv (hypercontainer)

### DIFF
--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -167,7 +167,7 @@ in
 
         driver = mkOption {
           # See: https://github.com/hyperhq/runv/blob/master/driverloader/driverloader_linux.go
-          type = types.enum [ "libvirt" "kvm" "qemu" ]; #TODO: Implement all drivers
+          type = types.enum [ "kvm" "qemu" ]; #TODO: Implement all drivers: libvirt, xenpv, xen, kvmtool
           default = "qemu";
           description = ''The driver to be used by runv.'';
         };
@@ -218,7 +218,8 @@ in
           ];
         };
         path = [ pkgs.kmod ] ++
-               (optional (builtins.any (x: cfg.runtime.runv.driver == x) [ "qemu" "kvm" ]) pkgs.qemu_kvm) ++
+               (optional (cfg.runtime.runv.driver == "kvm") pkgs.qemu_kvm) ++
+               (optional (cfg.runtime.runv.driver == "qemu") pkgs.qemu) ++
                (optional (cfg.storageDriver == "zfs") pkgs.zfs);
       };
 

--- a/pkgs/applications/virtualization/runv/default.nix
+++ b/pkgs/applications/virtualization/runv/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, buildGoPackage, libvirt }:
+
+with lib;
+
+buildGoPackage rec {
+  name = "runv-${version}";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "hyperhq";
+    repo = "runv";
+    rev = "v${version}";
+    sha256 = "0dw1li834jjda8hqry9jvpks5703ss0m930sqpvqlzwx4adwwghp";
+  };
+
+  buildInputs = [ libvirt ];
+
+  goPackagePath = "github.com/hyperhq/runv";
+
+  buildPhase = ''
+    go install -p $NIX_BUILD_CORES -tags "static_build with_libvirt" -v $goPackagePath/cli
+  '';
+
+  # The binary is called cli because of the package name, so rename it to runv
+  postInstall = ''
+    mv $bin/bin/cli $bin/bin/runv
+  '';
+
+  meta = {
+    homepage = https://github.com/hyperhq/runv;
+    description = "Hypervisor-based Runtime for OCI";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bachp ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/virtualization/runv/hyperstart.nix
+++ b/pkgs/applications/virtualization/runv/hyperstart.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, autoconf, automake, cpio }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "hyperstart-${version}";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "hyperhq";
+    repo = "hyperstart";
+    rev = "v${version}";
+    sha256 = "0caznq9c785zwqj4zj48ls60sy01imlc9mchdr9103jix5kc3hp5";
+  };
+
+
+  buildInputs = [ autoconf automake cpio ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -a build/kernel $out/
+    cp -a build/hyper-initrd.img $out/
+  '';
+
+  meta = {
+    homepage = https://github.com/hyperhq/hyperstart;
+    description = "The tiny Init service for HyperContainer";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bachp ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16182,6 +16182,7 @@ with pkgs;
   rubyripper = callPackage ../applications/audio/rubyripper {};
 
   runc = callPackage ../applications/virtualization/runc {};
+  runv = callPackage ../applications/virtualization/runv {};
 
   rxvt = callPackage ../applications/misc/rxvt { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16183,6 +16183,7 @@ with pkgs;
 
   runc = callPackage ../applications/virtualization/runc {};
   runv = callPackage ../applications/virtualization/runv {};
+  hyperstart = callPackage ../applications/virtualization/runv/hyperstart.nix {};
 
   rxvt = callPackage ../applications/misc/rxvt { };
 


### PR DESCRIPTION
###### Motivation for this change

Allow to select [runv](https://github.com/hyperhq/runv) as an alternative runtime for docker.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

