### PR TITLE
dnsmasq: 2.77->2.78

### DIFF
--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -11,11 +11,11 @@ let
   ]);
 in
 stdenv.mkDerivation rec {
-  name = "dnsmasq-2.77";
+  name = "dnsmasq-2.78";
 
   src = fetchurl {
     url = "http://www.thekelleys.org.uk/dnsmasq/${name}.tar.xz";
-    sha256 = "12lbbwpy1wxi6n5dngv30x8g8v13apdnvjgq7w71f9dfa0f3pb3f";
+    sha256 = "0ar5h5v3kas2qx2wgy5iqin15gc4jhqrqs067xacgc3lii1rz549";
   };
 
   preBuild = ''


### PR DESCRIPTION
In this version multiple vulnerabilities were fixed.

CVE-2017-14491, CVE-2017-14492, CVE-2017-14493, CVE-2017-14494,
CVE-2017-14495, CVE-2017-14496 and CVE-2017-13704

For details see:
https://security.googleblog.com/2017/10/behind-masq-yet-more-dns-and-dhcp.html

###### Motivation for this change

A new version with multiple security fixes.

###### Things done

I haven't tested the change. I've only built it on a fairly outdated NixOS version.