### PR TITLE
Fix buildStackProject in nix-build

### DIFF
--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -1,4 +1,4 @@
-{ stdenv, ghc, pkgconfig, glibcLocales, cacert }@depArgs:
+{ stdenv, ghc, pkgconfig, glibcLocales, cacert, stack }@depArgs:
 
 with stdenv.lib;
 
@@ -6,15 +6,17 @@ with stdenv.lib;
 , extraArgs ? []
 , LD_LIBRARY_PATH ? []
 , ghc ? depArgs.ghc
+, stack ? depArgs.stack
 , ...
 }@args:
 
-stdenv.mkDerivation (args // {
+let stackCmd = "stack --internal-re-exec-version=${stack.version}";
+in stdenv.mkDerivation (args // {
 
   buildInputs =
     buildInputs ++
     optional stdenv.isLinux glibcLocales ++
-    [ ghc pkgconfig ];
+    [ ghc pkgconfig stack ];
 
   STACK_PLATFORM_VARIANT="nix";
   STACK_IN_NIX_SHELL=1;
@@ -39,13 +41,13 @@ stdenv.mkDerivation (args // {
     export STACK_ROOT=$NIX_BUILD_TOP/.stack
   '';
 
-  buildPhase = args.buildPhase or "stack build";
+  buildPhase = args.buildPhase or "${stackCmd} build";
 
-  checkPhase = args.checkPhase or "stack test";
+  checkPhase = args.checkPhase or "${stackCmd} test";
 
   doCheck = args.doCheck or true;
 
   installPhase = args.installPhase or ''
-    stack --local-bin-path=$out/bin build --copy-bins
+    ${stackCmd} --local-bin-path=$out/bin build --copy-bins
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

It seems that `haskell.lib.buildStackProject` never really worked for `nix-build`, as it wouldn't have even had `stack` in the `PATH`. The primary usage of `buildStackProject` has always been to provide a `nix-shell` environment that Stack can use for its nix integration, but I see no reason that it can't also be used to perform a Stack build in Nix.

This PR adds `stack` to the `buildInputs`, and correctly passes the arguments it expects when used with nix integration. The behavior in `nix-shell` is unchanged, thus leaving the user interface for stack's nix integration the same.

EDIT: I also removed `preferLocalBuild` from the resulting derivation. It is unclear to me why that was there in the first place. If we ever create a top level package in `all-packages` using this, would we not want that cached? I suspect it was that way because `nix-build` didn't previously matter for these derivations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
