### PR TITLE
guile-lib: Disable a test which doesn't work with Guile 2.2

### DIFF
--- a/pkgs/development/guile-modules/guile-lib/default.nix
+++ b/pkgs/development/guile-modules/guile-lib/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, guile, texinfo}:
+{stdenv, fetchurl, guile, texinfo, pkgconfig}:
 
 assert stdenv ? cc && stdenv.cc.isGNU;
 
@@ -10,7 +10,13 @@ stdenv.mkDerivation rec {
     sha256 = "1f9n2b5b5r75lzjinyk6zp6g20g60msa0jpfrk5hhg4j8cy0ih4b";
   };
 
+  nativeBuildInputs = [pkgconfig];
   buildInputs = [guile texinfo];
+
+  # One test doesn't seem to be compatible with guile_2_2
+  patchPhase = ''
+    sed -i -e '/sxml.ssax.scm/d' unit-tests/Makefile*
+  '';
 
   doCheck = true;
 


### PR DESCRIPTION
https://hydra.nixos.org/build/61469403/nixlog/1

Error is:

    ERROR: In procedure %resolve-variable:
    ERROR: Unbound variable: use-syntax
    FAIL: sxml.ssax.scm

Also add pkg-config so that configure script can find libguile.

Relevant to #28643

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [/] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [/] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
