### PR TITLE
qtcreator: 4.4.0 -> 4.4.1

### DIFF
--- a/pkgs/development/qtcreator/default.nix
+++ b/pkgs/development/qtcreator/default.nix
@@ -7,7 +7,7 @@ with stdenv.lib;
 
 let
   baseVersion = "4.4";
-  revision = "0";
+  revision = "1";
 in
 
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://download.qt-project.org/official_releases/qtcreator/${baseVersion}/${version}/qt-creator-opensource-src-${version}.tar.xz";
-    sha256 = "00k2bb2pamqlq0i619wz8chii8yp884qnrjngzzxrdffk05d95wc";
+    sha256 = "0kn1k2zvc93xin4kdp2fpiz21i5j0qymyx6jjzkqp7r3x8yxwr06";
   };
 
   buildInputs = [ qtbase qtscript qtquickcontrols qtdeclarative ];


### PR DESCRIPTION
###### Motivation for this change

Update to version [4.4.1](https://blog.qt.io/blog/2017/10/06/qt-creator-4-4-1-released/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).