### PR TITLE
hdf5: remove references to gcc

### DIFF
--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -1,5 +1,7 @@
 { stdenv
 , fetchurl
+, gcc
+, removeReferencesTo
 , cpp ? false
 , gfortran ? null
 , zlib ? null
@@ -30,7 +32,7 @@ stdenv.mkDerivation rec {
     inherit mpi;
   };
 
-  buildInputs = []
+  buildInputs = [ removeReferencesTo ]
     ++ optional (gfortran != null) gfortran
     ++ optional (szip != null) szip;
 
@@ -46,6 +48,9 @@ stdenv.mkDerivation rec {
     ++ optional enableShared "--enable-shared";
 
   patches = [./bin-mv.patch];
+
+  postInstall =
+    '' find "$out" -type f -exec remove-references-to -t ${gcc} '{}' + '';
 
   meta = {
     description = "Data model, library, and file format for storing and managing data";


### PR DESCRIPTION
The build provides as text a summary of the build, including the
absolute path of the compiler used for compilation.  Unfortunately, this
pulls in gcc as a transitive closure.

So this change just calls remove-references-to as a postInstall step for
the one gcc dependency.

See #29889 for details.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

