### PR TITLE
WIP salt: fix patch once more, now using EAFP

### DIFF
--- a/pkgs/tools/admin/salt/fix-libcrypto-loading.patch
+++ b/pkgs/tools/admin/salt/fix-libcrypto-loading.patch
@@ -1,14 +1,16 @@
 diff --git a/salt/utils/rsax931.py b/salt/utils/rsax931.py
-index f827cc6db8..b728595186 100644
+index b7ecfcd..301c7b5 100644
 --- a/salt/utils/rsax931.py
 +++ b/salt/utils/rsax931.py
-@@ -47,6 +47,9 @@ def _load_libcrypto():
+@@ -44,8 +44,11 @@ def _load_libcrypto():
+             # two checks below
+             lib = glob.glob('/opt/local/lib/libcrypto.so*') + glob.glob('/opt/tools/lib/libcrypto.so*')
              lib = lib[0] if len(lib) > 0 else None
-         if lib:
-             return cdll.LoadLibrary(lib)
-+        else:
-+            return cdll.LoadLibrary('@libcrypto@')
-+
+-        if lib:
+-            return cdll.LoadLibrary(lib)
++        try:
++            return cdll.LoadLibrary("@libcrypto@")
++        except OSError:
++            if lib:
++                return cdll.LoadLibrary(lib)
          raise OSError('Cannot locate OpenSSL libcrypto')
- 
- 


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/29020#issuecomment-328891772

Patch introduced in PR #29020 was OK when installing salt on NixOS, but on Linux
behavior was switched to less pure variant. Here I'm returning back original
behavior (use hardcoded path to `libcrypto` by default), but don't disallow dynamic
library lookups (which was essential for `salt-ssh`).

"Easier to Ask Forgiveness than Permission" principle at work.