### PR TITLE
kore: init at 2.0.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -287,6 +287,7 @@
   joelmo = "Joel Moberg <joel.moberg@gmail.com>";
   joelteon = "Joel Taylor <me@joelt.io>";
   johbo = "Johannes Bornhold <johannes@bornhold.name>";
+  johnmh = "John M. Harris, Jr. <johnmh@openblox.org>";
   johnramsden = "John Ramsden <johnramsden@riseup.net>";
   joko = "Ioannis Koutras <ioannis.koutras@gmail.com>";
   jonafato = "Jon Banafato <jon@jonafato.com>";

--- a/pkgs/development/web/kore/default.nix
+++ b/pkgs/development/web/kore/default.nix
@@ -1,17 +1,26 @@
 { stdenv, fetchFromGitHub, openssl }:
 
-stdenv.mkDerivation {
-  name = "kore-2.0.0";
+stdenv.mkDerivation rec {
+  name = "kore-${version}";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "jorisvink";
     repo = "kore";
-    rev = "2.0.0-release";
+    rev = "${version}-release";
     sha256 = "1jjhx9gfjzpsrs7b9rgb46k6v03azrxz9fq7vkn9zyz6zvnjj614";
   };
 
   buildInputs = [ openssl ];
+
+  postPatch = ''
+    # Do not require kore to be on PATH when it launches itself as a subprocess.
+    sed -ie "s+\"kore\"+\"$out/bin/kore\"+" src/cli.c
+  '';
+
   makeFlags = [ "PREFIX=$(out)" ];
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "An easy to use web application framework for C";

--- a/pkgs/development/web/kore/default.nix
+++ b/pkgs/development/web/kore/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, openssl }:
+
+stdenv.mkDerivation {
+  name = "kore-2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "jorisvink";
+    repo = "kore";
+    rev = "2.0.0-release";
+    sha256 = "1jjhx9gfjzpsrs7b9rgb46k6v03azrxz9fq7vkn9zyz6zvnjj614";
+  };
+
+  buildInputs = [ openssl ];
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "An easy to use web application framework for C";
+    homepage = https://kore.io;
+    license = licenses.isc;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ johnmh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2828,6 +2828,8 @@ with pkgs;
 
   knockknock = callPackage ../tools/security/knockknock { };
 
+  kore = callPackage ../development/web/kore { };
+
   partition-manager = libsForQt5.callPackage ../tools/misc/partition-manager { };
 
   kpcli = callPackage ../tools/security/kpcli { };


### PR DESCRIPTION
###### Things done
Include kore web framework

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

