### PR TITLE
leo-editor: 5.5 -> 5.6, add docutils and use pyqt56

### DIFF
--- a/pkgs/applications/editors/leo-editor/default.nix
+++ b/pkgs/applications/editors/leo-editor/default.nix
@@ -1,20 +1,20 @@
-{ stdenv, python3Packages, fetchFromGitHub, makeWrapper, makeDesktopItem }:
+{ stdenv, python3, fetchFromGitHub, makeWrapper, makeDesktopItem }:
 
 stdenv.mkDerivation rec {
   name = "leo-editor-${version}";
-  version = "5.5";
+  version = "5.6";
 
   src = fetchFromGitHub {
     owner = "leo-editor";
     repo = "leo-editor";
     rev = version;
-    sha256 = "0crzljirzfiy9xn02ydd23clmd8bzdjxkyxdqsvdkgfy9j41b8hr";
+    sha256 = "1k6q3gvaf05bi0mzkmmb1p6wrgxwri7ivn38p6f0m0wfd3f70x2j";
   };
 
   dontBuild = true;
 
-  nativeBuildInputs = [ makeWrapper python3Packages.python ];
-  propagatedBuildInputs = with python3Packages; [ pyqt5 ];
+  nativeBuildInputs = [ makeWrapper python3 ];
+  propagatedBuildInputs = with python3.pkgs; [ pyqt56 docutils ];
 
   desktopItem = makeDesktopItem rec {
     name = "leo-editor";
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/leo-editor
     mv * $out/share/leo-editor
 
-    makeWrapper ${python3Packages.python.interpreter} $out/bin/leo \
+    makeWrapper ${python3.interpreter} $out/bin/leo \
       --set PYTHONPATH "$PYTHONPATH:$out/share/leo-editor" \
       --add-flags "-O $out/share/leo-editor/launchLeo.py"
   '';


### PR DESCRIPTION
###### Motivation for this change

Update leo to new version, recently released.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

