### PR TITLE
crystal: 0.23.0 -> 0.23.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -136,6 +136,7 @@
   dancek = "Hannu Hartikainen <hannu.hartikainen@gmail.com>";
   danielfullmer = "Daniel Fullmer <danielrf12@gmail.com>";
   dasuxullebt = "Christoph-Simon Senjak <christoph.senjak@googlemail.com>";
+  david50407 = "David Kuo <me@davy.tw>";
   davidak = "David Kleuker <post@davidak.de>";
   davidrusu = "David Rusu <davidrusu.me@gmail.com>";
   davorb = "Davor Babic <davor@davor.se>";

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -1,8 +1,9 @@
 { stdenv, fetchurl, boehmgc, libatomic_ops, pcre, libevent, libiconv, llvm_4, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  version = "0.23.0";
-  name = "crystal-${version}-1";
+  version = "0.23.1";
+  patch = "3";
+  name = "crystal-${version}-${patch}";
   arch =
     {
       "x86_64-linux" = "linux-x86_64";
@@ -11,18 +12,18 @@ stdenv.mkDerivation rec {
     }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   prebuiltBinary = fetchurl {
-    url = "https://github.com/crystal-lang/crystal/releases/download/${version}/crystal-${version}-1-${arch}.tar.gz";
+    url = "https://github.com/crystal-lang/crystal/releases/download/${version}/crystal-${version}-${patch}-${arch}.tar.gz";
     sha256 =
       {
-        "x86_64-linux" = "0nhs7swbll8hrk15kmmywngkhij80x62axiskb1gjmiwvzhlh0qx";
-        "i686-linux" = "03xp8d3lqflzzm26lpdn4yavj87qzgd6xyrqxp2pn9ybwrq8fx8a";
-        "x86_64-darwin" = "1prz6c1gs8z7dgpdy2id2mjn1c8f5p2bf9b39985bav448njbyjz";
+        "x86_64-linux" = "6a84cc866838ffa5250e28c3ce1a918a93f89c06393fe8cfd4068fcbbc66f3ab";
+        "i686-linux" = "268a39b8d37385ff60d113d4d9fc966472160faa1e3bbf7ae58860ab6678aceb";
+        "x86_64-darwin" = "d3f964ebfc5cd48fad73ab2484ea2a00268812276293dd0f7e9c7d184c8aad8a";
       }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
   };
 
   src = fetchurl {
     url = "https://github.com/crystal-lang/crystal/archive/${version}.tar.gz";
-    sha256 = "05ymwmjkl1b4m888p725kybpiap5ag2vj8l07d59j02inm5r0rcv";
+    sha256 = "8cf1b9a4eab29fca2f779ea186ae18f7ce444ce189c621925fa1a0c61dd5ff55";
   };
 
   # crystal on Darwin needs libiconv to build
@@ -46,27 +47,43 @@ stdenv.mkDerivation rec {
   sourceRoot = ".";
 
   fixPrebuiltBinary = if stdenv.isDarwin then ''
-    wrapProgram $(pwd)/crystal-${version}-1/embedded/bin/crystal \
+    wrapProgram $(pwd)/crystal-${version}-${patch}/embedded/bin/crystal \
         --suffix DYLD_LIBRARY_PATH : $libPath
   ''
   else ''
     patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-      crystal-${version}-1/embedded/bin/crystal
+      crystal-${version}-${patch}/embedded/bin/crystal
     patchelf --set-rpath ${ stdenv.lib.makeLibraryPath [ stdenv.cc.cc ] } \
-      crystal-${version}-1/embedded/bin/crystal
+      crystal-${version}-${patch}/embedded/bin/crystal
   '';
+
+  newline = "\n";
 
   buildPhase = ''
     # patch the script which launches the prebuilt compiler
-    substituteInPlace $(pwd)/crystal-${version}-1/bin/crystal --replace \
-      "/usr/bin/env bash" "${stdenv.shell}"
-    substituteInPlace $(pwd)/crystal-${version}/bin/crystal --replace \
-      "/usr/bin/env bash" "${stdenv.shell}"
-
+    patchShebangs $(pwd)/crystal-${version}-${patch}/bin/crystal
+    patchShebangs $(pwd)/crystal-${version}/bin/crystal
+    # Due to https://github.com/crystal-lang/crystal/issues/4719,
+    # when building Crystal with LLVM 4 with debug infos from prebuilt binary (w/ LLVM 3.8) will always be failed.
+    # So we are going to build a LLVM 4 version without debug info,
+    # and use it to build Crystal with debug info on LLVM 4.
+    substituteInPlace $(pwd)/crystal-${version}/Makefile --replace \
+      "release ?=" "no_debug ?= ##${newline}force_rebuild ?= ##${newline}release ?="
+    substituteInPlace $(pwd)/crystal-${version}/Makefile --replace \
+      "FLAGS := " "FLAGS := \$(if \$(no_debug),--no-debug )"
+    substituteInPlace $(pwd)/crystal-${version}/Makefile --replace \
+      "$(O)/crystal:" "\$(O)/crystal: \$(if \$(force_rebuild),../rebuild.tmp)"
     ${fixPrebuiltBinary}
 
     cd crystal-${version}
-    make release=1 PATH="../crystal-${version}-1/bin:$PATH"
+    # Build without debug infos on LLVM 4
+    make release=1 no_debug=1 PATH="../crystal-${version}-${patch}/bin:$PATH"
+    
+    # Rebuild Crystal with debug infos from the binary we just built
+    touch $(pwd)/../rebuild.tmp
+    wrapProgram .build/crystal \
+        --suffix LIBRARY_PATH : $libPath
+    make release=1 force_rebuild=1
     make doc
   '';
 
@@ -75,7 +92,6 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/crystal \
         --suffix CRYSTAL_PATH : $out/lib/crystal \
         --suffix LIBRARY_PATH : $libPath
-
     install -dm755 $out/lib/crystal
     cp -r src/* $out/lib/crystal/
 
@@ -97,8 +113,7 @@ stdenv.mkDerivation rec {
     description = "A compiled language with Ruby like syntax and type inference";
     homepage = https://crystal-lang.org/;
     license = stdenv.lib.licenses.asl20;
-    maintainers = with stdenv.lib.maintainers; [ sifmelcara ];
+    maintainers = with stdenv.lib.maintainers; [ sifmelcara david50407 ];
     platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
   };
 }
-

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -1,91 +1,65 @@
-{ stdenv, fetchurl, boehmgc, libatomic_ops, pcre, libevent, libiconv, llvm_4, makeWrapper }:
+{ stdenv, fetchurl, boehmgc, libatomic_ops, pcre, libevent, libiconv, llvm, makeWrapper }:
 
 stdenv.mkDerivation rec {
+  name = "crystal-${version}";
   version = "0.23.1";
-  patch = "3";
-  name = "crystal-${version}-${patch}";
-  arch =
-    {
-      "x86_64-linux" = "linux-x86_64";
-      "i686-linux" = "linux-i686";
-      "x86_64-darwin" = "darwin-x86_64";
-    }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
-
-  prebuiltBinary = fetchurl {
-    url = "https://github.com/crystal-lang/crystal/releases/download/${version}/crystal-${version}-${patch}-${arch}.tar.gz";
-    sha256 =
-      {
-        "x86_64-linux" = "6a84cc866838ffa5250e28c3ce1a918a93f89c06393fe8cfd4068fcbbc66f3ab";
-        "i686-linux" = "268a39b8d37385ff60d113d4d9fc966472160faa1e3bbf7ae58860ab6678aceb";
-        "x86_64-darwin" = "d3f964ebfc5cd48fad73ab2484ea2a00268812276293dd0f7e9c7d184c8aad8a";
-      }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
-  };
 
   src = fetchurl {
     url = "https://github.com/crystal-lang/crystal/archive/${version}.tar.gz";
     sha256 = "8cf1b9a4eab29fca2f779ea186ae18f7ce444ce189c621925fa1a0c61dd5ff55";
   };
 
+  prebuiltName = "crystal-0.23.0-1";
+  prebuiltSrc = let arch = {
+    "x86_64-linux" = "linux-x86_64";
+    "i686-linux" = "linux-i686";
+    "x86_64-darwin" = "darwin-x86_64";
+  }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
+  in fetchurl {
+    url = "https://github.com/crystal-lang/crystal/releases/download/0.23.0/${prebuiltName}-${arch}.tar.gz";
+    sha256 = {
+      "x86_64-linux" = "0nhs7swbll8hrk15kmmywngkhij80x62axiskb1gjmiwvzhlh0qx";
+      "i686-linux" = "03xp8d3lqflzzm26lpdn4yavj87qzgd6xyrqxp2pn9ybwrq8fx8a";
+      "x86_64-darwin" = "1prz6c1gs8z7dgpdy2id2mjn1c8f5p2bf9b39985bav448njbyjz";
+    }."${stdenv.system}";
+  };
+
+  srcs = [ src prebuiltSrc ];
+
   # crystal on Darwin needs libiconv to build
-  buildInputs = [
-    boehmgc libatomic_ops pcre libevent llvm_4 makeWrapper
+  libs = [
+    boehmgc libatomic_ops pcre libevent
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     libiconv
   ];
 
-  libPath = stdenv.lib.makeLibraryPath ([
-    boehmgc libatomic_ops pcre libevent
-  ] ++ stdenv.lib.optionals stdenv.isDarwin [
-    libiconv
-  ]);
+  nativeBuildInputs = [ makeWrapper ];
 
-  unpackPhase = ''
-    tar zxf ${src}
-    tar zxf ${prebuiltBinary}
-  '';
+  buildInputs = libs ++ [ llvm ];
 
-  sourceRoot = ".";
+  libPath = stdenv.lib.makeLibraryPath libs;
+
+  sourceRoot = "${name}";
 
   fixPrebuiltBinary = if stdenv.isDarwin then ''
-    wrapProgram $(pwd)/crystal-${version}-${patch}/embedded/bin/crystal \
+    wrapProgram ../${prebuiltName}/embedded/bin/crystal \
         --suffix DYLD_LIBRARY_PATH : $libPath
   ''
   else ''
     patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-      crystal-${version}-${patch}/embedded/bin/crystal
+      ../${prebuiltName}/embedded/bin/crystal
     patchelf --set-rpath ${ stdenv.lib.makeLibraryPath [ stdenv.cc.cc ] } \
-      crystal-${version}-${patch}/embedded/bin/crystal
+      ../${prebuiltName}/embedded/bin/crystal
   '';
 
-  newline = "\n";
-
-  buildPhase = ''
-    # patch the script which launches the prebuilt compiler
-    patchShebangs $(pwd)/crystal-${version}-${patch}/bin/crystal
-    patchShebangs $(pwd)/crystal-${version}/bin/crystal
-    # Due to https://github.com/crystal-lang/crystal/issues/4719,
-    # when building Crystal with LLVM 4 with debug infos from prebuilt binary (w/ LLVM 3.8) will always be failed.
-    # So we are going to build a LLVM 4 version without debug info,
-    # and use it to build Crystal with debug info on LLVM 4.
-    substituteInPlace $(pwd)/crystal-${version}/Makefile --replace \
-      "release ?=" "no_debug ?= ##${newline}force_rebuild ?= ##${newline}release ?="
-    substituteInPlace $(pwd)/crystal-${version}/Makefile --replace \
-      "FLAGS := " "FLAGS := \$(if \$(no_debug),--no-debug )"
-    substituteInPlace $(pwd)/crystal-${version}/Makefile --replace \
-      "$(O)/crystal:" "\$(O)/crystal: \$(if \$(force_rebuild),../rebuild.tmp)"
+  preBuild = ''
+    patchShebangs bin/crystal
+    patchShebangs ../${prebuiltName}/bin/crystal
     ${fixPrebuiltBinary}
-
-    cd crystal-${version}
-    # Build without debug infos on LLVM 4
-    make release=1 no_debug=1 PATH="../crystal-${version}-${patch}/bin:$PATH"
-    
-    # Rebuild Crystal with debug infos from the binary we just built
-    touch $(pwd)/../rebuild.tmp
-    wrapProgram .build/crystal \
-        --suffix LIBRARY_PATH : $libPath
-    make release=1 force_rebuild=1
-    make doc
+    export PATH="$(pwd)/../${prebuiltName}/bin:$PATH"
   '';
+
+  makeFlags = [ "CRYSTAL_CONFIG_VERSION=${version}" "release=1" "all" "doc" ];
 
   installPhase = ''
     install -Dm755 .build/crystal $out/bin/crystal
@@ -108,6 +82,8 @@ stdenv.mkDerivation rec {
   '';
 
   dontStrip = true;
+
+  enableParallelBuilding = true;
 
   meta = {
     description = "A compiled language with Ruby like syntax and type inference";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5410,7 +5410,9 @@ with pkgs;
     '';
   });
 
-  crystal = callPackage ../development/compilers/crystal { };
+  crystal = callPackage ../development/compilers/crystal {
+    llvm = llvm_4;
+  };
 
   devpi-client = callPackage ../development/tools/devpi-client {};
 


### PR DESCRIPTION
###### Motivation for this change

Update the package to the latest version (0.23.1-3).

> NOTE: Due to crystal-lang/crystal#4719, when building Crystal with LLVM 4 with debug infos from prebuilt binary (w/ LLVM 3.8) will always be failed.
> The temporary solution is to build a LLVM 4 version without debug info, then use it to build Crystal with debug info on LLVM 4.
> This will cause building phrase going longer than normal. But we can remove this hack after Crystal fix the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
