### PR TITLE
peco: 0.2.10 -> 0.5.1

### DIFF
--- a/pkgs/tools/text/peco/default.nix
+++ b/pkgs/tools/text/peco/default.nix
@@ -1,54 +1,28 @@
-{ stdenv, go, fetchgit }:
+{ stdenv, fetchFromGitHub, go, glide, git }:
 
-let
-  go-flags = fetchgit {
-    url = "git://github.com/jessevdk/go-flags";
-    rev = "ef51ed2000ee1721c7153e958511907b844b4a9c";
-    sha256 = "1abzc7ksglicaz6g6nry006vwvflsidvyzyig85pi3p852z6sc2j";
-  };
-  go-runewidth = fetchgit {
-    url = "git://github.com/mattn/go-runewidth";
-    rev = "63c378b851290989b19ca955468386485f118c65";
-    sha256 = "1z5mhfrpqdssn3603vwd95w69z28igwq96lh7b9rrdcx440i822d";
-  };
-  termbox-go = fetchgit {
-    url = "git://github.com/nsf/termbox-go";
-    rev = "bb19a81afd4bc2729799d1fedb19f7bd7ee284cf";
-    sha256 = "1zc8pb594l16yipis6xg2ra84bg315p63wqxa5abyam1y0333sn0";
-  };
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "peco-${version}";
-  version = "0.2.10";
+  version = "0.5.1";
 
-  src = fetchgit {
-    url = "git://github.com/peco/peco";
-    rev = "4952013023ae1d92c10d826e6970c5a68959678d";
-    sha256 = "15blxy6a9ph6hm5wn14p025qidbspjy6hhmp4zbbgpxx2l1x8fpg";
+  src = fetchFromGitHub {
+    owner = "peco";
+    repo = "peco";
+    rev = "v${version}";
+    sha256 = "0jnlpr3nxx8xmjb6w4jlwshzz0p9hlww9919qbkm66afv16k0vm8";
   };
 
-  buildInputs = [ go ];
-
-  sourceRoot = ".";
+  nativeBuildInputs = [ go glide git ];
 
   buildPhase = ''
-    mkdir -p src/github.com/jessevdk/go-flags/
-    ln -s ${go-flags}/* src/github.com/jessevdk/go-flags
-
-    mkdir -p src/github.com/mattn/go-runewidth/
-    ln -s ${go-runewidth}/* src/github.com/mattn/go-runewidth
-
-    mkdir -p src/github.com/nsf/termbox-go/
-    ln -s ${termbox-go}/* src/github.com/nsf/termbox-go
-
-    mkdir -p src/github.com/peco/peco
-    ln -s ${src}/* src/github.com/peco/peco
-
-    export GOPATH=$PWD
-    go build -v -o peco src/github.com/peco/peco/cmd/peco/peco.go
-  ''; # */
+    mkdir -p src
+    glide install
+    mkdir -p ../src/github.com/peco
+    (PECOSRC=$PWD && cd ../src/github.com/peco && ln -s $PECOSRC peco)
+    GOPATH=$PWD/../ go build github.com/peco/peco/cmd/peco
+  '';
 
   installPhase = ''
-    ensureDir $out/bin
+    mkdir -p $out/bin
     cp peco $out/bin
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Wanted newer version of `peco`

###### Things done

Simplified recipe to use glide to install depends.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

