### PR TITLE
kubecfg: init at 0.5.0

### DIFF
--- a/pkgs/applications/networking/cluster/kubecfg/default.nix
+++ b/pkgs/applications/networking/cluster/kubecfg/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoPackage, fetchFromGitHub, ... }:
+
+let version = "0.5.0"; in
+
+buildGoPackage {
+  name = "kubecfg-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ksonnet";
+    repo = "kubecfg";
+    rev = "v${version}";
+    sha256 = "1s8w133p8qkj3dr73jimajm9ddp678lw9k9symj8rjw5p35igr93";
+  };
+
+  goPackagePath = "github.com/ksonnet/kubecfg";
+
+  meta = {
+    description = "A tool for managing Kubernetes resources as code";
+    homepage = https://github.com/ksonnet/kubecfg;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ benley ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15206,6 +15206,8 @@ with pkgs;
 
   ktorrent = libsForQt5.callPackage ../applications/networking/p2p/ktorrent { };
 
+  kubecfg = callPackage ../applications/networking/cluster/kubecfg { };
+
   kubernetes = callPackage ../applications/networking/cluster/kubernetes {  };
 
   kubernetes-helm = callPackage ../applications/networking/cluster/helm { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

