### PR TITLE
fakenes: mark as broken

### DIFF
--- a/pkgs/misc/emulators/fakenes/default.nix
+++ b/pkgs/misc/emulators/fakenes/default.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchurl, allegro, openal, mesa, zlib, hawknl, freeglut, libX11,
   libXxf86vm, libXcursor, libXpm }:
 
-stdenv.mkDerivation { 
+stdenv.mkDerivation {
   name = "fakenes-0.5.9b3";
   src = fetchurl {
     url = mirror://sourceforge/fakenes/fakenes-0.5.9-beta3.tar.gz;
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     cp fakenes $out/bin
   '';
 
-  NIX_LDFLAGS = "-lX11 -lXxf86vm -lXcursor -lXpm"; 
+  NIX_LDFLAGS = "-lX11 -lXxf86vm -lXcursor -lXpm";
 
   patches = [ ./build.patch ];
 
@@ -27,5 +27,6 @@ stdenv.mkDerivation {
     license = stdenv.lib.licenses.gpl2Plus;
     description = "Portable Open Source NES Emulator";
     platforms = stdenv.lib.platforms.linux;
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Spent about an hour trying to make it build, but gave up at the end. Broken both on i686 and amd64.
Disabling all hardening, or adding `-fno-stack-protector` to CFLAGS, doesn't solve the issue.

```
these derivations will be built:
  /nix/store/kj8hv52zm2zqydkjnhvnz19dlfndk32y-fakenes-0.5.9b3.drv
building path(s) ‘/nix/store/wd4cjxfgkr792p4b2wwsjpwaj8hg14gn-fakenes-0.5.9b3’
unpacking sources
unpacking source archive /nix/store/dih5zmkbxnwar9qhf0axr95vgfrmq0rd-fakenes-0.5.9-beta3.tar.gz
source root is fakenes-0.5.9-beta3
setting SOURCE_DATE_EPOCH to timestamp 1182841723 of file fakenes-0.5.9-beta3/src/ppu.cpp
patching sources
applying patch /nix/store/nzn68gicn9l3x2qmpq2rzhz056f841dq-build.patch
patching file build/openal.cbd
patching file build/alleggl.cbd
patching file src/apu.cpp
patching file src/audio.cpp
patching file src/include/common.h
configuring
no configure script, doing nothing
building
build flags: SHELL=/nix/store/flb9ar1xdd13c606aa4my9miy3iv4vyk-bash-4.4-p12/bin/bash
gcc -O2 -W -Wall -o cbuild cbuild.c
cbuild.c: In function 'main':
cbuild.c:2027:12: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'long unsigned int' [-Wformat=]
     printf("\n\n!!! %s error, line %d !!!\n"
            ^
cbuild.c:2763:23: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'size_t {aka long unsigned int}' [-Wformat=]
       fprintf(stderr, "\n\n\n*** Critical Error ***\n"
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./cbuild
Creating directory build/unix/...
Creating directory build/unix/etc/...
Creating directory build/unix/renderer/...
Creating directory build/unix/shared/...
Creating directory build/unix/sound/...
Creating build/unix/buildconfig.h...
Converting support/fakenes.dat to build/unix/datafile.c...
Compiling src/etc/unzip.c...
src/etc/unzip.c: In function 'unzClose':
src/etc/unzip.c:456:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
     if (s->pfile_in_zip_read!=NULL)
     ^~
src/etc/unzip.c:459:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
  fclose(s->file);
  ^~~~~~
src/etc/unzip.c: In function 'unzLocateFile':
src/etc/unzip.c:781:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
     if (strlen(szFileName)>=UNZ_MAXFILENAMEINZIP)
     ^~
src/etc/unzip.c:784:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
  s=(unz_s*)file;
  ^
src/etc/unzip.c: In function 'unzlocal_CheckCurrentFileCoherencyHeader':
src/etc/unzip.c:862:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
     if ((err==UNZ_OK) && (s->cur_file_info.compression_method!=0) &&
     ^~
src/etc/unzip.c:866:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
  if (unzlocal_getLong(s->file,&uData) != UNZ_OK) /* date/time */
  ^~
src/etc/unzip.c: In function 'unzOpenCurrentFile':
src/etc/unzip.c:927:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
     if (s->pfile_in_zip_read != NULL)
     ^~
src/etc/unzip.c:930:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
  if (unzlocal_CheckCurrentFileCoherencyHeader(s,&iSizeVar,
  ^~
Compiling build/unix/datafile.c...
Compiling src/apu.cpp...
Compiling src/audio.cpp...
Compiling src/audiolib.cpp...
src/audiolib.cpp: In member function 'virtual void AudiolibOpenALDriver::closeStream()':
src/audiolib.cpp:486:14: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
    if(source != AL_INVALID) {
              ^
src/audiolib.cpp:493:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       if(buffers[0] != AL_INVALID)
                     ^
src/audiolib.cpp: In member function 'virtual void* AudiolibOpenALDriver::getBuffer(void*)':
src/audiolib.cpp:505:14: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
    if(source == AL_INVALID) {
              ^
src/audiolib.cpp:516:22: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
    if(floatingBuffer == AL_INVALID) {
                      ^
src/audiolib.cpp: In member function 'virtual void AudiolibOpenALDriver::freeBuffer(void*)':
src/audiolib.cpp:528:14: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
    if(source == AL_INVALID) {
              ^
src/audiolib.cpp:533:22: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
    if(floatingBuffer == AL_INVALID) {
                      ^
src/audiolib.cpp: In member function 'virtual void AudiolibOpenALDriver::suspend()':
src/audiolib.cpp:551:14: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
    if(source == AL_INVALID) {
              ^
src/audiolib.cpp: In member function 'virtual void AudiolibOpenALDriver::resume()':
src/audiolib.cpp:561:14: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
    if(source == AL_INVALID) {
              ^
Compiling src/cheats.c...
src/cheats.c: In function 'decode_raw':
src/cheats.c:24:16: warning: pointer targets in passing argument 1 of 'sscanf' differ in signedness [-Wpointer-sign]
    if (sscanf (code, "%04x?%02x:%02x", &decoded_address,
                ^~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/ctype.h:25,
                 from src/cheats.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/stdio.h:451:12: note: expected 'const char * restrict' but argument is of type 'const UINT8 * {aka const unsigned char *}'
 extern int __REDIRECT_NTH (sscanf, (const char *__restrict __s,
            ^
src/cheats.c:27:19: warning: pointer targets in passing argument 1 of 'sscanf' differ in signedness [-Wpointer-sign]
       if (sscanf (code, "%04x:%02x", &decoded_address, &decoded_value) < 2)
                   ^~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/ctype.h:25,
                 from src/cheats.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/stdio.h:451:12: note: expected 'const char * restrict' but argument is of type 'const UINT8 * {aka const unsigned char *}'
 extern int __REDIRECT_NTH (sscanf, (const char *__restrict __s,
            ^
src/cheats.c: In function 'decode_game_genie':
src/cheats.c:147:21: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
    length = strlen (code);
                     ^~~~
In file included from src/cheats.c:11:0:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'const UINT8 * {aka const unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
src/cheats.c: In function 'cheats_decode':
src/cheats.c:181:17: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
    if ((strlen (code) == 7) || (strlen (code) == 10))
                 ^~~~
In file included from src/cheats.c:11:0:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'const UINT8 * {aka const unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
src/cheats.c:181:41: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
    if ((strlen (code) == 7) || (strlen (code) == 10))
                                         ^~~~
In file included from src/cheats.c:11:0:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'const UINT8 * {aka const unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
src/cheats.c:186:22: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
    else if ((strlen (code) == 6) || (strlen (code) == 8))
                      ^~~~
In file included from src/cheats.c:11:0:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'const UINT8 * {aka const unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
src/cheats.c:186:46: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
    else if ((strlen (code) == 6) || (strlen (code) == 8))
                                              ^~~~
In file included from src/cheats.c:11:0:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'const UINT8 * {aka const unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
Compiling src/config.c...
Compiling src/core.c...
Compiling src/cpu.c...
In file included from src/include/cpu.h:112:0,
                 from src/cpu.c:15:
src/cpu.c: In function 'cpu_enable_sram':
src/include/cpu_in.h:23:48: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_read_address[index] = (address - start);
                                       ~~~~~~~~~^~~~~~~~
src/include/cpu_in.h:23:48: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_read_address[index] = (address - start);
                                       ~~~~~~~~~^~~~~~~~
src/include/cpu_in.h:23:48: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_read_address[index] = (address - start);
                                       ~~~~~~~~~^~~~~~~~
src/include/cpu_in.h:23:48: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_read_address[index] = (address - start);
                                       ~~~~~~~~~^~~~~~~~
src/include/cpu_in.h:69:49: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_write_address[index] = (address - start);
                                        ~~~~~~~~~^~~~~~~~
src/include/cpu_in.h:69:49: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_write_address[index] = (address - start);
                                        ~~~~~~~~~^~~~~~~~
src/include/cpu_in.h:69:49: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_write_address[index] = (address - start);
                                        ~~~~~~~~~^~~~~~~~
src/include/cpu_in.h:69:49: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_write_address[index] = (address - start);
                                        ~~~~~~~~~^~~~~~~~
src/cpu.c: In function 'cpu_disable_sram':
src/include/cpu_in.h:23:48: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_read_address[index] = (address - start);
                                       ~~~~~~~~~^~~~~~~~
src/include/cpu_in.h:23:48: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_read_address[index] = (address - start);
                                       ~~~~~~~~~^~~~~~~~
src/include/cpu_in.h:23:48: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_read_address[index] = (address - start);
                                       ~~~~~~~~~^~~~~~~~
src/include/cpu_in.h:23:48: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_read_address[index] = (address - start);
                                       ~~~~~~~~~^~~~~~~~
src/include/cpu_in.h:69:49: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_write_address[index] = (address - start);
                                        ~~~~~~~~~^~~~~~~~
src/include/cpu_in.h:69:49: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_write_address[index] = (address - start);
                                        ~~~~~~~~~^~~~~~~~
src/include/cpu_in.h:69:49: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_write_address[index] = (address - start);
                                        ~~~~~~~~~^~~~~~~~
src/include/cpu_in.h:69:49: warning: array subscript is below array bounds [-Warray-bounds]
    cpu_block_2k_write_address[index] = (address - start);
                                        ~~~~~~~~~^~~~~~~~
Compiling src/etc/hqx.c...
Compiling src/etc/snes_ntsc.c...
Compiling src/gui.c...
src/gui.c: In function 'main_cheat_manager_dialog_add':
src/gui.c:3692:23: warning: pointer targets in passing argument 1 of 'cheats_decode' differ in signedness [-Wpointer-sign]
    if (cheats_decode (code, &patch->address, &patch->value,
                       ^~~~
In file included from src/gui.c:18:0:
src/include/cheats.h:17:12: note: expected 'const UINT8 * {aka const unsigned char *}' but argument is of type 'fakenes_uchar_t * {aka char *}'
 extern int cheats_decode (const UINT8 *code, UINT16 *address, UINT8 *value, UINT8 *match_value);
            ^~~~~~~~~~~~~
Compiling src/input.c...
Compiling src/log.c...
src/log.c: In function 'log_open':
src/log.c:29:4: warning: 'file_size' is deprecated [-Wdeprecated-declarations]
    if (file_size (filename) >= MAX_LOG_SIZE)
    ^~
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:41:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/log.c:9:
/nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/alcompat.h:150:1: note: declared here
 AL_FUNC_DEPRECATED(long, file_size, (AL_CONST char *filename));
 ^
Compiling src/main.c...
Compiling src/mmc.c...
In file included from src/mmc.c:50:0:
src/include/mmc/mmc1.h:20:8: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     1, "MMC1",
        ^~~~~~
src/include/mmc/mmc1.h:20:8: note: (near initialization for 'mmc_mmc1.name')
src/include/mmc/mmc1.h:25:5: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     "MMC1\0\0\0\0",
     ^~~~~~~~~~~~~~
src/include/mmc/mmc1.h:25:5: note: (near initialization for 'mmc_mmc1.id')
In file included from src/mmc.c:52:0:
src/include/mmc/mmc3.h:20:8: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     4, "MMC3",
        ^~~~~~
src/include/mmc/mmc3.h:20:8: note: (near initialization for 'mmc_mmc3.name')
src/include/mmc/mmc3.h:25:5: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     "MMC3\0\0\0\0",
     ^~~~~~~~~~~~~~
src/include/mmc/mmc3.h:25:5: note: (near initialization for 'mmc_mmc3.id')
In file included from src/mmc.c:54:0:
src/include/mmc/mmc2and4.h:25:8: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     9, "MMC2",
        ^~~~~~
src/include/mmc/mmc2and4.h:25:8: note: (near initialization for 'mmc_mmc2.name')
src/include/mmc/mmc2and4.h:30:5: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     "MMC2\0\0\0\0",
     ^~~~~~~~~~~~~~
src/include/mmc/mmc2and4.h:30:5: note: (near initialization for 'mmc_mmc2.id')
src/include/mmc/mmc2and4.h:43:9: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     10, "MMC4",
         ^~~~~~
src/include/mmc/mmc2and4.h:43:9: note: (near initialization for 'mmc_mmc4.name')
src/include/mmc/mmc2and4.h:48:5: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     "MMC4\0\0\0\0",
     ^~~~~~~~~~~~~~
src/include/mmc/mmc2and4.h:48:5: note: (near initialization for 'mmc_mmc4.id')
In file included from src/mmc.c:56:0:
src/include/mmc/mmc5.h:20:8: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     5, "MMC5 + ExSound",
        ^~~~~~~~~~~~~~~~
src/include/mmc/mmc5.h:20:8: note: (near initialization for 'mmc_mmc5.name')
src/include/mmc/mmc5.h:25:5: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     "MMC5\0\0\0\0",
     ^~~~~~~~~~~~~~
src/include/mmc/mmc5.h:25:5: note: (near initialization for 'mmc_mmc5.id')
In file included from src/mmc.c:59:0:
src/include/mmc/unrom.h:13:7: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    2, "UNROM",
       ^~~~~~~
src/include/mmc/unrom.h:13:7: note: (near initialization for 'mmc_unrom.name')
src/include/mmc/unrom.h:15:4: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    "UNROM\0\0\0",
    ^~~~~~~~~~~~~
src/include/mmc/unrom.h:15:4: note: (near initialization for 'mmc_unrom.id')
In file included from src/mmc.c:61:0:
src/include/mmc/cnrom.h:13:7: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    3, "CNROM",
       ^~~~~~~
src/include/mmc/cnrom.h:13:7: note: (near initialization for 'mmc_cnrom.name')
src/include/mmc/cnrom.h:15:4: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    "CNROM\0\0\0",
    ^~~~~~~~~~~~~
src/include/mmc/cnrom.h:15:4: note: (near initialization for 'mmc_cnrom.id')
In file included from src/mmc.c:63:0:
src/include/mmc/aorom.h:13:7: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    7, "AOROM",
       ^~~~~~~
src/include/mmc/aorom.h:13:7: note: (near initialization for 'mmc_aorom.name')
src/include/mmc/aorom.h:15:4: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    "AOROM\0\0\0",
    ^~~~~~~~~~~~~
src/include/mmc/aorom.h:15:4: note: (near initialization for 'mmc_aorom.id')
In file included from src/mmc.c:65:0:
src/include/mmc/gnrom.h:13:8: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    66, "GNROM",
        ^~~~~~~
src/include/mmc/gnrom.h:13:8: note: (near initialization for 'mmc_gnrom.name')
src/include/mmc/gnrom.h:15:4: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    "GNROM\0\0\0",
    ^~~~~~~~~~~~~
src/include/mmc/gnrom.h:15:4: note: (near initialization for 'mmc_gnrom.id')
In file included from src/mmc.c:68:0:
src/include/mmc/bandai.h:26:9: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     16, "Bandai",
         ^~~~~~~~
src/include/mmc/bandai.h:26:9: note: (near initialization for 'mmc_bandai.name')
src/include/mmc/bandai.h:31:5: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     "BANDAI\0\0",
     ^~~~~~~~~~~~
src/include/mmc/bandai.h:31:5: note: (near initialization for 'mmc_bandai.id')
In file included from src/mmc.c:70:0:
src/include/mmc/dreams.h:13:8: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    11, "Color Dreams",
        ^~~~~~~~~~~~~~
src/include/mmc/dreams.h:13:8: note: (near initialization for 'mmc_dreams.name')
src/include/mmc/dreams.h:15:4: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    "DREAMS\0\0",
    ^~~~~~~~~~~~
src/include/mmc/dreams.h:15:4: note: (near initialization for 'mmc_dreams.id')
In file included from src/mmc.c:72:0:
src/include/mmc/nina.h:13:8: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    34, "NINA-001",
        ^~~~~~~~~~
src/include/mmc/nina.h:13:8: note: (near initialization for 'mmc_nina.name')
src/include/mmc/nina.h:15:4: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    "NINA\0\0\0\0",
    ^~~~~~~~~~~~~~
src/include/mmc/nina.h:15:4: note: (near initialization for 'mmc_nina.id')
In file included from src/mmc.c:74:0:
src/include/mmc/sunsoft4.h:11:8: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    68, "Sunsoft mapper #4",
        ^~~~~~~~~~~~~~~~~~~
src/include/mmc/sunsoft4.h:11:8: note: (near initialization for 'mmc_sunsoft4.name')
src/include/mmc/sunsoft4.h:13:4: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    "SUNSOFT4",
    ^~~~~~~~~~
src/include/mmc/sunsoft4.h:13:4: note: (near initialization for 'mmc_sunsoft4.id')
In file included from src/mmc.c:77:0:
src/include/mmc/vrc6.h:16:4: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    "Konami VRC6 + ExSound",
    ^~~~~~~~~~~~~~~~~~~~~~~
src/include/mmc/vrc6.h:16:4: note: (near initialization for 'mmc_vrc6.name')
src/include/mmc/vrc6.h:19:4: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    "VRC6\0\0\0\0",
    ^~~~~~~~~~~~~~
src/include/mmc/vrc6.h:19:4: note: (near initialization for 'mmc_vrc6.id')
src/include/mmc/vrc6.h:27:4: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    "Konami VRC6V + ExSound",
    ^~~~~~~~~~~~~~~~~~~~~~~~
src/include/mmc/vrc6.h:27:4: note: (near initialization for 'mmc_vrc6v.name')
src/include/mmc/vrc6.h:30:4: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
    "VRC6V\0\0\0",
    ^~~~~~~~~~~~~
src/include/mmc/vrc6.h:30:4: note: (near initialization for 'mmc_vrc6v.id')
In file included from src/mmc.c:80:0:
src/include/mmc/ffe_f3.h:23:8: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     8, "FFE F3xxx",
        ^~~~~~~~~~~
src/include/mmc/ffe_f3.h:23:8: note: (near initialization for 'mmc_ffe_f3.name')
src/include/mmc/ffe_f3.h:28:5: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     "FFE_F3\0\0",
     ^~~~~~~~~~~~
src/include/mmc/ffe_f3.h:28:5: note: (near initialization for 'mmc_ffe_f3.id')
src/mmc.c:104:8: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     0, "No mapper",
        ^~~~~~~~~~~
src/mmc.c:104:8: note: (near initialization for 'mmc_none.name')
src/mmc.c:109:5: warning: pointer targets in initialization differ in signedness [-Wpointer-sign]
     "NONE\0\0\0\0",
     ^~~~~~~~~~~~~~
src/mmc.c:109:5: note: (near initialization for 'mmc_none.id')
Compiling src/net.c...
Compiling src/netplay.c...
Compiling src/nsf.cpp...
Compiling src/platform.c...
src/platform.c: In function 'platform_init':
src/platform.c:58:13: warning: pointer targets in assignment differ in signedness [-Wpointer-sign]
     homedir = getenv ("HOME");
             ^
src/platform.c:69:46: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
         confdir = ((UINT8 *) malloc (strlen (homedir) + sizeof (confdir_base)));
                                              ^~~~~~~
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
src/platform.c:74:21: warning: pointer targets in passing argument 1 of 'strcpy' differ in signedness [-Wpointer-sign]
             strcpy (confdir, homedir);
                     ^~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:107:1: note: expected 'char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcpy (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:74:30: warning: pointer targets in passing argument 2 of 'strcpy' differ in signedness [-Wpointer-sign]
             strcpy (confdir, homedir);
                              ^~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:107:1: note: expected 'const char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcpy (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:76:21: warning: pointer targets in passing argument 1 of 'strcat' differ in signedness [-Wpointer-sign]
             strcat (confdir, confdir_base);
                     ^~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:145:1: note: expected 'char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcat (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:76:30: warning: pointer targets in passing argument 2 of 'strcat' differ in signedness [-Wpointer-sign]
             strcat (confdir, confdir_base);
                              ^~~~~~~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:145:1: note: expected 'const char * restrict' but argument is of type 'const UINT8 * {aka const unsigned char *}'
 __NTH (strcat (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:79:49: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
             logdir = ((UINT8 *) malloc (strlen (confdir) + sizeof (logdir_base)));
                                                 ^~~~~~~
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
src/platform.c:84:25: warning: pointer targets in passing argument 1 of 'strcpy' differ in signedness [-Wpointer-sign]
                 strcpy (logdir, confdir);
                         ^~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:107:1: note: expected 'char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcpy (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:84:33: warning: pointer targets in passing argument 2 of 'strcpy' differ in signedness [-Wpointer-sign]
                 strcpy (logdir, confdir);
                                 ^~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:107:1: note: expected 'const char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcpy (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:86:25: warning: pointer targets in passing argument 1 of 'strcat' differ in signedness [-Wpointer-sign]
                 strcat (logdir, logdir_base);
                         ^~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:145:1: note: expected 'char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcat (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:86:33: warning: pointer targets in passing argument 2 of 'strcat' differ in signedness [-Wpointer-sign]
                 strcat (logdir, logdir_base);
                                 ^~~~~~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:145:1: note: expected 'const char * restrict' but argument is of type 'const UINT8 * {aka const unsigned char *}'
 __NTH (strcat (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:92:25: warning: pointer targets in passing argument 1 of 'strcat' differ in signedness [-Wpointer-sign]
                 strcat (logfile, logdir);
                         ^~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:145:1: note: expected 'char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcat (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:92:34: warning: pointer targets in passing argument 2 of 'strcat' differ in signedness [-Wpointer-sign]
                 strcat (logfile, logdir);
                                  ^~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:145:1: note: expected 'const char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcat (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:94:25: warning: pointer targets in passing argument 1 of 'strcat' differ in signedness [-Wpointer-sign]
                 strcat (logfile, "/messages");
                         ^~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:145:1: note: expected 'char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcat (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:111:38: warning: pointer targets in passing argument 1 of 'opendir' differ in signedness [-Wpointer-sign]
             if (! (tmpdir = opendir (confdir)))
                                      ^~~~~~~
In file included from src/platform.c:22:0:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/dirent.h:134:13: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern DIR *opendir (const char *__name) __nonnull ((1));
             ^~~~~~~
src/platform.c:117:32: warning: pointer targets in passing argument 1 of 'mkdir' differ in signedness [-Wpointer-sign]
                     if (mkdir (confdir, (S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)) == -1)
                                ^~~~~~~
In file included from src/platform.c:20:0:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/sys/stat.h:317:12: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern int mkdir (const char *__path, __mode_t __mode)
            ^~~~~
src/platform.c:130:32: warning: pointer targets in passing argument 1 of 'mkdir' differ in signedness [-Wpointer-sign]
                         mkdir (logdir, (S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH));
                                ^~~~~~
In file included from src/platform.c:20:0:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/sys/stat.h:317:12: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern int mkdir (const char *__path, __mode_t __mode)
            ^~~~~
src/platform.c:138:29: warning: pointer targets in passing argument 1 of 'strcat' differ in signedness [-Wpointer-sign]
                     strcat (errorbuf, confdir);
                             ^~~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:145:1: note: expected 'char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcat (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:138:39: warning: pointer targets in passing argument 2 of 'strcat' differ in signedness [-Wpointer-sign]
                     strcat (errorbuf, confdir);
                                       ^~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:145:1: note: expected 'const char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcat (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:140:29: warning: pointer targets in passing argument 1 of 'perror' differ in signedness [-Wpointer-sign]
                     perror (errorbuf);
                             ^~~~~~~~
In file included from src/platform.c:10:0:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/stdio.h:849:13: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern void perror (const char *__s);
             ^~~~~~
src/platform.c:173:44: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
         UINT8 * conffile = malloc (strlen (confdir) + sizeof (conffile_base));
                                            ^~~~~~~
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
src/platform.c:176:17: warning: pointer targets in passing argument 1 of 'strcpy' differ in signedness [-Wpointer-sign]
         strcpy (conffile, confdir);
                 ^~~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:107:1: note: expected 'char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcpy (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:176:27: warning: pointer targets in passing argument 2 of 'strcpy' differ in signedness [-Wpointer-sign]
         strcpy (conffile, confdir);
                           ^~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:107:1: note: expected 'const char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcpy (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:178:17: warning: pointer targets in passing argument 1 of 'strcat' differ in signedness [-Wpointer-sign]
         strcat (conffile, conffile_base);
                 ^~~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:145:1: note: expected 'char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcat (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:178:27: warning: pointer targets in passing argument 2 of 'strcat' differ in signedness [-Wpointer-sign]
         strcat (conffile, conffile_base);
                           ^~~~~~~~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:145:1: note: expected 'const char * restrict' but argument is of type 'const UINT8 * {aka const unsigned char *}'
 __NTH (strcat (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:181:26: warning: pointer targets in passing argument 1 of 'set_config_file' differ in signedness [-Wpointer-sign]
         set_config_file (conffile);
                          ^~~~~~~~
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:41:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/config.h:28:1: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 AL_FUNC(void, set_config_file, (AL_CONST char *filename));
 ^
src/platform.c:202:34: warning: pointer targets in passing argument 1 of 'opendir' differ in signedness [-Wpointer-sign]
         if (! (tmpdir = opendir (logdir)))
                                  ^~~~~~
In file included from src/platform.c:22:0:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/dirent.h:134:13: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern DIR *opendir (const char *__name) __nonnull ((1));
             ^~~~~~~
src/platform.c:206:28: warning: pointer targets in passing argument 1 of 'mkdir' differ in signedness [-Wpointer-sign]
                 if (mkdir (logdir, (S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)) == -1)
                            ^~~~~~
In file included from src/platform.c:20:0:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/sys/stat.h:317:12: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern int mkdir (const char *__path, __mode_t __mode)
            ^~~~~
src/platform.c:221:25: warning: pointer targets in passing argument 1 of 'strcat' differ in signedness [-Wpointer-sign]
                 strcat (errorbuf, confdir);
                         ^~~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:145:1: note: expected 'char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcat (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:221:35: warning: pointer targets in passing argument 2 of 'strcat' differ in signedness [-Wpointer-sign]
                 strcat (errorbuf, confdir);
                                   ^~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/features.h:410:0,
                 from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/errno.h:28,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:24,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/platform.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/bits/string3.h:145:1: note: expected 'const char * restrict' but argument is of type 'UINT8 * {aka unsigned char *}'
 __NTH (strcat (char *__restrict __dest, const char *__restrict __src))
 ^
src/platform.c:223:25: warning: pointer targets in passing argument 1 of 'perror' differ in signedness [-Wpointer-sign]
                 perror (errorbuf);
                         ^~~~~~~~
In file included from src/platform.c:10:0:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/stdio.h:849:13: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern void perror (const char *__s);
             ^~~~~~
src/platform.c:243:15: warning: pointer targets in passing argument 1 of 'log_open' differ in signedness [-Wpointer-sign]
     log_open (logfile);
               ^~~~~~~
In file included from src/include/debug.h:13:0,
                 from src/include/common.h:12,
                 from src/platform.c:14:
src/include/log.h:17:6: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 void log_open (const char *);
      ^~~~~~~~
Compiling src/ppu.cpp...
Compiling src/renderer/background.cpp...
Compiling src/rewind.c...
src/rewind.c: In function 'pack':
src/rewind.c:464:28: warning: pointer targets in passing argument 2 of 'compress2' differ in signedness [-Wpointer-sign]
    if (compress2 (packbuf, &packsize, buffer, *size, compression_level) !=
                            ^
In file included from src/rewind.c:20:0:
/nix/store/q8k7r5zbf03ydrpm7imfzds5b2nmdf0a-zlib-1.2.11-dev/include/zlib.h:1242:21: note: expected 'uLongf * {aka long unsigned int *}' but argument is of type 'long int *'
 ZEXTERN int ZEXPORT compress2 OF((Bytef *dest,   uLongf *destLen,
                     ^~~~~~~~~
src/rewind.c: In function 'unpack':
src/rewind.c:509:28: warning: pointer targets in passing argument 2 of 'uncompress' differ in signedness [-Wpointer-sign]
    if (uncompress (outbuf, max, buffer, size) != Z_OK)
                            ^~~
In file included from src/rewind.c:20:0:
/nix/store/q8k7r5zbf03ydrpm7imfzds5b2nmdf0a-zlib-1.2.11-dev/include/zlib.h:1265:21: note: expected 'uLongf * {aka long unsigned int *}' but argument is of type 'long int *'
 ZEXTERN int ZEXPORT uncompress OF((Bytef *dest,   uLongf *destLen,
                     ^~~~~~~~~~
Compiling src/rom.c...
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
src/rom.c: In function 'load_ips':
src/rom.c:64:17: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "PATCH", 5) != 0)
                 ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
src/rom.c:64:17: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "PATCH", 5) != 0)
                 ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
src/rom.c:64:17: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "PATCH", 5) != 0)
                 ^
src/rom.c:64:17: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/rom.c:64:17: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "PATCH", 5) != 0)
                 ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
src/rom.c:64:17: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "PATCH", 5) != 0)
                 ^
src/rom.c:64:17: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/rom.c:64:17: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "PATCH", 5) != 0)
                 ^
src/rom.c:64:17: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/rom.c:64:17: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "PATCH", 5) != 0)
                 ^
src/rom.c:64:17: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/rom.c:64:17: warning: pointer targets in passing argument 1 of 'strncmp' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "PATCH", 5) != 0)
                 ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:144:12: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern int strncmp (const char *__s1, const char *__s2, size_t __n)
            ^~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
src/rom.c:82:20: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
       if (strncmp (marker, "EOF", 3) == 0)
                    ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
src/rom.c:82:20: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
       if (strncmp (marker, "EOF", 3) == 0)
                    ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
src/rom.c:82:20: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
       if (strncmp (marker, "EOF", 3) == 0)
                    ^
src/rom.c:82:20: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/rom.c:82:20: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
       if (strncmp (marker, "EOF", 3) == 0)
                    ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
src/rom.c:82:20: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
       if (strncmp (marker, "EOF", 3) == 0)
                    ^
src/rom.c:82:20: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/rom.c:82:20: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
       if (strncmp (marker, "EOF", 3) == 0)
                    ^
src/rom.c:82:20: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/rom.c:82:20: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
       if (strncmp (marker, "EOF", 3) == 0)
                    ^
src/rom.c:82:20: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/rom.c:82:20: warning: pointer targets in passing argument 1 of 'strncmp' differ in signedness [-Wpointer-sign]
       if (strncmp (marker, "EOF", 3) == 0)
                    ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:144:12: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern int strncmp (const char *__s1, const char *__s2, size_t __n)
            ^~~~~~~
src/rom.c: In function 'load_ines_rom':
src/rom.c:184:4: warning: implicit declaration of function 'mmc_request' [-Wimplicit-function-declaration]
    mmc_request (rom->mapper_number);
    ^~~~~~~~~~~
src/rom.c: In function 'load_rom':
src/rom.c:296:4: warning: 'file_size' is deprecated [-Wdeprecated-declarations]
    if (file_size (ips))
    ^~
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:41:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/rom.c:9:
/nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/alcompat.h:150:1: note: declared here
 AL_FUNC_DEPRECATED(long, file_size, (AL_CONST char *filename));
 ^
src/rom.c: In function 'free_rom':
src/rom.c:446:22: warning: passing argument 1 of 'ppu_free_chr_rom' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
    ppu_free_chr_rom (rom);
                      ^~~
In file included from src/rom.c:15:0:
src/include/ppu.h:79:13: note: expected 'ROM * {aka struct _ROM *}' but argument is of type 'const ROM * {aka const struct _ROM *}'
 extern void ppu_free_chr_rom (ROM *);
             ^~~~~~~~~~~~~~~~
Compiling src/save.c...
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
src/save.c: In function 'fnss_load':
src/save.c:179:17: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "FNSS", 4))
                 ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
src/save.c:179:17: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "FNSS", 4))
                 ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
src/save.c:179:17: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "FNSS", 4))
                 ^
src/save.c:179:17: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/save.c:179:17: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "FNSS", 4))
                 ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
src/save.c:179:17: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "FNSS", 4))
                 ^
src/save.c:179:17: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/save.c:179:17: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "FNSS", 4))
                 ^
src/save.c:179:17: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/save.c:179:17: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "FNSS", 4))
                 ^
src/save.c:179:17: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/save.c:179:17: warning: pointer targets in passing argument 1 of 'strncmp' differ in signedness [-Wpointer-sign]
    if (strncmp (signature, "FNSS", 4))
                 ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:144:12: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern int strncmp (const char *__s1, const char *__s2, size_t __n)
            ^~~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
src/save.c: In function 'open_replay':
src/save.c:521:20: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
       if (strncmp (signature, "REPL", 4))
                    ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
src/save.c:521:20: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
       if (strncmp (signature, "REPL", 4))
                    ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
src/save.c:521:20: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
       if (strncmp (signature, "REPL", 4))
                    ^
src/save.c:521:20: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/save.c:521:20: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
       if (strncmp (signature, "REPL", 4))
                    ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:394:15: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern size_t strlen (const char *__s)
               ^~~~~~
In file included from /nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:634:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
src/save.c:521:20: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
       if (strncmp (signature, "REPL", 4))
                    ^
src/save.c:521:20: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/save.c:521:20: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
       if (strncmp (signature, "REPL", 4))
                    ^
src/save.c:521:20: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/save.c:521:20: warning: pointer targets in passing argument 1 of '__builtin_strcmp' differ in signedness [-Wpointer-sign]
       if (strncmp (signature, "REPL", 4))
                    ^
src/save.c:521:20: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
src/save.c:521:20: warning: pointer targets in passing argument 1 of 'strncmp' differ in signedness [-Wpointer-sign]
       if (strncmp (signature, "REPL", 4))
                    ^
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:30:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/save.c:9:
/nix/store/zsfnlmvw8k7akg1s0ypdy5jd1kq0d8hn-glibc-2.25-49-dev/include/string.h:144:12: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 extern int strncmp (const char *__s1, const char *__s2, size_t __n)
            ^~~~~~~
Compiling src/shared/bufferfile.cpp...
Compiling src/shared/crc32.cpp...
Compiling src/sound/mmc5.cpp...
Compiling src/sound/sound.cpp...
Compiling src/sound/vrc6.cpp...
Compiling src/video.c...
src/video.c: In function 'draw_messages':
src/video.c:1944:20: warning: pointer targets in assignment differ in signedness [-Wpointer-sign]
         for (token = strtok (&video_messages [index] [0], " "); token; token = strtok (NULL, " "))
                    ^
src/video.c:1944:78: warning: pointer targets in assignment differ in signedness [-Wpointer-sign]
         for (token = strtok (&video_messages [index] [0], " "); token; token = strtok (NULL, " "))
                                                                              ^
src/video.c:1949:41: warning: pointer targets in passing argument 2 of 'text_length' differ in signedness [-Wpointer-sign]
             length = text_length (font, token);
                                         ^~~~~
In file included from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/base.h:41:0,
                 from /nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro.h:25,
                 from src/video.c:9:
/nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/include/allegro/text.h:44:1: note: expected 'const char *' but argument is of type 'UINT8 * {aka unsigned char *}'
 AL_FUNC(int, text_length, (AL_CONST struct FONT *f, AL_CONST char *str));
 ^
src/video.c:1962:54: warning: pointer targets in passing argument 3 of 'shadow_textout' differ in signedness [-Wpointer-sign]
                 shadow_textout (screen_buffer, font, token, x, y, VIDEO_COLOR_WHITE);
                                                      ^~~~~
src/video.c:621:20: note: expected 'const UCHAR * {aka const char *}' but argument is of type 'UINT8 * {aka unsigned char *}'
 static INLINE void shadow_textout (BITMAP *bitmap, FONT *font, const UCHAR
                    ^~~~~~~~~~~~~~
src/video.c:1966:54: warning: pointer targets in passing argument 3 of 'shadow_textout' differ in signedness [-Wpointer-sign]
                 shadow_textout (screen_buffer, font, token, x, y, silver);
                                                      ^~~~~
src/video.c:621:20: note: expected 'const UCHAR * {aka const char *}' but argument is of type 'UINT8 * {aka unsigned char *}'
 static INLINE void shadow_textout (BITMAP *bitmap, FONT *font, const UCHAR
                    ^~~~~~~~~~~~~~
Linking fakenes...
/nix/store/z470j6lybdsy4ql972k392490bprhd2g-binutils-2.28.1/bin/ld: warning: cannot find entry symbol _start; defaulting to 000000000040a190
build/unix/apu.o: In function `_GLOBAL__sub_I_apu.cpp':
apu.cpp:(.text.startup+0x76): undefined reference to `__dso_handle'
apu.cpp:(.text.startup+0x101): undefined reference to `__dso_handle'
build/unix/audio.o: In function `_GLOBAL__sub_I_audio.cpp':
audio.cpp:(.text.startup+0x11): undefined reference to `__dso_handle'
build/unix/main.o: In function `main':
main.c:(.text.startup+0x13a): undefined reference to `atexit'
/nix/store/alyb0i3b7bp8sixxscjvm34db7y0qm68-allegro-4.4.2/lib/liballeggl.a(alleggl.c.o): In function `install_allegro_gl':
(.text+0x1a30): undefined reference to `atexit'
/nix/store/z470j6lybdsy4ql972k392490bprhd2g-binutils-2.28.1/bin/ld: fakenes: hidden symbol `__dso_handle' isn't defined
/nix/store/z470j6lybdsy4ql972k392490bprhd2g-binutils-2.28.1/bin/ld: final link failed: Bad value
installing
cp: cannot stat 'fakenes': No such file or directory
builder for ‘/nix/store/kj8hv52zm2zqydkjnhvnz19dlfndk32y-fakenes-0.5.9b3.drv’ failed with exit code 1
[31;1merror:[0m build of ‘/nix/store/kj8hv52zm2zqydkjnhvnz19dlfndk32y-fakenes-0.5.9b3.drv’ failed
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

