### PR TITLE
latte dock: 0.6.0 -> 0.7.1

### DIFF
--- a/pkgs/applications/misc/latte-dock/default.nix
+++ b/pkgs/applications/misc/latte-dock/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, cmake, xorg, plasma-framework, fetchFromGitHub
-, extra-cmake-modules, karchive, kwindowsystem, qtx11extras }:
+, extra-cmake-modules, karchive, kwindowsystem, qtx11extras, kcrash }:
 
-let version = "0.6.0"; in
+let version = "0.7.1"; in
 
 mkDerivation {
   name = "latte-dock-${version}";
@@ -10,13 +10,13 @@ mkDerivation {
     owner = "psifidotos";
     repo = "Latte-Dock";
     rev = "v${version}";
-    sha256 = "1967hx4lavy96vvik8d5m2c6ycd2mlf9cmhrv40zr0784ni0ikyv";
+    sha256 = "0vdmsjj1qqlzz26mznb56znv5x7akbvw65ybbzakclp4q1xrsrm2";
   };
 
-  buildInputs = [ plasma-framework xorg.libpthreadstubs xorg.libXdmcp ];
+  buildInputs = [ plasma-framework xorg.libpthreadstubs xorg.libXdmcp xorg.libSM ];
 
   nativeBuildInputs = [ extra-cmake-modules cmake karchive kwindowsystem
-    qtx11extras ];
+    qtx11extras kcrash ];
 
   meta = with lib; {
     description = "Dock-style app launcher based on Plasma frameworks";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

