### PR TITLE
gpx-viewer: init at 0.4.0

### DIFF
--- a/pkgs/applications/misc/gpx-viewer/default.nix
+++ b/pkgs/applications/misc/gpx-viewer/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, intltool, pkgconfig, gnome3, shared_mime_info, desktop_file_utils, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "gpx-viewer-${version}";
+  version = "0.4.0";
+
+  src = fetchurl {
+    url = "https://launchpad.net/gpx-viewer/trunk/${version}/+download/${name}.tar.gz";
+    sha256 = "956acfaf870ac436300cd9953dece630df7fd7dff8e4ae2577a6002884466f80";
+  };
+
+  patches = fetchurl {
+    url = "https://code.launchpad.net/~chkr/gpx-viewer/gtk3-bugfix/+merge/260766/+preview-diff/628965/+files/preview.diff";
+    sha256 = "1yl7jk7skkcx10nny5zdixswcymjd9s9c1zhm1i5y3aqhchvmfs7";
+  };
+  patchFlags = [ "-p0" ];
+
+  nativeBuildInputs = [
+    intltool pkgconfig
+    shared_mime_info # For update-mime-database
+    desktop_file_utils # For update-desktop-database
+    wrapGAppsHook # Fix error: GLib-GIO-ERROR **: No GSettings schemas are installed on the system
+  ];
+  buildInputs = with gnome3; [ gdl libchamplain defaultIconTheme ];
+
+  meta = with stdenv.lib; {
+    homepage = https://blog.sarine.nl/tag/gpxviewer/;
+    description = "Simple tool to visualize tracks and waypoints stored in a gpx file";
+    platforms = with platforms; linux;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14387,6 +14387,8 @@ with pkgs;
 
   gqrx = qt5.callPackage ../applications/misc/gqrx { };
 
+  gpx-viewer = callPackage ../applications/misc/gpx-viewer { };
+
   grass = callPackage ../applications/gis/grass { };
 
   grepm = callPackage ../applications/search/grepm { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

