### PR TITLE
Add xf86-input-cmt touchpad driver from GalliumOS

### DIFF
--- a/pkgs/development/libraries/libevdevc/default.nix
+++ b/pkgs/development/libraries/libevdevc/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  name = "libevdevc-2016-05-20";
+
+  src = fetchFromGitHub {
+    owner = "GalliumOS";
+    repo = "libevdevc";
+    rev = "727ac200b6f6d7c0e7e945f5845a8d0fba2b88b8";
+    sha256 = "132k5iaddxw5p5dck1sjsk16piyv69iaf7qvg6wmdpafg3ilbq27";
+  };
+
+  preConfigure = ''
+    substituteInPlace common.mk --replace /bin/echo echo
+    substituteInPlace include/module.mk --replace /usr/include include
+  '';
+
+  installPhase = ''
+    DESTDIR=$out/ LIBDIR=lib make install
+  '';
+}

--- a/pkgs/development/libraries/libgestures/default.nix
+++ b/pkgs/development/libraries/libgestures/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchgit, fetchFromGitHub, glib, jsoncpp, pkgconfig }:
+
+stdenv.mkDerivation {
+  name = "libgestures-2016-05-20";
+
+  src = fetchFromGitHub {
+    owner = "GalliumOS";
+    repo = "libgestures";
+    rev = "3b6a3558ea390d345022ace5b187a7212f041d86";
+    sha256 = "1nxr3nxf2kzp90lqbhx2qmb52yxgd7q5ds8yzi4hll91wcx8by6l";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ glib jsoncpp ];
+
+  preConfigure = ''
+    sed -i "1i#include <cmath>" include/gestures/include/finger_metrics.h
+    substituteInPlace Makefile --replace /usr/include include
+  '';
+
+  installPhase = ''
+    make DESTDIR=$out/ LIBDIR=lib install
+  '';
+}

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1570,6 +1570,23 @@ let
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit ;};
 
+  xf86inputcmt = (stdenv.mkDerivation "xf86inputcmt" {
+    name = "xf86-input-cmt-2017-02-27";
+
+    buildInputs = [ pkgconfig inputproto xorgserver ];
+
+    src = fetchFromGitHub {
+      owner = "GalliumOS";
+      repo = "xf86-input-cmt";
+      rev = "543063720fc9520f615332eaf8b10b53ff3fdb90";
+      sha256 = "17k3ah8l17p0ra93xrd7pf5a9sdhgd7ca8cg2q8qd31hjmi7x21h";
+    };
+
+    preConfigure = ''
+      substituteInPlace include/Makefile.in --replace '$(sdkdir)' $out/include/xorg/
+    '';
+  }) {inherit inputproto xorgserver ;};
+  
   xf86inputevdev = (mkDerivation "xf86inputevdev" {
     name = "xf86-input-evdev-2.10.5";
     builder = ./builder.sh;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -300,6 +300,11 @@ in
     outputs = [ "out" "dev" ]; # mainly to get rid of propagating others
   };
 
+  xf86inputcmt = attrs: attrs // {
+    buildInputs = attrs.buildInputs ++ [ args.libevdevc args.libgestures args.utilmacros ];
+    installFlags = "sdkdir=\${out}/include/xorg";    
+  };
+
   xf86inputevdev = attrs: attrs // {
     outputs = [ "out" "dev" ]; # to get rid of xorgserver.dev; man is tiny
     preBuild = "sed -e '/motion_history_proc/d; /history_size/d;' -i src/*.c";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8923,6 +8923,8 @@ with pkgs;
 
   libetpan = callPackage ../development/libraries/libetpan { };
 
+  libevdevc = callPackage ../development/libraries/libevdevc { };
+
   libfaketime = callPackage ../development/libraries/libfaketime { };
 
   libfakekey = callPackage ../development/libraries/libfakekey { };


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

