### PR TITLE
ghc: Add enableBootLibPIC option.

### DIFF
--- a/pkgs/development/compilers/ghc/6.10.4.nix
+++ b/pkgs/development/compilers/ghc/6.10.4.nix
@@ -1,4 +1,7 @@
-{stdenv, fetchurl, libedit, ghc, perl, gmp, ncurses}:
+{ stdenv, fetchurl, libedit, ghc, perl, gmp, ncurses
+  # Whether or not to build shipped libraries with position independent code.
+, enableBootLibPIC ? false
+}:
 
 stdenv.mkDerivation rec {
   version = "6.10.4";
@@ -13,6 +16,48 @@ stdenv.mkDerivation rec {
   buildInputs = [ghc libedit perl gmp];
 
   hardeningDisable = [ "format" ];
+
+  picConfigString = ''
+    GhcRtsHcOpts += -fPIC
+    libraries/array_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/base_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/binary_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/bytestring_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/Cabal_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/containers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/deepseq_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/directory_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/dph_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/filepath_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot-th_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-compact_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-prim_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/haskeline_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/hpc_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/mtl_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parallel_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parsec_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/pretty_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/primitive_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/process_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/random_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/stm_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/template-haskell_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/terminfo_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/text_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/time_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/transformers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/unix_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/vector_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/xhtml_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
+  '';
+
+  preConfigure = stdenv.lib.optionalString enableBootLibPIC ''
+    echo ${picConfigString} >> mk/build.mk
+  '';
 
   configureFlags = [
     "--with-gmp-libraries=${gmp.out}/lib"

--- a/pkgs/development/compilers/ghc/6.12.3.nix
+++ b/pkgs/development/compilers/ghc/6.12.3.nix
@@ -1,4 +1,7 @@
-{stdenv, fetchurl, ghc, perl, gmp, ncurses}:
+{ stdenv, fetchurl, ghc, perl, gmp, ncurses
+  # Whether or not to build shipped libraries with position independent code.
+, enableBootLibPIC ? false
+}:
 
 stdenv.mkDerivation rec {
   version = "6.12.3";
@@ -17,6 +20,44 @@ stdenv.mkDerivation rec {
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
+  '' + stdenv.lib.optionalString enableBootLibPIC picConfigString;
+
+  picConfigString = ''
+    GhcRtsHcOpts += -fPIC
+    libraries/array_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/base_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/binary_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/bytestring_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/Cabal_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/containers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/deepseq_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/directory_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/dph_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/filepath_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot-th_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-compact_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-prim_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/haskeline_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/hpc_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/mtl_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parallel_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parsec_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/pretty_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/primitive_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/process_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/random_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/stm_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/template-haskell_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/terminfo_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/text_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/time_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/transformers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/unix_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/vector_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/xhtml_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
   '';
 
   preConfigure = ''

--- a/pkgs/development/compilers/ghc/7.0.4.nix
+++ b/pkgs/development/compilers/ghc/7.0.4.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, ghc, perl, gmp, ncurses, libiconv }:
+{ stdenv, fetchurl, ghc, perl, gmp, ncurses, libiconv
+  # Whether or not to build shipped libraries with position independent code.
+, enableBootLibPIC ? false
+}:
 
 stdenv.mkDerivation rec {
   version = "7.0.4";
@@ -13,6 +16,44 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ghc perl gmp ncurses ];
 
+  picConfigString = ''
+    GhcRtsHcOpts += -fPIC
+    libraries/array_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/base_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/binary_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/bytestring_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/Cabal_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/containers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/deepseq_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/directory_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/dph_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/filepath_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot-th_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-compact_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-prim_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/haskeline_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/hpc_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/mtl_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parallel_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parsec_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/pretty_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/primitive_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/process_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/random_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/stm_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/template-haskell_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/terminfo_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/text_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/time_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/transformers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/unix_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/vector_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/xhtml_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
+  '';
+
   buildMK = ''
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
@@ -22,7 +63,7 @@ stdenv.mkDerivation rec {
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-includes="${libiconv}/include"
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"
     ''}
-  '';
+  '' + stdenv.lib.optionalString enableBootLibPIC picConfigString;
 
   preConfigure = ''
     echo "${buildMK}" > mk/build.mk

--- a/pkgs/development/compilers/ghc/7.10.2.nix
+++ b/pkgs/development/compilers/ghc/7.10.2.nix
@@ -4,10 +4,52 @@
   # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
 , enableIntegerSimple ? false, gmp
+  # Whether or not to build shipped libraries with position independent code.
+, enableBootLibPIC ? false
 }:
 
 let
   inherit (bootPkgs) ghc;
+
+  picConfigString = ''
+    GhcRtsHcOpts += -fPIC
+    libraries/array_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/base_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/binary_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/bytestring_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/Cabal_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/containers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/deepseq_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/directory_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/dph_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/filepath_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot-th_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-compact_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-prim_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/haskeline_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/hpc_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/mtl_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parallel_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parsec_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/pretty_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/primitive_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/process_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/random_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/stm_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/template-haskell_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/terminfo_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/text_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/time_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/transformers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/unix_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/vector_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/xhtml_dist-install_EXTRA_HC_OPTS += -fPIC
+  '' + ( if enableIntegerSimple
+         then "libraries/integer-simple_dist-install_EXTRA_HC_OPTS += -fPIC"
+         else "libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC"
+       );
 
   buildMK = ''
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
@@ -21,7 +63,7 @@ let
   '' else ''
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
-  '');
+  '') + stdenv.lib.optionalString enableBootLibPIC picConfigString;
 
 in
 

--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -4,6 +4,8 @@
   # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
 , enableIntegerSimple ? false, gmp
+  # Whether or not to build shipped libraries with position independent code.
+, enableBootLibPIC ? false
 }:
 
 let
