### PR TITLE
axoloti: init at 1.0.12-1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -590,6 +590,7 @@
   taku0 = "Takuo Yonezawa <mxxouy6x3m_github@tatapa.org>";
   tari = "Peter Marheine <peter@taricorp.net>";
   tavyc = "Octavian Cerna <octavian.cerna@gmail.com>";
+  TealG = "Teal Gaure <~@Teal.Gr>";
   teh = "Tom Hunger <tehunger@gmail.com>";
   telotortium = "Robert Irelan <rirelan@gmail.com>";
   teto = "Matthieu Coudron <mcoudron@hotmail.com>";

--- a/pkgs/applications/audio/axoloti/default.nix
+++ b/pkgs/applications/audio/axoloti/default.nix
@@ -1,0 +1,101 @@
+{ stdenv, fetchFromGitHub, fetchurl, makeWrapper, unzip
+, gnumake, gcc-arm-embedded, dfu-util-axoloti, jdk, ant, libfaketime }:
+
+stdenv.mkDerivation rec {
+  version = "1.0.12-1";
+  name = "axoloti-${version}";
+
+  src = fetchFromGitHub {
+    owner = "axoloti";
+    repo = "axoloti";
+    rev = "${version}";
+    sha256 = "13njmv8zac0kaaxgkv4y4zfjcclafn9cw0m8lj2k4926wnwjmf50";
+  };
+
+  chibi_version = "2.6.9";
+  chibi_name = "ChibiOS_${chibi_version}";
+
+  chibios = fetchurl {
+    url = "mirror://sourceforge/project/chibios/ChibiOS_RT%20stable/Version%20${chibi_version}/${chibi_name}.zip";
+    sha256 = "0lb5s8pkj80mqhsy47mmq0lqk34s2a2m3xagzihalvabwd0frhlj";
+  };
+
+  buildInputs = [ makeWrapper unzip gcc-arm-embedded dfu-util-axoloti jdk ant libfaketime ];
+
+  patchPhase = ''
+    unzip ${chibios}
+    mv ${chibi_name} chibios
+    (cd chibios/ext; unzip -q -o fatfs-0.9-patched.zip)
+
+    # Remove source of non-determinism in ChibiOS
+    substituteInPlace "chibios/os/various/shell.c" \
+      --replace "#ifdef __DATE__" "#if 0"
+
+    # Hardcode full path to compiler tools
+    for f in "firmware/Makefile.patch" \
+             "firmware/Makefile" \
+             "firmware/flasher/Makefile" \
+             "firmware/mounter/Makefile"; do
+      substituteInPlace "$f" \
+        --replace "arm-none-eabi-" "${gcc-arm-embedded}/bin/arm-none-eabi-"
+    done
+
+    # Hardcode path to "make"
+    for f in "firmware/compile_firmware_linux.sh" \
+             "firmware/compile_patch_linux.sh"; do
+      substituteInPlace "$f" \
+        --replace "make" "${gnumake}/bin/make"
+    done
+
+    # Hardcode dfu-util path
+    substituteInPlace "platform_linux/upload_fw_dfu.sh" \
+      --replace "/bin/dfu-util" ""
+    substituteInPlace "platform_linux/upload_fw_dfu.sh" \
+      --replace "./dfu-util" "${dfu-util-axoloti}/bin/dfu-util"
+
+    # Fix build version
+    substituteInPlace "build.xml" \
+      --replace "(git missing)" "${version}"
+
+    # Remove build time
+    substituteInPlace "build.xml" \
+      --replace "<tstamp>" ""
+    substituteInPlace "build.xml" \
+      --replace \
+        '<format property="build.time" pattern="dd/MM/yyyy HH:mm:ss z"/>' \
+        '<property name="build.time" value=""/>'
+    substituteInPlace "build.xml" \
+      --replace "</tstamp>" ""
+    substituteInPlace "build.xml" \
+      --replace \
+       '{line.separator}</echo>' \
+       '{line.separator}</echo> <touch file="src/main/java/axoloti/Version.java" millis="0" />'
+  '';
+
+  buildPhase = ''
+    find . -exec touch -d '1970-01-01 00:00' {} \;
+    (cd platform_linux; sh compile_firmware.sh)
+    faketime "1970-01-01 00:00:00" ant -Dbuild.runtime=true
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/axoloti
+
+    cp -r doc firmware chibios platform_linux CMSIS *.txt $out/share/axoloti/
+    install -vD dist/Axoloti.jar $out/share/axoloti/
+
+    makeWrapper ${jdk}/bin/java $out/bin/axoloti --add-flags "-Daxoloti_release=$out/share/axoloti -Daxoloti_runtime=$out/share/axoloti -jar $out/share/axoloti/Axoloti.jar"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.axoloti.com;
+    description = ''
+      Sketching embedded digital audio algorithms.
+
+      To fix permissions of the Axoloti USB device node, add a similar udev rule to <literal>services.udev.extraRules</literal>:
+      <literal>SUBSYSTEM=="usb", ATTR{idVendor}=="16c0", ATTR{idProduct}=="0442", OWNER="someuser", GROUP="somegroup"</literal>
+    '';
+    license = licenses.gpl3;
+    maintainers = with lib.maintainers; [ TealG ];
+  };
+}

