### PR TITLE
focuswriter: 1.5.3 -> 1.6.7, Qt4 -> Qt5, GPLv2 -> GPLv3

### DIFF
--- a/pkgs/applications/editors/focuswriter/default.nix
+++ b/pkgs/applications/editors/focuswriter/default.nix
@@ -1,25 +1,27 @@
-{ stdenv, fetchurl, qt4, qmake4Hook, pkgconfig, hunspell }:
+{ stdenv, fetchurl, pkgconfig, qmake, qttools, hunspell, qtbase, qtmultimedia }:
 
 stdenv.mkDerivation rec {
   name = "focuswriter-${version}";
-  version = "1.5.3";
+  version = "1.6.7";
 
   src = fetchurl {
-    url = http://gottcode.org/focuswriter/focuswriter-1.5.3-src.tar.bz2;
-    sha256 = "1i58jxbiy95ijf81g8c3gwxhcg3irzssna3wv7vhrd57g4lcfj0w";
+    url = "https://gottcode.org/focuswriter/focuswriter-${version}-src.tar.bz2";
+    sha256 = "10rqzinr6yd6ca06rklg34kdc08a3xgygfzmprsfg7gdsybfay5z";
   };
 
-  buildInputs = [ qt4 qmake4Hook pkgconfig hunspell ];
-  
-  qmakeFlags = [ "PREFIX=/" ];
+  nativeBuildInputs = [ pkgconfig qmake qttools ];
+  buildInputs = [ hunspell qtbase qtmultimedia ];
 
+  enableParallelBuilding = true;
+
+  qmakeFlags = [ "PREFIX=/" ];
   installFlags = [ "INSTALL_ROOT=$(out)" ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Simple, distraction-free writing environment";
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.madjar ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ madjar ];
+    platforms = platforms.all;
     homepage = https://gottcode.org/focuswriter/;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14368,7 +14368,7 @@ with pkgs;
 
   fmsynth = callPackage ../applications/audio/fmsynth { };
 
-  focuswriter = callPackage ../applications/editors/focuswriter { };
+  focuswriter = libsForQt5.callPackage ../applications/editors/focuswriter { };
 
   font-manager = callPackage ../applications/misc/font-manager { };
 


### PR DESCRIPTION
###### Motivation for this change

New version, upstream has changed license, use Qt5. And enable parallel building :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

