### PR TITLE
opam: use aspcud on darwin

### DIFF
--- a/pkgs/development/tools/ocaml/opam/default.nix
+++ b/pkgs/development/tools/ocaml/opam/default.nix
@@ -1,6 +1,5 @@
 { stdenv, lib, fetchgit, fetchurl, makeWrapper,
-  ocaml, unzip, ncurses, curl,
-  aspcudSupport ? !stdenv.isDarwin, aspcud
+  ocaml, unzip, ncurses, curl, aspcud
 }:
 
 assert lib.versionAtLeast ocaml.version "3.12.1";
@@ -72,12 +71,10 @@ in stdenv.mkDerivation rec {
   # Dirty, but apparently ocp-build requires a TERM
   makeFlags = ["TERM=screen"];
 
-  postInstall =
-    if aspcudSupport then ''
-      wrapProgram $out/bin/opam \
-        --suffix PATH : ${aspcud}/bin
-    ''
-    else "";
+  postInstall = ''
+    wrapProgram $out/bin/opam \
+      --suffix PATH : ${aspcud}/bin
+  '';
 
   doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change

aspcud is the recommended solver for OPAM and the `aspcud` package is now building properly on Darwin. As such, we can remove the special case for Darwin that required OPAM to fall back to the built-in solver.

**Note:** The failure related to the `csv` package mentioned in #29336 has been fixed and `nox-review` now passes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).