### PR TITLE
mariadb: Add test

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -277,6 +277,7 @@ in rec {
   #tests.lightdm = callTest tests/lightdm.nix {};
   tests.login = callTest tests/login.nix {};
   #tests.logstash = callTest tests/logstash.nix {};
+  tests.mariadb = callTest tests/mariadb.nix {};
   tests.mathics = callTest tests/mathics.nix {};
   tests.mesos = callTest tests/mesos.nix {};
   tests.misc = callTest tests/misc.nix {};

--- a/nixos/tests/mariadb.nix
+++ b/nixos/tests/mariadb.nix
@@ -1,0 +1,25 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "mariadb";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ nequissimus ];
+  };
+
+  nodes = {
+    master =
+      { pkgs, config, ... }:
+
+      {
+        services.mysql.enable = true;
+        services.mysql.initialDatabases = [ { name = "testdb"; schema = ./testdb.sql; } ];
+        services.mysql.package = pkgs.mariadb;
+      };
+  };
+
+  testScript = ''
+    startAll;
+
+    $master->waitForUnit("mysql");
+    $master->sleep(10); # Hopefully this is long enough!!
+    $master->succeed("echo 'use testdb; select * from tests' | mysql -u root -N | grep 4");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change
So we can check that future PRs really work

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

