### PR TITLE
tex-gyre-termes-math: init at 1.543

### DIFF
--- a/pkgs/data/fonts/tex-gyre-termes-math/default.nix
+++ b/pkgs/data/fonts/tex-gyre-termes-math/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchzip }:
+
+stdenv.mkDerivation rec {
+  name = "tex-gyre-termes-math-${version}";
+  version = "1.543";
+
+  src = fetchzip {
+    url = "www.gust.org.pl/projects/e-foundry/tg-math/download/texgyretermes-math-1543.zip";
+    sha256 = "10ayqfpryfn1l35hy0vwyjzw3a6mfsnzgf78vsnccgk2gz1g9vhz";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype/
+    mkdir -p $out/share/doc/${name}/
+    cp -v opentype/*.otf $out/share/fonts/opentype/
+    cp -v doc/*.txt $out/share/doc/${name}/
+  '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "0pa433cgshlypbyrrlp3qq0wg972rngcp37pr8pxdfshgz13q1mm";
+
+  meta = with stdenv.lib; {
+    longDescription = ''
+      TeX Gyre Termes Math is a math companion for the TeX Gyre Termes family
+      of fonts (see http://www.gust.org.pl/projects/e-foundry/tex-gyre/) in
+      the OpenType format.
+    '';
+    homepage = http://www.gust.org.pl/projects/e-foundry/tg-math;
+    # "The TeX Gyre Math fonts are licensed under the GUST Font License (GFL),
+    # which is a free license, legally equivalent to the LaTeX Project Public
+    # License (LPPL), version 1.3c or later." - GUST website
+    license = licenses.lppl13c;
+    maintainers = with maintainers; [ siddharthist ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13377,6 +13377,8 @@ with pkgs;
 
   terminus_font_ttf = callPackage ../data/fonts/terminus-font-ttf { };
 
+  tex-gyre-termes-math = callPackage ../data/fonts/tex-gyre-termes-math { };
+
   tipa = callPackage ../data/fonts/tipa { };
 
   ttf_bitstream_vera = callPackage ../data/fonts/ttf-bitstream-vera { };


### PR DESCRIPTION
###### Motivation for this change
Another Unicode math font! See the AUR package: https://aur.archlinux.org/packages/otf-tex-gyre-ib/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

