### PR TITLE
ntk: 2017-04-22 -> 1.3.1000

### DIFF
--- a/pkgs/development/libraries/audio/ntk/default.nix
+++ b/pkgs/development/libraries/audio/ntk/default.nix
@@ -1,12 +1,13 @@
-{ stdenv, fetchgit, cairo, libjpeg, libXft, pkgconfig, python2 }:
+{ stdenv, fetchFromGitHub, cairo, libjpeg, libXft, pkgconfig, python2 }:
 
 stdenv.mkDerivation rec {
   name = "ntk-${version}";
-  version = "2017-04-22";
-  src = fetchgit {
-    url = "git://git.tuxfamily.org/gitroot/non/fltk.git";
-    rev = "92365eca0f9a6f054abc70489c009aba0fcde0ff";
-    sha256 = "0pph7hf07xaa011zr40cs62f3f7hclfbv5kcrl757gcp2s5pi2iq";
+  version = "1.3.1000";
+  src = fetchFromGitHub {
+    owner = "original-male";
+    repo = "ntk";
+    rev = "v${version}";
+    sha256 = "0j38mhnfqy6swcrnc5zxcwlqi8b1pgklyghxk6qs1lf4japv2zc0";
   };
 
   buildInputs = [
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
     version = "${version}";
     homepage = http://non.tuxfamily.org/;
     license = stdenv.lib.licenses.lgpl21;
-    maintainers = [ stdenv.lib.maintainers.magnetophon ];
+    maintainers = with stdenv.lib.maintainers; [ magnetophon nico202 ];
     platforms = stdenv.lib.platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
original-male tagged yesterday it's first ntk relea use version (https://github.com/original-male/non/issues/221)

###### Things done
- changed version number to this release
- It's suggested to use fetchFromGitHub where possible instead of fetchgit
- I've added myself as a contributor to this

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- compiled the non suite over it and it works
