### PR TITLE
bitcoin-classic: build with qt5

### DIFF
--- a/pkgs/applications/altcoins/bitcoin-classic.nix
+++ b/pkgs/applications/altcoins/bitcoin-classic.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, openssl, db48, boost
-, zlib, miniupnpc, qt4, utillinux, protobuf, qrencode, libevent
+, zlib, miniupnpc, qt5, utillinux, protobuf, qrencode, libevent
 , withGui }:
 
 with stdenv.lib;
@@ -16,13 +16,15 @@ stdenv.mkDerivation rec {
     sha256 = "129gkg035gv7zmc463jl2spvdh0fl4q8v4jdaslfnp34hbwi1p07";
   };
 
+  patches = [ ./fix-bitcoin-qt-build.patch ];
+
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = [ openssl db48 boost zlib
                   miniupnpc utillinux protobuf libevent ]
-                  ++ optionals withGui [ qt4 qrencode ];
+                  ++ optionals withGui [ qt5.qtbase qt5.qttools qrencode ];
 
   configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
-                     ++ optionals withGui [ "--with-gui=qt4" ];
+                     ++ optionals withGui [ "--with-gui=qt5" ];
 
   meta = {
     description = "Peer-to-peer electronic cash system (Classic client)";


### PR DESCRIPTION
###### Motivation for this change

using qt5 for bitcoin-classic

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

