### PR TITLE
libroxml: init at 2.3.0 and osm2xmap: init at 2.0 c1f7b68

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -461,6 +461,7 @@
   mounium = "Katona László <muoniurn@gmail.com>";
   MP2E = "Cray Elliott <MP2E@archlinux.us>";
   mpcsh = "Mark Cohen <m@mpc.sh>";
+  mpickering = "Matthew Pickering <matthewtpickering@gmail.com>";
   mpscholten = "Marc Scholten <marc@mpscholten.de>";
   mpsyco = "Francis St-Amour <fr.st-amour@gmail.com>";
   mrVanDalo = "Ingolf Wanger <contact@ingolf-wagner.de>";

--- a/pkgs/applications/misc/osm2xmap/default.nix
+++ b/pkgs/applications/misc/osm2xmap/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, libroxml, proj, libyamlcpp, boost } :
+
+stdenv.mkDerivation rec {
+  name = "osm2xmap-${version}";
+  version = "2.0";
+
+  src = fetchFromGitHub {
+    sha256 = "1d3f18wzk240yp0q8i2vskhcfj5ar61s4hw83vgps0wr2aglph3w";
+    repo = "osm2xmap";
+    owner = "sembruk";
+    rev = "v${version}";
+  };
+
+  makeFlags = [
+    "GIT_VERSION=$(version)"
+    "GIT_TIMESTAMP="
+    "SHAREDIR=$(out)/share/"
+    "INSTALL_BINDIR=$(out)/bin"
+    "INSTALL_MANDIR=$(out)/share/man/man1"
+    "INSTALL_SHAREDIR=$(out)/share/"
+  ];
+
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  buildInputs = [ libroxml proj libyamlcpp boost ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/sembruk/osm2xmap";
+    description = "Converter from OpenStreetMap data format to OpenOrienteering Mapper format.";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.mpickering ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+
+
+}
+
+

--- a/pkgs/applications/misc/osm2xmap/default.nix
+++ b/pkgs/applications/misc/osm2xmap/default.nix
@@ -31,8 +31,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.mpickering ];
     platforms = with stdenv.lib.platforms; linux;
   };
-
-
 }
-
-

--- a/pkgs/development/libraries/libroxml/default.nix
+++ b/pkgs/development/libraries/libroxml/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation {
+  name = "libroxml-2.3.0";
+  src = fetchurl {
+    url = "http://download.libroxml.net/pool/v2.x/libroxml-2.3.0.tar.gz";
+    sha256  = "0y0vc9n4rfbimjp28nx4kdfzz08j5xymh5xjy84l9fhfac5z5a0x";
+  };
+  meta = with stdenv.lib; {
+    homepage = "http://www.libroxml.net/";
+    description = "This library is minimum, easy-to-use, C implementation for xml file parsing.";
+    license = licenses.lgpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ mpickering ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9880,6 +9880,8 @@ with pkgs;
 
   libqalculate = callPackage ../development/libraries/libqalculate { };
 
+  libroxml = callPackage ../development/libraries/libroxml { };
+
   librsvg = callPackage ../development/libraries/librsvg { };
 
   librsync = callPackage ../development/libraries/librsync { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10101,6 +10101,13 @@ with pkgs;
 
   libyamlcpp = callPackage ../development/libraries/libyaml-cpp { };
 
+  libyamlcpp_0_3 = pkgs.libyamlcpp.overrideAttrs (oldAttrs: rec {
+    src = pkgs.fetchurl {
+      url = "https://github.com/jbeder/yaml-cpp/archive/release-0.3.0.tar.gz";
+      sha256 = "12aszqw6svwlnb6nzhsbqhz3c7vnd5ahd0k6xlj05w8lm83hx3db";
+      };
+    });
+
   # interception-tools needs this. This should be removed when there is a new
   # release of libyamlcpp, i.e. when the version of libyamlcpp is newer than
   # 0.5.3.
@@ -16525,6 +16532,10 @@ with pkgs;
     inherit (gnome3) yelp_tools;
   };
 
+  osm2xmap = callPackage ../applications/misc/osm2xmap {
+    libyamlcpp = libyamlcpp_0_3;
+  };
+
   osmctools = callPackage ../applications/misc/osmctools { };
 
   vivaldi = callPackage ../applications/networking/browsers/vivaldi {};
@@ -17463,7 +17474,7 @@ with pkgs;
   testssl = callPackage ../applications/networking/testssl { };
 
   umurmur = callPackage ../applications/networking/umurmur { };
-  
+
   udocker = pythonPackages.callPackage ../tools/virtualization/udocker { };
 
   unigine-valley = callPackage ../applications/graphics/unigine-valley { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10106,7 +10106,7 @@ with pkgs;
       url = "https://github.com/jbeder/yaml-cpp/archive/release-0.3.0.tar.gz";
       sha256 = "12aszqw6svwlnb6nzhsbqhz3c7vnd5ahd0k6xlj05w8lm83hx3db";
       };
-    });
+  });
 
   # interception-tools needs this. This should be removed when there is a new
   # release of libyamlcpp, i.e. when the version of libyamlcpp is newer than


### PR DESCRIPTION
###### Motivation for this change

A package which I packaged for my own personal use which wasn't already included. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

