### PR TITLE
urweb: support darwin, depend on gcc, fix paths.

### DIFF
--- a/pkgs/development/compilers/urweb/default.nix
+++ b/pkgs/development/compilers/urweb/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, file, openssl, mlton
-, mysql, postgresql, sqlite
+, mysql, postgresql, sqlite, gcc
 }:
 
 stdenv.mkDerivation rec {
@@ -20,12 +20,14 @@ stdenv.mkDerivation rec {
   configureFlags = "--with-openssl=${openssl.dev}";
 
   preConfigure = ''
-    export PGHEADER="${postgresql}/include/libpq-fe.h";
+    export PGHEADER="${postgresql.dev}/include/libpq-fe.h";
     export MSHEADER="${lib.getDev mysql.client}/include/mysql/mysql.h";
     export SQHEADER="${sqlite.dev}/include/sqlite3.h";
 
+    export CC="${gcc}/bin/gcc";
     export CCARGS="-I$out/include \
-                   -L${lib.getLib mysql.client}/lib/mysql \
+                   -L${openssl.out}/lib \
+                   -L${lib.getLib mysql.client}/lib \
                    -L${postgresql.lib}/lib \
                    -L${sqlite.out}/lib";
   '';
@@ -37,7 +39,7 @@ stdenv.mkDerivation rec {
     description = "Advanced purely-functional web programming language";
     homepage    = "http://www.impredicative.com/ur/";
     license     = stdenv.lib.licenses.bsd3;
-    platforms   = stdenv.lib.platforms.linux;
+    platforms   = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice stdenv.lib.maintainers.sheganinans ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
1. Add support for the darwing platform.
2. Make the urweb-compiler usable without manually installing dependencies and fiddling with arguments.

###### Things done
Tested on macOS Sierra (v 10.12) and NixOS 18.03pre116475.d757d8142e (Impala).

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

