### PR TITLE
webos: init novacom, novacomd, cmake-modules; add nixos service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -341,6 +341,7 @@
   ./services/misc/nix-optimise.nix
   ./services/misc/nixos-manual.nix
   ./services/misc/nix-ssh-serve.nix
+  ./services/misc/novacomd.nix
   ./services/misc/nzbget.nix
   ./services/misc/octoprint.nix
   ./services/misc/osrm.nix

--- a/nixos/modules/services/misc/novacomd.nix
+++ b/nixos/modules/services/misc/novacomd.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.novacomd;
+
+in {
+
+  options = {
+    services.novacomd = {
+      enable = mkEnableOption "Novacom service for connecting to WebOS devices";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.webos.novacom ];
+
+    systemd.services.novacomd = {
+      description = "Novacom WebOS daemon";
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        ExecStart = "${pkgs.webos.novacomd}/sbin/novacomd";
+      };
+    };
+  };
+
+  meta.maintainers = with maintainers; [ dtzWill ];
+}

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -318,7 +318,7 @@ in rec {
   tests.nfs4 = callTest tests/nfs.nix { version = 4; };
   tests.nginx = callTest tests/nginx.nix { };
   tests.nghttpx = callTest tests/nghttpx.nix { };
-  tests.novacomd = callTest tests/novacomd.nix { };
+  tests.novacomd = callTestOnTheseSystems ["x86_64-linux"] tests/novacomd.nix { };
   tests.leaps = callTest tests/leaps.nix { };
   tests.nsd = callTest tests/nsd.nix {};
   tests.openssh = callTest tests/openssh.nix {};

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -318,6 +318,7 @@ in rec {
   tests.nfs4 = callTest tests/nfs.nix { version = 4; };
   tests.nginx = callTest tests/nginx.nix { };
   tests.nghttpx = callTest tests/nghttpx.nix { };
+  tests.novacomd = callTest tests/novacomd.nix { };
   tests.leaps = callTest tests/leaps.nix { };
   tests.nsd = callTest tests/nsd.nix {};
   tests.openssh = callTest tests/openssh.nix {};

--- a/nixos/tests/novacomd.nix
+++ b/nixos/tests/novacomd.nix
@@ -1,0 +1,28 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "novacomd";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ dtzWill ];
+  };
+
+  machine = { config, pkgs, ... }: {
+    services.novacomd.enable = true;
+  };
+
+  testScript = ''
+    startAll;
+
+    $machine->waitForUnit("novacomd.service");
+
+    # Check status and try connecting with novacom
+    $machine->succeed("systemctl status novacomd.service >&2");
+    $machine->succeed("novacom -l");
+
+    # Stop the daemon, double-check novacom fails if daemon isn't working
+    $machine->stopJob("novacomd");
+    $machine->fail("novacom -l");
+
+    # And back again for good measure
+    $machine->startJob("novacomd");
+    $machine->succeed("novacom -l");
+  '';
+})

