### PR TITLE
openssh: 7.5p1 -> 7.6p1

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -13,11 +13,11 @@ assert withGssapiPatches -> withKerberos;
 let
 
   # **please** update this patch when you update to a new openssh release.
-  gssapiSrc = fetchpatch {
+  gssapiPatch = fetchpatch {
     name = "openssh-gssapi.patch";
     url = "https://anonscm.debian.org/cgit/pkg-ssh/openssh.git/plain/debian"
-        + "/patches/gssapi.patch?id=db2122d97eb1ecdd8d99b7bf79b0dd2b5addfd92";
-    sha256 = "1rw10pmvjw55521ys59x1kabvbvmla506znakwwjijggdsakvsjm";
+        + "/patches/gssapi.patch?id=1e0d55f9163793742d20eaadd4784db16fd3459d";
+    sha256 = "130phj87q87p9crigd6852nnaqsqkfg09h45a32lk4524h9kkxgb";
   };
 
 in
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   # Please ensure that openssh_with_kerberos still builds when
   # bumping the version here!
   name = "openssh-${version}";
-  version = "7.5p1";
+  version = if hpnSupport then "7.5p1" else "7.6p1";
 
   src = if hpnSupport then
       fetchurl {
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     else
       fetchurl {
         url = "mirror://openbsd/OpenSSH/portable/${name}.tar.gz";
-        sha256 = "1w7rb5gbrikxdkp8w7zxnci4549gk4bw1lml01s59w5rzb2y6ilq";
+        sha256 = "08qpsb8mrzcx8wgvz9insiyvq7sbg26yj5nvl2m5n57yvppcl8x3";
       };
 
   patches =
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
       # See discussion in https://github.com/NixOS/nixpkgs/pull/16966
       ./dont_create_privsep_path.patch
     ]
-    ++ optional withGssapiPatches gssapiSrc;
+    ++ optional withGssapiPatches gssapiPatch;
 
   postPatch =
     # On Hydra this makes installation fail (sometimes?),


### PR DESCRIPTION
Release notes are available at https://www.openssh.com/txt/release-7.6.
Mostly a bugfix release, no major backwards-incompatible changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).