@@ -44,7 +46,49 @@ stdenv.mkDerivation rec {
     export NIX_LDFLAGS+=" -no_dtrace_dof"
   '' + stdenv.lib.optionalString enableIntegerSimple ''
     echo "INTEGER_LIBRARY=integer-simple" > mk/build.mk
+  '' + stdenv.lib.optionalString  enableBootLibPIC ''
+      echo "${picConfigString}" >> mk/build.mk
   '';
+
+  picConfigString = ''
+    GhcRtsHcOpts += -fPIC
+    libraries/array_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/base_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/binary_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/bytestring_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/Cabal_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/containers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/deepseq_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/directory_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/dph_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/filepath_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot-th_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-compact_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-prim_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/haskeline_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/hpc_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/mtl_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parallel_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parsec_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/pretty_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/primitive_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/process_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/random_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/stm_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/template-haskell_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/terminfo_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/text_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/time_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/transformers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/unix_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/vector_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/xhtml_dist-install_EXTRA_HC_OPTS += -fPIC
+  '' + ( if enableIntegerSimple
+         then "libraries/integer-simple_dist-install_EXTRA_HC_OPTS += -fPIC"
+         else "libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC"
+       );
 
   configureFlags = [
     "--with-gcc=${stdenv.cc}/bin/cc"

--- a/pkgs/development/compilers/ghc/7.2.2.nix
+++ b/pkgs/development/compilers/ghc/7.2.2.nix
@@ -3,6 +3,8 @@
   # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
 , enableIntegerSimple ? false, gmp
+  # Whether or not to build shipped libraries with position independent code.
+, enableBootLibPIC ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -31,7 +33,47 @@ stdenv.mkDerivation rec {
   '' else ''
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
-  '');
+  '') + stdenv.lib.optionalString enableBootLibPIC picConfigString;
+
+  picConfigString = ''
+    GhcRtsHcOpts += -fPIC
+    libraries/array_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/base_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/binary_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/bytestring_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/Cabal_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/containers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/deepseq_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/directory_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/dph_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/filepath_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot-th_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-compact_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-prim_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/haskeline_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/hpc_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/mtl_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parallel_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parsec_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/pretty_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/primitive_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/process_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/random_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/stm_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/template-haskell_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/terminfo_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/text_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/time_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/transformers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/unix_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/vector_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/xhtml_dist-install_EXTRA_HC_OPTS += -fPIC
+  '' + ( if enableIntegerSimple
+         then "libraries/integer-simple_dist-install_EXTRA_HC_OPTS += -fPIC"
+         else "libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC"
+       );
 
   preConfigure = ''
     echo "${buildMK}" > mk/build.mk

--- a/pkgs/development/compilers/ghc/7.4.2.nix
+++ b/pkgs/development/compilers/ghc/7.4.2.nix
@@ -3,6 +3,8 @@
   # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
 , enableIntegerSimple ? false, gmp
+  # Whether or not to build shipped libraries with position independent code.
+, enableBootLibPIC ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -32,7 +34,47 @@ stdenv.mkDerivation rec {
   '' else ''
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
-  '');
+  '') + stdenv.lib.optionalString enableBootLibPIC picConfigString;
+
+  picConfigString = ''
+    GhcRtsHcOpts += -fPIC
+    libraries/array_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/base_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/binary_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/bytestring_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/Cabal_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/containers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/deepseq_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/directory_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/dph_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/filepath_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot-th_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-compact_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-prim_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/haskeline_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/hpc_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/mtl_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parallel_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parsec_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/pretty_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/primitive_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/process_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/random_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/stm_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/template-haskell_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/terminfo_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/text_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/time_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/transformers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/unix_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/vector_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/xhtml_dist-install_EXTRA_HC_OPTS += -fPIC
+  '' + ( if enableIntegerSimple
+         then "libraries/integer-simple_dist-install_EXTRA_HC_OPTS += -fPIC"
+         else "libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC"
+       );
 
   preConfigure = ''
     echo "${buildMK}" > mk/build.mk

