### PR TITLE
radiotray-ng: init at 0.1.7

### DIFF
--- a/pkgs/applications/audio/radiotray-ng/default.nix
+++ b/pkgs/applications/audio/radiotray-ng/default.nix
@@ -1,0 +1,96 @@
+{ stdenv, fetchFromGitHub, fetchpatch
+, cmake, pkgconfig
+# Transport
+, curl
+# Libraries
+, boost
+, jsoncpp
+, libbsd
+, pcre
+# GUI/Desktop
+, dbus
+, glibmm
+, gnome3
+, hicolor_icon_theme
+, libappindicator-gtk3
+, libnotify
+, libxdg_basedir
+# GStreamer
+, gst_all_1
+# User-agent info
+, lsb-release
+# rt2rtng
+, python2
+# Testing
+, gmock
+# Fixup
+, wrapGAppsHook
+, makeWrapper
+}:
+
+let
+  gstInputs = with gst_all_1; [
+    gstreamer gst-plugins-base
+    gst-plugins-good gst-plugins-bad gst-plugins-ugly
+    gst-libav
+  ];
+  # For the rt2rtng utility for converting bookmark file to -ng format
+  pythonInputs = with python2.pkgs; [ python2 lxml ];
+in
+stdenv.mkDerivation rec {
+  name = "radiotray-ng-${version}";
+  version = "0.1.7";
+
+  src = fetchFromGitHub {
+    owner = "ebruck";
+    repo = "radiotray-ng";
+    rev = "v${version}";
+    sha256 = "1m853gzh9r249crn0xyrq22x154r005j58b0kq3nsrgi5cps2zdv";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig wrapGAppsHook makeWrapper ];
+
+  buildInputs = [
+    curl
+    boost jsoncpp libbsd pcre
+    glibmm hicolor_icon_theme gnome3.gsettings_desktop_schemas libappindicator-gtk3 libnotify
+    libxdg_basedir
+    lsb-release
+  ] ++ stdenv.lib.optional doCheck gmock
+    ++ gstInputs
+    ++ pythonInputs;
+
+  prePatch = ''
+    substituteInPlace debian/CMakeLists.txt \
+      --replace /usr $out
+    substituteInPlace include/radiotray-ng/common.hpp \
+      --replace /usr $out
+  '';
+
+  patches = [
+    (fetchpatch {
+      # Fix menu separators and minor touchup to 'version'
+      url = "https://github.com/ebruck/radiotray-ng/commit/827e9f1baaa03ab4d8a5fb3aab043e72950eb965.patch";
+      sha256 = "1aykl6lq4pga34xg5r9mc616gxnd63q6gr8qzg57w6874cj3csrr";
+    })
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  checkPhase = "ctest";
+
+  preFixup = ''
+    gappsWrapperArgs+=(--suffix PATH : ${stdenv.lib.makeBinPath [ dbus ]})
+    wrapProgram $out/bin/rt2rtng --prefix PYTHONPATH : $PYTHONPATH
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An internet radio player for linux";
+    homepage = https://github.com/ebruck/radiotray-ng;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16187,6 +16187,8 @@ with pkgs;
 
   renoise = callPackage ../applications/audio/renoise {};
 
+  radiotray-ng = callPackage ../applications/audio/radiotray-ng { };
+
   rapcad = libsForQt56.callPackage ../applications/graphics/rapcad { boost = boost159; };
 
   rapidsvn = callPackage ../applications/version-management/rapidsvn { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Includes update for libxdg_basedir (https://github.com/NixOS/nixpkgs/pull/30104), since without it the program crashes on startup.
