### PR TITLE
poppler: add nss to allow for building pdfsig

### DIFF
--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -4,7 +4,7 @@
 , qt4Support ? false, qt4 ? null
 , qt5Support ? false, qtbase ? null
 , introspectionSupport ? false, gobjectIntrospection ? null
-, utils ? false
+, utils ? false, nss ? null
 , minimal ? false, suffix ? "glib"
 , hostPlatform
 }:
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
     ++ optionals (!minimal) [ cairo lcms curl ]
     ++ optional qt4Support qt4
     ++ optional qt5Support qtbase
+    ++ optional utils nss
     ++ optional introspectionSupport gobjectIntrospection;
 
   nativeBuildInputs = [ pkgconfig ];
@@ -65,7 +66,9 @@ stdenv.mkDerivation rec {
     description = "A PDF rendering library";
 
     longDescription = ''
-      Poppler is a PDF rendering library based on the xpdf-3.0 code base.
+      Poppler is a PDF rendering library based on the xpdf-3.0 code
+      base. In addition it provides a number of tools that can be
+      installed separately.
     '';
 
     license = licenses.gpl2;


### PR DESCRIPTION
###### Motivation for this change

Poppler_tools contains a very useful tool to check the digital signatures of PDF files (pdfsig).
This tool was not being built, due to the absence of nss as a dependency. This is added as an optional dependency, so that the tool is built and people can happily check PDF signatures on the command line.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