--- a/pkgs/development/compilers/ghc/7.6.3.nix
+++ b/pkgs/development/compilers/ghc/7.6.3.nix
@@ -3,6 +3,8 @@
   # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
 , enableIntegerSimple ? false, gmp
+  # Whether or not to build shipped libraries with position independent code.
+, enableBootLibPIC ? false
 }:
 
 let
@@ -43,7 +45,47 @@ in stdenv.mkDerivation rec {
   '' else ''
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
-  '');
+  '') + stdenv.lib.optionalString enableBootLibPIC picConfigString;
+
+  picConfigString = ''
+    GhcRtsHcOpts += -fPIC
+    libraries/array_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/base_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/binary_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/bytestring_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/Cabal_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/containers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/deepseq_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/directory_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/dph_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/filepath_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot-th_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-compact_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-prim_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/haskeline_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/hpc_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/mtl_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parallel_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parsec_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/pretty_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/primitive_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/process_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/random_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/stm_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/template-haskell_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/terminfo_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/text_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/time_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/transformers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/unix_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/vector_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/xhtml_dist-install_EXTRA_HC_OPTS += -fPIC
+  '' + ( if enableIntegerSimple
+         then "libraries/integer-simple_dist-install_EXTRA_HC_OPTS += -fPIC"
+         else "libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC"
+       );
 
   preConfigure = ''
     echo "${buildMK}" > mk/build.mk

--- a/pkgs/development/compilers/ghc/7.8.3.nix
+++ b/pkgs/development/compilers/ghc/7.8.3.nix
@@ -3,6 +3,8 @@
   # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
 , enableIntegerSimple ? false, gmp
