### PR TITLE
types: remove loeOf

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -240,25 +240,6 @@ rec {
         functor = (defaultFunctor name) // { wrapped = elemType; };
       };
 
-    # List or element of ...
-    loeOf = elemType: mkOptionType rec {
-      name = "loeOf";
-      description = "element or list of ${elemType.description}s";
-      check = x: isList x || elemType.check x;
-      merge = loc: defs:
-        let
-          defs' = filterOverrides defs;
-          res = (head defs').value;
-        in
-        if isList res then concatLists (getValues defs')
-        else if lessThan 1 (length defs') then
-          throw "The option `${showOption loc}' is defined multiple times, in ${showFiles (getFiles defs)}."
-        else if !isString res then
-          throw "The option `${showOption loc}' does not have a string value, in ${showFiles (getFiles defs)}."
-        else res;
-      functor = (defaultFunctor name) // { wrapped = elemType; };
-    };
-
     # Value of given type but with no merging (i.e. `uniq list`s are not concatenated).
     uniq = elemType: mkOptionType rec {
       name = "uniq";


### PR DESCRIPTION
###### Motivation for this change

`loeOf` isn't used anywhere in nixpkgs and it's broken. In particular it doesn't support element of type X:

```
$ nix-instantiate --eval -E 'with import <nixpkgs/lib>; (evalModules {
  modules = singleton { 
    options.derp = mkOption { 
      type = types.loeOf types.int;
      default = 23;
    };
  };
}).config.derp'
error: The option `derp' does not have a string value, in `<unknown-file>'.
```

The type could probably be fixed by replacing `isString` with `elemType.check`, but then, it's better to have less code, right? :) 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

