### PR TITLE
gnome3.nautilus: add thumbnailers

### DIFF
--- a/pkgs/desktops/gnome-3/core/nautilus/default.nix
+++ b/pkgs/desktops/gnome-3/core/nautilus/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, libxml2, dbus_glib, shared_mime_info, libexif
 , gtk, gnome3, libunique, intltool, gobjectIntrospection, gnome-autoar, glib
-, libnotify, wrapGAppsHook, exempi, librsvg, tracker, libselinux }:
+, libnotify, wrapGAppsHook, exempi, librsvg, tracker, libselinux, gdk_pixbuf }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
@@ -15,6 +15,14 @@ stdenv.mkDerivation rec {
 
   # fatal error: gio/gunixinputstream.h: No such file or directory
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      # Thumbnailers
+      --prefix XDG_DATA_DIRS : "${gdk_pixbuf}/share"
+      --prefix XDG_DATA_DIRS : "${librsvg}/share"
+    )
+  '';
 
 #  hardeningDisable = [ "format" ];
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Nautilus, resp. gnome-desktop, scans `thumbnailers` directories under the paths in `XDG_DATA_DIRS`. gdk-pixbuf was not, for some reason, listed in the variable, therefore Nautilus did not generate image thumbnails.

I also add librsvg to the variable so that SVG files can be rendered. It does not work at the moment, though, because of incorrect path to the renderer. **Edit**: Will be fixed in #29984

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @lethalman @teh 