### PR TITLE
nixos/tests: fix pgjwt test

### DIFF
--- a/nixos/tests/pgjwt.nix
+++ b/nixos/tests/pgjwt.nix
@@ -1,42 +1,42 @@
-import ./make-test.nix ({ pkgs, ...} : 
+import ./make-test.nix ({ pkgs, lib, ...}:
 let
-  test = pkgs.writeText "test.sql" ''
-    CREATE EXTENSION pgcrypto;
-    CREATE EXTENSION pgjwt;
-    select sign('{"sub":"1234567890","name":"John Doe","admin":true}', 'secret');
-    select * from verify('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ', 'secret');
+  test = with pkgs; runCommand "patch-test" {
+    nativeBuildInputs = [ pgjwt ];
+  }
+  ''
+    sed -e '12 i CREATE EXTENSION pgcrypto;\nCREATE EXTENSION pgtap;\nSET search_path TO tap,public;' ${pgjwt.src}/test.sql > $out;
   '';
 in
-{
+with pkgs; {
   name = "pgjwt";
-  meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ spinus ];
+  meta = with lib.maintainers; {
+    maintainers = [ spinus willibutz ];
   };
 
   nodes = {
-    master =
-      { pkgs, config, ... }:
-
-      {
-        services.postgresql = let mypg = pkgs.postgresql95; in {
-            enable = true;
-            package = mypg;
-            extraPlugins =[pkgs.pgjwt];
-            initialScript =  pkgs.writeText "postgresql-init.sql"
-          ''
-          CREATE ROLE postgres WITH superuser login createdb;
-          '';
-          };
+    master = { pkgs, config, ... }:
+    {
+      services.postgresql = {
+      enable = true;
+      package = postgresql96;
+      extraPlugins = [ pgjwt pgtap ];
+      initialScript =  writeText "postgresql-init.sql"
+      ''
+        CREATE ROLE postgres WITH superuser login createdb;
+      '';
       };
+    };
   };
 
-  testScript = ''
+  testScript = { nodes, ... }:
+  let
+    sqlSU = "${nodes.master.config.services.postgresql.superUser}";
+    pgProve = "${pkgs.perlPackages.TAPParserSourceHandlerpgTAP}";
+  in
+  ''
     startAll;
     $master->waitForUnit("postgresql");
-    $master->succeed("timeout 10 bash -c 'while ! psql postgres -c \"SELECT 1;\";do sleep 1;done;'");
-    $master->succeed("cat ${test} | psql postgres");
-    # I can't make original test working :[
-    # $master->succeed("${pkgs.perlPackages.TAPParserSourceHandlerpgTAP}/bin/pg_prove -d postgres ${pkgs.pgjwt.src}/test.sql");
-
+    $master->copyFileFromHost("${test}","/tmp/test.sql");
+    $master->succeed("${pkgs.sudo}/bin/sudo -u ${sqlSU} PGOPTIONS=--search_path=tap,public ${pgProve}/bin/pg_prove -d postgres -v -f /tmp/test.sql");
   '';
 })

--- a/pkgs/servers/sql/postgresql/pgjwt/default.nix
+++ b/pkgs/servers/sql/postgresql/pgjwt/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub }:
 stdenv.mkDerivation rec {
   name = "pgjwt-${version}";
-  version = "0.0.1";
+  version = "unstable-2017-04-24";
   src = fetchFromGitHub {
     owner = "michelp";
     repo = "pgjwt";
-    rev = "12a41eef15e6d3a22399e03178560d5174d496a3";
-    sha256 = "1dgx7kqkf9d7j5qj3xykx238xm8jg0s6c8h7zyl4lx8dmbz9sgsv";
+    rev = "546a2911027b716586e241be7fd4c6f1785237cd";
+    sha256 = "1riz0xvwb6y02j0fljbr9hcbqb2jqs4njlivmavy9ysbcrrv1vrf";
   };
   dontBuild = true;
   installPhase = ''

--- a/pkgs/servers/sql/postgresql/pgtap/default.nix
+++ b/pkgs/servers/sql/postgresql/pgtap/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, postgresql, perl, perlPackages, which }:
+
+stdenv.mkDerivation rec {
+  name = "pgtap-${version}";
+  version = "0.97.0";
+
+  src = fetchFromGitHub {
+    owner = "theory";
+    repo = "pgtap";
+    rev = "v${version}";
+    sha256 = "1vzc8pxzi0rbywmrvx7i5awngsvzcz75i4jl9bk2vqr223chax6f";
+  };
+
+  nativeBuildInputs = [ postgresql perl perlPackages.TAPParserSourceHandlerpgTAP which ];
+
+  installPhase = ''
+    install -D {sql/pgtap--${version}.sql,pgtap.control} -t $out/share/extension
+  '';
+
+  meta = with stdenv.lib; {
+    description = "pgTAP is a unit testing framework for PostgreSQL";
+    longDescription = ''
+      pgTAP is a unit testing framework for PostgreSQL written in PL/pgSQL and PL/SQL.
+      It includes a comprehensive collection of TAP-emitting assertion functions,
+      as well as the ability to integrate with other TAP-emitting test frameworks.
+      It can also be used in the xUnit testing style.
+    '';
+    maintainers = with maintainers; [ willibutz ];
+    homepage = http://pgtap.org;
+    inherit (postgresql.meta) platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2475,6 +2475,8 @@ with pkgs;
 
   pgjwt = callPackage ../servers/sql/postgresql/pgjwt {};
 
+  pgtap = callPackage ../servers/sql/postgresql/pgtap {};
+
   pigz = callPackage ../tools/compression/pigz { };
 
   pixz = callPackage ../tools/compression/pixz { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12857,11 +12857,11 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
-  TAPParserSourceHandlerpgTAP = buildPerlModule {
-    name = "TAP-Parser-SourceHandler-pgTAP-3.30";
+  TAPParserSourceHandlerpgTAP = buildPerlModule rec {
+    name = "TAP-Parser-SourceHandler-pgTAP-3.33";
     src = fetchurl {
-      url = mirror://cpan/authors/id/D/DW/DWHEELER/TAP-Parser-SourceHandler-pgTAP-3.30.tar.gz;
-      sha256 = "08gadqf898r23sx07sn13555cp9zkwp8igjlh1fza2ycfivpfl9f";
+      url = "mirror://cpan/authors/id/D/DW/DWHEELER/${name}.tar.gz";
+      sha256 = "35q46y2hbp2ij5n9ir76lmspqj3n8gb0z9l5ipb5g7q90l160m4k";
     };
     meta = {
       homepage = http://search.cpan.org/dist/Tap-Parser-Sourcehandler-pgTAP/;


### PR DESCRIPTION
###### Things done
- updated pgjwt to the most recent revision and adjusted the version numbering
- updated perlPackages.TAPParserSourceHandlerpgTAP from 3.30 to 3.33
- added the pgtap extension for postgresql
- rewrote the pgjwt test so that is now uses the test from the pgjwt repo which is much more extensive than our test was before

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

