### PR TITLE
qmake hook: force copy of binary fixes #29589

### DIFF
--- a/pkgs/development/libraries/qt-5/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/qtbase-setup-hook.sh
@@ -127,7 +127,7 @@ if [ -z "$NIX_QT5_TMP" ]; then
         echo "$subdir/" >> "$NIX_QT5_TMP/nix-support/qt-inputs"
     done
 
-    cp "@dev@/bin/qmake" "$NIX_QT5_TMP/bin"
+    cp -f "@dev@/bin/qmake" "$NIX_QT5_TMP/bin"
     echo "bin/qmake" >> "$NIX_QT5_TMP/nix-support/qt-inputs"
 
     cat >"$NIX_QT5_TMP/bin/qt.conf" <<EOF


### PR DESCRIPTION


###### Motivation for this change
When running nix-shell several times in the same folder with a qt program (such as wireshark),
qmake's hook can generate the error "Can't create __nix_qt5__/bin/qmake:
file already exists"
Following up of https://github.com/NixOS/nixpkgs/pull/29665

###### Things done
force copy of the binary

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

