### PR TITLE
mupdf: fix library linking

### DIFF
--- a/pkgs/applications/misc/k2pdfopt/default.nix
+++ b/pkgs/applications/misc/k2pdfopt/default.nix
@@ -2,7 +2,7 @@
 , zlib, libpng
 , enableGSL ? true, gsl
 , enableGhostScript ? true, ghostscript
-, enableMuPDF ? true, jbig2dec, openjpeg, freetype, harfbuzz, mupdf
+, enableMuPDF ? true, mupdf
 , enableJPEG2K ? true, jasper
 , enableDJVU ? true, djvulibre
 , enableGOCR ? false, gocr # Disabled by default due to crashes
@@ -51,7 +51,19 @@ stdenv.mkDerivation rec {
          url = "http://git.ghostscript.com/?p=mupdf.git;a=patch;h=2c4e5867ee699b1081527bc6c6ea0e99a35a5c27";
          sha256 = "14k7x47ifx82sds1c06ibzbmcparfg80719jhgwjk6w1vkh4r693";
         })
+
+        (fetchpatch {
+          name = "mupdf-1.10a-shared_libs-1.patch";
+          url = "http://www.linuxfromscratch.org/patches/downloads/mupdf/mupdf-1.10a-shared_libs-1.patch";
+          sha256 = "0kg4vahp7hlyyj5hl18brk8s8xcbqrx19pqjzkfq6ha8mqa3k4ab";
+        })
       ];
+
+      # Override this since the jpeg directory was renamed libjpeg in mupdf 1.11
+      preConfigure = ''
+        # Don't remove mujs because upstream version is incompatible
+        rm -rf thirdparty/{curl,freetype,glfw,harfbuzz,jbig2dec,jpeg,openjpeg,zlib}
+      '';
     });
     leptonica_modded = leptonica.overrideAttrs (attrs: {
       prePatch = ''
@@ -75,8 +87,8 @@ stdenv.mkDerivation rec {
     [ zlib libpng ] ++
     optional enableGSL gsl ++
     optional enableGhostScript ghostscript ++
-    optionals enableMuPDF [ jbig2dec openjpeg freetype harfbuzz mupdf_modded ] ++
-    optionals enableJPEG2K [ jasper ] ++
+    optional enableMuPDF mupdf_modded ++
+    optional enableJPEG2K jasper ++
     optional enableDJVU djvulibre ++
     optional enableGOCR gocr ++
     optionals enableTesseract [ leptonica_modded tesseract_modded ];

--- a/pkgs/applications/misc/k2pdfopt/default.nix
+++ b/pkgs/applications/misc/k2pdfopt/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
         (fetchpatch {
           name = "mupdf-1.10a-shared_libs-1.patch";
-          url = "http://www.linuxfromscratch.org/patches/downloads/mupdf/mupdf-1.10a-shared_libs-1.patch";
+          url = "https://ftp.osuosl.org/pub/blfs/conglomeration/mupdf/mupdf-1.10a-shared_libs-1.patch";
           sha256 = "0kg4vahp7hlyyj5hl18brk8s8xcbqrx19pqjzkfq6ha8mqa3k4ab";
         })
       ];

--- a/pkgs/applications/misc/k2pdfopt/k2pdfopt.patch
+++ b/pkgs/applications/misc/k2pdfopt/k2pdfopt.patch
@@ -17,11 +17,11 @@ index 4a2378b..502c477 100644
 -# willus.h
 -# HAVE_GSL_LIB
 +pkg_check_modules(GSL gsl)
-+if(MUPDF_FOUND)
++if(GSL_FOUND)
 +  set(HAVE_GSL_LIB 1)
 +  include_directories(SYSTEM ${GSL_INCLUDEDIR})
 +  set(K2PDFOPT_LIB ${K2PDFOPT_LIB} ${GSL_LDFLAGS})
-+endif(MUPDF_FOUND)
++endif(GSL_FOUND)
  
  
  # libfreetype6 (>= 2.3.9), libjbig2dec0, libjpeg8 (>= 8c), libx11-6, libxext6, zlib1g (>= 1:1.2.0)
@@ -30,7 +30,7 @@ index 4a2378b..502c477 100644
    message(STATUS "mupdf libraries: ${MUPDF_LDFLAGS}")
    set(K2PDFOPT_LIB ${K2PDFOPT_LIB} ${MUPDF_LDFLAGS} 
 -    -lmupdf-js-none -lopenjpeg -ljbig2dec -ljpeg -lfreetype
-+    -lopenjp2 -ljbig2dec -ljpeg -lfreetype -lharfbuzz
++ 
    )
  endif(MUPDF_FOUND)
  

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, fetchpatch, pkgconfig
-, freetype, harfbuzz, openjpeg, jbig2dec
+, freetype, harfbuzz, openjpeg, jbig2dec, libjpeg
 , enableX11 ? true, libX11, libXext
 , enableCurl ? true, curl, openssl
 }:
@@ -26,11 +26,17 @@ stdenv.mkDerivation rec {
       url = "http://git.ghostscript.com/?p=mupdf.git;a=blobdiff_plain;f=platform/x11/jstest_main.c;h=f158d9628ed0c0a84e37fe128277679e8334422a;hp=13c3a0a3ba3ff4aae29f6882d23740833c1d842f;hb=06a012a42c9884e3cd653e7826cff1ddec04eb6e;hpb=34e18d127a02146e3415b33c4b67389ce1ddb614";
       sha256 = "163bllvjrbm0gvjb25lv7b6sih4zr4g4lap3h0cbq8dvpjxx0jfc";
     })
