### PR TITLE
docs: 17.03 -> 17.09

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ build daemon as so-called channels. To get channel information via git, add
 ```
 
 For stability and maximum binary package support, it is recommended to maintain
-custom changes on top of one of the channels, e.g. `nixos-17.03` for the latest
+custom changes on top of one of the channels, e.g. `nixos-17.09` for the latest
 release and `nixos-unstable` for the latest successful build of master:
 
 ```
 % git remote update channels
-% git rebase channels/nixos-17.03
+% git rebase channels/nixos-17.09
 ```
 
 For pull-requests, please rebase onto nixpkgs `master`.
@@ -32,9 +32,9 @@ For pull-requests, please rebase onto nixpkgs `master`.
 * [Manual (NixOS)](https://nixos.org/nixos/manual/)
 * [Nix Wiki](https://nixos.org/wiki/) (deprecated, see milestone ["Move the Wiki!"](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+milestone%3A%22Move+the+wiki%21%22))
 * [Continuous package builds for unstable/master](https://hydra.nixos.org/jobset/nixos/trunk-combined)
-* [Continuous package builds for 17.03 release](https://hydra.nixos.org/jobset/nixos/release-17.03)
+* [Continuous package builds for 17.09 release](https://hydra.nixos.org/jobset/nixos/release-17.09)
 * [Tests for unstable/master](https://hydra.nixos.org/job/nixos/trunk-combined/tested#tabs-constituents)
-* [Tests for 17.03 release](https://hydra.nixos.org/job/nixos/release-17.03/tested#tabs-constituents)
+* [Tests for 17.09 release](https://hydra.nixos.org/job/nixos/release-17.09/tested#tabs-constituents)
 
 Communication:
 

--- a/maintainers/scripts/hydra-eval-failures.py
+++ b/maintainers/scripts/hydra-eval-failures.py
@@ -49,8 +49,8 @@ def get_maintainers(attr_name):
 @click.command()
 @click.option(
     '--jobset',
-    default="nixos/release-17.03",
-    help='Hydra project like nixos/release-17.03')
+    default="nixos/release-17.09",
+    help='Hydra project like nixos/release-17.09')
 def cli(jobset):
     """
     Given a Hydra project, inspect latest evaluation


### PR DESCRIPTION
###### Motivation for this change

Update `README.md` and `hydra-eval-failures.py` for 17.09
Needs cherry-pick to `release-17.09`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

