### PR TITLE
gnome3.gnome_control_center: fix thumbnailers path

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -41,6 +41,9 @@ stdenv.mkDerivation rec {
   preFixup = with gnome3; ''
     gappsWrapperArgs+=(
       --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:${sound-theme-freedesktop}/share"
+      # Thumbnailers (for setting user profile pictures)
+      --prefix XDG_DATA_DIRS : "${gdk_pixbuf}/share"
+      --prefix XDG_DATA_DIRS : "${librsvg}/share"
     )
     for i in $out/share/applications/*; do
       substituteInPlace $i --replace "gnome-control-center" "$out/bin/gnome-control-center"


### PR DESCRIPTION
###### Motivation for this change
Just like Nautilus (see #29970), GNOME Control Center also uses gnome-desktop for generating thumbnails. In particular, it tries to make a thumbnail from a file choosen as a profile picture, and
when it does not succeed, it will not allow that file to be chosen. Of course, whithout a thumbnailer, it will always fail.

https://github.com/GNOME/gnome-control-center/blob/43129a1cfd30374c3ff45c54eae9ee5cd68ae1b6/panels/user-accounts/um-photo-dialog.c#L190-L192

Since gnome-desktop scans `thumbnailers` directories under the paths in `XDG_DATA_DIRS`, gdk-pixbuf  had to be added to the path to provide access to image thumbnailer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @lethalman @teh @grahamc 