### PR TITLE
lsb-release: wrap to ensure needed utilities are available

### DIFF
--- a/pkgs/os-specific/linux/lsb-release/default.nix
+++ b/pkgs/os-specific/linux/lsb-release/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, getopt }:
+{ stdenv, fetchurl, perl, coreutils, getopt, makeWrapper }:
 
 stdenv.mkDerivation rec {
   version = "1.4";
@@ -16,7 +16,14 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "prefix=$(out)" ];
 
-  buildInputs = [ perl getopt ];
+  nativeBuildInputs  = [ makeWrapper perl ];
+
+  buildInputs = [ coreutils getopt ];
+
+  # Ensure utilities used are available
+  preFixup = ''
+    wrapProgram $out/bin/lsb_release --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils getopt ]}
+  '';
 
   meta = {
     description = "Prints certain LSB (Linux Standard Base) and Distribution information";


### PR DESCRIPTION
###### Motivation for this change

Ensures this tool can be used without specifying other dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

