### PR TITLE
bash-supergenpass: init at 2012-11-02

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -200,6 +200,7 @@
   fadenb = "Tristan Helmich <tristan.helmich+nixos@gmail.com>";
   falsifian = "James Cook <james.cook@utoronto.ca>";
   fare = "Francois-Rene Rideau <fahree@gmail.com>";
+  fgaz = "Francesco Gazzetta <francygazz@gmail.com>";
   florianjacob = "Florian Jacob <projects+nixos@florianjacob.de>";
   flosse = "Markus Kohlhase <mail@markus-kohlhase.de>";
   fluffynukeit = "Daniel Austin <dan@fluffynukeit.com>";

--- a/pkgs/tools/security/bash-supergenpass/default.nix
+++ b/pkgs/tools/security/bash-supergenpass/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, makeWrapper, bash, openssl, coreutils, gnugrep }:
+
+stdenv.mkDerivation rec {
+  name = "bash-supergenpass-unstable-${version}";
+  version = "2012-11-02";
+
+  buildInputs = [
+    makeWrapper
+  ];
+
+  src = fetchFromGitHub {
+    owner = "lanzz";
+    repo = "bash-supergenpass";
+    rev = "c84eaa22fb59ab6c390e7f2de7984513347e3a9a";
+    sha256 = "0d3l55kdrf6arb98vwwz9ww55ing5w323fg7546v56hlq3hs5qc9";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp supergenpass.sh "$out/bin/supergenpass"
+    chmod +x "$out/bin/supergenpass"
+    wrapProgram "$out/bin/supergenpass" --prefix PATH : "${stdenv.lib.makeBinPath [ openssl coreutils gnugrep ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Bash shell-script implementation of SuperGenPass password generation";
+    longDescription = ''
+    Bash shell-script implementation of SuperGenPass password generation
+    Usage: ./supergenpass.sh <domain> [ <length> ]
+
+    Default <length> is 10, which is also the original SuperGenPass default length.
+
+    The <domain> parameter is also optional, but it does not make much sense to omit it.
+
+    supergenpass will ask for your master password interactively, and it will not be displayed on your terminal.
+    '';
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ fgaz ];
+    homepage = https://github.com/lanzz/bash-supergenpass;
+  };
+}
+

--- a/pkgs/tools/security/bash-supergenpass/default.nix
+++ b/pkgs/tools/security/bash-supergenpass/default.nix
@@ -1,12 +1,10 @@
-{ stdenv, fetchFromGitHub, makeWrapper, bash, openssl, coreutils, gnugrep }:
+{ stdenv, fetchFromGitHub, makeWrapper, openssl, coreutils, gnugrep }:
 
 stdenv.mkDerivation rec {
   name = "bash-supergenpass-unstable-${version}";
   version = "2012-11-02";
 
-  buildInputs = [
-    makeWrapper
-  ];
+  nativeBuildInputs = [ makeWrapper ];
 
   src = fetchFromGitHub {
     owner = "lanzz";
@@ -16,23 +14,21 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp supergenpass.sh "$out/bin/supergenpass"
-    chmod +x "$out/bin/supergenpass"
+    install -m755 -D supergenpass.sh "$out/bin/supergenpass"
     wrapProgram "$out/bin/supergenpass" --prefix PATH : "${stdenv.lib.makeBinPath [ openssl coreutils gnugrep ]}"
   '';
 
   meta = with stdenv.lib; {
     description = "Bash shell-script implementation of SuperGenPass password generation";
     longDescription = ''
-    Bash shell-script implementation of SuperGenPass password generation
-    Usage: ./supergenpass.sh <domain> [ <length> ]
+      Bash shell-script implementation of SuperGenPass password generation
+      Usage: ./supergenpass.sh <domain> [ <length> ]
 
-    Default <length> is 10, which is also the original SuperGenPass default length.
+      Default <length> is 10, which is also the original SuperGenPass default length.
 
-    The <domain> parameter is also optional, but it does not make much sense to omit it.
+      The <domain> parameter is also optional, but it does not make much sense to omit it.
 
-    supergenpass will ask for your master password interactively, and it will not be displayed on your terminal.
+      supergenpass will ask for your master password interactively, and it will not be displayed on your terminal.
     '';
     license = licenses.mit;
     platforms = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1152,6 +1152,8 @@ with pkgs;
 
   stagit = callPackage ../development/tools/stagit { };
 
+  bash-supergenpass = callPackage ../tools/security/bash-supergenpass { };
+
   syscall_limiter = callPackage ../os-specific/linux/syscall_limiter {};
 
   syslogng = callPackage ../tools/system/syslog-ng { };


### PR DESCRIPTION
###### Motivation for this change

Add the bash implementation of supergenpass.com, since no other implementation is present in nixpkgs

###### Things done


- [x] (I actually used --pure. Is it the same?) Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The only thing I'm not sure of is whether to include or not the dependencies (`openssl` etc) in `buildInputs`.