### PR TITLE
pyqt,sip: 5.8.1 -> 5.9, 4.19.1 -> 4.19.3

### DIFF
--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -2,7 +2,7 @@
 , lndir, makeWrapper, qmake }:
 
 let
-  version = "5.8.1";
+  version = "5.9";
   inherit (pythonPackages) buildPythonPackage python dbus-python sip;
 in buildPythonPackage {
   name = "PyQt-${version}";
@@ -18,7 +18,7 @@ in buildPythonPackage {
 
   src = fetchurl {
     url = "mirror://sourceforge/pyqt/PyQt5/PyQt-${version}/PyQt5_gpl-${version}.tar.gz";
-    sha256 = "0biak7l574i2gc8lj1s45skajbxsmmx66nlvs6xaakzkc6r293qy";
+    sha256 = "15hh4z5vd45dcswjla58q6rrfr6ic7jfz2n7c8lwfb10rycpj3mb";
   };
 
   nativeBuildInputs = [ pkgconfig makeWrapper qmake ];

--- a/pkgs/development/python-modules/sip/default.nix
+++ b/pkgs/development/python-modules/sip/default.nix
@@ -2,13 +2,13 @@
 
 if isPyPy then throw "sip not supported for interpreter ${python.executable}" else buildPythonPackage rec {
   pname = "sip";
-  version = "4.19.1";
+  version = "4.19.3";
   name = "${pname}-${version}";
   format = "other";
 
   src = fetchurl {
     url = "mirror://sourceforge/pyqt/sip/${name}/${name}.tar.gz";
-    sha256 = "501852b8325349031b769d1c03d6eab04f7b9b97f790ec79f3d3d04bf065d83e";
+    sha256 = "0x2bghbprwl3az1ni3p87i0bq8r99694la93kg65vi0cz12gh3bl";
   };
 
   configurePhase = ''


### PR DESCRIPTION
###### Motivation for this change

Latest versions, pyqt 5.9 needed for Qt 5.9 features (if I'm reading [this](http://pyqt.sourceforge.net/Docs/PyQt5/introduction.html#an-explanation-of-version-numbers) right).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

nox-review testing underway, but have used with leo-editor so it's at least somewhat functional :).