### PR TITLE
sct: fix segfault when DISPLAY is empty, clean up derivation

### DIFF
--- a/pkgs/tools/X11/sct/DISPLAY-segfault.patch
+++ b/pkgs/tools/X11/sct/DISPLAY-segfault.patch
@@ -1,0 +1,10 @@
+--- a/sct.c	2017-09-22 00:44:20.270421881 +0000
++++ b/sct.c	2017-09-26 10:50:38.964562740 +0000
+@@ -36,6 +36,7 @@
+ main(int argc, char **argv)
+ {
+ 	Display *dpy = XOpenDisplay(NULL);
++	if (!dpy) exit(1);
+ 	int screen = DefaultScreen(dpy);
+ 	Window root = RootWindow(dpy, screen);
+ 

--- a/pkgs/tools/X11/sct/default.nix
+++ b/pkgs/tools/X11/sct/default.nix
@@ -1,31 +1,26 @@
-{stdenv, fetchurl, libX11, libXrandr}:
+{ stdenv, fetchurl, libX11, libXrandr }:
+
 stdenv.mkDerivation rec {
   name = "sct";
-  buildInputs = [libX11 libXrandr];
+
   src = fetchurl {
     url = http://www.tedunangst.com/flak/files/sct.c;
     sha256 = "01f3ndx3s6d2qh2xmbpmhd4962dyh8yp95l87xwrs4plqdz6knhd";
-    
-    # Discussion regarding the checksum and the source code can be found in issue #17163 
-    # The code seems unmaintained, yet an unknown (probably small change) in the code caused 
-    # failed builds as the checksum had changed.
-    # The checksum is updated for now, however, this is unpractical and potentially unsafe 
-    # so any future changes might warrant a fork of the (feature complete) project. 
-    # The code is under public domain.
-    
   };
-  phases = ["patchPhase" "buildPhase" "installPhase"];
-  patchPhase = ''
-    sed -re "/Xlibint/d" ${src} > sct.c 
-  '';
-  buildPhase = "gcc -std=c99 sct.c -o sct -lX11 -lXrandr -lm";
-  installPhase = ''
-    mkdir -p "$out/bin"
-    cp sct "$out/bin"
-  '';
-  meta = {
-    description = ''A minimal utility to set display colour temperature'';
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = with stdenv.lib.platforms; linux ++ freebsd ++ openbsd;
+
+  unpackPhase = "cat ${src} > sct.c";
+  patches = [ ./DISPLAY-segfault.patch ];
+
+  buildInputs = [ libX11 libXrandr ];
+  buildPhase = "cc sct.c -o sct -lm -lX11 -lXrandr";
+
+  installPhase = "install -Dt $out/bin sct";
+
+  meta = with stdenv.lib; {
+    homepage = https://www.tedunangst.com/flak/post/sct-set-color-temperature;
+    description = "A minimal utility to set display colour temperature";
+    maintainers = [ maintainers.raskin ];
+    license = licenses.publicDomain;
+    platforms = with platforms; linux ++ freebsd ++ openbsd;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

* `patchPhase` that is now redundant (`libXint` is not present in source code anymore: it was the unknown small change that was described in derivation comments)
* `meta.license`, `meta.homepage` not set
* `gcc` was explicitly used instead of `cc`

`sct` segfaults when `DISPLAY` environment variable is empty:

```
$ DISPLAY= sct
segmentation fault
```

This patch fixes that. Now it just exits with error code 1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

