### PR TITLE
hamster-time-tracker: wrap services

### DIFF
--- a/pkgs/applications/misc/hamster-time-tracker/default.nix
+++ b/pkgs/applications/misc/hamster-time-tracker/default.nix
@@ -31,6 +31,10 @@ pythonPackages.buildPythonApplication rec {
     python waf build
   '';
 
+  postFixup = ''
+    wrapPythonProgramsIn $out/lib/hamster-time-tracker "$out $pythonPath"
+  '';
+
   installPhase = ''
     python waf install
   '';


### PR DESCRIPTION
###### Motivation for this change
Hamster did not start because the PYTHONPATH was not set for its services.

Closes: #27498

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

