### PR TITLE
deepin-gtk-theme: init at 17.10.4

### DIFF
--- a/pkgs/misc/themes/deepin/default.nix
+++ b/pkgs/misc/themes/deepin/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  name = "deepin-gtk-theme-${version}";
+  version = "17.10.4";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = "deepin-gtk-theme";
+    rev = version;
+    sha256 = "1hb0y72fzmcj2yl6q7mbc0c7yxkd1qgnyw4vixdqxnxk2c82sxzw";
+  };
+
+  buildInputs = [ gtk-engine-murrine ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    description = "Deepin GTK Theme";
+    homepage = https://github.com/linuxdeepin/deepin-gtk-theme;
+    license = stdenv.lib.licenses.lgpl3;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18074,6 +18074,8 @@ with pkgs;
 
   orion = callPackage ../misc/themes/orion {};
 
+  deepin-gtk-theme = callPackage ../misc/themes/deepin { };
+
   albatross = callPackage ../misc/themes/albatross { };
 
   gtk_engines = callPackage ../misc/themes/gtk2/gtk-engines { };


### PR DESCRIPTION
###### Motivation for this change

Add deepin theme.

https://github.com/linuxdeepin/deepin-gtk-theme

https://www.gnome-look.org/p/1177633/



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).