### PR TITLE
php: fix build wrt. new postgres.dev build output

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -99,12 +99,12 @@ let
         };
 
         postgresql = {
-          configureFlags = ["--with-pgsql=${postgresql}"];
+          configureFlags = ["--with-pgsql=${postgresql.dev}"];
           buildInputs = [ postgresql ];
         };
 
         pdo_pgsql = {
-          configureFlags = ["--with-pdo-pgsql=${postgresql}"];
+          configureFlags = ["--with-pdo-pgsql=${postgresql.dev}"];
           buildInputs = [ postgresql ];
         };
 


### PR DESCRIPTION
Refs commit b0280f598e4b3f6ebf33ad2115734e4735df443a

###### Motivation for this change

Build of PHP is broken due to change b0280f598e4b3f6ebf33ad2115734e4735df443a

pg-config script has been moved to new build output "dev"

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

refs #29726