### PR TITLE
vim-plugins: add `overrideAttrs` support for `buildVimPluginFrom2Nix`

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -373,8 +373,10 @@ rec {
   }
   '';
 
-  addRtp = path: derivation:
-    derivation // { rtp = "${derivation}/${path}"; };
+  addRtp = path: attrs: derivation:
+    derivation // { rtp = "${derivation}/${path}"; } // {
+      overrideAttrs = f: buildVimPlugin (attrs // f attrs);
+    };
 
   buildVimPlugin = a@{
     name,
@@ -389,7 +391,7 @@ rec {
     addonInfo ? null,
     ...
   }:
-    addRtp "${rtpPath}/${path}" (stdenv.mkDerivation (a // {
+    addRtp "${rtpPath}/${path}" a (stdenv.mkDerivation (a // {
       name = namePrefix + name;
 
       inherit unpackPhase configurePhase buildPhase addonInfo preInstall postInstall;


### PR DESCRIPTION
###### Motivation for this change

Some days ago I packaged `xptemplate` for VIM.
However according to the docs the recommended approach to use custom snippets is to copy them into the `personal/` directory (https://github.com/drmingdrmer/xptemplate#extend-xptemplate-write-new-snippets)

The easiest approach is to override the plugin and add a `postInstall` script, however until now it wasn't possible to override VIM plugins.

I confirmed the change using the following expressions for a test VM:

``` nix
{
  vim = { pkgs, ... }: {
    environment.systemPackages = let
      vim = with pkgs; vim_configurable.customize {
        name = "xptemplatetest";
        vimrcConfig.vam.knownPlugins = vimPlugins;
        vimrcConfig.vam.pluginDictionaries = [
          { name = "xptemplate"; }
        ];
      };
    in [ vim ];

    nixpkgs.config.packageOverrides = super: {
      vimPlugins = super.vimPlugins // {
        xptemplate = super.vimPlugins.xptemplate.overrideAttrs(_: {
          postInstall = ''
            cp -R ${../nixos-config/apps/vim-snippets} $out/share/vim-plugins/xptemplate/personal/ftplugin
          '';
        });
      };
    };

    users.extraUsers.vm = {
      isNormalUser = true;
      password = "vm";
    };
  };
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

