### PR TITLE
bloaty: 2016-12-28 -> 2017-10-05

### DIFF
--- a/pkgs/development/tools/bloaty/default.nix
+++ b/pkgs/development/tools/bloaty/default.nix
@@ -1,21 +1,30 @@
-{ stdenv, binutils, fetchgit }:
+{ stdenv, binutils, cmake, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "2016.12.28";
+  version = "2017-10-05";
   name = "bloaty-${version}";
 
-  src = fetchgit {
-    url = "https://github.com/google/bloaty.git";
-    rev = "2234386bcee7297dfa1b6d8a5d20f95ea4ed9bb0";
-    sha256 = "0cfsjgbp9r16d6qi8v4k609bbhjff4vhdiapfkhr34z1cik1md4l";
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "bloaty";
+    rev = "e47b21b01ceecf001e1965e9da249d48d86a1749";
+    sha256 = "1il3z49hi0b07agjwr5fg1wzysfxsamfv1snvlp33vrlyl1m7cbm";
     fetchSubmodules = true;
   };
 
+  nativeBuildInputs = [ cmake ];
+
   enableParallelBuilding = true;
 
-  configurePhase = ''
-    sed -i 's,c++filt,${binutils}/bin/c++filt,' src/bloaty.cc
+  preConfigure = ''
+    substituteInPlace src/bloaty.cc \
+      --replace "c++filt" \
+                "${stdenv.lib.getBin binutils}/bin/c++filt"
   '';
+
+  doCheck = true;
+
+  checkPhase = "ctest";
 
   installPhase = ''
     install -Dm755 {.,$out/bin}/bloaty


### PR DESCRIPTION
* use fetchFromGitHub now that it supports submodules
* change version style to dashes per guidelines
  (https://nixos.org/nixpkgs/manual/#sec-package-naming)
* cmake
* prefer substituteInPlace
* run tests

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

