### PR TITLE
nixos/tests: clean up pgjwt test

### DIFF
--- a/nixos/tests/pgjwt.nix
+++ b/nixos/tests/pgjwt.nix
@@ -17,13 +17,8 @@ with pkgs; {
     master = { pkgs, config, ... }:
     {
       services.postgresql = {
-      enable = true;
-      package = postgresql96;
-      extraPlugins = [ pgjwt pgtap ];
-      initialScript =  writeText "postgresql-init.sql"
-      ''
-        CREATE ROLE postgres WITH superuser login createdb;
-      '';
+        enable = true;
+        extraPlugins = [ pgjwt pgtap ];
       };
     };
   };


### PR DESCRIPTION
###### Things done
- removed unneeded initscript
- use default postgres version for the test

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

