### PR TITLE
rpl: init at 1.5.6

### DIFF
--- a/pkgs/tools/text/rpl/default.nix
+++ b/pkgs/tools/text/rpl/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "${pname}-${version}";
+  pname = "rpl";
+  version = "1.5.7";
+
+  # Tests not included in pip package.
+  doCheck = false;
+
+  src = fetchFromGitHub {
+    owner  = "kcoyner";
+    repo   = "rpl";
+    rev    = "v${version}";
+    sha256 = "1xhpgcmq91ivy9ijfyz5ilg51m7fz8ar2077r7gq246j8gbf8ggr";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Replace strings in files";
+    homepage    = "https://github.com/kcoyner/rpl";
+    license     = licenses.gpl2;
+    maintainers = with maintainers; [ teto ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19064,6 +19064,10 @@ with pkgs;
 
   retrofe = callPackage ../misc/emulators/retrofe { };
 
+  rpl = callPackage ../tools/text/rpl {
+    pythonPackages = python3Packages;
+  };
+
   rss-glx = callPackage ../misc/screensavers/rss-glx { };
 
   runit = callPackage ../tools/system/runit { };


### PR DESCRIPTION
A python program that helps replacing string in files.

###### Motivation for this change
One hell of a program, kinda like "fd". I find it very helpful to replace strings in multiple files. It's packaged in debian too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

