### PR TITLE
routino: init at 3.2

### DIFF
--- a/pkgs/tools/misc/routino/default.nix
+++ b/pkgs/tools/misc/routino/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, perl, zlib, bzip2 }:
+
+stdenv.mkDerivation rec {
+  name = "Routino-${version}";
+  version = "3.2";
+
+  src = fetchurl {
+    url = "http://routino.org/download/routino-${version}.tgz";
+    sha256 = "0lkmpi8gn7qf40cx93jcp7nxa9dfwi1d6rjrhcqbdymszzm33972";
+  };
+
+  nativeBuildInputs = [ perl ];
+  buildInputs = [ zlib bzip2 ];
+
+  installFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = http://www.routino.org/;
+    description = "OpenStreetMap Routing Software";
+    license = licenses.agpl3;
+    maintainter = with maintainers; [ dotlambda ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/tools/misc/routino/default.nix
+++ b/pkgs/tools/misc/routino/default.nix
@@ -1,18 +1,21 @@
 { stdenv, fetchurl, perl, zlib, bzip2 }:
 
 stdenv.mkDerivation rec {
-  name = "Routino-${version}";
+  name = "routino-${version}";
   version = "3.2";
 
   src = fetchurl {
-    url = "http://routino.org/download/routino-${version}.tgz";
+    url = "http://routino.org/download/${name}.tgz";
     sha256 = "0lkmpi8gn7qf40cx93jcp7nxa9dfwi1d6rjrhcqbdymszzm33972";
   };
 
   nativeBuildInputs = [ perl ];
+
   buildInputs = [ zlib bzip2 ];
 
-  installFlags = [ "prefix=$(out)" ];
+  outputs = [ "out" "doc" ];
+
+  makeFlags = [ "prefix=$(out)" ];
 
   meta = with stdenv.lib; {
     homepage = http://www.routino.org/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4179,6 +4179,8 @@ with pkgs;
 
   rnv = callPackage ../tools/text/xml/rnv { };
 
+  routino = callPackage ../tools/misc/routino { };
+
   rq = callPackage ../development/tools/rq {
     v8 = v8_static;
   };


### PR DESCRIPTION
###### Motivation for this change
I need this for QMapShack, which I want to package next.

Even though the [installation instructions](http://www.routino.org/documentation/installation.html) talk about setting up a web interface, I have no use for this and I even don't know how to package that properly. Therefore I just didn't care about it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

