### PR TITLE
guile-fibers: init at 1.0.0

### DIFF
--- a/pkgs/development/guile-modules/guile-fibers/default.nix
+++ b/pkgs/development/guile-modules/guile-fibers/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, guile, texinfo }:
+
+let
+  version = "1.0.0";
+  name = "guile-fibers-${version}";
+in stdenv.mkDerivation {
+  inherit name;
+
+  src = fetchFromGitHub {
+    owner = "wingo";
+    repo = "fibers";
+    rev = "v${version}";
+    sha256 = "1r47m1m112kxf23xny99f0qkqsk6626iyc5jp7vzndfiyp5yskwi";
+  };
+
+  buildInputs = [ autoreconfHook pkgconfig guile texinfo ];
+
+  autoreconfPhase = "./autogen.sh";
+
+  meta = with stdenv.lib; {
+    description = "Concurrent ML-like concurrency for Guile";
+    homepage = "https://github.com/wingo/fibers";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ vyp ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/guile-modules/guile-fibers/default.nix
+++ b/pkgs/development/guile-modules/guile-fibers/default.nix
@@ -13,13 +13,14 @@ in stdenv.mkDerivation {
     sha256 = "1r47m1m112kxf23xny99f0qkqsk6626iyc5jp7vzndfiyp5yskwi";
   };
 
-  buildInputs = [ autoreconfHook pkgconfig guile texinfo ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ guile texinfo ];
 
   autoreconfPhase = "./autogen.sh";
 
   meta = with stdenv.lib; {
     description = "Concurrent ML-like concurrency for Guile";
-    homepage = "https://github.com/wingo/fibers";
+    homepage = https://github.com/wingo/fibers;
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ vyp ];
     platforms = platforms.all;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6662,6 +6662,8 @@ with pkgs;
 
   guileCairo = callPackage ../development/guile-modules/guile-cairo { };
 
+  guile-fibers = callPackage ../development/guile-modules/guile-fibers { };
+
   guileGnome = callPackage ../development/guile-modules/guile-gnome {
     gconf = gnome2.GConf;
     inherit (gnome2) gnome_vfs libglade libgnome libgnomecanvas libgnomeui;


### PR DESCRIPTION
###### Motivation for this change

Fibers is a concurrency library for Guile: https://github.com/wingo/fibers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

