### PR TITLE
unicode: change UnicodeData.txt to stable version

### DIFF
--- a/pkgs/tools/misc/unicode/default.nix
+++ b/pkgs/tools/misc/unicode/default.nix
@@ -12,8 +12,8 @@ python3Packages.buildPythonApplication rec {
   };
 
   ucdtxt = fetchurl {
-    url = http://www.unicode.org/Public/11.0.0/ucd/UnicodeData-11.0.0d1.txt;
-    sha256 = "0y9l0sap7yq7c7c8d0fivzycqaw0zncbxzh1inggg42308z974rn";
+    url = http://www.unicode.org/Public/10.0.0/ucd/UnicodeData.txt;
+    sha256 = "1cfak1j753zcrbgixwgppyxhm4w8vda8vxhqymi7n5ljfi6kwhjj";
   };
 
   postFixup = ''


### PR DESCRIPTION
latest final release of Unicode is 10.0.0. 11.0.0 is not yet released.

###### Motivation for this change

see https://github.com/NixOS/nixpkgs/pull/29891#pullrequestreview-66300711

> I think it is better not to depend on not-yet-released Unicode data. I guess this file will be renamed UnicodeData.txt in the future, and this URL will break.
— @xzfc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

