### PR TITLE
lispPackages.cl-protobufs: init at 20170403-git

### DIFF
--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-protobufs.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-protobufs.nix
@@ -1,0 +1,30 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-protobufs'';
+  version = ''20170403-git'';
+
+  description = ''Protobufs for Common Lisp'';
+
+  deps = [ args."alexandria" args."babel" args."closer-mop" args."trivial-features" args."trivial-garbage" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-protobufs/2017-04-03/cl-protobufs-20170403-git.tgz'';
+    sha256 = ''0ibpl076k8gq79sacg96mzjf5hqkrxzi5wlx3bjap52pla53w4g5'';
+  };
+
+  packageName = "cl-protobufs";
+
+  asdFilesToKeep = ["cl-protobufs.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-protobufs DESCRIPTION Protobufs for Common Lisp SHA256
+    0ibpl076k8gq79sacg96mzjf5hqkrxzi5wlx3bjap52pla53w4g5 URL
+    http://beta.quicklisp.org/archive/cl-protobufs/2017-04-03/cl-protobufs-20170403-git.tgz
+    MD5 86c8da92b246b4b77d6107bc5dfaff08 NAME cl-protobufs FILENAME
+    cl-protobufs DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME closer-mop FILENAME closer-mop)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-garbage FILENAME trivial-garbage))
+    DEPENDENCIES (alexandria babel closer-mop trivial-features trivial-garbage)
+    VERSION 20170403-git SIBLINGS (cl-protobufs-tests) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -33,6 +33,7 @@ closer-mop
 cl-ppcre
 cl-ppcre-template
 cl-ppcre-unicode
+cl-protobufs
 cl-reexport
 cl-smtp
 clsql

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -2012,6 +2012,19 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "cl-protobufs" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-protobufs" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-protobufs.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
+       }));
+
+
   "cl-ppcre-unicode" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."cl-ppcre-unicode" or (x: {}))


### PR DESCRIPTION
###### Motivation for this change

cl-protobufs is a useful Protobuf library for Common Lisp

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
