### PR TITLE
sudo and sssd: Enable sssd support in sudo and building of sudo library in sssd

### DIFF
--- a/pkgs/os-specific/linux/sssd/default.nix
+++ b/pkgs/os-specific/linux/sssd/default.nix
@@ -3,7 +3,8 @@
   python, python3, pam, popt, talloc, tdb, tevent, pkgconfig, ldb, openldap,
   pcre, kerberos, cifs_utils, glib, keyutils, dbus, fakeroot, libxslt, libxml2,
   docbook_xml_xslt, ldap, systemd, nspr, check, cmocka, uid_wrapper,
-  nss_wrapper, docbook_xml_dtd_44, ncurses, Po4a, http-parser, jansson }:
+  nss_wrapper, docbook_xml_dtd_44, ncurses, Po4a, http-parser, jansson
+  , withSudo ? false }:
 
 let
   docbookFiles = "${pkgs.docbook_xml_xslt}/share/xml/docbook-xsl/catalog.xml:${pkgs.docbook_xml_dtd_44}/xml/dtd/docbook/catalog.xml";
@@ -41,6 +42,8 @@ stdenv.mkDerivation rec {
       --with-ldb-lib-dir=$out/modules/ldb
       --with-nscd=${glibc.bin}/sbin/nscd
     )
+  '' + stdenv.lib.optionalString withSudo ''
+    configureFlagsArray+=("--with-sudo")
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/tools/filesystems/sheepdog/default.nix
+++ b/pkgs/tools/filesystems/sheepdog/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    description = "Distributed storage system for KVM"
+    description = "Distributed storage system for KVM";
 
     longDescription =
       ''

--- a/pkgs/tools/filesystems/sheepdog/default.nix
+++ b/pkgs/tools/filesystems/sheepdog/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, liburcu, corosync, fuse, zookeeper, curl, fcgi
+{ stdenv, fetchFromGitHub, liburcu, corosync, fuse, zookeeper_mt, curl, fcgi
  , automake, autoconf, libtool, pkgconfig, groff, yasm, systemd, libqb
  , withSheepFs ? false
  , withHttp ? false
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     libqb
     liburcu
     corosync
-    zookeeper
+    zookeeper_mt
   ] ++ stdenv.lib.optional withSheepFs [
     fuse
   ] ++ stdenv.lib.optional withHttp [

--- a/pkgs/tools/filesystems/sheepdog/default.nix
+++ b/pkgs/tools/filesystems/sheepdog/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchFromGitHub, liburcu, corosync, fuse, zookeeper, curl, fcgi
+ , withSheepFs ? false
+ , withHttp ? false
+}:
+
+stdenv.mkDerivation rec {
+  version = "v1.0.1"
+  name = "sheepdog-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "sheepdog";
+    repo   = "sheepdog";
+    rev    = "${version}";
+    sha256 = "0c4f454d6185617f67e6ebe60c6735f481ea46460c84e2132a1c47090cf8b857";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ 
+    liburcu
+    corosync
+    zookeeper
+  ] ++ stdenv.lib.optional withSheepFs [
+    fuse
+  ] ++ stdenv.lib.optional withHttp [
+    curl
+    fcgi
+  ];
+
+  configureFlags = [
+    "--enable-systemd"
+    "--enable-corosync"
+    "--enable-zookeeper"
+    "--enable-nfs"
+  ] ++ stdenv.lib.optional withSheepFs [
+    "--enable-sheepfs"
+  ] ++ stdenv.lib.optional withHttp [
+    "--enable-http"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Distributed storage system for KVM"
+
+    longDescription =
+      ''
+      Sheepdog is a distributed storage system for QEMU. It provides
+      highly available block level storage volumes to virtual machines.
+      Sheepdog supports advanced volume management features such as snapshot,
+      cloning, and thin provisioning.
+      '';
+
+    homepage = https://sheepdog.github.io/sheepdog/
+    license = https://raw.githubusercontent.com/sheepdog/sheepdog/master/COPYING
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/filesystems/sheepdog/default.nix
+++ b/pkgs/tools/filesystems/sheepdog/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
     sha256 = "0c4f454d6185617f67e6ebe60c6735f481ea46460c84e2132a1c47090cf8b857";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ 
     liburcu
     corosync

--- a/pkgs/tools/filesystems/sheepdog/default.nix
+++ b/pkgs/tools/filesystems/sheepdog/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, liburcu, corosync, fuse, zookeeper, curl, fcgi
- , automake, autoconf, libtool, pkgconfig, groff, yasm, systemd
+ , automake, autoconf, libtool, pkgconfig, groff, yasm, systemd, libqb
  , withSheepFs ? false
  , withHttp ? false
 }:
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
     groff
     yasm
     systemd
