### PR TITLE
shared-mime-info: 1.8 -> 1.9

### DIFF
--- a/pkgs/data/misc/shared-mime-info/default.nix
+++ b/pkgs/data/misc/shared-mime-info/default.nix
@@ -1,24 +1,25 @@
 {stdenv, fetchurl, pkgconfig, gettext, perl, perlXMLParser, intltool
 , libxml2, glib}:
 
-let version = "1.8"; in
+let version = "1.9"; in
 stdenv.mkDerivation rec {
   name = "shared-mime-info-${version}";
 
   src = fetchurl {
     url = "http://freedesktop.org/~hadess/${name}.tar.xz";
-    sha256 = "1sc96lv9dp1lkvs8dh3ngm3hbjb274d363dl9avhb61il3qmxx9a";
+    sha256 = "10ywzhzg8v1xmb9sz5xbqaci90id38knswigynyl33i29vn360aw";
   };
 
   nativeBuildInputs = [
     pkgconfig gettext intltool perl perlXMLParser libxml2 glib
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     inherit version;
     description = "A database of common MIME types";
     homepage = http://freedesktop.org/wiki/Software/shared-mime-info;
-    license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.mimadrid ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update shared-mime-info to last version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

