### PR TITLE
snes9x-gtk: 1.53 -> 1.54.1

### DIFF
--- a/pkgs/misc/emulators/snes9x-gtk/default.nix
+++ b/pkgs/misc/emulators/snes9x-gtk/default.nix
@@ -1,26 +1,26 @@
-{stdenv, fetchurl, nasm, SDL, zlib, libpng, ncurses, mesa, intltool, gtk2, pkgconfig, libxml2, xlibsWrapper, libpulseaudio}:
+{ stdenv, fetchFromGitHub, autoreconfHook, intltool, pkgconfig
+, SDL, zlib, gtk2, libxml2, libXv }:
 
 stdenv.mkDerivation rec {
   name = "snes9x-gtk-${version}";
-  version = "1.53";
+  version = "1.54.1";
 
-  src = fetchurl {
-    url = "http://files.ipherswipsite.com/snes9x/snes9x-${version}-src.tar.bz2";
-    sha256 = "9f7c5d2d0fa3fe753611cf94e8879b73b8bb3c0eab97cdbcb6ab7376efa78dc3";
+  src = fetchFromGitHub {
+    owner = "snes9xgit";
+    repo = "snes9x";
+    rev = version;
+    sha256 = "10fqm7lk36zj2gnx0ypps0nlws923f60b0zj4pmq9apawgx8k6rw";
   };
 
-  buildInputs = [ nasm SDL zlib libpng ncurses mesa intltool gtk2 pkgconfig libxml2 xlibsWrapper libpulseaudio];
+  nativeBuildInputs = [ autoreconfHook intltool pkgconfig ];
 
-  sourceRoot = "snes9x-${version}-src/gtk";
+  sourceRoot = "snes9x-${version}-src";
+  preAutoreconf = "cd gtk; intltoolize";  
+    
+  buildInputs = [ SDL zlib gtk2 libxml2 libXv ];
+  installPhase = "install -Dt $out/bin snes9x-gtk";
 
-  configureFlags = "--prefix=$out/ --with-opengl";
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp snes9x-gtk $out/bin
-  '';
-
-  meta = {
+  meta = with stdenv.lib; {
     description = "A portable, freeware Super Nintendo Entertainment System (SNES) emulator";
     longDescription = ''
       Snes9x is a portable, freeware Super Nintendo Entertainment System (SNES)
@@ -28,9 +28,9 @@ stdenv.mkDerivation rec {
       and Super Famicom Nintendo game systems on your PC or Workstation; which
       includes some real gems that were only ever released in Japan.
     '';
-    license = stdenv.lib.licenses.lgpl2;
-    maintainers = [ stdenv.lib.maintainers.qknight ];
+    license = licenses.lgpl2;
+    maintainers = with maintainers; [ qknight ];
     homepage = http://www.snes9x.com/;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fetch from GitHub repo, switch to Autoconf, throw away inputs not used in the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

