### PR TITLE
citrix-receiver: 13.4.0 -> 13.7.0

### DIFF
--- a/pkgs/applications/networking/remote/citrix-receiver/default.nix
+++ b/pkgs/applications/networking/remote/citrix-receiver/default.nix
@@ -20,9 +20,11 @@
 , fontconfig
 , gtk_engines
 , alsaLib
+, libidn
+, zlib
 }:
 
-let versionRec = { major = "13"; minor = "4"; patch = "0"; };
+let versionRec = { major = "13"; minor = "7"; patch = "0"; };
 in stdenv.mkDerivation rec {
   name = "citrix-receiver-${version}";
   version = with versionRec; "${major}.${minor}.${patch}";
@@ -31,11 +33,14 @@ in stdenv.mkDerivation rec {
   prefixWithBitness = if stdenv.is64bit then "linuxx64" else "linuxx86";
 
   src = with versionRec; requireFile rec {
-    name = "${prefixWithBitness}-${version}.10109380.tar.gz";
+    name =
+      if stdenv.is64bit
+      then "${prefixWithBitness}-${version}.10276927.tar.gz"
+      else "${prefixWithBitness}-${version}.10276925.tar.gz";
     sha256 =
       if stdenv.is64bit
-      then "133brs0sq6d0mgr19rc6ig1n9ahm3ryi23v5nrgqfh0hgxqcrrjb"
-      else "0r7jfl5yqv1s2npy8l9gsn0gbb82f6raa092ppkc8xy5pni5sh7l";
+      then "18fb374b9fb8e249b79178500dddca7a1f275411c6537e7695da5dcf19c5ba91"
+      else "4c68723b0327cf6f12da824056fce2b7853c38e6163a48c9d222b93dd8da75b6";
     message = ''
       In order to use Citrix Receiver, you need to comply with the Citrix EULA and download
       the ${if stdenv.is64bit then "64-bit" else "32-bit"} binaries, .tar.gz from:
@@ -79,6 +84,8 @@ in stdenv.mkDerivation rec {
     xlibs.libXinerama
     xlibs.libXfixes
     libpng12
+    libidn
+    zlib
     gtk_engines
     freetype
     fontconfig


### PR DESCRIPTION
###### Motivation for this change

New Citrix receiver release. The last two releases has caused issues in different environments, hope this is working again. It does for me.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

