### PR TITLE
quassel: fix daemon startup

### DIFF
--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -65,6 +65,9 @@ in with stdenv; mkDerivation rec {
     ++ edf withKDE "WITH_KDE";
 
   preFixup =
+    lib.optionalString daemon ''
+        wrapProgram "$out/bin/quasselcore" --suffix PATH : "${qtbase.bin}/bin"
+    '' +
     lib.optionalString buildClient ''
         wrapProgram "$out/bin/quassel${lib.optionalString client "client"}" \
           --prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules"


### PR DESCRIPTION
Fixes #28911.

###### Motivation for this change

Quassel daemon was unable to find Qt sqlite3 plugin. Adding Qt to its PATH helps because we have a patch that makes Qt look for its plugins relative to PATH items.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).