### PR TITLE
xwinwrap: init at 4

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -281,6 +281,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     url = https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception;
   };
 
+  hpnd = spdx {
+    spdxId = "HPND";
+    fullName = "Historic Permission Notice and Disclaimer";
+  };
+
   # Intel's license, seems free
   iasl = {
     fullName = "iASL";

--- a/pkgs/tools/X11/xwinwrap/default.nix
+++ b/pkgs/tools/X11/xwinwrap/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchbzr, x11 }:
+
+let
+  version = "4";
+in
+stdenv.mkDerivation {
+  name = "xwinwrap-${version}";
+
+  src = fetchbzr {
+    url = https://code.launchpad.net/~shantanu-goel/xwinwrap/devel;
+    rev = version;
+    sha256 = "1annhqc71jcgx5zvcy31c1c488ygx4q1ygrwyy2y0ww743smbchw";
+  };
+
+  buildInputs = [
+    x11
+  ];
+
+  buildPhase = if stdenv.system == "x86_64-linux" then ''
+    make all64
+  '' else if stdenv.system == "i686-linux" then ''
+    make all32
+  '' else throw "xwinwrap is not supported on ${stdenv.system}";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv */xwinwrap $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A utility that allows you to use an animated X window as the wallpaper";
+    longDescription = ''
+      XWinWrap is a small utility written a loooong time ago that allowed you to
+      stick most of the apps to your desktop background. What this meant was you
+      could use an animated screensaver (like glmatrix, electric sheep, etc) or
+      even a movie, and use it as your wallpaper. But only one version of this
+      app was ever released, and it had a few problems, like:
+
+      - Well, sticking didn’t work. So if you did a “minimize all” or “go to
+      desktop” kind of thing, your “wallpaper” got minimized as well.
+
+      - The geometry option didn’t work, so you could not create, e.g., a small
+      matrix window surrounded by your original wallpaper.
+
+      Seeing no-one picking it up, I decided to give it a bit of polish last
+      weekend by fixing the above problems and also add a few features. And here
+      it is, in its new avatar “Shantz XWinWrap”.
+    '';
+    license = licenses.hpnd;
+    homepage = https://shantanugoel.com/2008/09/03/shantz-xwinwrap/;
+    maintainers = with maintainers; [ infinisil ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5144,6 +5144,8 @@ with pkgs;
 
   xwinmosaic = callPackage ../tools/X11/xwinmosaic {};
 
+  xwinwrap = callPackage ../tools/X11/xwinwrap {};
+
   yaft = callPackage ../applications/misc/yaft { };
 
   yarn = callPackage ../development/tools/yarn  { };


### PR DESCRIPTION
###### Motivation for this change
Animated wallpapers, example usage (this runs a video as a wallpaper on repeat):
```
xwinwrap -ov -fs -ni -- mpv --loop=inf -wid WID --panscan=1 <path to video file>
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

