### PR TITLE
kea: fix path to pg_config

### DIFF
--- a/pkgs/tools/networking/kea/default.nix
+++ b/pkgs/tools/networking/kea/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--localstatedir=/var"
     "--with-botan-config=${botan}/bin/botan-config-1.10"
-    "--with-dhcp-pgsql=${postgresql}/bin/pg_config"
+    "--with-dhcp-pgsql=${postgresql.dev}/bin/pg_config"
     "--with-dhcp-mysql=${mysql.client.dev}/bin/mysql_config"
   ];
 


### PR DESCRIPTION
refs commit b0280f598e4b3f6ebf33ad2115734e4735df443a

###### Motivation for this change

kea build was also broken by commit b0280f598e4b3f6ebf33ad2115734e4735df443a

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

