### PR TITLE
exa: 0.7.0 -> 0.8.0, rustRegistry: 2017-09-10 -> 2017-10-03

### DIFF
--- a/pkgs/tools/misc/exa/default.nix
+++ b/pkgs/tools/misc/exa/default.nix
@@ -2,34 +2,17 @@
 
 with rustPlatform;
 
-let
-  # check for updates
-  zoneinfo_compiled = fetchFromGitHub {
-    owner = "rust-datetime";
-    repo = "zoneinfo-compiled";
-    rev = "f56921ea5e9f7cf065b1480ff270a1757c1f742f";
-    sha256 = "1xmw7c5f5n45lkxnyxp4llfv1bnqhc876w98165ccdbbiylfkw26";
-  };
-  cargoPatch = ''
-    # use non-git dependencies
-    patch Cargo.toml <<EOF
-    46c46
-    < git = "https://github.com/rust-datetime/zoneinfo-compiled.git"
-    ---
-    > path = "${zoneinfo_compiled}"
-    EOF
-  '';
-in buildRustPackage rec {
+buildRustPackage rec {
   name = "exa-${version}";
-  version = "0.7.0";
+  version = "0.8.0";
 
-  depsSha256 = "0j320hhf2vqaha137pjj4pyiw6d3p5h3nhy3pl9vna1g5mnl1sn7";
+  depsSha256 = "0yz41prkjs5rmvdhr9k58a52l7hvwy5mfg8rcpsq4ybgf601lja2";
 
   src = fetchFromGitHub {
     owner = "ogham";
     repo = "exa";
     rev = "v${version}";
-    sha256 = "0i9psgna2wwv9qyw9cif4qznqiyi16vl763hpm2yr195aj700339";
+    sha256 = "0jy11a3xfnfnmyw1kjmv4ffavhijs8c940kw24vafklnacx5n88m";
   };
 
   nativeBuildInputs = [ cmake pkgconfig perl ];
@@ -37,15 +20,6 @@ in buildRustPackage rec {
 
   # Some tests fail, but Travis ensures a proper build
   doCheck = false;
-
-  cargoUpdateHook = ''
-    ${cargoPatch}
-  '';
-  cargoDepsHook = ''
-    pushd $sourceRoot
-    ${cargoPatch}
-    popd
-  '';
 
   meta = with stdenv.lib; {
     description = "Replacement for 'ls' written in Rust";
@@ -57,7 +31,7 @@ in buildRustPackage rec {
       for a directory, or recursing into directories with a tree view. exa is
       written in Rust, so it’s small, fast, and portable.
     '';
-    homepage = http://the.exa.website;
+    homepage = https://the.exa.website;
     license = licenses.mit;
     maintainer = [ maintainers.ehegnes ];
   };

--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,13 +7,13 @@
 { stdenv, fetchFromGitHub, git }:
 
 stdenv.mkDerivation {
-  name = "rustRegistry-2017-09-10";
+  name = "rustRegistry-2017-10-03";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = "crates.io-index";
-    rev = "2e573cbbb2db591ff9d46339910f21e35b21339f";
-    sha256 = "0sgpc2aygmvyjb3kinzh83bj4j92ny18159alqb1x8w26wqmisfq";
+    rev = "f9e21955350caf67db45c4a4a38dbab2f2250bfc";
+    sha256 = "1yk0l0r9idn7crnnw44sig69kvvyq3ycv417s88hd16m1fpl5y77";
   };
   phases = [ "unpackPhase" "installPhase" ];
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

https://github.com/ogham/exa/releases/tag/v0.8.0

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

