### PR TITLE
giac, xcas: init at 1.4.9

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -575,6 +575,7 @@
   swarren83 = "Shawn Warren <shawn.w.warren@gmail.com>";
   swflint = "Samuel W. Flint <swflint@flintfam.org>";
   swistak35 = "Rafał Łasocha <me@swistak35.com>";
+  symphorien = "Guillaume Girol <symphorien_nixpkgs@xlumurb.eu>";
   szczyp = "Szczyp <qb@szczyp.com>";
   sztupi = "Attila Sztupak <attila.sztupak@gmail.com>";
   taeer = "Taeer Bar-Yam <taeer@necsi.edu>";

--- a/pkgs/applications/science/math/giac/default.nix
+++ b/pkgs/applications/science/math/giac/default.nix
@@ -59,5 +59,6 @@ stdenv.mkDerivation rec {
     ## xcas is buildable on darwin but there are specific instructions I could
     ## not test
     platforms = platforms.linux;
+    maintainers = [ maintainers.symphorien ];
   };
 }

--- a/pkgs/applications/science/math/giac/default.nix
+++ b/pkgs/applications/science/math/giac/default.nix
@@ -1,0 +1,63 @@
+{stdenv, fetchurl, gmp, mpfr, pari, ntl, gsl, blas,
+readline, gettext, liblapackWithAtlas, bison, yacc, flex,
+mpfi,  libpng, libao, gfortran, texlive, hevea, perl,
+enableGui ? true, mesa ? null, xorg ? null, fltk ? null,
+}:
+
+assert enableGui -> mesa != null && xorg != null && fltk != null;
+
+stdenv.mkDerivation rec {
+  name = "giac-${version}";
+  version = "1.4.9";
+
+  src = fetchurl {
+    url = "https://www-fourier.ujf-grenoble.fr/~parisse/giac/${name}.tar.bz2";
+    sha256 = "1n7xxgpqrsq7cv5wgcmgag6jvxw5wijkf1yv1r5aizlf1rc7dhai";
+  };
+
+
+  patchPhase = ''
+    for i in doc/*/Makefile* ; do
+      substituteInPlace "$i" --replace "/bin/cp" "cp";
+    done;
+    '';
+
+  nativeBuildInputs = [
+    texlive.combined.scheme-small hevea
+  ];
+
+  buildInputs = [
+    gmp mpfr pari ntl gsl mpfi liblapackWithAtlas bison yacc flex readline
+    gettext blas libpng gfortran perl
+  ] ++ stdenv.lib.optionals enableGui [
+    mesa fltk xorg.libX11
+  ];
+
+  enableParallelBuilding = true;
+  hardeningDisable = [ "format" "bindnow" "relro" ];
+
+  configureFlags = [
+      "--enable-gc" "--enable-png" "--enable-gsl" "--enable-lapack"
+      "--enable-pari" "--enable-ntl" "--enable-gmpxx" # "--enable-cocoa"
+      "--enable-ao" ] ++ stdenv.lib.optionals enableGui [
+      "--enable-gui" "--with-x"
+    ];
+
+  postInstall = ''
+    # example Makefiles contain the full path to some commands
+    # notably texlive, and we don't want texlive to become a runtime
+    # dependency
+    for file in $(find $out -name Makefile) ; do
+      sed -i "s@/nix/store/[^/]*/bin/@@" "$file" ;
+    done;
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A free computer algebra system (CAS)";
+    homepage = "https://www-fourier.ujf-grenoble.fr/~parisse/giac.html";
+    license = licenses.gpl3Plus;
+    ## xcas is buildable on darwin but there are specific instructions I could
+    ## not test
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9279,8 +9279,8 @@ with pkgs;
 
   libminc = callPackage ../development/libraries/libminc { };
 
-  libmirage = callPackage ../misc/emulators/cdemu/libmirage.nix { }; 
-  
+  libmirage = callPackage ../misc/emulators/cdemu/libmirage.nix { };
+
   libmkv = callPackage ../development/libraries/libmkv { };
 
   libmms = callPackage ../development/libraries/libmms { };
@@ -18435,8 +18435,8 @@ with pkgs;
 
   gfan = callPackage ../applications/science/math/gfan {};
 
-  xcas = callPackage ../applications/science/math/giac { };
-  giac = xcas.override { enableGui = false;};
+  giac = callPackage ../applications/science/math/giac { };
+  giac-with-xcas = giac.override { enableGUI = true; };
 
   ginac = callPackage ../applications/science/math/ginac { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18435,6 +18435,9 @@ with pkgs;
 
   gfan = callPackage ../applications/science/math/gfan {};
 
+  xcas = callPackage ../applications/science/math/giac { };
+  giac = xcas.override { enableGui = false;};
+
   ginac = callPackage ../applications/science/math/ginac { };
 
   glucose = callPackage ../applications/science/logic/glucose { };


### PR DESCRIPTION
###### Motivation for this change
 package xcas on NixOS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- NA Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

