### PR TITLE
platformio: 2.10.3 -> 3.4.1

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -91,6 +91,8 @@ in pythonPackages.buildPythonApplication rec {
       -e 's,psutil>=[^"]*,psutil,g' \
       -e 's,requests>=[^"]*,requests,g' \
       -e 's,future>=[^"]*,future,g' \
+      -e 's,pyserial>=[^"]*,pyserial,g' \
+      -e 's,semantic_version>=[^"]*,semantic_version,g' \
       setup.py
   '';
 

--- a/pkgs/development/python-modules/platformio/default.nix
+++ b/pkgs/development/python-modules/platformio/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, arrow, bottle, click_5, colorama
+, lockfile, pyserial, requests
+, semantic-version
+, isPy3k, isPyPy
+}:
+buildPythonPackage rec {
+  disabled = isPy3k || isPyPy;
+
+  pname = "platformio";
+  version="3.4.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1b4lba672l851sv1xwc320xbh46x7hx4ms6whc0k37hxkxj0nwm2";
+  };
+
+  propagatedBuildInputs =  [
+    arrow bottle click_5 colorama
+    lockfile pyserial requests semantic-version
+  ];
+
+  patches = [ ./fix-searchpath.patch ];
+
+  meta = with stdenv.lib; {
+    description = "An open source ecosystem for IoT development";
+    homepage = http://platformio.org;
+    maintainers = with maintainers; [ mog makefu ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/platformio/fix-searchpath.patch
+++ b/pkgs/development/python-modules/platformio/fix-searchpath.patch
@@ -1,0 +1,11 @@
+--- ./platformio/util.py-old	2017-09-29 01:20:08.174548250 +0200
++++ ./platformio/util.py	2017-09-29 01:19:48.410485308 +0200
+@@ -395,7 +395,7 @@
+                 isdir(join(p, "click")) or isdir(join(p, "platformio")))
+         if all(conditions):
+             _PYTHONPATH.append(p)
+-    os.environ['PYTHONPATH'] = os.pathsep.join(_PYTHONPATH)
++    os.environ['PYTHONPATH'] = os.pathsep.join(sys.path)
+ 
+ 
+ def get_serialports(filter_hwid=False):

--- a/pkgs/development/python-modules/pyserial/default.nix
+++ b/pkgs/development/python-modules/pyserial/default.nix
@@ -1,0 +1,21 @@
+{ lib, fetchPypi, buildPythonPackage }:
+
+buildPythonPackage rec {
+  pname = "pyserial";
+  version="3.4";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "09y68bczw324a4jb9a1cfwrbjhq179vnfkkkrybbksp0vqgl0bbf";
+  };
+
+  checkPhase = "python -m unittest discover -s test";
+
+  meta = with lib; {
+    homepage = "https://github.com/pyserial/pyserial";
+    license = licenses.psfl;
+    description = "Python serial port extension";
+    maintainers = with maintainers; [ makefu ];
+  };
+}

--- a/pkgs/development/python-modules/semantic-version/default.nix
+++ b/pkgs/development/python-modules/semantic-version/default.nix
@@ -1,0 +1,21 @@
+{ lib, fetchPypi, buildPythonPackage }:
+
+buildPythonPackage rec {
+  pname = "semantic_version";
+  version = "2.6.0";
+  name = "${pname}${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1h2l9xyg1zzsda6kjcmfcgycbvrafwci283vcr1v5sbk01l2hhra";
+  };
+
+  # ModuleNotFoundError: No module named 'tests'
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A library implementing the 'SemVer' scheme";
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ layus makefu ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17876,22 +17876,7 @@ in {
     };
   };
 
-  pyserial = buildPythonPackage rec {
-    name = "pyserial-2.7";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pyserial/${name}.tar.gz";
-      sha256 = "3542ec0838793e61d6224e27ff05e8ce4ba5a5c5cc4ec5c6a3e8d49247985477";
-    };
-
-    doCheck = false;
-
-    meta = {
-      homepage = "http://pyserial.sourceforge.net/";
-      license = licenses.psfl;
-      description = "Python serial port extension";
-    };
-  };
+  pyserial = callPackage ../development/python-modules/pyserial {};
 
   pymongo = callPackage ../development/python-modules/pymongo {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20341,22 +20341,7 @@ in {
     };
   };
 
-  semantic-version = buildPythonPackage rec {
-    pname = "semantic_version";
-    version = "2.4.2";
-    name = "${pname}${version}";
-
-    src = self.fetchPypi {
-      inherit pname version;
-      sha256 = "7e8b7fa74a3bc9b6e90b15b83b9bc2377c78eaeae3447516425f475d5d6932d2";
-    };
-
-    meta = {
-      description = "A library implementing the 'SemVer' scheme";
-      license = licenses.bsdOriginal;
-      maintainers = with maintainers; [ layus ];
-    };
-  };
+  semantic-version = callPackage ../development/python-modules/semantic-version { };
 
   sexpdata = buildPythonPackage rec {
     name = "sexpdata-0.0.2";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15611,27 +15611,7 @@ in {
   };
 
   pika-pool = callPackage ../development/python-modules/pika-pool { };
-
-  platformio =  buildPythonPackage rec {
-    name = "platformio-${version}";
-    version="2.10.3";
-
-    disabled = isPy3k || isPyPy;
-
-    src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/b7/a3/1d3a9d7bae91df1b607e0f31549ec3e0006f29484cc6a1431b3fe3c5b02e/platformio-2.10.3.tar.gz";
-      sha256 = "f3a646871f9baed05f336a32576edaab90abf0737d8adb54f2acb7bcad42a65f";
-     };
-
-     propagatedBuildInputs = with self; [ click_5 requests bottle pyserial lockfile colorama];
-
-     meta = with stdenv.lib; {
-     description = "An open source ecosystem for IoT development";
-     homepage = http://platformio.org;
-     maintainers = with maintainers; [ mog ];
-     license = licenses.asl20;
-     };
-  };
+  platformio = callPackage ../development/python-modules/platformio { };
 
   pylibconfig2 = buildPythonPackage rec {
     name = "pylibconfig2-${version}";


### PR DESCRIPTION
###### Motivation for this change

`platformio` was too old to build https://github.com/arendst/Sonoff-Tasmota 

bump as deps:
  pyserial: 2.7 -> 3.4
  semantic_version: 2.4.2 -> 2.6.0

add patch for fixing broken PYTHONPATH detection function. Without this patch the chrooted platformio will crash when forking itself and trying to `import requests` afterwards. We know how the search path looks like because we prepare it in the `.platformio-wrapped` executable.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] split commit
# Broken Deps
- [x] Octoprint - pinned deps
- [x] Tiros - equires requests2, seems to have never built correctly
---

