### PR TITLE
wmsm.app: compile in gnu89 mode

### DIFF
--- a/pkgs/applications/window-managers/windowmaker/dockapps/wmsm.app.nix
+++ b/pkgs/applications/window-managers/windowmaker/dockapps/wmsm.app.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation {
 
   postUnpack = "sourceRoot=\${sourceRoot}/wmsm";
 
+  NIX_CFLAGS_COMPILE = "-std=gnu89";
+
   installPhase = ''
     substituteInPlace Makefile --replace "PREFIX	= /usr/X11R6/bin" "" --replace "/usr/bin/install" "install"
     mkdir -pv $out/bin;


### PR DESCRIPTION
###### Motivation for this change

It expects `inline` to expose a symbol, which hasn't been the case since
C99, breaking linking.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

