### PR TITLE
perl-Mail-SPF: fix lib path

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8329,7 +8329,7 @@ let self = _self // overrides; _self = with self; {
     buildInputs = [ ModuleBuild NetDNSResolverProgrammable ];
     propagatedBuildInputs = [ Error NetAddrIP NetDNS URI ];
 
-    buildPhase = "perl Build.PL --install_base=$out --install_path=\"sbin=$out/bin\"; ./Build build ";
+    buildPhase = "perl Build.PL --install_base=$out --install_path=\"sbin=$out/bin\" --install_path=\"lib=$out/lib/perl5/site_perl\"; ./Build build ";
 
     doCheck = false; # The main test performs network access
     meta = {


### PR DESCRIPTION
###### Motivation for this change

The `MailSPF` Perl module can't be included as a library in other Perl modules because it puts library code in `$out/lib/perl5` instead of `$out/lib/perl5/site_perl`.

I'm not familiar with Perl and the way Nixpkgs works with Perl, but basically, without this patch, having `MailSPF` in `buildInputs` doesn't add it to the `PERL5LIB` environment variable, while all other Perl dependencies in `buildInputs` that install library code to `$out/lib/perl5/site_perl` are automatically added to `PERL5LIB`. After this patch, `MailSPF` is properly added to `PERL5LIB`.

###### Things done

Force the install library path to be  `$out/lib/perl5/site_perl`.