### PR TITLE
enpass: 5.4.0.post4 ->  5.6.0

### DIFF
--- a/pkgs/tools/security/enpass/data.json
+++ b/pkgs/tools/security/enpass/data.json
@@ -1,12 +1,12 @@
 {
   "amd64": {
-    "path": "pool/main/e/enpass/enpass_5.4.0-4_amd64.deb", 
-    "sha256": "6b460fed2d7d8473e2b5d069dbe60263195b916c8b79a8fc7c2e8cb953134579", 
-    "version": "5.4.0.post4"
+    "path": "pool/main/e/enpass/enpass_5.6.0_amd64.deb", 
+    "sha256": "129ae4b4bfb8e0b4fa9acdfb3aebac3dd894364f2f31e9cd3bd5d3567e3a13b7", 
+    "version": "5.6.0"
   }, 
   "i386": {
-    "path": "pool/main/e/enpass/enpass_5.4.0-4_i386.deb", 
-    "sha256": "1ec8088d5c3b2906d6820f96e1868c473e78dbe882f04e74a7816d19d43e3692", 
-    "version": "5.4.0.post4"
+    "path": "pool/main/e/enpass/enpass_5.6.0_i386.deb", 
+    "sha256": "c456002194c0be08a2c0da68ecf224425e35c46de5292098208e4e2b1f6d88ae", 
+    "version": "5.6.0"
   }
 }


### PR DESCRIPTION
###### Motivation for this change
The file was generated with the update script that is part of the nix expressions for enpass.

Also, it seems that 5.4 has some issues with dropbox sync, this was the original rationale to look for a newer version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

