### PR TITLE
rosegarden: Qt4 -> Qt5

### DIFF
--- a/pkgs/applications/audio/rosegarden/default.nix
+++ b/pkgs/applications/audio/rosegarden/default.nix
@@ -1,23 +1,35 @@
-{ stdenv, fetchurl, cmake, qt4, pkgconfig, ladspaPlugins, ladspaH,
-  dssi, liblo, liblrdf, fftwSinglePrec, libsndfile,
-  libsamplerate, perl, makedepend, libjack2,
-  withLirc ? false, lirc ? null } :
+{ stdenv, fetchurl, cmake, makedepend, perl, pkgconfig, qttools
+, dssi, fftwSinglePrec, ladspaH, ladspaPlugins, libjack2
+, liblo, liblrdf, libsamplerate, libsndfile, lirc ? null, qtbase }:
 
 stdenv.mkDerivation (rec {
   version = "17.04";
   name = "rosegarden-${version}";
 
   src = fetchurl {
-    url  = "mirror://sourceforge/rosegarden/${name}.tar.bz2";
+    url = "mirror://sourceforge/rosegarden/${name}.tar.bz2";
     sha256 = "1khfcj22asdhjh0jvhkqsz200wgmigkhsrcz09ffia5hqm0n32lq";
   };
 
-  QTDIR = qt4;
+  patchPhase = ''
+    substituteInPlace src/CMakeLists.txt --replace svnheader svnversion
+  '';
+
+  nativeBuildInputs = [ cmake makedepend perl pkgconfig qttools ];
 
   buildInputs = [
-    cmake qt4 pkgconfig ladspaPlugins ladspaH dssi liblo liblrdf fftwSinglePrec
-    libsndfile libsamplerate perl makedepend libjack2
-  ] ++ stdenv.lib.optional withLirc [ lirc ];
+    dssi
+    fftwSinglePrec
+    ladspaH
+    ladspaPlugins
+    libjack2
+    liblo
+    liblrdf
+    libsamplerate
+    libsndfile
+    lirc
+    qtbase
+  ];
 
   enableParallelBuilding = true;
 
@@ -25,11 +37,15 @@ stdenv.mkDerivation (rec {
     homepage = http://www.rosegardenmusic.com/;
     description = "Music composition and editing environment";
     longDescription = ''
-      Rosegarden is a music composition and editing environment based around a MIDI sequencer that features a rich understanding of music notation and includes basic support for digital audio.
-      Rosegarden is an easy-to-learn, attractive application that runs on Linux, ideal for composers, musicians, music students, and small studio or home recording environments.
-      '';
+      Rosegarden is a music composition and editing environment based around
+      a MIDI sequencer that features a rich understanding of music notation
+      and includes basic support for digital audio.
 
-    maintainers = [ maintainers.lebastr ];
+      Rosegarden is an easy-to-learn, attractive application that runs on Linux,
+      ideal for composers, musicians, music students, and small studio or home
+      recording environments.
+    '';
+    maintainers = with maintainers; [ lebastr ];
     license = licenses.lgpl2Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4200,7 +4200,7 @@ with pkgs;
 
   rockbox_utility = libsForQt5.callPackage ../tools/misc/rockbox-utility { };
 
-  rosegarden = callPackage ../applications/audio/rosegarden { };
+  rosegarden = libsForQt5.callPackage ../applications/audio/rosegarden { };
 
   rowhammer-test = callPackage ../tools/system/rowhammer-test { };
 


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

