### PR TITLE
lxqt.screengrab: 2017-02-18 -> 1.97

### DIFF
--- a/pkgs/desktops/lxqt/optional/screengrab/default.nix
+++ b/pkgs/desktops/lxqt/optional/screengrab/default.nix
@@ -1,13 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, qtbase, qttools, qtx11extras, qtsvg, kwindowsystem, libqtxdg, xorg }:
 
 stdenv.mkDerivation rec {
-  name = "screengrab-unstable-2017-02-18";
+  name = "screengrab-${version}";
+  version = "1.97";
 
   srcs = fetchFromGitHub {
     owner = "QtDesktop";
     repo = "screengrab";
-    rev = "6fc03c70fe132b89f35d4cef2f62c9d804de3b64";
-    sha256 = "1h3rlpmaqxzysaibcw7s5msbrwaxkg6sz7a8xv6cqzjvggv09my0";
+    rev = version;
+    sha256 = "0qhdxnv1pz745qgvdv5x7kyfx9dz9rrq0wxyfimppzxcszv4pl2z";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Update to version 1.97

[Release](https://github.com/QtDesktop/screengrab/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).