### PR TITLE
 17.09 release notes: fix typo

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1709.xml
+++ b/nixos/doc/manual/release-notes/rl-1709.xml
@@ -534,7 +534,7 @@ FLUSH PRIVILEGES;
       Nixpkgs overlays may now be specified with a file as well as a directory. The
       value of <literal>&lt;nixpkgs-overlays></literal> may be a file, and
       <filename>~/.config/nixpkgs/overlays.nix</filename> can be used instead of the
-      <filename>~/.config/nixpkgs/overalys</filename> directory.
+      <filename>~/.config/nixpkgs/overlays</filename> directory.
     </para>
     <para>
       See the overlays chapter of the Nixpkgs manual for more details.


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

