### PR TITLE
iozone: enable aarch64-linux build

### DIFF
--- a/pkgs/development/tools/misc/iozone/default.nix
+++ b/pkgs/development/tools/misc/iozone/default.nix
@@ -7,6 +7,8 @@ let
     "linux-AMD64"
   else if stdenv.system == "x86_64-darwin" then
     "macosx"
+  else if stdenv.system == "aarch64-linux" then
+    "linux-arm"
   else abort "Platform ${stdenv.system} not yet supported.";
 in
 
@@ -53,7 +55,7 @@ stdenv.mkDerivation rec {
     description = "IOzone Filesystem Benchmark";
     homepage    = http://www.iozone.org/;
     license     = stdenv.lib.licenses.unfreeRedistributable;
-    platforms   = ["i686-linux" "x86_64-linux" "x86_64-darwin"];
-    maintainers = [ stdenv.lib.maintainers.Baughn ];
+    platforms   = ["i686-linux" "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
+    maintainers = with stdenv.lib.maintainers; [ Baughn makefu ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

iozone was marked as broken even though the build environment they are using supports arm.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS aarch64
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

