### PR TITLE
gcolor3: init at 2.2

### DIFF
--- a/pkgs/applications/graphics/gcolor3/default.nix
+++ b/pkgs/applications/graphics/gcolor3/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, gnome3, libtool, intltool, pkgconfig, gtk3, hicolor_icon_theme, wrapGAppsHook } :
+
+let
+  version = "2.2";
+in stdenv.mkDerivation {
+  name = "gcolor3-${version}";
+
+  src = fetchFromGitHub {
+    owner = "hjdskes";
+    repo = "gcolor3";
+    rev = "v${version}";
+    sha256 = "1rbahsi33pfggpj5cigy6wy5333g3rpm8v2q0b35c6m7pwhmf2gr";
+  };
+
+  nativeBuildInputs = [ gnome3.gnome_common libtool intltool pkgconfig hicolor_icon_theme wrapGAppsHook ];
+
+  buildInputs = [ gtk3 ];
+
+  configureScript = "./autogen.sh";
+
+  # clang-4.0: error: argument unused during compilation: '-pthread'
+  NIX_CFLAGS_COMPILE = stdenv.lib.optional stdenv.cc.isClang "-Wno-error=unused-command-line-argument";
+
+  meta = {
+    description = "A simple color chooser written in GTK3";
+    homepage = https://hjdskes.github.io/projects/gcolor3/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ jtojnar ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14615,6 +14615,8 @@ with pkgs;
 
   gcolor2 = callPackage ../applications/graphics/gcolor2 { };
 
+  gcolor3 = callPackage ../applications/graphics/gcolor3 { };
+
   get_iplayer = callPackage ../applications/misc/get_iplayer {};
 
   getxbook = callPackage ../applications/misc/getxbook {};


### PR DESCRIPTION
###### Motivation for this change
Fueh

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

