### PR TITLE
Fix coreclr and upgrade to 2.0.0

### DIFF
--- a/pkgs/development/compilers/coreclr/default.nix
+++ b/pkgs/development/compilers/coreclr/default.nix
@@ -12,19 +12,20 @@
 , lttng-ust
 , liburcu
 , libuuid
+, libkrb5
 , ed
 , debug ? false
 }:
 
 stdenv.mkDerivation rec {
   name = "coreclr-${version}";
-  version = "1.0.4";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner  = "dotnet";
     repo   = "coreclr";
     rev    = "v${version}";
-    sha256 = "1wpig71q0kh2yrq162d32x00zlwrrs1wymkgijh49cqkn4cwkh91";
+    sha256 = "16z58ix8kmk8csfy5qsqz8z30czhrap2vb8s8vdflmbcfnq31jcw";
   };
 
   buildInputs = [
@@ -41,6 +42,7 @@ stdenv.mkDerivation rec {
     lttng-ust
     liburcu
     libuuid
+    libkrb5
     ed
   ];
 
@@ -73,7 +75,9 @@ stdenv.mkDerivation rec {
   ];
 
   buildPhase = ''
+    # set -x
     ./build.sh $BuildArch $BuildType
+    # set +x
 
     # Try to make some sensible hierarchy out of the output
     pushd bin/Product/Linux.$BuildArch.$BuildType

--- a/pkgs/development/compilers/coreclr/default.nix
+++ b/pkgs/development/compilers/coreclr/default.nix
@@ -13,7 +13,6 @@
 , liburcu
 , libuuid
 , libkrb5
-, ed
 , debug ? false
 }:
 
@@ -43,52 +42,42 @@ stdenv.mkDerivation rec {
     liburcu
     libuuid
     libkrb5
-    ed
   ];
 
   configurePhase = ''
-    patchShebangs build.sh
-    patchShebangs src/pal/tools/gen-buildsys-clang.sh
+    # override to avoid cmake running
+    patchShebangs .
   '';
 
   BuildArch = if stdenv.is64bit then "x64" else "x86";
   BuildType = if debug then "Debug" else "Release";
 
-  hardeningDisable = [ "strictoverflow" "format" ];
-  NIX_CFLAGS_COMPILE = [
-    "-Wno-error=unused-result" "-Wno-error=delete-non-virtual-dtor"
-    "-Wno-error=null-dereference"
+  hardeningDisable = [
+    "strictoverflow"
+    "format"
   ];
 
   buildPhase = ''
-    ./build.sh $BuildArch $BuildType
-
-    # Try to make some sensible hierarchy out of the output
-    pushd bin/Product/Linux.$BuildArch.$BuildType
-    mkdir lib2
-    mv *.so *.so.dbg lib2
-    mv bin lib3
-    mkdir lib4
-    mv Loader lib4
-    mv inc include
-    mv gcinfo include
-    mkdir bin
-    mkdir -p share/doc
-    mv sosdocsunix.txt share/doc
-    for f in * ; do test -f $f && mv -v $f bin; done
-    popd
+    runHook preBuild
+    ./build.sh $BuildArch Release
+    runHook postBuild
   '';
 
   installPhase = ''
-    mkdir -p $out
-    cp -rv bin/Product/Linux.$BuildArch.$BuildType/* $out
+    runHook preInstall
+    mkdir -p $out/share/dotnet $out/bin
+    cp -r bin/Product/Linux.$BuildArch.$BuildType/* $out/share/dotnet
+    for cmd in coreconsole corerun createdump crossgen ilasm ildasm mcs superpmi; do
+      ln -s $out/share/dotnet/$cmd $out/bin/$cmd
+    done
+    runHook postInstall
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://dotnet.github.io/core/;
     description = ".NET is a general purpose development platform";
     platforms = [ "x86_64-linux" ];
-    maintainers = with stdenv.lib.maintainers; [ obadz ];
-    license = stdenv.lib.licenses.mit;
+    maintainers = with maintainers; [ obadz ];
+    license = licenses.mit;
   };
 }

--- a/pkgs/development/compilers/coreclr/default.nix
+++ b/pkgs/development/compilers/coreclr/default.nix
@@ -47,22 +47,8 @@ stdenv.mkDerivation rec {
   ];
 
   configurePhase = ''
-    # Prevent clang-3.5 (rather than just clang) from being selected as the compiler as that's
-    # not wrapped
-    # substituteInPlace src/pal/tools/gen-buildsys-clang.sh --replace "which \"clang-\$" "which \"clang-DoNotFindThisOne\$"
-
     patchShebangs build.sh
     patchShebangs src/pal/tools/gen-buildsys-clang.sh
-
-    # See https://github.com/dotnet/coreclr/issues/7573#issuecomment-253081323
-    ed -v ./src/pal/src/include/pal/palinternal.h << EOF
-    /^#undef memcpy
-    -1
-    d
-    +1
-    d
-    w
-    EOF
   '';
 
   BuildArch = if stdenv.is64bit then "x64" else "x86";

--- a/pkgs/development/compilers/coreclr/default.nix
+++ b/pkgs/development/compilers/coreclr/default.nix
@@ -61,9 +61,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildPhase = ''
-    # set -x
     ./build.sh $BuildArch $BuildType
-    # set +x
 
     # Try to make some sensible hierarchy out of the output
     pushd bin/Product/Linux.$BuildArch.$BuildType
@@ -92,6 +90,5 @@ stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
     maintainers = with stdenv.lib.maintainers; [ obadz ];
     license = stdenv.lib.licenses.mit;
-    broken = true; # CoreCLR has proven to be very difficult to package. PRs welcome if someone wants to shave that yak.
   };
 }

--- a/pkgs/development/compilers/coreclr/default.nix
+++ b/pkgs/development/compilers/coreclr/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     homepage = http://dotnet.github.io/core/;
     description = ".NET is a general purpose development platform";
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ obadz ];
+    maintainers = with maintainers; [ kuznero ];
     license = licenses.mit;
   };
 }

--- a/pkgs/development/compilers/coreclr/default.nix
+++ b/pkgs/development/compilers/coreclr/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     runHook preBuild
-    ./build.sh $BuildArch Release
+    ./build.sh $BuildArch $BuildType
     runHook postBuild
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13177,7 +13177,9 @@ with pkgs;
 
   comic-relief = callPackage ../data/fonts/comic-relief {};
 
-  coreclr = callPackage ../development/compilers/coreclr { };
+  coreclr = callPackage ../development/compilers/coreclr {
+    debug = config.coreclr.debug or false;
+  };
 
   corefonts = callPackage ../data/fonts/corefonts { };
 


### PR DESCRIPTION
###### Motivation for this change

Fix coreclr package currently marked as broken. In addition upgrade it to latest and greatest 2.0.0. Related to issue #25498. Ping @obadz @copumpkin, @janvorli.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

