### PR TITLE
Dejà Dup: init at 36.1

### DIFF
--- a/pkgs/applications/backup/deja-dup/default.nix
+++ b/pkgs/applications/backup/deja-dup/default.nix
@@ -1,0 +1,83 @@
+{ stdenv, fetchurl, meson, ninja, pkgconfig, vala_0_38, gettext
+, gnome3, libnotify, intltool, itstool, glib, gtk3, libxml2
+, coreutils, libsecret, pcre, libxkbcommon, wrapGAppsHook
+, libpthreadstubs, libXdmcp, epoxy, at_spi2_core, dbus, libgpgerror
+, appstream-glib, desktop_file_utils, atk, pango, duplicity
+}:
+
+stdenv.mkDerivation rec {
+  name = "deja-dup-${version}";
+  version = "36.1";
+
+  src = fetchurl {
+    url = "https://launchpad.net/deja-dup/36/${version}/+download/deja-dup-${version}.tar.xz";
+    sha256 = "1s48k2sxrpwkzp37s4x7934lyg5194c47nv9ks15rksd5s0alnld";
+  };
+
+  patches = [
+    ./fix-paths.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace libdeja/tools/duplicity/DuplicityInstance.vala --replace \
+      "/bin/rm" \
+      "${coreutils}/bin/rm"
+  '';
+
+  # couldn't find gio/gdesktopappinfo.h
+  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
+
+  nativeBuildInputs = [
+    meson ninja pkgconfig vala_0_38 gettext intltool itstool
+    appstream-glib desktop_file_utils libxml2 wrapGAppsHook
+  ];
+
+  buildInputs = [
+   libnotify gnome3.libpeas glib gtk3 libsecret
+   pcre libxkbcommon libpthreadstubs libXdmcp epoxy gnome3.nautilus
+   at_spi2_core dbus gnome3.gnome_online_accounts libgpgerror
+  ];
+
+  propagatedUserEnvPkgs = [ duplicity ];
+
+  postInstall = ''
+    glib-compile-schemas $out/share/glib-2.0/schemas
+  '';
+
+  # Manual rpath definition until https://github.com/mesonbuild/meson/issues/314 is fixed
+  postFixup =
+    let
+      rpath = stdenv.lib.makeLibraryPath [
+        glib
+        gtk3
+        gnome3.gnome_online_accounts
+        gnome3.libpeas
+        gnome3.nautilus
+        libgpgerror
+        libsecret
+        # Transitive
+        atk
+        pango
+      ];
+    in ''
+      # Unwrap accidentally wrapped library
+      mv $out/libexec/deja-dup/tools/.libduplicity.so-wrapped $out/libexec/deja-dup/tools/libduplicity.so
+
+      for elf in "$out"/bin/.*-wrapped "$out"/libexec/deja-dup/.deja-dup-monitor-wrapped "$out"/libexec/deja-dup/tools/*.so "$out"/lib/deja-dup/*.so "$out"/lib/nautilus/extensions-3.0/*.so; do
+        patchelf --set-rpath '${rpath}':"$out/lib/deja-dup" "$elf"
+      done
+    '';
+
+  meta = with stdenv.lib; {
+    description = "A simple backup tool";
+    longDescription = ''
+      Déjà Dup is a simple backup tool. It hides the complexity \
+      of backing up the Right Way (encrypted, off-site, and regular) \
+      and uses duplicity as the backend.
+    '';
+    homepage = https://launchpad.net/deja-dup;
+    license = with licenses; gpl3;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/applications/backup/deja-dup/fix-paths.patch
+++ b/pkgs/applications/backup/deja-dup/fix-paths.patch
@@ -1,0 +1,12 @@
+diff --git a/deja-dup/nautilus/meson.build b/deja-dup/nautilus/meson.build
+index 04b136f3..ed8f7cba 100644
+--- a/deja-dup/nautilus/meson.build
++++ b/deja-dup/nautilus/meson.build
+@@ -31,6 +31,6 @@ shared_module('deja-dup', ['NautilusExtension.c'],
+     link_with: [dirhandling],
+     dependencies: [nautilus_dep],
+     install: true,
+-    install_dir: nautilus_dep.get_pkgconfig_variable('extensiondir'))
++    install_dir: join_paths(get_option('libdir'), 'nautilus', 'extensions-3.0'))
+ 
+ endif

--- a/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, libxslt, gtk, wrapGAppsHook
+{ stdenv, fetchurl, pkgconfig, vala, glib, libxslt, gtk, wrapGAppsHook
 , webkitgtk, json_glib, rest, libsecret, dbus_glib, gnome_common
 , telepathy_glib, intltool, dbus_libs, icu, glib_networking
 , libsoup, docbook_xsl_ns, docbook_xsl, gnome3
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   buildInputs = [ pkgconfig glib libxslt gtk webkitgtk json_glib rest gnome_common wrapGAppsHook
-                  libsecret dbus_glib telepathy_glib glib_networking intltool icu libsoup
+                  libsecret dbus_glib telepathy_glib glib_networking intltool icu libsoup vala
                   docbook_xsl_ns docbook_xsl gnome3.defaultIconTheme ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/backup/duplicity/default.nix
+++ b/pkgs/tools/backup/duplicity/default.nix
@@ -11,7 +11,7 @@ python2Packages.buildPythonApplication rec {
 
   buildInputs = [ librsync makeWrapper python2Packages.wrapPython ];
   propagatedBuildInputs = with python2Packages; [
-    boto cffi cryptography ecdsa enum idna
+    boto cffi cryptography ecdsa enum idna pygobject3
     ipaddress lockfile paramiko pyasn1 pycrypto six
   ];
   checkInputs = with python2Packages; [ lockfile mock pexpect ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -951,6 +951,8 @@ with pkgs;
 
   deisctl = callPackage ../development/tools/deisctl {};
 
+  deja-dup = callPackage ../applications/backup/deja-dup { };
+
   devmem2 = callPackage ../os-specific/linux/devmem2 { };
 
   dbus-broker = callPackage ../os-specific/linux/dbus-broker {};


### PR DESCRIPTION
###### Motivation for this change
Just a backup utility plus some needed changes. Depends on #30043.

Closes: #29955 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

