### PR TITLE
closure-compiler: 20170218 -> 20170910

### DIFF
--- a/pkgs/development/compilers/closure/default.nix
+++ b/pkgs/development/compilers/closure/default.nix
@@ -1,31 +1,30 @@
-{ stdenv, fetchurl, jre, gnutar, bash }:
+{ stdenv, fetchurl, jre, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "closure-compiler-${version}";
-  version = "20170218";
+  version = "20170910";
 
   src = fetchurl {
-    url = "http://dl.google.com/closure-compiler/compiler-${version}.tar.gz";
-    sha256 = "06snabmpy07x4xm8d1xgq5dfzbjli10xkxk3nx9jms39zkj493cd";
+    url = "https://dl.google.com/closure-compiler/compiler-${version}.tar.gz";
+    sha256 = "0znzsks8ql9qajhcjzfkhmnpz8zs6b8cji04fhivyq973jpxxrak";
   };
 
-  phases = [ "installPhase" ];
+  sourceRoot = ".";
 
-  buildInputs = [ gnutar ];
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ jre ];
 
   installPhase = ''
     mkdir -p $out/share/java $out/bin
-    tar -xzf $src
-    cp -r closure-compiler-v${version}.jar $out/share/java/
-    echo "#!${bash}/bin/bash" > $out/bin/closure-compiler
-    echo "${jre}/bin/java -jar $out/share/java/closure-compiler-v${version}.jar \"\$@\"" >> $out/bin/closure-compiler
-    chmod +x $out/bin/closure-compiler
+    cp closure-compiler-v${version}.jar $out/share/java
+    makeWrapper ${jre}/bin/java $out/bin/closure-compiler \
+      --add-flags "-jar $out/share/java/closure-compiler-v${version}.jar"
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A tool for making JavaScript download and run faster";
     homepage = https://developers.google.com/closure/compiler/;
-    license = stdenv.lib.licenses.asl20;
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.asl20;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Hasn't been updated in a while, HTTP -> HTTPS, use idiomatic `makeWrapper`, `unpackPhase`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

