### PR TITLE
firefox: 55.0.3 -> 56.0.1, firefox-esr: 52.3.0esr -> 52.4.0esr [Critical security fixes]

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -6,10 +6,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "55.0.3";
+    version = "56.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "3cacc87b97871f3a8c5e97c17ef7025079cb5c81f32377d9402cdad45815ac6c4c4762c79187f1e477910161c2377c42d41de62a50b6741d5d7c1cd70e8c6416";
+      sha512 = "3aeb0ff54e10c83894f61734daa4f0801a1bb499d4667adad9c78520e588eae809d0e4d61e9227206466d62c3b453e2ce9ca8198f59f5354cd1b6804c00f0990";
     };
 
     patches =

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -32,10 +32,10 @@ rec {
 
   firefox-esr = common rec {
     pname = "firefox-esr";
-    version = "52.3.0esr";
+    version = "52.4.0esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "36da8f14b50334e36fca06e09f15583101cadd10e510268255587ea9b09b1fea918da034d6f1d439ab8c34612f6cebc409a0b8d812dddb3f997afebe64d09fe9";
+      sha512 = "be3be7f9dbf4bd0344d5d76f26d1a5090bb012154d25833d5cd58e5e707c080515b42ed751e1f7e58b15b96939d7da634cafb6e8aa9bb1627ff420836b802183";
     };
 
     meta = firefox.meta // {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -6,10 +6,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "56.0";
+    version = "56.0.1";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "3aeb0ff54e10c83894f61734daa4f0801a1bb499d4667adad9c78520e588eae809d0e4d61e9227206466d62c3b453e2ce9ca8198f59f5354cd1b6804c00f0990";
+      sha512 = "6a07de6bfb71ccdef04b0f2ced720e309d037dd89fe983178ac59ea972147360552e2b8e33d8caa476008cabf53a99003807b0e817150b7a39e0bc143d82b88f";
     };
 
     patches =

--- a/pkgs/development/libraries/icu/58.nix
+++ b/pkgs/development/libraries/icu/58.nix
@@ -1,0 +1,14 @@
+args @ { stdenv, fetchurl, fetchpatch, fixDarwinDylibNames }:
+let
+  keywordFix = fetchurl {
+    url = "http://bugs.icu-project.org/trac/changeset/39484?format=diff";
+    name = "icu-changeset-39484.diff";
+    sha256 = "0hxhpgydalyxacaaxlmaddc1sjwh65rsnpmg0j414mnblq74vmm8";
+  };
+in
+import ./base.nix {
+  version = "58.2";
+  sha256 = "036shcb3f8bm1lynhlsb4kpjm9s9c2vdiir01vg216rs2l8482ib";
+  patches = [ keywordFix ];
+  patchFlags = "-p4";
+} args

--- a/pkgs/development/libraries/icu/59.nix
+++ b/pkgs/development/libraries/icu/59.nix
@@ -1,0 +1,4 @@
+import ./base.nix {
+  version = "59.1";
+  sha256 = "1zkmbg2932ggvpgjp8pys0cj6z8bw087y8858009shkrjfpzscki";
+}

--- a/pkgs/development/libraries/icu/base.nix
+++ b/pkgs/development/libraries/icu/base.nix
@@ -1,8 +1,8 @@
+{ version, sha256, patches ? [], patchFlags ? "" }:
 { stdenv, fetchurl, fetchpatch, fixDarwinDylibNames }:
 
 let
   pname = "icu4c";
