### PR TITLE
Safer defaults for immutable znc config

### DIFF
--- a/nixos/modules/services/networking/znc.nix
+++ b/nixos/modules/services/networking/znc.nix
@@ -379,7 +379,7 @@ in
         # If mutable, regenerate conf file every time.
         ${optionalString (!cfg.mutable) ''
           ${pkgs.coreutils}/bin/echo "znc is set to be system-managed. Now deleting old znc.conf file to be regenerated."
-          ${pkgs.coreutils}/bin/rm ${cfg.dataDir}/configs/znc.conf
+          ${pkgs.coreutils}/bin/rm -f ${cfg.dataDir}/configs/znc.conf
         ''}
 
         # Ensure essential files exist.

--- a/nixos/modules/services/networking/znc.nix
+++ b/nixos/modules/services/networking/znc.nix
@@ -379,8 +379,7 @@ in
         # If mutable, regenerate conf file every time.
         ${optionalString (!cfg.mutable) ''
           ${pkgs.coreutils}/bin/echo "znc is set to be system-managed. Now deleting old znc.conf file to be regenerated."
-          ${pkgs.coreutils}/bin/echo "You can still recover you old config from '${cfg.dataDir}/configs/znc.conf.bak'."
-          ${pkgs.coreutils}/bin/mv ${cfg.dataDir}/configs/znc.conf{,.bak}
+          ${pkgs.coreutils}/bin/rm ${cfg.dataDir}/configs/znc.conf
         ''}
 
         # Ensure essential files exist.

--- a/nixos/modules/services/networking/znc.nix
+++ b/nixos/modules/services/networking/znc.nix
@@ -329,7 +329,7 @@ in
       };
 
       mutable = mkOption {
-        default = false;
+        default = true;
         type = types.bool;
         description = ''
           Indicates whether to allow the contents of the `dataDir` directory to be changed
@@ -379,7 +379,8 @@ in
         # If mutable, regenerate conf file every time.
         ${optionalString (!cfg.mutable) ''
           ${pkgs.coreutils}/bin/echo "znc is set to be system-managed. Now deleting old znc.conf file to be regenerated."
-          ${pkgs.coreutils}/bin/rm -f ${cfg.dataDir}/configs/znc.conf
+          ${pkgs.coreutils}/bin/echo "You can still recover you old config from '${cfg.dataDir}/configs/znc.conf.bak'."
+          ${pkgs.coreutils}/bin/mv ${cfg.dataDir}/configs/znc.conf{,.bak}
         ''}
 
         # Ensure essential files exist.


### PR DESCRIPTION
I just lost all the options I configured in ZNC, because the mutable config was overwritten.
I accept any suggestions on the way to implement this, but overwriting a mutable config by default seems weird. If we want to do this, we should ensure that ZNC does not allow to edit the config via the webmin when cfg.mutable is false.