+
+    (fetchpatch {
+      name = "mupdf-1.11-shared_libs-1.patch";
+      url = "http://www.linuxfromscratch.org/patches/downloads/mupdf/mupdf-1.11-shared_libs-1.patch";
+      sha256 = "127x8jhyj3i9cn3mxw9mm5barw2yk43rvmghg54bhn4rjalx857j";
+    })
   ];
 
   makeFlags = [ "prefix=$(out)" ];
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ freetype harfbuzz openjpeg jbig2dec ]
+  buildInputs = [ freetype harfbuzz openjpeg jbig2dec libjpeg ]
                 ++ lib.optionals enableX11 [ libX11 libXext ]
                 ++ lib.optionals enableCurl [ curl openssl ];
   outputs = [ "bin" "dev" "out" "man" "doc" ];
@@ -41,13 +47,6 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    for i in $out/lib/*.a; do
-      so="''${i%.a}.so"
-      gcc -shared -o $so.${version} -Wl,--whole-archive $i -Wl,--no-whole-archive
-      ln -s $so.${version} $so
-      rm $i
-    done
-
     mkdir -p "$out/lib/pkgconfig"
     cat >"$out/lib/pkgconfig/mupdf.pc" <<EOF
     prefix=$out

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
     (fetchpatch {
       name = "mupdf-1.11-shared_libs-1.patch";
-      url = "http://www.linuxfromscratch.org/patches/downloads/mupdf/mupdf-1.11-shared_libs-1.patch";
+      url = "https://ftp.osuosl.org/pub/blfs/conglomeration/mupdf/mupdf-1.11-shared_libs-1.patch";
       sha256 = "127x8jhyj3i9cn3mxw9mm5barw2yk43rvmghg54bhn4rjalx857j";
     })
   ];


### PR DESCRIPTION
###### Motivation for this change

A recent change 47f099777cadb1110abde73279e0ebf148c05308 broke a package I maintain (`k2pdfopt`), which would complain about missing `openssl` symbols. While a quick fix would just be to link in `openssl` manually for my package, I believe this is the proper fix to make `libmupdf` behave more like a normal shared library.

Specifically, `libmupdf.so` does not have `DT_NEEDED` references to its
dependencies. Packages which link against `libmupdf.so` would have to also
manually link against its dependencies as well. This adds unnecessary complexity to packages which depend on it. (See also `llpp`, `jfbview`, and `zathura-pdf-mupdf`)

The first commit includes a patch which ensures that `libmupdf.so` is built with references to its own dependencies.
An additional commit fixes k2pdfopt, which uses a patched version of mupdf and requires another patch for an older version.

Output of `readelf -d libmupdf.so` before change:
>  ...
> 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
> 0x000000000000001d (RUNPATH)            Library runpath: [/nix/store/zpg78y1mf0di6127q6r51kgx2q8cxsvv-glibc-2.25-49/lib]
> ...

After change:
> ...
>  0x0000000000000001 (NEEDED)             Shared library: [libmupdfthird.so]
> 0x0000000000000001 (NEEDED)             Shared library: [libmuthreads.so]
> 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
> 0x0000000000000001 (NEEDED)             Shared library: [libfreetype.so.6]
> 0x0000000000000001 (NEEDED)             Shared library: [libharfbuzz.so.0]
> 0x0000000000000001 (NEEDED)             Shared library: [libjbig2dec.so.0]
> 0x0000000000000001 (NEEDED)             Shared library: [libjpeg.so.62]
> 0x0000000000000001 (NEEDED)             Shared library: [libopenjp2.so.7]
> 0x0000000000000001 (NEEDED)             Shared library: [libz.so.1]
> 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
> 0x000000000000000e (SONAME)             Library soname: [libmupdf.so]
> 0x000000000000001d (RUNPATH)            Library runpath: [/nix/store/05j0i5jhbp1j0mv36mj08rvn7pk7a3s4-mupdf-1.11/lib:/nix/store/7rda899md2d4q26lxb43yg3cmrgcdr1r-freetype-2.7.1/lib:/nix/store/riicxh9dp1bx90fjcf2yr7gw3wj0x7fm-harfbuzz-1.5.1/lib:/nix/store/gdnvg9j2hr4fh43arflqbzx5a86f7gpc-openjpeg-2.1.2/lib:/nix/store/i8wz3m067dzbs5x2glhxvcg7lvds1942-zlib-1.2.11/lib:/nix/store/bsqid2phn9ad8fyw2d63anzrrxp7a9x4-libjpeg-turbo-1.5.2/lib:/nix/store/0yqg15g97va4xrdzkgjd74nfxgw1c3ij-jbig2dec-0.13/lib:/nix/store/zpg78y1mf0di6127q6r51kgx2q8cxsvv-glibc-2.25-49/lib]
> ...

I believe `llpp`, `jfbview`, and `zathura-pdf-mupdf` could also be cleaned to not have to refer to mupdf's dependencies. Those packages build anyway, so it's not strictly necessary. Finally, I'm not an expert on compilers or linking so let me know if I'm misunderstanding anything.

CC @abbradar  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

