### PR TITLE
Backport sysdig/bcc modules

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -102,6 +102,7 @@
   ./programs/spacefm.nix
   ./programs/ssh.nix
   ./programs/ssmtp.nix
+  ./programs/sysdig.nix
   ./programs/thefuck.nix
   ./programs/tmux.nix
   ./programs/venus.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -73,6 +73,7 @@
   ./programs/adb.nix
   ./programs/atop.nix
   ./programs/bash/bash.nix
+  ./programs/bcc.nix
   ./programs/blcr.nix
   ./programs/browserpass.nix
   ./programs/cdemu.nix

--- a/nixos/modules/programs/bcc.nix
+++ b/nixos/modules/programs/bcc.nix
@@ -1,0 +1,9 @@
+{ config, lib, pkgs, ... }:
+{
+  options.programs.bcc.enable = lib.mkEnableOption "bcc";
+
+  config = lib.mkIf config.programs.bcc.enable {
+    environment.systemPackages = [ config.boot.kernelPackages.bcc ];
+    boot.extraModulePackages = [ config.boot.kernelPackages.bcc ];
+  };
+}

--- a/nixos/modules/programs/sysdig.nix
+++ b/nixos/modules/programs/sysdig.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.sysdig;
+in {
+  options.programs.sysdig.enable = mkEnableOption "sysdig";
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.sysdig ];
+    boot.extraModulePackages = [ config.boot.kernelPackages.sysdig ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Let's call it a usability bug that people don't know how to enable sysdig/bcc kernel modules correctly.
Also see:

https://github.com/NixOS/nixpkgs/issues/17683
https://github.com/NixOS/nixpkgs/issues/29913

cc @orivej 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