--- a/pkgs/development/mobile/webos/cmake-modules.nix
+++ b/pkgs/development/mobile/webos/cmake-modules.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "cmake-modules-webos-${version}";
+  version = "19";
+
+  src = fetchFromGitHub {
+    owner = "openwebos";
+    repo = "cmake-modules-webos";
+    rev = "submissions/${version}";
+    sha256 = "1l4hpcmgc98kp9g1642sy111ki5qyk3q7j10xzkgmnvz8lqffnxp";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  prePatch = ''
+    substituteInPlace CMakeLists.txt --replace "CMAKE_ROOT}/Modules" "CMAKE_INSTALL_PREFIX}/lib/cmake"
+    substituteInPlace webOS/webOS.cmake \
+      --replace ' ''${CMAKE_ROOT}/Modules' " $out/lib/cmake" \
+      --replace 'INSTALL_ROOT}/usr' 'INSTALL_ROOT}'
+
+    sed -i '/CMAKE_INSTALL_PREFIX/d' webOS/webOS.cmake
+  '';
+
+  setupHook = ./cmake-setup-hook.sh;
+
+  meta = with stdenv.lib; {
+    description = "CMake modules needed to build Open WebOS components";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/development/mobile/webos/cmake-setup-hook.sh
+++ b/pkgs/development/mobile/webos/cmake-setup-hook.sh
@@ -1,0 +1,9 @@
+_addWebOSCMakeFlags() {
+  # Help find the webOS cmake module
+  cmakeFlagsArray+=(-DCMAKE_MODULE_PATH=@out@/lib/cmake)
+
+  # fix installation path (doesn't use CMAKE_INSTALL_PREFIX)
+  cmakeFlagsArray+=(-DWEBOS_INSTALL_ROOT=${!outputBin})
+}
+
+preConfigureHooks+=(_addWebOSCMakeFlags)

--- a/pkgs/development/mobile/webos/novacom.nix
+++ b/pkgs/development/mobile/webos/novacom.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, webos, cmake, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "novacom-${version}";
+  version = "18";
+
+  src = fetchFromGitHub {
+    owner = "openwebos";
+    repo = "novacom";
+    rev = "submissions/${version}";
+    sha256 = "12s6g7l20kakyjlhqpli496miv2kfsdp17lcwhdrzdxvxl6hnf4n";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig webos.cmake-modules ];
+
+  postInstall = ''
+    install -Dm755 -t $out/bin ../scripts/novaterm
+    substituteInPlace $out/bin/novaterm --replace "exec novacom" "exec $out/bin/novacom"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Utility for communicating with WebOS devices";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/mobile/webos/novacomd.nix
+++ b/pkgs/development/mobile/webos/novacomd.nix
@@ -1,0 +1,40 @@
+{ stdenv,
+fetchFromGitHub, fetchpatch,
+webos, cmake, pkgconfig,
+libusb }:
+
+stdenv.mkDerivation rec {
+  name = "novacomd-${version}";
+  version = "127";
+
+  src = fetchFromGitHub {
+    owner = "openwebos";
+    repo = "novacomd";
+    rev = "submissions/${version}";
+    sha256 = "1gahc8bvvvs4d6svrsw24iw5r0mhy4a2ars3j2gz6mp6sh42bznl";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/0001-Use-usb_bulk_-read-write-instead-of-homemade-handler.patch?h=palm-novacom-git";
+      sha256 = "116r6p4l767fqxfvq03sy6v7vxja8pkxlrc5hqby351a40b5dkiv";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/feniksa/webos-overlay/40e2c113fc9426d50bdf37779da57ce4ff06ee6e/net-misc/novacomd/files/0011-Remove-verbose-output.patch";
+      sha256 = "09lmv06ziwkfg19b1h3jsmkm6g1f0nxxq1717dircjx8m45ypjq9";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake pkgconfig webos.cmake-modules ];
+
+  buildInputs = [ libusb ];
+
+  cmakeFlags = [ "-DWEBOS_TARGET_MACHINE_IMPL=host" ];
+
+  meta = with stdenv.lib; {
+    description = "Daemon for communicating with WebOS devices";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -685,6 +685,13 @@ with pkgs;
 
   androidsdk_extras = self.androidenv.androidsdk_8_0_extras;
 
+  webos = recurseIntoAttrs {
+    cmake-modules = callPackage ../development/mobile/webos/cmake-modules.nix { };
+
+    novacom = callPackage ../development/mobile/webos/novacom.nix { };
+    novacomd = callPackage ../development/mobile/webos/novacomd.nix { };
+  };
+
   arc-theme = callPackage ../misc/themes/arc { };
 
   arc-kde-theme = callPackage ../misc/themes/arc-kde { };


### PR DESCRIPTION
###### Motivation for this change

Add novacom, novacomd for communicating with WebOS devices.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm using the provided nixos service presently! :grin: