### PR TITLE
msr-tools: nixos module to avoid CPU throttling

### DIFF
--- a/nixos/modules/hardware/cpu/intel-peg.nix
+++ b/nixos/modules/hardware/cpu/intel-peg.nix
@@ -1,0 +1,86 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hardware.cpu.intel.pegCpu;
+
+  machineConfigs = {
+    dell_latitude_e6x00 = {
+      link = "https://wiki.archlinux.org/index.php/Dell_Latitude_E6x00";
+      read = "44:32 0xCE";
+      write = [
+        "0x199 0x$val"
+        "0x19A 0x0"
+      ];
+    };
+  };
+
+  machine = builtins.getAttr cfg.machine machineConfigs;
+
+  script = pkgs.writeScript "peg-cpu.sh" (with pkgs; ''
+    #!${runtimeShell} -e
+
+    # ${machine.link}
+
+    val=$(${msr-tools}/bin/rdmsr -f ${machine.read})
+
+    while : ; do
+      ${concatStringsSep "\n" (map (r: "${msr-tools}/bin/wrmsr --all ${r}") machine.write)}
+      ${coreutils}/bin/sleep ${cfg.sleepInterval}
+    done
+  '');
+
+in {
+
+  ###### interface
+
+  options = {
+
+    hardware.cpu.intel.pegCpu = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Peg the CPU to run at max speed to work around broken throttling. Unless you know that you need this, you probably don't.
+          </para>
+          <para>
+          WARNING: This is likely to harm you computer as it WILL cause it to run significantly hotter!!!
+        '';
+      };
+
+      machine = mkOption {
+        default = null;
+        type = types.nullOr (types.enum (attrNames machineConfigs));
+        description = ''
+          The machine type for which you want to disable throttling by pegging the CPU at the maximum power state.
+        '';
+      };
+
+      sleepInterval = mkOption {
+        default = "0.1";
+        type = types.string;
+        description = ''How long to sleep after reading/writing the registers.'';
+      };
+    };
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.pegCpu.enable && cfg.machine != null {
+
+    boot.kernelModules = [ "cpuid" ];
+
+    systemd.services.peg-cpu = {
+      description = "Peg CPU at full speed";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = script;
+        Restart = "on-failure";
+        PrivateNetwork = true;
+        PrivateTmp = true;
+      };
+    };
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -43,6 +43,7 @@
   ./hardware/cpu/amd-microcode.nix
   ./hardware/cpu/intel-microcode.nix
   ./hardware/digitalbitbox.nix
+  ./hardware/cpu/intel-peg.nix
   ./hardware/sensor/iio.nix
   ./hardware/ksm.nix
   ./hardware/ledger.nix


### PR DESCRIPTION
###### Motivation for this change

The BIOS on the Dell Latitude E6x00 series is badly broken (despite 38 tries at getting a working version) and the BIOS *will* throttle the CPU even with just a little load.

This PR keeps kicking the CPU into the maximum power state to avoid any kind of throttling.

As a consequence the hardware will get QUITE hot, but at least it will perform.

I'm not entirely sure what is the best way to ship a feature that is capable of physically harming the hardware. Do we need more warnings?

Additionally, I don't know if the magic numbers being written to the registers will also work on other CPUs/BIOSes.

I could make the registers configurable (or hide them behind a model variable that sets them in case anyone has any good ideas. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

