### PR TITLE
darcnes: use web.archive.org links, clean up

### DIFF
--- a/pkgs/misc/emulators/darcnes/default.nix
+++ b/pkgs/misc/emulators/darcnes/default.nix
@@ -1,28 +1,24 @@
-{stdenv, fetchurl, libX11, libXt, libXext, libXaw }:
+{ stdenv, fetchurl, libX11, libXt, libXext, libXaw }:
 
-assert stdenv.system == "i686-linux";
+stdenv.mkDerivation rec {
+  name = "darcnes-${version}";
+  version = "9b0401";
 
-stdenv.mkDerivation {
-  name = "darcnes-9b0401";
   src = fetchurl {
-    url = http://www.dridus.com/~nyef/darcnes/download/dn9b0401.tgz;
+    url = "https://web.archive.org/web/20130511081532/http://www.dridus.com/~nyef/darcnes/download/dn${version}.tgz";
     sha256 = "05a7mh51rg7ydb414m3p5mm05p4nz2bgvspqzwm3bhbj7zz543k3";
   };
 
-  buildInputs = [ libX11 libXt libXext libXaw ];
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp darcnes $out/bin
-  '';
-
   patches = [ ./label.patch ];
 
-  meta = {
-    homepage = http://www.dridus.com/~nyef/darcnes/;
-    description = "Multi-System emulator, specially for NES";
-    /* Prohibited commercial use, credit required. */
-    license = stdenv.lib.licenses.free;
-  };
+  buildInputs = [ libX11 libXt libXext libXaw ];
+  installPhase = "install -Dt $out/bin darcnes";
 
+  meta = {
+    homepage = https://web.archive.org/web/20130502171725/http://www.dridus.com/~nyef/darcnes/;
+    description = "Sega Master System, Game Gear, SG-1000, NES, ColecoVision and Apple II emulator";
+    # Prohibited commercial use, credit required.
+    license = stdenv.lib.licenses.free;
+    platforms = [ "i686-linux" ];
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

Source URL (and homepage) is down, falling back to Web Archive. Description should include list of platforms supported by the emulator. Use `meta.platforms` instead of assertion. `mkdir`, `cp` -> `install`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

