### PR TITLE
glib-networking: 2.50.0 → 2.54.0

### DIFF
--- a/pkgs/development/libraries/glib-networking/default.nix
+++ b/pkgs/development/libraries/glib-networking/default.nix
@@ -2,7 +2,7 @@
 , gsettings_desktop_schemas }:
 
 let
-  ver_maj = "2.50";
+  ver_maj = "2.54";
   ver_min = "0";
 in
 stdenv.mkDerivation rec {
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib-networking/${ver_maj}/${name}.tar.xz";
-    sha256 = "3f1a442f3c2a734946983532ce59ed49120319fdb10c938447c373d5e5286bee";
+    sha256 = "5961b3779080b72314b373ff5d4790eb7e41b75ca91816ad7a81ef32922f7096";
   };
 
   outputs = [ "out" "dev" ]; # to deal with propagatedBuildInputs


### PR DESCRIPTION
###### Motivation for this change

Updates translations, improves gnutls compatibility and error messages.

Cherry-picked from #29392 (GNOME 3.26).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @vcunat 