### PR TITLE
facter: 3.7.1 -> 3.9.0 and related deps

### DIFF
--- a/pkgs/development/libraries/cpp-hocon/default.nix
+++ b/pkgs/development/libraries/cpp-hocon/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "cpp-hocon-${version}";
-  version = "0.1.5";
+  version = "0.1.6";
 
   src = fetchFromGitHub {
-    sha256 = "0fc5468458mz572nbp45x5sblp6dsb4d1b6jqv77zf3mx5xyziz7";
+    sha256 = "0qf2nqp28ahypnzjrr37f54i06ylni40y18q9kwp5s7i5cwbjqgc";
     rev = version;
     repo = "cpp-hocon";
     owner = "puppetlabs";
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ boost curl leatherman ];
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;

--- a/pkgs/development/libraries/leatherman/default.nix
+++ b/pkgs/development/libraries/leatherman/default.nix
@@ -2,16 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "leatherman-${version}";
-  version = "1.0.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
-    sha256 = "15kg6vdr1iav5x3pzwvrdsi54lbl8zh2xwqlp03gaq4n3kg5wj3y";
+    sha256 = "1pcbfgq9khlcvxjsqpdshjskwljzawryzps0ickazwm7l3m7hrln";
     rev = version;
     repo = "leatherman";
     owner = "puppetlabs";
   };
 
   buildInputs = [ boost cmake curl ruby ];
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/puppetlabs/leatherman/;  

--- a/pkgs/development/libraries/libwhereami/default.nix
+++ b/pkgs/development/libraries/libwhereami/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, cmake, boost, curl, leatherman }:
+
+stdenv.mkDerivation rec {
+  name = "libwhereami-${version}";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    sha256 = "0nhbmxm626cgawprszw6c03a3hasxjn1i9ldhhj5xyvxp8r5l9q4";
+    rev = version;
+    repo = "libwhereami";
+    owner = "puppetlabs";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ boost curl leatherman ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Library to report hypervisor information from inside a VM";
+    license = licenses.asl20;
+    maintainers = [ maintainers.womfoo ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/tools/system/facter/default.nix
+++ b/pkgs/tools/system/facter/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchFromGitHub, boost, cmake, cpp-hocon, curl, leatherman, libyamlcpp, openssl, ruby, utillinux }:
+{ stdenv, fetchFromGitHub, boost, cmake, cpp-hocon, curl, leatherman, libwhereami, libyamlcpp, openssl, ruby, utillinux }:
 
 stdenv.mkDerivation rec {
   name = "facter-${version}";
-  version = "3.7.1";
+  version = "3.9.0";
 
   src = fetchFromGitHub {
-    sha256 = "0v5g7qlqqixgvc2hf9440a8sfh8jvgzynwk5ipcb505hi00ddq7a";
+    sha256 = "1picxrmvka57ph4zqgwqdsqvz3mqppg41wkj8dx37hscwwlbdw0s";
     rev = version;
     repo = "facter";
     owner = "puppetlabs";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   # since we cant expand $out in cmakeFlags
   preConfigure = "cmakeFlags+=\" -DRUBY_LIB_INSTALL=$out/lib/ruby\"";
 
-  buildInputs = [ boost cmake cpp-hocon curl leatherman libyamlcpp openssl ruby utillinux ];
+  buildInputs = [ boost cmake cpp-hocon curl leatherman libwhereami libyamlcpp openssl ruby utillinux ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9520,6 +9520,8 @@ with pkgs;
 
   libupnp = callPackage ../development/libraries/pupnp { };
 
+  libwhereami = callPackage ../development/libraries/libwhereami { };
+
   giflib = giflib_5_1;
   giflib_4_1 = callPackage ../development/libraries/giflib/4.1.nix { };
   giflib_5_0 = callPackage ../development/libraries/giflib/5.0.nix { };


### PR DESCRIPTION
###### Motivation for this change

* bump to latest upstream
* add new libwhereami package
* update dependencies

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
