### PR TITLE
Get rid of most @rpath nonsense on Darwin

### DIFF
--- a/pkgs/applications/altcoins/go-ethereum.nix
+++ b/pkgs/applications/altcoins/go-ethereum.nix
@@ -19,14 +19,6 @@ buildGoPackage rec {
     sha256 = "1rhqnqp2d951d4084z7dc07q0my4wd5401968a0nqj030a9vgng2";
   };
 
-  # Fix cyclic referencing on Darwin
-  postInstall = stdenv.lib.optionalString (stdenv.isDarwin) ''
-    for file in $bin/bin/*; do
-      # Not all files are referencing $out/lib so consider this step non-critical
-      install_name_tool -delete_rpath $out/lib $file || true
-    done
-  '';
-
   meta = with stdenv.lib; {
     homepage = https://ethereum.github.io/go-ethereum/;
     description = "Official golang implementation of the Ethereum protocol";

--- a/pkgs/applications/networking/syncthing/inotify.nix
+++ b/pkgs/applications/networking/syncthing/inotify.nix
@@ -25,8 +25,6 @@ buildGoPackage rec {
     substitute $src/etc/linux-systemd/user/syncthing-inotify.service \
                $bin/lib/systemd/user/syncthing-inotify.service \
                --replace /usr/bin/syncthing-inotify $bin/bin/syncthing-inotify
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
-    install_name_tool -delete_rpath $out/lib -add_rpath $bin $bin/bin/syncthing-inotify
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/version-management/gogs/default.nix
+++ b/pkgs/applications/version-management/gogs/default.nix
@@ -29,9 +29,7 @@ buildGoPackage rec {
 
   outputs = [ "bin" "out" "data" ];
 
-  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
-    install_name_tool -delete_rpath $out/lib $bin/bin/gogs
-  '' + ''
+  postInstall = ''
     mkdir $data
     cp -R $src/{public,templates} $data
 

--- a/pkgs/build-support/cc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-wrapper.sh
@@ -171,11 +171,13 @@ if [ "$NIX_@infixSalt@_DONT_SET_RPATH" != 1 ]; then
         done
     done
 
-    if [ -n "${NIX_COREFOUNDATION_RPATH:-}" ]; then
-      extraAfter+=(-rpath $NIX_COREFOUNDATION_RPATH)
-    fi
 fi
 
+# This is outside the DONT_SET_RPATH branch because it's more targeted and we
+# usually want it (on Darwin) even if DONT_SET_RPATH is set.
+if [ -n "${NIX_COREFOUNDATION_RPATH:-}" ]; then
+  extraAfter+=(-rpath $NIX_COREFOUNDATION_RPATH)
+fi
 
 # Only add --build-id if this is a final link. FIXME: should build gcc
 # with --enable-linker-build-id instead?

--- a/pkgs/development/compilers/llvm/3.5/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.5/llvm.nix
@@ -33,6 +33,12 @@ in stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ ncurses zlib ];
 
+  prePatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace 'set(CMAKE_INSTALL_NAME_DIR "@rpath")' "set(CMAKE_INSTALL_NAME_DIR "$out/lib")" \
+      --replace 'set(CMAKE_INSTALL_RPATH "@executable_path/../lib")' ""
+  '';
+
   # hacky fix: created binaries need to be run before installation
   preBuild = ''
     mkdir -p $out/

--- a/pkgs/development/compilers/llvm/3.8/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.8/llvm.nix
@@ -44,7 +44,11 @@ in stdenv.mkDerivation rec {
   # 10.9. This is a temporary measure until nixpkgs darwin support is
   # updated.
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
-        sed -i 's/os_trace(\(.*\)");$/printf(\1\\n");/g' ./projects/compiler-rt/lib/sanitizer_common/sanitizer_mac.cc
+    sed -i 's/os_trace(\(.*\)");$/printf(\1\\n");/g' ./projects/compiler-rt/lib/sanitizer_common/sanitizer_mac.cc
+
+    substituteInPlace CMakeLists.txt \
+      --replace 'set(CMAKE_INSTALL_NAME_DIR "@rpath")' "set(CMAKE_INSTALL_NAME_DIR "$out/lib")" \
+      --replace 'set(CMAKE_INSTALL_RPATH "@executable_path/../lib")' ""
   '';
 
   # hacky fix: created binaries need to be run before installation
@@ -75,7 +79,6 @@ in stdenv.mkDerivation rec {
   '';
 
   postInstall = stdenv.lib.optionalString (stdenv.isDarwin && enableSharedLibraries) ''
-    install_name_tool -id $out/lib/libLLVM.dylib $out/lib/libLLVM.dylib
     ln -s $out/lib/libLLVM.dylib $out/lib/libLLVM-${version}.dylib
   '';
 

--- a/pkgs/development/compilers/llvm/3.9/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.9/llvm.nix
@@ -82,6 +82,10 @@ in stdenv.mkDerivation rec {
   + stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace ./projects/compiler-rt/cmake/config-ix.cmake \
       --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
+
+    substituteInPlace CMakeLists.txt \
+      --replace 'set(CMAKE_INSTALL_NAME_DIR "@rpath")' "set(CMAKE_INSTALL_NAME_DIR "$lib/lib")" \
+      --replace 'set(CMAKE_INSTALL_RPATH "@executable_path/../lib")' ""
   ''
   # Patch llvm-config to return correct library path based on --link-{shared,static}.
   + stdenv.lib.optionalString (enableSharedLibraries) ''
@@ -130,8 +134,6 @@ in stdenv.mkDerivation rec {
   + stdenv.lib.optionalString (stdenv.isDarwin && enableSharedLibraries) ''
     substituteInPlace "$out/lib/cmake/llvm/LLVMExports-release.cmake" \
       --replace "\''${_IMPORT_PREFIX}/lib/libLLVM.dylib" "$lib/lib/libLLVM.dylib"
-    install_name_tool -id $lib/lib/libLLVM.dylib $lib/lib/libLLVM.dylib
-    install_name_tool -change @rpath/libLLVM.dylib $lib/lib/libLLVM.dylib $out/bin/llvm-config
     ln -s $lib/lib/libLLVM.dylib $lib/lib/libLLVM-${shortVersion}.dylib
     ln -s $lib/lib/libLLVM.dylib $lib/lib/libLLVM-${version}.dylib
   '';

--- a/pkgs/development/compilers/llvm/4/llvm.nix
+++ b/pkgs/development/compilers/llvm/4/llvm.nix
@@ -58,6 +58,10 @@ in stdenv.mkDerivation rec {
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace ./projects/compiler-rt/cmake/config-ix.cmake \
       --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
+
+    substituteInPlace cmake/modules/AddLLVM.cmake \
+      --replace 'set(_install_name_dir INSTALL_NAME_DIR "@rpath")' "set(_install_name_dir INSTALL_NAME_DIR "$lib/lib")" \
+      --replace 'set(_install_rpath "@loader_path/../lib" ''${extra_libdir})' ""
   ''
   # Patch llvm-config to return correct library path based on --link-{shared,static}.
   + stdenv.lib.optionalString (enableSharedLibraries) ''
@@ -121,8 +125,6 @@ in stdenv.mkDerivation rec {
   + stdenv.lib.optionalString (stdenv.isDarwin && enableSharedLibraries) ''
     substituteInPlace "$out/lib/cmake/llvm/LLVMExports-${if debugVersion then "debug" else "release"}.cmake" \
       --replace "\''${_IMPORT_PREFIX}/lib/libLLVM.dylib" "$lib/lib/libLLVM.dylib"
-    install_name_tool -id $lib/lib/libLLVM.dylib $lib/lib/libLLVM.dylib
-    install_name_tool -change @rpath/libLLVM.dylib $lib/lib/libLLVM.dylib $out/bin/llvm-config
     ln -s $lib/lib/libLLVM.dylib $lib/lib/libLLVM-${shortVersion}.dylib
     ln -s $lib/lib/libLLVM.dylib $lib/lib/libLLVM-${release_version}.dylib
   '';

--- a/pkgs/development/tools/continuous-integration/drone/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone/default.nix
@@ -53,10 +53,6 @@ buildGoPackage rec {
     go generate github.com/drone/drone/store/datastore/ddl
   '';
 
-  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
-    install_name_tool -delete_rpath $out/lib -add_rpath $bin $bin/bin/drone
-  '';
-
   src = fetchFromGitHub {
     owner = "drone";
     repo = "drone";

--- a/pkgs/development/tools/textql/default.nix
+++ b/pkgs/development/tools/textql/default.nix
@@ -16,10 +16,6 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
-  preFixup = stdenv.lib.optionalString stdenv.isDarwin ''
-    install_name_tool -delete_rpath $out/lib $bin/bin/textql
-  '';
-
   meta = with stdenv.lib; {
     description = "Execute SQL against structured text like CSV or TSV";
     homepage = https://github.com/dinedal/textql;

--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
@@ -113,7 +113,6 @@ appleDerivation rec {
     install_name_tool \
       -id $out/lib/libresolv.9.dylib \
       -change "$resolv_libSystem" $out/lib/libSystem.dylib \
-      -delete_rpath ${libresolv}/lib \
       $out/lib/libresolv.9.dylib
     ln -s libresolv.9.dylib $out/lib/libresolv.dylib
   '';

--- a/pkgs/servers/consul/default.nix
+++ b/pkgs/servers/consul/default.nix
@@ -21,10 +21,6 @@ buildGoPackage rec {
     buildFlagsArray+=("-ldflags" "-X github.com/hashicorp/consul/version.GitDescribe=v${version} -X github.com/hashicorp/consul/version.Version=${version} -X github.com/hashicorp/consul/version.VersionPrerelease=")
   '';
 
-  preFixup = stdenv.lib.optionalString stdenv.isDarwin ''
-    install_name_tool -delete_rpath $out/lib $bin/bin/consul
-  '';
-
   meta = with stdenv.lib; {
     description = "Tool for service discovery, monitoring and configuration";
     homepage = https://www.consul.io/;

--- a/pkgs/servers/dgraph/default.nix
+++ b/pkgs/servers/dgraph/default.nix
@@ -31,14 +31,6 @@ buildGoPackage rec {
       -X github.com/dgraph-io/dgraph/cmd/dgraph/main.uiDir=$dashboard/src/assets/"
   '';
 
-  preFixup = stdenv.lib.optionalString stdenv.isDarwin ''
-    # Somehow on Darwin, $out/lib (which doesn't exist) ends up in RPATH.
-    # Removing it fixes cycle between $out and $bin
-    install_name_tool -delete_rpath $out/lib $bin/bin/dgraph
-    install_name_tool -delete_rpath $out/lib $bin/bin/dgraphloader
-    install_name_tool -delete_rpath $out/lib $bin/bin/bulkloader
-  '';
- 
   meta = {
     homepage = "https://dgraph.io/";
     description = "Fast, Distributed Graph DB";

--- a/pkgs/servers/monitoring/prometheus/node-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/node-exporter.nix
@@ -14,10 +14,6 @@ buildGoPackage rec {
     sha256 = "0rm43jjqv7crfahl973swi4warqmqnmv740cg800yvzvnlp37kl4";
   };
 
-  preFixup = stdenv.lib.optionalString stdenv.isDarwin ''
-    install_name_tool -delete_rpath $out/lib $bin/bin/node_exporter
-  '';
-
   # FIXME: megacli test fails
   doCheck = false;
 

--- a/pkgs/shells/elvish/default.nix
+++ b/pkgs/shells/elvish/default.nix
@@ -4,10 +4,6 @@ buildGoPackage rec {
   name = "elvish-${version}";
   version = "0.10";
 
-  postInstall = stdenv.lib.optionalString (stdenv.isDarwin) ''
-    install_name_tool -delete_rpath $out/lib $bin/bin/elvish
-  '';
-
   goPackagePath = "github.com/elves/elvish";
 
   src = fetchFromGitHub {

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -81,7 +81,20 @@ let
 
       setup = setupScript;
 
-      inherit preHook initialPath shell
+      # We pretty much never need rpaths on Darwin, since all library path references
+      # are absolute unless we go out of our way to make them relative (like with CF)
+      # TODO: This really wants to be in stdenv/darwin but we don't have hostPlatform
+      # there (yet?) so it goes here until then.
+      preHook = preHook+ lib.optionalString buildPlatform.isDarwin ''
+        export NIX_BUILD_DONT_SET_RPATH=1
+      '' + lib.optionalString hostPlatform.isDarwin ''
+        export NIX_DONT_SET_RPATH=1
+        export NIX_NO_SELF_RPATH=1
+      '' + lib.optionalString targetPlatform.isDarwin ''
+        export NIX_TARGET_DONT_SET_RPATH=1
+      '';
+
+      inherit initialPath shell
         defaultNativeBuildInputs defaultBuildInputs;
     }
     // lib.optionalAttrs buildPlatform.isDarwin {

--- a/pkgs/tools/filesystems/go-mtpfs/default.nix
+++ b/pkgs/tools/filesystems/go-mtpfs/default.nix
@@ -16,9 +16,5 @@ buildGoPackage rec {
     sha256 = "1jcqp9n8fd9psfsnhfj6w97yp0zmyxplsig8pyp2gqzh4lnb5fqm";
   };
 
-  preFixup = stdenv.lib.optionalString stdenv.isDarwin ''
-    install_name_tool -delete_rpath "$out/lib" $bin/bin/go-mtpfs
-  '';
-
   goDeps = ./deps.nix;
 }

--- a/pkgs/tools/misc/direnv/default.nix
+++ b/pkgs/tools/misc/direnv/default.nix
@@ -25,8 +25,6 @@ buildGoPackage rec {
     make install DESTDIR=$bin
     mkdir -p $bin/share/fish/vendor_conf.d
     echo "eval ($bin/bin/direnv hook fish)" > $bin/share/fish/vendor_conf.d/direnv.fish
-  '' + stdenv.lib.optionalString (stdenv.isDarwin) ''
-    install_name_tool -delete_rpath $out/lib $bin/bin/direnv
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/networking/assh/default.nix
+++ b/pkgs/tools/networking/assh/default.nix
@@ -9,9 +9,7 @@ buildGoPackage rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  postInstall = stdenv.lib.optionalString (stdenv.isDarwin) ''
-    install_name_tool -delete_rpath $out/lib $bin/bin/assh
-  '' + ''
+  postInstall = ''
     wrapProgram "$bin/bin/assh" \
       --prefix PATH : ${openssh}/bin
   '';

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -16,10 +16,6 @@ buildGoPackage rec {
     sha256 = "1zgvriyir2ga0p4ah9ia1sbl9ydnrnw5ggq4c1ya8gcfgn8vzdsf";
   };
 
-  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
-    install_name_tool -delete_rpath $out/lib $bin/bin/keybase
-  '';
-
   buildFlags = [ "-tags production" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/security/sudolikeaboss/default.nix
+++ b/pkgs/tools/security/sudolikeaboss/default.nix
@@ -22,10 +22,6 @@ buildGoPackage rec {
     fixDarwinDylibNames
   ];
 
-  postInstall = ''
-    install_name_tool -delete_rpath $out/lib -add_rpath $bin $bin/bin/sudolikeaboss
-  '';
-
   meta = with stdenv.lib; {
     inherit version;
     inherit (src.meta) homepage;

--- a/pkgs/tools/text/sift/default.nix
+++ b/pkgs/tools/text/sift/default.nix
@@ -16,10 +16,6 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
-  postInstall = lib.optionalString stdenv.isDarwin ''
-    install_name_tool -delete_rpath $out/lib -add_rpath $bin $bin/bin/sift
-  '';
-
   meta = with lib; {
     description = "sift is a fast and powerful alternative to grep";
     homepage = https://sift-tool.org;


### PR DESCRIPTION
This requires some small changes in the stdenv, then working around the weird choice LLVM made to hardcode `@rpath` in its install name, and then lets us remove a ton of annoying workaround hacks in many of our Go packages. With any luck this will mean less hackery going forward.

###### Motivation for this change

I got sick of seeing people getting weird rpath-related errors when packaging Go programs.

Fixes #18131

@acowley this should fix the Go issue you encountered earlier today

###### Things left to do

- [x] Test some other stuff that depends on LLVM (e.g., `rustc`) to make sure it still runs now that I took out the `rpath` install name in libLLVM. I expect it to but it might have an extraneous `rpath` load command or two in it.
- [x] Remove `rpath` crap from other LLVM versions too, since they'll probably break without the stdenv support
- [x] Rebase onto staging because this is a mass rebuild. I forgot to work off staging and was too lazy to switch over and wait another couple of hours for everything to build again
- [ ] Make sure I didn't break anything on Linux (but I'm pretty sure I didn't)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
