### PR TITLE
mate-power-manager: init at 1.18.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -107,6 +107,7 @@
   chaoflow = "Florian Friesdorf <flo@chaoflow.net>";
   chattered = "Phil Scott <me@philscotted.com>";
   choochootrain = "Hurshal Patel <hurshal@imap.cc>";
+  chpatrick = "Patrick Chilton <chpatrick@gmail.com>";
   chris-martin = "Chris Martin <ch.martin@gmail.com>";
   chrisjefferson = "Christopher Jefferson <chris@bubblescope.net>";
   chrisrosset = "Christopher Rosset <chris@rosset.org.uk>";

--- a/nixos/modules/services/x11/desktop-managers/mate.nix
+++ b/nixos/modules/services/x11/desktop-managers/mate.nix
@@ -72,6 +72,7 @@ in
     ];
 
     services.gnome3.gnome-keyring.enable = true;
+    services.upower.enable = config.powerManagement.enable;
 
     environment.pathsToLink = [ "/share" ];
   };

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -25,6 +25,7 @@ let
     mate-menus = callPackage ./mate-menus { };
     mate-notification-daemon = callPackage ./mate-notification-daemon { };
     mate-panel = callPackage ./mate-panel { };
+    mate-power-manager = callPackage ./mate-power-manager { };
     mate-session-manager = callPackage ./mate-session-manager { };
     mate-settings-daemon = callPackage ./mate-settings-daemon { };
     mate-terminal = callPackage ./mate-terminal { };
@@ -55,6 +56,7 @@ let
       engrampa
       eom
       mate-icon-theme-faenza
+      mate-power-manager
       mate-terminal
       pluma
     ];

--- a/pkgs/desktops/mate/mate-power-manager/default.nix
+++ b/pkgs/desktops/mate/mate-power-manager/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl, pkgconfig, intltool, glib, itstool, libxml2, mate, libnotify, libcanberra_gtk3, dbus_glib, upower, gnome3, libtool, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "mate-power-manager-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "0";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "1gmka9ybxvkrdjaga1md6pbw6q1cx5yxb58ai5315a0f5p45y36x";
+  };
+
+  buildInputs = [
+     glib
+     itstool
+     libxml2
+     libcanberra_gtk3
+     gnome3.gtk
+     gnome3.libgnome_keyring
+     libnotify
+     dbus_glib
+     upower
+
+     mate.mate-panel
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    libtool
+    wrapGAppsHook
+  ];
+
+  configureFlags = [ "--enable-applets" ];
+
+  meta = with stdenv.lib; {
+    description = "The MATE Power Manager";
+    homepage = http://mate-desktop.org;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo maintainers.chpatrick ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

