### PR TITLE
guile-gnome: fix build by building gwrap with guile-2.0

### DIFF
--- a/pkgs/development/guile-modules/guile-gnome/default.nix
+++ b/pkgs/development/guile-modules/guile-gnome/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, guile, guile-lib, gwrap
 , pkgconfig, gconf, glib, gnome_vfs, gtk2
 , libglade, libgnome, libgnomecanvas, libgnomeui
-, pango, guile-cairo, autoconf, automake, texinfo
+, pango, guile-cairo, texinfo
 }:
 
 stdenv.mkDerivation rec {
@@ -10,19 +10,19 @@ stdenv.mkDerivation rec {
   version = "2.16.4";
 
   src = fetchurl {
-    url = "http://ftp.gnu.org/pub/gnu/guile-gnome/${pname}/${name}.tar.gz";
+    url = "mirror://gnu/guile-gnome/${pname}/${name}.tar.gz";
     sha256 = "adabd48ed5993d8528fd604e0aa0d96ad81a61d06da6cdd68323572ad6c216c3";
   };
 
   buildInputs = [
-    autoconf automake texinfo guile gwrap pkgconfig gconf glib gnome_vfs gtk2
+    texinfo guile gwrap pkgconfig gconf glib gnome_vfs gtk2
     libglade libgnome libgnomecanvas libgnomeui pango guile-cairo
   ] ++ stdenv.lib.optional doCheck guile-lib;
 
-  preConfigure = "./autogen.sh";
-
   # The test suite tries to open an X display, which fails.
   doCheck = false;
+
+  GUILE_AUTO_COMPILE = 0;
 
   meta = with stdenv.lib; {
     description = "GNOME bindings for GNU Guile";

--- a/pkgs/development/guile-modules/guile-gnome/default.nix
+++ b/pkgs/development/guile-modules/guile-gnome/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
     license = licenses.gpl2Plus;
 
-    maintainers = with maintainers; [ taktoa amiloradovsky ];
+    maintainers = with maintainers; [ vyp ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/development/guile-modules/guile-gnome/default.nix
+++ b/pkgs/development/guile-modules/guile-gnome/default.nix
@@ -1,58 +1,41 @@
 { fetchurl, stdenv, guile, guile-lib, gwrap
 , pkgconfig, gconf, glib, gnome_vfs, gtk2
 , libglade, libgnome, libgnomecanvas, libgnomeui
-, pango, guile-cairo, autoconf, automake, texinfo }:
+, pango, guile-cairo, autoconf, automake, texinfo
+}:
 
 stdenv.mkDerivation rec {
-  name = "guile-gnome-platform-2.16.4";
+  name = "${pname}-${version}";
+  pname = "guile-gnome-platform";
+  version = "2.16.4";
 
   src = fetchurl {
-    url = "http://ftp.gnu.org/pub/gnu/guile-gnome/guile-gnome-platform/${name}.tar.gz";
+    url = "http://ftp.gnu.org/pub/gnu/guile-gnome/${pname}/${name}.tar.gz";
     sha256 = "adabd48ed5993d8528fd604e0aa0d96ad81a61d06da6cdd68323572ad6c216c3";
   };
 
   buildInputs = [
-    autoconf
-    automake
-    texinfo
-    guile
-    gwrap
-    pkgconfig
-    gconf
-    glib
-    gnome_vfs
-    gtk2
-    libglade
-    libgnome
-    libgnomecanvas
-    libgnomeui
-    pango
-    guile-cairo
+    autoconf automake texinfo guile gwrap pkgconfig gconf glib gnome_vfs gtk2
+    libglade libgnome libgnomecanvas libgnomeui pango guile-cairo
   ] ++ stdenv.lib.optional doCheck guile-lib;
 
-  preConfigure = ''
-      ./autogen.sh
-  '';
+  preConfigure = "./autogen.sh";
 
   # The test suite tries to open an X display, which fails.
   doCheck = false;
 
   meta = with stdenv.lib; {
     description = "GNOME bindings for GNU Guile";
-
-    longDescription =
-      '' GNU guile-gnome brings the power of Scheme to your graphical
-         application.  guile-gnome modules support the entire Gnome library
-         stack: from Pango to GnomeCanvas, Gtk+ to GStreamer, Glade to
-         GtkSourceView, you will find in guile-gnome a comprehensive
-         environment for developing modern applications.
-      '';
-
-    homepage = http://www.gnu.org/software/guile-gnome/;
-
+    longDescription = ''
+      GNU guile-gnome brings the power of Scheme to your graphical application.
+      guile-gnome modules support the entire Gnome library stack: from Pango to
+      GnomeCanvas, Gtk+ to GStreamer, Glade to GtkSourceView, you will find in
+      guile-gnome a comprehensive environment for developing modern
+      applications.
+    '';
+    homepage = "http://www.gnu.org/software/guile-gnome/";
     license = licenses.gpl2Plus;
-
     maintainers = with maintainers; [ vyp ];
-    platforms = with platforms; linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/tools/guile/g-wrap/default.nix
+++ b/pkgs/development/tools/guile/g-wrap/default.nix
@@ -1,11 +1,9 @@
 { fetchurl, stdenv, guile, guile-lib, libffi, pkgconfig, glib }:
 
-let
+stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "g-wrap";
   version = "1.9.15";
-in stdenv.mkDerivation {
-  inherit name;
 
   src = fetchurl {
     url = "mirror://savannah/${pname}/${name}.tar.gz";

--- a/pkgs/development/tools/guile/g-wrap/default.nix
+++ b/pkgs/development/tools/guile/g-wrap/default.nix
@@ -29,7 +29,7 @@ in stdenv.mkDerivation {
     '';
     homepage = "http://www.nongnu.org/g-wrap/";
     license = licenses.lgpl2Plus;
-    maintainers = with maintainers; [ taktoa ];
+    maintainers = with maintainers; [ vyp ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/tools/guile/g-wrap/default.nix
+++ b/pkgs/development/tools/guile/g-wrap/default.nix
@@ -1,30 +1,35 @@
-{ fetchurl, stdenv, guile, libffi, pkgconfig, glib, guile-lib }:
+{ fetchurl, stdenv, guile, guile-lib, libffi, pkgconfig, glib }:
 
-stdenv.mkDerivation rec {
-  name = "g-wrap-1.9.15";
+let
+  name = "${pname}-${version}";
+  pname = "g-wrap";
+  version = "1.9.15";
+in stdenv.mkDerivation {
+  inherit name;
+
   src = fetchurl {
-    url = "mirror://savannah/g-wrap/${name}.tar.gz";
+    url = "mirror://savannah/${pname}/${name}.tar.gz";
     sha256 = "0ak0bha37dfpj9kmyw1r8fj8nva639aw5xr66wr5gd3l1rqf5xhg";
   };
 
-  # Note: Glib support is optional, but it's quite useful (e.g., it's
-  # used by Guile-GNOME).
+  # Note: Glib support is optional, but it's quite useful (e.g., it's used by
+  # Guile-GNOME).
   buildInputs = [ guile pkgconfig glib guile-lib ];
 
   propagatedBuildInputs = [ libffi ];
 
   doCheck = true;
 
-  meta = {
-    description = "G-Wrap, a wrapper generator for Guile";
+  meta = with stdenv.lib; {
+    description = "A wrapper generator for Guile";
     longDescription = ''
-      G-Wrap is a tool (and Guile library) for generating function
-      wrappers for inter-language calls.  It currently only supports
-      generating Guile wrappers for C functions.
+      G-Wrap is a tool (and Guile library) for generating function wrappers for
+      inter-language calls.  It currently only supports generating Guile
+      wrappers for C functions.
     '';
-    homepage = http://www.nongnu.org/g-wrap/;
-    license = stdenv.lib.licenses.lgpl2Plus;
-    maintainers = [ stdenv.lib.maintainers.taktoa ];
-    platforms = stdenv.lib.platforms.linux;
+    homepage = "http://www.nongnu.org/g-wrap/";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ taktoa ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6712,16 +6712,21 @@ with pkgs;
 
   jython = callPackage ../development/interpreters/jython {};
 
-  guile-cairo = callPackage ../development/guile-modules/guile-cairo { };
+  guile-cairo = callPackage ../development/guile-modules/guile-cairo {
+    guile = guile_2_0;
+  };
 
   guile-fibers = callPackage ../development/guile-modules/guile-fibers { };
 
   guile-gnome = callPackage ../development/guile-modules/guile-gnome {
     gconf = gnome2.GConf;
+    guile = guile_2_0;
     inherit (gnome2) gnome_vfs libglade libgnome libgnomecanvas libgnomeui;
   };
 
-  guile-lib = callPackage ../development/guile-modules/guile-lib { };
+  guile-lib = callPackage ../development/guile-modules/guile-lib {
+    guile = guile_2_0;
+  };
 
   guile-ncurses = callPackage ../development/guile-modules/guile-ncurses { };
 
@@ -7169,7 +7174,9 @@ with pkgs;
 
   guileLint = callPackage ../development/tools/guile/guile-lint { };
 
-  gwrap = callPackage ../development/tools/guile/g-wrap { };
+  gwrap = callPackage ../development/tools/guile/g-wrap {
+    guile = guile_2_0;
+  };
 
   help2man = callPackage ../development/tools/misc/help2man {
     inherit (perlPackages) LocaleGettext;


### PR DESCRIPTION
###### Motivation for this change

Fixes the build for guile-gnome, which currently does not work: https://github.com/NixOS/nixpkgs/pull/29732#issuecomment-331711946

@taktoa I also went ahead and removed you from maintainers for gwrap since it seems to only be a guile related package. (There's nothing to 'maintain' anyway since if you look at the commit messages in this PR, you'll see that it seems as though it's not being developed anymore, but wanted to ping you just in case.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

