### PR TITLE
snowman: 2017-07-22 -> 2017-08-13

### DIFF
--- a/pkgs/development/tools/analysis/snowman/default.nix
+++ b/pkgs/development/tools/analysis/snowman/default.nix
@@ -6,13 +6,13 @@ assert qtbase != null -> qt4 == null;
 
 stdenv.mkDerivation rec {
   name = "snowman-${version}";
-  version = "2017-07-22";
+  version = "2017-08-13";
 
   src = fetchFromGitHub {
     owner = "yegord";
     repo = "snowman";
-    rev = "6c4d9cceb56bf2fd0f650313131a2240579d1bea";
-    sha256 = "1d0abh0fg637jksk7nl4yl54b4cadinj93qqvsm138zyx7h57xqf";
+    rev = "cd9edcddf873fc40d7bcb1bb1eae815faedd3a03";
+    sha256 = "10f3kd5m5xw7hqh92ba7dcczwbznxvk1qxg0yycqz7y9mfr2282n";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Minor update but notably includes fix
for breakage when using cmake 3.9

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

