### PR TITLE
znc: fix openFirewall option

### DIFF
--- a/nixos/modules/services/networking/znc.nix
+++ b/nixos/modules/services/networking/znc.nix
@@ -212,6 +212,14 @@ in
         '';
       };
 
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to open ports in the firewall for ZNC.
+        '';
+      };
+
       zncConf = mkOption {
         default = "";
         example = "See: http://wiki.znc.in/Configuration";
@@ -273,14 +281,6 @@ in
           type = types.string;
           description = ''
             The IRC nick.
-          '';
-        };
-
-        openFirewall = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Whether to open ports in the firewall for ZNC.
           '';
         };
 
@@ -359,7 +359,7 @@ in
   config = mkIf cfg.enable {
 
     networking.firewall = mkIf cfg.openFirewall {
-      allowedTCPPorts = [ cfg.port ];
+      allowedTCPPorts = [ cfg.confOptions.port ];
     };
 
     systemd.services.znc = {


### PR DESCRIPTION
###### Motivation for this change

The current version is broken (from #29171):
- there's no `openFirewall` attribute directly in the `cfg` set
- the `port` option is an attribute of the `confOptions` set

I used the proper attribute for the firewall port and moved the `openFirewall`
option directly up to the `services.znc` set, as it's rather a general option
for the whole service than a znc-specific option (which are located inside the
`confOptions` set).

@vaibhavsagar Did this work for you? Should have failed during evaluation already...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

