### PR TITLE
libxdg-basedir: 1.0.2 -> 1.2.0

### DIFF
--- a/pkgs/development/libraries/libxdg-basedir/default.nix
+++ b/pkgs/development/libraries/libxdg-basedir/default.nix
@@ -1,16 +1,24 @@
-{stdenv, fetchurl}:
+{stdenv, fetchurl, fetchpatch}:
 
 stdenv.mkDerivation rec {
-  name = "libxdg-basedir-1.0.2";
+  name = "libxdg-basedir-1.2.0";
   src = fetchurl {
-    url = "http://n.ethz.ch/student/nevillm/download/libxdg-basedir/${name}.tar.gz";
-    sha256 = "0fibbzba228gdk05lfi8cgfrsp80a2gnjbwka0pzpkig0fz8pp9i";
+    url = "https://nevill.ch/libxdg-basedir/downloads/${name}.tar.gz";
+    sha256 = "2757a949618742d80ac59ee2f0d946adc6e71576406cdf798e6ced507708cdf4";
   };
 
-  meta = {
-    homepage = http://n.ethz.ch/student/nevillm/download/libxdg-basedir/;
+  patches = [
+    # Overflow bug
+    (fetchpatch {
+      url = "https://github.com/devnev/libxdg-basedir/commit/14e000f696ef8b83264b0ca4407669bdb365fb23.patch";
+      sha256 = "0lpy1ijir0x0hhb0fz0w5vxy1wl1cw9kkd6gva0rkp41i6vrp2wq";
+    })
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/devnev/libxdg-basedir;
     description = "Implementation of the XDG Base Directory specification";
-    license = "BSD";
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.mit;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
minor fixes:
* upstream patch for overflow bug
* license is MIT, at least it is now
* fix URLs

###### Motivation for this change

Without this change, radiotray-ng crashes on startup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

