### PR TITLE
Rhino: enable on Darwin

### DIFF
--- a/pkgs/development/libraries/java/rhino/default.nix
+++ b/pkgs/development/libraries/java/rhino/default.nix
@@ -2,7 +2,6 @@
 
 let
   version = "1.7R2";
-  options = "-Dbuild.compiler=gcj";   # FIXME: We assume GCJ here.
 
   xbeans  = fetchurl {
     url = "http://archive.apache.org/dist/xmlbeans/binaries/xmlbeans-2.2.0.zip";
@@ -33,7 +32,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ unzip ant javac jvm ];
 
-  buildPhase = "ant ${options} jar";
+  buildPhase = "ant jar";
   doCheck    = false;
 
   # FIXME: Install javadoc as well.

--- a/pkgs/development/libraries/java/rhino/default.nix
+++ b/pkgs/development/libraries/java/rhino/default.nix
@@ -54,6 +54,6 @@ stdenv.mkDerivation {
     homepage = http://www.mozilla.org/rhino/;
 
     license = with licenses; [ mpl11 /* or */ gpl2Plus ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10371,8 +10371,8 @@ with pkgs;
   resolv_wrapper = callPackage ../development/libraries/resolv_wrapper { };
 
   rhino = callPackage ../development/libraries/java/rhino {
-    javac = gcj;
-    jvm = gcj;
+    javac = jdk;
+    jvm = jre;
   };
 
   rlog = callPackage ../development/libraries/rlog { };


### PR DESCRIPTION
###### Motivation for this change

When I worked on https://github.com/NixOS/nixpkgs/pull/29759
I had allowBroken == true 🤦‍♂️ 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

