### PR TITLE
Pysmbc

### DIFF
--- a/pkgs/development/python-modules/pysmbc/default.nix
+++ b/pkgs/development/python-modules/pysmbc/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, samba, pkgconfig
+, setuptools }:
+
+buildPythonPackage rec {
+  version = "1.0.15.8";
+  pname = "pysmbc";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "tar.bz2";
+    sha256 = "07dzxfdqaj6zjg2rxxdww363bh8m02mcvgk47jw005cik9wc2rq5";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ setuptools samba ];
+
+  meta = with stdenv.lib; {
+    description = "libsmbclient binding for Python";
+    homepage = https://github.com/hamano/pysmbc;
+    license = licenses.gplv2;
+  };
+}

--- a/pkgs/tools/misc/system-config-printer/default.nix
+++ b/pkgs/tools/misc/system-config-printer/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ wrapGAppsHook ];
 
   pythonPath = with pythonPackages;
-    [ pycups pycurl dbus-python pygobject3 requests pycairo pythonPackages.pycurl ];
+    [ pycups pycurl dbus-python pygobject3 requests pycairo pysmbc ];
 
   configureFlags =
     [ "--with-udev-rules"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16879,6 +16879,8 @@ in {
 
   pyshp = callPackage ../development/python-modules/pyshp { };
 
+  pysmbc = callPackage ../development/python-modules/pysmbc { };
+
   pyspread = callPackage ../development/python-modules/pyspread { };
 
   pyx = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

https://askubuntu.com/questions/548361/browse-button-disabled-in-windows-printer-via-samba-for-printer-shares

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

