### PR TITLE
libproxy: 0.4.13 -> 0.4.15

### DIFF
--- a/pkgs/development/libraries/libproxy/default.nix
+++ b/pkgs/development/libraries/libproxy/default.nix
@@ -1,28 +1,30 @@
 { stdenv, lib, fetchFromGitHub, pkgconfig, cmake
-, dbus, networkmanager, webkitgtk216x, pcre, python2 }:
+, dbus, networkmanager, spidermonkey_38, pcre, python2, python3 }:
 
 stdenv.mkDerivation rec {
   name = "libproxy-${version}";
-  version = "0.4.13";
+  version = "0.4.15";
 
   src = fetchFromGitHub {
     owner = "libproxy";
     repo = "libproxy";
     rev = version;
-    sha256 = "0yg4wr44ync6x3p107ic00m1l04xqhni9jn1vzvkw3nfjd0k6f92";
+    sha256 = "10swd3x576pinx33iwsbd4h15fbh2snmfxzcmab4c56nb08qlbrs";
   };
 
   outputs = [ "out" "dev" ]; # to deal with propagatedBuildInputs
 
   nativeBuildInputs = [ pkgconfig cmake ];
 
-  buildInputs = [ dbus networkmanager webkitgtk216x pcre ];
+  buildInputs = [ dbus networkmanager spidermonkey_38 pcre python2 python3 ];
 
-  cmakeFlags = [
-    "-DWITH_WEBKIT3=ON"
-    "-DWITH_MOZJS=OFF"
-    "-DPYTHON_SITEPKG_DIR=$(out)/${python2.sitePackages}"
-  ];
+  preConfigure = ''
+    cmakeFlagsArray+=(
+      "-DWITH_MOZJS=ON"
+      "-DPYTHON2_SITEPKG_DIR=$out/${python2.sitePackages}"
+      "-DPYTHON3_SITEPKG_DIR=$out/${python3.sitePackages}"
+    )
+  '';
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;


### PR DESCRIPTION
reduces closure size from ~200mb to ~100mb

fixes #29775

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

