### PR TITLE
 thunderbird: 52.3.0 -> 52.4.0 

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,595 +1,595 @@
 {
-  version = "52.3.0";
+  version = "52.4.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/ar/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ar/thunderbird-52.4.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "55c80c62ad45ece24f90b99a994d35aa130e2a42be5512e6efcebbcf66a6b26905cd28a42944bddc1b1c0c6ba9c488331c88ff478983c8ff8ab61c3fa7c6d234";
+      sha512 = "28a0114c665250f419d77f1f3898af6533e1b8b82b546ecd3ca9baf801751fd189239093eaecdabab9a9318fd47020b647086a31676158a21656ff7c477dbbf8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/ast/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ast/thunderbird-52.4.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "714006603d091000b777130c45bfb5a0e4e2ed3c782d7bf17c1244d4c860a13dc0be58adaf447307149a2a5da90a1a08c3aac0a598c764d2bd491eef5c161c1e";
+      sha512 = "f7b9d53202597ef666ca87eb1f8cbb439af386eb78460558e8bef33502a7eac591d43751beb52319d046d780fb38a78e685fa8cb3baaa6abfef439bed6ab3d1a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/be/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/be/thunderbird-52.4.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "be529be10ab41deab394e8a2b18f5247e64dd00fccb16cd3f95924baf0a9f1924a05f1fea97346ea171d416d44b4cdb9e5d38ea678ad1f64912aac0224f4ee63";
+      sha512 = "a9a39cf4477e469774f2ce7b7012948911009ff2ab26948a177f3efa9e8ccbcb7d7f3d3ab609742fe1d177253dcdeacb78f7b4a9874f3156f6f54203d0ed42ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/bg/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/bg/thunderbird-52.4.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "4726efa8ca6b72fea6acec1f8c0aec6b208f495b3dfaa68d6e26797f4998c5e3150e4e3b725e0042dc953c7b9d88c97468fa03e382b636b057c8dd451126710c";
+      sha512 = "38fc89a687344467f98cb2e31967aa53f3c502a8f288b5d65e6aa91a578b250c17750ea998d32d58511920a0a5a1224e77e2691a381b7526585e341712d82cbd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/bn-BD/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/bn-BD/thunderbird-52.4.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "d0f16014b3dce0b6de06233038a8585ee6a8ec2b7a45ae406dbb71370d931bdd51100d1d68ce29ddd2329efb6eed033d1856ddf29b6515484247e6f11c4f7dd7";
+      sha512 = "437d943339c4955b5264f95bdd4aaa2a91d448a393e6561bbb41c078a960100962c1d51bad73172c5f5cd691f713ab34c218ff5c3e3cde3641d8a6ad604f6d75";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/br/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/br/thunderbird-52.4.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "c52c416dda11dd69e78a7ace3d6309b1cc8327adaac74cf831af42b75bf4da9dabec50771014189128dec79487d224f0ad6e9c335a5343c75bf54f828829058d";
+      sha512 = "5c43e3cc4366792b7c7a44ae36fe2bd9e6b459f540868dcee767193826648b03a4e4a447f83f5787036e48c96e75639a305304e050a91f0925d9ee4db97e5b75";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/ca/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ca/thunderbird-52.4.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "d0ab90bd0262476565ac48d597c699529cdfa2d4773397f1a458f7d97989b982bd9dc34c2a689d03a1a0f67c53d67ff86af1010bb0e5db55f61bfc68db96011b";
+      sha512 = "c2243ee5f160f786ebced364432b4a3b489699a3f024a8da327cfaa3c5e2d0d58884870311416fcb019723d5bfec8294440c701c6c453c15346f5f765c4449c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/cs/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/cs/thunderbird-52.4.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "ae3e3c12f0e75b449ea6d6d24858bf6036e9db8b7d6a08156d5a9026cbdb53d736a1b459109cc6dddae3d0d6c08856e829beabc8a53c20ba8741cfc0c18d395f";
+      sha512 = "332faf549d1d988defdce1531fb4cc81e5f1565423f3e24ebfe16581275224539ed50857dec04c8aa66cc55372a76b676816831d08842bbafd227ca3058f9b5b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/cy/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/cy/thunderbird-52.4.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "c6ff55856517ed5b99ad30e649b1ac31d7d529706eb8154eb235817f4b168331e57e845d6648e2bcea574b3233587cadb63c118614598e0dcfabe3ae3d5370b1";
+      sha512 = "bfe220ed1e1d8d156f0c1cf7ea11b0778bc0b23f7335b90c65bf581c9e2cd22db9a7f5d48d7a6a95f1d21693714a216d2a24249f36aed7ce097f205d4d05d6f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/da/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/da/thunderbird-52.4.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "c0bff66366fcd9b7c62c352dbd25bec95a444b3bcc513598ec834191e7eef47a07cd0ab6a72dbe7b9f14dd323c085f4b8bb4b31ac0f2536d08b08d1c86693bb6";
+      sha512 = "dcff4359821cb6b24ba129671a1716394afd642a5c4b887a1905baf82cf5d2a94512a547780cd42b1478f443f59db5a3363a52d719824af050dd69af54f97a02";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/de/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/de/thunderbird-52.4.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "010b56755f7107e32df25481a2febc7d0468bd27a6ec5521af32d80382c96653a2989a70e2dd7350452ebfb25f5691a161ff5fd74228b9b3670475942f7b0f6b";
+      sha512 = "f5071c052814eab801f3d2c98751c05486b211f23b511b27a1ad5810634b763ada3bd890288e4934c16a28742ef023ef089de9d84a188f6e19d07f471b289583";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/dsb/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/dsb/thunderbird-52.4.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "735d07ecbbff46b242a103676fb8190e082fe71f8a64f19f82f18a42dae50328cd4e473bd06722a20521cbce50afceb24b61d144b4ebdd1cb83a8ff3b041530a";
+      sha512 = "522d365f32b28620a7936cf5a8fb230db6fee8c1ae055a27e6649cff8559811684168eacf019ec16d6268e405607a576d46e1d5ba4759c1e3fd10736d7560370";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/el/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/el/thunderbird-52.4.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "29361a698dab6b4d3f369393ec4c06797c1a37fe4bbce8b48f0f5216225fb26125b4f0c814255c0c964a24fb37c2865dce64197d1584385c01f0e655947d9884";
+      sha512 = "ecf3dcadb1a82310494063cc317ee248b91c30594ba89a9c58a71349a423cf9e66c5bd06be4d1488ee6cd5027187bae1364144037b9ac3cd4bc8af7cd4396810";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/en-GB/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/en-GB/thunderbird-52.4.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "8d3fc25a21aa2f38089bbfa8013104de0c6c6e95407289ecc82f5c003e732d51bf160106dff07b202d6a6d0fee989a08e75bf616cd98ac1b080605b631c2be69";
+      sha512 = "8ddde6cd0270cffc26cdb4c4513213405b71ea4315d69a3b1bef602bbd58eca30bc09d0ddd41996cd77881e2d678dd13a93d07fa833210780dba146a931db383";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/en-US/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/en-US/thunderbird-52.4.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "ce05330aa7032f0cae542578cb49f7e8bbc7971be455817126bc77212ebd35ec701691ed91758e7c5b663f4731ed19c2864728908816e71023be36d13ba98bfb";
+      sha512 = "edf130b3b061f15137e6eb83c9674642f0f475de56b293d4acde60f1e7ebcf0d262085fa2a513787ac201ceec5552c029167cec5ad0556baa7b0dd3b52ae4c3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/es-AR/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/es-AR/thunderbird-52.4.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "52058cd4b0eaa68756fd7b7ffa294fe0720a876fe176199cc67892b3d33615a92238c4fc90ce7cf9b70b3a57f3272ca7bdab8499b3d6d864775e97ab2f91c68a";
+      sha512 = "931644cbf5e7b4f032f607a52a78f553a7a2ee8fc77fb7d0e73e6d276a6a1ba4a724cc91921c5ef5ac5ad21a3536ffbff264b80eb8d8a658133a24ca0b869456";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/es-ES/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/es-ES/thunderbird-52.4.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "f447cfcf7c4febbe5244f5004e2b6a19bd03a7dc1cac5b609af8726bf9cd915e1ca2ff81aac65ac62386390b28aa1d3a6f2283d8c479b4d97c6df34e54918544";
+      sha512 = "c2673d9f6b347493e3fc807cec86f55300a6e894c9c1edd7f7bec63cb073fdda2e9cf7794269f02f744280788bbcb8e42ee6249c317aabc57f91cbaa3635492f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/et/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/et/thunderbird-52.4.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "46744b2d6cd187ae58967e1be2962ae7cc4e3d4a32d195767777634d4c8b9843979896524ec90a00fe8bb1d367c7ae9d540da5705a9529d0126a165b4b7148d4";
+      sha512 = "dd634f76848fb990b4fb1bd28e2cceafca651280ece9ead3aad6b9746d0eaeef76b5ad925163a68367d84f66949e799e2649cf358ad0949ee4f2538c71b8914b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/eu/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/eu/thunderbird-52.4.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "c00558d88e6f8d9e89dc5717d677caa2a1bcb319a06b03f20e951b94d8dd79bb6d2d8875dde07f59be344330a8b36db00d0c57c7542877207f344e25dda91488";
+      sha512 = "1c9f04cc1b32ffb21bfacb186f327aa945f36f12ae316a9cff8b2a4f8584ff8847ac5be1c8bd898ea1a71fbf3294a2f54b270eb6f0b63abb3da3178c6a125600";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/fi/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/fi/thunderbird-52.4.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "668d7f4793fa0c700b1abb75f185a26b9734da8f9d9faf327ad08503802017e93726de3124818650099570de58650709f3886dc6d8af24731d83c16486a54acd";
+      sha512 = "03880d8334ede087a419443e9fb56bcf6727c652f435a366b4b49fb6116a62225686297ba82f298378e03267dc1aa50e90d75b81ea277a7afeb93331c45c3459";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/fr/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/fr/thunderbird-52.4.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "aabeea2843ac8c126c53d862054b27263b03f65f3ba848445a55615ef7e6f972792b2e634133877cbeeabd74e455a2b47d36ff76e5a4162fb7caeac3856f10d1";
+      sha512 = "6f9909df3329a32d6d0c2203b484fdaa8b54a17849283bffcb04298601a284a6fe30eac20ec6b3a97ad2e8e3d4e0360c6145e87baa2af11049ae0d94fe9dcd44";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/fy-NL/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/fy-NL/thunderbird-52.4.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "a0e1132009e63654dc5fdde6989f758c88ce02327dc4b2e870c925886fd350867ee78958095743b582bfa77af4f2f80a497980cb3e5308dac47bcdeef88c493e";
+      sha512 = "b20f130ad4a9b0f8448707945773cc76198e04854a0114a06379fd33c3d5abd9abb1f14e4f145df9c1c46e5d1e09522af640ded99f4f20543fd444e365d81fb9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/ga-IE/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ga-IE/thunderbird-52.4.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "ff43e823765ec9354edc3c0009ec5a2e004e31c01602b875f538b01957bb4953e15f8a60c4ea5695af6e541566d21e4d4ea7ef4d8d3464f4dd59072269cc2eec";
+      sha512 = "3fd6839351470d65f14165e3633c80950270ede2c4c9e658c001424126ffbf29c7bde86a720ca33e50cbe9a5306f0339c5cd491371e3ad03a6ee575c75889d63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/gd/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/gd/thunderbird-52.4.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "d2f1c25cef09c4e3946050af1bfadb3f8ee70bea6c9ac2d8c25e2f422a160c3cabd76373679b4fefdfe838722f69e4ce138c50c03de221c31e71878d66377d22";
+      sha512 = "a7aae188c866586606f9adb82d5110bc2b89a6bd757191e798b9b2dc799916ae56cbc82932f4b8da76e88a3c1f5ffc828c58aee0cd8f83ede19bde2be2164b79";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/gl/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/gl/thunderbird-52.4.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "3ef058fa97459f41f204ea80393f27a0b572039bec4a49eef80db0402579620e28acda8613adbfe6c2cc267386a5cdb8d95fac4dfff2358a9bf4ba22a1bc24c5";
+      sha512 = "3cdab0c553f1d09cdb4dfd1160371eec3d1f878329dcf2f81a177f17647f8dd9b73566a56427d2a593f70f6aecfec951e3dfc2a389c838a4069e5f4db68c10eb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/he/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/he/thunderbird-52.4.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "b54188bf2ba0e2e6470db0a938c77710c66e1b1d359be2ae3f306a7a2ecf34501f797baf9348609c63fdc68d1374382855509ccfe619c444150a4214ee819bf2";
+      sha512 = "b71593a5c7cf8fe3960c701f5bce270366f5717b7ccd2a5f20dcdf402d1435b79db06662629deb4bd28e24b251fd2fa1a71a9e932f132e2df7a25ab5a8849de3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/hr/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/hr/thunderbird-52.4.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "bc5ca4099fa6d5f7884f7fefb1942aecac4aa6cdc338d8608433f3aca9ce14c8838e68aa79e48e88b453498d5d0b992a583daf6abf6f97bb4cda5d7ffdcf8194";
+      sha512 = "d55deeebb9605565ae3c062c8617d7e351f2f514c13f00507d75a5da4ef8e8d845247147d2aa111d4e78c57ceb01404ed3ac2bb69883bddab7b59ce0ff5eff35";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/hsb/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/hsb/thunderbird-52.4.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "5b8c7468fd777d9a4f046224ad516a740fd4acabc5dd30578dfc843f772dc1d0f08b4fb257db7d4d39d58eeb6468126ddd9267c1562e8ee7d23f07e02e4babbe";
+      sha512 = "c177a0e3c6074eef1abf086fa34e95b09f39a1529ce640927b7be6ee8b7ee8c740ba4e2afbadefe3fa83314cb7c3223499b1a5f08e3b4e381b60bee1ffbdac7c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/hu/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/hu/thunderbird-52.4.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "3dfb629b804513e40852d810ce5ed3e0af0cd8c7bb92a44dc6c08f2e3a45de45d2c3ccb75616a9f9d7019a8ce9b4856e27baa283647eb63e953071fd410dd418";
+      sha512 = "1442a03fa4367d1f33337d0e88a193de8a6992ab8aa91e28e4a46b8f1860a3cc346d15c00d745b5074b8dec1beca5dba182b5fe2e87827e7ea83b82aba28b721";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/hy-AM/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/hy-AM/thunderbird-52.4.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "4dfc61099b3f8502add36f3b215283140b8084504048d95ac31b948cb8e53fca658076fc7164cd2c20742edafb8f7ad5e08f2cdcb8c9cc764573e2e065364b20";
+      sha512 = "c01325976516765a14a196ff04eb3296a2dfd81670cbf4d693682e78795b14b54f4d2801566f0ccd52c52f0b7100b6040f4e3540c4f3cb8c8b92038e059df45d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/id/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/id/thunderbird-52.4.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "5525d0507fbf7c7503b9a58c50ec248932e70d899ff88c1b8cdb18484d3cf4ce76fa1121a7cb5adfa3c19e1c83ecc5e888d652275400a2f92dce3e0fdbe51353";
+      sha512 = "db56686b1d8713da9584e03633bcb2b14706c0b44d24484d6625de638eddcbdad1b1afacecf7dba52db6d18b2bbaaa15ea5f4d492366c24c5e2e212050f16c12";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/is/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/is/thunderbird-52.4.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "1fe92018d666ccfe1bf063dd191d88f3c9fbd452e7820065e45b79de534baad9d8750d4cefbc39902d49d532fd5500f4b3a167ddd7dcec61677f490daad01d9e";
+      sha512 = "5423202ebccaddd114393e5a2038b2efbe93fd528dc3d7b659987ab5aa2a4ad82921b3b835249285135be67216eed03de6d58b72800d9c7bf87ec812a37f21ab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/it/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/it/thunderbird-52.4.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "80d6036462d74bb180b0f3d4d384be3b644dda9b3fc008a8d63478ec877462defc88b6f3dc2eb2358489956ef20e057975fbff9f7cf5afd0d894926e617d3225";
+      sha512 = "b64e31155c73f13cd84bb4488e63df5c95473957c792f63f8cf25308d2b860b084aa6beb519a7666fde83d3db25e28ffb1064ddd0abca73ff631924cfa83d7f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/ja/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ja/thunderbird-52.4.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "d1185fda652104759bc84a095b289ccf6a3721425d60c8f0781578eaf113349de9fca18dd1138f73dd13081ea5388d0f04fd0cfb47142236c1354a167d0362d9";
+      sha512 = "8852c526663f69b038ded6bb1382e02de700eab741cb04ccb8d3e329ee4534477a6ea402134a76fe82a020bad279c66e70bc06b0ed8d0fbaea9aaeaafa051b44";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/kab/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/kab/thunderbird-52.4.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "4bb2184a4a968f6b33c29fab44b11f06743f88b8ecb8d83e5a892c608a03dbe3f643c2e8b5a5fc9ef844801b8bfc2891c9bbbbb306b94698bac5441051c22783";
+      sha512 = "b08dc52afb713142e11805c5b99f73a11bd3c16756dc5bbb6a0c3de13cc801f27438887d8733cf4b97d70d4741abcb0d8782b9e6f6ffc359f38318f1702fcb7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/ko/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ko/thunderbird-52.4.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "49dc08f3a98205e433e81c9bdbeab3f6ed7dca5f3df9af1b6a01470dcfb1a3fb72ce3447ead492fd8f0d49dfcf9028194c94a4cc6e20b1b4c28c64a706975615";
+      sha512 = "0de39397e4401ad939dbce0c02e35505c593398bc2078ad19d680a797a8cfa3f0950a810c8650634e3d40ea3b5265f9e193b77408f1588b51575d87446a336c9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/lt/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/lt/thunderbird-52.4.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "e8b35d834e122dce0b9996060b7582a5b2c0bcd06e1ee7a4b12298bc4aa501ab18bc140fe0f0e2fd63ffad97ec9d287d1614ed76718525c86296ad1167658f9a";
+      sha512 = "13842d9f210dd192e2072c138d8d0778e85d028dde92b08e616dff6ba62f84b6aa36363a259dca69bb006850de2fb8c42fd93874a4befa970d817aad34d47b57";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/nb-NO/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/nb-NO/thunderbird-52.4.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "5efba8423c744c61be72d679e4943e901488984415cbdae9533ef5a26010d0ba072f107cf8a53389f831559e8093b35c01f6eddc76b8a361f60af8166c781207";
+      sha512 = "ec9c96abe94ac17139e9fa83ac2d7ca8ddc6889e7286a4d31e61625db6daea3969fcbaa0796ae0bea41e3a433ed3e170a73c4be1a177bedcbfcf705e306e28e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/nl/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/nl/thunderbird-52.4.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "b4c6c95cf6df97ffc65d03f04af7221d819ec28b464fcb8173beebb9d810af9b78f64b39e0750d11446ff88a209677512f3735d8f38ebe91ab9842abbf183e65";
+      sha512 = "52e117078f1871bfc7b549a47617d277c763267f7033136c9715223d8f876184c0b5012b193a5f497e1fdba78b902a3c38651e0115829b0f5ca7f0cbb1c439d3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/nn-NO/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/nn-NO/thunderbird-52.4.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "3bc0ea3e17a1161345d4c1313c774a312e591248f07be7c11d9b6c738aea2d91aeee202f2a67ad38df9fda43f5f853aa162990475dcf9248667fc546370b4083";
+      sha512 = "24258bbf5e3643544ba5db26fab9678f7e2a44b390ee993be4a304d148b5a57674158afd308d6ef93a86c8e525b37e1aee55ed07be6953301f164a2da00688d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/pa-IN/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/pa-IN/thunderbird-52.4.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "2fef099c73db55dd082f4a9e207ff47096870caef6ef4e9346c7faf3e40dab4d3b0e1e68d1a9dd7a427d97ae65aa347976641aef1872a4c7a6764e8a8c2cfe5b";
+      sha512 = "e9d8b4e6019d4cf1ce562e6cc9b9aeac0e93d8b9ac9283c7e8f260b4d611fe2bd0bf6d71c9f82c9d2cbfba5770659d21cfb03fc2deb36b80be0a424178a65936";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/pl/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/pl/thunderbird-52.4.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "f523fd0d1b1656e80b52dcd8d2f52f7403c22f46eeea850c75c78fb3c1903ba4edc44ae69db755c0a105379855c0c9c33f149fb83d8016a182a32cd5bbea113f";
+      sha512 = "81ced2424282fe6dc7ca6f5e043f6c42ae87cddef900b73fddfe6cd8c488a90e3099824b57d0971816a60c3f43ce66e1799195ae21369958b2e8085018017267";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/pt-BR/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/pt-BR/thunderbird-52.4.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "6428f601375bc877def880aef3ff6b8ff4856696a2040381ca22c60df8e1364cef12e1c878db6b7863d10f8cb02143c06cc58d5df6cc83d1c25e90c846be3fc4";
+      sha512 = "4120b94c13a9fcf1aa31a2abc3fdde27ef8c0354550ae8511b61641745cdd5eaec16e1ddd1d22193ca6680f070b71c188d94cdc75a40fa1596fa88ed59545b28";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/pt-PT/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/pt-PT/thunderbird-52.4.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "6dc2fed4b003f4f120c79a0673d9d7455c0b6362dadc06e15ff612a29758c521d87cea073ca0b81018e57872e6262a09c5efc6e9fdf7b494c152ae4e992260de";
+      sha512 = "a89dd739da5262713c99aa9aa28544e48710e80b83770810b240681ff0546c3b3faa37b48ae56c018a6d1d625f0411df557ced12eddfb3a1198eea474418eb68";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/rm/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/rm/thunderbird-52.4.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "b22bcdbe338fec3267f352ec5554b8e5bd732961917496c6d06a6eef188cabe337bf3fcaac1afce49cd16c891fe7604fa77c13b3eedc7706b262957d5d01171f";
+      sha512 = "3665bad7a0d1f2d725d0a44ad55918228c2d9cef49112fb19d2c3d885d1ec62af89c15aa0ce96ddebdabf97c8a5e10fdd58d892c085e5b9d17bab6658e7bf444";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/ro/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ro/thunderbird-52.4.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "cd2f67456fcd20ed48effa2363f4088e48d91f93df66e803527e83a3f8f2f3a74ba22fc0d5c4ef736bc38ad6a6416830833948210ee900600bc36ebde81a9976";
+      sha512 = "07afa28b22705e0e84e17026d04111cb9a5283838fcb94225e2c05da1fa0692770b17052c52d8cfcdb7bd3372fdbba9cd9ed9bc16f6f59f2e3ab6f4308543d91";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/ru/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ru/thunderbird-52.4.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "1b6b0adb47f3c52230297b86ead0d259acd12fc56353ed5de9afb84042d82d74193785b4cbb4be2caad302283ff54f8630b69fcc9b846009fa7dc6fdcd7e2525";
+      sha512 = "189c40a8d950496d62f980180502ad342621caf3a2ddffb0fe4f813c9c2d4a25aa375d8ad70c8b7e8ff85f09607bc2ced3366524346a70eed731bd8d9409e5d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/si/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/si/thunderbird-52.4.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "95c4864692410aa7f9a071f9d4629614b52a05a4a2d8f3d898feb7bbb75e766a8efb8daec9e3badb32c3dc8b4bb1a2b3be80452dbc9bbeb625c9275862396d95";
+      sha512 = "0b6ee1e5ca86472a5cc67cdc242a6b62aeea50609661e369c8dd3dfac5a774f50eaf0a68973b1fe5d6d9bdf6a385c52a90b8711c80facbf9fb301981a7aae395";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/sk/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/sk/thunderbird-52.4.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "04d594a095a4862ac32e8385ad7740afb2033d0601f520206ea504c9b367d685a2c84c43a0279f39105ef56628b66f13f2875c5b6f19f5252a3b63f6d549d876";
+      sha512 = "9c1f164a2da43aeb51e8b64115618590ba0e9284f3eca8b16d3792b33e269a0acc253314ab7943cbaee94ffc2ae321247b4982798d9d48608e85a935afcb6faf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/sl/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/sl/thunderbird-52.4.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "fe46ca8960024da81fcef7b2aad12bb58431f0cbb4d4c107fdfa8096764221f07feba468bdd2ef5d99665afd0404ae286b37bf2afe8cb6e6fc2a8ae98f9a0ef6";
+      sha512 = "5d4698be05af9f9181af63eb3ca6718feb1c74c81f0a6fbc82217791c911dc5f14ab433d32f6484ced2cd75d5db4b76aff3bbe420d619afcddfcbcaef25873e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/sq/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/sq/thunderbird-52.4.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "f44325e596690d0f383699debeb8450f02b7969232f1291ba0b02f657a80552ea09caa899948506674818159a98b646217d53c386908cfbb926791dc61a36e82";
+      sha512 = "32d62e6dfe28c67cc7b0e2cd27c96fd7c7e1079790eb73a8731af44e8a62f8fd1ea2e7298dc772e3014fc8255f022f38bbd5478430629140d0dca9ba0daa401e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/sr/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/sr/thunderbird-52.4.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "67ceca6c23768094799eb266cfc09a7340941fc49ae82c608ae6593a7bb1c9d22cf5525577e7815a1c5c8ee64744d7f6c5b790b3e5b46ceef1fde0001a9209ad";
+      sha512 = "6aca04c1b4378489239cef6b5032ef6dfd6d39d84308c335d03e97ea7c48acf021f6cffe35d652e117f71e6ae3f31f54e5ca73a44b4dc51dedcb3f5faf7d016f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/sv-SE/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/sv-SE/thunderbird-52.4.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "7f4ca5dca587ccc3a20c9e962d266ed1f7127d9e0707f585407efc58596e590d6650e8322bd13889afff73eeb7025942d636f3a17c327f9c2dece946ca67e50b";
+      sha512 = "099e22013b8d6791857c378c0f94373ca42d35bbc442cf273c9de2360ab8e64d712eccaedd5a13915ee19a195b6c9f04748ba738e7bbf9b8153edc4c66070d31";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/ta-LK/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ta-LK/thunderbird-52.4.0.tar.bz2";
       locale = "ta-LK";
       arch = "linux-x86_64";
-      sha512 = "6a0024f3da37a0ecd2015c9fc574ef3ca3d3f62d75324b006bc32c3be901054549525cef79597489edf22c5de1cd65c1826167132d1e5f7e62a23f12bc966ea3";
+      sha512 = "d3c95f37ffbbc5ef78b7c050a4e091bd9f36fa9529ed7c38e25f5495694c1b792d0bfcf53d15b74b52239acb21bd0d235ceb07c7f68f99e1b31e59e6f6282aaf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/tr/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/tr/thunderbird-52.4.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "fc897cc02261f65d45ce243367f6cec3f08f08d6e6f64083e81a848c3efbc9098228e3b1bb0d4f9914fe5315748cc8b07d662a204ac4ee2e0e1bd075070614d5";
+      sha512 = "2f79b9d45d747424a65271033a75a86ff503694d88a30238452fbf817ba153c4638395d3e59f5f6cc662ab3361d2304d5a4c925957d9d6e6d7bddf34947acdf7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/uk/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/uk/thunderbird-52.4.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "9c1aa0abdc9d008a40c5681ceac5add498f91fa9454b1b46ac199609e714d01a941705f729f99bc478a37db53cbf0e3c2f2c49e5d4b04a25b629f3fcfa29ad7b";
+      sha512 = "e0d891b4cc082e32d3f6af318f9224e996a8ed3c7e1385bb86a5e2f963239999712c444fed00d779320f6b06efb38f3eb97023e353f91eeb7831b44a870c6394";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/vi/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/vi/thunderbird-52.4.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "84441bc6c6a9882e0b90f9942148e70a5fe3a5d353819fed7aaaf38a7ec985d061e89a99c46e6d42c3c057dd07b44c8123f85a3db0f62b630575e51703d138d6";
+      sha512 = "5a9e13e126c7bc8ef435b8edde1896b9773ce1dfc39fe3fe1bb31e54fe4f592acdb3db360fe0890eb35b1896aeed0954bbd051fde6116b07cb513b1390ee56e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/zh-CN/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/zh-CN/thunderbird-52.4.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "c1cd1d26ffc425986abdd08b1c3695bb9904087de1f6f192e2bb7ec187f0f433faacd6bc98700b31a11d75e28cb4c9e6f7dd2239d79ef2d0a5b866a58badb9b2";
+      sha512 = "b0374f022c2a259076d52bc0dc142098975f9f1d3a886192332fd1c1b2a5c9dabc0d3fc1a7fc0f28f6f17979931b9c78a9682be1226ff751446c5427a5219a51";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-x86_64/zh-TW/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/zh-TW/thunderbird-52.4.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "dae4fff5b67b90db1e1e48ca24d63c294b8628cfc64f90227e2100d5f02459757131c7cf51efeba166273fa25a38d5addc035ebb5e945b31826d152f140eb3cd";
+      sha512 = "7e289afc737339be5a3db5869125d891da65fb75a62b7670c3880943ae11bda33122f81cab46bfa95223c45662684b8fb66ec11cfc5f375e024f4d57be098684";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/ar/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ar/thunderbird-52.4.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "1bc9384d57827d3d42ba4b2ccaf1ee83077301c855cb98c9ebb58453f96c37429387df7cebbf381fd6a711263584c857e5f6f1c52c915584c97f56051cb03df4";
+      sha512 = "872ceb5933a562d352cb3bfc6e9cc95a7485625e5256380cae367d38a560f75bd7964fed1becfa5359db3befbe4aa249f114df307cf14e2db75dd047d87e5c53";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/ast/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ast/thunderbird-52.4.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "11f718f280c3cb0e1b759b721d4133dd76cae85e6e1217f66403956cb08c637de99cecc4954e58f6f1d9e8275dc8607e501e6fbbe3bf71051831336d583042ca";
+      sha512 = "9955dde6ae54c096dbc5e5a28729963a72997fda97505657ccec6e0b5f95f35508815fe663f266932c79ef91463ef6c5da79ace4c19149b17dde9655dbe8017f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/be/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/be/thunderbird-52.4.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "fc376bcd502ae98da16e48e72234e1b8c860aa9e42153c7e89d6ad829d9f4b2696aa7dee75bd240fc25cc7aa291a808184236ace14978a6f203997433db24148";
+      sha512 = "94106fb12bf932f3a8217f3252b4f76394f13cb19c602d1b4a67e4477c3a0c781c3481ac973e40af7b306fdb32c88d4c70f8302b14e693c7270e2afab0dc2539";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/bg/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/bg/thunderbird-52.4.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "076184b227fdb364fa8f09f121735a6b6752b11c4f8537b45374db550c2fa9f6e81bb0c2cd145508973df8cbc2901de793d1f4c47696ab2165f5c819db659640";
+      sha512 = "194a420d07f952f7d088cb15fd14dce30e352dac13e543321e94fc60b7780678ea1ba51d450aac2d7566a8f23a583cba70e3aed373602ac896e0be13d234f8f2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/bn-BD/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/bn-BD/thunderbird-52.4.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "604fb9985b6a69cf563b86bbaabd890f487ca3e510a93b612949af5759b339e10b67c70c17aab9b35d1fe8ac126e69ea1a6123aae75a0eca6a9b4f133fbe1fd9";
+      sha512 = "08a439a7fe40121f318131b035e7a5a1b44a56a6f3434b2854136103b0e11fd720540352ed04bde23f33c7ef75cb57eabbe86425c8f2e440f92c9260ddf1a902";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/br/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/br/thunderbird-52.4.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "f5706905bb9da0c3ec9e841b7694619db321ecedc85ab20e52fe9bd2e2ea2e1ad0cd9e0dbaee4159237881000fd2d3d4eeb1c86911c0c5ca13fb718c7cbf75e3";
+      sha512 = "68984b8fb564e24f3e331504a0c8a2e88cc1021319b2a47beeffd145eb42a19bd555aca495ac60612efb191830c273c473e0c3cd5844f109e78a4908834926b1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/ca/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ca/thunderbird-52.4.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "a240c6653153c35f4cf40c7266eda3ebf499cd95cae7a62e0f2025bfb8b0c46538710a9b3b5486e1fea88354d7bd654f50faa06a6d246d2c97c0913e51e62257";
+      sha512 = "2202c43a63bb283d9eef16c27e0d6125d43284b9c1acdb8cbbdc71f3a9d6f6d527c4a03363dced911321f28399a86ef25defd294befddb8fae41912e17c2fdef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/cs/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/cs/thunderbird-52.4.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "3f639e7244a32891c2cbe0059456edb241895d7f5f5aeb2636699dccb5b71d4bae855f31352575957c7edbcf4925506e76ddfa0f0b83a81a61d9a8d9b543c564";
+      sha512 = "d01c6ba52794d3850656c1538e46b64eb69a7c1e3a17347ab5cfda9fb1e91976a4bfc7096f7d12bdf2f15625387aec7066b0a25879d979687c955058b92ce6c7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/cy/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/cy/thunderbird-52.4.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "26c6ae97d0982d9e91bffe04918b27da55489ec00fbfa1783acfe69cd2136bd139fa9cb434a473b5f63097adb2768e73a929f8f06bec97a13ad6750837f1cf5b";
+      sha512 = "3d056c91e1599e91249774cb21d8fbc887b7bab38546aca1815ca9c49fbf4d641bab2427f03ea993a72dc29793feb1cb0cb26217a4f6827e9e0d9d3cb5e3ca0c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/da/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/da/thunderbird-52.4.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "f516ecbf3124df27cb5c4dcc00505f2a1ab8806c3965755ae28ea3db7e06be173a82e5b171493af977686e31bd623984a0428d5781268cd7ab4094510ee88ec9";
+      sha512 = "c940d26284c8ab0a45bc6a55b67b467df7ac160c8774f0e2e2deb9082ea9500142a1d3c8851031a7e7a1763fdf5348c14de57d7168c3f1bb23fed3cf31a1b09e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/de/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/de/thunderbird-52.4.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "053ddf755cdb5b76174b18f674169c1b478b636ac90af21d5c5108a7fb9463e4e247567421abe1fdb6cf1cab1f83b2426e2fad5d0d0a2b259b3526f5dc477bd9";
+      sha512 = "b1b63590885f30797ae9825f2286deca69a82a73e7c407be87fa92280b904c0605e7047a402bf6ce1e13936933a27efaa2b35d534b23f745a2ab4a9538d31b47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/dsb/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/dsb/thunderbird-52.4.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "0217fa4e1ceb68a9bdd8d99d93bd2d523c2ecc649154eb7c22b970389a285efaaa8b2dd20f590214483cfbabdec5cac8b6120315d9b500d80038e85bf8dda80f";
+      sha512 = "fc81fbfcc6533d34fde2e08351dea6d7e2a561a3620a6d0d225dc1081f59d9927ceb0abfca7c2d21b1cc727c0319646a2f386c022524178e90aa6bba344371c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/el/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/el/thunderbird-52.4.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "8fea2697ca07a8f0007a5987e59ee2ab56d9f7a4753f3e4656e872e7201f001eb80831eba64167444d0391cf05c8af5f3d44f3aaedcd8b2d8fe48838e5097240";
+      sha512 = "baf8d0a52fbb12afdccd003209614ce8d5b4062336744ee783a6c3e7eb5a542c4da233fb680f320226f3681b440ab1d0717616a3664051d231b6638729903b00";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/en-GB/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/en-GB/thunderbird-52.4.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "269217e4eddac4a29a4c3b045240b63cf623e276d6dfbf7d874ed732fb63748ab82072ca1a482012c8d25d5852ddd0b9bef8fa756723372d4be35ef4b067fca8";
+      sha512 = "0f5fac2fd3da05cbdece404fe3d170ef49574b5abff07a17120d189338140fadbc0971c7be05656544819df2b1987fd86c0f9fdfcd312e540035e70877212342";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/en-US/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/en-US/thunderbird-52.4.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "c436d084accd3b195f9dd0b9c96d9e45ecaec730bf5a35e35db65c7ef6328383fa82ebeb3b143f2c92bfbcb3f7983f451e35e68443f6fe24fc43baf686610207";
+      sha512 = "1f3a640d140fa305e115158d98aadf95d180b396aa3935de4505f0f94f510d206ae6e45adf36572cb160175383d0aaad11c3244003e4a99dae613e1a749430cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/es-AR/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/es-AR/thunderbird-52.4.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "8d6491206cc1bb41132da43eb812d1f548e7ff8414b7644809d2f42819b94c583793baafc94815b70345b43c2ad3922c5d116379a6fe0c85e1c09c7cf7431067";
+      sha512 = "42525a75e154fdf263f276330a998f127de697519a79b447d4860403c40ca2a6caec0a225a978461ae776e56218313a3fa31441817cbb13db34cd47afb9a5eb8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/es-ES/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/es-ES/thunderbird-52.4.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "21ffc568d5aaf6ff9188846c9b6ab0483831d5c6db84c0504cbe95a5ccc2dee3ae4a8df2ddbf81a9a02c328fbf452d569cfae5f0b85f029bd62836795db41e0c";
+      sha512 = "86b47481b760206b49f87d15a917754d875203d83613c0c8b83e181f95986e6252ff26cd6dd6f7c6545f9d4da4801f6f236fa82dcce0d0172f19228b4eb5fe33";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/et/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/et/thunderbird-52.4.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "aa73dd4e5cc8ba643584b88fef3accd56b71b030a91035aca342ce4281b79372af8ee9a67a9fdb9eec2b869d0d9815f00a40e1ca6988b71f174b6e0412a31d40";
+      sha512 = "4bbfa1fde3a6270b49989747b4b27c284abb89819c46119cc3f2f90f0cad1648e49a2e1e01a35ef193eed4cf504a3e027138ea30a225c3d75347aa062d56afeb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/eu/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/eu/thunderbird-52.4.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "53f6223554a11340ff5f435438e31406682bb5364bd4cc69a9909b42293095fb4a040882cc038d95ca8ea3b85dbaef31d6e6a3ce5de58e99fb5a5b7427501052";
+      sha512 = "292fd0f2db956e5bc86a84d5edf51e3e36141610c99f75b1dd8af0f086fa8bc4a4e5a4e1c3d085587b6bf2d6e3435bc70ee66d379809886a391d67e2c243d762";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/fi/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/fi/thunderbird-52.4.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "eb143cc250bca4043476764e08ad1d7d8020318db832a4be7577036be2ec933518c5c2c9ceb2cb3c11d5e402aaf9ba41e251b95f505c6eca63cd28d52bec7ebf";
+      sha512 = "b8df95d4ca36efdc4370821068590b1d7e3fb9f348afeb18a0a02c977027312457aaa59c38ee02908e944f166d485576522ea0cb087b28fa857963107e43ced7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/fr/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/fr/thunderbird-52.4.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "16bed03812d5a4163a5d52e35ab1b9b8d91be8d772929730cd5dc92bfc62139d0778526e6e9d88d40ddb981020f6b02a19915f5dfd8993f0f477589a873c2435";
+      sha512 = "7880654b4133e50ee248b6e287d52ba867361b900fbbdd149c6f06c9d5df1d0b57ce6d9d9bed3e1ab68e90b0ddf874d0b2427553b24ea39f267f576c63357bca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/fy-NL/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/fy-NL/thunderbird-52.4.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "3c1093eab90febc62ddbd69cdeb559fc95fa6b2e67893b2d9e8ee38e67387825cfd0b50475268b7b489ad69c80f2667abbbc4cc5be3a2b81747b5858d5cf0126";
+      sha512 = "4784b06aeb705141d84103bf46635e6ba6a7f7795b40e654f63c783a63ee19d54843c211eac90c4246c5131ecc8808940e560f2fd2a2543522cef13bf3828938";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/ga-IE/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ga-IE/thunderbird-52.4.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "153dc5005e913f36dbe1840d46a91d235207fc393a7f8f294518f1095ff590f706ff7015c823dda5da6e200a43b2f278c93f910d97517452eaab972ccedc6bef";
+      sha512 = "91b4145d82a4748ef2cfe6d4d46c9e92c3a54a55f72ab1c28135363471d68ee028064ec0c0bb334fb731c6577305177a06d85b2a9d820d9e2a44fb01ac961beb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/gd/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/gd/thunderbird-52.4.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "253a9cecce89ffdd771c70b06d23216046689a0a8e70dd922328590a4a39137d93919b4052c7e928b180f2c8fe088199583c67f96602e9de150927ea08be65b4";
+      sha512 = "4e979ce305a014de612c0f3797b9f8c8d89445f05972a24d8c13cd01160aa2c15007b0e505f9a0cb354f8cf65e286ba52eae8a6bbdcf4c7cf4e89809e0ce530a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/gl/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/gl/thunderbird-52.4.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "b77978888a918d297419897f008f0fe05a09903d7a0364c43b20adcad883f926a9c51af3e7132825bf19dd487d7058c83209112d5ebb09f202c49a5c8e126f58";
+      sha512 = "b3081eee4473c097b37b9070cdcdd8eb48e1cf69ee63fd76f1eee0d5ed84009b69d0b31fb38c36f7d5137b78d0ab32087a8e668f1ad01e6ef96984ecd973af11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/he/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/he/thunderbird-52.4.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "56f1b9204c0ad5251011abf388cd3ed95b2e6cbddbb7993f967c68c8f8258c3695550025f437ddc3db455c3cbf0efbe146d0612bc40d8ad3a3482648c4bace46";
+      sha512 = "2781cc8fcac549ea394629ba1d7c43c683ea25b4d3c5807f7a4da50541e47ba18ed4d4080e7f3c785be8e71e0a8e2ae0cb9a24e348f830b71b7398efd06863e5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/hr/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/hr/thunderbird-52.4.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "c225c39f93bd12f822fdb523bdce20ca64266d81f007acba861466d61d155bded183e305bbb829aafdd0b64cc10d6d7054752bc3e99286b90a29864425cdf6b7";
+      sha512 = "d42587bb96454e3ee24b964dee1de0f51283b2c3316dd25e798a8809d2289306bf6eba6078f664f87720e7038b14f009640fdb4d3acf211195dc881e6e207c6c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/hsb/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/hsb/thunderbird-52.4.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "b7c85448a5dbc2f820d866d8e307e8221ae58d66187ae259df3d93e761fa484e0c7909c61030682efa5817613104d88813c1fb7e7286d0d7c45f6ee9dc4c5ccc";
+      sha512 = "49e3ee2559c124db79e2dbb2fe74291a377ccf1fbd75b450c8d4913000a055cea855fad03369e7420391faf114e160e35b02d432de847e673e352b731986bb84";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/hu/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/hu/thunderbird-52.4.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "6291b35868569e924a3efa54abded62742d7212d4a7dc039e09baa00d77ab3595a22adb042be753b75c1ce50342c20781931e366fe2b73d4b598065fb02a1d0f";
+      sha512 = "fad46a1ea3e8a1df49e4ba836c68b1744577fdfec319d9dc0b2bd8756d4dc859cb5af7484791b83f2260bd40d1ae64f19539f8f4b3977252a1f559b7df9fef35";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/hy-AM/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/hy-AM/thunderbird-52.4.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "ee0193ec3e1df85c3cfbc9118d479078ae3d61a70b36c582ea222338b49db4c5c2c8b0d10a0663154fdc465b23184e204b509734d2b55862c6075d1b48fd29d2";
+      sha512 = "6a34e03e5e272c847f674bd8c48cee66fb659cbf88251debe505c54011b029cea7b7e8a9722c61b3e603d66aaa4313a5971fdbf2035fd06d305cf229cd8b2afa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/id/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/id/thunderbird-52.4.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "a882202254e23635dc51c10b332ae8953e61c6ffcdf42f9d5794cf3c2a7c665bb350171bda84da8388d2323b0359b1e0c3fd44a838c0979c35fa80387b312a21";
+      sha512 = "1cce3d3653b474219f00f4555990406b661a14c4198f3d246624def4e5a3ad3ea393a74f6c80e0f17b5799784e212778ccb8b56bda31c5e48a55193bef09c417";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/is/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/is/thunderbird-52.4.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "69ad01aa6a7a84630bfaf10f4eda5b8d04af7bf5cba742943fb474ea32e926908db0f94877c1d6f9904063802dd9e219b20fbcf597aa291490726f15f6ca1379";
+      sha512 = "f3604e918502d16ba92e65e9def425efbb829a261d2c433ce83ec89d6ebfebbfcddd1b01508f953ec3c26166c6d01112486cdab6d1a0fe1e6a582f0566900b89";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/it/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/it/thunderbird-52.4.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "d9a1897dc1665d69868dcf0b5d4998316a76a721ca67c5729d0b5cf2a8de516d7ec1ff92a6db1cf29dabe6544ea10482dc8ec58740fab8ee704a98596c69573b";
+      sha512 = "458bc19bd6b08f6834e310f7ec4591ad4e84067ae2373864ca9019c20551abbcbc067467fffada229000dda01369da3c28967df522182d8eda1a147d136b6315";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/ja/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ja/thunderbird-52.4.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "c9b7e197cf9fb00292b39a7769dd06be243d3ac46ed90f5db19b612823872bebc06b330eab087295a6d91edc48ed8c40af04ac69a0b5ead05a11ad960dc36aba";
+      sha512 = "05faf43b8b0f616bf552988a577891e816fe36b208b7d6292c9896a6946386815e117278feef33063b4f2eb7b5ec89aebc59e1d4432021969bf3b95e750defa3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/kab/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/kab/thunderbird-52.4.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "065d73e3cb20593a18a556535aba02ee5b01e5aa07c146a02a76130ab9474962fcbf56ed5f5733638e2c73af1cfcccf9684b6799a30112e8e6da32069bea87ea";
+      sha512 = "594669d5518b0be87095527b3013799812c9f45254434523903ad19edb2ebd4bc32409df6f646b1d1e953098e126673427400238a056e0a8c44b672009a12a2c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/ko/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ko/thunderbird-52.4.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "1260ecda4f82475857ac17c8e4825bb9e8aae458797a8fb92ce6fd90220dc2eafdc03447116f2063e5a66661a8869b10a4280bb481f3278b08e135466a0ab74b";
+      sha512 = "db3e6c9efbeeed833384256814a713a5bf3d2a220a74c88fd28f91ec0dd6c7600d77e18ce66c9dc9f1929f5da7452c5904f012fa8f5e4fa04084892e17b2647f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/lt/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/lt/thunderbird-52.4.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "3437bdfcd7ff3ed1f628558dfe34b82319fefb4f133062ffe8a04ddf1bb554b1d5ab881cc2a288cfe494c7e4520147bbf4c23fe38b7c0b0ddaae8a061d7ba839";
+      sha512 = "2b8e8b74bbba2a72dc88a8dba457189cad1c902c0bf2cbc54bf989c6444c8b164238f1d9e21c2c8e470df5198d8586cd613b40292b737c04f4c2d834d298dc13";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/nb-NO/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/nb-NO/thunderbird-52.4.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "e321b1ce86913287ad239f235f97e481c1f1a26931da1f17ac4827767735208a31ac0c418301476551ad1c73781dbae890da15ebd8113a59d11e45359d592537";
+      sha512 = "bf99756bb7bc5fa699cae5ef3da5a3614e57483b2892e2f6f769699ef3478e22847ddeaf63fc0c521cd1fbcccbdf9bc5054430a5cdbb50e26e371818cae404fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/nl/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/nl/thunderbird-52.4.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "656e6bec81d40f1dee9bd51d5313f6625485458f47c45a4f77b8f114df9463257765870982bf704f108f84df064d51a7c5c5500440e3b66a690b15d248977070";
+      sha512 = "80170d51276bb77de4af8d45d5869069c7d9c6db7ad6d5786fd4c2c5cfb0a20ceb1cdce7b5dbf99a79dca329efa5d9a53d4ed738cbe7f77bdcb65a8b6e2e7511";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/nn-NO/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/nn-NO/thunderbird-52.4.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "d7a460705e2debb51423612059425094e88a0ee552ce8b75097845763d4c65039fffabcba2f0d95bc655a84f3d1d1c7e1290905f56c5c8c461e14a9eaf87efc7";
+      sha512 = "f223dd33108a750563a498e92b53cd3e68e3d50fdb1a08e295a9c3e893c20908ea56c9c5312874469b2f96d1046f754df55bc38d1595d5b811b7ed659e267d98";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/pa-IN/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/pa-IN/thunderbird-52.4.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "ab12d8a23b649b5fd7cc71caa71dc0cf15f4a5baab69be44ec71daa4f643a2f5dd83974d88e6d5deb06c9e89bb7f39af3940edd551588c28d42d1304bc092f53";
+      sha512 = "a418fea2521ff6971d68d975823bd0917580450a7ff38975455b891c8e3cbcfdf51c40502fa072ebc1f43ce93a3b07ce93db369edfbd511beee5dfc5041a0a84";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/pl/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/pl/thunderbird-52.4.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "f85deb706d0ae38c53965951c09991bac85a05486b23e6c364871d9d68dab057b4ad963d4287bab4f1d6c3ba60841827ad6b1861c3dda15dbd29f42c9442dbf1";
+      sha512 = "05adc7298c91853b373756944d360589caeef6a999f6c5ea9babe3b12ff9409909040b69b641b69b78bd17bddda59f9828e294f5cd5f7d7061cc3f51eb3c48b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/pt-BR/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/pt-BR/thunderbird-52.4.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "a3e955d25fc48b8e2051a131c437b1075a773b69fbc17f4cbb8ff60548d47449be70e3aab97d569802c925ffb57462bd144f3eeb0cdde7b2508ecff536a9193f";
+      sha512 = "4a2503e3a1daf5b9cb26acf25720c4d0fdc7a170bd454a185e4cf2cd9c9429dcbdee4c13e59e11a2a275d88513b1ae31dffae8bdf70c3196249e432360fbe705";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/pt-PT/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/pt-PT/thunderbird-52.4.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "051f55a3530c7d90a0f7791d6bf2ed1af015eb6813ffe3f1b43d7fd4da992c079bc6836e38eb027f7246aef7245f480e9300dfca9c512f55e62c3d851c7d9b16";
+      sha512 = "cb02054a64a74c2e1f936594f001dd721e3016cc68cf705c0413a732153bbe45aaa14736d38b22358bda5f3d059f7306087c27faf040d91bd7f92066403e65c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/rm/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/rm/thunderbird-52.4.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "f42c1f0cbd76b7425d986b26a1e2d0342c4c99c7d283bd2d6719179c5b14912853b7af20de214dcf06ef1f89bfa9d5a9eb0052effecab505738c80abf168b67b";
+      sha512 = "8e745e5d1e5a4d3f432bf8c5f90906a22c8d2fe4c6d77ec032cb7eccae1f2f9e7cf0620dd3ef378414d6f34cc25346ff44b7fbee05016f34c49a0c8c5959184c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/ro/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ro/thunderbird-52.4.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "30cd95effe6597aeb0e686511a3b59f064269562337c924af06198600a9c19dee54931255cb9e5400e034de8d9c08f2e99943084ad9360eeedbd0615339df3fd";
+      sha512 = "20d9b9666704c87f73f4c8cbe8d09cf79349e811f4c4da93f2754886cc89fabf7c2388430f9f072a3918b38984742adab48ada320dd75761a7443f3be1198a8e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/ru/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ru/thunderbird-52.4.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "3e8a7501295ad1a41f3b79efaff4c76c25e5201f2ddfb02749ce950b66d81b8cfd870da2570eddf4381e8928a6a355dae06906043bc6912da23feda3706ac12d";
+      sha512 = "ff7c64ed9a4403e24b7f0f9fb06bc4b96153fbe7d30b94ea7e145d33dc24bb1b2807db8d6e3398dc84e13f68d9c5c4fbaacc3027cd46ee58fecaa8b7b17b27a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/si/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/si/thunderbird-52.4.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "ddaf492f1d6c219ff503fa50ae1f415c7d24dd6431cd55d02a222e5eec7265b80e96fcfb0ca38092e06aeea78f698ed5b229d8527785e90b49fed6ca69acb9a2";
+      sha512 = "b2358e6df5f5cda477c530dddd9d27e35a8919aa346b66521336fb0cddd2821bb7dd867f4ad005c135ce040a1eb64ad9f1feef81a268a299ca2170312f7c89ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/sk/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/sk/thunderbird-52.4.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "dec6bfebf69c1db120ebee8b61cec49eb3c27209f9bbc0fd914c4f22956829cd9759f0671cd7b6ca24dda6598dd45791d566a55db5395cc089ea15696d791a3a";
+      sha512 = "fc3eae35914d2a2ec6d44bf6348f71872f7ccb09d25ed974843b8010526f219437e6530c4d86825d027f1593da0943e0b9a5557bf41d4095e4e9d37108a94c3a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/sl/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/sl/thunderbird-52.4.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "3fd4b5dcc631b65f0509272156be238d4c9f99835fb7d23730d99267351f9ac58d370cc95f3a4839bf0b1a45fc0fd34b1b6cdb9efa88b75f991aa5fedf74521f";
+      sha512 = "532b87d22bd05194470801cccf242ffbae57685e69a836c8179e2fc562bdf2aba196f214b7a66006ef90d7fb1781d66e1ea62c2cf95820402deb9a73122ad143";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/sq/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/sq/thunderbird-52.4.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "a72d7db408855d53eda896280a114dbe667a914a5c5d17da7a242697a44b974f54f0b02d0884150c1f27602296df17cadc96f4b27057ae094df9680d3b48f6bb";
+      sha512 = "b621973b1f76f2d789afa854917e20b7b48e3381344da29e07b8c5bfd469162c47d51e9552ab2428895c45dab9662d8fdc2704e65c96faa4afbddc4649a77dec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/sr/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/sr/thunderbird-52.4.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "dbd9862ca22f038defb83b8df9cde748eaab1a4d68afbbbe6dfe45c73334616bf7f64536d6ab2d42166d1196e548acf697fa29a5d37184e9ccb198bc713ecae8";
+      sha512 = "d26812c232168c30c6a76dad5f3f7e20fe88cd75fc63f863bca255fa353928b8d3988c56abbb649266e52b8d31d70182c59ded496607aae17d7d2d0409ecc53a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/sv-SE/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/sv-SE/thunderbird-52.4.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "7c3804d7681cffc6e979975a898b1cc2b1bac0d2e6a17058025629b8ad308cade808401f99e43cf0c1662a9597f2f6848d12839c3e1fe7606fca5926e6b484cf";
+      sha512 = "294e141cabec4edab0695e7c8e29149543e4cf4d451cfe9ba038a6997a822e02f223045ac3a8ac25b99a1e847740fac4d9d5c0b5ce0c5d69d331d823bf8e4899";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/ta-LK/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ta-LK/thunderbird-52.4.0.tar.bz2";
       locale = "ta-LK";
       arch = "linux-i686";
-      sha512 = "38e8a0370c8ea7c7b7936da47dea583dbd282eb0cbe504337ac9e35efaf67cb1e6e9d7220efec243581d7a04a19e4f6f78892fd1a84461b30035d01ab225920a";
+      sha512 = "9c9b79cf21e64461b8a78dd0f7816346ada2cce0ef4bce4da291497c9fd1aa414c199d57265390e5b885828b1efa38f9883882870b84a5b3a64ffffb47da79e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/tr/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/tr/thunderbird-52.4.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "053e0e6e88c92c6c8d398cb8c38d8ce9b1340c4ff4455a7c4b1225090d5d10387b8b14e6f71dfee2a159329478cada995f05b75986c6a57d01ae7c1e1a65772b";
+      sha512 = "61a671ae2804b06143e636c9e8ae0badb460bf9cbb3555213bf43aa2d56b2a9f13ca3a13362f2a9b7ecafb4b03451093ea2f817a104cc7d4555e11b1ffb18103";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/uk/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/uk/thunderbird-52.4.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "98cabbbd8314ba80d74a0f3a9b17ee49aced8b5832f13e5b6060896dd9dee4abff8a15e1b509387254416f6e49652fcf797a1cb6934b7ae6f65909ba85a8e01d";
+      sha512 = "629ede67d8bbfd6b1233d2030234fed7f99915045131caa11edce99b6e9c314b7cfd6ef457d26a0e628b525bb78c05426e8c078364ade5e606dfaba90200feee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/vi/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/vi/thunderbird-52.4.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "2937330459ec576ba9678c465bd5aea7cb536002574a23e3043363d562bee2d1c58de1a6a73870ee27e363b9a64b82ae2a483dd21e3b6fc3b28bdda5d8c349f5";
+      sha512 = "728644651b7eff73be44bceccf8038bca79e020fbaad87d74fb1ff4856554766e6494e1e16a0d93187615f5f8cb663fc3233855d66e8cf0996fe597c9645273c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/zh-CN/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/zh-CN/thunderbird-52.4.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "80e640c07514c215f170606353a97b058fe2b6b8f03adeb1526d3f5e237cfe71123b945b82b00726b00101a11a3207930af622775e4a0b5c5f9c464aca34aad0";
+      sha512 = "ef5a81e04ed973fd2ed576d1654f1ada7d9cefb6943bf604bee53053fedc4b2127c780ac2ff3c9b568813699f29f744950e899bc71733cd8d385368e1d0c07c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.3.0/linux-i686/zh-TW/thunderbird-52.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/zh-TW/thunderbird-52.4.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "9ea9bb1121f3f1731d3e1748af70ebce153a7cdf8bc44034928f618e21f2c1c1ac50f13f2e42d42e3105fbabe7cbb919bf785de032b615b2a1e732700c436ad9";
+      sha512 = "ddf5a00621d6916c6033f81589c9376a8aaba3bf12810a2fd41358af323d9f6354384a5b938f299855d27a1272d36e99ca3f45a8ab8299aa7afc118d942ae624";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -22,11 +22,11 @@ let
   wrapperTool = if enableGTK3 then wrapGAppsHook else makeWrapper;
 in stdenv.mkDerivation rec {
   name = "thunderbird-${version}";
-  version = "52.3.0";
+  version = "52.4.0";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "10e6495d207328aae325a797be1de5e535b5d967df929b0af9d7554d0473b5a7931c8f9cb1793e843b1913f441f790169dd4ac1ad9e0e53e66bc8e1c1dd60e66";
+    sha512 = "6ac39cecca9e53b51754d7a8bd7cae228d197eb234b03a2386c16fd665f4f7a67f10bbdf981c20b3f7a21a5ef67e2771154a3dd9f249c6a884c48a9e59bcfc78";
   };
 
   # New sed no longer tolerates this mistake.


### PR DESCRIPTION
###### Motivation for this change

- Various security fixes
- In Thunderbird 52 a new behavior was introduced for replies to mailing list posts: "When replying to a mailing list, reply will be sent to address in From header ignoring Reply-to header". A new preference mail.override_list_reply_to allows to restore the previous behavior.
- Other bug fixes

https://www.mozilla.org/en-US/thunderbird/52.4.0/releasenotes/
https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird52.4 (not updated yet)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

