### PR TITLE
wtftfw: 20161001 -> 20170921

### DIFF
--- a/pkgs/applications/window-managers/wtftw/default.nix
+++ b/pkgs/applications/window-managers/wtftw/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, rustPlatform, cargo, libXinerama, libX11, xlibs, pkgconfig }:
 
 rustPlatform.buildRustPackage rec {
-  name = "wtftw-0.0pre20161001";
+  name = "wtftw-0.0pre20170921";
   src = fetchFromGitHub {
     owner = "kintaro";
     repo = "wtftw";
-    rev = "b72a1bd24430a614d953d6ecf61732805277cc0c";
-    sha256 = "1ajxkncqh4azyhmsdyk07r1kbhwv81vl1ix3w4iaz8cyln4gs0kp";
+    rev = "13712d4c051938520b90b6639d4ff813f6fe5f48";
+    sha256 = "1r74nhcwiy2rmifzjhdal3jcqz4jz48nfvhdyw4gasa6nxp3msdl";
   };
 
   depsSha256 = "0z7h8ybh2db3xl8qxbzby5lncdaijixzmbn1j8a45lbky1xiix71";
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
     cp -p target/release/wtftw $out/bin/
     echo "[Desktop Entry]
       Name=wtftw
-      Exec=/bin/wtftw
+      Exec=$out/bin/wtftw
       Type=XSession
       DesktopName=wtftw" > $out/share/xsessions/wtftw.desktop
   '';


### PR DESCRIPTION
- Bump revision
- Prefix Exec path with output directory

###### Motivation for this change
see above

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---