### PR TITLE
devtodo: init at 0.1.20

### DIFF
--- a/pkgs/development/tools/devtodo/default.nix
+++ b/pkgs/development/tools/devtodo/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, readline, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "devtodo-${version}";
+  version = "0.1.20";
+
+  src = fetchurl {
+    url = "http://swapoff.org/files/devtodo/${name}.tar.gz";
+    sha256 = "029y173njydzlznxmdizrrz4wcky47vqhl87fsb7xjcz9726m71p";
+  };
+
+  buildInputs = [ readline ncurses ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://swapoff.org/devtodo1.html;
+    description = "A hierarchical command-line task manager";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.woffs ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7095,6 +7095,8 @@ with pkgs;
 
   dejagnu = callPackage ../development/tools/misc/dejagnu { };
 
+  devtodo = callPackage ../development/tools/devtodo { };
+
   dfeet = callPackage ../development/tools/misc/d-feet { };
 
   dfu-programmer = callPackage ../development/tools/misc/dfu-programmer { };


### PR DESCRIPTION
###### Motivation for this change

use devtodo, which is included in debian and arch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

