### PR TITLE
caneda: git-2012-02-16 -> 0.3.1

### DIFF
--- a/pkgs/applications/science/electronics/caneda/default.nix
+++ b/pkgs/applications/science/electronics/caneda/default.nix
@@ -1,37 +1,20 @@
-{stdenv, fetchgit, qt4, cmake, libxml2, libxslt}:
-
-let
-
-  srcComponents = fetchgit {
-    url = git://caneda.git.sourceforge.net/gitroot/caneda/components;
-    rev = "34cd36b620e0dfc57ba2d2b6168734ea9a2cfa9a";
-    sha256 = "840f07921eecbf10e38e44e5c61c716295a16c98fbb75016d9a44e7dfee40e59";
-  };
-
-in
+{stdenv, fetchFromGitHub, cmake, qtbase, qttools, qtsvg, qwt }:
 
 stdenv.mkDerivation rec {
-  name = "caneda-git-2012-02-16";
+  name = "caneda-${version}";
+  version = "0.3.1";
 
-  src = fetchgit {
-    url = git://caneda.git.sourceforge.net/gitroot/caneda/caneda;
-    rev = "fff9e2f7988fe5d062548cafeda1e5cd660769d1";
-    sha256 = "dfbcac97f5a1b41ad9a63392394f37fb294cbf78c576673c9bc4a5370957b2c8";
+  src = fetchFromGitHub {
+    owner = "Caneda";
+    repo = "Caneda";
+    rev = version;
+    sha256 = "0hx8qid50j9xvg2kpbpqmbdyakgyjn6m373m1cvhp70v2gp1v8l2";
   };
 
-  hardeningDisable = [ "format" ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qtbase qttools qtsvg qwt ];
 
-  buildInputs = [ cmake qt4 libxml2 libxslt ];
-
-  patches = [
-    ./gcc6.patch
-  ];
-
-  postInstall = ''
-    mkdir $out/share/caneda/components
-    cp -R ${srcComponents}/* $out/share/caneda/components
-    chmod u+w -R $out/share/caneda/components
-  '';
+  enableParallelBuilding = true;
 
   meta = {
     description = "Open source EDA software focused on easy of use and portability";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18618,7 +18618,7 @@ with pkgs;
 
   eagle = callPackage ../applications/science/electronics/eagle { };
 
-  caneda = callPackage ../applications/science/electronics/caneda { };
+  caneda = libsForQt5.callPackage ../applications/science/electronics/caneda { };
 
   geda = callPackage ../applications/science/electronics/geda {
     guile = guile_2_0;


### PR DESCRIPTION
cc #15558

Components are now part of the base install
(previously it seems no components were included),
which I believe mostly removes the need for the srcComponents bit.

Debian is only other distro packaging this according
to repology, and they don't include additional libraries
which further suggests they're at least non-essential :).

As for the Caneda/Libraries repository, copying these
into the "libraries" directory with similar files
does not cause them to be auto-registered anyway,
as far as I can tell the application has a static
list of components (in the source) and additional
components need to be added using the GUI
making bundling them a bit useless and misleading.

caneda also now requires qt5 and doesn't appear to require
either libxml2 or libxslt.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I don't believe anything depends on this (judging by grep'ing for "caneda"), kicking off a nox-review to be super-sure :).