### PR TITLE
mongodb-tools: 3.0.12 -> 3.5.13

### DIFF
--- a/pkgs/tools/misc/mongodb-tools/default.nix
+++ b/pkgs/tools/misc/mongodb-tools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, openssl_1_0_2, pkgconfig, libpcap }:
 
 let
   tools = [
@@ -8,7 +8,7 @@ let
 in
 buildGoPackage rec {
   name = "mongo-tools-${version}";
-  version = "3.0.12";
+  version = "3.5.13";
   rev = "r${version}";
 
   goPackagePath = "github.com/mongodb/mongo-tools";
@@ -18,10 +18,22 @@ buildGoPackage rec {
     inherit rev;
     owner = "mongodb";
     repo = "mongo-tools";
-    sha256 = "142vxgniri1mfy2xmfgxhbdp6k6h8c5milv454krv1b51v43hsbm";
+    sha256 = "00klm4pyx5k39nn4pmfrpnkqxdhbzm7lprgwxszpirzrarh2g164";
   };
 
   goDeps = ./deps.nix;
+  
+  buildInputs = [ pkgconfig openssl_1_0_2 libpcap ];
+  
+ 
+  buildPhase = ''
+    ./go/src/github.com/mongodb/mongo-tools/build.sh ssl
+  '';
+  
+  buildFlags = [ "-tags ssl" ];
+  
+  allowGoReference = true;
+  
 
   # Mongodb incorrectly names all of their binaries main
   # Let's work around this with our own installer

--- a/pkgs/tools/misc/mongodb-tools/deps.nix
+++ b/pkgs/tools/misc/mongodb-tools/deps.nix
@@ -1,11 +1,20 @@
 [
   {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "314a259e304ff91bd6985da2a7149bbf91237993";
+      sha256 = "0vya62c3kmhmqx6awlxx8hc84987xkym9rhs0q28vlhwk9kczdaa";
+    };
+  }
+  {
     goPackagePath = "golang.org/x/crypto";
     fetch = {
       type = "git";
-      url = "https://go.googlesource.com/crypto";
-      rev = "575fdbe86e5dd89229707ebec0575ce7d088a4a6";
-      sha256 = "1kgv1mkw9y404pk3lcwbs0vgl133mwyp294i18jg9hp10s5d56xa";
+      url = "https://github.com/golang/crypto";
+      rev = "1f22c0103821b9390939b6776727195525381532";
+      sha256 = "1acy12f396sr3lrnbcnym5q72qnlign5bagving41qijzjnc219m";
     };
   }
   {
@@ -13,17 +22,62 @@
     fetch = {
       type = "git";
       url = "https://github.com/howeyc/gopass";
-      rev = "2c70fa70727c953c51695f800f25d6b44abb368e";
-      sha256 = "152lrkfxk205rlxiign0w5wb0fmfh910yz4jhlv4f4l1qr1h2lx8";
+      rev = "bf9dde6d0d2c004a008c27aaee91170c786f6db8";
+      sha256 = "1jxzyfnqi0h1fzlsvlkn10bncic803bfhslyijcxk55mgh297g45";
     };
   }
   {
     goPackagePath = "gopkg.in/mgo.v2";
     fetch = {
       type = "git";
-      url = "https://gopkg.in/mgo.v2";
-      rev = "c6a7dce14133ccac2dcac3793f1d6e2ef048503a";
-      sha256 = "0rg232q1bkq3y3kd5816hgk1jpf7i38aha5q5ia7j6p9xashz7vj";
+      url = "https://github.com/10gen/mgo";
+      rev = "39b4000d99037e917f3a3b9d2dcab667a9ef284a";
+      sha256 = "1m0xgd3y32g15fhl204g2caarfi5rn41m8pyym0i2gl3jnv5zw99";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/gopacket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/gopacket";
+      rev = "93b782132903d1846aab74cb1f62e6138564949f";
+      sha256 = "0l5m5a8dnqbkhphyfq7anj5zv59s74q2l7i6w9r7xwysfiqyq335";
+    };
+  }
+  {
+    goPackagePath = "github.com/patrickmn/go-cache";
+    fetch = {
+      type = "git";
+      url = "https://github.com/patrickmn/go-cache";
+      rev = "1881a9bccb818787f68c52bfba648c6cf34c34fa";
+      sha256 = "1nd0kqijx6mrxb8wlh20bx73mwj0fqzla2sr68y6j6lz3fsy1fw2";
+    };
+  }
+  {
+    goPackagePath = "github.com/spacemonkeygo/openssl";
+    fetch = {
+      type = "git";
+      url = "https://github.com/10gen/openssl";
+      rev = "2692b9f6fa95e72c75f8d9ba76e49c5dfd2cf8e4";
+      sha256 = "16x2mx51977jrqw8d9hqhqmx892v2qf1k5xb01hhfklh58f527k2";
+    };
+  }
+  {
+    goPackagePath = "github.com/jtolds/gls";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jtolds/gls";
+      rev = "8ddce2a84170772b95dd5d576c48d517b22cac63";
+      sha256 = "11rp9wbzkd71640rq0nwmgsddskx3qac8wzqz71ksdb7ixjj5fmj";
+    };
+  }
+  {
+    goPackagePath = "github.com/spacemonkeygo/spacelog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spacemonkeygo/spacelog";
+      rev = "f936fb050dc6b5fe4a96b485a6f069e8bdc59aeb";
+      sha256 = "00an6zlhjk5l0vk1zjzshhswsd0h4syi48n50hv0fcnbmpxc5hv2";
     };
   }
   {
@@ -36,12 +90,93 @@
     };
   }
   {
+    goPackagePath = "github.com/jtolds/gls";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jtolds/gls";
+      rev = "8ddce2a84170772b95dd5d576c48d517b22cac63";
+      sha256 = "11rp9wbzkd71640rq0nwmgsddskx3qac8wzqz71ksdb7ixjj5fmj";
+    };
+  }
+  {
+    goPackagePath = "github.com/smartystreets/assertions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smartystreets/assertions";
+      rev = "287b4346dc4e71a038c346375a9d572453bc469b";
+      sha256 = "1nw9j9aircra68lbkp5bq4l8ayq4g3fvbb2x8qd2hg0vwgn5yaij";
+    };
+  }
+  {
+    goPackagePath = "github.com/smartystreets/goconvey";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smartystreets/goconvey";
+      rev = "bf58a9a1291224109919756b4dcc469c670cc7e4";
+      sha256 = "1k8k6vvlpl5a19dbrywxjmcia36macjbajx2hb6ci64rdfyf5kz5";
+    };
+  }
+  {
+    goPackagePath = "github.com/jacobsa/oglematchers";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jacobsa/oglematchers";
+      rev = "3ecefc49db07722beca986d9bb71ddd026b133f0";
+      sha256 = "0vrk5sfs1ymkg0gv5n5dn9x0kqiaw8gaapljj8q75mgrr1p5149y";
+    };
+  }
+  {
+    goPackagePath = "github.com/3rf/mongo-lint";
+    fetch = {
+      type = "git";
+      url = "https://github.com/3rf/mongo-lint";
+      rev = "3550fdcf1f43b89aaeabaa4559eaae6dc4407e42";
+      sha256 = "19b60a3i6kzssd15dg57y4bg49sw41idrsjdi8vr4j5lr5d7gviv";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev = "d6bea18f789704b5f83375793155289da36a3c7f";
+      sha256 = "1hnigpn7rjbwd1ircxkyx9hvi0xmxr32b2jdy2jzw6b3jmcnz1fs";
+    };
+  }
+  {
+    goPackagePath = "github.com/10gen/escaper";
+    fetch = {
+      type = "git";
+      url = "https://github.com/10gen/escaper";
+      rev = "17fe61c658dcbdcbf246c783f4f7dc97efde3a8b";
+      sha256 = "1iw86lg8ad5gdm46ryf4v431ix834l52lrjvcahq3c4dw1ylnbvl";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/snappy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/snappy";
+      rev = "d9eb7a3d35ec988b8585d4a0068e462c27d28380";
+      sha256 = "0wynarlr1y8sm9y9l29pm9dgflxriiialpwn01066snzjxnpmbyn";
+    };
+  }
+  {
+    goPackagePath = "github.com/nsf/termbox-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nsf/termbox-go";
+      rev = "0723e7c3d0a317dea811f0fbe4d6edd81908c971";
+      sha256 = "1ak35nhlgjpbpnh7v9qvjyfsq52liz3niqfqva76p7a68pblwbr7";
+    };
+  }
+  {
     goPackagePath = "github.com/jessevdk/go-flags";
     fetch = {
       type = "git";
       url = "https://github.com/jessevdk/go-flags";
-      rev = "1b89bf73cd2c3a911d7b2a279ab085c4a18cf539";
-      sha256 = "027nglc5xx1cm03z9sisg0iqrhwcj6gh5z254rrpl8p4fwrxx680";
+      rev = "97448c91aac742cbca3d020b3e769013a420a06f";
+      sha256 = "0fv3yxvq8m3639a279hq4pf0c52ngqfl5n1vklcfympndrb7zjzj";
     };
   }
 ]


### PR DESCRIPTION
###### Motivation for this change
Need to connect to newer mongodb databases with SSL

I could use a little help with this upgrade as I am new to NixOS. Despite the build output saying all of the tools were compiled with SSL they behave as if they were compiled without ssl (--ssl option is not there).

Also the build somehow contains a reference to go, so I added allowGoReference but I know that is not the correct solution. 

Thanks in advance for any help.

