### PR TITLE
mosquitto: fix darwin build

### DIFF
--- a/pkgs/servers/mqtt/mosquitto/default.nix
+++ b/pkgs/servers/mqtt/mosquitto/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl libuuid libwebsockets c-ares libuv ]
     ++ stdenv.lib.optional stdenv.isDarwin cmake;
 
-  makeFlags = [
+  makeFlags = stdenv.lib.optionals stdenv.isLinux [
     "DESTDIR=$(out)"
     "PREFIX="
   ];

--- a/pkgs/servers/mqtt/mosquitto/default.nix
+++ b/pkgs/servers/mqtt/mosquitto/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     "PREFIX="
   ];
 
-  preBuild = ''
+  postPatch = ''
     substituteInPlace config.mk \
       --replace "/usr/local" ""
     substituteInPlace config.mk \


### PR DESCRIPTION
On Darwin ```mosquitto``` is a CMake-project, so ```preBuild```'s current directory is ```build/``` where ```substituteInPlace``` cannot not find ```config.mk```