### PR TITLE
guile-modules: add vyp as maintainer to unmaintained guile modules

### DIFF
--- a/pkgs/development/guile-modules/guile-cairo/default.nix
+++ b/pkgs/development/guile-modules/guile-cairo/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, guile, pkgconfig, cairo, expat, guile_lib }:
+{ fetchurl, stdenv, guile, pkgconfig, cairo, expat, guile-lib }:
 
 stdenv.mkDerivation rec {
   name = "guile-cairo-1.4.1";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ guile pkgconfig cairo expat ]
-    ++ stdenv.lib.optional doCheck guile_lib;
+    ++ stdenv.lib.optional doCheck guile-lib;
 
   doCheck = true;
 

--- a/pkgs/development/guile-modules/guile-cairo/default.nix
+++ b/pkgs/development/guile-modules/guile-cairo/default.nix
@@ -1,7 +1,8 @@
-{ fetchurl, stdenv, guile, pkgconfig, cairo, expat, guile-lib }:
+{ stdenv, fetchurl, pkgconfig, guile, guile-lib, cairo, expat }:
 
 stdenv.mkDerivation rec {
-  name = "guile-cairo-1.4.1";
+  name = "guile-cairo-${version}";
+  version = "1.4.1";
 
   src = fetchurl {
     url = "http://download.gna.org/guile-cairo/${name}.tar.gz";
@@ -13,25 +14,20 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = {
-    description = "Guile-Cairo, Cairo bindings for GNU Guile";
+  meta = with stdenv.lib; {
+    description = "Cairo bindings for GNU Guile";
+    longDescription = ''
+      Guile-Cairo wraps the Cairo graphics library for Guile Scheme.
 
-    longDescription =
-      '' Guile-Cairo wraps the Cairo graphics library for Guile Scheme.
-
-         Guile-Cairo is complete, wrapping almost all of the Cairo API.  It
-         is API stable, providing a firm base on which to do graphics work.
-         Finally, and importantly, it is pleasant to use.  You get a powerful
-         and well-maintained graphics library with all of the benefits of
-         Scheme: memory management, exceptions, macros, and a dynamic
-         programming environment.
-      '';
-
-    license = stdenv.lib.licenses.lgpl3Plus;
-
-    homepage = http://home.gna.org/guile-cairo/;
-
-    maintainers = [ stdenv.lib.maintainers.vyp ];
-    platforms = stdenv.lib.platforms.linux;
+      Guile-Cairo is complete, wrapping almost all of the Cairo API.  It is API
+      stable, providing a firm base on which to do graphics work.  Finally, and
+      importantly, it is pleasant to use.  You get a powerful and well
+      maintained graphics library with all of the benefits of Scheme: memory
+      management, exceptions, macros, and a dynamic programming environment.
+    '';
+    homepage = "http://home.gna.org/guile-cairo/";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ vyp ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/guile-modules/guile-cairo/default.nix
+++ b/pkgs/development/guile-modules/guile-cairo/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
     homepage = http://home.gna.org/guile-cairo/;
 
-    maintainers = [ ];
+    maintainers = [ stdenv.lib.maintainers.vyp ];
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/development/guile-modules/guile-gnome/default.nix
+++ b/pkgs/development/guile-modules/guile-gnome/default.nix
@@ -1,7 +1,7 @@
-{ fetchurl, stdenv, guile, guile_lib, gwrap
+{ fetchurl, stdenv, guile, guile-lib, gwrap
 , pkgconfig, gconf, glib, gnome_vfs, gtk2
 , libglade, libgnome, libgnomecanvas, libgnomeui
-, pango, guileCairo, autoconf, automake, texinfo }:
+, pango, guile-cairo, autoconf, automake, texinfo }:
 
 stdenv.mkDerivation rec {
   name = "guile-gnome-platform-2.16.4";
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
     libgnomecanvas
     libgnomeui
     pango
-    guileCairo
-  ] ++ stdenv.lib.optional doCheck guile_lib;
+    guile-cairo
+  ] ++ stdenv.lib.optional doCheck guile-lib;
 
   preConfigure = ''
       ./autogen.sh

--- a/pkgs/development/guile-modules/guile-lib/default.nix
+++ b/pkgs/development/guile-modules/guile-lib/default.nix
@@ -1,44 +1,45 @@
-{stdenv, fetchurl, guile, texinfo, pkgconfig}:
+{ stdenv, fetchurl, guile, texinfo, pkgconfig }:
 
 assert stdenv ? cc && stdenv.cc.isGNU;
 
-stdenv.mkDerivation rec {
-  name = "guile-lib-0.2.2";
+let
+  name = "guile-lib-${version}";
+  version = "0.2.2";
+in stdenv.mkDerivation {
+  inherit name;
 
   src = fetchurl {
     url = "mirror://savannah/guile-lib/${name}.tar.gz";
     sha256 = "1f9n2b5b5r75lzjinyk6zp6g20g60msa0jpfrk5hhg4j8cy0ih4b";
   };
 
-  nativeBuildInputs = [pkgconfig];
-  buildInputs = [guile texinfo];
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ guile texinfo ];
 
-  # One test doesn't seem to be compatible with guile_2_2
+  # One test doesn't seem to be compatible with guile_2_2.
   patchPhase = ''
     sed -i -e '/sxml.ssax.scm/d' unit-tests/Makefile*
   '';
 
   doCheck = true;
 
-  preCheck =
+  preCheck = ''
     # Make `libgcc_s.so' visible for `pthread_cancel'.
-    '' export LD_LIBRARY_PATH="$(dirname $(echo ${stdenv.cc.cc.lib}/lib*/libgcc_s.so)):$LD_LIBRARY_PATH"
+    export LD_LIBRARY_PATH=\
+    "$(dirname $(echo ${stdenv.cc.cc.lib}/lib*/libgcc_s.so)):$LD_LIBRARY_PATH"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A collection of useful Guile Scheme modules";
+    longDescription = ''
+      guile-lib is intended as an accumulation place for pure-scheme Guile
+      modules, allowing for people to cooperate integrating their generic Guile
+      modules into a coherent library.  Think "a down-scaled, limited-scope CPAN
+      for Guile".
     '';
-
-  meta = {
-    description = "Guile-Library, a collection of useful Guile Scheme modules";
-
-    longDescription =
-      '' guile-lib is intended as an accumulation place for pure-scheme Guile
-         modules, allowing for people to cooperate integrating their generic
-         Guile modules into a coherent library.  Think "a down-scaled,
-         limited-scope CPAN for Guile".
-      '';
-
-    homepage = http://www.nongnu.org/guile-lib/;
-    license = stdenv.lib.licenses.gpl3Plus;
-
-    maintainers = [ stdenv.lib.maintainers.vyp ];
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    homepage = "http://www.nongnu.org/guile-lib/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ vyp ];
+    platforms = platforms.gnu;
   };
 }

--- a/pkgs/development/guile-modules/guile-lib/default.nix
+++ b/pkgs/development/guile-modules/guile-lib/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     homepage = http://www.nongnu.org/guile-lib/;
     license = stdenv.lib.licenses.gpl3Plus;
 
-    maintainers = [ ];
+    maintainers = [ stdenv.lib.maintainers.vyp ];
     platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
   };
 }

--- a/pkgs/development/guile-modules/guile-ncurses/default.nix
+++ b/pkgs/development/guile-modules/guile-ncurses/default.nix
@@ -1,7 +1,10 @@
-{ fetchurl, stdenv, pkgconfig, guile, ncurses, libffi }:
+{ stdenv, fetchurl, pkgconfig, guile, ncurses, libffi }:
 
-stdenv.mkDerivation rec {
-  name = "guile-ncurses-1.7";
+let
+  name = "guile-ncurses-${version}";
+  version = "1.7";
+in stdenv.mkDerivation {
+  inherit name;
 
   src = fetchurl {
     url = "mirror://gnu/guile-ncurses/${name}.tar.gz";
@@ -11,31 +14,31 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ guile ncurses libffi ];
 
-  preConfigure =
-    '' configureFlags="$configureFlags --with-guilesitedir=$out/share/guile/site" '';
+  preConfigure = ''
+    configureFlags="$configureFlags --with-guilesitedir=$out/share/guile/site"
+  '';
 
-  postFixup =
-    '' for f in $out/share/guile/site/ncurses/**.scm; do \
-           substituteInPlace $f \
-             --replace "libguile-ncurses" "$out/lib/libguile-ncurses"; \
-       done
+  postFixup = ''
+    for f in $out/share/guile/site/ncurses/**.scm; do \
+      substituteInPlace $f \
+        --replace "libguile-ncurses" "$out/lib/libguile-ncurses"; \
+    done
+  '';
+
+  # XXX: 1 of 65 tests failed.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Scheme interface to the NCurses libraries";
+    longDescription = ''
+      GNU Guile-Ncurses is a library for the Guile Scheme interpreter that
+      provides functions for creating text user interfaces.  The text user
+      interface functionality is built on the ncurses libraries: curses, form,
+      panel, and menu.
     '';
-
-  doCheck = false;  # XXX: 1 of 65 tests failed
-
-  meta = {
-    description = "GNU Guile-Ncurses, Scheme interface to the NCurses libraries";
-
-    longDescription =
-      '' GNU Guile-Ncurses is a library for the Guile Scheme interpreter that
-         provides functions for creating text user interfaces.  The text user
-         interface functionality is built on the ncurses libraries: curses,
-         form, panel, and menu.
-      '';
-
-    license = stdenv.lib.licenses.lgpl3Plus;
-
-    maintainers = [ stdenv.lib.maintainers.vyp ];
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    homepage = "https://www.gnu.org/software/guile-ncurses/";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ vyp ];
+    platforms = platforms.gnu;
   };
 }

--- a/pkgs/development/guile-modules/guile-ncurses/default.nix
+++ b/pkgs/development/guile-modules/guile-ncurses/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.lgpl3Plus;
 
-    maintainers = [ ];
+    maintainers = [ stdenv.lib.maintainers.vyp ];
     platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
   };
 }

--- a/pkgs/development/guile-modules/guile-opengl/default.nix
+++ b/pkgs/development/guile-modules/guile-opengl/default.nix
@@ -1,15 +1,10 @@
 { stdenv, fetchurl, pkgconfig, guile }:
 
-stdenv.mkDerivation rec {
-  name = "guile-opengl-0.1.0";
-
-  meta = with stdenv.lib; {
-    description = "Guile binding for the OpenGL graphics API";
-    homepage    = "http://gnu.org/s/guile-opengl";
-    license     = licenses.gpl3Plus;
-    maintainers = with maintainers; [ vyp ];
-    platforms   = platforms.linux;
-  };
+let
+  name = "guile-opengl-${version}";
+  version = "0.1.0";
+in stdenv.mkDerivation {
+  inherit name;
 
   src = fetchurl {
     url = "mirror://gnu/guile-opengl/${name}.tar.gz";
@@ -17,4 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig guile ];
+
+  meta = with stdenv.lib; {
+    description = "Guile bindings for the OpenGL graphics API";
+    homepage = "http://gnu.org/s/guile-opengl";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ vyp ];
+    platforms = platforms.linux;
+  };
 }

--- a/pkgs/development/guile-modules/guile-opengl/default.nix
+++ b/pkgs/development/guile-modules/guile-opengl/default.nix
@@ -7,6 +7,7 @@ stdenv.mkDerivation rec {
     description = "Guile binding for the OpenGL graphics API";
     homepage    = "http://gnu.org/s/guile-opengl";
     license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ vyp ];
     platforms   = platforms.linux;
   };
 

--- a/pkgs/development/guile-modules/guile-sdl/default.nix
+++ b/pkgs/development/guile-modules/guile-sdl/default.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
     description = "Guile bindings for SDL";
     homepage    = "http://gnu.org/s/guile-sdl";
     license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ vyp ];
     platforms   = platforms.linux;
   };
 

--- a/pkgs/development/guile-modules/guile-sdl/default.nix
+++ b/pkgs/development/guile-modules/guile-sdl/default.nix
@@ -3,15 +3,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "guile-sdl-0.5.1";
-
-  meta = with stdenv.lib; {
-    description = "Guile bindings for SDL";
-    homepage    = "http://gnu.org/s/guile-sdl";
-    license     = licenses.gpl3Plus;
-    maintainers = with maintainers; [ vyp ];
-    platforms   = platforms.linux;
-  };
+  name = "guile-sdl-${version}";
+  version = "0.5.1";
 
   src = fetchurl {
     url = "mirror://gnu/guile-sdl/${name}.tar.xz";
@@ -20,9 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig guile ];
 
-  buildInputs = [
-    SDL.dev SDL_image SDL_ttf SDL_mixer
-  ];
+  buildInputs = [ SDL.dev SDL_image SDL_ttf SDL_mixer ];
 
   GUILE_AUTO_COMPILE = 0;
 
@@ -32,4 +23,12 @@ stdenv.mkDerivation rec {
       paths = buildInputs;
     };
   in "SDLMINUSI=-I${sdl}/include/SDL";
+
+  meta = with stdenv.lib; {
+    description = "Guile bindings for SDL";
+    homepage = "http://gnu.org/s/guile-sdl";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ vyp ];
+    platforms = platforms.linux;
+  };
 }

--- a/pkgs/development/guile-modules/guile-xcb/default.nix
+++ b/pkgs/development/guile-modules/guile-xcb/default.nix
@@ -1,18 +1,13 @@
 { stdenv, fetchurl, pkgconfig, guile, texinfo }:
 
-stdenv.mkDerivation {
-  name = "guile-xcb-1.3";
-
-  meta = with stdenv.lib; {
-    description = "XCB bindings for Guile";
-    homepage    = "http://www.markwitmer.com/guile-xcb/guile-xcb.html";
-    license     = licenses.gpl3Plus;
-    maintainers = with maintainers; [ vyp ];
-    platforms   = platforms.linux;
-  };
+let
+  name = "guile-xcb-${version}";
+  version = "1.3";
+in stdenv.mkDerivation {
+  inherit name;
 
   src = fetchurl {
-    url = "http://www.markwitmer.com/dist/guile-xcb-1.3.tar.gz";
+    url = "http://www.markwitmer.com/dist/${name}.tar.gz";
     sha256 = "04dvbqdrrs67490gn4gkq9zk8mqy3mkls2818ha4p0ckhh0pm149";
   };
 
@@ -24,4 +19,12 @@ stdenv.mkDerivation {
       --with-guile-site-ccache-dir=$out/share/guile/site
     ";
   '';
+
+  meta = with stdenv.lib; {
+    description = "XCB bindings for Guile";
+    homepage = "http://www.markwitmer.com/guile-xcb/guile-xcb.html";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ vyp ];
+    platforms = platforms.linux;
+  };
 }

--- a/pkgs/development/guile-modules/guile-xcb/default.nix
+++ b/pkgs/development/guile-modules/guile-xcb/default.nix
@@ -7,6 +7,7 @@ stdenv.mkDerivation {
     description = "XCB bindings for Guile";
     homepage    = "http://www.markwitmer.com/guile-xcb/guile-xcb.html";
     license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ vyp ];
     platforms   = platforms.linux;
   };
 

--- a/pkgs/development/tools/guile/g-wrap/default.nix
+++ b/pkgs/development/tools/guile/g-wrap/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, guile, libffi, pkgconfig, glib, guile_lib }:
+{ fetchurl, stdenv, guile, libffi, pkgconfig, glib, guile-lib }:
 
 stdenv.mkDerivation rec {
   name = "g-wrap-1.9.15";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   # Note: Glib support is optional, but it's quite useful (e.g., it's
   # used by Guile-GNOME).
-  buildInputs = [ guile pkgconfig glib guile_lib ];
+  buildInputs = [ guile pkgconfig glib guile-lib ];
 
   propagatedBuildInputs = [ libffi ];
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -66,6 +66,10 @@ mapAliases (rec {
   gst_plugins_bad = gst-plugins-bad;  # added 2017-02
   gst_plugins_ugly = gst-plugins-ugly;  # added 2017-02
   gst_python = gst-python;  # added 2017-02
+  guileCairo = guile-cairo; # added 2017-09-24
+  guileGnome = guile-gnome; # added 2017-09-24
+  guile_lib = guile-lib; # added 2017-09-24
+  guile_ncurses = guile-ncurses; # added 2017-09-24
   gupnptools = gupnp-tools;  # added 2015-12-19
   gnustep-make = gnustep.make; # added 2016-7-6
   htmlTidy = html-tidy;  # added 2014-12-06

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6708,18 +6708,18 @@ with pkgs;
 
   jython = callPackage ../development/interpreters/jython {};
 
-  guileCairo = callPackage ../development/guile-modules/guile-cairo { };
+  guile-cairo = callPackage ../development/guile-modules/guile-cairo { };
 
   guile-fibers = callPackage ../development/guile-modules/guile-fibers { };
 
-  guileGnome = callPackage ../development/guile-modules/guile-gnome {
+  guile-gnome = callPackage ../development/guile-modules/guile-gnome {
     gconf = gnome2.GConf;
     inherit (gnome2) gnome_vfs libglade libgnome libgnomecanvas libgnomeui;
   };
 
-  guile_lib = callPackage ../development/guile-modules/guile-lib { };
+  guile-lib = callPackage ../development/guile-modules/guile-lib { };
 
-  guile_ncurses = callPackage ../development/guile-modules/guile-ncurses { };
+  guile-ncurses = callPackage ../development/guile-modules/guile-ncurses { };
 
   guile-opengl = callPackage ../development/guile-modules/guile-opengl { };
 


### PR DESCRIPTION
###### Motivation for this change

When [packaging guile-fibers](https://github.com/NixOS/nixpkgs/pull/29727), I noticed that a lot of the guile modules are unmaintained, so I would be happy to (try to) maintain them.

I also took this opportunity to rename the guile modules attributes in pkgs/top-level/all-packages.nix to be consistent kebab case (vs camel case and snake case), because git grepping showed that the ones I renamed were relatively unreferenced throughout nixpkgs. In fact only g-wrap referenced one of them, and the other references were from other guile modules themselves. Still, this at least affects @taktoa and @amiloradovsky, so you guys would have to be okay with this? Also, maybe there is a policy against renaming top level attributes? Obviously I'm willing to revert this change if anyone has issues with it.

I also took the opportunity to make a lot of stylistic changes to the modules I've added myself as maintainer for, seeing as though I would be the sole maintainer (so I think no one should have issues with it).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

