### PR TITLE
ppsspp: 1.3 -> 1.4.2

### DIFF
--- a/pkgs/misc/emulators/ppsspp/default.nix
+++ b/pkgs/misc/emulators/ppsspp/default.nix
@@ -1,37 +1,41 @@
-{ stdenv, fetchgit, zlib, libpng, qt4, qmake4Hook, pkgconfig
-, withGamepads ? true, SDL # SDL is used for gamepad functionality
-}:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, qtbase, qtmultimedia
+, glew, libzip, snappy, zlib, withGamepads ? true, SDL2 }:
 
-assert withGamepads -> (SDL != null);
-
-let
-  version = "1.3";
-  fstat = x: fn: "-D" + fn + "=" + (if x then "ON" else "OFF");
-in
+assert withGamepads -> (SDL2 != null);
 with stdenv.lib;
-stdenv.mkDerivation rec{
-  name = "PPSSPP-${version}";
 
-  src = fetchgit {
-    url = "https://github.com/hrydgard/ppsspp.git";
-    rev = "refs/tags/v${version}";
+stdenv.mkDerivation rec {
+  name = "PPSSPP-${version}";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "hrydgard";
+    repo = "ppsspp";
+    rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "0l8vgdlw657r8gv7rz8iqa6zd9zrbzw10pwhcnahzil7w9qrd03g";
+    sha256 = "0m4qkhx7q496sm7ibg2n7rm3npxzfr93iraxgndk0vhfk8vy8w75";
   };
 
-  buildInputs = [ zlib libpng qt4 ]
-                ++ (if withGamepads then [ SDL ] else [ ]);
+  patchPhase = ''
+    echo 'const char *PPSSPP_GIT_VERSION = "${src.rev}";' >> git-version.cpp
+    substituteInPlace UI/NativeApp.cpp --replace /usr/share $out/share
+  '';
 
-  nativeBuildInputs = [ pkgconfig qmake4Hook ];
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ qtbase qtmultimedia glew libzip snappy zlib ]
+    ++ optionals withGamepads [ SDL2 SDL2.dev ];
 
-  qmakeFlags = [ "PPSSPPQt.pro" ];
+  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" "-DUSING_QT_UI=ON" ];
 
-  preConfigure = "cd Qt";
-  installPhase = "mkdir -p $out/bin && cp ppsspp $out/bin";
+  installPhase = ''
+    mkdir -p $out/bin $out/share/ppsspp
+    mv PPSSPPQt $out/bin/ppsspp
+    mv assets $out/share/ppsspp
+  '';
 
   meta = {
-    homepage = http://www.ppsspp.org/;
-    description = "A PSP emulator, the Qt4 version";
+    homepage = https://www.ppsspp.org/;
+    description = "A PSP emulator for Android, Windows, Mac and Linux, written in C++";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ fuuzetsu AndersonTorres ];
     platforms = platforms.linux ++ platforms.darwin ++ platforms.cygwin;

--- a/pkgs/misc/emulators/ppsspp/default.nix
+++ b/pkgs/misc/emulators/ppsspp/default.nix
@@ -5,7 +5,7 @@ assert withGamepads -> (SDL2 != null);
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "PPSSPP-${version}";
+  name = "ppsspp-${version}";
   version = "1.4.2";
 
   src = fetchFromGitHub {
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
     mv PPSSPPQt $out/bin/ppsspp
     mv assets $out/share/ppsspp
   '';
+
+  enableParallelBuilding = true;
 
   meta = {
     homepage = https://www.ppsspp.org/;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -25,7 +25,7 @@ in
 
 mapAliases (rec {
   accounts-qt = libsForQt5.accounts-qt;  # added 2015-12-19
-  adobeReader = adobe-reader;
+  adobeReader = adobe-reader; # added 2013-11-04
   aircrackng = aircrack-ng; # added 2016-01-14
   ammonite-repl = ammonite; # added 2017-05-02
   arduino_core = arduino-core;  # added 2015-02-04
@@ -117,6 +117,7 @@ mapAliases (rec {
   pidgin-with-plugins = pidgin; # added 2016-06
   pidginlatexSF = pidginlatex; # added 2014-11-02
   poppler_qt5 = libsForQt5.poppler;  # added 2015-12-19
+  PPSSPP = ppsspp; # added 2017-10-01
   prometheus-statsd-bridge = prometheus-statsd-exporter;  # added 2017-08-27
   qca-qt5 = libsForQt5.qca-qt5;  # added 2015-12-19
   QmidiNet = qmidinet;  # added 2016-05-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19107,7 +19107,7 @@ with pkgs;
 
   pjsip = callPackage ../applications/networking/pjsip { };
 
-  PPSSPP = libsForQt5.callPackage ../misc/emulators/ppsspp { };
+  ppsspp = libsForQt5.callPackage ../misc/emulators/ppsspp { };
 
   pt = callPackage ../applications/misc/pt { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19107,7 +19107,7 @@ with pkgs;
 
   pjsip = callPackage ../applications/networking/pjsip { };
 
-  PPSSPP = callPackage ../misc/emulators/ppsspp { SDL = SDL2; };
+  PPSSPP = libsForQt5.callPackage ../misc/emulators/ppsspp { };
 
   pt = callPackage ../applications/misc/pt { };
 


### PR DESCRIPTION
###### Motivation for this change

Update to the latest version, unbundle some dependencies, use new build system, Qt4 -> Qt5... I've removed libpng from inputs since it's not used, PPSSPP bundles libpng17 and we don't have that yet.

Played Patapon 3 a bit, everything seems to work fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

