### PR TITLE
trezor-agent: add systemd service

### DIFF
--- a/nixos/modules/programs/gnupg.nix
+++ b/nixos/modules/programs/gnupg.nix
@@ -52,6 +52,27 @@ in
         Enables GnuPG network certificate management daemon with socket-activation for every user session.
       '';
     };
+
+    trezor-agent.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable the Trezor GnuPG agent service, which allows you to use your
+        Trezor as a GnuPG agent for signing and decrypting.
+      '';
+    };
+
+    trezor-agent.configPath = mkOption {
+      type = types.string;
+      default = "/var/empty";
+      example = "/home/alice/.gnupg/trezor";
+      description = ''
+        The GNUPGHOME path for your Trezor GnuPG config. See
+        https://github.com/romanz/trezor-agent/blob/master/README-GPG.md on how
+        to set this up.
+      '';
+    };
+
   };
 
   config = mkIf cfg.agent.enable {
@@ -96,6 +117,19 @@ in
         message = "You can't use ssh-agent and GnuPG agent with SSH support enabled at the same time!";
       }
     ];
-  };
+  } // (mkIf cfg.trezor-agent.enable  {
+    systemd.user.services.trezor-agent = {
+      description = "Trezor GnuPG Agent";
+
+      wantedBy = [ "default.target" ];
+      path = [ pkgs.gnupg ];
+
+      environment = {
+        GNUPGHOME=cfg.trezor-agent.configPath;
+      };
+
+      serviceConfig.ExecStart = "${pkgs.python27Packages.trezor_agent}/bin/trezor-gpg-agent";
+    };
+  });
 
 }

--- a/pkgs/development/python-modules/libagent/default.nix
+++ b/pkgs/development/python-modules/libagent/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchPypi, buildPythonPackage, ed25519, ecdsa
-, semver, keepkey, trezor, mnemonic, ledgerblue
+, semver, keepkey, trezor, mnemonic, ledgerblue, unidecode
 }:
 
 buildPythonPackage rec {
@@ -9,12 +9,12 @@ buildPythonPackage rec {
 
   src = fetchPypi{
     inherit pname version;
-    sha256 = "d6c6dccc0a7693fc966f5962604a69a800e044ac5add3dd030c34cfd4d64311f";
+    sha256 = "07rici6zsk636383vpasmi2f0058d5560qjrdybgr4vn1b6drinn";
   };
 
   buildInputs = [
     ed25519 ecdsa semver keepkey
-    trezor mnemonic ledgerblue
+    trezor mnemonic ledgerblue unidecode
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25802,16 +25802,18 @@ EOF
   trezor_agent = buildPythonPackage rec{
     name = "${pname}-${version}";
     pname = "trezor_agent";
-    version = "0.9.0";
+    version = "0.9.2";
 
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "1i5cdamlf3c0ym600pjklij74p8ifj9cv7xrpnrfl1b8nkadswbz";
-    };
+    src = "${pkgs.fetchFromGitHub {
+      repo = "trezor-agent";
+      owner = "romanz";
+      rev = "v${version}";
+      sha256 = "1wrmf76016ksx394l1xknnqn08sc5pid5ihri619cd83zsxpkfvk";
+    }}/agents/trezor";
 
     propagatedBuildInputs = with self; [
       trezor libagent ecdsa ed25519
-      mnemonic keepkey semver
+      mnemonic semver unidecode
     ];
 
     meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25813,8 +25813,14 @@ EOF
 
     propagatedBuildInputs = with self; [
       trezor libagent ecdsa ed25519
-      mnemonic semver unidecode
+      mnemonic semver unidecode pyqt5
     ];
+
+    postFixup = ''
+      # fix for qt pinentry in non-tty environments such as systemd services
+      wrapProgram $out/bin/trezor-gpg-agent \
+        --set QT_QPA_PLATFORM_PLUGIN_PATH "${pkgs.qt59.qtbase.bin}/lib/qt-5.9/plugins/platforms/"
+    '';
 
     meta = {
       description = "Using Trezor as hardware SSH agent";


### PR DESCRIPTION
###### Motivation for this change

Option to enable a [trezor-agent](https://github.com/romanz/trezor-agent) service that allows you to use your Trezor as a GnuPG agent. This builds upon #28656.

Closes #28656 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

