### PR TITLE
phantomjs2: add qtbase's bin to PATH

### DIFF
--- a/pkgs/development/tools/phantomjs2/default.nix
+++ b/pkgs/development/tools/phantomjs2/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, fetchpatch
 , bison2, flex, fontconfig, freetype, gperf, icu, openssl, libjpeg
 , libpng, perl, python, ruby, sqlite, qtwebkit, qmake, qtbase
-, darwin, writeScriptBin, cups
+, darwin, writeScriptBin, cups, makeWrapper
 }:
 
 let
@@ -47,6 +47,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     bison2 flex fontconfig freetype gperf icu openssl
     libjpeg libpng perl python ruby sqlite qtwebkit qtbase
+    makeWrapper
   ] ++ stdenv.lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     AGL ApplicationServices AppKit Cocoa OpenGL
     darwin.libobjc fakeClang cups
@@ -98,6 +99,9 @@ in stdenv.mkDerivation rec {
         ${darwin.configd}/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration \
         /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration \
     $out/bin/phantomjs
+  '' + ''
+    wrapProgram $out/bin/phantomjs \
+    --prefix PATH : ${stdenv.lib.makeBinPath [ qtbase ]}
   '';
 
   preFixup = ''


### PR DESCRIPTION
###### Motivation for this change

Phantomjs2 fails to load within selenium, as reported in https://github.com/NixOS/nixpkgs/issues/29144

This aplies the fix proposed by @7c6f434c in that ticket.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

