### PR TITLE
bower2nix: 3.1.1 -> 3.2.0

### DIFF
--- a/pkgs/development/node-packages/node-packages-v6.nix
+++ b/pkgs/development/node-packages/node-packages-v6.nix
@@ -23701,10 +23701,10 @@ in
   bower2nix = nodeEnv.buildNodePackage {
     name = "bower2nix";
     packageName = "bower2nix";
-    version = "3.1.1";
+    version = "3.2.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.1.1.tgz";
-      sha1 = "77cc8f966a3595686f5d6fae30ad9bd2cc20bfe3";
+      url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.2.0.tgz";
+      sha1 = "nlzr17lidjf72s60vcsnqpjxgnnsn32s";
     };
     dependencies = [
       sources."argparse-1.0.4"

--- a/pkgs/top-level/node-packages-generated.nix
+++ b/pkgs/top-level/node-packages-generated.nix
@@ -5381,15 +5381,15 @@
     cpu = [ ];
   };
   by-spec."bower2nix"."*" =
-    self.by-version."bower2nix"."3.1.1";
-  by-version."bower2nix"."3.1.1" = self.buildNodePackage {
-    name = "bower2nix-3.1.1";
-    version = "3.1.1";
+    self.by-version."bower2nix"."3.2.0";
+  by-version."bower2nix"."3.2.0" = self.buildNodePackage {
+    name = "bower2nix-3.2.0";
+    version = "3.2.0";
     bin = true;
     src = fetchurl {
-      url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.1.1.tgz";
-      name = "bower2nix-3.1.1.tgz";
-      sha1 = "wfzj1k6jkfnk1bkgbmpni59mdab8zk3p";
+      url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.2.0.tgz";
+      name = "bower2nix-3.2.0.tgz";
+      sha1 = "nlzr17lidjf72s60vcsnqpjxgnnsn32s";
     };
     deps = {
       "argparse-1.0.4" = self.by-version."argparse"."1.0.4";
@@ -5410,7 +5410,7 @@
     os = [ ];
     cpu = [ ];
   };
-  "bower2nix" = self.by-version."bower2nix"."3.0.1";
+  "bower2nix" = self.by-version."bower2nix"."3.2.0";
   by-spec."bplist-creator"."0.0.4" =
     self.by-version."bplist-creator"."0.0.4";
   by-version."bplist-creator"."0.0.4" = self.buildNodePackage {


### PR DESCRIPTION
###### Motivation for this change

New bug fix release.

/cc @peterhoeg -- if you regen `uchiwa/bower-packages.nix` with this version it will work.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [/] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
