### PR TITLE
pykms: init at 20170719 and corresponding NixOS module

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -297,6 +297,7 @@
       rslsync = 279;
       minio = 280;
       kanboard = 281;
+      pykms = 282;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -563,6 +564,7 @@
       rslsync = 279;
       minio = 280;
       kanboard = 281;
+      pykms = 282;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -333,6 +333,7 @@
   ./services/misc/parsoid.nix
   ./services/misc/phd.nix
   ./services/misc/plex.nix
+  ./services/misc/pykms.nix
   ./services/misc/radarr.nix
   ./services/misc/redmine.nix
   ./services/misc/rippled.nix

--- a/nixos/modules/services/misc/pykms.nix
+++ b/nixos/modules/services/misc/pykms.nix
@@ -1,0 +1,90 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.pykms;
+
+  home = "/var/lib/pykms";
+
+  services = {
+    serviceConfig = {
+      Restart = "on-failure";
+      RestartSec = "10s";
+      StartLimitInterval = "1min";
+      PrivateTmp = true;
+      ProtectSystem = "full";
+      ProtectHome = true;
+    };
+  };
+
+in {
+
+  options = {
+    services.pykms = rec {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable the PyKMS service.";
+      };
+
+      listenAddress = mkOption {
+        type = types.str;
+        default = "0.0.0.0";
+        description = "The IP address on which to listen.";
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = 1688;
+        description = "The port on which to listen.";
+      };
+
+      verbose = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Show verbose output.";
+      };
+
+      openFirewallPort = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether the listening port should be opened automatically.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewallPort [ cfg.port ];
+
+    systemd.services = {
+      pykms = services // {
+        description = "Python KMS";
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = with pkgs; {
+          User = "pykms";
+          Group = "pykms";
+          ExecStartPre = "${getBin pykms}/bin/create_pykms_db.sh ${home}/clients.db";
+          ExecStart = "${getBin pykms}/bin/server.py ${optionalString cfg.verbose "--verbose"} ${cfg.listenAddress} ${toString cfg.port}";
+          WorkingDirectory = home;
+          MemoryLimit = "64M";
+        };
+      };
+    };
+
+    users = {
+      extraUsers.pykms = {
+        name = "pykms";
+        group = "pykms";
+        home  = home;
+        createHome = true;
+        uid = config.ids.uids.pykms;
+        description = "PyKMS daemon user";
+      };
+
+      extraGroups.pykms = {
+        gid = config.ids.gids.pykms;
+      };
+    };
+  };
+}

--- a/pkgs/tools/networking/pykms/default.nix
+++ b/pkgs/tools/networking/pykms/default.nix
@@ -1,0 +1,82 @@
+{ stdenv, fetchFromGitHub, python2Packages, writeText, writeScript
+, coreutils, sqlite }:
+
+let
+  dbSql = writeText "create_pykms_db.sql" ''
+    CREATE TABLE clients(
+      clientMachineId TEXT,
+      machineName     TEXT,
+      applicationId   TEXT,
+      skuId           TEXT,
+      licenseStatus   TEXT,
+      lastRequestTime INTEGER,
+      kmsEpid         TEXT,
+      requestCount    INTEGER
+    );
+  '';
+
+  dbScript = writeScript "create_pykms_db.sh" (with stdenv.lib; ''
+    #!${stdenv.shell} -eu
+
+    db=$1
+
+    ${getBin coreutils}/bin/install -d $(dirname $db)
+
+    if [ ! -e $db ] ; then
+      ${getBin sqlite}/bin/sqlite3 $db < ${dbSql}
+    fi
+  '');
+
+in python2Packages.buildPythonApplication rec {
+  name = "pykms-${version}";
+  version = "20170719";
+
+  src = fetchFromGitHub {
+    owner  = "ThunderEX";
+    repo   = "py-kms";
+    rev    = "27355d88affd740330174a7c2bae9f50b9efce56";
+    sha256 = "0cpywj73jmyijjc5hs3b00argjsdwpqzmhawbxkx3mc2l4sgzc88";
+  };
+
+  propagatedBuildInputs = with python2Packages; [ argparse pytz ];
+
+  prePatch = ''
+    siteDir=$out/${python2Packages.python.sitePackages}
+
+    substituteInPlace kmsBase.py \
+      --replace "'KmsDataBase.xml'" "'$siteDir/KmsDataBase.xml'"
+  '';
+
+  dontBuild = true;
+
+  # there are no tests
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/doc/pykms} $siteDir
+
+    mv * $siteDir
+    for b in client server ; do
+      chmod 0755 $siteDir/$b.py
+      makeWrapper ${python2Packages.python.interpreter} $out/bin/$b.py \
+        --add-flags $siteDir/$b.py
+    done
+
+    install -m755 ${dbScript} $out/bin/create_pykms_db.sh
+
+    mv $siteDir/README.md $out/share/doc/pykms/
+
+    ${python2Packages.python.interpreter} -m compileall $siteDir
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Windows KMS (Key Management Service) server written in Python";
+    homepage    = "https://forums.mydigitallife.info/threads/50234-Emulated-KMS-Servers-on-non-Windows-platforms/page2?p=840410&viewfull=1#post840410";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19216,6 +19216,8 @@ with pkgs;
 
   pt = callPackage ../applications/misc/pt { };
 
+  pykms = callPackage ../tools/networking/pykms { };
+
   pyload = callPackage ../applications/networking/pyload {};
 
   uae = callPackage ../misc/emulators/uae { };


### PR DESCRIPTION
###### Motivation for this change

Have been running it here for testing purposes on 17.03 and 17.09 without problems.

While it works, I don't feel particularly proud of how the binaries are being wrapped as well as the handling of the DB creation script, so I'm very open to feedback on that.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

