### PR TITLE
elixir: Fix locale problem on NixOS

### DIFF
--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -22,6 +22,8 @@ in
 
     buildInputs = [ erlang rebar makeWrapper ];
 
+    LOCALE_ARCHIVE = stdenv.lib.optionalString stdenv.isLinux
+      "${pkgs.glibcLocales}/lib/locale/locale-archive";
     LANG = "en_US.UTF-8";
     LC_TYPE = "en_US.UTF-8";
 
@@ -30,8 +32,8 @@ in
     inherit debugInfo;
 
     buildFlags = if debugInfo
-     then "ERL_COMPILER_OPTIONS=debug_info"
-     else "";
+      then "ERL_COMPILER_OPTIONS=debug_info"
+      else "";
 
     preBuild = ''
       # The build process uses ./rebar. Link it to the nixpkgs rebar


### PR DESCRIPTION
It looks like Erlang/OTP requires access to LOCALE_ARCHIVE for locales to correctly work. Elixir depends on this here:
https://github.com/elixir-lang/elixir/blob/7a556b8f26f42f6b7510dc1d2351564d91ab746c/lib/elixir/src/elixir.erl#L76

Fixes #30047

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS: build output http://ix.io/AHl
   - [ ] macOS
   - [x] Linux: build output http://ix.io/AHq
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

