### PR TITLE
gnuradio: fix build for gcc6

### DIFF
--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -41,8 +41,14 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  postPatch = ''
+    substituteInPlace \
+        gr-fec/include/gnuradio/fec/polar_decoder_common.h \
+        --replace BOOST_CONSTEXPR_OR_CONST const
+  '';
+
   preConfigure = ''
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-unused-variable"
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-unused-variable -std=c++11"
   '';
 
   # - Ensure we get an interactive backend for matplotlib. If not the gr_plot_*


### PR DESCRIPTION
Patch comes via Arch Linux via Fedora. It should hopefully fix the build for gcc7 (in future) as well as gcc6.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
