### PR TITLE
Revert "cudatoolkit: Move libcudart to a separate output"

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -22,7 +22,7 @@ let
           }
         else throw "cudatoolkit does not support platform ${stdenv.system}";
 
-      outputs = [ "out" "lib" "doc" ];
+      outputs = [ "out" "doc" ];
 
       buildInputs = [ perl ];
 
@@ -51,11 +51,7 @@ let
             patchelf \
               --set-interpreter "''$(cat $NIX_CC/nix-support/dynamic-linker)" $i
           fi
-          if [[ $i =~ libcudart ]]; then
-            rpath2=
-          else
-            rpath2=$rpath:$lib/lib:$out/jre/lib/amd64/jli:$out/lib:$out/lib64:$out/nvvm/lib:$out/nvvm/lib64
-          fi
+          rpath2=$rpath:$lib/lib:$out/jre/lib/amd64/jli:$out/lib:$out/lib64:$out/nvvm/lib:$out/nvvm/lib64
           patchelf --set-rpath $rpath2 --force-rpath $i
         done < <(find . -type f -print0)
       '';
@@ -83,11 +79,6 @@ let
         # Ensure that cmake can find CUDA.
         mkdir -p $out/nix-support
         echo "cmakeFlags+=' -DCUDA_TOOLKIT_ROOT_DIR=$out'" >> $out/nix-support/setup-hook
-
-        # Move some libraries to the lib output so that programs that
-        # depend on them don't pull in this entire monstrosity.
-        mkdir -p $lib/lib
-        mv -v $out/lib64/libcudart* $lib/lib/
 
         # Remove OpenCL libraries as they are provided by ocl-icd and driver.
         rm -f $out/lib64/libOpenCL*


### PR DESCRIPTION
This reverts commit bb1c9b027d343f2ce263496582d6b56af8af92e6.

###### Motivation for this change

See https://github.com/NixOS/nixpkgs/issues/29798

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

