### PR TITLE
nixos/tinc: add "restartTriggers" back

### DIFF
--- a/nixos/modules/services/networking/tinc.nix
+++ b/nixos/modules/services/networking/tinc.nix
@@ -163,6 +163,12 @@ in
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
         path = [ data.package ];
+        restartTriggers =
+          let
+            drvlist = [ config.environment.etc."tinc/${network}/tinc.conf".source ]
+                        ++ mapAttrsToList (host: _: config.environment.etc."tinc/${network}/hosts/${host}".source) data.hosts;
+          in # drvlist might be too long to be used directly
+            [ (builtins.hashString "sha256" (concatMapStrings (d: d.outPath) drvlist)) ];
         serviceConfig = {
           Type = "simple";
           Restart = "always";


### PR DESCRIPTION
Add "restartTriggers" back to restart the Tinc daemon when its peer is removed.
Reverted #27660

Discussed 
here: https://github.com/NixOS/nixpkgs/pull/27660#issuecomment-321415123

cc @fpletz