### PR TITLE
epsxe: init at 2.0.5

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -652,6 +652,7 @@
   xvapx = "Marti Serra <marti.serra.coscollano@gmail.com>";
   xwvvvvwx = "David Terry <davidterry@posteo.de>";
   yarr = "Dmitry V. <savraz@gmail.com>";
+  yegortimoshenko = "Yegor Timoshenko <yegortimoshenko@gmail.com>";
   yochai = "Yochai <yochai@titat.info>";
   yorickvp = "Yorick van Pelt <yorickvanpelt@gmail.com>";
   yuriaisaka = "Yuri Aisaka <yuri.aisaka+nix@gmail.com>";

--- a/pkgs/misc/emulators/epsxe/default.nix
+++ b/pkgs/misc/emulators/epsxe/default.nix
@@ -1,12 +1,14 @@
 { stdenv, fetchurl, alsaLib, curl, gdk_pixbuf, gcc, glib, gtk3,
   libX11, openssl, ncurses5, SDL, SDL_ttf, unzip, zlib, wrapGAppsHook }:
 
+with stdenv.lib;
+
 stdenv.mkDerivation rec {
   name = "epsxe-${version}";
   version = "2.0.5";
 
   src = with stdenv.lib; let
-    version2 = concatStrings (splitString "." version);  
+    version2 = concatStrings (splitString "." version);
     platform = "linux" + (optionalString stdenv.is64bit "_x64");
   in fetchurl {
     url = "http://www.epsxe.com/files/ePSXe${version2}${platform}.zip";
@@ -34,17 +36,16 @@ stdenv.mkDerivation rec {
   ];
 
   dontStrip = true;
-  
+
   installPhase = ''
-    mv epsxe_* epsxe || true
-    install -Dt $out/bin epsxe
+    install -D epsxe${optionalString stdenv.is64bit "_x64"} $out/bin/epsxe
     patchelf \
       --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
-      --set-rpath ${stdenv.lib.makeLibraryPath buildInputs} \
+      --set-rpath ${makeLibraryPath buildInputs} \
       $out/bin/epsxe
   '';
 
-  meta = with stdenv.lib; {
+  meta = {
     homepage = http://epsxe.com/;
     description = "Enhanced PSX (PlayStation 1) emulator";
     license = licenses.unfree;

--- a/pkgs/misc/emulators/epsxe/default.nix
+++ b/pkgs/misc/emulators/epsxe/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchurl, alsaLib, curl, gdk_pixbuf, gcc, glib, gtk3,
+  libX11, openssl, ncurses5, SDL, SDL_ttf, unzip, zlib, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "epsxe-${version}";
+  version = "2.0.5";
+
+  src = with stdenv.lib; let
+    version2 = concatStrings (splitString "." version);  
+    platform = "linux" + (optionalString stdenv.is64bit "_x64");
+  in fetchurl {
+    url = "http://www.epsxe.com/files/ePSXe${version2}${platform}.zip";
+    sha256 = if stdenv.is64bit
+             then "16fa9qc2xhaz1f6294m0b56s5l86cbmclwm9w3mqnch0yjsrvab0"
+             else "1677lclam557kp8jwvchdrk27zfj50fqx2q9i3bcx26d9k61q3kl";
+  };
+
+  nativeBuildInputs = [ unzip wrapGAppsHook ];
+  sourceRoot = ".";
+
+  buildInputs = [
+    alsaLib
+    curl
+    gdk_pixbuf
+    glib
+    gtk3
+    libX11
+    openssl
+    ncurses5
+    SDL
+    SDL_ttf
+    stdenv.cc.cc.lib
+    zlib
+  ];
+
+  dontStrip = true;
+  
+  installPhase = ''
+    mv epsxe_* epsxe || true
+    install -Dt $out/bin epsxe
+    patchelf \
+      --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
+      --set-rpath ${stdenv.lib.makeLibraryPath buildInputs} \
+      $out/bin/epsxe
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://epsxe.com/;
+    description = "Enhanced PSX (PlayStation 1) emulator";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ yegortimoshenko ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1881,6 +1881,8 @@ with pkgs;
 
   epstool = callPackage ../tools/graphics/epstool { };
 
+  epsxe = callPackage ../misc/emulators/epsxe { };
+
   ethtool = callPackage ../tools/misc/ethtool { };
 
   ettercap = callPackage ../applications/networking/sniffers/ettercap { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

