### PR TITLE
cleanSource now filters cmake cache

### DIFF
--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -23,7 +23,11 @@ rec {
     lib.hasSuffix ".o" baseName ||
     lib.hasSuffix ".so" baseName ||
     # Filter out nix-build result symlinks
-    (type == "symlink" && lib.hasPrefix "result" baseName)
+    (type == "symlink" && lib.hasPrefix "result" baseName) ||
+
+    # Filter out cmakefile
+    (type == "regular" && baseName == "CMakeCache.txt") ||
+    (type == "directory" && baseName == "CMakeFiles")
   );
 
   cleanSource = builtins.filterSource cleanSourceFilter;


### PR DESCRIPTION


###### Motivation for this change
With my overlays, nix-shell keeps complaining about outdated cmake files see https://github.com/NixOS/nixpkgs/issues/29605

###### Things done
cleanSource now filters
- CMakeCache.txt
- CMakeFiles directory

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

