### PR TITLE
fix build for proot on aarch64

### DIFF
--- a/pkgs/tools/system/proot/default.nix
+++ b/pkgs/tools/system/proot/default.nix
@@ -46,6 +46,6 @@ stdenv.mkDerivation rec {
     description = "User-space implementation of chroot, mount --bind and binfmt_misc";
     platforms = platforms.linux;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ ianwookim nckx ];
+    maintainers = with maintainers; [ ianwookim nckx makefu ];
   };
 }

--- a/pkgs/tools/system/proot/default.nix
+++ b/pkgs/tools/system/proot/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, talloc, docutils
+{ stdenv, fetchFromGitHub, fetchpatch
+, talloc, docutils
 , enableStatic ? false }:
 
 stdenv.mkDerivation rec {
@@ -16,6 +17,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ docutils ];
 
   enableParallelBuilding = true;
+
+  patches = [
+    (fetchpatch { # debian patch for aarch64 build
+      sha256 = "18milpzjkbfy5ab789ia3m4pyjyr9mfzbw6kbjhkj4vx9jc39svv";
+      url = "https://sources.debian.net/data/main/p/proot/5.1.0-1.2/debian/patches/arm64.patch";
+    })
+  ];
 
   preBuild = stdenv.lib.optionalString enableStatic ''
     export LDFLAGS="-static"


### PR DESCRIPTION
###### Motivation for this change

right now proot does not build on aarch64. This commit uses the aarch64 patch from debian to fix the build.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (aarch64)
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

