### PR TITLE
mednaffe: 0.8 -> 0.8.6, drop autoreconfHook, drop g_strdup() from patch

### DIFF
--- a/pkgs/misc/emulators/mednaffe/default.nix
+++ b/pkgs/misc/emulators/mednaffe/default.nix
@@ -1,28 +1,29 @@
-{ stdenv, fetchFromGitHub, pkgconfig, gtk2, mednafen }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gtk2, mednafen }:
 
 stdenv.mkDerivation rec {
-
-  version = "0.8";
   name = "mednaffe-${version}";
+  version = "0.8.6";
 
   src = fetchFromGitHub {
-	repo = "mednaffe";
-	owner = "AmatCoder";
-	rev = "v${version}";
-	sha256 = "1j4py4ih14fa6dv0hka03rs4mq19ir83qkbxsz3695a4phmip0jr";
+    owner = "AmatCoder";
+    repo = "mednaffe";
+    rev = "v${version}";
+    sha256 = "13l7gls430dcslpan39k0ymdnib2v6crdsmn6bs9k9g30nfnqi6m";
   };
 
-  prePatch = ''
-    substituteInPlace src/mednaffe.c --replace "binpath = NULL" "binpath = g_strdup( \"${mednafen}/bin/mednafen\" )"
+  patchPhase = ''
+    substituteInPlace src/mednaffe.c \
+      --replace 'binpath = NULL' 'binpath = "${mednafen}/bin/mednafen"'
   '';
 
-  buildInputs = [ pkgconfig gtk2 mednafen ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ gtk2 mednafen ];
 
   meta = with stdenv.lib; {
     description = "A GTK based frontend for mednafen";
     homepage = https://github.com/AmatCoder/mednaffe;
     license = licenses.gpl3;
-    maintainers = [ maintainers.sheenobu ];
+    maintainers = with maintainers; [ sheenobu ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Hasn't been updated in a while, and `g_strdup()` in patch is not required.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

