### PR TITLE
sfml: 2.4.1 -> 2.4.2

### DIFF
--- a/pkgs/development/libraries/sfml/default.nix
+++ b/pkgs/development/libraries/sfml/default.nix
@@ -3,14 +3,14 @@
 }:
 
 let
-  version = "2.4.1";
+  version = "2.4.2";
 in
 
 stdenv.mkDerivation rec {
   name = "sfml-${version}";
   src = fetchurl {
-    url = "https://github.com/LaurentGomila/SFML/archive/${version}.tar.gz";
-    sha256 = "13irazmqk9vcgkigsjcxns7xjmnz1gifw0b656z1rpz208diklgr";
+    url = "https://github.com/SFML/SFML/archive/${version}.tar.gz";
+    sha256 = "cf268fb487e4048c85e5b2f53d62596854762c98cba1c1b61ccd91f78253ef4b";
   };
   buildInputs = [ cmake libX11 freetype libjpeg openal flac libvorbis glew
                   libXrandr libXrender udev xcbutilimage


### PR DESCRIPTION
###### Motivation for this change
Package update to latest upstream version.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

