### PR TITLE
gitAndTools.git-dit: Remove me as maintainer

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-dit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-dit/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     inherit (src.meta) homepage;
     description = "Decentralized Issue Tracking for git";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ profpatsch matthiasbeyer ];
+    maintainers = with maintainers; [ profpatsch ];
   };
 
 


### PR DESCRIPTION
Because the main developer (I'm co-author) of git-dit refuses to add a `Cargo.lock` file to the repository and follow some basic ways to ensure packaging is easy, I refuse to maintain the package any longer.

We have git-dit in version 0.1.0. Current version is 0.4.0, but we cannot package it because `Cargo.lock` missing. I refuse to break my head for packaging this.

---

I submitted this as patch to the other maintainers of the package before so they can apply this to their tree for eventual merge... but as this hasn't happened yet, I submit it here.