### PR TITLE
bitcoin-abc: init at 0.15.0

### DIFF
--- a/pkgs/applications/altcoins/bitcoin-abc.nix
+++ b/pkgs/applications/altcoins/bitcoin-abc.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, openssl, db48, boost
+, zlib, miniupnpc, qt4, utillinux, protobuf, qrencode, libevent
+, withGui }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+
+  name = "bitcoin" + (toString (optional (!withGui) "d")) + "-abc-" + version;
+  version = "0.15.0";
+
+  src = fetchFromGitHub {
+    owner = "bitcoin-ABC";
+    repo = "bitcoin-abc";
+    rev = "v${version}";
+    sha256 = "1fygn6cc99iasg5g5jyps5ps873hfnn4ln4hsmcwlwiqd591qxyv";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [ openssl db48 boost zlib
+                  miniupnpc utillinux protobuf libevent ]
+                  ++ optionals withGui [ qt4 qrencode ];
+
+  configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
+                     ++ optionals withGui [ "--with-gui=qt4" ];
+
+  meta = {
+    description = "Peer-to-peer electronic cash system (Cash client)";
+    longDescription= ''
+      Bitcoin ABC is the name of open source software which enables the use of Bitcoin.
+      It is designed to facilite a hard fork to increase Bitcoin's block size limit.
+      "ABC" stands for "Adjustable Blocksize Cap".
+
+      Bitcoin ABC is a fork of the Bitcoin Core software project.
+    '';
+    homepage = https://bitcoinabc.org/;
+    maintainers = with maintainers; [ lassulus ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/altcoins/bitcoin-abc.nix
+++ b/pkgs/applications/altcoins/bitcoin-abc.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, openssl, db48, boost
-, zlib, miniupnpc, qt4, utillinux, protobuf, qrencode, libevent
+, zlib, miniupnpc, qt5, utillinux, protobuf, qrencode, libevent
 , withGui }:
 
 with stdenv.lib;
@@ -16,13 +16,15 @@ stdenv.mkDerivation rec {
     sha256 = "1fygn6cc99iasg5g5jyps5ps873hfnn4ln4hsmcwlwiqd591qxyv";
   };
 
+  patches = [ ./fix-bitcoin-qt-build.patch ];
+
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = [ openssl db48 boost zlib
                   miniupnpc utillinux protobuf libevent ]
-                  ++ optionals withGui [ qt4 qrencode ];
+                  ++ optionals withGui [ qt5.qtbase qt5.qttools qrencode ];
 
   configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
-                     ++ optionals withGui [ "--with-gui=qt4" ];
+                     ++ optionals withGui [ "--with-gui=qt5" ];
 
   meta = {
     description = "Peer-to-peer electronic cash system (Cash client)";

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -5,6 +5,9 @@ rec {
   bitcoin  = callPackage ./bitcoin.nix { withGui = true; };
   bitcoind = callPackage ./bitcoin.nix { withGui = false; };
 
+  bitcoin-abc  = callPackage ./bitcoin-abc.nix { withGui = true; };
+  bitcoind-abc = callPackage ./bitcoin-abc.nix { withGui = false; };
+
   bitcoin-unlimited  = callPackage ./bitcoin-unlimited.nix { withGui = true; };
   bitcoind-unlimited = callPackage ./bitcoin-unlimited.nix { withGui = false; };
 

--- a/pkgs/applications/altcoins/fix-bitcoin-qt-build.patch
+++ b/pkgs/applications/altcoins/fix-bitcoin-qt-build.patch
@@ -1,0 +1,15 @@
+--- bitcoin-abc-v0.15.0-src/build-aux/m4/bitcoin_qt.m4	1970-01-01 01:00:01.000000000 +0100
++++ bitcoin-abc-v0.15.0-src.org/build-aux/m4/bitcoin_qt.m4	2017-09-27 23:38:44.748384197 +0100
+@@ -35,11 +35,7 @@
+ dnl Output: $1 is set to the path of $2 if found. $2 are searched in order.
+ AC_DEFUN([BITCOIN_QT_PATH_PROGS],[
+   BITCOIN_QT_CHECK([
+-    if test "x$3" != "x"; then
+-      AC_PATH_PROGS($1,$2,,$3)
+-    else
+-      AC_PATH_PROGS($1,$2)
+-    fi
++    AC_PATH_PROGS($1,$2)
+     if test "x$$1" = "x" && test "x$4" != "xyes"; then
+       BITCOIN_QT_FAIL([$1 not found])
+     fi


### PR DESCRIPTION
###### Motivation for this change

add bitcoin-abc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

