### PR TITLE
qt5, plasma-5: Make 'bin' output the first one

### DIFF
--- a/pkgs/applications/editors/kdevelop5/kdevelop.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop.nix
@@ -39,7 +39,7 @@ mkDerivation rec {
 
   postInstall = ''
     # The kdevelop! script (shell environment) needs qdbus and kioclient5 in PATH.
-    wrapProgram "$out/bin/kdevelop!" --prefix PATH ":" "${qttools}/bin:${kde-cli-tools}/bin"
+    wrapProgram "$out/bin/kdevelop!" --prefix PATH ":" "${lib.makeBinPath [ qttools kde-cli-tools ]}"
 
     # Fix the (now wrapped) kdevelop! to find things in right places:
     # - Make KDEV_BASEDIR point to bin directory of kdevplatform.

--- a/pkgs/applications/misc/xca/default.nix
+++ b/pkgs/applications/misc/xca/default.nix
@@ -20,12 +20,6 @@ mkDerivation rec {
 
   configureFlags = [ "CXXFLAGS=-std=c++11" ];
 
-  preBuild = ''
-    substituteInPlace Local.mak \
-      --replace ${qtbase}/bin/moc ${qtbase.dev}/bin/moc \
-      --replace ${qtbase}/bin/uic ${qtbase.dev}/bin/uic
-  '';
-
   meta = with lib; {
     description = "Interface for managing asymetric keys like RSA or DSA";
     homepage = http://xca.sourceforge.net/;

--- a/pkgs/desktops/plasma-5/breeze-qt5.nix
+++ b/pkgs/desktops/plasma-5/breeze-qt5.nix
@@ -15,6 +15,6 @@ mkDerivation {
     kguiaddons ki18n kwayland kwindowsystem plasma-framework qtdeclarative
     qtx11extras
   ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   cmakeFlags = [ "-DUSE_Qt4=OFF" ];
 }

--- a/pkgs/desktops/plasma-5/khotkeys.nix
+++ b/pkgs/desktops/plasma-5/khotkeys.nix
@@ -12,6 +12,6 @@ mkDerivation {
     kcmutils kdbusaddons kdelibs4support kglobalaccel ki18n kio kxmlgui
     plasma-framework plasma-workspace qtx11extras
   ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   enableParallelBuilding = false;
 }

--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -28,7 +28,7 @@ mkDerivation {
     kidletime kinit kio knewstuff knotifications kpackage kscreenlocker kservice
     kwayland kwidgetsaddons kwindowsystem kxmlgui plasma-framework
   ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
   NIX_CFLAGS_COMPILE = [
     ''-DNIXPKGS_XWAYLAND="${lib.getBin xwayland}/bin/Xwayland"''

--- a/pkgs/desktops/plasma-5/libksysguard/default.nix
+++ b/pkgs/desktops/plasma-5/libksysguard/default.nix
@@ -17,5 +17,5 @@ mkDerivation {
     kcoreaddons kservice kwidgetsaddons plasma-framework qtscript qtx11extras
     qtwebkit
   ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
 }

--- a/pkgs/desktops/plasma-5/oxygen.nix
+++ b/pkgs/desktops/plasma-5/oxygen.nix
@@ -14,5 +14,5 @@ mkDerivation {
     ki18n kservice kwayland kwidgetsaddons kwindowsystem qtdeclarative
     qtx11extras
   ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
 }

--- a/pkgs/desktops/plasma-5/plasma-workspace/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-workspace/default.nix
@@ -33,7 +33,7 @@ mkDerivation {
 
     qtgraphicaleffects qtquickcontrols qtquickcontrols2 qtscript qtwayland qtx11extras
   ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
 
   cmakeFlags = [
     "-DNIXPKGS_XMESSAGE=${getBin xmessage}/bin/xmessage"

--- a/pkgs/desktops/plasma-5/systemsettings.nix
+++ b/pkgs/desktops/plasma-5/systemsettings.nix
@@ -13,5 +13,5 @@ mkDerivation {
     kwindowsystem kxmlgui qtquickcontrols qtquickcontrols2
     kactivities kactivities-stats kirigami2
   ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
 }

--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -78,7 +78,7 @@ let
             inherit (args) name;
             inherit (srcs."${name}") src version;
 
-            outputs = args.outputs or [ "out" "dev" "bin" ];
+            outputs = args.outputs or [ "bin" "dev" "out" ];
             hasBin = lib.elem "bin" outputs;
             hasDev = lib.elem "dev" outputs;
 

--- a/pkgs/development/libraries/libplist/default.nix
+++ b/pkgs/development/libraries/libplist/default.nix
@@ -12,7 +12,7 @@ in stdenv.mkDerivation rec {
 
   passthru.swig = swig2;
 
-  outputs = ["out" "dev" "bin" "py"];
+  outputs = ["bin" "dev" "out" "py"];
 
   postFixup = ''
     moveToOutput "lib/${python.libPrefix}" "$py"

--- a/pkgs/development/libraries/qt-5/5.9/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtbase/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation {
     [ bison flex gperf lndir perl pkgconfig python2 which ]
     ++ lib.optional (!stdenv.isDarwin) patchelf;
 
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
 
   patches =
     copyPathsToStore (lib.readPathsFromFile ./. ./series)

--- a/pkgs/development/libraries/qt-5/5.9/qtcharts.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtcharts.nix
@@ -3,7 +3,7 @@
 qtSubmodule {
   name = "qtcharts";
   qtInputs = [ qtbase qtdeclarative ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   postInstall = ''
     moveToOutput "$qtQmlPrefix" "$bin"
   '';

--- a/pkgs/development/libraries/qt-5/5.9/qtconnectivity.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtconnectivity.nix
@@ -3,7 +3,7 @@
 qtSubmodule {
   name = "qtconnectivity";
   qtInputs = [ qtbase qtdeclarative ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   postInstall = ''
     moveToOutput "$qtQmlPrefix" "$bin"
   '';

--- a/pkgs/development/libraries/qt-5/5.9/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtdeclarative/default.nix
@@ -7,7 +7,7 @@ qtSubmodule {
   patches = copyPathsToStore (readPathsFromFile ./. ./series);
   qtInputs = [ qtbase qtsvg qtxmlpatterns ];
   nativeBuildInputs = [ python2 ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
 
   preConfigure = ''
     NIX_CFLAGS_COMPILE+=" -DNIXPKGS_QML2_IMPORT_PREFIX=\"$qtQmlPrefix\""

--- a/pkgs/development/libraries/qt-5/5.9/qtlocation.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtlocation.nix
@@ -3,7 +3,7 @@
 qtSubmodule {
   name = "qtlocation";
   qtInputs = [ qtbase qtmultimedia ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   postInstall = ''
     moveToOutput "$qtPluginPrefix" "$bin"
     moveToOutput "$qtQmlPrefix" "$bin"

--- a/pkgs/development/libraries/qt-5/5.9/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtmultimedia.nix
@@ -11,7 +11,7 @@ qtSubmodule {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ gstreamer gst-plugins-base libpulseaudio]
     ++ optional (stdenv.isLinux) alsaLib;
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   qmakeFlags = [ "GST_VERSION=1.0" ];
   NIX_LDFLAGS = optionalString (stdenv.isDarwin) "-lobjc";
   postInstall = ''

--- a/pkgs/development/libraries/qt-5/5.9/qtquickcontrols2.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtquickcontrols2.nix
@@ -3,7 +3,7 @@
 qtSubmodule {
   name = "qtquickcontrols2";
   qtInputs = [ qtdeclarative ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   postInstall = ''
     moveToOutput "$qtQmlPrefix" "$bin"
   '';

--- a/pkgs/development/libraries/qt-5/5.9/qtsensors.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtsensors.nix
@@ -5,7 +5,7 @@ with stdenv.lib;
 qtSubmodule {
   name = "qtsensors";
   qtInputs = [ qtbase qtdeclarative ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   postInstall = ''
     moveToOutput "$qtPluginPrefix" "$bin"
     moveToOutput "$qtQmlPrefix" "$bin"

--- a/pkgs/development/libraries/qt-5/5.9/qtsvg.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtsvg.nix
@@ -3,7 +3,7 @@
 qtSubmodule {
   name = "qtsvg";
   qtInputs = [ qtbase ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   postInstall = ''
     moveToOutput "$qtPluginPrefix" "$bin"
   '';

--- a/pkgs/development/libraries/qt-5/5.9/qttools/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qttools/default.nix
@@ -5,7 +5,7 @@ with stdenv.lib;
 qtSubmodule {
   name = "qttools";
   qtInputs = [ qtbase ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   patches = copyPathsToStore (readPathsFromFile ./. ./series);
   # qmake moves all binaries to $dev in preFixup
   postFixup = ''

--- a/pkgs/development/libraries/qt-5/5.9/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtwayland.nix
@@ -5,7 +5,7 @@ qtSubmodule {
   qtInputs = [ qtbase qtquickcontrols ];
   buildInputs = [ wayland ];
   nativeBuildInputs = [ pkgconfig ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   postInstall = ''
     moveToOutput "$qtPluginPrefix" "$bin"
     moveToOutput "$qtQmlPrefix" "$bin"

--- a/pkgs/development/libraries/qt-5/5.9/qtwebchannel.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtwebchannel.nix
@@ -3,7 +3,7 @@
 qtSubmodule {
   name = "qtwebchannel";
   qtInputs = [ qtbase qtdeclarative ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   postInstall = ''
     moveToOutput "$qtQmlPrefix" "$bin"
   '';

--- a/pkgs/development/libraries/qt-5/5.9/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtwebengine/default.nix
@@ -25,7 +25,7 @@ qtSubmodule {
     bison coreutils flex git gperf ninja pkgconfig python2 which
   ];
   doCheck = true;
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/qt-5/5.9/qtwebsockets.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtwebsockets.nix
@@ -3,7 +3,7 @@
 qtSubmodule {
   name = "qtwebsockets";
   qtInputs = [ qtbase qtdeclarative ];
-  outputs = [ "out" "dev" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   postInstall = ''
     moveToOutput "$qtQmlPrefix" "$bin"
   '';

--- a/pkgs/development/qtcreator/default.nix
+++ b/pkgs/development/qtcreator/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   installFlags = [ "INSTALL_ROOT=$(out)" ] ++ optional withDocumentation "install_docs";
 
   preBuild = optional withDocumentation ''
-    ln -s ${qtbase}/$qtDocPrefix $NIX_QT5_TMP/share
+    ln -s ${getLib qtbase}/$qtDocPrefix $NIX_QT5_TMP/share
   '';
 
   postInstall = ''

--- a/pkgs/games/qgo/default.nix
+++ b/pkgs/games/qgo/default.nix
@@ -43,6 +43,6 @@ stdenv.mkDerivation rec {
     # libQt5XcbQpa is a platform plugin dependency and doesn't get linked
     patchelf --add-needed libQt5XcbQpa.so.5 $out/bin/qgo
     wrapProgram $out/bin/qgo \
-      --set QT_QPA_PLATFORM_PLUGIN_PATH "${qt56.qtbase}/lib/qt-5.6/plugins/platforms/"
+      --set QT_QPA_PLATFORM_PLUGIN_PATH "${stdenv.lib.getBin qt56.qtbase}/lib/qt-5.6/plugins/platforms/"
   '';
 }


### PR DESCRIPTION
Stay consistent with other multiple output packages.

This was discussed previously at https://github.com/NixOS/nixpkgs/pull/28470#issuecomment-324688600 and AFAICT this simply does work. Full `nox-review` is still running overnight but `nixos/release.nix  -A tests.plasma5.x86_64-linux` passed.

According to 
````
git grep -E '(breeze-qt5|frameworkintegration|kapidox|baloo|bluez-qt|frameworkintegration|kactivities|kapidox|kcmutils|kconfig|kcoreaddons|kdbusaddons|kdeclarative|kdesignerplugin|kemoticons|kfilemetadata|kglobalaccel|khtml|ki18n|kiconthemes|kidletime|kinit|kio|kjobwidgets|kjsembed|kjs|kmediaplayer|knewstuff|knotifications|kpackage|kparts|kpeople|kross|krunner|kservice|ktexteditor|ktextwidgets|kwallet|kwayland|kxmlgui|plasma-framework|solid|sonnet|syntax-highlighting|kinit|kwin|libplist|baloo|kactivities|kcmutils|kdeclarative|kdesignerplugin|kemoticons|kfilemetadata|kglobalaccel|khotkeys|khtml|kiconthemes|kio|kjobwidgets|kjsembed|kjs|kmediaplayer|knewstuff|knotifications|kpackage|kparts|kpeople|kross|krunner|kservice|ktexteditor|ktextwidgets|kwallet|kxmlgui|libksysguard|plasma-framework|baloo|bluez-qt|kactivities|kcmutils|kconfig|kcoreaddons|kdbusaddons|kdeclarative|kdesignerplugin|kemoticons|kfilemetadata|kglobalaccel|khotkeys|khtml|ki18n|kiconthemes|kidletime|kio|kjobwidgets|kjsembed|kjs|kmediaplayer|knewstuff|knotifications|kpackage|kparts|kpeople|kross|krunner|kservice|ktexteditor|ktextwidgets|kwallet|kwayland|kxmlgui|libksysguard|plasma-framework|solid|sonnet|syntax-highlighting|baloo|bluez-qt|kactivities|kcmutils|kconfig|kcoreaddons|kdbusaddons|kdeclarative|kdesignerplugin|kemoticons|kfilemetadata|kglobalaccel|khotkeys|khtml|ki18n|kiconthemes|kidletime|kio|kjobwidgets|kjsembed|kjs|kmediaplayer|knewstuff|knotifications|kpackage|kparts|kpeople|kross|krunner|kservice|ktexteditor|ktextwidgets|kwallet|kwayland|kxmlgui|libksysguard|plasma-framework|solid|sonnet|syntax-highlighting|oxygen|breeze-qt5|khotkeys|kwin|libksysguard|oxygen|plasma-workspace|systemsettings|plasma-workspace|caffe|libplist|caffe|qtbase|qtcharts|qtconnectivity|qtdeclarative|qtlocation|qtmultimedia|qtquickcontrols2|qtsensors|qtsvg|qttools|qtwayland|qtwebchannel|qtwebengine|qtwebsockets|qtbase|qtcharts|qtconnectivity|qtdeclarative|qtlocation|qtmultimedia|qtquickcontrols2|qtsensors|qtsvg|qttools|qtwayland|qtwebchannel|qtwebengine|qtwebsockets|systemsettings)}'
````

all package references should be fixed as well (all using `getLib` and such).