### PR TITLE
chromium: disable patch chromium-gn-bootstrap-r14 for version 62

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -133,8 +133,10 @@ let
       # https://gitweb.gentoo.org/repo/gentoo.git/plain/www-client/chromium/
       # https://git.archlinux.org/svntogit/packages.git/tree/trunk?h=packages/chromium
       # for updated patches and hints about build flags
-      ++ optionals (versionRange "61" "62") [
+      ++ optionals (versionOlder version "62") [
       ./patches/chromium-gn-bootstrap-r14.patch
+    ]
+      ++ optionals (versionRange "61" "62") [
       ./patches/chromium-gcc-r1.patch
       ./patches/chromium-atk-r1.patch
       ./patches/chromium-gcc5-r1.patch


### PR DESCRIPTION
###### Motivation for this change
tried installing chromiumDev on 17.09 and it failed trying to apply this patch. Note that on master, this affects chromiumBeta, but on 17.09 it affects chromiumDev.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

