### PR TITLE
postgresql: add version 10.0

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -114,4 +114,10 @@ in {
     sha256 = "0k3ls2x182jz6djjiqj9kycddabdl2gk1y1ajq1vipnxwfki5nh6";
   };
 
+  postgresql100 = common {
+    version = "10.0";
+    psqlSchema = "10";
+    sha256 = "1lbzwpmdxmk5bh0ix0rn72qbd52dq5cb55nzajscb0bvwa95abvi";
+  };
+
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11778,7 +11778,8 @@ with pkgs;
     postgresql93
     postgresql94
     postgresql95
-    postgresql96;
+    postgresql96
+    postgresql100;
 
   postgresql_jdbc = callPackage ../servers/sql/postgresql/jdbc { };
 


### PR DESCRIPTION
See: https://www.postgresql.org/docs/current/static/release-10.html

The test succeeds: `nix-build nixos/release.nix -A tests.postgresql.postgresql100`

It feels a bit weird calling the attribute `postgresql100` but it's consistent with the other attributes like `postgresql96`. It might be better calling it `postgresql10_0` but then we should rename (or add aliases for) the other attributes like `postgresql9_6`. Of course we can always do this later...