-  version = "59.1";
 in
 stdenv.mkDerivation {
   name = pname + "-" + version;
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   src = fetchurl {
     url = "http://download.icu-project.org/files/${pname}/${version}/${pname}-"
       + (stdenv.lib.replaceChars ["."] ["_"] version) + "-src.tgz";
-    sha256 = "1zkmbg2932ggvpgjp8pys0cj6z8bw087y8858009shkrjfpzscki";
+    inherit sha256;
   };
 
   outputs = [ "out" "dev" ];
@@ -24,6 +24,8 @@ stdenv.mkDerivation {
     sourceRoot=''${sourceRoot}/source
     echo Source root reset to ''${sourceRoot}
   '';
+
+  inherit patchFlags patches;
 
   preConfigure = ''
     sed -i -e "s|/bin/sh|${stdenv.shell}|" configure

--- a/pkgs/development/libraries/icu/default.nix
+++ b/pkgs/development/libraries/icu/default.nix
@@ -2,15 +2,7 @@
 
 let
   pname = "icu4c";
-  version = "58.2";
-
-  # this patch should no longer be needed in 58.3
-  # https://bugs.gentoo.org/show_bug.cgi?id=599142#c14
-  keywordFix = fetchurl {
-    url = "http://bugs.icu-project.org/trac/changeset/39484?format=diff";
-    name = "icu-changeset-39484.diff";
-    sha256 = "0hxhpgydalyxacaaxlmaddc1sjwh65rsnpmg0j414mnblq74vmm8";
-  };
+  version = "59.1";
 in
 stdenv.mkDerivation {
   name = pname + "-" + version;
@@ -18,7 +10,7 @@ stdenv.mkDerivation {
   src = fetchurl {
     url = "http://download.icu-project.org/files/${pname}/${version}/${pname}-"
       + (stdenv.lib.replaceChars ["."] ["_"] version) + "-src.tgz";
-    sha256 = "036shcb3f8bm1lynhlsb4kpjm9s9c2vdiir01vg216rs2l8482ib";
+    sha256 = "1zkmbg2932ggvpgjp8pys0cj6z8bw087y8858009shkrjfpzscki";
   };
 
   outputs = [ "out" "dev" ];
@@ -32,10 +24,6 @@ stdenv.mkDerivation {
     sourceRoot=''${sourceRoot}/source
     echo Source root reset to ''${sourceRoot}
   '';
-
-  patchFlags = "-p4";
-
-  patches = [ keywordFix ];
 
   preConfigure = ''
     sed -i -e "s|/bin/sh|${stdenv.shell}|" configure

--- a/pkgs/development/libraries/nspr/default.nix
+++ b/pkgs/development/libraries/nspr/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl
 , CoreServices ? null }:
 
-let version = "4.15"; in
+let version = "4.16"; in
 
 stdenv.mkDerivation {
   name = "nspr-${version}";
 
   src = fetchurl {
     url = "mirror://mozilla/nspr/releases/v${version}/src/nspr-${version}.tar.gz";
-    sha256 = "101dksqm1z0hzd7ap82ccbxjr48s6q3xhshdl81qkj6hqdmy1p97";
+    sha256 = "1l9wlnb9y0bzicv448jjl9kssqn044dc2qrkwzp4ll35fvch4ccv";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8634,7 +8634,10 @@ with pkgs;
 
   hyena = callPackage ../development/libraries/hyena { };
 
-  icu = callPackage ../development/libraries/icu { };
+  icu58 = callPackage ../development/libraries/icu/58.nix { };
+  icu59 = callPackage ../development/libraries/icu/59.nix { };
+
+  icu = icu59;
 
   id3lib = callPackage ../development/libraries/id3lib { };
 
@@ -14544,6 +14547,7 @@ with pkgs;
       libpng = libpng_apng;
       python = python2;
       gnused = gnused_422;
+      icu = icu59;
     };
   });
 


### PR DESCRIPTION
###### Motivation for this change

- Critical security fixes 
- Firefox Screenshots
- Address form autofill (en-US only)
- Updated Preferences
- Media opened in a background tab will not play until the tab is selected
- Improved Send Tabs feature of Sync
- Other improvements

https://www.mozilla.org/en-US/security/advisories/mfsa2017-21/
https://www.mozilla.org/en-US/firefox/56.0/releasenotes/

Firefox now uses more Rust code. It generates bindings with Clang, but it fails if `cstddef` or other headers are in non-standard directories. So I added `-cxx-isystem` and `-isystem` to `ServoBindings.toml`.

`pkg-config` script for NSS was provided as a patch, but NSS now have an official one. It still requires some `postInstall` script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

