### PR TITLE
notmuch-bower: init at 2017-09-27

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -190,6 +190,7 @@
   eqyiel = "Ruben Maher <r@rkm.id.au>";
   ericbmerritt = "Eric Merritt <eric@afiniate.com>";
   ericsagnes = "Eric Sagnes <eric.sagnes@gmail.com>";
+  erictapen = "Justin Humm <justin.humm@posteo.de>";
   erikryb = "Erik Rybakken <erik.rybakken@math.ntnu.no>";
   ertes = "Ertugrul Söylemez <esz@posteo.de>";
   ethercrow = "Dmitry Ivanov <ethercrow@gmail.com>";

--- a/pkgs/applications/networking/mailreaders/bower/default.nix
+++ b/pkgs/applications/networking/mailreaders/bower/default.nix
@@ -1,36 +1,36 @@
-{ stdenv, fetchFromGitHub, mercury, ncurses, gpgme, pandoc, gawk }:
+{ stdenv, fetchFromGitHub, gawk, mercury, pandoc, ncurses, gpgme }:
 
 stdenv.mkDerivation rec {
   name = "bower-${version}";
-  version = "2017-08-05";
+  version = "2017-09-27";
 
   src = fetchFromGitHub {
     owner = "wangp";
     repo = "bower";
-    rev = "ff95a1eb709ba998913a78b6bf7c50ef4ed480af";
-    sha256 = "0m6zmcz132ylaisvz73skpw4f9bg3av0dljzf43db3g2cm1wwi2d";
+    rev = "e4918ed581984bf2813f51f007a0aaaa7fa0da7f";
+    sha256 = "13np5yharjik1pp23cfgffi0g0ikl6pl5sqqyy0ki7gk7gyy913i";
   };
 
-  buildInputs = [ mercury ncurses gpgme pandoc gawk ];
+  nativeBuildInputs = [ gawk mercury pandoc ];
 
-  buildPhase = ''
-    patchShebangs make_man
-    make man
-    make PARALLEL=-j6
-  '';
+  buildInputs = [ ncurses gpgme ];
+
+  makeFlags = [ "PARALLEL=-j$(NIX_BUILD_CORES)" "bower" "man" ];
 
   installPhase = ''
-    mkdir -p $out/share/man/man1
-    mv bower.1 $out/share/man/man1/
     mkdir -p $out/bin
     mv bower $out/bin/
+    mkdir -p $out/share/man/man1
+    mv bower.1 $out/share/man/man1/
   '';
 
-  meta = {
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
     homepage = https://github.com/wangp/bower;
-    description = "A curses terminal client for the Notmuch email system ";
-    maintainers = with stdenv.lib.maintainers; [ erictapen ];
-    license = stdenv.lib.licenses.gpl3;
-    platforms = stdenv.lib.platforms.linux;
+    description = "A curses terminal client for the Notmuch email system";
+    maintainers = with maintainers; [ erictapen ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/networking/mailreaders/bower/default.nix
+++ b/pkgs/applications/networking/mailreaders/bower/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, mercury, ncurses, gpgme, pandoc, gawk }:
+
+stdenv.mkDerivation rec {
+  name = "bower-${version}";
+  version = "2017-08-05";
+
+  src = fetchFromGitHub {
+    owner = "wangp";
+    repo = "bower";
+    rev = "ff95a1eb709ba998913a78b6bf7c50ef4ed480af";
+    sha256 = "0m6zmcz132ylaisvz73skpw4f9bg3av0dljzf43db3g2cm1wwi2d";
+  };
+
+  buildInputs = [ mercury ncurses gpgme pandoc gawk ];
+
+  buildPhase = ''
+    patchShebangs make_man
+    make man
+    make PARALLEL=-j6
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/man/man1
+    mv bower.1 $out/share/man/man1/
+    mkdir -p $out/bin
+    mv bower $out/bin/
+  '';
+
+  meta = {
+    homepage = https://github.com/wangp/bower;
+    description = "A curses terminal client for the Notmuch email system ";
+    maintainers = with stdenv.lib.maintainers; [ erictapen ];
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/mailreaders/notmuch-bower/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch-bower/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, gawk, mercury, pandoc, ncurses, gpgme }:
 
 stdenv.mkDerivation rec {
-  name = "bower-${version}";
+  name = "notmuch-bower-${version}";
   version = "2017-09-27";
 
   src = fetchFromGitHub {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13695,7 +13695,7 @@ with pkgs;
 
   brackets = callPackage ../applications/editors/brackets { gconf = gnome3.gconf; };
 
-  bower = callPackage ../applications/networking/mailreaders/bower { };
+  notmuch-bower = callPackage ../applications/networking/mailreaders/notmuch-bower { };
 
   bristol = callPackage ../applications/audio/bristol { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13695,6 +13695,8 @@ with pkgs;
 
   brackets = callPackage ../applications/editors/brackets { gconf = gnome3.gconf; };
 
+  bower = callPackage ../applications/networking/mailreaders/bower { };
+
   bristol = callPackage ../applications/audio/bristol { };
 
   bs1770gain = callPackage ../applications/audio/bs1770gain {


### PR DESCRIPTION
###### Motivation for this change

This adds the `bower` MUA, which I may use in the future.

The reason why I didn't use the latest version `0.8` but the most recent commit wangp/bower@ff95a1eb709ba998913a78b6bf7c50ef4ed480af is, that this commit introduces man pages. Therefore, the package version `2017-08-05` is the date of that commit.

###### Things done

Added `bower` package and added `erictapen` as maintainer.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

