### PR TITLE
nixos/nullmailer: fixes and `remotesFile` option

### DIFF
--- a/nixos/modules/services/mail/nullmailer.nix
+++ b/nixos/modules/services/mail/nullmailer.nix
@@ -142,7 +142,16 @@ with lib;
           type = types.nullOr types.str;
           default = null;
           description = ''
-            If set, content will override the envelope sender on all messages.
+            A list of remote servers to which to send each message. Each line
+            contains a remote host name or address followed by an optional
+            protocol string, separated by white space.
+
+            See <code>man 8 nullmailer-send</code> for syntax and available
+            options.
+
+            WARNING: This is stored world-readable in the nix store. If you need
+            to specify any secret credentials here, consider using the
+            <code>remotesFile</code> option instead.
           '';
         };
 

--- a/nixos/modules/services/mail/nullmailer.nix
+++ b/nixos/modules/services/mail/nullmailer.nix
@@ -194,18 +194,10 @@ with lib;
     environment = {
       systemPackages = [ pkgs.nullmailer ];
       etc = let
-        getval  = attr: builtins.getAttr attr cfg.config;
-        attrs   = builtins.attrNames cfg.config;
-        remotesFilter = if cfg.remotesFile != null
-                        then (attr: attr != "remotes")
-                        else (_: true);
-        optionalRemotesFileLink = if cfg.remotesFile != null
-                                  then { "nullmailer/remotes".source = cfg.remotesFile; }
-                                  else {};
-        attrs'  = builtins.filter (attr: (! isNull (getval attr)) && (remotesFilter attr)) attrs;
+        validAttrs = filterAttrs (name: value: value != null) cfg.config;
       in
-        (foldl' (as: attr: as // { "nullmailer/${attr}".text = getval attr; }) {} attrs')
-        // optionalRemotesFileLink;
+        (foldl' (as: name: as // { "nullmailer/${name}".text = validAttrs.${name}; }) {} (attrNames validAttrs))
+          // optionalAttrs (cfg.remotesFile != null) { "nullmailer/remotes".source = cfg.remotesFile; };
     };
 
     users = {

--- a/nixos/modules/services/mail/nullmailer.nix
+++ b/nixos/modules/services/mail/nullmailer.nix
@@ -192,7 +192,7 @@ with lib;
 
       preStart = ''
         mkdir -p /var/spool/nullmailer/{queue,tmp}
-        rm -f var/spool/nullmailer/trigger && mkfifo -m 660 /var/spool/nullmailer/trigger
+        rm -f /var/spool/nullmailer/trigger && mkfifo -m 660 /var/spool/nullmailer/trigger
         chown ${cfg.user} /var/spool/nullmailer/*
       '';
 


### PR DESCRIPTION
###### Motivation for this change

Please see individual commit messages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

