### PR TITLE
glusterfs service: a few fixes and improvements

### DIFF
--- a/nixos/modules/services/network-filesystems/glusterfs.nix
+++ b/nixos/modules/services/network-filesystems/glusterfs.nix
@@ -106,7 +106,6 @@ in
 
       requires = [ "rpcbind.service" ];
       after = [ "rpcbind.service" "network.target" "local-fs.target" ];
-      before = [ "network-online.target" ];
 
       preStart = ''
         install -m 0755 -d /var/log/glusterfs

--- a/nixos/modules/services/network-filesystems/glusterfs.nix
+++ b/nixos/modules/services/network-filesystems/glusterfs.nix
@@ -41,6 +41,25 @@ in
         default = "INFO";
       };
 
+      useRpcbind = mkOption {
+        type = types.bool;
+        description = ''
+          Enable use of rpcbind. This is required for Gluster's NFS functionality.
+
+          You may want to turn it off to reduce the attack surface for DDoS reflection attacks.
+
+          See https://davelozier.com/glusterfs-and-rpcbind-portmap-ddos-reflection-attacks/
+          and https://bugzilla.redhat.com/show_bug.cgi?id=1426842 for details.
+        '';
+        default = true;
+      };
+
+      enableGlustereventsd = mkOption {
+        type = types.bool;
+        description = "Whether to enable the GlusterFS Events Daemon";
+        default = true;
+      };
+
       extraFlags = mkOption {
         type = types.listOf types.str;
         description = "Extra flags passed to the GlusterFS daemon";
@@ -89,7 +108,7 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.glusterfs ];
 
-    services.rpcbind.enable = true;
+    services.rpcbind.enable = cfg.useRpcbind;
 
     environment.etc = mkIf (cfg.tlsSettings != null) {
       "ssl/glusterfs.pem".source = cfg.tlsSettings.tlsPem;
@@ -104,8 +123,8 @@ in
 
       wantedBy = [ "multi-user.target" ];
 
-      requires = [ "rpcbind.service" ];
-      after = [ "rpcbind.service" "network.target" "local-fs.target" ];
+      requires = lib.optional cfg.useRpcbind "rpcbind.service";
+      after = [ "network.target" "local-fs.target" ] ++ lib.optional cfg.useRpcbind [ "rpcbind.service" ];
 
       preStart = ''
         install -m 0755 -d /var/log/glusterfs
@@ -133,7 +152,7 @@ in
       };
     };
 
-    systemd.services.glustereventsd = {
+    systemd.services.glustereventsd = mkIf cfg.enableGlustereventsd {
       inherit restartTriggers;
 
       description = "Gluster Events Notifier";

--- a/nixos/modules/services/network-filesystems/glusterfs.nix
+++ b/nixos/modules/services/network-filesystems/glusterfs.nix
@@ -74,7 +74,7 @@ in
           (for example, when you want to restart them manually at a later time),
           set this to 'process'.
         '';
-        default = "process";
+        default = "control-group";
       };
 
       stopKillTimeout = mkOption {

--- a/nixos/modules/services/network-filesystems/glusterfs.nix
+++ b/nixos/modules/services/network-filesystems/glusterfs.nix
@@ -194,6 +194,10 @@ in
 
       after = [ "syslog.target" "network.target" ];
 
+      preStart = ''
+        install -m 0755 -d /var/log/glusterfs
+      '';
+
       serviceConfig = {
         Type="simple";
         Environment="PYTHONPATH=${glusterfs}/usr/lib/python2.7/site-packages";


### PR DESCRIPTION
###### Motivation for this change

These commits fix issues I found in my production cluster; see their commit messages for individual motivations.

These are the changes I promised in https://github.com/NixOS/nixpkgs/pull/27340#discussion_r139311268.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

FYI @bachp who's another user of this service.

CC @joachifm 