### PR TITLE
set-source-date-epoch-to-latest.sh: ignore generated files - episode 2

### DIFF
--- a/pkgs/build-support/setup-hooks/set-source-date-epoch-to-latest.sh
+++ b/pkgs/build-support/setup-hooks/set-source-date-epoch-to-latest.sh
@@ -4,7 +4,9 @@ updateSourceDateEpoch() {
     # Get the last modification time of all regular files, sort them,
     # and get the most recent. Maybe we should use
     # https://github.com/0-wiz-0/findnewest here.
-    local -a res=($(find "$path" -type f -not -newer "$NIX_BUILD_TOP/.." -printf '%T@ %p\0' \
+    local -a res=($(find "$path" -type f \
+                      -not -newermt "$(date --date @$(( $(date +%s -r "$NIX_BUILD_TOP/..") - 1 )))" \
+                      -printf '%T@ %p\0' \
                     | sort -n --zero-terminated | tail -n1 --zero-terminated | head -c -1))
     local time="${res[0]//\.[0-9]*/}" # remove the fraction part
     local newestFile="${res[1]}"

--- a/pkgs/build-support/setup-hooks/set-source-date-epoch-to-latest.sh
+++ b/pkgs/build-support/setup-hooks/set-source-date-epoch-to-latest.sh
@@ -1,16 +1,23 @@
 updateSourceDateEpoch() {
     local path="$1"
 
-    # Get the last modification time of all regular files, sort them,
-    # and get the most recent. Maybe we should use
-    # https://github.com/0-wiz-0/findnewest here.
-    local -a res=($(find "$path" -type f \
-                      -not -newermt "$(date --date @$(( $(date +%s -r "$NIX_BUILD_TOP/..") - 1 )))" \
-                      -printf '%T@ %p\0' \
-                    | sort -n --zero-terminated | tail -n1 --zero-terminated | head -c -1))
-    local time="${res[0]//\.[0-9]*/}" # remove the fraction part
-    local newestFile="${res[1]}"
-
+    # Get the last modification time of all regular files, sort them, and get the most recent. 
+    local time="0"
+    local newestFile=""
+    local threshold=$(date +%s -r "$NIX_BUILD_TOP/..")
+    IFS=$'\n'
+    for r in $(find "$path" -type f -printf '%T@ %p\n'); do
+      IFS=' '
+      local -a res=( $r )
+      local t="${res[0]//\.[0-9]*/}" # remove the fraction part
+      if [ "$t" -ge "$threshold" ]; then
+        echo "ignore generated file ${res[1]}"
+      elif [ "$time" -lt "$t" ]; then
+        time="$t"
+        newestFile="${res[1]}"
+      fi
+    done
+    
     # Update $SOURCE_DATE_EPOCH if the most recent file we found is newer.
     if [ "$time" -gt "$SOURCE_DATE_EPOCH" ]; then
         echo "setting SOURCE_DATE_EPOCH to timestamp $time of file $newestFile"


### PR DESCRIPTION
###### Motivation for this change

Follow up https://github.com/NixOS/nixpkgs/pull/28227

On Darwin, file modification times (mtimes) have 1 second granularity and it happens that generated files (e.g. ```".sandbox.sb"```) have exactly the same mtime as ```..```

So, the mtime comparision shouldn't actually be ```-not -newer``` but ```-older```. not ```≤``` but ```<```.
Unfortunately, ```find``` has no such option.

Here I hacked ```(mtime - 1)``` on bash which is very ugly, it would be nice if someone has the idea how to code it more succintly, or replace ```find``` with somehing else (perl one-liner?)

cc @vcunat
