### PR TITLE
[RDY] kernel doc: explain how to configure custom kernel

### DIFF
--- a/nixos/doc/manual/configuration/linux-kernel.xml
+++ b/nixos/doc/manual/configuration/linux-kernel.xml
@@ -67,6 +67,57 @@ nixpkgs.config.packageOverrides = pkgs:
   parameters, run <command>sysctl -a</command>.
  </para>
  <section>
+  <title>Customize your kernel</title>
+
+  <para>
+   The first step before compiling the kernel is to generate an appropriate
+   <literal>.config</literal> configuration. Either you pass your own config via
+   the <literal>configfile</literal> setting of <literal>linuxManualConfig</literal>:
+  <screen><![CDATA[
+  custom-kernel = super.linuxManualConfig {
+    inherit (super) stdenv hostPlatform;
+    inherit (linux_4_9) src;
+    version = "${linux_4_9.version}-custom";
+
+    configfile = /home/me/my_kernel_config;
+    allowImportFromDerivation = true;
+  };
+  ]]></screen>
+
+You can edit the config with this snippet (by default <command>make menuconfig</command> won't work
+  out of the box on nixos):
+  <screen><![CDATA[
+      nix-shell -E 'with import <nixpkgs> {}; kernelToOverride.overrideAttrs (o: {nativeBuildInputs=o.nativeBuildInputs ++ [ pkgconfig ncurses ];})'
+  ]]></screen>
+
+
+  or you can let nixpkgs generate the configuration.
+  Nixpkgs generates it via answering the interactive kernel utility <command>make config</command>.
+  The answers depend on parameters passed to <filename>pkgs/os-specific/linux/kernel/generic.nix</filename>
+  (which you can influence by overriding <literal>extraConfig, autoModules, modDirVersion, preferBuiltin, extraConfig</literal>).
+<screen><![CDATA[
+
+  mptcp93.override ({
+      name="mptcp-local";
+
+      ignoreConfigErrors = true;
+      autoModules = false;
+      kernelPreferBuiltin = true;
+
+      enableParallelBuilding = true;
+
+      extraConfig = ''
+        DEBUG_KERNEL y
+        FRAME_POINTER y
+        KGDB y
+        KGDB_SERIAL_CONSOLE y
+        DEBUG_INFO y
+      '';
+    });
+  ]]></screen>
+  </para>
+ </section>
+ <section>
   <title>Developing kernel modules</title>
 
   <para>


### PR DESCRIPTION
###### Motivation for this change

compiling kernel is currently hard, hopefully it will improve overtime. (for instance:
```
 nix-build <nixpkgs> --arg crossSystem '(import <nixpkgs/lib>).systems.examples.aarch64-multiplatform' -iA lin

$ nix-build -A linux_mptcp --arg 'localSystem' 'let lib = (import <nixpkgs/lib>); in lib.recursiveUpdate (lib.systems.elaborate { system = builtins.currentSystem; }) { platform = test-platform; }' '<nixpkgs>' --show-trace
```
)
Until then here is some doc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