+  # Whether or not to build shipped libraries with position independent code.
+, enableBootLibPIC ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -34,7 +36,47 @@ stdenv.mkDerivation rec {
   '' else ''
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
-  '');
+  '') + stdenv.lib.optionalString enableBootLibPIC picConfigString;
+
+  picConfigString = ''
+    GhcRtsHcOpts += -fPIC
+    libraries/array_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/base_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/binary_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/bytestring_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/Cabal_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/containers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/deepseq_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/directory_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/dph_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/filepath_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot-th_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-compact_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-prim_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/haskeline_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/hpc_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/mtl_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parallel_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parsec_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/pretty_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/primitive_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/process_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/random_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/stm_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/template-haskell_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/terminfo_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/text_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/time_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/transformers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/unix_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/vector_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/xhtml_dist-install_EXTRA_HC_OPTS += -fPIC
+  '' + ( if enableIntegerSimple
+         then "libraries/integer-simple_dist-install_EXTRA_HC_OPTS += -fPIC"
+         else "libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC"
+       );
 
   preConfigure = ''
     echo "${buildMK}" > mk/build.mk

--- a/pkgs/development/compilers/ghc/7.8.4.nix
+++ b/pkgs/development/compilers/ghc/7.8.4.nix
@@ -3,6 +3,8 @@
   # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
 , enableIntegerSimple ? false, gmp
