### PR TITLE
kbfs: 20170429.44efa06 -> 20170922.f76290

### DIFF
--- a/pkgs/tools/security/kbfs/default.nix
+++ b/pkgs/tools/security/kbfs/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "kbfs-${version}";
-  version = "20170429.44efa06";
+  version = "20170922.f76290";
 
   goPackagePath = "github.com/keybase/kbfs";
   subPackages = [ "kbfsfuse" ];
@@ -12,8 +12,8 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "keybase";
     repo = "kbfs";
-    rev = "44efa0682d931d8489f5e84542e8d00baeb12592";
-    sha256 = "1q6hklyr6zq3xr1azz1c6rlpsjc036f222cd20vf79m58dn906n5";
+    rev = "f76290f6e1a8cbaa6046980c67c548fbff9e123a";
+    sha256 = "1v086wmc0hly4b91y6xndfdhj981n2yr6nnb3rl6f4kwx291ih54";
   };
 
   buildFlags = [ "-tags production" ];


### PR DESCRIPTION
###### Motivation for this change
kbfs was not working with the lastest keybase update
(https://github.com/NixOS/nixpkgs/commit/ef3cb5cc4750114a90ade7c0ea17f6967d01df39).

We should enforce update of keybase/keybase-ui and kbfs (like done here:
https://github.com/NixOS/nixpkgs/commit/f74a1e6bcb982ad423075bba28fa888f78dfa152)
all together to avoid API problems.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

