### PR TITLE
gmsh: 2.12.0 -> 3.0.5

### DIFF
--- a/pkgs/applications/science/math/gmsh/default.nix
+++ b/pkgs/applications/science/math/gmsh/default.nix
@@ -1,24 +1,26 @@
-{ stdenv, fetchurl, cmake, blas, liblapack, gfortran, fltk, libjpeg
+{ stdenv, fetchurl, cmake, blas, liblapack, gfortran, gmm, fltk, libjpeg
 , zlib, mesa, mesa_glu, xorg }:
 
-let version = "2.12.0"; in
+let version = "3.0.5"; in
 
 stdenv.mkDerivation {
   name = "gmsh-${version}";
 
   src = fetchurl {
     url = "http://gmsh.info/src/gmsh-${version}-source.tgz";
-    sha256 = "02cx2mfbxx6m18s54z4yzbk4ybch3v9489z7cr974y8y0z42xgbz";
+    sha256 = "ae39ed81178d94b76990b8c89b69a5ded8910fd8f7426b800044d00373d12a93";
   };
 
   # The original CMakeLists tries to use some version of the Lapack lib
   # that is supposed to work without Fortran but didn't for me.
   patches = [ ./CMakeLists.txt.patch ];
 
-  buildInputs = [ cmake blas liblapack gfortran fltk libjpeg zlib mesa
+  buildInputs = [ cmake blas liblapack gfortran gmm fltk libjpeg zlib mesa
     mesa_glu xorg.libXrender xorg.libXcursor xorg.libXfixes xorg.libXext
     xorg.libXft xorg.libXinerama xorg.libX11 xorg.libSM xorg.libICE
   ];
+
+  enableParallelBuilding = true;
 
   meta = {
     description = "A three-dimensional finite element mesh generator";


### PR DESCRIPTION
###### Motivation for this change

This fixes building of the `gmsh` package that was broken on gcc 6 (due to more strict handling of signed vs. unsigned char conversions, I assume).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

