### PR TITLE
fetchpatch: allow callers to specify postFetch sensibly

### DIFF
--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -27,4 +27,4 @@ fetchurl ({
       "$tmpfile" > "$out"
     ${args.postFetch or ""}
   '';
-} // builtins.removeAttrs args ["stripLen" "addPrefixes" "excludes"])
+} // builtins.removeAttrs args ["stripLen" "addPrefixes" "excludes" "postFetch"])


### PR DESCRIPTION
Before this fix, it seemed to be trying to merge our `postFetch` with the patch normalization logic, but accidentally clobbering the whole thing with the passed-in value.

###### Motivation for this change

I tried to pass in `postFetch` but it clobbered the patch normalization logic, causing the hash to change.
