### PR TITLE
splint: Add darwin support

### DIFF
--- a/pkgs/development/tools/analysis/splint/darwin.patch
+++ b/pkgs/development/tools/analysis/splint/darwin.patch
@@ -1,0 +1,13 @@
+diff --git a/src/osd.c b/src/osd.c
+index ebe214a..4ba81d5 100644
+--- a/src/osd.c
++++ b/src/osd.c
+@@ -516,7 +516,7 @@ osd_getPid ()
+ # if defined (WIN32) || defined (OS2) && defined (__IBMC__)
+   int pid = _getpid ();
+ # else
+-  __pid_t pid = getpid ();
++  pid_t pid = getpid ();
+ # endif
+ 
+   return (int) pid;

--- a/pkgs/development/tools/analysis/splint/default.nix
+++ b/pkgs/development/tools/analysis/splint/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "02pv8kscsrkrzip9r08pfs9xs98q74c52mlxzbii6cv6vx1vd3f7";
   };
 
-  patches = [ ./tmpdir.patch ];
+  patches = [ ./tmpdir.patch ] ++ stdenv.lib.optional stdenv.isDarwin ./darwin.patch;
 
   buildInputs = [ flex ];
 
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
     '';
 
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Enables `splint` to compile on darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

