### PR TITLE
samtools: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/applications/science/biology/bcftools/default.nix
+++ b/pkgs/applications/science/biology/bcftools/default.nix
@@ -1,23 +1,37 @@
-{ stdenv, fetchurl, htslib, zlib, bzip2, lzma, perl }:
+{ stdenv, fetchurl, htslib, zlib, bzip2, lzma, perl, bash }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "bcftools";
-  major = "1.5";
+  major = "1.6";
   version = "${major}.0";
 
   src = fetchurl {
     url = "https://github.com/samtools/bcftools/releases/download/${major}/bcftools-${major}.tar.bz2";
-    sha256 = "0093hkkvxmbwfaa7905s6185jymynvg42kq6sxv7fili11l5mxwz";
+    sha256 = "10prgmf09a13mk18840938ijqgfc9y92hfc7sa2gcv07ddri0c19";
   };
 
-  buildInputs = [ zlib bzip2 lzma perl ];
+
+  nativeBuildInputs = [ bash ];
+
+  buildInputs = [ zlib bzip2 lzma ];
+
+  propagatedBuildInputs = [ htslib ];
 
   makeFlags = [
     "HSTDIR=${htslib}"
     "prefix=$(out)"
     "CC=cc"
   ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  preCheck = ''
+    sed -ie 's|/usr/bin/\(env[[:space:]]\)\{0,1\}perl|${perl}/bin/perl|' test/test.pl test/csq/{sort-csq,make-csq-test} misc/plot-vcfstats
+    sed -ie 's|/bin/bash|${bash}/bin/bash|' test/test.pl
+  '';
 
   meta = with stdenv.lib; {
     description = "Tools for manipulating BCF2/VCF/gVCF format, SNP and short indel sequence variants";

--- a/pkgs/applications/science/biology/bcftools/default.nix
+++ b/pkgs/applications/science/biology/bcftools/default.nix
@@ -1,22 +1,18 @@
-{ stdenv, fetchurl, htslib, zlib, bzip2, lzma, perl, bash }:
+{ stdenv, fetchurl, htslib, zlib, bzip2, lzma, curl, perl, bash }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "bcftools";
-  major = "1.6";
-  version = "${major}.0";
+  version = "1.6";
 
   src = fetchurl {
-    url = "https://github.com/samtools/bcftools/releases/download/${major}/bcftools-${major}.tar.bz2";
+    url = "https://github.com/samtools/bcftools/releases/download/${version}/${name}.tar.bz2";
     sha256 = "10prgmf09a13mk18840938ijqgfc9y92hfc7sa2gcv07ddri0c19";
   };
 
+  nativeBuildInputs = [ perl ];
 
-  nativeBuildInputs = [ bash ];
-
-  buildInputs = [ zlib bzip2 lzma ];
-
-  propagatedBuildInputs = [ htslib ];
+  buildInputs = [ htslib zlib bzip2 lzma curl ];
 
   makeFlags = [
     "HSTDIR=${htslib}"
@@ -24,14 +20,15 @@ stdenv.mkDerivation rec {
     "CC=cc"
   ];
 
+  preCheck = ''
+    patchShebangs misc/
+    patchShebangs test/
+    sed -ie 's|/bin/bash|${bash}/bin/bash|' test/test.pl
+  '';
+
   enableParallelBuilding = true;
 
   doCheck = true;
-
-  preCheck = ''
-    sed -ie 's|/usr/bin/\(env[[:space:]]\)\{0,1\}perl|${perl}/bin/perl|' test/test.pl test/csq/{sort-csq,make-csq-test} misc/plot-vcfstats
-    sed -ie 's|/bin/bash|${bash}/bin/bash|' test/test.pl
-  '';
 
   meta = with stdenv.lib; {
     description = "Tools for manipulating BCF2/VCF/gVCF format, SNP and short indel sequence variants";

--- a/pkgs/applications/science/biology/samtools/default.nix
+++ b/pkgs/applications/science/biology/samtools/default.nix
@@ -3,28 +3,27 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "samtools";
-  major = "1.6";
-  version = "${major}.0";
+  version = "1.6";
 
   src = fetchurl {
-    url = "https://github.com/samtools/samtools/releases/download/${major}/samtools-${major}.tar.bz2";
+    url = "https://github.com/samtools/samtools/releases/download/${version}/${name}.tar.bz2";
     sha256 = "17p4vdj2j2qr3b2c0v4100h6cg4jj3zrb4dmdnd9d9aqs74d4p7f";
   };
 
-  buildInputs = [ zlib ncurses ];
+  nativeBuildInputs = [ perl ];
 
-  propagatedBuildInputs = [ htslib ];
+  buildInputs = [ zlib ncurses htslib ];
 
   configureFlags = [ "--with-htslib=${htslib}" ]
     ++ stdenv.lib.optional (ncurses == null) "--without-curses";
 
+  preCheck = ''
+    patchShebangs test/
+  '';
+
   enableParallelBuilding = true;
 
   doCheck = true;
-
-  preCheck = ''
-    sed -ie 's|/usr/bin/\(env[[:space:]]\)\{0,1\}perl|${perl}/bin/perl|' test/test.pl
-  '';
 
   meta = with stdenv.lib; {
     description = "Tools for manipulating SAM/BAM/CRAM format";

--- a/pkgs/applications/science/biology/samtools/default.nix
+++ b/pkgs/applications/science/biology/samtools/default.nix
@@ -1,20 +1,30 @@
-{ stdenv, fetchurl, zlib, htslib,  ncurses ? null }:
+{ stdenv, fetchurl, zlib, htslib, perl, ncurses ? null }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "samtools";
-  major = "1.5";
+  major = "1.6";
   version = "${major}.0";
 
   src = fetchurl {
     url = "https://github.com/samtools/samtools/releases/download/${major}/samtools-${major}.tar.bz2";
-    sha256 = "1xidmv0jmfy7l0kb32hdnlshcxgzi1hmygvig0cqrq1fhckdlhl5";
+    sha256 = "17p4vdj2j2qr3b2c0v4100h6cg4jj3zrb4dmdnd9d9aqs74d4p7f";
   };
 
   buildInputs = [ zlib ncurses ];
 
+  propagatedBuildInputs = [ htslib ];
+
   configureFlags = [ "--with-htslib=${htslib}" ]
     ++ stdenv.lib.optional (ncurses == null) "--without-curses";
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  preCheck = ''
+    sed -ie 's|/usr/bin/\(env[[:space:]]\)\{0,1\}perl|${perl}/bin/perl|' test/test.pl
+  '';
 
   meta = with stdenv.lib; {
     description = "Tools for manipulating SAM/BAM/CRAM format";

--- a/pkgs/development/libraries/science/biology/htslib/default.nix
+++ b/pkgs/development/libraries/science/biology/htslib/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  version = "${major}.0";
   pname = "htslib";
-  major = "1.6";
+  version = "1.6";
 
   src = fetchurl {
-    url = "https://github.com/samtools/htslib/releases/download/${major}/htslib-${major}.tar.bz2";
+    url = "https://github.com/samtools/htslib/releases/download/${version}/${name}.tar.bz2";
     sha256 = "1jsca3hg4rbr6iqq6imkj4lsvgl8g9768bcmny3hlff2w25vx24m";
   };
 
-  propagatedNativeBuildInputs = [ perl ];
+  # perl is only used during the check phase.
+  nativeBuildInputs = [ perl ];
 
   buildInputs = [ zlib bzip2 lzma curl ];
 
@@ -19,13 +19,13 @@ stdenv.mkDerivation rec {
 
   installFlags = "prefix=$(out)";
 
+  preCheck = ''
+    patchShebangs test/
+  '';
+
   enableParallelBuilding = true;
 
   doCheck = true;
-
-  preCheck = ''
-    find test -name "*.pl" -exec sed -ie 's|/usr/bin/\(env[[:space:]]\)\{0,1\}perl|${perl}/bin/perl|' {} +
-  '';
 
   meta = with stdenv.lib; {
     description = "A C library for reading/writing high-throughput sequencing data";
@@ -35,4 +35,3 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.mimadrid ];
   };
 }
-

--- a/pkgs/development/libraries/science/biology/htslib/default.nix
+++ b/pkgs/development/libraries/science/biology/htslib/default.nix
@@ -1,21 +1,31 @@
-{ stdenv, fetchurl, zlib, bzip2, lzma, curl }:
+{ stdenv, fetchurl, zlib, bzip2, lzma, curl, perl }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   version = "${major}.0";
   pname = "htslib";
-  major = "1.5";
+  major = "1.6";
 
   src = fetchurl {
     url = "https://github.com/samtools/htslib/releases/download/${major}/htslib-${major}.tar.bz2";
-    sha256 = "0bcjmnbwp2bib1z1bkrp95w9v2syzdwdfqww10mkb1hxlmg52ax0";
+    sha256 = "1jsca3hg4rbr6iqq6imkj4lsvgl8g9768bcmny3hlff2w25vx24m";
   };
+
+  propagatedNativeBuildInputs = [ perl ];
 
   buildInputs = [ zlib bzip2 lzma curl ];
 
   configureFlags = "--enable-libcurl"; # optional but strongly recommended
 
   installFlags = "prefix=$(out)";
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  preCheck = ''
+    find test -name "*.pl" -exec sed -ie 's|/usr/bin/\(env[[:space:]]\)\{0,1\}perl|${perl}/bin/perl|' {} +
+  '';
 
   meta = with stdenv.lib; {
     description = "A C library for reading/writing high-throughput sequencing data";


### PR DESCRIPTION
###### Motivation for this change

htslib, samtools and bcftools
- Update to the last versions
- Prograte htslib to samtools and bcftools
- Enable enableParallelBuilding
- Do tests


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

