### PR TITLE
networkd: also load builtin modules

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -649,7 +649,11 @@ let
   unitFiles = map (name: {
     target = "systemd/network/${name}";
     source = "${cfg.units.${name}.unit}/${name}";
-  }) (attrNames cfg.units);
+  }) (attrNames cfg.units) ++
+  (map (entry: {
+    target = "systemd/network/${entry}";
+    source = "${config.systemd.package}/lib/systemd/network/${entry}";
+  }) (attrNames (builtins.readDir "${config.systemd.package}/lib/systemd/network")));
 in
 
 {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

