### PR TITLE
xpad: init at 5.0.0

### DIFF
--- a/pkgs/applications/misc/xpad/default.nix
+++ b/pkgs/applications/misc/xpad/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, glib, intltool, gtk3, gtksourceview }:
+
+stdenv.mkDerivation rec {
+  name = "xpad-${version}";
+  version = "5.0.0";
+
+  src = fetchurl {
+    url = "https://launchpad.net/xpad/trunk/${version}/+download/xpad-${version}.tar.bz2";
+    sha256 = "02yikxg6z9bwla09ka001ppjlpbv5kbza3za9asazm5aiz376mkb";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ glib intltool gtk3 gtksourceview ];
+
+  autoreconfPhase = ''
+    ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A sticky note application for jotting down things to remember";
+    homepage = https://launchpad.net/xpad;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ michalrus ];
+  };
+}

--- a/pkgs/applications/misc/xpad/default.nix
+++ b/pkgs/applications/misc/xpad/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, autoreconfHook, pkgconfig, glib, intltool, gtk3, gtksourceview }:
+{ stdenv, fetchurl
+, autoreconfHook, pkgconfig, wrapGAppsHook
+, glib, intltool, gtk3, gtksourceview }:
 
 stdenv.mkDerivation rec {
   name = "xpad-${version}";
@@ -9,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "02yikxg6z9bwla09ka001ppjlpbv5kbza3za9asazm5aiz376mkb";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig wrapGAppsHook ];
 
   buildInputs = [ glib intltool gtk3 gtksourceview ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19288,6 +19288,10 @@ with pkgs;
 
   xosd = callPackage ../misc/xosd { };
 
+  xpad = callPackage ../applications/misc/xpad {
+    inherit (gnome3) gtksourceview;
+  };
+
   xsane = callPackage ../applications/graphics/sane/xsane.nix {
     libpng = libpng12;
   };


### PR DESCRIPTION
###### Motivation for this change

We only have `gnome3.bijiben` which is worse! (ﾉ^_^)ﾉ

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

