### PR TITLE
dovecot: 2.2.27 -> 2.2.32, dovecot_pigeonhole: 0.4.10 -> 0.4.20

### DIFF
--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -8,7 +8,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "dovecot-2.2.27";
+  name = "dovecot-2.2.32";
 
   nativeBuildInputs = [ perl pkgconfig ];
   buildInputs = [ openssl bzip2 zlib clucene_core_2 icu openldap ]
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://dovecot.org/releases/2.2/${name}.tar.gz";
-    sha256 = "1s8qvr6fa9d0n179kdwgpsi72zkvpbh9q57q8fr2fjysgjl94zw9";
+    sha256 = "0bmwyvi1crmrca2knvknsf517x53w7gxrclwyrvrhddgw98j22qn";
   };
 
   preConfigure = ''

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "dovecot-pigeonhole-${version}";
-  version = "0.4.10";
+  version = "0.4.20";
 
   src = fetchurl {
     url = "http://pigeonhole.dovecot.org/releases/2.2/dovecot-2.2-pigeonhole-${version}.tar.gz";
-    sha256 = "0vvjj1yjr189rn8f41z5rj8gfvk24a8j33q6spb6bd6k1wbfgpz9";
+    sha256 = "0nxy007wmyamwj01yfiqbqjnbsd98z783b811rcavwi5iw5pvqbg";
   };
 
   buildInputs = [ dovecot openssl ];


### PR DESCRIPTION
###### Motivation for this change

dovecot-pigeonhole-0.4.10 is currently broken (which affects the 17.09 release as well)
It seems this is due to changes in dovecot and pigeonhole-0.4.10 does not work together anymore with dovecot-2.2.27.
(It crashes during the sieve "execute" command, the [change log](https://raw.githubusercontent.com/dovecot/pigeonhole/0.4.20/NEWS) mentions 
"Part of the Sieve extprograms implementation was moved to Dovecot" in dovecot-2.2.26)

This change updates dovecot + dovecot-pigeonhole to their latest releases,
and fixes the above crash issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of the `dovecot-lda` binary
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

