### PR TITLE
u3-tool: init at 0.3

### DIFF
--- a/pkgs/tools/filesystems/u3-tool/default.nix
+++ b/pkgs/tools/filesystems/u3-tool/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "u3-tool";
+  version = "0.3";
+  name = "${pname}-${version}";
+
+  enableParallelBuilding = true;
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/${name}.tar.gz";
+    sha256 = "1p9c9kibd1pdbdfa0nd0i3n7bvzi3xg0chm38jg3xfl8gsn0390f";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Tool for controlling the special features of a 'U3 smart drive' USB Flash disk";
+    homepage = https://sourceforge.net/projects/u3-tool/ ;
+    license = licenses.gpl2;
+    platforms = with platforms; linux;
+    maintainers = with maintainers; [ makefu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1446,6 +1446,8 @@ with pkgs;
 
   cuetools = callPackage ../tools/cd-dvd/cuetools { };
 
+  u3-tool = callPackage ../tools/filesystems/u3-tool { };
+
   unifdef = callPackage ../development/tools/misc/unifdef { };
 
   unionfs-fuse = callPackage ../tools/filesystems/unionfs-fuse { };


### PR DESCRIPTION
###### Motivation for this change

add u3-tool for managing u3-enabled usbsticks

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [NA] macOS
   - [ ] Linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

