### PR TITLE
mednafen: 0.9.47 -> 0.9.48, disable PIC, unversioned docs

### DIFF
--- a/pkgs/misc/emulators/mednafen/default.nix
+++ b/pkgs/misc/emulators/mednafen/default.nix
@@ -1,36 +1,42 @@
-{ stdenv, fetchurl, pkgconfig
-, libX11, mesa, freeglut
-, libjack2, libcdio, libsndfile, libsamplerate
-, SDL, SDL_net, zlib
-}:
+{ stdenv, fetchurl, pkgconfig, freeglut, mesa, libcdio, libjack2
+, libsamplerate, libsndfile, libX11, SDL, SDL_net, zlib }:
 
-with stdenv.lib;
 stdenv.mkDerivation rec {
-
   name = "mednafen-${version}";
-  version = "0.9.47";
+  version = "0.9.48";
 
   src = fetchurl {
     url = "https://mednafen.github.io/releases/files/${name}.tar.xz";
-    sha256 = "0flz6bjkzs9qrw923s4cpqrz4b2dhc2w7pd8mgw0l1xbmrh7w4si";
+    sha256 = "00i12mywhp43274aq466fwavglk5b7d8z8bfdna12ra9iy1hrk6k";
   };
 
-  buildInputs =
-  [ pkgconfig libX11 mesa freeglut libjack2 libcdio
-    libsndfile libsamplerate SDL SDL_net zlib ];
+  nativeBuildInputs = [ pkgconfig ];
 
-  # Install docs
+  buildInputs = [
+    freeglut
+    mesa
+    libcdio
+    libjack2
+    libsamplerate
+    libsndfile
+    libX11
+    SDL
+    SDL_net
+    zlib
+  ];
+
+  hardeningDisable = [ "pic" ];
+
   postInstall = ''
-    mkdir -p $out/share/doc/$name
-    cd Documentation
-    install -m 644 -t $out/share/doc/$name *.css *.def *.html *.php *.png *.txt
+    mkdir -p $out/share/doc
+    mv Documentation $out/share/doc/mednafen
   '';
 
   meta = with stdenv.lib; {
     description = "A portable, CLI-driven, SDL+OpenGL-based, multi-system emulator";
-    homepage = http://mednafen.github.io/;
+    homepage = https://mednafen.github.io/;
     license = licenses.gpl2;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/misc/emulators/mednafen/server.nix
+++ b/pkgs/misc/emulators/mednafen/server.nix
@@ -1,25 +1,21 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-
   name = "mednafen-server-${version}";
   version = "0.5.2";
 
   src = fetchurl {
-    url = "https://mednafen.github.io/releases/files/mednafen-server-0.5.2.tar.xz";
+    url = "https://mednafen.github.io/releases/files/mednafen-server-${version}.tar.xz";
     sha256 = "0xm7dj5nwnrsv69r72rcnlw03jm0l8rmrg3s05gjfvxyqmlb36dq";
   };
 
-  postInstall = ''
-    mkdir -p $out/share/$name
-    install -m 644 -t $out/share/$name standard.conf
-  '';
+  postInstall = "install -m 644 -Dt $out/share/mednafen-server standard.conf";
 
   meta = with stdenv.lib; {
     description = "Netplay server for Mednafen";
-    homepage = http://mednafen.github.io/;
+    homepage = https://mednafen.github.io/;
     license = licenses.gpl2;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


Version bump. HTTP -> HTTPS in `meta.homepage`, simpler `postInstall`.
Mednafen doesn't want to be compiled with PIC, so now it's disabled:

```
../../include/mednafen/types.h:28:4: warning: #warning "Compiling with position-independent code generation enabled is not recommended, for performance reasons." [-Wcpp]
   #warning "Compiling with position-independent code generation enabled is not recommended, for performance reasons."
    ^~~~~~~
```

This also includes using `$out/share` directory that is similar to what other distros use, i.e. no version in the directory name.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

