### PR TITLE
merkaartor: 0.18.2 -> 0.18.3, Qt4 -> Qt5

### DIFF
--- a/pkgs/applications/misc/merkaartor/default.nix
+++ b/pkgs/applications/misc/merkaartor/default.nix
@@ -1,25 +1,27 @@
-{ stdenv, fetchFromGitHub, qt4, qmake4Hook, boost, proj, gdal, sqlite, pkgconfig }:
+{ stdenv, fetchFromGitHub, qmake, pkgconfig, boost, gdal, proj
+, qtbase, qtsvg, qtwebkit }:
 
 stdenv.mkDerivation rec {
   name = "merkaartor-${version}";
-  version = "0.18.2";
+  version = "0.18.3";
 
   src = fetchFromGitHub {
     owner = "openstreetmap";
     repo = "merkaartor";
     rev = version;
-    sha256 = "1a8kzrc9w0b2a2zgw9dbbi15jy9ynv6nf2sg3k4dbh7f1s2ajx9l";
+    sha256 = "0ls3q8m1hxiwyrypy6qca8wczhl4969ncl0sszfdwfv70rzxjk88";
   };
 
-  buildInputs = [ qt4 boost proj gdal sqlite ];
+  nativeBuildInputs = [ qmake pkgconfig ];
 
-  nativeBuildInputs = [ qmake4Hook pkgconfig ];
+  buildInputs = [ boost gdal proj qtbase qtsvg qtwebkit ];
 
-  meta = {
-    description = "An openstreetmap editor";
-    homepage = http://merkaartor.org/;
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [viric];
-    inherit (qt4.meta) platforms;
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "OpenStreetMap editor";
+    homepage = http://merkaartor.be/;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ viric ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15376,7 +15376,7 @@ with pkgs;
 
   mercurialFull = appendToName "full" (pkgs.mercurial.override { guiSupport = true; });
 
-  merkaartor = callPackage ../applications/misc/merkaartor { };
+  merkaartor = libsForQt5.callPackage ../applications/misc/merkaartor { };
 
   meshlab = callPackage ../applications/graphics/meshlab { };
 


### PR DESCRIPTION
###### Motivation for this change

Qt5, fixed homepage, bumped version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

