### PR TITLE
cudatoolkit: move libcu[...] to lib output

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -51,7 +51,7 @@ let
             patchelf \
               --set-interpreter "''$(cat $NIX_CC/nix-support/dynamic-linker)" $i
           fi
-          if [[ $i =~ libcudart ]]; then
+          if [[ $i =~ libcublas ]] || [[ $i =~ libcudart ]] || [[ $i =~ libcufft.* ]] || [[ $i =~ libcurand ]] || [[ $i =~ libcusolver ]] ; then
             rpath2=
           else
             rpath2=$rpath:$lib/lib:$out/jre/lib/amd64/jli:$out/lib:$out/lib64:$out/nvvm/lib:$out/nvvm/lib64
@@ -87,7 +87,7 @@ let
         # Move some libraries to the lib output so that programs that
         # depend on them don't pull in this entire monstrosity.
         mkdir -p $lib/lib
-        mv -v $out/lib64/libcudart* $lib/lib/
+        mv -v $out/lib64/libcublas* $out/lib64/libcudart* $out/lib64/libcufft* $out/lib64/libcurand* $out/lib64/libcusolver* $lib/lib/
 
         # Remove OpenCL libraries as they are provided by ocl-icd and driver.
         rm -f $out/lib64/libOpenCL*


### PR DESCRIPTION
where [...] is blas, fft*, rand and solver.

This fixes #29798.  Namely it makes the above libs visible to
tensorflow (and presumably other cudatoolkit.lib users)

###### Motivation for this change

Fixing #29798

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

