### PR TITLE
llvm: download source over https

### DIFF
--- a/pkgs/development/compilers/llvm/4/default.nix
+++ b/pkgs/development/compilers/llvm/4/default.nix
@@ -10,7 +10,7 @@ let
   version = release_version; # differentiating these is important for rc's
 
   fetch = name: sha256: fetchurl {
-    url = "http://llvm.org/releases/${release_version}/${name}-${version}.src.tar.xz";
+    url = "https://releases.llvm.org/${release_version}/${name}-${version}.src.tar.xz";
     inherit sha256;
   };
 


### PR DESCRIPTION
The source distribution contains binaries (probably for testing) that
make the Avira virus scanner treat it as malware on account of a “bad
ELF header”. Apart from being preferable in general, the HTTPS download
makes the file opaque to the overeager AV scanner in transparent
proxying setups.

Also adapt to the fact that the canonical downloads now point to a URL
like this:

    https://releases.llvm.org/4.0.1/llvm-4.0.1.src.tar.xz

###### Motivation for this change

Download broken over virus scanning proxy (Avira). HTTPS can’t be scanned transparently.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

