### PR TITLE
nixos/monit: install monit as system package, use default config file path

### DIFF
--- a/nixos/modules/services/monitoring/monit.nix
+++ b/nixos/modules/services/monitoring/monit.nix
@@ -17,20 +17,22 @@ in
       };
       config = mkOption {
         default = "";
-        description = "monit.conf content";
+        description = "monitrc content";
       };
     };
   };
 
   config = mkIf config.services.monit.enable {
 
+    environment.systemPackages = [ pkgs.monit ];
+
     environment.etc = [
       {
         source = pkgs.writeTextFile {
-          name = "monit.conf";
+          name = "monitrc";
           text = config.services.monit.config;
         };
-        target = "monit.conf";
+        target = "monitrc";
         mode = "0400";
       }
     ];
@@ -40,9 +42,9 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
-        ExecStart = "${pkgs.monit}/bin/monit -I -c /etc/monit.conf";
-        ExecStop = "${pkgs.monit}/bin/monit -c /etc/monit.conf quit";
-        ExecReload = "${pkgs.monit}/bin/monit -c /etc/monit.conf reload";
+        ExecStart = "${pkgs.monit}/bin/monit -I -c /etc/monitrc";
+        ExecStop = "${pkgs.monit}/bin/monit -c /etc/monitrc quit";
+        ExecReload = "${pkgs.monit}/bin/monit -c /etc/monitrc reload";
         KillMode = "process";
         Restart = "always";
       };


### PR DESCRIPTION
###### Motivation for this change

The motivation is wanting `sudo monit status` to work. This enables that by making monit available as a system package and using the default monitrc file, so you do not have to specify the configuration file at the command line.

###### Things done

- [x] Tested this works on NixOS

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

