### PR TITLE
oath-toolkit: 2.6.1 -> 2.6.2

### DIFF
--- a/pkgs/tools/security/oath-toolkit/default.nix
+++ b/pkgs/tools/security/oath-toolkit/default.nix
@@ -6,14 +6,14 @@ let
     else pam;
 in
 stdenv.mkDerivation rec {
-  name = "oath-toolkit-2.6.1";
+  name = "oath-toolkit-2.6.2";
 
   src = fetchurl {
     url = "mirror://savannah/oath-toolkit/${name}.tar.gz";
-    sha256 = "0ybg0gnddmhxga0jwdipyz8jv5mxs0kiiflhvzffl9mw0wcq6mww";
+    sha256 = "182ah8vfbg0yhv6mh1b6ap944d0na6x7lpfkwkmzb6jl9gx4cd5h";
   };
 
-  
+
   buildInputs = [ securityDependency ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
New version available


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

