### PR TITLE
flat-plat: 20170917 -> 20171005 and renamed to materia-theme

### DIFF
--- a/pkgs/misc/themes/materia-theme/default.nix
+++ b/pkgs/misc/themes/materia-theme/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, gnome3, libxml2, gtk-engine-murrine, gdk_pixbuf, librsvg }:
 
 stdenv.mkDerivation rec {
-  name = "flat-plat-gtk-theme-${version}";
-  version = "20170917";
+  name = "materia-theme-${version}";
+  version = "20171005";
 
   src = fetchFromGitHub {
     owner = "nana-4";
-    repo = "Flat-Plat";
+    repo = "materia-theme";
     rev = "v${version}";
-    sha256 = "17r4wl27yx49xg0l3s5d67174r63p4cw6cbdmzl81if7iab69hv0";
+    sha256 = "0znm7mx2nv2sgvy8fyams1ckp1ly3nbbs0k09d24w1zzd90xhzqp";
   };
 
   nativeBuildInputs = [ gnome3.glib libxml2 ];
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A Material Design-like theme for GTK+ based desktop environments";
-    homepage = https://github.com/nana-4/Flat-Plat;
+    description = "A Material Design-like theme for GNOME/GTK+ based desktop environments (formerly Flat-Plat)";
+    homepage = https://github.com/nana-4/materia-theme;
     license = licenses.gpl2;
     platforms = platforms.all;
     maintainers = [ maintainers.mounium ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18994,8 +18994,6 @@ with pkgs;
 
   fceux = callPackage ../misc/emulators/fceux { };
 
-  flat-plat = callPackage ../misc/themes/flat-plat { };
-
   flockit = callPackage ../tools/backup/flockit { };
 
   foldingathome = callPackage ../misc/foldingathome { };
@@ -19077,6 +19075,9 @@ with pkgs;
   mailcore2 = callPackage ../development/libraries/mailcore2 { };
 
   martyr = callPackage ../development/libraries/martyr { };
+
+  # previously known as flat-plat
+  materia-theme = callPackage ../misc/themes/materia-theme { };
 
   mess = callPackage ../misc/emulators/mess {
     inherit (pkgs.gnome2) GConf;


### PR DESCRIPTION
###### Motivation for this change

- The package has been renamed upstream to *materia-theme*
- Update to version 20171005.
- [Release notes](https://github.com/nana-4/materia-theme/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).