### PR TITLE
twolame: init at 2017-09-27

### DIFF
--- a/pkgs/development/libraries/twolame/default.nix
+++ b/pkgs/development/libraries/twolame/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub
+, autoreconfHook, pkgconfig
+, libsndfile }:
+
+stdenv.mkDerivation rec {
+
+  name = "twolame-${version}";
+  version = "2017-09-27";
+
+  src = fetchFromGitHub {
+    owner = "njh";
+    repo = "twolame";
+    rev = "977c8ac55d8ca6d5f35d1d413a119dac2b3b0333";
+    sha256 = "1rq3yc8ygzdqid9zk6pixmm4w9sk2vrlx217lhn5bjaglv7iyf7x";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ libsndfile ];
+
+  meta = with stdenv.lib;{
+    description = "A MP2 encoder";
+    longDescription = ''
+      TwoLAME is an optimised MPEG Audio Layer 2 (MP2) encoder based on
+      tooLAME by Mike Cheng, which in turn is based upon the ISO dist10
+      code and portions of LAME.
+    '';
+    homepage = http://www.twolame.org/;
+    license = with licenses; [ lgpl2Plus ];
+    platforms = with platforms; [ unix ];
+    maintainers = with maintainers; [ AndersonTorres ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10720,6 +10720,8 @@ with pkgs;
 
   tremor = callPackage ../development/libraries/tremor { };
 
+  twolame = callPackage ../development/libraries/twolame { };
+
   udns = callPackage ../development/libraries/udns { };
 
   uid_wrapper = callPackage ../development/libraries/uid_wrapper { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

