### PR TITLE
git-crypt: patch don't hard code path to git-crypt

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
@@ -14,6 +14,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl makeWrapper ];
 
+  patchPhase = ''
+    substituteInPlace commands.cpp \
+      --replace '(escape_shell_arg(our_exe_path()))' '= "git-crypt"'
+  '';
+
   installPhase = ''
     make install PREFIX=$out
     wrapProgram $out/bin/* --prefix PATH : ${gnupg1compat}/bin


### PR DESCRIPTION
Fix #30034

###### Motivation for this change


###### Things done


- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

