### PR TITLE
Backport to 17.09: go-ethereum: Fix libusb segmentation faults on Darwin

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, boost155, boost162, boost163, openssl_1_1_0, haskellPackages }:
+{ callPackage, boost155, boost162, boost163, openssl_1_1_0, haskellPackages, darwin }:
 
 rec {
 
@@ -26,7 +26,10 @@ rec {
   dogecoind = callPackage ./dogecoin.nix { withGui = false; };
 
   freicoin = callPackage ./freicoin.nix { boost = boost155; };
-  go-ethereum = callPackage ./go-ethereum.nix { };
+  go-ethereum = callPackage ./go-ethereum.nix {
+    inherit (darwin) libobjc;
+    inherit (darwin.apple_sdk.frameworks) IOKit;
+  };
   go-ethereum-classic = callPackage ./go-ethereum-classic { };
 
   hivemind = callPackage ./hivemind.nix { withGui = true; };

--- a/pkgs/applications/altcoins/go-ethereum.nix
+++ b/pkgs/applications/altcoins/go-ethereum.nix
@@ -1,9 +1,13 @@
-{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, libobjc, IOKit }:
 
 buildGoPackage rec {
   name = "go-ethereum-${version}";
   version = "1.7.0";
   goPackagePath = "github.com/ethereum/go-ethereum";
+
+  # Fix for usb-related segmentation faults on darwin
+  propagatedBuildInputs =
+    stdenv.lib.optionals stdenv.isDarwin [ libobjc IOKit ];
 
   # Fixes Cgo related build failures (see https://github.com/NixOS/nixpkgs/issues/25959 )
   hardeningDisable = [ "fortify" ];


### PR DESCRIPTION
###### Motivation for this change
Backporting https://github.com/NixOS/nixpkgs/pull/30045 to release 17.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

