### PR TITLE
epsxe: fix install, 32-bit executable uses mixed case

### DIFF
--- a/pkgs/misc/emulators/epsxe/default.nix
+++ b/pkgs/misc/emulators/epsxe/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
   installPhase = ''
-    install -D epsxe${optionalString stdenv.is64bit "_x64"} $out/bin/epsxe
+    install -D ${if stdenv.is64bit then "epsxe_x64" else "ePSXe"} $out/bin/epsxe
     patchelf \
       --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
       --set-rpath ${makeLibraryPath buildInputs} \


### PR DESCRIPTION
###### Motivation for this change

Sorry about this one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

