### PR TITLE
latinmodern-math: init at 1.959

### DIFF
--- a/pkgs/data/fonts/lm-math/default.nix
+++ b/pkgs/data/fonts/lm-math/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchzip }:
+
+stdenv.mkDerivation rec {
+  name = "latinmodern-math-${version}";
+  version = "1.959";
+
+  src = fetchzip {
+    url = "www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip";
+    sha256 = "15l3lxjciyjmbh0q6jjvzz16ibk4ij79in9fs47qhrfr2wrddpvs";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype/
+    mkdir -p $out/share/doc/${name}/
+    cp otf/*.otf $out/share/fonts/opentype/
+    cp doc/*.txt $out/share/doc/${name}/
+  '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "05k145bxgxjh7i9gx1ahigxfpc2v2vwzsy2mc41jvvg51kjr8fnn";
+
+  meta = with stdenv.lib; {
+    description = "The Latin Modern Math (LM Math) font completes the modernization of the Computer Modern family of typefaces designed and programmed by Donald E. Knuth.";
+    homepage = http://www.gust.org.pl/projects/e-foundry/lm-math;
+    # "The Latin Modern Math font is licensed under the GUST Font License (GFL),
+    # which is a free license, legally equivalent to the LaTeX Project Public
+    # License (LPPL), version 1.3c or later." - GUST website
+    license = licenses.lppl13c;
+    maintainers = with maintainers; [ siddharthist ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13170,6 +13170,8 @@ with pkgs;
 
   kochi-substitute-naga10 = callPackage ../data/fonts/kochi-substitute-naga10 {};
 
+  latinmodern-math = callPackage ../data/fonts/lm-math {};
+
   lato = callPackage ../data/fonts/lato {};
 
   league-of-moveable-type = callPackage ../data/fonts/league-of-moveable-type {};


### PR DESCRIPTION
###### Motivation for this change
The Latin Modern fonts are a modernization of Knuth's legendary Computer Modern. This is the set of mathematical glyphs. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

