### PR TITLE
qt59.qtbase: fix darwin build so qtdeclarative can build

### DIFF
--- a/pkgs/development/libraries/qt-5/5.9/qtbase/darwin-series
+++ b/pkgs/development/libraries/qt-5/5.9/qtbase/darwin-series
@@ -1,0 +1,3 @@
+mkspecs-common-mac.patch
+mkspecs-features-mac.patch
+darwin-cf.patch

--- a/pkgs/development/libraries/qt-5/5.9/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtbase/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
       libjpeg libpng libtiff
     ]
 
-    ++ lib.optional mesaSupported mesa
+    ++ lib.optional (mesaSupported && !stdenv.isDarwin) mesa
 
     ++ lib.optionals (!stdenv.isDarwin) [
       dbus glib udev
@@ -80,7 +80,7 @@ stdenv.mkDerivation {
 
   patches =
     copyPathsToStore (lib.readPathsFromFile ./. ./series)
-    ++ stdenv.lib.optional stdenv.isDarwin ./darwin-cf.patch;
+    ++ stdenv.lib.optional stdenv.isDarwin (copyPathsToStore (lib.readPathsFromFile ./. ./darwin-series));
 
   postPatch =
     ''
@@ -94,7 +94,7 @@ stdenv.mkDerivation {
       sed -i '/PATHS.*NO_DEFAULT_PATH/ d' mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
     ''
 
-    + lib.optionalString mesaSupported ''
+    + lib.optionalString (mesaSupported && !stdenv.isDarwin) ''
       sed -i mkspecs/common/linux.conf \
           -e "/^QMAKE_INCDIR_OPENGL/ s|$|${mesa.dev or mesa}/include|" \
           -e "/^QMAKE_LIBDIR_OPENGL/ s|$|${mesa.out}/lib|"
@@ -110,10 +110,10 @@ stdenv.mkDerivation {
           -e 's#sdk_val=$(/usr/bin/xcrun -sdk $sdk -find $(echo $val | cut -d \x27 \x27 -f 1))##' \
           -e 's#val=$(echo $sdk_val $(echo $val | cut -s -d \x27 \x27 -f 2-))##' \
           ./configure
-      sed -i '3,$d' ./mkspecs/features/mac/default_pre.prf
-      sed -i '27,$d' ./mkspecs/features/mac/default_post.prf
-      sed -i '1,$d' ./mkspecs/features/mac/sdk.prf
-      sed -i 's/QMAKE_LFLAGS_RPATH      = -Wl,-rpath,/QMAKE_LFLAGS_RPATH      =/' ./mkspecs/common/mac.conf
+          substituteInPlace ./mkspecs/common/mac.conf \
+              --replace "/System/Library/Frameworks/OpenGL.framework/" "${darwin.apple_sdk.frameworks.OpenGL}/Library/Frameworks/OpenGL.framework/"
+          substituteInPlace ./mkspecs/common/mac.conf \
+              --replace "/System/Library/Frameworks/AGL.framework/" "${darwin.apple_sdk.frameworks.AGL}/Library/Frameworks/AGL.framework/"
      '';
      # Note on the above: \x27 is a way if including a single-quote
      # character in the sed string arguments.
@@ -144,7 +144,7 @@ stdenv.mkDerivation {
       ''-DNIXPKGS_LIBXCURSOR="${libXcursor.out}/lib/libXcursor"''
     ]
 
-    ++ lib.optional mesaSupported
+    ++ lib.optional (mesaSupported && !stdenv.isDarwin)
        ''-DNIXPKGS_MESA_GL="${mesa.out}/lib/libGL"''
 
     ++ lib.optionals (!stdenv.isDarwin)

--- a/pkgs/development/libraries/qt-5/5.9/qtbase/mkspecs-common-mac.patch
+++ b/pkgs/development/libraries/qt-5/5.9/qtbase/mkspecs-common-mac.patch
@@ -1,0 +1,11 @@
+--- qtbase-opensource-src-5.9.1.orig/mkspecs/common/mac.conf	2017-09-16 16:40:30.000000000 +0800
++++ qtbase-opensource-src-5.9.1/mkspecs/common/mac.conf	2017-09-16 16:41:27.000000000 +0800
+@@ -23,7 +23,7 @@
+ 
+ QMAKE_FIX_RPATH         = install_name_tool -id
+ 
+-QMAKE_LFLAGS_RPATH      = -Wl,-rpath,
++QMAKE_LFLAGS_RPATH      =
+ QMAKE_LFLAGS_GCSECTIONS = -Wl,-dead_strip
+ 
+ QMAKE_LFLAGS_REL_RPATH  =

--- a/pkgs/development/libraries/qt-5/5.9/qtbase/mkspecs-features-mac.patch
+++ b/pkgs/development/libraries/qt-5/5.9/qtbase/mkspecs-features-mac.patch
@@ -1,0 +1,278 @@
+diff -u qtbase-opensource-src-5.9.1.orig/mkspecs/features/mac/default_post.prf qtbase-opensource-src-5.9.1/mkspecs/features/mac/default_post.prf
+--- qtbase-opensource-src-5.9.1.orig/mkspecs/features/mac/default_post.prf	2017-09-16 16:40:30.000000000 +0800
++++ qtbase-opensource-src-5.9.1/mkspecs/features/mac/default_post.prf	2017-09-16 16:41:03.000000000 +0800
+@@ -24,165 +24,3 @@
+         }
+     }
+ }
+-
+-# Add the same default rpaths as Xcode does for new projects.
+-# This is especially important for iOS/tvOS/watchOS where no other option is possible.
+-!no_default_rpath {
+-    QMAKE_RPATHDIR += @executable_path/Frameworks
+-    equals(TEMPLATE, lib):!plugin:lib_bundle: QMAKE_RPATHDIR += @loader_path/Frameworks
+-}
+-
+-# Don't pass -headerpad_max_install_names when using Bitcode.
+-# In that case the linker emits a warning stating that the flag is ignored when
+-# used with bitcode, for reasons that cannot be determined (rdar://problem/20748962).
+-# Using this flag is also unnecessary in practice on UIKit platforms since they
+-# are sandboxed, and only UIKit platforms support bitcode to begin with.
+-!bitcode: QMAKE_LFLAGS += $$QMAKE_LFLAGS_HEADERPAD
+-
+-app_extension_api_only {
+-    QMAKE_CFLAGS              += $$QMAKE_CFLAGS_APPLICATION_EXTENSION
+-    QMAKE_CXXFLAGS            += $$QMAKE_CFLAGS_APPLICATION_EXTENSION
+-    QMAKE_CXXFLAGS_PRECOMPILE += $$QMAKE_CFLAGS_APPLICATION_EXTENSION
+-    QMAKE_LFLAGS              += $$QMAKE_CFLAGS_APPLICATION_EXTENSION
+-}
+-
+-macx-xcode {
+-    !isEmpty(QMAKE_XCODE_DEBUG_INFORMATION_FORMAT) {
+-        debug_information_format.name = DEBUG_INFORMATION_FORMAT
+-        debug_information_format.value = $$QMAKE_XCODE_DEBUG_INFORMATION_FORMAT
+-        debug_information_format.build = debug
+-        QMAKE_MAC_XCODE_SETTINGS += debug_information_format
+-    }
+-
+-    QMAKE_XCODE_ARCHS =
+-
+-    arch_device.name = "ARCHS[sdk=$${device.sdk}*]"
+-    arch_device.value = $$QMAKE_APPLE_DEVICE_ARCHS
+-    QMAKE_XCODE_ARCHS += $$QMAKE_APPLE_DEVICE_ARCHS
+-    QMAKE_MAC_XCODE_SETTINGS += arch_device
+-
+-    simulator {
+-        arch_simulator.name = "ARCHS[sdk=$${simulator.sdk}*]"
+-        arch_simulator.value = $$QMAKE_APPLE_SIMULATOR_ARCHS
+-        QMAKE_XCODE_ARCHS += $$QMAKE_APPLE_SIMULATOR_ARCHS
+-        QMAKE_MAC_XCODE_SETTINGS += arch_simulator
+-    }
+-
+-    only_active_arch.name = ONLY_ACTIVE_ARCH
+-    only_active_arch.value = YES
+-    only_active_arch.build = debug
+-    QMAKE_MAC_XCODE_SETTINGS += only_active_arch
+-} else {
+-    device|!simulator: VALID_DEVICE_ARCHS = $$QMAKE_APPLE_DEVICE_ARCHS
+-    simulator: VALID_SIMULATOR_ARCHS = $$QMAKE_APPLE_SIMULATOR_ARCHS
+-    VALID_ARCHS = $$VALID_DEVICE_ARCHS $$VALID_SIMULATOR_ARCHS
+-
+-    isEmpty(VALID_ARCHS): \
+-        error("QMAKE_APPLE_DEVICE_ARCHS or QMAKE_APPLE_SIMULATOR_ARCHS must contain at least one architecture")
+-
+-    single_arch: VALID_ARCHS = $$first(VALID_ARCHS)
+-
+-    ACTIVE_ARCHS = $(filter $(EXPORT_VALID_ARCHS), $(ARCHS))
+-    ARCH_ARGS = $(foreach arch, $(if $(EXPORT_ACTIVE_ARCHS), $(EXPORT_ACTIVE_ARCHS), $(EXPORT_VALID_ARCHS)), -arch $(arch))
+-
+-    QMAKE_EXTRA_VARIABLES += VALID_ARCHS ACTIVE_ARCHS ARCH_ARGS
+-
+-    arch_flags = $(EXPORT_ARCH_ARGS)
+-
+-    QMAKE_CFLAGS += $$arch_flags
+-    QMAKE_CXXFLAGS += $$arch_flags
+-    QMAKE_LFLAGS += $$arch_flags
+-
+-    QMAKE_PCH_ARCHS = $$VALID_ARCHS
+-
+-    macos: deployment_target = $$QMAKE_MACOSX_DEPLOYMENT_TARGET
+-    ios: deployment_target = $$QMAKE_IOS_DEPLOYMENT_TARGET
+-    tvos: deployment_target = $$QMAKE_TVOS_DEPLOYMENT_TARGET
+-    watchos: deployment_target = $$QMAKE_WATCHOS_DEPLOYMENT_TARGET
+-
+-    # If we're doing a simulator and device build, device and simulator
+-    # architectures use different paths and flags for the sysroot and
+-    # deployment target switch, so we must multiplex them across multiple
+-    # architectures using -Xarch. Otherwise we fall back to the simple path.
+-    # This is not strictly necessary, but results in cleaner command lines
+-    # and makes it easier for people to override EXPORT_VALID_ARCHS to limit
+-    # individual rules to a different set of architecture(s) from the overall
+-    # build (such as machtest in QtCore).
+-    simulator:device {
+-        QMAKE_XARCH_CFLAGS =
+-        QMAKE_XARCH_LFLAGS =
+-        QMAKE_EXTRA_VARIABLES += QMAKE_XARCH_CFLAGS QMAKE_XARCH_LFLAGS
+-
+-        for (arch, VALID_ARCHS) {
+-            contains(VALID_SIMULATOR_ARCHS, $$arch) {
+-                sdk = $$simulator.sdk
+-                version_identifier = $$simulator.deployment_identifier
+-            } else {
+-                sdk = $$device.sdk
+-                version_identifier = $$device.deployment_identifier
+-            }
+-
+-            version_min_flags = \
+-                -Xarch_$${arch} \
+-                -m$${version_identifier}-version-min=$$deployment_target
+-            QMAKE_XARCH_CFLAGS_$${arch} = $$version_min_flags \
+-                -Xarch_$${arch} \
+-                -isysroot$$xcodeSDKInfo(Path, $$sdk)
+-            QMAKE_XARCH_LFLAGS_$${arch} = $$version_min_flags \
+-                -Xarch_$${arch} \
+-                -Wl,-syslibroot,$$xcodeSDKInfo(Path, $$sdk)
+-
+-            QMAKE_XARCH_CFLAGS += $(EXPORT_QMAKE_XARCH_CFLAGS_$${arch})
+-            QMAKE_XARCH_LFLAGS += $(EXPORT_QMAKE_XARCH_LFLAGS_$${arch})
+-
+-            QMAKE_EXTRA_VARIABLES += \
+-                QMAKE_XARCH_CFLAGS_$${arch} \
+-                QMAKE_XARCH_LFLAGS_$${arch}
+-        }
+-
+-        QMAKE_CFLAGS += $(EXPORT_QMAKE_XARCH_CFLAGS)
+-        QMAKE_CXXFLAGS += $(EXPORT_QMAKE_XARCH_CFLAGS)
+-        QMAKE_LFLAGS += $(EXPORT_QMAKE_XARCH_LFLAGS)
+-    } else {
+-        simulator: \
+-            version_identifier = $$simulator.deployment_identifier
+-        else: \
+-            version_identifier = $$device.deployment_identifier
+-        version_min_flag = -m$${version_identifier}-version-min=$$deployment_target
+-        QMAKE_CFLAGS += -isysroot $$QMAKE_MAC_SDK_PATH $$version_min_flag
+-        QMAKE_CXXFLAGS += -isysroot $$QMAKE_MAC_SDK_PATH $$version_min_flag
+-        QMAKE_LFLAGS += -Wl,-syslibroot,$$QMAKE_MAC_SDK_PATH $$version_min_flag
+-    }
+-
+-    # Enable precompiled headers for multiple architectures
+-    QMAKE_CFLAGS_USE_PRECOMPILE =
+-    for (arch, VALID_ARCHS) {
+-        icc_pch_style: \
+-            use_flag = "-pch-use "
+-        else: \
+-            use_flag = -include
+-
+-        # Only use Xarch with multi-arch, as the option confuses ccache
+-        count(VALID_ARCHS, 1, greaterThan): \
+-            QMAKE_CFLAGS_USE_PRECOMPILE += \
+-                -Xarch_$${arch}
+-
+-        QMAKE_CFLAGS_USE_PRECOMPILE += \
+-            $${use_flag}${QMAKE_PCH_OUTPUT_$${arch}}
+-    }
+-    icc_pch_style {
+-        QMAKE_CXXFLAGS_USE_PRECOMPILE = $$QMAKE_CFLAGS_USE_PRECOMPILE -include ${QMAKE_PCH_INPUT}
+-        QMAKE_CFLAGS_USE_PRECOMPILE =
+-    } else {
+-        QMAKE_CXXFLAGS_USE_PRECOMPILE = $$QMAKE_CFLAGS_USE_PRECOMPILE
+-        QMAKE_OBJCFLAGS_USE_PRECOMPILE = $$QMAKE_CFLAGS_USE_PRECOMPILE
+-        QMAKE_OBJCXXFLAGS_USE_PRECOMPILE = $$QMAKE_CFLAGS_USE_PRECOMPILE
+-    }
+-
+-    QMAKE_PCH_OUTPUT_EXT = _${QMAKE_PCH_ARCH}$${QMAKE_PCH_OUTPUT_EXT}
+-}
+-
+-cache(QMAKE_XCODE_DEVELOPER_PATH, stash)
+-cache(QMAKE_XCODE_VERSION, stash)
+-
+-QMAKE_XCODE_LIBRARY_SUFFIX = $$qtPlatformTargetSuffix()
+diff -u qtbase-opensource-src-5.9.1.orig/mkspecs/features/mac/default_pre.prf qtbase-opensource-src-5.9.1/mkspecs/features/mac/default_pre.prf
+--- qtbase-opensource-src-5.9.1.orig/mkspecs/features/mac/default_pre.prf	2017-09-16 16:40:30.000000000 +0800
++++ qtbase-opensource-src-5.9.1/mkspecs/features/mac/default_pre.prf	2017-09-16 16:40:45.000000000 +0800
+@@ -1,51 +1,2 @@
+ CONFIG = asset_catalogs rez $$CONFIG
+ load(default_pre)
+-
+-isEmpty(QMAKE_XCODE_DEVELOPER_PATH) {
+-    # Get path of Xcode's Developer directory
+-    QMAKE_XCODE_DEVELOPER_PATH = $$system("/usr/bin/xcode-select --print-path 2>/dev/null")
+-    isEmpty(QMAKE_XCODE_DEVELOPER_PATH): \
+-        error("Xcode path is not set. Please use xcode-select to choose Xcode installation path.")
+-
+-    # Make sure Xcode path is valid
+-    !exists($$QMAKE_XCODE_DEVELOPER_PATH): \
+-        error("Xcode is not installed in $${QMAKE_XCODE_DEVELOPER_PATH}. Please use xcode-select to choose Xcode installation path.")
+-
+-    # Make sure Xcode is set up properly
+-    isEmpty($$list($$system("/usr/bin/xcrun -find xcodebuild 2>/dev/null"))): \
+-        error("Xcode not set up properly. You may need to confirm the license agreement by running /usr/bin/xcodebuild.")
+-}
+-
+-isEmpty(QMAKE_XCODE_VERSION) {
+-    # Extract Xcode version using xcodebuild
+-    xcode_version = $$system("/usr/bin/xcodebuild -version")
+-    QMAKE_XCODE_VERSION = $$member(xcode_version, 1)
+-    isEmpty(QMAKE_XCODE_VERSION): error("Could not resolve Xcode version.")
+-    unset(xcode_version)
+-}
+-
+-isEmpty(QMAKE_TARGET_BUNDLE_PREFIX) {
+-    QMAKE_XCODE_PREFERENCES_FILE = $$(HOME)/Library/Preferences/com.apple.dt.Xcode.plist
+-    exists($$QMAKE_XCODE_PREFERENCES_FILE): \
+-        QMAKE_TARGET_BUNDLE_PREFIX = $$system("/usr/libexec/PlistBuddy -c 'print IDETemplateOptions:bundleIdentifierPrefix' $$QMAKE_XCODE_PREFERENCES_FILE 2>/dev/null")
+-
+-    !isEmpty(_QMAKE_CACHE_):!isEmpty(QMAKE_TARGET_BUNDLE_PREFIX): \
+-        cache(QMAKE_TARGET_BUNDLE_PREFIX)
+-}
+-
+-QMAKE_ASSET_CATALOGS_APP_ICON = AppIcon
+-
+-# Make the default debug info format for static debug builds
+-# DWARF instead of DWARF with dSYM. This cuts down build times
+-# for application debug builds significantly, as Xcode doesn't
+-# have to pull out all the DWARF info from the Qt static libs
+-# and put it into a dSYM file. We don't need that dSYM file in
+-# the first place, since the information is available in the
+-# object files inside the archives (static libraries).
+-macx-xcode:qtConfig(static): \
+-    QMAKE_XCODE_DEBUG_INFORMATION_FORMAT = dwarf
+-
+-# This variable is used by the xcode_dynamic_library_suffix
+-# feature, which allows Xcode to choose the Qt libraries to link to
+-# at build time, depending on the current Xcode SDK and configuration.
+-QMAKE_XCODE_LIBRARY_SUFFIX_SETTING = QT_LIBRARY_SUFFIX
+diff -u qtbase-opensource-src-5.9.1.orig/mkspecs/features/mac/sdk.prf qtbase-opensource-src-5.9.1/mkspecs/features/mac/sdk.prf
+--- qtbase-opensource-src-5.9.1.orig/mkspecs/features/mac/sdk.prf	2017-09-16 16:40:30.000000000 +0800
++++ qtbase-opensource-src-5.9.1/mkspecs/features/mac/sdk.prf	2017-09-16 16:41:16.000000000 +0800
+@@ -1,49 +0,0 @@
+-
+-isEmpty(QMAKE_MAC_SDK): \
+-    error("QMAKE_MAC_SDK must be set when using CONFIG += sdk.")
+-
+-contains(QMAKE_MAC_SDK, .*/.*): \
+-    error("QMAKE_MAC_SDK can only contain short-form SDK names (eg. macosx, iphoneos)")
+-
+-defineReplace(xcodeSDKInfo) {
+-    info = $$1
+-    sdk = $$2
+-    isEmpty(sdk): \
+-        sdk = $$QMAKE_MAC_SDK
+-
+-    isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}) {
+-        QMAKE_MAC_SDK.$${sdk}.$${info} = $$system("/usr/bin/xcodebuild -sdk $$sdk -version $$info 2>/dev/null")
+-        isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}): error("Could not resolve SDK $$info for \'$$sdk\'")
+-        cache(QMAKE_MAC_SDK.$${sdk}.$${info}, set stash, QMAKE_MAC_SDK.$${sdk}.$${info})
+-    }
+-
+-    return($$eval(QMAKE_MAC_SDK.$${sdk}.$${info}))
+-}
+-
+-QMAKE_MAC_SDK_PATH = $$xcodeSDKInfo(Path)
+-QMAKE_MAC_SDK_PLATFORM_PATH = $$xcodeSDKInfo(PlatformPath)
+-QMAKE_MAC_SDK_VERSION = $$xcodeSDKInfo(SDKVersion)
+-
+-sysrootified =
+-for(val, QMAKE_INCDIR_OPENGL): sysrootified += $${QMAKE_MAC_SDK_PATH}$$val
+-QMAKE_INCDIR_OPENGL = $$sysrootified
+-
+-QMAKESPEC_NAME = $$basename(QMAKESPEC)
+-
+-# Resolve SDK version of various tools
+-for(tool, $$list(QMAKE_CC QMAKE_CXX QMAKE_FIX_RPATH QMAKE_AR QMAKE_RANLIB QMAKE_LINK QMAKE_LINK_SHLIB QMAKE_ACTOOL)) {
+-    tool_variable = QMAKE_MAC_SDK.$${QMAKESPEC_NAME}.$${QMAKE_MAC_SDK}.$${tool}
+-    !isEmpty($$tool_variable) {
+-        $$tool = $$eval($$tool_variable)
+-        next()
+-    }
+-
+-    value = $$eval($$tool)
+-    isEmpty(value): next()
+-
+-    sysrooted = $$system("/usr/bin/xcrun -sdk $$QMAKE_MAC_SDK -find $$first(value) 2>/dev/null")
+-    isEmpty(sysrooted): next()
+-
+-    $$tool = $$sysrooted $$member(value, 1, -1)
+-    cache($$tool_variable, set stash, $$tool)
+-}
+Common subdirectories: qtbase-opensource-src-5.9.1.orig/mkspecs/features/mac/unsupported and qtbase-opensource-src-5.9.1/mkspecs/features/mac/unsupported

--- a/pkgs/development/libraries/qt-5/qtbase-setup-hook-darwin.sh
+++ b/pkgs/development/libraries/qt-5/qtbase-setup-hook-darwin.sh
@@ -2,6 +2,12 @@ qtPluginPrefix=@qtPluginPrefix@
 qtQmlPrefix=@qtQmlPrefix@
 qtDocPrefix=@qtDocPrefix@
 
+_qtRmCMakeLink() {
+    find "${!outputLib}" -name "*.cmake" -type l | xargs rm
+}
+
+postInstallHooks+=(_qtRmCMakeLink)
+
 addToSearchPathOnceWithCustomDelimiter() {
     local delim="$1"
     local search="$2"


### PR DESCRIPTION
###### Motivation for this change

All changes are for Darwin: move sed command to patch files; disable mesa; fix OpenGL and AGL header files path. qtdeclarative and qtwebkit can be built

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

