### PR TITLE
vagrant: fix Ruby and libffi libraries on Darwin

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -85,6 +85,22 @@ in stdenv.mkDerivation rec {
     ln -s ${openssl.bin}/bin/c_rehash opt/vagrant/embedded/bin
     ln -s ${openssl.bin}/bin/openssl opt/vagrant/embedded/bin
 
+    # libiconv: iconv
+    rm opt/vagrant/embedded/bin/iconv
+    ln -s ${libiconv}/bin/iconv opt/vagrant/embedded/bin
+
+    # libxml: xml2-config, xmlcatalog, xmllint
+    rm opt/vagrant/embedded/bin/{xml2-config,xmlcatalog,xmllint}
+    ln -s ${libxml2.dev}/bin/xml2-config opt/vagrant/embedded/bin
+    ln -s ${libxml2.bin}/bin/xmlcatalog opt/vagrant/embedded/bin
+    ln -s ${libxml2.bin}/bin/xmllint opt/vagrant/embedded/bin
+
+    # libxslt: xslt-config, xsltproc
+    rm opt/vagrant/embedded/bin/{xslt-config,xsltproc}
+    ln -s ${libxslt.dev}/bin/xslt-config opt/vagrant/embedded/bin
+    ln -s ${libxslt.bin}/bin/xsltproc opt/vagrant/embedded/bin
+
+  '' + (stdenv.lib.optionalString (! stdenv.isDarwin) ''
     # ruby: erb, gem, irb, rake, rdoc, ri, ruby
     rm opt/vagrant/embedded/bin/{erb,gem,irb,rake,rdoc,ri,ruby}
     ln -s ${ruby}/bin/erb opt/vagrant/embedded/bin
@@ -101,24 +117,10 @@ in stdenv.mkDerivation rec {
       ln -s $lib opt/vagrant/embedded/lib/''${lib##*/}
     done
 
-    # libiconv: iconv
-    rm opt/vagrant/embedded/bin/iconv
-    ln -s ${libiconv}/bin/iconv opt/vagrant/embedded/bin
-
-    # libxml: xml2-config, xmlcatalog, xmllint
-    rm opt/vagrant/embedded/bin/{xml2-config,xmlcatalog,xmllint}
-    ln -s ${libxml2.dev}/bin/xml2-config opt/vagrant/embedded/bin
-    ln -s ${libxml2.bin}/bin/xmlcatalog opt/vagrant/embedded/bin
-    ln -s ${libxml2.bin}/bin/xmllint opt/vagrant/embedded/bin
-
-    # libxslt: xslt-config, xsltproc
-    rm opt/vagrant/embedded/bin/{xslt-config,xsltproc}
-    ln -s ${libxslt.dev}/bin/xslt-config opt/vagrant/embedded/bin
-    ln -s ${libxslt.bin}/bin/xsltproc opt/vagrant/embedded/bin
-
     # libffi
     ln -s ${libffi}/lib/libffi.so.6 opt/vagrant/embedded/lib/libffi.so.6
 
+  '') + ''
     mkdir -p "$out"
     cp -r opt "$out"
     cp -r usr/bin "$out"


### PR DESCRIPTION
On Darwin, keep the Ruby and libffi libraries and binaries bundled
with Vagrant instead of linking to the Nix ones, to avoid errors about
libraries not found.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