+    libqb
     liburcu
     corosync
     zookeeper

--- a/pkgs/tools/filesystems/sheepdog/default.nix
+++ b/pkgs/tools/filesystems/sheepdog/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
     fcgi
   ];
 
+  preConfigure = "./autogen.sh";
+
   configureFlags = [
     "--enable-systemd"
     "--enable-corosync"

--- a/pkgs/tools/filesystems/sheepdog/default.nix
+++ b/pkgs/tools/filesystems/sheepdog/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner  = "sheepdog";
     repo   = "sheepdog";
     rev    = "${version}";
-    sha256 = "0c4f454d6185617f67e6ebe60c6735f481ea46460c84e2132a1c47090cf8b857";
+    sha256 = "0f4l44w2a8zl92agwsmrxssdw3z4lvcxi0hac4kcj8yr4rqwlm0z";
   };
 
   buildInputs = [ 

--- a/pkgs/tools/filesystems/sheepdog/default.nix
+++ b/pkgs/tools/filesystems/sheepdog/default.nix
@@ -4,7 +4,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "v1.0.1"
+  version = "v1.0.1";
   name = "sheepdog-${version}";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/filesystems/sheepdog/default.nix
+++ b/pkgs/tools/filesystems/sheepdog/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, liburcu, corosync, fuse, zookeeper, curl, fcgi
+{ stdenv, fetchFromGitHub, liburcu, corosync, fuse, zookeeper, curl, fcgi, automake, autoconf
  , withSheepFs ? false
  , withHttp ? false
 }:
@@ -14,7 +14,9 @@ stdenv.mkDerivation rec {
     sha256 = "0f4l44w2a8zl92agwsmrxssdw3z4lvcxi0hac4kcj8yr4rqwlm0z";
   };
 
-  buildInputs = [ 
+  buildInputs = [
+    automake
+    autoconf
     liburcu
     corosync
     zookeeper

--- a/pkgs/tools/filesystems/sheepdog/default.nix
+++ b/pkgs/tools/filesystems/sheepdog/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, liburcu, corosync, fuse, zookeeper, curl, fcgi
- , automake, autoconf, libtool, pkgconfig, groff, yasm
+ , automake, autoconf, libtool, pkgconfig, groff, yasm, systemd
  , withSheepFs ? false
  , withHttp ? false
 }:
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     pkgconfig
     groff
     yasm
+    systemd
     liburcu
     corosync
     zookeeper

--- a/pkgs/tools/filesystems/sheepdog/default.nix
+++ b/pkgs/tools/filesystems/sheepdog/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, liburcu, corosync, fuse, zookeeper, curl, fcgi, automake, autoconf, libtool
+{ stdenv, fetchFromGitHub, liburcu, corosync, fuse, zookeeper, curl, fcgi, automake, autoconf, libtool, pkgconfig
  , withSheepFs ? false
  , withHttp ? false
 }:
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
     automake
     autoconf
     libtool
+    pkgconfig
     liburcu
     corosync
     zookeeper

--- a/pkgs/tools/filesystems/sheepdog/default.nix
+++ b/pkgs/tools/filesystems/sheepdog/default.nix
@@ -50,8 +50,8 @@ stdenv.mkDerivation rec {
       cloning, and thin provisioning.
       '';
 
-    homepage = https://sheepdog.github.io/sheepdog/
-    license = https://raw.githubusercontent.com/sheepdog/sheepdog/master/COPYING
+    homepage = https://sheepdog.github.io/sheepdog/;
+    license = https://raw.githubusercontent.com/sheepdog/sheepdog/master/COPYING;
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/tools/filesystems/sheepdog/default.nix
+++ b/pkgs/tools/filesystems/sheepdog/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, liburcu, corosync, fuse, zookeeper, curl, fcgi, automake, autoconf, libtool, pkgconfig
+{ stdenv, fetchFromGitHub, liburcu, corosync, fuse, zookeeper, curl, fcgi
+ , automake, autoconf, libtool, pkgconfig, groff, yasm
  , withSheepFs ? false
  , withHttp ? false
 }:
@@ -19,6 +20,8 @@ stdenv.mkDerivation rec {
     autoconf
     libtool
     pkgconfig
+    groff
+    yasm
     liburcu
     corosync
     zookeeper

--- a/pkgs/tools/filesystems/sheepdog/default.nix
+++ b/pkgs/tools/filesystems/sheepdog/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, liburcu, corosync, fuse, zookeeper, curl, fcgi, automake, autoconf
+{ stdenv, fetchFromGitHub, liburcu, corosync, fuse, zookeeper, curl, fcgi, automake, autoconf, libtool
  , withSheepFs ? false
  , withHttp ? false
 }:
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     automake
     autoconf
+    libtool
     liburcu
     corosync
     zookeeper

--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, coreutils, pam, groff
+{ stdenv, fetchurl, coreutils, pam, groff, sssd
 , sendmailPath ? "/run/wrappers/bin/sendmail"
 , withInsults ? false
 , withSssd ? false
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     installFlags="sudoers_uid=$(id -u) sudoers_gid=$(id -g) sysconfdir=$out/etc rundir=$TMPDIR/dummy vardir=$TMPDIR/dummy"
     '';
 
-  buildInputs = [ coreutils pam groff ] ++ stdenv.lib.optionals withSssd [ sssd ];
+  buildInputs = [ coreutils pam groff ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, coreutils, pam, groff
 , sendmailPath ? "/run/wrappers/bin/sendmail"
 , withInsults ? false
+, withSssd ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -30,6 +31,9 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional withInsults [
     "--with-insults"
     "--with-all-insults"
+  ] ++ stdenv.lib.optional withSssd [
+    "--with-sssd"
+    "--with-sssd-lib=${sssd}/lib"
   ];
 
   configureFlagsArray = [
@@ -46,7 +50,7 @@ stdenv.mkDerivation rec {
     installFlags="sudoers_uid=$(id -u) sudoers_gid=$(id -g) sysconfdir=$out/etc rundir=$TMPDIR/dummy vardir=$TMPDIR/dummy"
     '';
 
-  buildInputs = [ coreutils pam groff ];
+  buildInputs = [ coreutils pam groff ] ++ stdenv.lib.optionals withSssd [ sssd ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4426,6 +4426,8 @@ with pkgs;
 
   sl = callPackage ../tools/misc/sl { };
 
+  sheepdog = callPackage ../tools/filesystems/sheepdog { };
+
   socat = callPackage ../tools/networking/socat { };
 
   socat2pre = lowPrio (callPackage ../tools/networking/socat/2.x.nix { });


### PR DESCRIPTION
###### Motivation for this change
Sudo has support to poll SSSD for its sudoers rules, but it has to be compiled into sudo and it requires a sudo plugin, libsss_sudo.so, from SSSD to function.

Added optional arguments to sudo and sssd to enable this functionality and have tested it, via packageOverrides, on a baremetal nixos machine. Both sssd and sudo was built with nix.useSandbox = true and I tried the functionality it brings and it works, I have sudoers rules in an openldap directory which I could apply after appending sudoers: files sss to nsswitch.conf.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

