### PR TITLE
dockerTools.examples.nix: set NIX_PAGER=cat environment variable

### DIFF
--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -107,11 +107,13 @@ rec {
   nix = buildImageWithNixDb {
     name = "nix";
     contents = [
-      # nix-store -qR uses the 'more' program which is not included in
-      # the pkgs.nix dependencies. We then have to manually get it
-      # from the 'eject' package:/
-      pkgs.eject
+      # nix-store uses cat program to display results as specified by
+      # the image env variable NIX_PAGER.
+      pkgs.coreutils
       pkgs.nix
     ];
+    config = {
+      Env = [ "NIX_PAGER=cat" ];
+    };
   };
 }


### PR DESCRIPTION
###### Motivation for this change
`nix-store` was using `more` that was imported from the `eject` package. This commit explicitly sets the `NIX_PAGER` environment variable.

###### Things done
Manually tested the nix docker image:
```
nix-build ./ -A dockerTools.examples.nix
docker load -i result
docker run -it nix nix-store -qR /nix/store/zv86mp9qr1kk2sxv174fxrmly82wakr0-xz-5.2.3-bin
warning: the group ‘nixbld’ specified in ‘build-users-group’ does not exist
/nix/store/zpg78y1mf0di6127q6r51kgx2q8cxsvv-glibc-2.25-49
/nix/store/j41pm590lflva7kkx643kycix8njjrld-xz-5.2.3
/nix/store/zv86mp9qr1kk2sxv174fxrmly82wakr0-xz-5.2.3-bin
```