### PR TITLE
devpi-client: 2.7.0 -> 3.1.0rc1

### DIFF
--- a/pkgs/development/python-modules/devpi-common/default.nix
+++ b/pkgs/development/python-modules/devpi-common/default.nix
@@ -1,0 +1,26 @@
+{ pythonPackages }:
+
+with pythonPackages;buildPythonPackage rec {
+  pname = "devpi-common";
+  version = "3.2.0rc1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ws35g1r0j2xccsna4r6fc9a08przfi28kf9hciq3rmd6ndbr9c9";
+  };
+
+  propagatedBuildInputs = [ requests py ];
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = {
+    homepage = https://github.com/devpi/devpi;
+    description = "Utilities jointly used by devpi-server and devpi-client";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lewo makefu ];
+  };
+}

--- a/pkgs/development/tools/devpi-client/default.nix
+++ b/pkgs/development/tools/devpi-client/default.nix
@@ -1,20 +1,22 @@
-{ stdenv, fetchurl, pythonPackages, glibcLocales} :
+{ stdenv, pythonPackages, glibcLocales} :
 
 pythonPackages.buildPythonApplication rec {
-  name = "devpi-client-${version}";
-  version = "2.7.0";
+  name = "${pname}-${version}";
+  pname = "devpi-client";
+  version = "3.1.0rc1";
 
-  src = fetchurl {
-    url = "mirror://pypi/d/devpi-client/${name}.tar.gz";
-    sha256 = "0z7vaf0a66n82mz0vx122pbynjvkhp2mjf9lskgyv09y3bxzzpj3";
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "0kfyva886k9zxmilqb2yviwqzyvs3n36if3s56y4clbvw9hr2lc3";
   };
-
-  doCheck = false;
+  # requires devpi-server which is currently not packaged
+  doCheck = true;
+  checkInputs = with pythonPackages; [ pytest webtest mock ];
+  checkPhase = "py.test";
 
   LC_ALL = "en_US.UTF-8";
-  buildInputs = with pythonPackages; [ glibcLocales tox check-manifest pkginfo ];
-
-  propagatedBuildInputs = with pythonPackages; [ py devpi-common ];
+  buildInputs = with pythonPackages; [ glibcLocales pkginfo tox check-manifest ];
+  propagatedBuildInputs = with pythonPackages; [ py devpi-common pluggy ];
 
   meta = {
     homepage = http://doc.devpi.net;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2355,25 +2355,7 @@ in {
     };
   };
 
-  devpi-common = buildPythonPackage rec {
-    name = "devpi-common";
-    version = "3.0.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/devpi-common/devpi-common-${version}.tar.gz";
-      sha256 = "0l3a7iyk596x6pvzg7604lzzi012qszr804fqn6f517zcy1xz23j";
-    };
-
-    propagatedBuildInputs = [ self.requests self.py ];
-
-    meta = {
-      homepage = https://bitbucket.org/hpk42/devpi;
-      description = "Utilities jointly used by devpi-server and devpi-client";
-      license = licenses.mit;
-      maintainers = with maintainers; [ lewo makefu ];
-    };
-  };
-
+  devpi-common = callPackage ../development/python-modules/devpi-common { };
   # A patched version of buildout, useful for buildout based development on Nix
   zc_buildout_nix = callPackage ../development/python-modules/buildout-nix { };
 


### PR DESCRIPTION
###### Motivation for this change

update devpi-client to the latest version.
With this commit i also bump the version of devpi-common from 3.0.1 -> 3.2.0rc1 and enable tests for the package.
Right now we cannot enable devpi-client tests because the devpi-server package is not yet packaged.

###### Things done



- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

