### PR TITLE
security.pam.usb: fix url

### DIFF
--- a/nixos/modules/security/pam_usb.nix
+++ b/nixos/modules/security/pam_usb.nix
@@ -22,7 +22,7 @@ in
         description = ''
           Enable USB login for all login systems that support it.  For
           more information, visit <link
-          xlink:href="http://pamusb.org/doc/quickstart#setting_up" />.
+          xlink:href="https://github.com/aluzzardi/pam_usb/wiki/Getting-Started#setting-up-devices-and-users" />.
         '';
       };
 


### PR DESCRIPTION
Hey,

pamusb.org no longer serves the intended content. This links to the most current version on archive.org with meaningful content.

