### PR TITLE
nfsd: add extraNfsdConfig

### DIFF
--- a/nixos/modules/services/network-filesystems/nfsd.nix
+++ b/nixos/modules/services/network-filesystems/nfsd.nix
@@ -27,6 +27,14 @@ in
           '';
         };
 
+        extraNfsdConfig = mkOption {
+          type = types.str;
+          default = "";
+          description = ''
+            Extra configuration options for the [nfsd] section of /etc/nfs.conf.
+          '';
+        };
+
         exports = mkOption {
           type = types.lines;
           default = "";
@@ -107,6 +115,7 @@ in
       [nfsd]
       threads=${toString cfg.nproc}
       ${optionalString (cfg.hostName != null) "host=${cfg.hostName}"}
+      ${cfg.extraNfsdConfig}
 
       [mountd]
       ${optionalString (cfg.mountdPort != null) "port=${toString cfg.mountdPort}"}


### PR DESCRIPTION
###### Motivation for this change

To run Genera, I need NFS v2, with the non-default option `vers2=on` in the `[nfsd]` section of `nfs.conf`.

###### Things done

Tested manually by renaming to MYnfs add using imports = in my configuration.nix

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

