### PR TITLE
Ipfs: prepare for autoMigrate fix

### DIFF
--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -7,7 +7,7 @@ let
 
   ipfsFlags = toString ([
     (optionalString  cfg.autoMount                   "--mount")
-    (optionalString  cfg.autoMigrate                 "--migrate")
+    #(optionalString  cfg.autoMigrate                 "--migrate")
     (optionalString  cfg.enableGC                    "--enable-gc")
     (optionalString (cfg.serviceFdlimit != null)     "--manage-fdlimit=false")
     (optionalString (cfg.defaultMode == "offline")   "--offline")
@@ -36,6 +36,7 @@ let
 
   baseService = recursiveUpdate commonEnv {
     wants = [ "ipfs-init.service" ];
+    # NB: migration must be performed prior to pre-start, else we get the failure message!
     preStart = ''
       ipfs repo fsck # workaround for BUG #4212 (https://github.com/ipfs/go-ipfs/issues/4214)
       ipfs --local config Addresses.API ${cfg.apiAddress}
@@ -97,11 +98,17 @@ in {
         description = "systemd service that is enabled by default";
       };
 
+      /*
       autoMigrate = mkOption {
         type = types.bool;
         default = false;
-        description = "Whether IPFS should try to migrate the file system automatically";
+        description = ''
+          Whether IPFS should try to migrate the file system automatically.
+
+          The daemon will need to be able to download a binary from https://ipfs.io to perform the migration.
+        '';
       };
+      */
 
       autoMount = mkOption {
         type = types.bool;

--- a/pkgs/applications/networking/ipfs-migrator/default.nix
+++ b/pkgs/applications/networking/ipfs-migrator/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "ipfs-migrator-${version}";
+  version = "6";
+
+  goPackagePath = "github.com/ipfs/fs-repo-migrations";
+
+  goDeps = ./deps.nix;
+
+  src = fetchFromGitHub {
+    owner = "ipfs";
+    repo = "fs-repo-migrations";
+    rev = "a89e9769b9cac25ad9ca31c7e9a4445c7966d35b";
+    sha256 = "0x4mbkx7wlqjmkg6852hljq947v9y9k3hjd5yfj7kka1hpvxd7bn";
+  };
+
+  patches = [ ./lru-repo-path-fix.patch ];
+
+  meta = with stdenv.lib; {
+    description = "Migration tool for ipfs repositories";
+    homepage = https://ipfs.io/;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ elitak ];
+  };
+}

--- a/pkgs/applications/networking/ipfs-migrator/deps.nix
+++ b/pkgs/applications/networking/ipfs-migrator/deps.nix
@@ -1,0 +1,56 @@
+[
+  {
+    goPackagePath = "github.com/dustin/go-humanize";
+    fetch = {
+      type = "git";
+      url = https://github.com/dustin/go-humanize;
+      rev = "79e699ccd02f240a1f1fbbdcee7e64c1c12e41aa";
+      sha256 = "0awfqszgjw8qrdw31v74jnvj1jbp7czhd8aq59j57yyj4hy50fzj";
+    };
+  }
+  {
+    goPackagePath = "github.com/jbenet/goprocess";
+    fetch = {
+      type = "git";
+      url = https://github.com/jbenet/goprocess;
+      rev = "b497e2f366b8624394fb2e89c10ab607bebdde0b";
+      sha256 = "1lnvkzki7vnqn5c4m6bigk0k85haicmg27w903kwg30rdvblm82s";
+    };
+  }
+  {
+    goPackagePath = "github.com/jbenet/go-random";
+    fetch = {
+      type = "git";
+      url = https://github.com/jbenet/go-random;
+      rev = "384f606e91f542a98e779e652eed88051618f0f7";
+      sha256 = "0gcshzl9n3apzc0jaxqrjsc038yfrzfyhpdqgbpcnajin83l2msa";
+    };
+  }
+  {
+    goPackagePath = "github.com/jbenet/go-random-files";
+    fetch = {
+      type = "git";
+      url = https://github.com/jbenet/go-random-files;
+      rev = "737479700b40b4b50e914e963ce8d9d44603e3c8";
+      sha256 = "1klpdc4qkrfy31r7qh00fcz42blswzabmcnry9byd5adhszxj9bw";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/golang-lru";
+    fetch = {
+      type = "git";
+      url = https://github.com/hashicorp/golang-lru;
+      rev = "0a025b7e63adc15a622f29b0b2c4c3848243bbf6";
+      sha256 = "1iq7lbpsz7ks052mpznmkf8s4k43p51z4dik2n9ivrxk666q2wxi";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "71a035914f99bb58fe82eac0f1289f10963d876c";
+      sha256 = "06m16c9vkwc8m2mcxcxa7p8mb26ikc810lgzd5m8k1r6lp3hc8wm";
+    };
+  }
+]

--- a/pkgs/applications/networking/ipfs-migrator/lru-repo-path-fix.patch
+++ b/pkgs/applications/networking/ipfs-migrator/lru-repo-path-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/ipfs-1-to-2/go-datastore/lru/datastore.go b/ipfs-1-to-2/go-datastore/lru/datastore.go
+index 7eb18eb..cd8dcb7 100644
+--- a/ipfs-1-to-2/go-datastore/lru/datastore.go
++++ b/ipfs-1-to-2/go-datastore/lru/datastore.go
+@@ -3,7 +3,7 @@ package lru
+ import (
+ 	"errors"
+ 
+-	lru "github.com/ipfs/fs-repo-migrations/ipfs-1-to-2/golang-lru"
++	lru "github.com/hashicorp/golang-lru"
+ 
+ 	ds "github.com/ipfs/fs-repo-migrations/ipfs-1-to-2/go-datastore"
+ 	dsq "github.com/ipfs/fs-repo-migrations/ipfs-1-to-2/go-datastore/query"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2690,6 +2690,7 @@ with pkgs;
   iperf = iperf3;
 
   ipfs = callPackage ../applications/networking/ipfs { };
+  ipfs-migrator = callPackage ../applications/networking/ipfs-migrator { };
 
   ipmitool = callPackage ../tools/system/ipmitool {
     static = false;


### PR DESCRIPTION
###### Motivation for this change

I was trying the dev branch of ipfs v0.11 and found that the `services.ipfs.autoMigrate` option was broken. The daemon tries to download and run a golang binary that is improperly linked and can't even be `patchelf`ed, not to mention the pre-start script fails before it even gets to that point, because of the repo version mismatch.

The best approach I see right now is do the migration automatically ourselves, rather than relying on the daemon's fault-prone internal method. The first step is to detect the actual ipfs repo version by looking at `/var/lib/ipfs/version`, then determining the version the installed binary wants (hard, since `ipfs version --all` refuses to run, IIRC, which may be an upstream bug that needs to be filed). Finally, we can run the appropriate X-to-Y binaries, in order, provided in the new `ipfs-migrator` package, to get to the correct version, then launch the daemon.

###### Things done

I've disabled the `autoMigrate` option in `services.ipfs`. I'm including a build of the migration tools so that re-adding the `autoMigrate` feature is easier on whomever ends up fixing the option. 

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

