### PR TITLE
dockerTools: Fix pullImage with sandboxing enabled

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -45,7 +45,12 @@ rec {
         outputHashAlgo="sha256";
         outputHash=sha256;
       }
-      "${pkgs.skopeo}/bin/skopeo copy docker://${imageId} docker-archive://$out:${imageId}";
+      ''
+        ${pkgs.skopeo}/bin/skopeo copy \
+            docker://${imageId} \
+            docker-archive://$out:${imageId} \
+            --src-tls-verify=false
+      '';
 
   # We need to sum layer.tar, not a directory, hence tarsum instead of nix-hash.
   # And we cannot untar it, because then we cannot preserve permissions ecc.


### PR DESCRIPTION
When pulling images with skopeo, we have to disable certificate
validation, because certificate authorities don't seem to be available
in nix builders.  This shouldn't be a problem though because we check
the sha checksum after downloading the image anyway.

check #29636

###### Motivation for this change
`dockertool.pullImage` did not work with nix sandboxes.  No it does.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

