### PR TITLE
nixos/gogs: fixed user creation if non-default user

### DIFF
--- a/nixos/modules/services/misc/gogs.nix
+++ b/nixos/modules/services/misc/gogs.nix
@@ -240,7 +240,7 @@ in
       };
     };
 
-    users = {
+    users = mkIf (cfg.user == "gogs") {
       extraUsers.gogs = {
         description = "Go Git Service";
         uid = config.ids.uids.gogs;


### PR DESCRIPTION
###### Motivation for this change

fix for #29922

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested with the following configuration:
```
{ config, pkgs, ... }:

{
	services.gogs = {
		enable = true;

		user = "git";
		group = "git";

		domain ="git.example.com";
		rootUrl = "https://git.example.com/";

		database.path = "/data/git/data/gogs.db";
		repositoryRoot = "/data/git/repositories";
		stateDir = "/data/git/";
	};

	users.users.git = {
		isSystemUser = true;
		group = "git";
		shell = pkgs.bash;
		home = "/data/git";
	};
	users.groups.git = {};
}
```

- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Edit: fixed typo in example configuration