### PR TITLE
vala: add 0.38.0

### DIFF
--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurl, pkgconfig, flex, bison, libxslt
-, glib, libiconv, libintlOrEmpty
+{ stdenv, fetchurl, pkgconfig, flex, bison, libxslt, autoconf, graphviz
+, glib, libiconv, libintlOrEmpty, libtool, expat
 }:
 
 let
-  generic = { major, minor, sha256 }:
+  generic = { major, minor, sha256, extraNativeBuildInputs ? [], extraBuildInputs ? [] }:
   stdenv.mkDerivation rec {
     name = "vala-${major}.${minor}";
 
@@ -12,9 +12,9 @@ let
       inherit sha256;
     };
 
-    nativeBuildInputs = [ pkgconfig flex bison libxslt ];
+    nativeBuildInputs = [ pkgconfig flex bison libxslt ] ++ extraNativeBuildInputs;
 
-    buildInputs = [ glib libiconv ] ++ libintlOrEmpty;
+    buildInputs = [ glib libiconv ] ++ libintlOrEmpty ++ extraBuildInputs;
 
     meta = with stdenv.lib; {
       description = "Compiler for GObject type system";
@@ -55,6 +55,14 @@ in rec {
     major   = "0.34";
     minor   = "1";
     sha256  = "16cjybjw100qps6jg0jdyjh8hndz8a876zmxpybnf30a8vygrk7m";
+  };
+
+  vala_0_38 = generic {
+    major   = "0.38";
+    minor   = "1";
+    sha256  = "112hl3lkcyakrk8c3qgw12gzn3nxjkvx7bn0jhl5f2m57d7k8d8h";
+    extraNativeBuildInputs = [ autoconf ] ++ stdenv.lib.optionals stdenv.isDarwin [ libtool expat ];
+    extraBuildInputs = [ graphviz ];
   };
 
   vala = vala_0_34;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6264,6 +6264,7 @@ with pkgs;
     vala_0_28
     vala_0_32
     vala_0_34
+    vala_0_38
     vala;
 
   valadoc = callPackage ../development/tools/valadoc { };


### PR DESCRIPTION
###### Motivation for this change
Update for software that requires newer version of Vala.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Successfully compiled deja-dup with the compiler
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

