### PR TITLE
gogs: avoid creating symlinks each run

### DIFF
--- a/nixos/modules/services/misc/gogs.nix
+++ b/nixos/modules/services/misc/gogs.nix
@@ -25,6 +25,7 @@ let
     HTTP_ADDR = ${cfg.httpAddress}
     HTTP_PORT = ${toString cfg.httpPort}
     ROOT_URL = ${cfg.rootUrl}
+    STATIC_ROOT_PATH = ${cfg.staticRootPath}
 
     [session]
     COOKIE_NAME = session
@@ -175,6 +176,13 @@ in
         '';
       };
 
+      staticRootPath = mkOption {
+        type = types.str;
+        default = "${pkgs.gogs.data}";
+        example = "/var/lib/gogs/data";
+        description = "Upper level of template and static files path.";
+      };
+
       extraConfig = mkOption {
         type = types.str;
         default = "";
@@ -195,6 +203,8 @@ in
         runConfig = "${cfg.stateDir}/custom/conf/app.ini";
         secretKey = "${cfg.stateDir}/custom/conf/secret_key";
       in ''
+        mkdir -p ${cfg.stateDir}
+
         # copy custom configuration and generate a random secret key if needed
         ${optionalString (cfg.useWizard == false) ''
           mkdir -p ${cfg.stateDir}/custom/conf

--- a/pkgs/applications/version-management/gogs/default.nix
+++ b/pkgs/applications/version-management/gogs/default.nix
@@ -16,9 +16,12 @@ buildGoPackage rec {
     sha256 = "1xn1b4dxf7r8kagps3yvp31zskfxn50k1gfic9abl4kjwpwk78c0";
   };
 
-  patchPhase = ''
+  patches = [ ./static-root-path.patch ];
+
+  postPatch = ''
     patchShebangs .
-    '';
+    substituteInPlace pkg/setting/setting.go --subst-var data
+  '';
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/version-management/gogs/default.nix
+++ b/pkgs/applications/version-management/gogs/default.nix
@@ -33,10 +33,7 @@ buildGoPackage rec {
     cp -R $src/{public,templates} $data
 
     wrapProgram $bin/bin/gogs \
-      --prefix PATH : ${makeBinPath [ bash git gzip openssh ]} \
-      --run 'export GOGS_WORK_DIR=''${GOGS_WORK_DIR:-$PWD}' \
-      --run 'mkdir -p "$GOGS_WORK_DIR" && cd "$GOGS_WORK_DIR"' \
-      --run "ln -fs $data/{public,templates} ."
+      --prefix PATH : ${makeBinPath [ bash git gzip openssh ]}
   '';
 
   goPackagePath = "github.com/gogits/gogs";

--- a/pkgs/applications/version-management/gogs/static-root-path.patch
+++ b/pkgs/applications/version-management/gogs/static-root-path.patch
@@ -1,0 +1,13 @@
+diff --git a/pkg/setting/setting.go b/pkg/setting/setting.go
+index f206592d..796da6ef 100644
+--- a/pkg/setting/setting.go
++++ b/pkg/setting/setting.go
+@@ -474,7 +474,7 @@ func NewContext() {
+ 	LocalURL = sec.Key("LOCAL_ROOT_URL").MustString(string(Protocol) + "://localhost:" + HTTPPort + "/")
+ 	OfflineMode = sec.Key("OFFLINE_MODE").MustBool()
+ 	DisableRouterLog = sec.Key("DISABLE_ROUTER_LOG").MustBool()
+-	StaticRootPath = sec.Key("STATIC_ROOT_PATH").MustString(workDir)
++	StaticRootPath = sec.Key("STATIC_ROOT_PATH").MustString("@data@")
+ 	AppDataPath = sec.Key("APP_DATA_PATH").MustString("data")
+ 	EnableGzip = sec.Key("ENABLE_GZIP").MustBool()
+ 


### PR DESCRIPTION
###### Motivation for this change

Currently gogs will create symlinks to its static data each run. It does so because there wasn't any way to define where gogs needed to find the static data and looked in its current directory.

Now `STATIC_ROOT_PATH` was introduced which allows setting the path where to find the static content. This PR makes use of that setting for the gogs module while also removing the creation of symlinks in the gogs wrapper.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested using: https://gist.github.com/bobvanderlinden/0c6914310f56a691cb12e00c8bca7059

Fixes #27866