### PR TITLE
nvidia-x11: generate nvidia_icd.json from template

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -46,7 +46,8 @@ installPhase() {
 
     # Install ICDs.
     install -Dm644 nvidia.icd $out/etc/OpenCL/vendors/nvidia.icd
-    if [ -e nvidia_icd.json ]; then
+    if [ -e nvidia_icd.json.template ]; then
+        sed "s#__NV_VK_ICD__#libGLX_nvidia.so#" nvidia_icd.json.template > nvidia_icd.json
         install -Dm644 nvidia_icd.json $out/share/vulkan/icd.d/nvidia.json
     fi
     if [ "$useGLVND" = "1" ]; then


### PR DESCRIPTION
###### Motivation for this change

Vulkan applications stopped running as nvidia started shipping a template for nvidia_icd.json instead of the final file. This makes them work again (tested with vulkaninfo and sascha willems's vulkan examples).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

