### PR TITLE
make-wrapper: add `--no-assert` to skip assertExecutable()

### DIFF
--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -11,6 +11,7 @@ assertExecutable() {
 # makeWrapper EXECUTABLE ARGS
 
 # ARGS:
+# --no-assert       : skip assertion that the file is readable/exists/is executable
 # --argv0 NAME      : set name of executed process to NAME
 #                     (otherwise it’s called …-wrapped)
 # --set   VAR VAL   : add VAR with value VAL to the executable’s environment
@@ -33,7 +34,9 @@ makeWrapper() {
     local params varName value command separator n fileNames
     local argv0 flagsBefore flags
 
-    assertExecutable "$original"
+    if ! [[ "${@}" == *"--no-assert"* ]]; then
+      assertExecutable "$original"
+    fi
 
     mkdir -p "$(dirname "$wrapper")"
 
@@ -95,6 +98,8 @@ makeWrapper() {
         elif [[ "$p" == "--argv0" ]]; then
             argv0="${params[$((n + 1))]}"
             n=$((n + 1))
+        elif [[ "$p" == "--no-assert" ]]; then
+            : # processed previously
         else
             die "makeWrapper doesn't understand the arg $p"
         fi
@@ -131,7 +136,9 @@ wrapProgram() {
     local prog="$1"
     local hidden
 
-    assertExecutable "$prog"
+    if ! [[ "${@}" == *"--no-assert"* ]]; then
+      assertExecutable "$prog"
+    fi
 
     hidden="$(dirname "$prog")/.$(basename "$prog")"-wrapped
     while [ -e "$hidden" ]; do


### PR DESCRIPTION
###### Motivation for this change
This allows to disable the assertion introduced in #24944.
The assertion prevents from wrapping a file that is not accessible in the sandbox, which is too restrictive for development environments, e.g. when wrapping a script that is somewhere in $HOME.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

