### PR TITLE
qmapshack: init at 1.9.1

### DIFF
--- a/pkgs/applications/misc/qmapshack/default.nix
+++ b/pkgs/applications/misc/qmapshack/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromBitbucket, cmake, qtscript, qtwebkit, gdal, proj, routino, quazip }:
+
+stdenv.mkDerivation rec {
+  name = "qmapshack-${version}";
+  version = "1.9.1";
+
+  src = fetchFromBitbucket {
+    owner = "maproom";
+    repo = "qmapshack";
+    rev = "V%20${version}";
+    sha256 = "1yswdq1s9jjhwb3wfiy3kkiiaqzagw28vjqvl13jxcnmq7y763sr";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ qtscript qtwebkit gdal proj routino quazip ];
+
+  cmakeFlags = [
+    "-DROUTINO_XML_PATH=${routino}/share/routino"
+    "-DQUAZIP_INCLUDE_DIR=${quazip}/include/quazip"
+    "-DLIBQUAZIP_LIBRARY=${quazip}/lib/libquazip.so"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://bitbucket.org/maproom/qmapshack/wiki/Home;
+    description = "Plan your next outdoor trip";
+    license = licenses.gpl3;
+    maintainter = with maintainers; [ dotlambda ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16013,6 +16013,8 @@ with pkgs;
 
   qjackctl = libsForQt5.callPackage ../applications/audio/qjackctl { };
 
+  qmapshack = libsForQt5.callPackage ../applications/misc/qmapshack { };
+
   qmetro = callPackage ../applications/misc/qmetro { };
 
   qmidinet = callPackage ../applications/audio/qmidinet { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

