### PR TITLE
purePackages.gen: Don't build on Hydra

### DIFF
--- a/pkgs/development/pure-modules/gen/default.nix
+++ b/pkgs/development/pure-modules/gen/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
     homepage = http://puredocs.bitbucket.org/pure-gen.html;
     license = stdenv.lib.licenses.free;
     platforms = stdenv.lib.platforms.linux;
+    hydraPlatforms = [];
     maintainers = with stdenv.lib.maintainers; [ asppsa ];
   };
 }


### PR DESCRIPTION
Until https://github.com/agraef/pure-lang/issues/8 is resolved, this
package can't be compiled.  This patch turns off Hydra builds of this
package as part of #28643 (zero Hydra failures)

###### Motivation for this change

See #28643.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

