### PR TITLE
googler: init at 3.3

### DIFF
--- a/pkgs/applications/misc/googler/default.nix
+++ b/pkgs/applications/misc/googler/default.nix
@@ -1,0 +1,25 @@
+{stdenv, fetchFromGitHub, python}:
+
+stdenv.mkDerivation rec {
+  version = "3.3";
+  name = "googler-${version}";
+
+  src = fetchFromGitHub {
+    owner = "jarun";
+    repo = "googler";
+    rev = "v${version}";
+    sha256 = "0gkzgcf0qss7fskgswryk835vivlv1f99ym1pbxy3vv9wcwx6a43";
+  };
+
+  propagatedBuildInputs = [ python ];
+
+  makeFlags = "PREFIX=$(out)";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/jarun/googler;
+    description = "Google Search, Google Site Search, Google News from the terminal";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ koral ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14401,6 +14401,10 @@ with pkgs;
 
   google-musicmanager = callPackage ../applications/audio/google-musicmanager { };
 
+  googler = callPackage ../applications/misc/googler {
+    python = python3;
+  };
+
   gopher = callPackage ../applications/networking/gopher/gopher { };
 
   gopherclient = libsForQt5.callPackage ../applications/networking/gopher/gopherclient { };


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---