+  # Whether or not to build shipped libraries with position independent code.
+, enableBootLibPIC ? false
 }:
 
 stdenv.mkDerivation (rec {
@@ -34,7 +36,47 @@ stdenv.mkDerivation (rec {
   '' else ''
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
-  '');
+  '') + stdenv.lib.optionalString enableBootLibPIC picConfigString;
+
+  picConfigString = ''
+    GhcRtsHcOpts += -fPIC
+    libraries/array_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/base_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/binary_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/bytestring_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/Cabal_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/containers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/deepseq_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/directory_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/dph_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/filepath_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot-th_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-compact_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-prim_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/haskeline_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/hpc_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/mtl_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parallel_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parsec_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/pretty_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/primitive_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/process_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/random_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/stm_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/template-haskell_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/terminfo_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/text_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/time_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/transformers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/unix_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/vector_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/xhtml_dist-install_EXTRA_HC_OPTS += -fPIC
+  '' + ( if enableIntegerSimple
+         then "libraries/integer-simple_dist-install_EXTRA_HC_OPTS += -fPIC"
+         else "libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC"
+       );
 
   preConfigure = ''
     echo "${buildMK}" > mk/build.mk

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -5,6 +5,8 @@
   # library instead of the faster but GPLed integer-gmp library.
 , enableIntegerSimple ? false, gmp
 , cross ? null
+  # Whether or not to build shipped libraries with position independent code.
+, enableBootLibPIC ? false
 }:
 
 let
@@ -37,7 +39,49 @@ stdenv.mkDerivation rec {
     export NIX_LDFLAGS+=" -no_dtrace_dof"
   '' + stdenv.lib.optionalString enableIntegerSimple ''
     echo "INTEGER_LIBRARY=integer-simple" > mk/build.mk
+  '' + stdenv.lib.optionalString  enableBootLibPIC ''
+      echo "${picConfigString}" >> mk/build.mk
   '';
+
+  picConfigString = ''
+    GhcRtsHcOpts += -fPIC
+    libraries/array_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/base_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/binary_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/bytestring_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/Cabal_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/containers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/deepseq_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/directory_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/dph_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/filepath_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot-th_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-compact_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-prim_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/haskeline_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/hpc_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/mtl_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parallel_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parsec_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/pretty_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/primitive_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/process_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/random_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/stm_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/template-haskell_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/terminfo_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/text_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/time_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/transformers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/unix_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/vector_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/xhtml_dist-install_EXTRA_HC_OPTS += -fPIC
+  '' + ( if enableIntegerSimple
+         then "libraries/integer-simple_dist-install_EXTRA_HC_OPTS += -fPIC"
+         else "libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC"
+       );
 
   configureFlags = [
     "--with-gcc=${stdenv.cc}/bin/cc"

--- a/pkgs/development/compilers/ghc/8.2.1.nix
+++ b/pkgs/development/compilers/ghc/8.2.1.nix
@@ -5,11 +5,53 @@
   # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
 , enableIntegerSimple ? false, gmp
+  # Whether or not to build shipped libraries with position independent code.
+, enableBootLibPIC ? false
 }:
 
 let
   inherit (bootPkgs) ghc;
   version = "8.2.1";
+
+  picConfigString = ''
+    GhcRtsHcOpts += -fPIC
+    libraries/array_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/base_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/binary_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/bytestring_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/Cabal_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/containers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/deepseq_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/directory_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/dph_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/filepath_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot-th_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-compact_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-prim_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/haskeline_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/hpc_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/mtl_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parallel_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parsec_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/pretty_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/primitive_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/process_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/random_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/stm_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/template-haskell_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/terminfo_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/text_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/time_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/transformers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/unix_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/vector_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/xhtml_dist-install_EXTRA_HC_OPTS += -fPIC
+  '' + ( if enableIntegerSimple
+         then "libraries/integer-simple_dist-install_EXTRA_HC_OPTS += -fPIC"
+         else "libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC"
+       );
 
   commonBuildInputs = [ alex autoconf automake ghc happy hscolour perl python3 sphinx ];
   commonPreConfigure =  ''
@@ -20,6 +62,8 @@ let
     export NIX_LDFLAGS+=" -no_dtrace_dof"
   '' + stdenv.lib.optionalString enableIntegerSimple ''
     echo "INTEGER_LIBRARY=integer-simple" > mk/build.mk
+  '' + stdenv.lib.optionalString  enableBootLibPIC ''
+      echo "${picConfigString}" >> mk/build.mk
   '';
 in stdenv.mkDerivation (rec {
   inherit version;

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -5,6 +5,8 @@
   # If enabled GHC will be build with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
 , enableIntegerSimple ? false, gmp
+  # Whether or not to build shipped libraries with position independent code.
+, enableBootLibPIC ? false
 , version ? "8.3.20170808"
 }:
 
@@ -14,6 +16,46 @@ let
   commonBuildInputs = [ ghc perl autoconf automake happy alex python3 ];
 
   rev = "14457cf6a50f708eecece8f286f08687791d51f7";
+
+  picConfigString = ''
+    GhcRtsHcOpts += -fPIC
+    libraries/array_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/base_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/binary_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/bytestring_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/Cabal_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/containers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/deepseq_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/directory_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/dph_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/filepath_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-boot-th_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-compact_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/ghc-prim_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/haskeline_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/hpc_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/mtl_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parallel_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/parsec_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/pretty_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/primitive_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/process_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/random_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/stm_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/template-haskell_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/terminfo_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/text_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/time_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/transformers_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/unix_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/vector_dist-install_EXTRA_HC_OPTS += -fPIC
+    libraries/xhtml_dist-install_EXTRA_HC_OPTS += -fPIC
+  '' + ( if enableIntegerSimple
+         then "libraries/integer-simple_dist-install_EXTRA_HC_OPTS += -fPIC"
+         else "libraries/integer-gmp_dist-install_EXTRA_HC_OPTS += -fPIC"
+       );
 
   commonPreConfigure =  ''
     echo ${version} >VERSION
@@ -26,7 +68,10 @@ let
     export NIX_LDFLAGS+=" -no_dtrace_dof"
   '' + stdenv.lib.optionalString enableIntegerSimple ''
     echo "INTEGER_LIBRARY=integer-simple" > mk/build.mk
+  '' + stdenv.lib.optionalString  enableBootLibPIC ''
+      echo "${picConfigString}" >> mk/build.mk
   '';
+
 in stdenv.mkDerivation (rec {
   inherit version rev;
   name = "ghc-${version}";


### PR DESCRIPTION
###### Motivation for this change
This adds an option called `enableBootLibPIC` to the non-binary GHC derivations. This option simply builds the GHC boot libraries with `-fPIC`. Providing position-independent boot libraries allows one to easily build Haskell code into shared objects that are statically linked against all Haskell dependencies, including the RTS. This is not possible with the default GHC build. This is principally desirable when providing Haskell libraries that are meant to be called from foreign code, since the calling code's linking process doesn't have to know anything about GHC at all.

This may be a rather niche use case, although it would be nice to add GHCs with this option set true to the binary cache.

###### Things done

- [ pending ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ pending ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

