### PR TITLE
luaiconv: init at 7

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -215,6 +215,31 @@ let
     '';
   };
 
+  lua-iconv = buildLuaPackage rec {
+    name = "lua-iconv-${version}";
+    version = "7";
+    src = fetchFromGitHub {
+      owner = "ittner";
+      repo = "lua-iconv";
+      rev = "e8d34024a6b185a759733915f116cc5588550261";
+      sha256 = "0rd76966qlxfp8ypkyrbif76nxnm1acclqwfs45wz3972jsk654i";
+    };
+
+    preBuild = ''
+      makeFlagsArray=(
+        INSTALL_PATH="$out/lib/lua/${lua.luaversion}"
+      );
+    '';
+
+    meta = {
+      platforms = stdenv.lib.platforms.unix;
+      license = stdenv.lib.licenses.mit;
+      description = "Lua bindings for POSIX iconv";
+      maintainers = [ maintainers.richardipsum ];
+      homepage = "https://ittner.github.io/lua-iconv/";
+    };
+  };
+
   luasec = buildLuaPackage rec {
     name = "sec-0.6";
     src = fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change
Hi!

I would like to package a git network auth package known as Gitano
lua-iconv is a dependency of Gitano's

I'll be opening separate PRs for each Gitano dependency, since that should make it easier to review.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This package has been tested on Debian through installation and test of Gitano itself.

Thanks!
Richard
