### PR TITLE
firefox-beta-bin: 56.0b5 -> 57.0b4

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,955 +1,955 @@
 {
-  version = "56.0b5";
+  version = "57.0b4";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/ach/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/ach/firefox-57.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "01376c4365dc8c5cba1e37708f9a2b2e9408c6a2a06790a433e058dae5d245b35ed1f7e8f573e496442d8657f96db662c540a70c4d6cf8f154ff8cf04b5f06eb";
+      sha512 = "5233cd6358d0a87c58799f50a30bd92c36793394b451fa70f8b789810137d2f478dea9f27a15ce7c141c54e6fa62e5c2088021b90f4261c889843ca5dce7c905";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/af/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/af/firefox-57.0b4.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "f502bb10230ee5dba28e7dd84a0d76a9e868c2da99588c00f35492e9c355902cb39d383bf7a8b6440d7e7811e70a7a1945978de0e59a85514eb8c16d939e799c";
+      sha512 = "62c17ef12991df223e58e32cd148b7c254ef2d8a415cb923a5a74b363e15902b0272b3f09377dad24193867dff50ba84f0128e5b7c171b70572aed6a47f07aba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/an/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/an/firefox-57.0b4.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "488e58bde0417b70c7da08ae22c40089f759a5f2919f2a3dad595f880607880e3a4a202944c8d03f71f1d420147fa0e3e896ef88753723d8c4ee92e0c32cdb0d";
+      sha512 = "0b141040b179269d567f7d40afafc4816e9316a75c69dab51a23e50b497c8c828b5a0c064a3f79d4804ab35e3c4bef5bb5defb89322e3efbf28ffdd394c7c050";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/ar/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/ar/firefox-57.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "96d1f3dba912702eb6d467ff1be67fae112b82a77620a53125aaa861c241bcaeb441c73339e20fbc5c41eb8883a370c2371b4a3d7b0af04555dc07bff5f1cd78";
+      sha512 = "0b74174e2d243a0db86d633e7c82357e138429572c8454df647a87dbf7aca585d00b6ee1ca58681d561f911a32e613a4b1a5b8a3c1c94a0dbcb678f680f30cdf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/as/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/as/firefox-57.0b4.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "75873538776101e59c5544aa644bf563bd7bc0b3882f43e9d3ada94cdcb39d3ca2d34cd796445fb680f81bdfa1604cf6bc7b79175625b5e56ea12a6790171c2c";
+      sha512 = "e829ca5b93fd5e6640e8a45f4299eeb4c8c50716489876eba390327fba292192be4749ef294a58ad2978b1fdb4972ee8fe9a451875398cb7a1b996b887d7fcea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/ast/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/ast/firefox-57.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "84b975021ff95e4d0490d82ce7666539f7806b8563ab42cf9a8139db06f3558a4680d33840405a497e92ed5f2366af979ae0bc8d188be3c3015131f4459c1a1f";
+      sha512 = "1ed6b51420daeeeb9fbc81808555a492410f51865968b5e1e8e02c0e740885f32a26187128e1f732a8297400c19d760f43583fc59ff08d1e70c79519e047511e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/az/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/az/firefox-57.0b4.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "3989e10d2884c827a82f8202cd440b9f5867e6af38cfa952848789cb855963e2ed75a13b029d47ca04a93a0bf94d53e7e1dc253e913edef6e45922a0b05bbce7";
+      sha512 = "d27affe6ffe5de90a2c640b1475ebd1294fc8d8fd15ad26e34463c9f38c25733e495558dd38f6c8b9425628637e653bb119eb3aa3915476c43955c907f77dcac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/be/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/be/firefox-57.0b4.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "3fa693d5d909a32bf206e81f69a1bae19560a6e4d281d1c023d956e890089e3bd4f006b3b44b9186f7f50bcb6566dd375386aff634171cc9cc27955a4ac64043";
+      sha512 = "ff03e12fb623eaf5f5d2f419bee861b208bbd42072decf6168666e23c332fccf86a75b5b871513fdf2937fb4090010b34ddf5275929bd033f9bd88123f439912";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/bg/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/bg/firefox-57.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "e595c12a4c0e542be9954b3ae633f55d94bd9b402e854dae04c16d9c2c4e28814e31dc48e669ddca2bb76a55191b223f225e01cd6c23010725da0e8c29ce111e";
+      sha512 = "86ff0cb3a64e829b3db005baf49f4a156e2c9c3923538384b9ac0a58f659688defd054c889db1623fc04c119a82503eb0a32eca22f7c6853530516de3cfd2bfe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/bn-BD/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/bn-BD/firefox-57.0b4.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "af7f0023f5abb0ea9446380165c9c955a0bfe824377a3ebdfefcfc5dee079aabf317c832de459da41d330697c69ba3f4519136ea5922fe26827745f2b8567bb7";
+      sha512 = "6a519b62b04aecc4016c8fabb06efc32c2c582f9a385bfe784e7cd81ea746fd955e039a9a851ca4798c41f5b3dfa43d037be8813e9d16e2a27b4360bf2d9c6ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/bn-IN/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/bn-IN/firefox-57.0b4.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "5911b03099379731bde2c904ed11e5eef69e6d53a1492cb07c4d1ee6f3747fd891ef34a168adea716d867b9ab02ce0faaeff2f60a47ab0863abe0578e5829ea6";
+      sha512 = "200b35f5caf5a9b146f79de343969ff25f70f72c3021808ac837ccbc797e594109694648b4ed4ff1d11feb04a53c6d2ce23c90521951a0f67c3b84f893915201";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/br/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/br/firefox-57.0b4.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "2e8c4776671c29b4d885c8ebd87ae107656117d826081230890c6deabd0106b75d53334a718b36a2cec4ef9060bfc9c1a4f1d3543d13fc17218ad594f4d0f0cd";
+      sha512 = "da457ee63b89cb1be3e9a8016ee1c22ee7e31ffd949fa60ada8559a396234f54658cd06da2ff952bad145e23ca5e461977834da3118962322daf601ad3bb02ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/bs/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/bs/firefox-57.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "e1bc29dfad9794ba95f81f611cd9075550024976651812053b1e976fa7c9e6aafb5d375c30d6164afd93255830a5d336a5c2522199701bd26bedcc6cdab7177f";
+      sha512 = "83b88e141125d55c670e307351a21572e284b1911fd5861fcc7786cae06cb150152e80abdad15f65d0c0fc8d1e5440e36181f16656e2275c4f90adce77e4079d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/ca/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/ca/firefox-57.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "4122426fc6b58472f4c57c03618f7b1039958a5e5e66309472279a59df077ef08eabee1237c59fa5ede0ea18b927b60a9ed8319cbb396c5b204d6b55842b4d51";
+      sha512 = "8eba16fb06961b3b6c8305f866e1d2168e29c1eb423f97949e980a2b51772453049bc5064c6eb6df6af1aea26efc2fea1edf5baae408c18bd4e750f3c8e4b46f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/cak/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/cak/firefox-57.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "d1c0dc77a7a06d5fcbe231c5ee3802aae200f578febb77c41c675a5a525675442772e585fc399ff79777ab66516df4ec05c0a22348fbbc29594ca0cfa35b3b7c";
+      sha512 = "5eec8675ecff45e359ccbfc36d781514b8afc19119a5e68a1a97a8b1765504ae6c89e41ce370d37eca879f5353d8bf3fc594ea69fa9071ea1ffef06d23e638c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/cs/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/cs/firefox-57.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "8934f3b7d2644dab828090e8aa6a2edfe1b21efc95d63b1a7821dd9c4cb9367d1a387d97e2a8c54f4815877533e9e20a4a0bf49446d9429f4519f28fd382e128";
+      sha512 = "2fef9e66dd10a224e31213d587d7ec574ffa25a09dcdecd3dff449c1b756634de906809b70e4f55b75adc0c853db96f2917658af824f3df15c16017f35c57e2d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/cy/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/cy/firefox-57.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "d072efc296e744273c081b1fa78348c9b48137d0d42ef8aaa26f1607768af3dd62179c693bca567c4fde993f913da856ea36af350fc90df18d8e726f227b44ba";
+      sha512 = "d675a1e182c4d186bb599d25ca4ae0ff29cefc70a8bc2ada76ed89ab6c57ea8b92b8ace9e5e5cd0b5baa8166fe8196ac23164dec66955ef4a0c5720a75fa0d1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/da/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/da/firefox-57.0b4.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "358d83de5408d2cfeef5b8e77054b528ed736a0b2552e93d7cae405d346dcf3a4ebe3470612cdf37170ef9e4ec00c87b23ececbf07bc07f67fbfe013576278dd";
+      sha512 = "01087b3ab9273c459c5a665d5662a0223ef5b7e956aad9b469d77d7f61dac2b87f7c1749675a05a79da8f8d04de05617bcceb8d7a2a2b6a445a58d27adb95d52";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/de/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/de/firefox-57.0b4.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "02045240e122fb3f8339c8c09f90ced093d8c92d80f65ed03d922ebd10e454bf9b8d25df36eb8548f1249f43cb8f5d91f50993ec3623e5107115dee9de405b89";
+      sha512 = "28742310978f4578153eadace5e965328e431f1d4d4d2146d35bb65aee9771dd8dd35117fd599d514070a0414c7c1c0d28b6ed5fad727b8cf7a45f0949b3009f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/dsb/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/dsb/firefox-57.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "eaa5f2e6f2fd7447f79c9bebf8046ab05ab67f5717c15f01af676c3b384750b7929fea818bf064b2949dfc0cf36cd4e12f17c4c11c5f7a563474666b217b4ed9";
+      sha512 = "9a4f8a8a144a5516c87175d0384ec4f6f2895fc1efd7552bc79e373c64b879c34afa82f6f4ecf33e39a9a138e2648f761f5747299bc9f95a46eb742c9089b2ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/el/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/el/firefox-57.0b4.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "93573cdb8088effd34206a9525bec895aed4920c878ec77fe847871c4e01d70ed35cd00aee4311e3409beb04e2f3aa4504c6bdb9b16f05b4540093db2d0924e5";
+      sha512 = "cb84f7a645fb315746566afc3a8c256ad3e04ad801689363de17fe91dc99784170558715e5696ac3c041b4a3a079b18a5efa3c18ec092067f1c0448db10febad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/en-GB/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/en-GB/firefox-57.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "765e34242d93d6f53fb59d9400444e8d236b11b5ef9335324e6b0fb57c04036121935e88068fc13dc669e0fcae50d0e84cd4b393b47689d2204aec86d4daf48c";
+      sha512 = "2f2c2c56a90926c7070673e5b020f446ac39e4c60ace8a0f9204fe81a004e89f8e29066e51468cf6614001930d3c827687d893df34a3a3fd3baa2a28dc6bde09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/en-US/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/en-US/firefox-57.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "bbcdf507dec439732a4c3c030c876c135d99126c9b35df52b6ad377575b971931eda12b9ec446be768058edc71d7331fbd1635b39baf837fc428887edbc8d5bb";
+      sha512 = "a7acf5cb3c82e4fb2ea09a947517b9488ef81d01abbca9c2a1aee48b449be6deb9cd42739f37a198467c3b0c420852bc6238193bb9c1aa462e489d84bf813451";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/en-ZA/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/en-ZA/firefox-57.0b4.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "06d2e4cbf018dbff55d8f91e3ad9754b6a191cf9cf22ba38eb316421f732141e44c3d3b4b475e97e548ac8701652f2e9887be3789d78c9f06bcb9d1fdd4e5156";
+      sha512 = "9ca185f4b22424be7372b5d85c9442b37fc277a11b5b864093cda4992a09a390fa3532257c7d3c1ffd156e3a998d99cd7050536420044c5913421d8c9409add4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/eo/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/eo/firefox-57.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "9612deca064158eb9981a24946ab612b472c48a897aeeb22729677cd86a8209b85e75a3f89a408de4823947ad28fb2b0c66541e27433236aaf337ceef02166cf";
+      sha512 = "728c825bb787b0bb87bb7036081e8107b0a8bdaa943f0677e2b3a9685eaa3f1caede0a5683a4913883fe21bedd0d8405b10f695ea2f2b17059a68bf5bfee9748";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/es-AR/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/es-AR/firefox-57.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "a507fc11e9a528afd89c32fdc1bfc1255edace78cb11db1b238cde52ee113f6ffc2506908ad4d1331c3b80655de193b4c5b3890c979953cc01711fb2a7d9cad1";
+      sha512 = "215ec52c40468fbac5d82f7ba7a568a780898eef7c9d3c813036472222b731ad40a83373adfefd0a54642209f1d3d6153bc12dc49b0c4a286f824c2b0895110d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/es-CL/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/es-CL/firefox-57.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "028aa444658a288ce5fe84825aad85a340ab36383d04012a8dd93fc057cd3d2ad2084c84db87bbcde4778915eb7eed080d4fdf8baac009c0ad6a00d1ecee2f96";
+      sha512 = "aa3c46ed2b7f7794da86956bb10e4ebbbddb1e0dfec295e7893c6082f963c800156da7dc041c902d645902b57cb14de4c4c07ea03057ac84aaf325a9eb889d7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/es-ES/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/es-ES/firefox-57.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "9ed4b5a1631110ccec6b31ea3d666fec54e9dbe9746552fc02b0eadd09053020abfb6053c763ce9f3877eaa2e1f318003177e9c3cc12e16120a7ba2881795525";
+      sha512 = "7ae1c2bfff96f3bc2e4aef293f230226783cd82ecccb0d6f38770876143ade93e12f7ddcb46ecfb7e2655f60d8c09e23cbc87f15a0b0987a5613be765d22da49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/es-MX/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/es-MX/firefox-57.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "bb13cb8455d87244a8f5216b765293ba13816ee08a0f73e70d706279d5e322e69b5627ee22aa9ad44ed20ce54730bc2f072d326ec669d509674855f835702a9c";
+      sha512 = "2109e865e1e29fb8c216d742e8d34a61d49c464a5c6cac9c4aa5a2d4f6f4b5a89b9433d2ed99ea5d051637b6214c12dedce42b35b10619f09874ef2e84b11b7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/et/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/et/firefox-57.0b4.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "e7e099b80ce94392f53dc1ed3a696cad77ea1a1910ef79dd7160366f6f880857c5d3b867ca3635dde72d22d40000b2acd9495fd3804aa479c5e5adf0a3bb44db";
+      sha512 = "42d488173f29b49bc3356d3cd9ed83c7ac63801dd8affc48235d73fa71b2fe9cd7af9a835c89787839b565521406a30cc10bf6df27be9a5b3150253834d98e41";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/eu/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/eu/firefox-57.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "2b6ae7dbec4facca5a00a0c9827ad634b7862ead7c8694bccda7f90cd5183687bf122e29e38515b6457839913b8dd5c6e24a156edd74d3ac4ae9ff6fe8b5688b";
+      sha512 = "c6763a44e619d1dc5959dfa307908e39e9f81e11e18b5dd65e2e4c2353c1b7e06b9243c1e726df274cad635b31193ba2cf3461ea87ff5d700cfeeba46aa27d1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/fa/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/fa/firefox-57.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "07a376c694df8a306fc169c8e0abb311361dcd3ee252654e8821673a69e6de9b3f25a47094091bfae620db152c471c39f7fd895d81acab877ffc471aaefc2439";
+      sha512 = "6d2c0e40eddca26513746f80721a951af2348e8cb1dbfd3453bc99423d57e76f9a45a2673d1f29e10c0a338b1919e95b05775937e060f437fa7514108beeb3c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/ff/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/ff/firefox-57.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "745c62ac6f055bc01dfbf8814c54cf823718d472533a3650f3ebb59f4c907109cd15d881ea19d80566cb66121c6ff2ffdd9c551c4eca62ec1cad3976d1b513f0";
+      sha512 = "b3381922e4a88568f3d034207e7ccc2ce96e3580dc037feea0b2fb415c0c3511e15e63cbbdfe3f44f61049e10d9d09a81069a0a3b9a4b50def0ea3fe3500a18f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/fi/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/fi/firefox-57.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "f679b7e843a0626ac2e7f6fb9f85cb6628d162692263eba6506e94f8b22b543268b1de64e4cc9ae5977c7fca0725dee337a120647a5dd73edb56ee678b8088cd";
+      sha512 = "7cb21fb4daa9c70ea9cd124c42d94bfb599b6bca3b00821f8482da2e844024ecf4a02bc5250e7cd4d574465ec87c04b41620b4d4cf78a0560bcad184c6c9c656";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/fr/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/fr/firefox-57.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "a95c3dd2946bcffaf8a34fea1e11df826e1dddd642cf79677465379e43343711a18fa88d1c74247624b7e7f690ecfd62edc38d9971dd5df81d05be490fa3672e";
+      sha512 = "4f702162126708851bb2922dad4530718cb899efd8c31241a66d650e5aa91c8bba30f7247601a21e79c82bbd52e943ad050e801719dca8257ac51d21533db35a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/fy-NL/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/fy-NL/firefox-57.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "bc6a82e5de1fd2f9c4b9fc4915604443d9102ffd8caa348a42054a1a251e820ccc69db4dcea5b4aa43e04e5c07e904b10db8b25c60986eecf91cbed89fff4f6b";
+      sha512 = "765a5714a7270d00faf81c516874acf02b0ec6fa030db8edc6c4e08362542cc80cd044f639ffcc74e1031ef51c75246aed6892b84f101aba7665ce89b3e2a327";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/ga-IE/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/ga-IE/firefox-57.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "271dca766101881c0869a3201f5312790d11befc96c3106f92740b798052434191389f86522b40cecd882d6f85a920556d53ce409ad5f12d1ca68434fc836a0b";
+      sha512 = "b95e5ac5cabac758f77828379a3303bb8b62c253ba77f14c3a74f9e9663fef3838f1e221546fa85955e2b16791d1470bd798425e8553170151271587e49cd1fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/gd/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/gd/firefox-57.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "afc35f1f071fe307df82582a19b817f1cb395c975f047c04a9b64790d87efe4fcb2486d4523b9144cf63f1b2949f3b67d74a7c8005c658b22eb6d363a407533d";
+      sha512 = "24ee86e508695f8aa515bbf9d89cac77b48f9bad6d257c2bdb1fbfa0a3183e3344e3a0e2cdda2a05b45141e5959d715db6ae09a32e8d1d01c6ac31f7366fba00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/gl/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/gl/firefox-57.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "36a054c5d56752ddb8e5af417d53e4811b23ee5ac00b57d12bdad2152ef4a237579001f44ae41c9959a68fb144862e0185b0607df3c9801ddeba7f9a27edabb8";
+      sha512 = "810629d39cc027fe9701d54c27edfa916913d857c018f9e5e2da218db2f93b81c16e9225f664eb4db670d3293492d4027a9586376a205fb51efd661ee2f4b307";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/gn/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/gn/firefox-57.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "f29d9f9d793730324399d6edf5d724f1ebd7f25037865af74616ab660bf6f469616fec7a7e2f1c5d8b7427a5b3b610c876100e5f737facc366d7ecc92606baae";
+      sha512 = "65712a992ff1edb57642ca1d12e60ec009acbf23f5a4a56b68d3c521bb46aa02d1ea4b03f628e23911032f6f030acfceb6ec2aca0f86f616c57ecc71d578723f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/gu-IN/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/gu-IN/firefox-57.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "b2e0626abe14e87420528b8e1875c22c5a97717f9d6fd781956fd7858a1a08c5014dbdac5dae6378fc2fee92bfd50ac4bacb29aff738ea8288cbbee68cf58ce0";
+      sha512 = "2b78ea305213f7c1200887e77be4f01b47a699ea8f8e55975987912d78142519a3d19b26d82f9060cffb139cf9c560e2935412f602dc93511d786470dfd0e64a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/he/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/he/firefox-57.0b4.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "3a29a3f008b226c760d488e5673b6ca8d545a309aa8c19bb56df4208143663e92d29b4dfb0ae6606ac5f83826d1c6ec2118adfdf5ffb55e954193407b2249d7d";
+      sha512 = "aa9ea68571404c166c4ce70824a2f8ae38e39b43bdf4181cb2d17d1810d2aa49640186b9ebfcadac8826347d9169c0d396f7a3375035ef961e8e8aa36209dd09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/hi-IN/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/hi-IN/firefox-57.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "cf0894c7b4e954ab39b847ff21a88b68152e3eb1577d6ce6b513c73ad8c26fe184227da022b827b35442a069fcdf3182a843bd4266d29ec525436f7bb9761cb9";
+      sha512 = "a2cef484eda6af5979d2d9971d4342ce184a57a383de9c22d4dcbff5ce55ab56e73ed29a03d2a4175b9cecf7ae5d73911ea9be31fde0b8d799b0b1d17357b56d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/hr/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/hr/firefox-57.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "7f512df549b19e82d054298b1b5284956ea9568793aa0a7c676fd5f52792ff943a1f8bbcaff05996236e4ab19cf4e914d6e1178a493e7077ea97877d14ee8d70";
+      sha512 = "c5192160ca2b4fc04692ce48b4c0516a1112caa50313a7a8624497de6bd131413ed09e87a62eeae18ce363c55d617edaf4567c905523ec8296fc6b2ca6219de7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/hsb/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/hsb/firefox-57.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "d7626253732cf868d1f414e297cf4598b1a3bcef10c43641030c599b6d04599139f268a993d4d151bdf08ecc0129dbb638f581de58c1e76f28bea30be0eca68d";
+      sha512 = "463caa60951f5a1eabb7c78115b70c88f29697ae56082a76c64dead001344917c00ee6db211f8fc09767a8a684da7500beb69ec42a0515cbf643642501ee24db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/hu/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/hu/firefox-57.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "f74dd31a8987d35ee1e3c96546d6b180830b174bc03bce12ce83bd52e01f7f1ca9242830f785953ab0ec73cf2dcd19be61cd55981bec6c8926bfadc9045bfbe1";
+      sha512 = "304e1b44d648da76e7818dcfab2901c9ec6d4685649aef6bba8fc4883fb2d5da8bb4baf5b7608b4acb2c53891ad2b1c68d48fe18024ac47b373eefa1d680385d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/hy-AM/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/hy-AM/firefox-57.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "2b1902d366b7de359b8ea0a5fa75897b76293630710d30e17413a1990bc96a8cbc0032e68d73e1ff298cd366ced5f4c51f0a693c665bd3761db3646cdb536666";
+      sha512 = "571a1d4780a5c74accf3e5b022923367c23f02cbffac6eb82baf82f4211a0e37fd1ef1d810db01e243fcc0ec2882c00f6e261cbf5f6bd8ebd25ab3ade0a4cd24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/id/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/id/firefox-57.0b4.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "424d9aa341405c5a6ea5441e0c471debd7d49c4a4df632d796142db9d4c944b49317758e2211b806bbc93904d4341094fe29aa44d6ef936346cc17263c357e89";
+      sha512 = "01107f1a301f178b5a1377dda5ef1fef588fbfd09e835247beb3ca6914ee9f7a95e6652ee2f3fd5feed123ed06711a6b255def41488ceedd562b62462f2813ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/is/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/is/firefox-57.0b4.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "3ad0b286a36467973c4910eb20b09d20ec46d47fb6796078fda35335266f791f7e82d01ae8b7a0fa49361cc79cdf2864240286b6a8a447e6dfa6f49b23f2b1f6";
+      sha512 = "69192251968511b76a416315fc1a35af21ed1b5c2cfe19a03f885ef1a2f99cbe65996d6f32ad344219004dd521e692c43fd7f8c85be3efa792899f9d9805b5aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/it/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/it/firefox-57.0b4.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "3c47bec4d903795f522d227d085e0d7ffccadb0e219f7a67159e5bcdcf7f7f2e1543b95ee8acd495982a464095521ec9dc22d9f90599d267eee8d2f6b4a543ea";
+      sha512 = "a9b37f11ad4c4bb52d83e8806ca3088ea9c6cd9d12adefa83d63325d6ec7ca7d332fb80d5a084aa97e6c8fd608e0a120eeb2f0c05fbe50f350ad5c5370ad4b09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/ja/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/ja/firefox-57.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "2a1e435e0f74205577c28a6265ac0acaf165b4b891129994f4d42cf78ea66216a04c9f4b7652053281e3717a51135c12324640c5ce285981a1165d9e749a64d6";
+      sha512 = "76134087adf8f2167544f4b510c9e98f99b011dd22523345eca8d112457cd6d9d08f23453000783f31386a8cf67e502155ac8739061e59e76492c82b18738605";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/ka/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/ka/firefox-57.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "177acdc588044116cd4efb5ff10f178a6af2ebf7b90b80c06b07587e11d89a45a5f0ed4b0a9c7b2b2cd4896f3f4c5003b9dbed33bd7ed01ae6d331e637f2237f";
+      sha512 = "22823e464aadfaea952808d0fcf32e79877e63fe784080c23e7fc02753bd6cdc6de9a766847818eee3315df48ea8d08671c49d25f2f9b7b14a2e5be353179dee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/kab/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/kab/firefox-57.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "6e13833052dd32ea168d0e939ea7703c6c5a092848cd45ed8e6b1b0c18bcbe92e1a4c37ff7b1cfdc1c1e618f4efb83dffaf58501ce4f851d845b273fde5ac513";
+      sha512 = "d5d4a5ba6a876fb4bf8abb71d89ab7ea5feb1f81c3022fc751afbd5681c3e10d3c51780145b4639e4dac315454884be7a7570bc26482dd5822d5919f227ca6cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/kk/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/kk/firefox-57.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "1deb2df839e0708f2b8bedebd47a4643e1a3ef2abcf892b14fc4842688918cfac99b8345944a00fcb36495bbce92fe2f76b3bd6f7616220a4a4758396d031d75";
+      sha512 = "738a221dadd5c6568fa62881d4e6241e30d9360c8c8da6f1f55af21948133b35fd9e7f79360b91d609cf06ad8f024a3ce425dfe3001f42e43615dfa72f23eb44";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/km/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/km/firefox-57.0b4.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "aed5a7b6e3fb2d4f4260703f83b1092953fb4ee7891ec8dc50250f9b00c4f1ad51d6f9e15ccb8500faf87f723ab891e474b43d4caf4a22620f5660ee8736c9eb";
+      sha512 = "b10e116e65d57c2e6a6f22fd10c1783677e7c974775f26a8914808e942953e48b126dbc63710bee8aea2e411b5c56d6d9727f0b5249e553fb3c3f9c0c7227656";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/kn/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/kn/firefox-57.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "d83b0af01fe7f335b3fd3bf89e9162a2c54ce95332de8687e265666b417a3103a508c57f770a4d075d3062cc48f652324fb1c73b1edfb8158b6f5cae597dbb59";
+      sha512 = "1c4b4933f04467ba06b86c55d2983e633ff5213f15ad40bc91cd89f399e66e9ff5c4026c5b17c9f743468388c36f75134cb6b78722e4b47e53038dfd14e2fdb4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/ko/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/ko/firefox-57.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "74bfe8e9a084348b7f1911c2cbbea89757b72ea8b584fd7bf26c79cc64f3b38ac642558ec3fe059464f252667d2e04dd70cbb34b92ffaa0467f5067636b05311";
+      sha512 = "a855a2fab85e2cc85ab60f90790b05d4da8aceb7e4d0d464f2589b2a6ba513fb8ce0a0637c18c49f87d8236c705576b679d258de736bc6591fef4fe1d724f1fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/lij/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/lij/firefox-57.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "31fbd3b75c1c7d64a9b13c52680c6c3b36e604893a768a572d41481b388e9beb7942f435510b7dcc90e7f9ef42d81e05c7c77f28e5cbca63b51beaa54b09de40";
+      sha512 = "e82c6c7008cedf675ed22dd2b3d6d000fa202908f370c0ebca3c3c81ffc95b5da823a68113852c90e8f91ddf1056dae6e5bb97678fc3c98fe34b0e6be7b77104";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/lt/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/lt/firefox-57.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "ce6ebfb5a34f90ea5a8f742a3ac9a6216909c8843fe255f9906c297693a64e2ebd0318ca697cb02a896a122e29d2a8bd055957022a7cb770bad6687e83e9fa24";
+      sha512 = "e6d927f0dd8cd5765490515d5d952eb7c94e526fa0af5f18c92c2b880a0c15b58f798bfbb8e8ccd8eb931e18fa1316ab1fb26c18a2870c2c20a3745efae338da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/lv/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/lv/firefox-57.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "b965eb09bcb9d5e0cbabc1c8ea7fc674aca2b185b2ef83f3c3560fc68fdd2fd428ee6a9d1e72980123816c01b2ab6877add15e706eb2a90b2f9220db3e411a8c";
+      sha512 = "28b85eec882060a0c367b94cb8af1d488abffc34c76faa0ada418c92d5c7a343b169ed38e44f0c290e1aa81eaa33c05f54deecda1cbf66fdb76c37aba339210b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/mai/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/mai/firefox-57.0b4.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "3d6daf9e6e2459a246f9bd4d8e66c01f7acb0a4a63f7413c38c7158134c31b5986ee86233482d80cb33a3d8f0d9946c6cb79ec357f80c3ef22dd0ecd173dfacf";
+      sha512 = "256f3b2b27c7eee4feda7f7dea86c1260220677f4691c27c625b00b7d2e9310753e5b81fc4956de2eaddfc3abfa1d8caf36a420d2ab5adf0c00d5a78e2d6448e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/mk/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/mk/firefox-57.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "f8e0208c360cc9b87ce917f51d2302df31f1cc137a16fbd8678aa664d0ae8626dc08f534dcb4f34e1a56cca1d0a3bcdad01eb506b04b0e2054c1db5acaaa8300";
+      sha512 = "f441b6d15607f46246a82165c9131023403fd0af05fb54e7a1e717d38c2df56fbf57543c4ede612037584e756038286f125a8b1677bd49c6582a68c022c65498";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/ml/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/ml/firefox-57.0b4.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "7c184b7bb8bcd115b4a3d10543a4805291ccc13a3b807d71a862b8d166e324d9f4ff28dbb71f2b36c26731d6d7085dbd45f708f20d6bb20a918c361fc0dec218";
+      sha512 = "21e98314efe24409f111679d954bed110d0044a54222a9962891943ed38c3224d135615734c837d345e581f6a7b2cd15a1b965f23c13eb8ca22e8dcd96c9b5a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/mr/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/mr/firefox-57.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "cf55c41a5ffef1fb41d6c82f5b9492f5cb4cf5aac4e14cd4ae751e81c15acdf30264653b8adee86fc343552c21484c8a1390d3872d30afe113fad94ff68a574a";
+      sha512 = "6c91df84d4375838db437776f3773584eff798eb3904f42c1454706db7de2421933a001dc6f69574d7366585b4a6922e1bc163d6f21a0de107665cb127e27147";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/ms/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/ms/firefox-57.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "a54c9904e67547d2c2c7bcd2c1a5df3b54ceaaed65bf6cdc35466d530797136b38e1f79cab4fa544d122ccb8787039cc3fd2cf3a1f166fcab8c27ddfa820a291";
+      sha512 = "5f8b6cdf80d95c8b7702f8f411ec5abeca35b41b2aaf2a3f02ae4e6a033dee9231a853b5d3da144aa13ff62d4052cc55e728dfdc7607d3c763881902cea16024";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/my/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/my/firefox-57.0b4.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "a267f9ce6aced112b488e90b859ebb2d6e02fc73dd208bad34ab5c1dd7a122e4b97b68813769b85f036ccfe8af7e56ea0782914c210b684f863cf2f268f27050";
+      sha512 = "1db6cae3d9c86bcb91f116dcd82d95d60c5712be2ec4704bccb76dc8cc6244cbabc665c606bdc47dfc1f89d1bad347213b7fdab383a8997fbdf728575161eac6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/nb-NO/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/nb-NO/firefox-57.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "99b1b97f5c78cbeb67f7ba66c05d04d37bf808e52f98c25dcf2d0c51a400a26499101e4706a20162a805da2493db2919bfc1714940234e94247c2a17e18f7358";
+      sha512 = "934eccb15bfa5e99ed9fc74b36d9ace3a2d48aede41182c3f66c0250b88f089ecb4a7c59112d15b142743aee9e617137b3125caa3ef03960b3ee687411df92cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/nl/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/nl/firefox-57.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "b19d2699ffd4bd0e5de12a87f8a5461fe28869cbbfe573098e628ed3936baff9ca582c47104133bbab6199472182c9f71af18756ea750e9f2b256b01314884bd";
+      sha512 = "b469b7a60a5119093e9ae7fa357fcaffda96f453ce4fedd409d69ee7891b83f81fb27a58201649c49a47b0a19f79b5a028db13af87f52b979877cfe66754407f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/nn-NO/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/nn-NO/firefox-57.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "87e3dc181130019499cceb8b3a2f86e0b4ed32defe44eeaeb3df8dc4bae1827eeb90742394c3112cbbddd8960f3aa1a2157dd8903c2eae1cf4c17fa9e3179dc3";
+      sha512 = "e4f1715ada847b40a9c516cc565908bd69d21395c81165721d14b01298c2af96c5925659b2c4485e5b2758df579818ab1508d5dd8435d5f36a13a0692ab228c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/or/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/or/firefox-57.0b4.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "cd6220bdd6f2ef82b0af214c62ca77b48cfd0f790b9f62316b2a2267aebeee3954935999bd6f1cb2fa4cb64650755ffe208f14b322990704daae742ed126140f";
+      sha512 = "f87c4dd9eff7e211fffb8d8c6ae4d7f541bd953f8eaadfa4b6adb41ab587d477e030e6f3b6f04ac56b07ff66b096979aa42939a283f78f68340ba40149a7ae7a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/pa-IN/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/pa-IN/firefox-57.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "cc7c72ec73a7618664f759ae9f96d06174d835ff6779f6bb3b199e4a38651de695db0149041f619ca4fc4c9d2284757cf33683c6c107dfc08e25bc39e3a5f6b0";
+      sha512 = "6036cda65bcda4827d4516927280399385a70cbaaba4148c8464b68736eb2c515494b3c38f36588b36851e6ce78a44c4f05314a4c52f915e3475d5d2f489116f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/pl/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/pl/firefox-57.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "718ec975c1511130799ae59188034dfca681659596755aff6809336be2dd41e0ae744fa2fc245e51f8de86409d5677796efad33c7bdf29873b90dba075c941d0";
+      sha512 = "7982e11b9489c92d3794e3beff168e55f8aed19f20e477789d8586256c61c7714bfa7c84fb02a9f7fd3214537acea6227336185fb94fd6ed67936de11276b4cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/pt-BR/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/pt-BR/firefox-57.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "f6063c710d24d74714b2661e7918566904d3ad4e189ceeec662253f7039f5bc8fe9612ebf618c858c15d64e90e2eafbfaafbec78e441a956c7cb9ad21467a547";
+      sha512 = "99fd0a93634d8145721671b414817519890d08e286431358d83f7e0af5451f12a152c8162736e1688d51a70db1e6169ab5831dd52f4253e2de63c85540f58acc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/pt-PT/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/pt-PT/firefox-57.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "450f191ffd823d3a079f486dccd7cc2480f3aef840c1168b38e187a9073f1c8f3ad093ef5c56951440716d6dc6bcf98b5352d4b863308a14bd5b6b7e6a0f8480";
+      sha512 = "ad5ee4c2e33698f545c5bb5d300b8d1fa8356757c01b7f5b0647e226bb615698d379f5968967dd91b81e1b3553ef7b30a40be5879bb73c9fd007ede10bf26f12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/rm/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/rm/firefox-57.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "552cdfa2dcd7db775fe9591246c5c96997f0a86a031a2f6cb2a31a00fe05c78667e46cf288e30a3453d26d8e7fd2480d2f94857720488b6a291bc359553cb668";
+      sha512 = "d864ca476efb09ae3a0d867db5b2730d0055f4ae1f3743f9daa93d44d01f976a8559efd299c2e268ff96f181785ce24747e758b1da3671e49cbb3e70caedd2dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/ro/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/ro/firefox-57.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "be2b95672070d82fc92849832a37ba41caff186c1c9203a2cd113f6b949c4d86ad162a607688d3e3f546cc29553e8acd9b3d94c14593cee10365a580af0b7d1c";
+      sha512 = "6066f6be7e0b641c13f9a32056c9a98f0700205d45002a7259cadcbf128e7c2d0e9abcae14521f64678263cf802b7f72f360820d0ce67a0ba2ecc23fa8dac86e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/ru/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/ru/firefox-57.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "2825967493d4a3a39aac644484556a09bc9a63e601539115d8c28bf5f2724b22b3a374a5ea30cf8f312e6c075203014df850cce3436da0c5a0dffefe9452f371";
+      sha512 = "654ed8232ff61c0ed20bc04930d38bdba2f95bdc49a6163bf7d40137f3254fbf83bb49156a2f377605228a2d6c2cf9147f24bd22ff4ec8c75b8f946db651f7f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/si/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/si/firefox-57.0b4.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "7407388751b8df127156f5ac4519d459df4b929d79f4d82c0d150b8f327698da435460b911a077e25fe5affd05f692d4a18bbb8f71cf3921179c60d107460103";
+      sha512 = "bf9dd06c36c6c7ce701cb7bdac2cd8874701115aaa294953b83ae3ae7556bca397dffac05a481711c15c37d4d8a037f8aa4fb6b862d01b4d12a85d755a7d6b9e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/sk/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/sk/firefox-57.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "2b6ca2922e28b061024c1738fc70fb0b31737b938a8fdee3676504a87c73c29751d22f33241a450941200e7fc1920cf66847dc8188d987d47f4990af00622b31";
+      sha512 = "413f0389c5829b5a08f16d8f0836e4a2ecbe6605435c3265f3bb9980b6a17971e00fb5f1d5b6cc0c46d93bd71224dbcd18a8b3afead45d466801749cf12e320f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/sl/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/sl/firefox-57.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "ec9d090376d17c8ca283870d62b50961c520e1d841e11137d19f6083ded9ef683cc0d14cca37446be0eb2b5a6c9a9fc79e12c5753316bb7ce0f3cd07b1a0fd00";
+      sha512 = "5d89c50e68e11965d7f9ecc562020b48df59dfde8d79d97af3e235f8adcb4a55e0def64cc1885acdb1a4c92107c2462eeb2038b27b16d1d7219edf27e437d152";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/son/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/son/firefox-57.0b4.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "0f175c5dfeb93d07cd4008967b4f3e492cdf0fe44e3280b1f761a5d9f552a7bc2df12b3e4e5bc8ec388e93ff4d9f8ceff46b46edbb331e7e92e2648804e80e67";
+      sha512 = "884d6c8802c1c6668b559ddd01b3d29401f1189966626b5701ae54913cc2980eaaddc1481dcfd3143e653d2b832f6a04111a3036f28bd23904077bd7736dcc46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/sq/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/sq/firefox-57.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "6ec09ee64afc4cf4e6f710d49f8010dc62394e1a912fa6139994a741c6abbb99a570478ecf94801a1ef8316704614fca5e807b0830f77ac5714a7fa3a53d5007";
+      sha512 = "6c427a6ce4adc894f348abe9fd08ee5f257394c93ee7447eaab201fb8d22c0f1da7f5d20e7a3321a81ca2063efd4db9208613d36d13c39905d1b15f68b07f0ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/sr/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/sr/firefox-57.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "0515e265c0ee0a223af68c6406a04c0264e3e806e5a575afe6c6adaed5bc8030b37c70352f84742a85eb70884cf43484cdbabd8de1980034246bdbd2d46d93a4";
+      sha512 = "873da4ffcfeae90e05604adc52144dc6328cad2084bcb022ad028e7c62daa75978c077eac127371180d21fcd81e62db171b46616b5652bf1cc62b335263e522f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/sv-SE/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/sv-SE/firefox-57.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "c2982e666bd96ff6bc4af4af2faecd84235a1e314766414f521e0fac9aaf184635a3b40e118fadd3cfbb0bb50fb91834f26a608128125eee5d023dd2fbd6d87f";
+      sha512 = "b285af881b6d76b7d9ff2e840ad80a455f97055b71cef28ab58c5e0b6852dad674a50b8b4e0a72a3093dd5c506c7fd76d60ecc6e954bf276507a04069f7b861b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/ta/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/ta/firefox-57.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "603799faab54ec78905c8b5413357a50723090c5c362f3bfd5eb6ae7f62264c5111c4062766848f6f487c0f107a0a17bae87362bfe05e86c448ec455c4c9bf2a";
+      sha512 = "b5efeb840ecead2b84ed9a7e32a84ec469ce25e473ef738d95adad958db6eb1b5da3935e0f1af6155d05b10d341cea7ff48bf9dd06fb8b6527dda87045cfe6f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/te/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/te/firefox-57.0b4.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "be6afcbd8a3ea34ceb53237eeff1b271a92fc46b2138f3c5df9bd33c8be83c7d22a7d3198b91f540cae542aa3eab28a9184fc6b544de906f89fd4732c1a59ba6";
+      sha512 = "f9e284a4e5fd2927cdfdf51e7dc5a12b9b47d1fa9df7cfe3faad694664ef2db939d3722ef80f798c4adfcd08db7360da97b2bdd9d64978f899e679ee19adb305";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/th/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/th/firefox-57.0b4.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "3de3994a01bb3238888754ef27a41d37568d7e9e55b42e24071fb8187129008d06b5b41015d612f9caa5777a2e6ea5cecf772fc76e1b0629191126565751d014";
+      sha512 = "ad0d84915ba72bddd55a44d79863aecc9688da70863e4627d1971ab19d0b1f04dd0da24d7e5719bc141cbf8f747a9b714c1267871ab42d2101e707392e2ceab5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/tr/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/tr/firefox-57.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "34bb2d9358202072ce71b052b4876a2124a4263904a74582fc9973d4c8ee92c00bfdc92a88d663b045bd94945abd8e9d843cd626c16504c2543b0c1bb6a6303e";
+      sha512 = "3792e10afe5d04716bd759b694a2c486a02fd47b89069d263075491982367ec0e41c9fc23bc8388af2192ae62220be85bd08739ddea11e78ed39d83354497c3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/uk/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/uk/firefox-57.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "228f227258a73e9b945c8b6101598fe5a1f963eac7db546bc730dbde6c114630152767e54367939281aa9d97780d1643250140cf94e0f6032efe2a170c88eb40";
+      sha512 = "0840194bf1aee9fc5271cd8c63ac864c629e1793551ec1a15f59eee356be2833bc0616e66df18df46a5e2c14eb259bec5062672625325d9d68ac183fc7fd4bc3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/ur/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/ur/firefox-57.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "34b3371285df53ed817032cfca1caf0eee92e8b15de741c7c1babeb9bf3671c3bd7ae43d80113d44f6ef5deedbd586ad36721dc6d92b73c6b1a889700e07e99c";
+      sha512 = "285c75aa425f6ced8ba5f95b506d9ea0d5ffb50b59f860ca67fbe4dc13d00df44e8de87a815fd29f24851baeb12de0d06f378f43a9e41714d19ffcab7fd76293";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/uz/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/uz/firefox-57.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "8c82d7db9a48bf70658a1d086c94d0071e2b42677ab4b2eb552f6f42bd57e20a7c8580f065448346d810c0d76704bdd8d318bf0489302f8807f695529df8d4f2";
+      sha512 = "e84624ec9156dc9546951a7fdd0e4fc440ec47d05e0ae3ae97b7eb66765b154eaff5bfcad59ec3f8d3dfa0f40c110986d0d069896d8cad234a95758c19104111";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/vi/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/vi/firefox-57.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "64d3173fe6514b17025a85119da84178cd72409763ac4b415d3527afb77eddd2c6b344be9ac74f9c9e066b468bb6c7094c579df6a9379f230b44c21c3bc2c215";
+      sha512 = "bcdfb25758096b10ff8e24c9052d8cd78a5560657133232f4c99ff7aa7359714ca9a41e83c8ad11ef7c50cb0102f206b5908259ff47f9772f659c36ceb1d195b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/xh/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/xh/firefox-57.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "9a2aaa10778b8da82077b40e3fe5e295c34e7b75dd1d28329f786729059c7dcdd9a74f8e4a3dd123f3e3246c227173df23a3c5e8235fc8e3e05c64c79d03cdc9";
+      sha512 = "0fccb36a38403e24c0e53e8b38be64e7588204e75e5970c6bfe68d50d9572aeafbe9e146070d1d628b6dde151ec2e05cc5226e512022d178e487556ade16f593";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/zh-CN/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/zh-CN/firefox-57.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "8fff898917a7d05c2d808eb272ea5c0e9a8eacea5d62dc3a40f652a12ec9c48594190c4d5c97ea9720a0da86e3322dfdf3760fc275f1bf23f4c6f328a4d6462d";
+      sha512 = "28cadf527919cdc85886f0cc232a839942524f72164a15d0d0a272110de474908d50315811988197a07a8cdf542a9fc3ec1a54ad6f390b0cda7f30d0890ddf10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-x86_64/zh-TW/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-x86_64/zh-TW/firefox-57.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "c396e60a474d6869ac1023edc957b1b3d06e6b6a79bebe4512450e237c5f5707ce6d0ecdd5c904b0366c95a3edea331a1a6cace5171a3480fa47c08ee41c1ac7";
+      sha512 = "01e61bf83819b77ee7190eb2f8da3d9cd6ff17e913fd6e88646f72f44b275ca29b461e4d3f6ec962c77c5a69fc0ca8dcbbdc87454616ebed308b514102f28bc4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/ach/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/ach/firefox-57.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "90fca234d227c88264494120a5da0433c4efebdf273074acbe073250a5d71a736314859dd9d29e693c8cf5c2056a17b215757fb2e2625c7832673179c2dda632";
+      sha512 = "6fd626194215d93e3027d28fef689525f0b6c57173542e1474a7d98f380c3b9824b7fa2191d689d9335b5be4d89920e3caeba36cee1f27dd6a8ea098e500c4aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/af/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/af/firefox-57.0b4.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "a45a503a524c7207c120c9981425278f04454da2762ae024ab0c4df37fe355bafa4344a38c2bec49e232bcef100478f3a722c44056516a06fdcc939bb7f76939";
+      sha512 = "a282bc4550e59edbe44ad09c0ad2216d37c3c825102eff41ef44dd804dcb20635b2a02e98ecc27c71c932065ce8d4ced5298494a3792854880a90f64aea1ed93";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/an/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/an/firefox-57.0b4.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "f0195a1aa23b895c08b2afe1569e968534e203442d5a5831cabdef49b9e5f335f46a33f26fb58e585f46907fd059ec28a80b8c5d724a998109b635905a504109";
+      sha512 = "ce20afe18b8b2c9665a1b34674dec85605ddd351025a9b70e755e979f6fdf64c0882254563dda63dedfb610b8a42784b9ab7bbd4dac876dc9fe3e3144be3dc7c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/ar/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/ar/firefox-57.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "2649fb1096d06dcfce03b4a53acf3bda1bdc89cecd1267df8a67551cd1a8b3ca8d56c6e2a8be9f26d477e68d5e91a8538af2d3e76a7a1a8bff969972bec8ed46";
+      sha512 = "2afd627a2cfb3d25895c76a898cf025dd95ea212bf935dd46cff493151255ff152107ab967d9caca61e5bdbde784b4cffdba1a703a1d8c0e894ca0642daa38ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/as/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/as/firefox-57.0b4.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "204a40f2fb1a55bbb0ca9e6f03764ac3a4e9c24f17a61029f3b6809e54d81ce7d1bf5b87799106956723efb5d9f3cca6db7a32197b7912b079ed786b6325b4c3";
+      sha512 = "259765855256a6386804213bf1a948b1bebf382df085cb391fbd05cf31acbcff1ead282abd118ed89de0b8e7772b5327c32a898728270a29195222266f940293";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/ast/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/ast/firefox-57.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "68a1c622459ddc75d667ee3dd969788c76524c1d81e45cfa99f846063f264fec6c9fb2bbd12134af9a2e139e0c272b8031cb432df29838d3c08f93bdc8b4a522";
+      sha512 = "2cac1679b674f8bdfb8d0adfe0ee23550fb0289d436cfd9d815730515d32d66f61071145244ca11dd0dba5885bf52ad8d548815220b909e62ecc2e866376730d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/az/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/az/firefox-57.0b4.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "7fe10e5952b1798241f3269d1b98baaff0608d9aa4dd46977c49383732386256aa0c696b59602c65ad386b0132c70cd5188a791474b20a2fc211eb7364437782";
+      sha512 = "e709408f276677f6393d2da954744d70cab977172a61e95177203d54c1d590a51fb35cb35aae202159475f78710486c80fb7617ab38bdcbc48c1ad3146f475e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/be/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/be/firefox-57.0b4.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "4fed1eab9d2c1c1290ab6b0117324ce5cf2913a9d7d39082b11aafea6bd69a8a9178ae1474bc971e64fe63a26aedb6f7af5944ce9f5ec311d6e395997a766ab0";
+      sha512 = "ad5ba8e3660db6a452ace1570d653a4405d3d86bce834408f7e2f69931313903aec2c9b1e2867cfb4ddc6a8116535e266d1a8364a210647475f1c11f1a42d2a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/bg/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/bg/firefox-57.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "0e9b1e31ff2c0684275a9839f67b3b04ff28f4dbee09e07b5ad8b0b29eb63c5c8c37ed693a65c932268681276504eb84ec9abf97627a4d3c6e9b431bada37e2f";
+      sha512 = "0361f33cae76818dbbbe6d880b4d9d55393847ba38ca782a32fd8561a2182aac5477bcbe32a84196fca980c1e5b88f3de5f2e37a8d3fbedc3e7192018ae691eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/bn-BD/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/bn-BD/firefox-57.0b4.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "21281a5729c17002152af5ab2e0dc0344ff66b89ba0f1b566fd2a17e71d7515767d3ab1098c746fa8f87be6603dddda2b7d060720b753a07389db82e7f98df22";
+      sha512 = "590c6139ed81c04b8aefe1c7047b62418b5f03ca25f895bf61f31065756ae0e7111f500131f59d5bace19c91eec6295d36333ef672b0710dcb3eff7937355901";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/bn-IN/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/bn-IN/firefox-57.0b4.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "5dae77a2ef94e01155a547b2d853bc8c78166a37cecffd367e648e4f04fb87333d716c8f65d521710207f3a46a69a405592a2476b95dbf9bbd799b1ef8837145";
+      sha512 = "0353cccd7eaff7768578e90aa88f2e83523d48fc0b982018a373df6789713a3b2c794f3cd1585b4a45c21e906f8fd502672bcb66996f7b5db32582d78fe889b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/br/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/br/firefox-57.0b4.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "73726276e5920205bc9e5d281dac7995133cf2073b69ba4a5996919a68e19c9fd2b6c57f305a4e3f88feeb890f4f006fd2ccd0ae3c5e89e0cc6ff4f3ba657e70";
+      sha512 = "5a049250b11925ca0627ead2866aa0b84ebd5f3502c892a0bdc4a5e50e72750618228fda77259711c2fecf0572e1c9052d5239eb97f0960700c7e664c5bac4e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/bs/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/bs/firefox-57.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "4ce3ce74a8f61de0a2334292ab35ce8189cccf240ae9e3f249f6d736f01803460d2c09504de94f23347886369b1af4d29a3a338ddb2879ef6f2d95b253c40eff";
+      sha512 = "8b01fb4f35067a9a4bcbe045609ec6c6563401a812361ac3eb6df1ca0aaf0a804f485da7be220dccc01d4b8e4cfed96338120e3b1def1dfe9a0a04c1b44ffe26";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/ca/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/ca/firefox-57.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "0b57c6754d47109089aa33edcc12f483bbc81d3027d9f09f3e69c47aa17092477d60447e19c0d1ef991927127307d448772fc5e050e73d4b1c75fc91043c18fc";
+      sha512 = "f3f9a9618ccbfd2668c43619b3cf0aa6b3ad42814dcf3e48a828e1555a6d364245f3dbd7721ccea38fa7fbc228067d0fb47be66a21efab22ccc0fb4ec3769204";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/cak/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/cak/firefox-57.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "5315a9c31ef931c69875415245628cb9b11bfdf6a0900be21ae58a67301e4380b479e4426400081ba9e2735418f0eb2c6d071e830c1ff37b3e5ac2a354b0c46d";
+      sha512 = "14392133ce23b7231b21e531505f711002c908b58955b2756802c8718241792417a841f6c341722e249d4f0bf129791cd87796df3fb271a13fdd2038b8951090";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/cs/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/cs/firefox-57.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "82e827a0a23b80783bc0bedd7cd2522a5fabb9cbcd63e6d644b4859a34a7ec8f1b6a80df02a389e6ac92c6116f74d642599726cece33c77612dd37de4a106ed9";
+      sha512 = "d2712df5ef00534b853420ea954328e92fd8cee2357357bda7929f174e9cefd6666e2e347dc816c5cea2f54efa075c78ccc6de42c9457e12b8744a89d775d904";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/cy/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/cy/firefox-57.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "cd5b9e70099f7529561553a12c307f4541de147b7bb7cb45a62c65f8f2eef98b4488458eb3316c6d5102a3f29dc9f9604f7aa9619a179bcc40e28050eb51d0cc";
+      sha512 = "bb0e33a04190a6946d3aaf86c68fba9c52b7417cc46ef7310d0d8aec1e79c7ad47f988f1be48213ca27e664da98b35f84bae28629255f9941f056c51109d8b37";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/da/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/da/firefox-57.0b4.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "af9a2f686bc68f54b4fab2030933c49ae8218e1de6e538d6e46f9144e338a3b4684b195ba743cd900bb5a8890e72824491d36a94c0e07ce4cd465b40d931e05c";
+      sha512 = "1b5cf9c35245be1e9aafcd95e4cd54e5e67fd1e9ecab3eeee19fad050bdbffa9dc972c9cecb8370c5bd09e3e49348e199cba4959d46763cd59fdf74c034b6928";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/de/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/de/firefox-57.0b4.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "5c2c13831b8ee7591cae89ad7fa8bae9f34d20d4b473e4ad755a2396a382115f1665ef5bcc0c58faaf01a112dde04a3df391dc77901d0858d90533ac557cd957";
+      sha512 = "07cc00f6c3f2ead40425059eec604b2665bb7bcbd1458f6ca79111d9a903a87de6306fac437d951d70f0b9dea49ec78699cea3beb4fb26eab9eb191fc6d81999";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/dsb/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/dsb/firefox-57.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "75d765e2869ff7ee0487471a5b1c15af22afa9bc8027f13f67de4265277ebc079ff769cae3a051300fc5c682a3d799fe64870e87161dd8e063c9b89cbf6477d2";
+      sha512 = "1f4d29c5b8a0ffca63eba1051ac9fa2e24304cb4acc726557490825bdaa9e6967c6c79c80c00b38195ad98f14ca4e789720dcd1ce0e68fdf6d0e89d7330a3563";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/el/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/el/firefox-57.0b4.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "c430ce65539e96de0646307b9618a64f3d0441637798ecc4d0a59f77efee9cc6d269647d22f77e0f50ed01f3bf6f3786d78a4ef95cdb5e92d7765fb142d13d16";
+      sha512 = "37b2b81afe8d4b731057c100b454e24e6bf396c6f70020bcb67a2036a987585775d8affbc978606dabd15729d77d024b8cb9217654588376689f6063e5b2cd13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/en-GB/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/en-GB/firefox-57.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "f371086cc83b0274133244566720d66120fe086410e768f91bf737870316a9398dc5ebae67b4d5da5dd5df72940d77e93655e94f051cc8b813cc2a40aa7de547";
+      sha512 = "d3deff040bbaedaf22dbdbaf594cc594febf3ae7cdc89b5de270aa6534afaa1adb67d7e33f9dc8e48faebd6456bc19bf156e60be027d0566816b31e99c98851c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/en-US/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/en-US/firefox-57.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "59884b1998bcf9a2a9ec0722852b8b29f20d67a32516f00dc28f46ad2c00047e799d8a0a8de3ea5ce28e6e536feaf49ac28c38b5b68e7f304481315ccba71a7a";
+      sha512 = "685740c39f481e6484a25f59e544c441bb668f0ec1d66cae625d633a94c756a640f14148571098f26af885a4620990f7ebe81979ad2dad61fce19f1e922b7dd7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/en-ZA/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/en-ZA/firefox-57.0b4.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "5119056668a3e539309192dc61ad2bc30d5677c297da4a18d423576bda292218e53b149da825225a016f990fbe5e2538257343dd1fb87a216ea1fa7a37586544";
+      sha512 = "3491e2c503bd465c85b080d9b55ee7f41363ce84357d272ac5d12bc7280f2041f24b4ebce162276bd302e8cf10c6014925db60f629881d7483782092c00accb6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/eo/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/eo/firefox-57.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "2eaf2e224cf43d5a5920c690c83e4cdddd8f1c2d2813aff1057d99db77a7a68ac818ae311400efd6cea91ac89151c3b532563a9238b26d022be7c260d6fde28f";
+      sha512 = "5f7686a6e33359c8e2465f3fadb9d3fb273be8355fb9aa262df5fe3ad37a0cba6c549191ae23af03cd67156fce49db013a8b92e335dd64483b014c0477abc696";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/es-AR/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/es-AR/firefox-57.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "d74ef9bd620f4d62b79c0cb4c1033b3cc2278375c61f699c3251bbcc0390c657860adfb2c438f5b3eb9ab69413e2767269bdc96000a052b0ed73c0f572ad82a2";
+      sha512 = "bb3a8fc248ba0109279147bef3e08908560dfff27e5aa771d4395a5b202810aefd53e58f916295bf4978708351c04cdd5d33efd9b5b19d74f86d60dc56a71224";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/es-CL/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/es-CL/firefox-57.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "dab3dfceb1ad8073cbcc02fad1eedd530db1b9092374929c6e5eca55923f30d36f848862fc60aef3b71deebdf5bdf3f7a222951a3b3daffd32a9a60dd6ce5176";
+      sha512 = "6aee5d9019a087c07d5c3974dba4883582c2d5e7d0e8432d4d7bc2db211a112cf6153bb5f3da42a77883c34b06b22d5d6f0e7f1d50d62a1161e9cce42ef24486";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/es-ES/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/es-ES/firefox-57.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "c099fd1756b0e11e05656e08e50c78263f3d75c640322144bee5ced382987461c33327ced61d57cef7119c4b133246b075f443edc0b17ed0fa1e94ac37cfbc70";
+      sha512 = "caaaaf61e57257da03d1f2863464fef30b56cc4cadfb1d2ea7706cdb754d81b1a0bf999c860efc674d8fa4a94a48281f831fccd0908b3c2ba539054e2ec80a02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/es-MX/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/es-MX/firefox-57.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "2c1f85ddfe21f9fd9cff763fa1760fe74e501cbc01fab33d2f06b089550be8f6c9fbd3d3ced7f57efd33073adc9632c1a0bfebbe45acc8edebc69bf3b36a3a80";
+      sha512 = "cb592d991d16756061ea8fce8954a3d0634e1940ca2a063e7f3951ba25405510a95e083cb69f391588e9089c7add02bb0d16f28ebf3d18cf6c260fd117c58545";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/et/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/et/firefox-57.0b4.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "fb1e3c9beb39c79c073181f96e84fe7c840146c8e28480618b8d44d1ca7a4930f34e44b415ae02273661a8f4f3918a39760ebb00962a938c9c3f9a7c1179bb5c";
+      sha512 = "33e241c60b202f38fc686ff0fa0749c98beb281fadfd874e69ce6c94f23c90dd59f2cc1cdfdbfd2435a910cd68ff8820929064020b62d4a6e30127efa3025d6e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/eu/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/eu/firefox-57.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "f896c5066102e5d5ac16d580e3b70b703c015aea4ced26019824b181cecbd75c8c01d777d36eab6a9cdfd926f722e9351d02b3da8e42e9abe031529b439b1f84";
+      sha512 = "0253e4f86464c775e84d79d393cb33977a9cc1be269c1753d6edb39228d9e3ffb6fb11f31759e62b8fabcb2b490e3afaeab02e99aab18ed1035bd349b5c77bed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/fa/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/fa/firefox-57.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "a2d88f92dfbe449504b0d68450f56acb6dcb1051d51f54851eb30968bc762e3208ee7a3005f5ed4371c8a81bb3b21fe41bf88a9d9b1736e3d5d34caeda8422fb";
+      sha512 = "bebd048e309816a089fe81e5bbe55c65aea5e1ae5dab509089d12b00f99ec5ef4005965ade424578af21f6d0f8ddd2d9ac9be1499bb050c5b81fe58a6c3e77ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/ff/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/ff/firefox-57.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "ad7fbe231d45c96ec00d5a3c2ae5d6e47d0ba13745f0415539bd2eef40442364cb8417ff1b86e6400179ef571ee90e10348dded1197d0fdef64bb5f83f143d04";
+      sha512 = "636114444a5e81b939f8123cf06ac96c3f0f481269172c6ac64480694a307c81fed33c7d9f1531f26a9298eff2134bce93c408d5bb45d4e611adb8a912e9d79c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/fi/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/fi/firefox-57.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "613c7e26c71e758bde31c294c8a063ab72bc1a9795b4a0206c0629c1d70a0153b03e0a0337f21c91df1f11f9c9228c997300a26978c4af6473c52c45d4eb1740";
+      sha512 = "ba0766f65d590fc3ebeba21d9ef43a958928b0748e12e2c5b7d82fe00e74a06cce462cd686d99e41317e4afe65693139dd6673f133ba43816025543f53af355f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/fr/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/fr/firefox-57.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "fd065d962171f8438738385cc160396f7ca48e3ac89494bb772d9a778826803ac8d08893b9b1327018121020c190a7cd42e01a540a896019b5f9522a4727515a";
+      sha512 = "410f03d70413cedf2434ce6cdfeec3611f772059eb46a470b2fbf851d76a58249f4dcce281489f438df799c4a81ddd98410f7d2a5801b53515cb7a13ae555a97";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/fy-NL/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/fy-NL/firefox-57.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "0742a8ad845fd5269fca4f75716355de149a78768cd20fc2cc44ab3ecb8704a7e9fe75a376ce5b2419946f03b31d1fa702b7d4792f95a728bbec5a9ebb481205";
+      sha512 = "afb638f901404516acaced85175605b43b4592bbd55db7d55c2ed0011a39340565fb6191b7a6642e76ca44ab9c84d3545d903b1282fa7adf71db6080c8619f8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/ga-IE/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/ga-IE/firefox-57.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "9c6ad31ac03fcccab8fb7499c3d9243bebb8307ef3881c45eeccdede5180d3ed7b3ce49d12b403286836aa523020e2c400f10f8b6cc392906a41829e15aac4c0";
+      sha512 = "94807b2a6b867dafadff69d99df866541ab442ab97b264e93264bd6130761385e9f7b1235f4668e25783b37eaab7bbfa15bd3edf085a7c563df7050cc52d302d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/gd/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/gd/firefox-57.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "524e7f7ad6b055f1deb9e6d38632bdb7de2f77fbc67ddf1eb83ca419fcaf056d5a9c697146a252e999f2d4f1595ece70e293dfcb18e9bd6fd6a1d0b1f886deb3";
+      sha512 = "19774051018b2b74650ebc6082f92161b7dbc2257d212d592cfc881e7daadf23657dc9d6375168d54d74f9b2ecfd21e1e44a418185cc4dc1bfc360e842ee7fde";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/gl/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/gl/firefox-57.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "d8d25e18080b72497ea69962afa364f0cfbd8671ed5ef1e52b2fa2cd8f6dd23d71182544651e9a1508b1d50da8f6beac361b9426ea5be1a819bfc858b3d7cb73";
+      sha512 = "9200148aadb1fc1ee3b3481dbc2d2d9a2f7905fd5030aa6c3ca908765150ebfdf8022ac18ee8ff712d46f12d5d9c4f51ee1ab41f80065e8642e4866923757e40";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/gn/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/gn/firefox-57.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "4664536b70c34c35b43ab278874d13c0011890b071d1e3582959315b6edb54b3018135b1fa94ac482860cf6cb15ead63420c1896574348b78265c48f2a016ca6";
+      sha512 = "efff686e4c472629fb4f4581bae75f5a41ee14d4e92a6de908663a9e755736e75a67963b38fbcf9d88ebda5a5a7a1704b0ef30f64019e370e638a73039e62372";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/gu-IN/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/gu-IN/firefox-57.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "c6b5374c4bb866314acfd01f1e95713ca50d51fb77a9251e6b228695fb45ae5492d11798369f27bbe1b254b77ce46b67528f1eec72b4b91a68819030f6500c01";
+      sha512 = "6c60b30e57999dd04f2b265836719748eb89520f3ab848c19e4f25b85c31a83c52a40b611b0cdc2ea8be8b9df92e75a31e0c9a462676d0ababce51e8f03a897c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/he/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/he/firefox-57.0b4.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "b3a652dbf92a1e2b252d40b6c419c508842c779c3d5fa8458402a129eb773762048abe64cd04f41658b566b3a0add948c998ec6ec1ee32fc96f8152785a7b21d";
+      sha512 = "5773b812756d20e7006389c14cd94d2e12fb1934e69d7725ffe9379e9c42a06b2f9f9ca32b72577cab5ad43c08a7ec5519f02bf90365abfbca69241c9b159cd8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/hi-IN/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/hi-IN/firefox-57.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "7e857cbeaf419a3e1685b778c38f5d8f2b437eda2ac0c67576ed50cabf3abc13d8c95045649a3a68cadf053a7af9b64b8bdf84e614f2e52f35fd50b69b234eff";
+      sha512 = "df5bad202fa13774f46c582fdcf7ae588908b1e50194f4ae46af9be2b693c5fc523b7c127ec5905d6185873fd45f3296f59ebbe69cddccd1d9bf48f3cd06db32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/hr/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/hr/firefox-57.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "f71b627e820eb44f7b6a61f6d2a0637712a2a516eecde38c2bd13c37f92b34add41b4b274a616697e96340e44144adb0d9812dabd19aea563f90409d605d6ca6";
+      sha512 = "6a4a22b5ee9bb6fd86e016882b3d33f33f2245027a869c10472466e0c0d40bcca2ad5a6b76f92298e5aab174237976f6072f47b85610d5567ebac955b69f3c34";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/hsb/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/hsb/firefox-57.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "e5f9eaa358e3f87d78daa8eceea39dcff1ba6854252f3327791ce51ed6a51030cc3fd493a11647142edfb94bdfdaef82893d89f7796c0e3bebb674876fcde554";
+      sha512 = "22dc98ee44d6b735f6c56127054ae5be4112a318eb7334b3e4455c1315a4cbce30a90f3f67f2767380a23e9bb2a25f9ece51cdc97376a590f0ea48edcee12015";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/hu/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/hu/firefox-57.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "9d74b920a7ebab561d2a812c33b3abfe73d4e2343f4f6fc903b65b8d2f6dbc7b63fdca3a567966e9ad4dd2bbf9ab50e88d71b95eb5a667aea5bf913ddf635ad6";
+      sha512 = "28e3c20123999d2c17ff66533db241e6add3f9c4a3d23c1e9fbee3d2ce8748d8a39a3f1b1ea92fe8231258ecf2dad0687a46b7b00c3095276d79845c7a065156";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/hy-AM/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/hy-AM/firefox-57.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "0315f4276f80aa0cb4a3e90dd452d1b65a270e830da91f9464f336f9fb9cad35eb446855ee63bfdc08219065580609a29870d1bfca873a88db0f0dc1ea39e362";
+      sha512 = "d6fa2c684613009b2865c1c4f8de8718a41fd5e21cf395de5641251b175c30dde405f421f2c2b453e151ce7208474ce4f9d9647e5477aed4e6ff3e9a9e177921";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/id/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/id/firefox-57.0b4.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "a447dafebf5892dcc5e316fa1fb325a926bd6d5b3f8d808dfb1136f5fe83eed57bb065844288d7634d8a61f260f87974b67ecc2efb42f5ac8c6cccec5a198908";
+      sha512 = "5d020afa3810b1ed82c61df265c6a6506f5b86de23f71ffabc2b1124e1664a3539e4d8e21a36aada76be854af333cf1bd053c62a5f82488369ff6b9321eccd4c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/is/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/is/firefox-57.0b4.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "84e35402b9f5e7cab69276f2780f89c20361fa463afccf985866861d41775bf5e4efd81c8b7d5233d3851910f0c36420ad78e735995d49acbe48201e3162f99f";
+      sha512 = "e5ab0c5f8c52094f41f644318b7b969faf494fda35ab2c29b9c2b45563d6daa0b95b8e2890dd651514d6f4e7789b8d3f439b5b966c3b466dff7b94f07ca88293";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/it/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/it/firefox-57.0b4.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "53e5969577b9fe93e64f7c4e45825290ccfd4ee7f7a18b53229f8040cb15c45ad558f274a072e92ddbec03af8e405216386e07414886193241e1efbc07b9dc72";
+      sha512 = "246ffecf1d0eed68fac533123190b1b2a29539cb00f44ae5c8b72a073a829f21daea47f706024e980cc63ee05f510c920b5bba9b7fa11a150818ac741049d862";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/ja/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/ja/firefox-57.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "e0b26b41bc58dcb4f2bfa29fc806fedc3547d4e8b6e97c79750d77c3c822ed8f410bd0f1e99c3d261cd7f187468828c0d1eb86b67d7c67a4ed164647c323dd39";
+      sha512 = "b2c045c1b559fbc91d20dfb2abc89488503330ede0d66216bef4592e0bab3d469f5b179c485fc0563ee345b204eee770ded9b46abdbe9e4b381af08018a7daee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/ka/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/ka/firefox-57.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "d14fef9f3efa294df9919d25a43233d979ccede7107d502354b2ab62949d6df3325b8b920684d0994a3894f88730f3edc5450d90bca9056fefc58739b60afe48";
+      sha512 = "42c4f3f86dd7d8225f1e51a74fddd5222297d2cc1ed546c768fb16a2440e53e679722040677ab22cc1f48744ec301ca639a36832b4d72df527fdf136929f90bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/kab/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/kab/firefox-57.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "24212c3f06b204a348a6f864c9354d93317098093e84f57d6c8017618f2ceb15098136bc0afb70d315254cdce37ed73f7ede1db18ae1d909ce85deead4fae61a";
+      sha512 = "f0817f398bfb1ab4bb4061ae0f010d6b782826fa64191cdc4b907f256593c5f975d9ee19e69119ea7bd1d5eb6c3c91a59d68ea57bef7dc3abc307e676d70b0e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/kk/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/kk/firefox-57.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "2cb4bfeb2f2d3f0462e776ea82882f3431fc1877f89500aa70933f9a352b2a2fc77a9f2453954459fc6c9a22103476262bf5239e8bd4252ca7bd29a33536390c";
+      sha512 = "c10356919c509b3ee0040ab327504c68d3d79d35738cc218e6d2aed448432193a2ca5493d4029bf636d160a945bfcd68789832d99d55240fcc13c5296bb71fc8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/km/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/km/firefox-57.0b4.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "745a5cf7ed4435ebfc1f2bb2dbee3ea76820c1758835c032579ec7e4afdfc9e43e28836a65bb667ffaa9bf1168244ebdc1ea14c14265e2ffb8d1fb7d4321aaa0";
+      sha512 = "e8ed8ba59655279495afacbb94b5fa6f5a38046416dd7a3036cd278e26123714746fdc805a35590c94e05ad688af4474af06d0bf2b3730c1b6266576cc832997";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/kn/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/kn/firefox-57.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "95be01ed5085dc900679c23eda769fe0d83f09fa1269dd006cf2f2a4585b3d4e4175472db9e54d9dde45bdabe517149346a15c3eb42a47a935b2ceea7dd31f82";
+      sha512 = "0c371ca752cb60168d1527340264906b660bcb7a4910134bd95c8144c21e7c6395b143d491c9ed0ab1904626b3993e7a802e89117ec795784c66f9f7e47cdb44";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/ko/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/ko/firefox-57.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "339f3d3353a7d2f739f3796b53f42f8b1aec930a0bc63a2593f3019b5ff246de2ac99753638924138cb9febd5e0359b77108261337166e3018d974a3f88f2714";
+      sha512 = "934382f0a1d568c79b380ef0dfd969b68a2cd06b9b9d388830b62039b0232ca058dfa3ba9f17cac7bd45867fe391e50fcc183823377431d82cea1d6df5d7ebad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/lij/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/lij/firefox-57.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "80de8bbe41e6d5a7076f3300cd90820d75068c0bf08cd8e7d79a63f2118fc3c5f5ddc4316afb884d767dcf95ba4b710e40e78d5b35880779ecb286350c9e834a";
+      sha512 = "8612b1599f10fbb4b2161ea64593c2c71604a483d0bdcc2239cab316c63b0bf3acd6cb9a65a652f9a6ff91e47b02682f60718d58580a6c660932550efa71c3ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/lt/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/lt/firefox-57.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "8bdd86ddd12f39820a639dbeb248c419efb0a7aa11223ee25b98edaa0c1aa514edb29c498932a9d2b5a368811b902e1a875c74704661f4785a38c4ec867bcfc8";
+      sha512 = "577da9aa99ff5ba653d036d7c79f743ded7ee5b9bdded8650338eeae72a11d85304c0ef9c035f8477ef460fab5e1e4127b04ca32748f0e73e4e7caeeef52bfe2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/lv/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/lv/firefox-57.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "51692ee445ab31d6443a823017405305af68594242c6a24be59db1ada2f9dfeb479fe595fc0590178b23daef59ce6dd84be3dd1779b4dd9f516a8f59be9d7c7b";
+      sha512 = "c34a63194b5f88c59d5b5c1ba9a69fda93d6d6461ba65a6aec8233f573a28b8ac420c5806c98c20a4f4766b58e901a40eda528b7750d058c515abcba293f8d78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/mai/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/mai/firefox-57.0b4.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "8459e52c6961e5f42f4547e6ea33707584a10a85fcf5b3b83eea4b4f06b2169c7dc39659ea41f3a4f1e554da5af2f9063503d9333d0d5553a521499b1efa24fe";
+      sha512 = "01aae7ae050d7bf75a22292785cdb9bb1e6d37ed571118fa8ee4f27b7052d405ab99d3b82308dd4b347eff3d4a1040dc57438c0c76d6d9db7ca8e151a25c3921";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/mk/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/mk/firefox-57.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "666e675faf3747877eeb8e188a68a1c9979a5823a7bcc63c56e53697084d4673363e057c3c73c51dc281c107161867d20adf615bcdda14f2c1dc6f3876630d6a";
+      sha512 = "b7ded40b4d9855cb8a0a9854fc69add177e53725d7649c171a803a9245384651962994e050e46c25b734307f2b8df6dbb99c0f7e7085f2a8f380b7453a755948";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/ml/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/ml/firefox-57.0b4.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "db10acd345e98dae88e059df5ab0db7cddbf4243d0fa1fe43d4c1581286d1a625fe0d8808d6b23d6740116cbd99c487562b667e32c42c6749750090b3b0a287c";
+      sha512 = "08c891cfe51c47df214d169a767d1f6eb1a229857759cde979b41b7d384d0f033c11b44f5d605ef6dd6fae0e553fbb9457f3869d3719b241d599416091c7ddd8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/mr/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/mr/firefox-57.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "1715b23b260872a8aeabda5476fe6ba6499485566525542968f2cd144e10983b38b7713614a846d06dbfea18f49f08ee7b5eeeb90baf908b5886a09f7d874f46";
+      sha512 = "4f7219a2a5448885a5ac8867fe98e3c39467f540c3e937796595480a20fa4daa5b81b6054d0dbeff0a306d920dbdebf6c7fb31d202184bdd9cac2f4c5fe5f705";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/ms/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/ms/firefox-57.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "548616f8d58c140ce0d0d8c181219c8a62702c1d4a11addc54edceec81cb3e98e6743a5999c03f5076466e9bb0fd00345306ab7e91686c4b1815ac6c99755228";
+      sha512 = "1c48af4419ad73a7b74dacb789614a020afefbfc06d6129ba54bb96c79f95a403ce1ee64f4bac505afe39bec3d189feecc7aa42f29bdecae44e6b3a930c08c44";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/my/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/my/firefox-57.0b4.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "e13dc5258eb2f751ae79b3aef7892aa9ed3c56eb44fc7e32aea240b2d73dfe5cc6b2ab07ab49548023a099f378c98b8245800edbe73d320b45d1607350145990";
+      sha512 = "470f46c7c72988daea4648acca7f857cc090e54b7bc1ea2c3053253c8d7f51a2d8b1e5d80b5856f0d1d9ad79072a14630abb62a183df741701e2bfcfe28d37e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/nb-NO/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/nb-NO/firefox-57.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "75e02e3aac37c840bd6725207ba53beb7cae3bb7a34bcc4c4114b412774114315d17a98457970b3f8ded7911610811bd12b9614826755f99bf6cb3e9018f2909";
+      sha512 = "af4dfbae6964f43925fb83585acb7539090acc770f632888ae5c32811635e68b3d97e61126db58d6dc39db1975eb0fabc6ce77a7d848a4574ddace2585d99332";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/nl/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/nl/firefox-57.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "480de8826af835dda939f63fc007b01e88ea1cc2145e80e27ac9abb36bf85d5f0f7441a28623fc6b648b28c81ae02133df654a874942a497682c14a03280c4d2";
+      sha512 = "a3bc479da0ba04b5d8dcac09f9679d8895495568b1686def8c2c173c77c95e3d9af5109f9409488e787f2bab2fb425760419dae92f898cba4574a14aacd1fc87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/nn-NO/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/nn-NO/firefox-57.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "be5c63efa39bc574cd5f41bde6b35d3ccffa43069c61b11c75e0f9039c90e47b56bf41f20b041463cc1638639c581c1682605b24fc1621ef6380396e64d57f71";
+      sha512 = "9d184510c4aab71c70256d29b896cee00bbc3014dd42a4d9aca1a9fe44642926b9e6fb074838ac09848939480de15c3a3d4d16acf5fb46bf2f7c2f21e276205f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/or/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/or/firefox-57.0b4.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "a448cf44d66e795cf2549b21728ceedca364091224720c1e72524ad55660721fe48b6ab5a3b3824a4de962bcf093a467f2dca34921bf7107495b9592bd87886e";
+      sha512 = "c485124e62d34feef8ab41a9ba887cbad236ada2577ac3e433c6b045aacf427b469b438e92f268c083fae2b3f740dd5ebe733c80f62b69d62a1cfd489055909d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/pa-IN/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/pa-IN/firefox-57.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "f3b3f12a19ad1ab45709f1294f21bca08b9d39bc3b1a4bb3d7bca304443de3c5718c4b714a95c3d858dc87b1bbddbe34d7479bbb2890cb5f5dfe5adcc639479d";
+      sha512 = "d121f493e206b4c906ec001ebf4943289608b9d247fde4e7cc192651bb5a7fa4b5731670fbd6e1e5894c82db73330f4cdd179e0e8613b6ec9d588c3e4409e45c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/pl/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/pl/firefox-57.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "03be7e535ce2e13d87c19e95711bea4d76e26517b8e877c4dd5885c7917c0079e8642126ad19365325c224e10a419586f109de5b71767777c0488c0213447c09";
+      sha512 = "3836babbfd8213820ee62dff188f0d6ac077822719bf72add215612a088055ccfc4c143a638a3b9590f9b347d0a3dc911e9a90847dd5bf2713696e55cf94e837";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/pt-BR/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/pt-BR/firefox-57.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "64be7571a7ec3a89098f309edced9f492cf0c3cd7a1fe0154d7e9cb645548a21f55c1631ae5ef36cb4ef0cc1f9f977ef5beeb8fcaeccae42279c2028339b3825";
+      sha512 = "d53501a90c321e4d725f5fdefa9692d28c93625794661f1b89f9405635b8b077ed690a5f285a3c9c1765eec8c3ef195cbb55c6ffbfc8c35f92f91972541bba4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/pt-PT/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/pt-PT/firefox-57.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "0a72d994790d9ff05e799fdac7f74e7033bbab686b0c8ea5a997e01ef1e9c93e59ba760eca254bb177358fc09b7663416972428939189a709599685db543661a";
+      sha512 = "6aeac0ff132c6a4b42d577204e2f8b6c4bc77d07db8d4eef8e782189b037112979f8eea78c4f739d81b0fae2f47089bcd3c050b6c0080a15727018e2b31640c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/rm/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/rm/firefox-57.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "d5e1872e7d05b854c04b67eb920950bd66f62d37c747b656f87cf37506a111df222557d8cb8b7968a4123f6e8e490256f91d13d64a0744991c8f9e1e41329aa3";
+      sha512 = "83493068d9d94d937b3bebe5f95ed1e57a719fe3620f9a51cae606fc3784d18c1da7c7d429aaa6f6e617f5a984924a199dc6274e90ebe1fdf74c5c9f64bcc1c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/ro/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/ro/firefox-57.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "80f9394ab1d00cc4b933f9460e7ad1ea6092b5caf4dcd72db53536dc46d3f2fbacd83770a1fb5a29713ae11b7f3c0c0fc2b96734169ce45a5addbf03cdf6b2f1";
+      sha512 = "15c4ad11cc009a0f1df62af17df17c6ad4b779c19f6236d312b2a071562b95cac3557de2add148a0aee2b2125d18286596a68c0a188088c9b4fcde3335478908";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/ru/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/ru/firefox-57.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "f116481b96b8bf426f034b6374c8559b7695946fabe898683035be02d20b7ffee6a2feeb3b16a575e107996b017ef8f4e3f23c887ccbd04ad7b8f687e2af760e";
+      sha512 = "a52d3fc83da91bd90809a5d3b7894abc2aeba3547d975a56068ab243df6ed85f0d4f7f865f713084804a65248444a59dd2737f6d5693755ff0ac56e056d372f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/si/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/si/firefox-57.0b4.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "af93d52c290d07a60120cc0422e44099fdaf0e3c1fd7babc1f4779f77cd8c8848985fd1c7bb558d8eb1252cb4f96d1b65f5ba9e739e91e6008b5f8f2b581f324";
+      sha512 = "74fa5a39486317b7351e57e52b588ebef13b3314ebc5991d1b28d2c0d62d1cc47c1e861dd4db8dcc2cbf684e4318f72b48da651a84698d65f629fa07e67e9119";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/sk/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/sk/firefox-57.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "88680ad43f541a8ad9780188b92883aaeb805f47b11346f40d236b8a4ff3ca7e719270c01ae9765e336788d93c54ca8f2a80df3e0316022169702db75fbf5ecf";
+      sha512 = "bd4db3ff2385dc873494e3c6e92d5b2428ffb1e06d8befe88ae9c094341f0d81dfde38adbf82563c64357f8ed29bdf12cdfaa062c51facab4b1eb61a44bb77d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/sl/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/sl/firefox-57.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "45692963e9c6c9122832ca105a19e4a9d6a4ae0c0fa66c5573e0b02ca74e2b72bfc229619a3ea3899ff591f70775949e53fc36a5a6ffad699f3824d8b5723b75";
+      sha512 = "7f2f3cb7757526ca36a9f2b7f61fa1fd1f14d979fe1dcafcb8ddb8dc01898bc1b15eaf4e0c0ba426d4b200c5c4b0490d5e0aa908eaac08408d0e888c87bcbe2e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/son/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/son/firefox-57.0b4.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "e1a43d8d56105fc7ae69b23f3cc596363d7e0e22b18614cb512a32ecf3f9369be240cbd2d5775537363e40e3de0f0494054331554f093c40dc85d0f1aacde366";
+      sha512 = "4688b484acbd58f02a109b18566ece245f99c46c35e40004347075a8185d9c82077bf0c295d377b4055d6090b41a7e9151e25c45199ab3b3756d0f7aa4e1544b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/sq/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/sq/firefox-57.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "a80d2f2dda50f2977346c51d25eec1f52363282e83eb83dd8d6ac36ce41ae5d8d5f3925db70e2942e38e9cc61b30341c47d1fae7e60c68f8bb1ef28f1978d695";
+      sha512 = "8425a72e20bf76ae2435a9c0fd596810a39909060dd908dadc5e77a26a3ae241321621df2196587e35edb527fde2732b7ece479b909bbb18d64c91c195eb54da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/sr/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/sr/firefox-57.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "e379874f97402001a48954674d84243c8da577533e309fa7f61c832c413519f784fa418d35f00b7af760e55a75f192fd97532ef2b2796130b396782b1c6b9d2c";
+      sha512 = "2f13f30bb3bbcf3acdbecc2630451f1c130d32187a6745b394ab7d984aaef20addc12fab79395eb14a0f64300cc91aa4a8acda33e8664837079e63aa8c64339e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/sv-SE/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/sv-SE/firefox-57.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "272861b15c0476f10482f4ffba5178a7e4cc5a62e52337eb217ab06386d75998bdca7f31f478541cbcf330823b3c187fb5d247cc311c973b41f7cc56f458814d";
+      sha512 = "5a18ed2846e7ff05d1990b6e9e073356dd527fe1e24ce5516df562905d3c14a3cf0dfac8684651b734320701618155660352af773f9c5be6c07295abe3457a80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/ta/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/ta/firefox-57.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "bf2d304c978fbbf65aafa5ae01fb7da0cda9d2b133e0a78c21923d9f35c9fdf41d5aba17c863aca79ad021875cdfea934d6ed9db8010f66f6552860ea9cb6bf3";
+      sha512 = "44e4c605856e2dda8e492ec02c252998d089d8833bd19f93a010bda164864ee247edc3b5b41fe0da8a3077c2aab5a6dcad275303a340b1df2dc7d4f99d15eb08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/te/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/te/firefox-57.0b4.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "a407d5fcaf5b1cb01d7bdbe3175327d9f985af0ff8b5b27ac93345c1a4266f4cb1753f357603220757202539c5dd7c2c7bc197d18e68585a4118384b729317d3";
+      sha512 = "0d6345c10e8d27542e9871c398c553a8378b185ae6c3a4876c4a626475801d9c528bd506fa56d99c6bdb04e4053340b7ec6ca506a289e8ce280abb46905de297";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/th/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/th/firefox-57.0b4.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "a3ae0aea5eb5b4df9e12c039cb2876fa1bc39c0c6a1d62971a7cef532ddcf6d76dd3c2314efde74b3226cc75213b2e1cb0f80718408f707ef4c986320dbe3c66";
+      sha512 = "cc0c6e481e6eca9abf4d02b590afca9f2700111ce648ad7719fdd58751f6d54eee2ebd4b881269ccfefc594c62855dad4d42f9248b65a35d2b5c57e75153815c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/tr/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/tr/firefox-57.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "4dc598410320ef44ad558da2f678791796dbe86c3d4c4891f7c50496984b2afc9f9879488f4f7fc4446ddc237ada5bb9d443b9822ad5dfa9f0c6e46d6afc1ac5";
+      sha512 = "f11df9e253cdbf1ab9f03c3a0033d34d120ec1b69cdd12f2b2734648a86d309303d35367349f8d994975e23284bd96699a1cd47e8aa483dddf7baef63fbb35c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/uk/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/uk/firefox-57.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "989dceca0a7c5a0b091b1ab80d15c140a3b59f950b520a0e2e87436fe4e32a28e9508ba82335e269e5fd562e31a56d7040097e1fe2365330aa257c5ee227aa4a";
+      sha512 = "dfd70428cf6b793ac147a5fcffcbe80b33dcadc0669d6fac33b6dcb6355fb4147eb44e08af635b81d58aee3d50e74d41c036e427254e655fa4d72a4c5c56cf07";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/ur/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/ur/firefox-57.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "cda7780cf5a9bc6a06c1ae9cd6f9f52911f2ac55aa700f87b3a3021d46dcb31f1ada5550009ed801f7754b7a5a19c3ef25f537e6280014c80672543701658b90";
+      sha512 = "f308793aedc14c78d9b2fc092359ac88b9a7b138b1b71720958eb3745fbec3214b75bb5d698093bf12ce0bdbe131765243a959fcd368b0bff13577b767132aa2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/uz/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/uz/firefox-57.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "755d03ebdeede91ac2380d53f4cb130a48331f6e8685eca21f717fc3b8768239a96328086733f768349ed231ad9b2716b58c4912fd8044f644d775489c4030d4";
+      sha512 = "571b936f3f27dd42e90bd89bed8cf93a22a97ecb31c0c7cc7cbcb9f2aafa86f1580e6c644963ed82237dd0032cae17df425e0933f23245809e0ec56ad5fa58f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/vi/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/vi/firefox-57.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "56946ebb5e9746d9cfd9ec14cf72708fa17237915c5fd9d953d7ebf5ded0f3e2778b8777a1ed9da191741baafa47e27cc12eaa2a1de46013104aafce251110cc";
+      sha512 = "61f9f22cdaa88bb2ffe1eb64b77957f136fdadc7025eca72f3e91ce30a208fc0ba4f77e66cce069bd2ace6b6c968ff8925d8fc0ba2854a3ed658d50351efbc5d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/xh/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/xh/firefox-57.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "081be12a468f7c8dc79336cbf9e08082d0f79c39baa491a10b9a68cde05de78cea67cb247008d99c241e3c66deb5b92bc3518150138103eb1c75f141f6ed03ed";
+      sha512 = "2bcc9bcfbddde2fdca28575249c5fe248d5a254e9fc722597d988378c79f160c50be5d49c77b729eac0a01987c8ee9a705380dbcdfe469a73d59be887c616898";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/zh-CN/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/zh-CN/firefox-57.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "015d744fa850e529d61e4dcd0fc5459fca47e7a4048dd5b3ddab29c2474cef6e76bf5fdb1e91ff1df843e3dd1834373099372bc36270358a77d42d4e39eff8c9";
+      sha512 = "16ca490aae09854a8cc3642d176abe2d9301cb50b19ba40071e6fe62bff5053172beba929de27e3560a1d9cfbb9bf0ab8b7dcf4c880c637189064bfe1ca0b09a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0b5/linux-i686/zh-TW/firefox-56.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b4/linux-i686/zh-TW/firefox-57.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "2fe5c828da675b1b1e5b53fe9d292db27ef449eec8f53160fd60893d0bc523a0131209253d9b7c1846e8fcec2145fc760fba29c4e3850f97b2c3cd3a1b13a085";
+      sha512 = "6768835f93d4523b2b126b2ff050dbca8ff8bc64828a6eac7441bd2eb2bda37bf53ba74376ae2533accc567090555947c671fdfc7ea6d72af206efafae3a7281";
     }
     ];
 }


### PR DESCRIPTION
Updated using the script: `firefox-beta-bin-unwrapped.passthru.updateScript`.
```

-----
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

