### PR TITLE
libinput update

### DIFF
--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -1,48 +1,39 @@
-{ stdenv, fetchurl, pkgconfig
-, libevdev, mtdev, udev, libwacom
+{ stdenv, fetchurl, pkgconfig, meson, ninja, libevdev, mtdev, udev, libwacom
 , documentationSupport ? false, doxygen ? null, graphviz ? null # Documentation
 , eventGUISupport ? false, cairo ? null, glib ? null, gtk3 ? null # GUI event viewer support
-, testsSupport ? false, check ? null, valgrind ? null
-, autoconf, automake
-}:
+, testsSupport ? false, check ? null, valgrind ? null }:
 
 assert documentationSupport -> doxygen != null && graphviz != null;
 assert eventGUISupport -> cairo != null && glib != null && gtk3 != null;
 assert testsSupport -> check != null && valgrind != null;
 
-let
-  mkFlag = optSet: flag: if optSet then "--enable-${flag}" else "--disable-${flag}";
-in
-
-with stdenv.lib;
-stdenv.mkDerivation rec {
+let mkFlag = c: flag: if c then "-D${flag}=true" else "-D${flag}=false";
+in with stdenv.lib; stdenv.mkDerivation rec {
   name = "libinput-${version}";
-  version = "1.7.3";
+  version = "1.8.2";
 
   src = fetchurl {
-    url = "http://www.freedesktop.org/software/libinput/${name}.tar.xz";
-    sha256 = "07fbzxddvhjcch43hdxb24sj7ri96zzpcjalvsicmw0i4wnn2v89";
+    url = "https://freedesktop.org/software/libinput/${name}.tar.xz";
+    sha256 = "0f5brc28yww3nycm7nya703k4dr1pbpi517hw7k8f8nv1bp1hd81";
   };
 
   outputs = [ "out" "dev" ];
-
-  configureFlags = [
+  
+  mesonFlags = [
     (mkFlag documentationSupport "documentation")
-    (mkFlag eventGUISupport "event-gui")
+    (mkFlag eventGUISupport "debug-gui")
     (mkFlag testsSupport "tests")
   ];
 
-  nativeBuildInputs = [ pkgconfig ];
-
-  buildInputs = [ libevdev mtdev libwacom autoconf automake ]
+  patches = [ ./udev-absolute-path.patch ];
+  
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+  buildInputs = [ libevdev mtdev libwacom ]
     ++ optionals eventGUISupport [ cairo glib gtk3 ]
     ++ optionals documentationSupport [ doxygen graphviz ]
     ++ optionals testsSupport [ check valgrind ];
 
   propagatedBuildInputs = [ udev ];
-
-  patches = [ ./udev-absolute-path.patch ];
-  patchFlags = [ "-p0" ];
 
   meta = {
     description = "Handles input devices in Wayland compositors and provides a generic X.Org input driver";

--- a/pkgs/development/libraries/libinput/udev-absolute-path.patch
+++ b/pkgs/development/libraries/libinput/udev-absolute-path.patch
@@ -1,12 +1,11 @@
---- configure.ac	2016-05-27 14:00:25.248388226 +0200
-+++ configure.ac	2016-05-27 14:01:28.228943416 +0200
-@@ -214,7 +214,8 @@ AM_CONDITIONAL(BUILD_DOCS, [test "x$buil
- # Used by the udev rules so we can use callouts during testing without
- # installing everything first. Default is the empty string so the installed
- # rule will use udev's default path. Override is in udev/Makefile.am
--AC_SUBST(UDEV_TEST_PATH, "")
-+UDEV_TEST_PATH="${UDEV_DIR}/"
-+AC_SUBST(UDEV_TEST_PATH)
- AC_PATH_PROG(SED, [sed])
+--- a/meson.build	2017-09-25 11:37:07.787726521 +0000
++++ b/meson.build	2017-09-25 11:38:48.958233247 +0000
+@@ -100,7 +100,7 @@
+      args : model_quirks)
  
- AC_CONFIG_FILES([Makefile
+ udev_rules_config = configuration_data()
+-udev_rules_config.set('UDEV_TEST_PATH', '')
++udev_rules_config.set('UDEV_TEST_PATH', udev_dir + '/')
+ configure_file(input : 'udev/80-libinput-device-groups.rules.in',
+ 	       output : '80-libinput-device-groups.rules',
+ 	       install : true,

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -18,7 +18,11 @@ python3Packages.buildPythonApplication rec {
     popd
   '';
 
-  setupHook = ./setup-hook.sh;
+  postPatch = ''
+    sed -i -e 's|e.fix_rpath(install_rpath)||' mesonbuild/scripts/meson_install.py
+  '';
+
+  setupHook = ./setup-hook.sh;    
 
   meta = with lib; {
     homepage = http://mesonbuild.com;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -315,11 +315,11 @@ in
     installFlags = "sdkdir=\${out}/include/xorg";
   };
 
-  xf86inputlibinput = attrs: attrs // {
-    name = "xf86-input-libinput-0.25.1";
+  xf86inputlibinput = attrs: attrs // rec {
+    name = "xf86-input-libinput-0.26.0";
     src = args.fetchurl {
-      url = mirror://xorg/individual/driver/xf86-input-libinput-0.25.1.tar.bz2;
-      sha256 = "1q67hjd67ni1nq7kgxdrrdgkyhzaqvvn2vlnsiiq9w4y3icpv7s8";
+      url = "mirror://xorg/individual/driver/${name}.tar.bz2";
+      sha256 = "0yrqs88b7yn9nljwlxzn76jfmvf0sh939kzij5b2jvr2qa7mbjmb";
     };
     buildInputs = attrs.buildInputs ++ [ args.libinput ];
     installFlags = "sdkdir=\${out}/include/xorg";


### PR DESCRIPTION
###### Motivation for this change

New version of libinput provides improved support for MacBook touchpads.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Update libinput to the latest version. This includes a switch to Meson build system, patch to Meson itself (see https://github.com/NixOS/nixpkgs/pull/28444#issuecomment-324033323), and xf86-input-libinput update.

NB: this triggers a mass rebuild. I've rebuilt all packages I use on my system, and they all work fine.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


---