--- a/pkgs/applications/audio/axoloti/dfu-util.nix
+++ b/pkgs/applications/audio/axoloti/dfu-util.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, pkgconfig, libusb1-axoloti }:
+
+stdenv.mkDerivation rec {
+  name="dfu-util-${version}";
+  version = "0.8";
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libusb1-axoloti ];
+
+  src = fetchurl {
+    url = "http://dfu-util.sourceforge.net/releases/${name}.tar.gz";
+    sha256 = "0n7h08avlzin04j93m6hkq9id6hxjiiix7ff9gc2n89aw6dxxjsm";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Device firmware update (DFU) USB programmer";
+    longDescription = ''
+      dfu-util is a program that implements the host (PC) side of the USB
+      DFU 1.0 and 1.1 (Universal Serial Bus Device Firmware Upgrade) protocol.
+
+      DFU is intended to download and upload firmware to devices connected over
+      USB. It ranges from small devices like micro-controller boards up to mobile
+      phones. With dfu-util you are able to download firmware to your device or
+      upload firmware from it.
+    '';
+    homepage = http://dfu-util.gnumonks.org/;
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/applications/audio/axoloti/libusb1.nix
+++ b/pkgs/applications/audio/axoloti/libusb1.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, pkgconfig, systemd ? null, libobjc, IOKit, fetchpatch }:
+
+stdenv.mkDerivation rec {
+  name = "libusb-1.0.19";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/libusb/${name}.tar.bz2";
+    sha256 = "0h38p9rxfpg9vkrbyb120i1diq57qcln82h5fr7hvy82c20jql3c";
+  };
+
+  outputs = [ "out" "dev" ]; # get rid of propagating systemd closure
+
+  buildInputs = [ pkgconfig ];
+  propagatedBuildInputs =
+    stdenv.lib.optional stdenv.isLinux systemd ++
+    stdenv.lib.optionals stdenv.isDarwin [ libobjc IOKit ];
+
+  patches = [
+    (fetchpatch {
+      name = "libusb.stdfu.patch";
+      url = "https://raw.githubusercontent.com/axoloti/axoloti/1.0.12/platform_linux/src/libusb.stdfu.patch";
+      sha256 = "194j7j61i4q6x0ihm9ms8dxd4vliw20n2rj6cm9h17qzdl9xr33d";
+    })
+  ];
+
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
+
+  preFixup = stdenv.lib.optionalString stdenv.isLinux ''
+    sed 's,-ludev,-L${systemd.lib}/lib -ludev,' -i $out/lib/libusb-1.0.la
+  '';
+
+  meta = {
+    homepage = http://www.libusb.info;
+    description = "User-space USB library";
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -677,6 +677,13 @@ with pkgs;
     libssl = openssl;
   };
 
+  axoloti = callPackage ../applications/audio/axoloti { };
+  dfu-util-axoloti = callPackage ../applications/audio/axoloti/dfu-util.nix { };
+  libusb1-axoloti = callPackage ../applications/audio/axoloti/libusb1.nix {
+    inherit (darwin) libobjc;
+    inherit (darwin.apple_sdk.frameworks) IOKit;
+  };
+
   azureus = callPackage ../tools/networking/p2p/azureus { };
 
   backblaze-b2 = callPackage ../development/tools/backblaze-b2 { };


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

