### PR TITLE
goklp: init at 1.6

### DIFF
--- a/pkgs/tools/networking/goklp/default.nix
+++ b/pkgs/tools/networking/goklp/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "goklp-${version}";
+  version = "1.6";
+
+  goPackagePath = "github.com/AppliedTrust/goklp";
+
+  src = fetchFromGitHub {
+    owner = "AppliedTrust";
+    repo = "goklp";
+    rev = "v${version}";
+    sha256 = "054qmwfaih8qbvdyy4rqbb1ip3jpnm547n390hgab8yc3bdd840c";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    description = "Golang OpenSSH Keys Ldap Provider for AuthorizedKeysCommand";
+    homepage = https://github.com/AppliedTrust/goklp;
+    maintainers = with maintainers; [ disassembler ];
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/tools/networking/goklp/deps.nix
+++ b/pkgs/tools/networking/goklp/deps.nix
@@ -1,0 +1,56 @@
+[
+  {
+    goPackagePath = "github.com/asaskevich/govalidator";
+    fetch = {
+      type = "git";
+      url = "https://github.com/asaskevich/govalidator";
+      rev = "ca5f9e638c83bac66bfac70ded5bded1503135a7";
+      sha256 = "0lk4irlf4a4q8qharwjxl71y1s2cf5bjpg9cv5jlyp574331pn1w";
+    };
+  }
+  {
+    goPackagePath = "github.com/docopt/docopt-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docopt/docopt-go";
+      rev = "784ddc588536785e7299f7272f39101f7faccc3f";
+      sha256 = "0wwz48jl9fvl1iknvn9dqr4gfy1qs03gxaikrxxp9gry6773v3sj";
+    };
+  }
+  {
+    goPackagePath = "github.com/kardianos/osext";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kardianos/osext";
+      rev = "ae77be60afb1dcacde03767a8c37337fad28ac14";
+      sha256 = "056dkgxrqjj5r18bnc3knlpgdz5p3yvp12y4y978hnsfhwaqvbjz";
+    };
+  }
+  {
+    goPackagePath = "github.com/vaughan0/go-ini";
+    fetch = {
+      type = "git";
+      url = "https://github.com/vaughan0/go-ini";
+      rev = "a98ad7ee00ec53921f08832bc06ecf7fd600e6a1";
+      sha256 = "1l1isi3czis009d9k5awsj4xdxgbxn4n9yqjc1ac7f724x6jacfa";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/asn1-ber.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/asn1-ber.v1";
+      rev = "379148ca0225df7a432012b8df0355c2a2063ac0";
+      sha256 = "1y8bvzbxpw0lfnn7pbcdwzqj4l90qj6xf88dvv9pxd9yl5g6cskx";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/ldap.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/ldap.v2";
+      rev = "8168ee085ee43257585e50c6441aadf54ecb2c9f";
+      sha256 = "1w0993i8bl8sap01gwm1v6hjp0rsanj2mbpyabwcwnns2g79n895";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2297,6 +2297,8 @@ with pkgs;
 
   godot = callPackage ../development/tools/godot {};
 
+  goklp = callPackage ../tools/networking/goklp {};
+
   go-mtpfs = callPackage ../tools/filesystems/go-mtpfs { };
 
   go-pup = callPackage ../development/tools/pup { };


### PR DESCRIPTION
###### Motivation for this change
This adds a go program that queries an ldap server for ssh public keys for a user.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

