### PR TITLE
vimPlugins.xptemplate: init at 2017-04-18

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -652,6 +652,17 @@ rec {
 
   };
 
+  xptemplate = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "xptemplate-2017-04-18";
+    src = fetchgit {
+      url = "https://github.com/drmingdrmer/xptemplate";
+      rev = "52d84e361e9da53c4309b0d96a1ab667c67b7f07";
+      sha256 = "195r5p4cyiip64zmgcih56c59gwm0irgid6cdrqc2y747gyxmf7m";
+    };
+    dependencies = [];
+
+  };
+
   neco-ghc = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "neco-ghc-2017-07-22";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -45,6 +45,7 @@
 "github:digitaltoad/vim-jade"
 "github:dleonard0/pony-vim-syntax"
 "github:dracula/vim"
+"github:drmingdrmer/xptemplate"
 "github:eagletmt/neco-ghc"
 "github:editorconfig/editorconfig-vim"
 "github:eikenb/acp"


### PR DESCRIPTION
###### Motivation for this change

`xptemplate` is a snippet templating engine for ViM.

I confirmed the change using the following expression:

``` nix
with import <nixpkgs>{};

vim_configurable.customize {
  name = "vimtest";
  vimrcConfig.vam.pluginDictionaries = [
    { name = "xptemplate"; }
  ];
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

