### PR TITLE
stupidterm: init at 20170315-752316a

### DIFF
--- a/pkgs/applications/misc/stupidterm/default.nix
+++ b/pkgs/applications/misc/stupidterm/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, pkgconfig, vte, gtk }:
+
+stdenv.mkDerivation rec {
+  name = "stupidterm-20170315-752316a";
+
+  buildInputs = [ pkgconfig vte gtk ];
+
+  src = fetchFromGitHub {
+    owner = "esmil";
+    repo = "stupidterm";
+    rev = "752316a783f52317ffd9f05d32e208dbcafc5ba6";
+    sha256 = "1d8fyhr9sgpxgkwzkyiws0kvhmqfwwyycvcr1qf2wjldiax222lv";
+  };
+
+  preBuild = ''
+    makeFlags="PKGCONFIG=${pkgconfig}/bin/pkg-config binary=stupidterm"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/applications $out/share/stupidterm
+    cp stupidterm $out/bin
+    substituteAll ${./stupidterm.desktop} $out/share/applications/stupidterm.desktop
+    substituteAll stupidterm.ini $out/share/stupidterm/stupidterm.ini
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple wrapper around the VTE terminal emulator widget for GTK+";
+    longDescription = ''
+      Simple wrapper around the VTE terminal emulator widget for GTK+
+    '';
+    homepage = https://github.com/esmil/stupidterm;
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.etu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/stupidterm/stupidterm.desktop
+++ b/pkgs/applications/misc/stupidterm/stupidterm.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=20170315
+Name=stupidterm
+Comment=VTE based terminal emulator
+Exec=stupidterm
+Icon=utilities-terminal
+Terminal=false
+Type=Application
+Categories=System;TerminalEmulator;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16232,6 +16232,11 @@ with pkgs;
 
   ssvnc = callPackage ../applications/networking/remote/ssvnc { };
 
+  stupidterm = callPackage ../applications/misc/stupidterm {
+    vte = gnome3.vte;
+    gtk = gtk3;
+  };
+
   styx = callPackage ../applications/misc/styx { };
 
   tecoc = callPackage ../applications/editors/tecoc { };


### PR DESCRIPTION
###### Motivation for this change
Stupidterm is a simple and fast VTE-Based terminal emulator which is
configured by a simple ini-file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

