### PR TITLE
electron-cash: init at 2.9.3

### DIFF
--- a/pkgs/applications/misc/electron-cash/default.nix
+++ b/pkgs/applications/misc/electron-cash/default.nix
@@ -1,0 +1,66 @@
+{ stdenv, fetchFromGitHub, python2Packages }:
+
+python2Packages.buildPythonApplication rec {
+  version = "2.9.3";
+  name = "electron-cash-${version}";
+
+  src = fetchFromGitHub {
+    owner = "fyookball";
+    repo = "electrum";
+    rev = version;
+    sha256 = "1r39b5ag5fipzgr84pzb53cfm8a4dy53257608754dwr1gfpma3v";
+  };
+
+  propagatedBuildInputs = with python2Packages; [
+    dns
+    ecdsa
+    jsonrpclib
+    pbkdf2
+    pyaes
+    pycrypto
+    pyqt4
+    pysocks
+    qrcode
+    requests
+    tlslite
+
+    # plugins
+    keepkey
+    trezor
+  ];
+
+  preBuild = ''
+    sed -i 's,usr_share = .*,usr_share = "'$out'/share",g' setup.py
+    pyrcc4 icons.qrc -o gui/qt/icons_rc.py
+    # Recording the creation timestamps introduces indeterminism to the build
+    sed -i '/Created: .*/d' gui/qt/icons_rc.py
+  '';
+
+  postInstall = ''
+    # Despite setting usr_share above, these files are installed under
+    # $out/nix ...
+    mv $out/lib/python2.7/site-packages/nix/store"/"*/share $out
+    rm -rf $out/lib/python2.7/site-packages/nix
+
+    substituteInPlace $out/share/applications/electron.desktop \
+      --replace "Exec=electrum %u" "Exec=$out/bin/electrum %u"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/electrum help >/dev/null
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A lightweight Bitcoin wallet";
+    longDescription = ''
+      An easy-to-use Bitcoin client featuring wallets generated from
+      mnemonic seeds (in addition to other, more advanced, wallet options)
+      and the ability to perform transactions without downloading a copy
+      of the blockchain.
+    '';
+    homepage = https://www.electroncash.org/;
+    maintainers = with maintainers; [ lassulus ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14050,6 +14050,8 @@ with pkgs;
 
   ekho = callPackage ../applications/audio/ekho { };
 
+  electron-cash = callPackage ../applications/misc/electron-cash { };
+
   electrum = callPackage ../applications/misc/electrum { };
 
   electrum-dash = callPackage ../applications/misc/electrum-dash { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

