### PR TITLE
mednaffe: GTK3, correct license, find mednafen w/o patching source

### DIFF
--- a/pkgs/misc/emulators/mednaffe/default.nix
+++ b/pkgs/misc/emulators/mednaffe/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gtk2, mednafen }:
+{ stdenv, fetchFromGitHub, makeWrapper, autoreconfHook, pkgconfig, wrapGAppsHook
+, gtk2 ? null, gtk3 ? null, mednafen }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "mednaffe-${version}";
@@ -11,19 +14,17 @@ stdenv.mkDerivation rec {
     sha256 = "13l7gls430dcslpan39k0ymdnib2v6crdsmn6bs9k9g30nfnqi6m";
   };
 
-  patchPhase = ''
-    substituteInPlace src/mednaffe.c \
-      --replace 'binpath = NULL' 'binpath = "${mednafen}/bin/mednafen"'
-  '';
+  nativeBuildInputs = [ autoreconfHook makeWrapper pkgconfig wrapGAppsHook ];
+  buildInputs = [ gtk2 gtk3 mednafen ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ gtk2 mednafen ];
+  configureFlags = [ (enableFeature (gtk3 != null) "gtk3") ];
+  postInstall = "wrapProgram $out/bin/mednaffe --set PATH ${mednafen}/bin";
 
-  meta = with stdenv.lib; {
-    description = "A GTK based frontend for mednafen";
+  meta = {
+    description = "GTK-based frontend for mednafen emulator";
     homepage = https://github.com/AmatCoder/mednaffe;
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ sheenobu ];
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ sheenobu yegortimoshenko ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3265,7 +3265,9 @@ with pkgs;
 
   mednafen-server = callPackage ../misc/emulators/mednafen/server.nix { };
 
-  mednaffe = callPackage ../misc/emulators/mednaffe/default.nix { };
+  mednaffe = callPackage ../misc/emulators/mednaffe/default.nix {
+    gtk2 = null;
+  };
 
   megacli = callPackage ../tools/misc/megacli { };
 


### PR DESCRIPTION
/cc @AmatCoder 

###### Motivation for this change

See https://github.com/NixOS/nixpkgs/pull/29855#issuecomment-333308467.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

