### PR TITLE
unicode: init at 2.5

### DIFF
--- a/pkgs/tools/misc/unicode/default.nix
+++ b/pkgs/tools/misc/unicode/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, fetchurl, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  name = "unicode-${version}";
+  version = "2.5";
+
+  src = fetchFromGitHub {
+    owner = "garabik";
+    repo = "unicode";
+    rev = "v${version}";
+    sha256 = "0vg1zshlzgdva8gzw6fya28fc4jhypjkj743x3q0yabx6934k0g2";
+  };
+
+  ucdtxt = fetchurl {
+    url = http://www.unicode.org/Public/11.0.0/ucd/UnicodeData-11.0.0d1.txt;
+    sha256 = "0y9l0sap7yq7c7c8d0fivzycqaw0zncbxzh1inggg42308z974rn";
+  };
+
+  postFixup = ''
+    substituteInPlace "$out/bin/.unicode-wrapped" \
+      --replace "/usr/share/unicode/UnicodeData.txt" "$ucdtxt"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Display unicode character properties";
+    homepage = https://github.com/garabik/unicode;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.woffs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19224,6 +19224,8 @@ with pkgs;
 
   utf8proc = callPackage ../development/libraries/utf8proc { };
 
+  unicode-paracode = callPackage ../tools/misc/unicode { };
+
   valauncher = callPackage ../applications/misc/valauncher { };
 
   vault = callPackage ../tools/security/vault { };


### PR DESCRIPTION
###### Motivation for this change

a great tool to explore unicode from the command line

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

