### PR TITLE
Firefox bin updates

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,955 +1,955 @@
 {
-  version = "57.0b5";
+  version = "57.0b6";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/ach/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/ach/firefox-57.0b6.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "f3e10268d9a2b5813a2d69fcbf099de3ae9c136b06d4042448c26da7d9c4109719875c7c46bb0e27cd849abbdcabb5d70905e308dc19faa398184d3679700596";
+      sha512 = "3c6a528013d0fd7f002990a095e1b1c3e1e01f82444d2a53f73544c4ad4e0aad62e49af561f90b8d0fd983e7f3e515e57f14e8b9c01ed625eb90db348d5f6b50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/af/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/af/firefox-57.0b6.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "58b9c13c779fb09def3cc1a83835a21428c41650e8f83d42670bc5c6cabd1b4a87e83ad73f5c2deb8129a8399b624c542682f5a640eb119d512f08f07da0c6dd";
+      sha512 = "f8ef0a994e3ad04a02f86f381020be2087674f56ca747be529bbf6bcfab03da221305767a1b056240524e473a986ac7987485bd3a94a21d2030e561eb16fd1ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/an/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/an/firefox-57.0b6.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "c7616977f35733c98caa748a27bcd75d64a8c992f9bea76de76c69dd7adb2ce248eae2cc2791dec27b743a1dce67db22a546a339f5af3ca160bccdbb34caad66";
+      sha512 = "4df60570c8c7352fa1e9a0520c795947db6f03a7c757a8a554b2072fefb36bc2636c15ae58fc7bb28ec5e8aa471fda26c91c7e8aec06013407419e9522144c9f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/ar/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/ar/firefox-57.0b6.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "11918be6f23f095b738111441cbf035a67270a45145ce8df01e6c7e5067d3b54a521094c90abaa7715ab1b0ad6b9063d319a53c3f5ea2ed0ef6d8fb124815652";
+      sha512 = "8908830c2bf333d6d008cb900b97132abe26d84c4cbd4e0d281ce2d4cb211eab4241139836e5b39bcb8f48012254d8d5a06b227b1ecbdadc6539899bce1326f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/as/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/as/firefox-57.0b6.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "b5269a9b178183688d32efa2962c80d1bd448a5c378f3d6453c083b6fb5aa114a130096a40f02bb17a76d05c1ef03afbb814cd7bab2d545b7bba085e9a010794";
+      sha512 = "28773583524bb22de708ddd9341192b631674b644ec639122661c25feaba70ccacdcbd77efed9997e490ccf59882fa9f5f5f3010a62f361fda2808ca73061276";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/ast/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/ast/firefox-57.0b6.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "af1ed67fc78944d4480306d9c230bb1a831e093fda6e9ccd357f20ef8b94eb8581230c2eb918719564b427ea741eff9b8eb762059dcc4150dc79e98c4ecc7d3f";
+      sha512 = "7510a259f3ef4bcc38163b7ccf2f090cd4a4cad1133bd2d961470116d0f0bb34d41087a40d744cd31207afab1f5299049558657d02f4f0f23a3c99a98d752624";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/az/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/az/firefox-57.0b6.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "67d93ab8d23a5c036a34aeed756af9eb021b86167becb2cb42a393802736a296dfa90b363c1dd6cc86aa3f25e514b4de5d7a13bb3de511baaa98874c6a128dec";
+      sha512 = "8282183bc02bd7d4bad0cd9d74956634dc0db8988245caf1eb89f16d596d78a6ec00739065b38cb399dc93b113d35eef5cf1188a2a9c78256d002cfeb87114d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/be/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/be/firefox-57.0b6.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "ed69789fe7db560a213280bde9ee79944a50bd2b29efaadb864cc2465dc304c39f3c40005da5f35f570dc1cdfdc4abd2d7b7ed6264b351ec8108fd1b67450ce9";
+      sha512 = "6440aa65e05ddbddf4629051be4b05bbb030317c241fe51de08d8d11c003fc094808a532192651d874b6ad7e6d8f89aab66485442839b34df22189fa89ee8efe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/bg/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/bg/firefox-57.0b6.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "2484d220a64ea2087a8b68f0502b2a866d405eb8c3ffa98e571053fc6b7fb270e041691f55c6833c4ccc7884abad75432fe9ad87124055075832ba078ad6db1c";
+      sha512 = "9489b8125e992f213c06583e6b4205d9195091824ff39b5b171896be2766c834261f648c34edc992da72bf1c4609e92224a119402913b4e8298edbe94159a860";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/bn-BD/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/bn-BD/firefox-57.0b6.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "4fe4bc4b6d14d93daf49d751de73304098fac6c83172b35d1999bf205a6ca4f0c94f210b70e1cec7a7c24ea0e3bc8d5cabcda58c1e7df33e840a72e9cf9f2722";
+      sha512 = "22db87e53116fc8db9b2c917dcd2416f0a14e19eef5834ce58cc141a4123b51e97e9d29f222c341f30180905e9e261d1f634579d8efde4db221ea78fa82cae32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/bn-IN/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/bn-IN/firefox-57.0b6.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "211285374dc5dee3e0c2034fa6b2171e837e2d0ce78a3ea459362915cce71ff19ed71259bad4fd44ff82b89d5f675e9cc1ce3f76dbf94fe2985ecff01311ecd5";
+      sha512 = "91800665d44a074cdd56333722ce3d1da54c4df40a9a964f63ff6153bd077e452008097f6bd678635d2ea16e30491ed960f60a473d7f95fa2ad35c9e717e6bc8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/br/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/br/firefox-57.0b6.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "800a2653c08bab91916e792e460900fb4099f46042497b3e27a77016f32ae83b9acdd9ac37863fb9d1aaa116ededc6902854762a4f7c280baa817130cfc7b449";
+      sha512 = "b95dba3b94b48d63b1954ac4983bb6d736777630899c60a84dce07d3f55843c23bb7af7215eee081cb3432c705700dc4e4df3665b329d0e5cd9e691e7da9bfe6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/bs/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/bs/firefox-57.0b6.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "919e4e89e8e29837e8a9af0b50422e2ebe114c23aa2f0d36cf63e81b572074ec2887031499f3b22511a6a9ee2842ea69f3587b1c4e71a684989c1cf73fa25dd3";
+      sha512 = "cc656b07f6cd1a2783fae5e09e9ba4e0abd3ba3b29649e8d496511564075a8dc442206b8f2955aa0f5ddf36329c6b184278204e9398eda210b51774091341be8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/ca/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/ca/firefox-57.0b6.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "6044334fae462ce72a8a9b32b392f531733f83d8db0e34f07bfdd5b95b6aa8363a6fc0c99c18274bc277b6e797f99b76e42b7affc1d01f5a83a5a47e2a96cda7";
+      sha512 = "c61f7f062989d10372bb79664ee94d5ae59e89ddd69d5eebaa3da7c3c639ba7c50a3f9608144e76a40befdda32c87ba5d32e14eaa0b98130fbf7d6b8ffdecad9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/cak/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/cak/firefox-57.0b6.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "a8ca1f88e997b0edee57c84d9157cbf298e27d26ec82c5aa1de3b73a38e8c9edfe9bd4f05eb32078c2d4d4f300f4561cc7a06e377f847c64052a07036fc9a30d";
+      sha512 = "f2b5db704e668fe3e8e97aacea1663a2849eec0ea527b5107927c5710d95bc8a8d89f73a23f53b430fd24cd19b5c7c0e4a6ae34d71aabfa87b5a743e760dc0a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/cs/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/cs/firefox-57.0b6.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "8fb7bce6d69a6e57ee7c93013cbe8023334b4252844fe5d47a71868de2c6a30d6d0dda8776a1104b4616afd0c921325c569a6fc98f1c3b86e6fc436837d934ea";
+      sha512 = "104f7498bcde823ea1f28e79e2be25acfefc5f9cd4755ef5332f160e15a63ba54ccb713a69c694027f2e99ce0e1b7ab07134c6bcc8a4d3caf8b10241ae27d3b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/cy/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/cy/firefox-57.0b6.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "9d891997a1d2f09f82198280d2b090360cbec38296548d10ce356cce5f80dd8fd0f607b009cfc8b01d8f82c262ff50aac1dd5a0494785348eca3e43e804d8e44";
+      sha512 = "dbf802eaca0fb11a5453cbbea4f050ae7fcc5081712cd9fcf3ce9b04a1e042dd4bc1ca721d82abafe26b9d6cb5bbea41ff6b58252bd52651ea5fbca580cad479";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/da/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/da/firefox-57.0b6.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "a0a0fe3c7729e8c402ef141476f2a6e482dbd652e084fbfbfd7e10af76164fd00ee6c5f3e8590bed972cca05628676b67601c1e6e38261c4fd688c183d032318";
+      sha512 = "4dad1125de1f8010b3b30fd1ec84e26317046d5579c7841bf3bde480c059f088ca3dcf6e2b4a7843f1cd086798e28dcc95a6dfbf533919f456e2d6af062279e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/de/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/de/firefox-57.0b6.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "9c234314140c41bf8fe33de55221e5a07a4015f99b713500ac31830831f17f4fd3cfae6aef0358bcf825b11a4b0e47e9f784f0d6eeb98618d9b8ced8a2effb7d";
+      sha512 = "dcba94836bc0f0409992e33d65814cca86811bb6ba6695a082a8b109ff153a0d12e36b6d2ad2d62ee9b588a68315f40420efa7c2b70ee667900fba470f01cdba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/dsb/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/dsb/firefox-57.0b6.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "d181b0328507bf4e491e53d41a93b548f2355886f87e3e9951338857c13ea6001d6e376dbeb430dfca8be47a4edc09530c7f64e2141cb12230dea0ed14ec622a";
+      sha512 = "4bcc69f67901776a153f7b2bdd22d3dc7c23246a616095579008d4c2c2798ec09985488ae0c870e2c794aa553b687e95a56f262f9a5568b1712e04ef3dc884b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/el/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/el/firefox-57.0b6.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "3eb8a6b826111249a371af07b38e3ac631fbdf62f467b3620b32a8a4cfa81e80e417ddb396fa48611c8553cd0db1813a9fb620087875a7dd00385d26060b610a";
+      sha512 = "2cd4d4ebc3099761a4f3aac6edebd662b4e4397e276e2fa1afa8b0acf6ff2d9367ff7f27909350b5ad8bda3a309a73d46375d46fe8c986b35c209859b79da4fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/en-GB/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/en-GB/firefox-57.0b6.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "45e1e54533828b7657d5ff11d1c6097e4c0fd50b6c603f8d1ffe804cc7ca19488a079f35b84fc81bf1324aefc5b4c82581b467d938586e7dc4b966d91388740a";
+      sha512 = "86812a5b80bbe2845f628e9b02cfa037077f9a9bd39e292dbe8857437498ef48dd5576ff98f70765ce342faa55459c0df7ec57810c4491c5fcf1f874c02f6382";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/en-US/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/en-US/firefox-57.0b6.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "dd9ae76565f0b30872de561723a5209a967b2d89131f62155ca1d78b1f34b69bdf30a7ed382c62aa59b9a386ae255fdc423f29f296771ca4bc04b043214ff4ea";
+      sha512 = "27d107999a86f31451ef4086d62a6449088619625b46c599869564cf0bd4484ba13c92c8a368afa1111039a81c01f8f49cc3a270680822638f8c73c3d088683b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/en-ZA/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/en-ZA/firefox-57.0b6.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "22807d9c11e2caf910b12dea7bdf9b48256d8aff417373b1b89fc98a42cf07b1fcdc33180b71562855895655ce9f46e1ff26b7e1572ad21664aac5fee6f682e5";
+      sha512 = "0fa620dfc562e187fe799251d98c7caaec3021f5317f4bb31a78ffd9fd9501461d17cd66e0d47080e91cc2fa7247c1a1de8731896ad0daa8f891585d894a294c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/eo/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/eo/firefox-57.0b6.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "4194e80f7f4a8a87baec636fd2fba3772e92de20b1776734cbbe0391da69528e3127fed5e5dca0adefeaa82abc40a1b884a215f7ac943b1c39104c90edfda26c";
+      sha512 = "3a07022582140f4a25992c5e0e93ae2d0f695c5a258a98c6f2b1d3edee41248b9eee3e655084d61b21a7c32b29dc03f4bbf5e605365a2d077d9b5ca069cbc2a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/es-AR/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/es-AR/firefox-57.0b6.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "9444d57d1a1534f826177e8d41a2b86434294d2e8de725d87cf8953603cd1b671075b1f62ae0c6be0736d46e6c3e65c781e88985698aa48da3b68a83801f93f3";
+      sha512 = "bb5f9b65b6d92654761d99911afa9d10dd1adb2a80140f6c1beaf5e014cf46929512af716c1fc8c01bc7f13baa5b924252a11a71b916d3945c1d28ce52686019";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/es-CL/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/es-CL/firefox-57.0b6.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "c98240f2b66b8b460d6634e0ea00f8ab7b5381fd56619fcb32614dc89c2497111103f177bec27a55cde57a5534ba3c46dbb81abafe5f3e4e882603923d9ba2fb";
+      sha512 = "6f7df550a90d2d8fa9b8417ae4bcad8158b544c3a49f240a0be4b0bdd350b92ba1c7cf99edddfda85d4d702693f52dce2ef053ef985001b5cd0899302087b21b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/es-ES/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/es-ES/firefox-57.0b6.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "5b2df0b8031030d9f1e1869cabfc9a6a5581d400c80518386e0c2b836d1b37c29f155c64a1cfdd80d7b9c38294ebacc1955ed5513633807ff234b4ba678b7065";
+      sha512 = "d472091717f237a163db30be066589bcc1c0b2b72aee751dbad0e47557fc92075c29b2c65336961fbd91e3292307be0366a89220888f3ddf966a29ec1f2c765a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/es-MX/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/es-MX/firefox-57.0b6.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "1858f5208a9cc15f87d3a5f368bd460ebba368d079751a59f67b5a13ffedba52530445d920d8e3fd73efe6161101c6cd157c1dc62cf182a087ad978008bdb66d";
+      sha512 = "ebf9eebe47cdec6ec2beae0d6edf48295089c7ee5aa1ead26e0ddb45fef583aa5be3941c4bf4c27b4fd7504f141a34342f674c6e15beb086f6994e8e3fe45ccc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/et/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/et/firefox-57.0b6.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "7cf60f113face3f0c4263ee802ec9716fc85f948292d3316f13a0093ceed03141ef2330b1019297a45a3524b4aba698588cc68a48539a2eeca48845c3609bedb";
+      sha512 = "818c7c4cd486988496f50d5c5a4a56a12ac8538113549433f11aeeb33242d7337f144413e27920cdf2029fcdbc9a2b9a47a9dc7d92fd67f2066ec5b742b6c625";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/eu/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/eu/firefox-57.0b6.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "b1f7ad50308507729a10d4cb62b2193bc6740fe97d7fec0f4a5ff3b14e72a4814941430d0dfe641fd1c8f7ec333732365b5e779b6b07f90ab20356b741e7560a";
+      sha512 = "781df02d0977a9e50ff01e214e2ba3bda27fc9052119d0b03989304d2db13009583e7d6fe32a9d502eaff1abbfb81c55658c3682e4f59c6da78ab16b59e3bcbe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/fa/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/fa/firefox-57.0b6.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "fa9170df228d9d782c92fd2a92ba35e780744234e7c62b635be8cc31c18762916eab0163c17de602052215ec082f212191f97bdf555f35a97eec46fe8df6e6f0";
+      sha512 = "8e10c6d61d145a1dce790dc55691091b514749fd7565c41d1f5aec6a863814fa5a7b4d012068682dead8f87e4c1813787bc724438018393f5989f9dc49a1275c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/ff/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/ff/firefox-57.0b6.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "30aba17f5298ce341db0946f987a99e040e301b4f5b771d8c92a9adbd361b75ced431796c9917ce0dbcda2208075d07ae5b4d7f11085be65d273857222030976";
+      sha512 = "1429a4d627e655edc245c375cff00e39b4cc42176e1141e49e9bf5eb2a9564de88a0915795bb94dc842d44e0de1aea28601c30fbe14bee0b210e15384c958c34";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/fi/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/fi/firefox-57.0b6.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "59065d98324c77aa30cbeef091316aa055cd95d9e7abb0c5895e168d75252d6d9b205717a4182e97428fccecc4d7703699dce80e0b661353cf8713c6b0af2373";
+      sha512 = "65e1034b856a51dd6e21a7c21436a7f2ebd6794d6eea8f0631161feed5c06c34725e99473bfe9d169ef963632cd4aae72ceba24b658369f3da6f1f34017baf1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/fr/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/fr/firefox-57.0b6.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "64a9d891781ed74b25d10afe210dfc549f9c0dbef6ac3e92a8eec551c7a97a488808e7f6d76ea70615c5f90af4319aeb92df95eb3d6495fccf53993a7bc6600f";
+      sha512 = "9369f1ada09541a46745d66722884b3eae920f79673763cdce587a56d36515d6a9c799775791d587dbe5cb33d683b87194996134cf530d20bd3509d09f62546f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/fy-NL/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/fy-NL/firefox-57.0b6.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "1b8968b66fbe9caaceefd65a06f0cb536f6b8356823fa2fbd0c1a5e7111537311e8aa5376c3fba032afcba515b7a7dc3ae2380e249d8acfb67ed1eade6218d7d";
+      sha512 = "e765ec0dee9ae728274c594906dc57124582006f0d2c1bcb671d2d85812a5656ee99955f00d262095664b9bfce9e664c62f2b8dd61cf08fa4e460f68b8b6da69";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/ga-IE/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/ga-IE/firefox-57.0b6.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "d4d39834be823db0b188674ae59b157ae0a85abb2b0c4b4772d9185953eb13745c501d7bdbf6eec46fd84dc92585f0e6c862f9acba3662359e16bf68e70d043d";
+      sha512 = "32e409050d2d45cf2d8eefc7c55c62c89c4e510b7d69806ccd3b8dcd7b68f58abc75eaeecc7c899fce832daaa3954acafb1d7e35d1e70f62a10f78dd4dfb7712";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/gd/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/gd/firefox-57.0b6.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "96396e9ca1743edece33274e7d0a14ad3741d146b37b65436e526604f8aac3f28fb31b2e18eafc03461231b0c179ca75157c271b44a85a3c07d8a1a93dcc6777";
+      sha512 = "5b2418a12844bbf5943e57891a31ac7f95bc214a4708fdaccde772890bab94be88251cdb4a13b031623c396767e6386b5741f9bb46a6878ea28c380f91a28963";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/gl/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/gl/firefox-57.0b6.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "6dda04fbfd701030d58b0ef48bcd348870c34159ad3c552ac284537ba841a44e9eeb627249017ee686cc165772c1e7aa4cdd77c07c80a64397ccffee72ed7815";
+      sha512 = "e45193079948904b1900bcde30128aa8e1aa29d7ca70269dd1ad73e55d9dc7a1f6b18d9c31a6b93fd13c84ecc7d8f6c474e41831434cf3455783597857f4cb34";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/gn/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/gn/firefox-57.0b6.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "6704e4e85f7903096d70bd715ea6186e219a114741a5f333343c39ea0327a5731733b14847f1690078d9cedc7b20e3132d71be96a14752772256b5427d4c4cd1";
+      sha512 = "e062ae0ce3458bf95cfa37ba439d7da7f19d612240f9a23363cfe0724d264c48ec50826e4ef959fa22d7a211e964a9dca8eb23281fddc8069af267b015c9ad20";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/gu-IN/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/gu-IN/firefox-57.0b6.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "2dd643952d8a28cca487a616d9218c9fd50289a294f40d76edbe1b154aac9d9fe886861cec078e126af72182ba5fe6cc1945fdc4c587ff3f614fa880aa9373aa";
+      sha512 = "42e641fa032601903d34652996c08c6e74b1bb44bb2b579a20edcd064dc668739b4e4b8b973d571cd3ee5818bc99667e5f8114d8744de0043141c205c6ad320f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/he/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/he/firefox-57.0b6.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "85fe1aa9c4f63dcfa541cc1a6c54b05644993a3de770031b6bee151306b7663cd481078c20ac2bb8b1e338721b7fc31d060514a782a1cd907e55436b1df3394a";
+      sha512 = "1303b9dea95512a85112097a2b1871d6415acb2134bc538e27fdbf5af005f3ea5da58c813aa2d02242636bb1211943dcb8c62f47593b9cd2846c26d0f8f93d3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/hi-IN/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/hi-IN/firefox-57.0b6.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "5518977fb66e44b39acc21bb97b8b03dc12f240f8570182e7920897d908473b19646df81720bfa63947276465982b53594e7398858db950c3e6849e7bd522818";
+      sha512 = "d8300d7678b5989884bce54fd7969c758eae4c7503aa25855279a3a24c3fe3c95097e4aee2a4e29c86e53c833be973571fa496290754d7da001cc6712fa11d2e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/hr/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/hr/firefox-57.0b6.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "904e853143ae4bdb4951c22afa8f61d2199d374b10005cfcda9ba3a2667f8e4bfa81eb07875094e106cfec60c117391500a397ec519ad1d65a00421b2f07dc3a";
+      sha512 = "f6b7ef155300dd782ff5acd35202e42c64eac06d1eb623e3fddcfe60bdddd098649e477c7260d22f787591a54486ccae54d915ecb20ab114f05f88305bd4e099";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/hsb/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/hsb/firefox-57.0b6.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "7cad8d88f39c4aeaadbba6a9e10a356d2d72d251658b28d1320b31adc09f97233718123264faa2baaa87549e4cee41bf3d60d2b8cbbe20c4b5944b06ce7a1228";
+      sha512 = "00e30546e596c8d2c06f57de0125e7f366356e4ecd4ec4c499120e459492b45965fe95ee9698e98bcb1272249b0c99240765f5b2cc98099403585b644add4a04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/hu/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/hu/firefox-57.0b6.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "087df7bc49d7e76018829940adbe0d650715fd38c57927af7c34fc9c29f198ebc3f14eeacfddea2ffbdb60d325de6038cdd29763103295b47f3412f8db9092d8";
+      sha512 = "6fa2b613d550edc2ce3328b020d868474e1a523b6aefdbe94a84b7d38800a81abea2ce177217aef88703672293ae2083ed7b0f278265b83430f8f2bc6c3aeacb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/hy-AM/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/hy-AM/firefox-57.0b6.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "7ad25dd04232b7ecb61914ef6b14261e6e6498acb0ffc5760d6945108665bb97e1bd5e64b1281766434d34a597dfdd460673632dc50238062abd838c25b1a9d1";
+      sha512 = "14d31727a1ad12438ea4883c15c073bd76a4158a5eba874530068afef9e1f2ce017ff0733eaaaa27f1296b00276aab3875129ce01aaf98a148df6677875f3954";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/id/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/id/firefox-57.0b6.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "a9dc65f2160ab88b6adbdd50fd2e501980a97a8f5066bebdb518a5c76e906b6a0acaca3c5e2e8b5dca7968f55381bbd81e6bcc4edf22cf51480a7c6e84f1955d";
+      sha512 = "aa8d47e406e391111958419b45bf88150dcb945d2f3dbcad901a641e1c2008eb25538c987ca3c8ea3b55c8c62c3adba7987c0cedd997cefd8ccd74e77c3e9a55";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/is/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/is/firefox-57.0b6.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "a94a576e8f6b6f50ba41ed8c8001ff7595a0a439c742a15c4c468a1e026db147868172ab5c9accd18f2fef9bfb3a152e1e02316453ee621165ab125ba420622f";
+      sha512 = "18c714e424abb23d48e449a58ff883414e5426c1c8a0f1e54f3f0f0eb4759e94f33facc6d919299c2fe5f4db62bf6daba166576debdfea6be1456b5749494e89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/it/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/it/firefox-57.0b6.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "c86a4c41aaf0e07de359e5b7d3a5cb331ea99c9a670707f05de5d27f6354c6c6f8ef5ba3855c3e8448916b852ebbdc594e986dbc325dc31eef421e514d145dc0";
+      sha512 = "2da3a75200238e35a69622585da79cf31379e9a3386388c087a7706b6deae76db56ca0eb6f63d02689c79fa8cb8ec9a08dd3c304c203c5de64a8da3401f25a3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/ja/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/ja/firefox-57.0b6.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "8628eb65c733856ee719019f38c54fd07ce63a39cdfce66fbd98462c353a81dbad97b5d490d22260505400f1f656af67b3f518fbde2e92843dd9dc66cdfed44b";
+      sha512 = "5656c13478d3bdfc8fa0d1e01335f1d6c49bcd3ddd85a5a786b97418adaaa1a64632b7b8c1e5a6cc72431dbf128e4e3d81508fbc5fa6cb0d79f2f79b58778bb3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/ka/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/ka/firefox-57.0b6.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "d2ec85b3d71964850c3b06c500f5bf59ede7c8a38e12de70d0033a2da404718ed03f16714f09ce8a340de53845094d8e63d185c9a86a24ea016d8db31aefbe40";
+      sha512 = "1a8b488bfa87ef950453c9479943e41fdbe8c26051d68af06d341c0a555e84abf390b50d16b8a99b0d3799182a5781c4808bfece4e055e0b3a834f9b81a4c416";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/kab/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/kab/firefox-57.0b6.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "6ebf73f503f0cf491eb3c15e54aaa0b8989cbf21474c681b5b734bb14400c9388cd5848840c7107f02230a4f3bd41e8e52797858ccbce1bce035f29b286c78d6";
+      sha512 = "23ef286dcb57f552268aeb5ca01368bb6f5541812a0cfae1e88161b522b3097e86be3ad93a26f51618dd818f6a6014eb96352f75a952de5aa76f7a94d9a466e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/kk/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/kk/firefox-57.0b6.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "c5c53aded97db7a6e4f835b459027a8d48b72a88b079f589a618cc14a48a749c41a0e66562a6483c89ef5a7fc016b3b573924c023fd166d12a90038c8d1d76ef";
+      sha512 = "f2324279d127b6a626114edb1f947e45073ee99751c960bba06cb02dc71ef2e32554be8d85756c7f76947dbab0af00969222b0bf25d896562e4e0d8ee832b959";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/km/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/km/firefox-57.0b6.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "476189a0774fff34733ca8fa3ef50c4ed20c11a2cd591b41a337d94e649d3d4313c73cfec63be6b5269a40818ae05ebd5d3d4e6e9fed0a34a0f1e0166fb8b8f3";
+      sha512 = "2a4a1b22e6d3aeb61e1a3e7446feff92fb85873862f02d4b201952c99dddf67fcab219e69681df29429d6603468c83ded93af90fee938b5eefe8fc2cc58d17bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/kn/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/kn/firefox-57.0b6.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "154ac09b2c43bde58664f2beefadea0eede18ed827e2fb7b9f66016b957685eae0f6ef203f13e1ee2200f3d0bd998f3043ceabbf64f017f09a1de9a6b8d664d3";
+      sha512 = "ab1a4fd00b09dc73c971be1cca674408f5474ea7da77b4da8fb692c046a0ecb69743912ad47313efdd6ea9338e338f4093904e42cda125f67be13f281e7841f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/ko/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/ko/firefox-57.0b6.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "d2e34a9364e5b0806233114809d36ac6a62da7add5cecdcaf56077d8286de0708bb8fac826bc2b6b237f44c6b828d9a6c44a7d7cdf7f74d12fc561d8d7028c10";
+      sha512 = "76482e0199dfde34f0fbd5a32ea79875285331a65f1270246bf8b413dc72f07b8bfea7b6a721005189107c8f2baf54f5b4c2aa5e9008e7ab70ca5c5f3bf2656a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/lij/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/lij/firefox-57.0b6.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "1a69326a0636e2f7a9dc7ce1405fc80a02431a798a9ef69950266b6c6e43277eaa42021003d924dff0e82acba98705a21d75d31d6515edf88acbd619dc2b36b0";
+      sha512 = "bdc30b4a4ce2fb4a4f0a761066ea17cd30fe0d4c682f7b5ae4a4a9d6f220e9aca7a918f69a2fbca85adec8eb95d4c5c664e8958caa73d57d79152549f03e4bff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/lt/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/lt/firefox-57.0b6.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "5c644eda282da9d486aa8755c28e1e3f02f881826d6b2679404bd17185d5731b8b1293b65b52216435ff3a11ce12e589b1f428a71a4ea976e52a5267292abf38";
+      sha512 = "afcb9b001e0751530d179dd3f797240d72a31a51263ff91b8ba055a90b474958b62cf7a7142ff43a84e2d7c3388feefc13232f818a96d82bf58d6d2a39c52db1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/lv/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/lv/firefox-57.0b6.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "90abf5dee87397da507d3932565a7e17d6936e94bc47b7f5c629c4cc4c687773dbbba8ad371c4a463c359bd3e81ee8e4222df0edb5c0749d503de52cb15e86f9";
+      sha512 = "75c712b5df622308e113ec2dc04d513b911f15d180ceff0439b2bef9304c9ff359ecb895945b5328579906eb5d0e2fff6f1fa2698a085d104ecdb19d06727341";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/mai/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/mai/firefox-57.0b6.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "a50ed82251d5bf1f77fe5d44e5e16076da7a1081f3ac5ae23254342ba9dc5c70f95d1e4fb0023c5be4b72b97f12dd164e988374a79f5fcf3c90fdc9deaf67580";
+      sha512 = "e2e0654d8f43062fb173dc4782b83641c2e9a5d5aeff4e0bfa38293956f321d7410eb9c5e2a5e17992d6895575fe5f1c94956cb67ad6a4571673a093b44b84bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/mk/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/mk/firefox-57.0b6.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "a9f3830cd8f3e1b0b97c63ffc0ad16b9d3ebf80bd9fb7e416f7001eba84651bb0392d62c802e57f74e6c606f750a1dc278901bf81e20d8579f6046bfd791aaa2";
+      sha512 = "7eb2cec4b09a6204986c6a71333d5b08802617a0ee29f1bbca52c8a268c27456904e518128d15f74fcec0cdb040f5696c365669d0a8f1653740cfb2a25815161";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/ml/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/ml/firefox-57.0b6.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "a8dcb1996e707d740f4b040b9d86db9a43bca02763c855ce71fc8c3fe6849621cb8ea9d83113e9972f33cbf73bb0bbeff6f730036e71e8d7184efb71467f9804";
+      sha512 = "cb7f5fa2d2b1650ec24969c25fb2d42dcf2f478b2f7a4ff48aa2afd2a08b07ca2fde842c830bee2c3f6de588fd83c3970ca965dc62677400c43beca6472fdfa3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/mr/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/mr/firefox-57.0b6.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "8e62ef5dd26384e6d5435e95da28f544eda58f458a48e608dd70ba6766fe45d2c7b5e7ef2cb69b3e9a9bc538905280307d22c037307633afe15949c8e407edc3";
+      sha512 = "b67631b0ac97123053b5e941df3b833ae3881b8a37d1c25e18ca962a04f2a600ee23257561a5a7b69bd37948b480cbe75b610313d67f1a3ea0c64b36ccb1b0d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/ms/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/ms/firefox-57.0b6.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "cffd43b21d3c9a00d68c4513909864f38c7f23eae36301978d4849988c1b18bd0eddefe7ef176aefe47406e65037041a99153beb649a191e532f0a314b6a1103";
+      sha512 = "614fb7f03b2fca659575600c2d7bceee35e4066f0c16cd3d88364b2b4c36fc6261161d5ece691ae8230767d5af4302d84d6e24ecc2786ef7f500547c8d039850";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/my/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/my/firefox-57.0b6.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "921232def7f322eaf0ea95bb2372ffc653eb81384d1c60d9f40fc25517028929f81110b7c50a2376cfae1810c8b328e71d35030aa712164b79fd6570be198326";
+      sha512 = "e568525fa0151e5188a325d695fad47af3e2f59b15ce4075d27c6e6b16b387e86cd94d03dd5207c675cb0f7a4fa95d3f7e67248876391259d858277cb5ab339e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/nb-NO/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/nb-NO/firefox-57.0b6.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "d564f9010be1a2638474e65e9a9cfee390d7ebfcdf172d87033a9c55b469fed0c61cd1da3df7f3f5b1f5f203dc37c692751d81aecc2edb650402ff3bca9aa6ad";
+      sha512 = "a7008a0e2da4d0a273d0fa9b9a7fb1c873570227536600820df353deab63b7fd3eca438e0647e73a9e93207fdd66513c051e91949f83f6af4a064f50392eef27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/nl/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/nl/firefox-57.0b6.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "5a6a454ba3c1d5d902e157e9fb7ad40499ddd3ffe6021eb7a27993f028ca5dcde7ba916c389142e5b0156f65a7cd18d6972b70412aeabff1bc95292d1e88a711";
+      sha512 = "380d4d0381cbcd9eeab57a1eb0d7b90a73d0c163c825033d3f7c65412ac418a7dcdc07ec0a10131035f4d02a9ce37133b4514ef953dc5bdac3f0d415149b4364";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/nn-NO/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/nn-NO/firefox-57.0b6.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "0501d60d85d05cc1a66fbfd7bbedb7ffbb672071ddba5c37493db1131e4abf427ee0a2f37eab1e7ec41c663ae9e9a2ba36fb7bfd180c8cc99a2bed60b5d82be3";
+      sha512 = "60d9157c1add1064b9f5d3d0873a36fa7a29f9f19da6b0da83385db86798ea645ca98162a63a43f4eaafa8b79a8c19cc2e547e08b3c06da8c36c077993fa8faf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/or/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/or/firefox-57.0b6.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "b5879d81d0f51c54419fabe5f9ef42f00869ba15fb2ce85d7eb36423127522431dc52ffb2918a77977a940519fe57ab05bc4bb2f3cda9035015cc21d986321f8";
+      sha512 = "0ab3abff83d0d992c929ead73e2a2de174475b386559395a2256d40e7ce8c4c6bd48d59bd2f3e343b12c2c31c2fe2febe5c4baf658fb38a9dc4bce2106c8d159";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/pa-IN/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/pa-IN/firefox-57.0b6.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "32018c0e2b50651cbe0d9310da2818f54ee87e148e12d7a195b22d14cb5d9907cdee0771b7fca2ac2e4263a189c1c89fead3aa8ecea340b0b013e8b95f31089f";
+      sha512 = "29d743e8f90568a1f4f4a1e0988c9f5f598dceb589ea4a6366d9793c4e78e650c0c5f8caf0a30c5839d5226c0788c40e5e128c027554b33e33f883a65504ac6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/pl/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/pl/firefox-57.0b6.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "929c67e2d3792fbd76c88758c23aaffd818fe3884b297b19c6609d7fcdcf4432b1920d21039150c880e14e8148ac76b9b4ad4b796599c420b60eb463a6ddc2ef";
+      sha512 = "7738550ad840a14871da75c913816f9c7d27dd5037c3a8a6ade0415094c28e2f1a00c6b92dace368284ffb0f859131f1894da3b0ba720442dfecd6ed67bd3b3a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/pt-BR/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/pt-BR/firefox-57.0b6.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "dfd3d6ece181ab5be296a017baade85e2dacc4beaf9da94aaab42840bb47400e141e0c45f21ad485e9fb627f5e4d11c388309eb2be4a29b13b3987223768641d";
+      sha512 = "0a738deb89fed9c4faecde5412bba4bba9c83829f31ad79253265fbcb7d5e479160729ba537935c2f88d29b987cb984f338dc6232489938d22333da49aedbec5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/pt-PT/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/pt-PT/firefox-57.0b6.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "89efd6c0a4a1977857dc61dc7a16f47722ac9f432ecca7876d4b40417ae7559f49f4af4065320ff4a946e9089792a91c13273c7cde8403ac467d221e7ea1657a";
+      sha512 = "d51ce8adfb710e8061abae49b47a580278936b819be2d438833ebdd81bfc1d7cf631acf13c4837ef3134be6b9dc31b5f08714d7f37271faa5116d3fd2d4c7937";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/rm/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/rm/firefox-57.0b6.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "651ad7fbf9e1ad3b71172f351712a2415d96705e1ff2e4600d213f15d1faa88f87a79b665668652be991b3fbff5f0608db78d9a3c7b44530620467a8735f99ac";
+      sha512 = "bc2f9d3cb33474c330c637a8e5001d3fe427172ac9ecee4a9ed2f612cdf0f4e6e8213f5a4f01d964e8326b6ed713de5a6d4470fa87685487800f29485727ce8c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/ro/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/ro/firefox-57.0b6.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "2c92a4379f016cc2b91fbacaa9e212c055c26154e852b1c18b664777276ac59f9a453228bb6f34db5c38a5af8d34250c38616e72971a2ed87f1b9bae66f36cbf";
+      sha512 = "66e25774ab24a48988bd8963d089c375f8bc48d73ca104bc83df36c1ee8da7d1c46831dce2539fd447e956a2378060999b53e60a9cd7dcf5dc780ae3aef21648";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/ru/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/ru/firefox-57.0b6.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "38bb9401094d619a09b3e505873bcb3af956fc14c342ffbb3c03b64e597d3b434cd56985b0e3ff489790e335a3e175f66fb57fc023d0a057226c6a941bf98920";
+      sha512 = "0b3548eaeadceb0f15dc0d9ff198feb2fe94be579be3ebb77026894a3dd6aef6c4be36b32cc0876795fece91ce96fd6233ab12bb85aac415e5368c8f00dd97fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/si/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/si/firefox-57.0b6.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "8a76bfd5650f2325e83e349b430095ee72cf411f5502418538c725ffd3361ef39c3f9b0bd37f2dc1f90fee0e54de6786c70a8eeb64d3e6d5c0eabd5f37626060";
+      sha512 = "a77772ce7197a9878cdd1f9fdfe9bedd21984bac5846a81ef9e1d08fa64da6bb8dbc80b758b0aceff58e3a97f0aa4446e9f82126430c56690a87363fb65b02f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/sk/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/sk/firefox-57.0b6.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "d244cd574d1f16fc400b3681360655c90b8a40666d82b9824dd113f4b4f1b4a9b058d7e2a99c467294cb1f3fa3ac6849e1c7ea8b06310848b29db03a6d445f31";
+      sha512 = "a9ae3d06e954d07da9cb3312e0f567593952e9b8cd8597a42f5fbfa80009f8ff79f3bb502e2032402c62ba3dfd10887a7314406d25301e5c00ff653af5fa3046";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/sl/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/sl/firefox-57.0b6.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "661c9b83e69479adbe5551540b650835ed85e65a1be9d805a568568acf427f0225b6cf6d8062125bf73111d36770fa08594ed6680287aef438bd020e90040d79";
+      sha512 = "6b63b681bffdfe6942ed11a1483c7072f5d8322a513a2a6a8caf45cafa3e8f1bd750ef9db3a48ceccc49ba281dcd57655805a483a52325d542607511afb1c6bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/son/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/son/firefox-57.0b6.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "e93d9e6d791c9f2da9e2f57df262c3413321d44b5d73c7d8839d2b502055da734391b048632c2578e85d3014c5f14e66337484e45a0adc8965913c5a6ca0812b";
+      sha512 = "121e67c39bbc546aa06f409cc62699a3c7f43307a11140c0ed57f5daa009be92e527fc5a8eccba7311fefe650baede394c0e0ecd01e2adecf783439536caec72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/sq/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/sq/firefox-57.0b6.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "79a2e9fae68a5ad21432957923a65b2b4416a86b3ef948a4e5d36ff9fd383142ce1f21bbbe86302c4443473264ddc6048506efc880cc8a446e6c11b5c76ccbe8";
+      sha512 = "6e4db28b27bb6991faa10703b07dd251a53d9f30b27a9bb6f640c491a05059c6706f13363557d455d5529281d8797620272eda189da74c0f449d03bac8973b96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/sr/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/sr/firefox-57.0b6.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "03f8ec959ead21c55db5c6d5a86bf36857eac3dd9d480b0ffb8ba262c14148dd94ce1c082b47085d312196baeaface008902b90729cce8af4578e89deff0b4bd";
+      sha512 = "eb2d92f3470e97f54b70fb12b87e2b0653664ea0f7a59e93f85a907564dc9619a639d6ce418e1ab90e8c40676e37463d9e4ecc29c07d810500186bc1c234e6e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/sv-SE/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/sv-SE/firefox-57.0b6.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "558935b691cbb68df102a996766f536e361778dac12bbada54e7b944f8f782bf2a03ee3f9cadce40269efe66cefd2a73bbcbbe64dca95d4826ade237c994e35b";
+      sha512 = "faad39482bc2ee50ab66ab8172097860cbdf7d5d81270bce700af8300896b4d30d1b9ff4737ca0841015058ff42fd1ff16db68672109e64edd67d6f0592add7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/ta/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/ta/firefox-57.0b6.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "8289def19004e12739086e383922cecce1983c5084ae9913fdf7a7d7bd3ea66b89de49eda7365cb8bb0634dcdd6fc12052f850b26924859ccb04f26d425967cf";
+      sha512 = "ac0cd929bfd9dd5e112077194601e1d70d40b86b0c8fb347be8edcd30b4d622974ea7580709f6502627f0cfb99eee465a615b9899e38d427181a567e47593e20";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/te/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/te/firefox-57.0b6.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "2ae2323bd7cd6752d3841e5a8072f5932063d27d7702dae06d4401273d419c36ef9e4ffa9b3c77ceec7be95e03707cf33711f4f0adb8ffd3b7abd796c5f7aa91";
+      sha512 = "7c45aa88117399629b0985d4f64e503c63e116e05acffcdad18c05cde84556d359834ea1c478a0585bcbd8838d23c1ca9ee117cb3fddd2957a10acfc243f5e70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/th/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/th/firefox-57.0b6.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "803fd7e692c85c9f65118216b49119bc05fbae18c04ac80880f334976aad4a42da58b0da10fe31ed577b3fe8c5e46bbba7df6fba99d814a4248729f3c6b09cd6";
+      sha512 = "fae97f4b0dad5a0e474be35ebb9ff2195a94e5d11512697a41fa45cfe1f131816283107110f723de319f2d4e9bdb7a311e7d72cf02eb4eed325b10e7067f95e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/tr/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/tr/firefox-57.0b6.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "db43556af5a05ceda590a22b4042566f2b68e7c22b70fc4896c4c67355629b32096da4d1f71611fae22a6ea081659d57095ed27ad841abb9521f10b09e57f0ab";
+      sha512 = "a54215a44aec2972d55ec698b44144bed15174aceb445c0710b3e3e5cfb8539784e1ad6c98317a1f1a585f7601d33d28a4d65936ab9bae219ccf42c3d0e98a33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/uk/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/uk/firefox-57.0b6.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "ae13aa237a3d531ecc840d8f4b38e4849e97b082d49c46e903875d156c0ff5779ee7653179a78c865699df2f830d868e1074d8e32cde1b3b663296a5dc947afa";
+      sha512 = "10098291464cbd4e48caebdf9b95bb30f4df61a0cd5e617c6fb09b22cd0aa46eb214e3f2b19bce14c9bb703deedcd7b22fc2d25f780759c955a65d1bdacb2603";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/ur/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/ur/firefox-57.0b6.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "32acdc008ae647c5d1f0b9ccc437ccdffa433db790e6f0e2c9de53d908784a21c08ec8aca28e6eb130ce39d57cd2b65b593d1702f0db0d6d47fca052064b832e";
+      sha512 = "5d40e66225e097eac31889c1f5ffe8389ba3a3f159956cf6f0083ae40decd1141d306805cb51e79b69de84c73b84858121d40b0244b645efcae1b791cbc788ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/uz/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/uz/firefox-57.0b6.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "21940f34975ea474f4e78c9d60b4c85269b60e68c5200a9a6509c61549bb38e46504ed010f887daaee85c6a36780b8518e3a4cc8de0a2a072104b88347ebab8b";
+      sha512 = "d3a6e6310dfba8182cb529ef96c650a5344065be61569a56f310e23bc443c500af99d0e61092867c0ea94fbc65d63af2e94bb077dd8a5d0dbe1dca1aff1f6183";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/vi/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/vi/firefox-57.0b6.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "fedd5827e023861892197dc17ed8d2de39203f7a9ae4213ca99cce6ad1d9ed7f50613838526dc9edaa697438d33150a3987bf5fdb5b347faf0081617c1f7ab18";
+      sha512 = "fc4a085b72e31a92d9ed708eb02b42d3bba1d2d747b50891e4fce5e1b24578ac0637eb46c6a99cae7d81911cb2d6987659465e1168beb4fb27a0e128cdc06d7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/xh/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/xh/firefox-57.0b6.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "3713cbae54066f793187c5d7cfc69c544a54e25b77b4dc52bf653f05585b9ebf1ea0f2d59eeacebf46a346240b4509c40dad5fdf6caf27721c25d3659cf1c768";
+      sha512 = "57f6cf74ca703f00d29a5c1f11223728c6f9e06bd25696effa69b155820d839680f29033dee1294ee71a2a658f35482fa05c4840a812a8aec8c9b052882b8fbf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/zh-CN/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/zh-CN/firefox-57.0b6.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "543104bf2f065bdcd914186e8ea46407f7286409cd229d9341f639dec9a8108e537f1a8f82e918514fd5fb104136a26b5d6a2f026813b391703047f614718847";
+      sha512 = "52f2c50c3d65a2edaf033d313a4e2221c074cd76f1d89ccfd1101b9deb363fadf15acb9a795604c343e55ec11fa61705559d7f71134c71726b92801df348f677";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-x86_64/zh-TW/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-x86_64/zh-TW/firefox-57.0b6.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "5c75f4da2525c076ce270be57ce22aa653b7c3716b971964cd0560fc0069927083de3dc662097eae60901aea28737626c64507c82f76eef24ac350104571e9ce";
+      sha512 = "0f22ee573b8ca0a041373c33588496d1717eeab134210dc9cc23c951fecdfd319a10ccca18329543f969445bf261bbecb1b6de6a1223101bd50af8a1244a9475";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/ach/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/ach/firefox-57.0b6.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "9de80c393b6ad0c6042ea8867980b97fe41a68713539d7c7b3479ab5b0a7ddc4da3208b24e42c4979003786593d3d1ff73db0035b6566edc1acb2600f8a1caea";
+      sha512 = "0c474ecba92d8c6132a1bb484702db6f9cb34c9503babcc9f339cfbd97f03cbf6f9e51a4b7b7a69efa6cc9acffc648a0912d2ab92753d6e00ff9bc92667f263c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/af/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/af/firefox-57.0b6.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "0864f0127acc2fed3ecfda420b409884fe892427c4d2e8d9df6a126a69c460a10b302dad78e9c34c6ae73609116e444d7210185302ff072833387ba5e7b74627";
+      sha512 = "68e0875f2aa221d639067c2479cc949a6bec5a8097efdb20452b9c6c9ca1c781570405356775c05c02939f04ce4a4ff23a84ffc1eefd5c213a37d6ed7da64fd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/an/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/an/firefox-57.0b6.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "40d613fcc5b6d23b69bb56fa2f0537ff440df5a6a8ad49f79461817a2eb1fa472cca694042e02716d3b8553d5a26581c0ddef133f3a6b961c8343b416d2aa5be";
+      sha512 = "c5c95b2bb6822d80dbb83277d9efcc7e750581a7d46295257802c760dec6016dbd79c9d90767c2bc75842775ddb489b6cacdf3e7e66d63dc19f6c310fcbf0b97";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/ar/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/ar/firefox-57.0b6.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "3a3fcd70d11d133477852e450e2a5312d52c8d70d6ffe5eecfd906e126e4d1be0413b580349005f732ecfb375998e893e946d520b8190b0c1412bdd6c8fc1cf0";
+      sha512 = "7a86badfad03dbb4198d2cdc287c502c54df2a8eab6be487211b3c4372b0d8d82104fdd136f84a3f6b265225f639b12f3b23f3378ac0fe185919cde202a9e542";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/as/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/as/firefox-57.0b6.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "d88e4e0b7f73b0eaa2abaf87562ba9693dd0cb50a8e91ee362e9df8867116af5535acf7907483e9fce0d9b416fadbc07b57d29631898780321c226c2929618e0";
+      sha512 = "1fde68d53458c0916f49be591c5bd744b7a3e3b4dcdbc0118ccfad103c357d5317e8d1fa7419cc1ffd48deee4ba196a2a41d9f8429c53be444fbcc5a8385bcf7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/ast/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/ast/firefox-57.0b6.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "fd5adb4a10b2c3a18dfbe1c021870377a1c8c03f9cece3ab4d045acb8b1ae1fb56b311a04176bd925dc5f10d9289fcb3347c593fbe4b61d6c732746fa24a2027";
+      sha512 = "721e9822c9638299ffdb39eafc1f2b485d862acfc6bb0ecb02563433fefa4a081845d31b75586984b1b7db768815dd5823a8ee8c0d22b655be13c15f3c840e53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/az/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/az/firefox-57.0b6.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "f94ffbb20fca06b2204ae81f277abcf31011ccc4910e9c3408e34d66796972c063d07c45ea88d9a672265c6ae8af2d230d6dd511bdec51a37abcb5792db31626";
+      sha512 = "99afed4563ad52bb2573c66a974cd47688a5f951635cd28c85ce745d8b846473adf488ededc22d0737b6406e98c6f2de6c828434b9637e57f0b9973997241691";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/be/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/be/firefox-57.0b6.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "728ba0c9204b45d722f3d4249cf2b6970e75be540b744178e6a1e4e08692755c344815294a98c6c7d231a44383bd2d606bfb7ffb29ed5d7d077050e34d1dcf37";
+      sha512 = "6e7e0306dfff0bdcc4af40a63c8003b7e06bf8e555129cccd88ee0a1d726f5e914a30980548d69db28b2df16fcaca3e9e88f4b7b1bf672e0048fb1c27d00da44";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/bg/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/bg/firefox-57.0b6.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "396b18d49164808d5199cc2ac53868cb5a4639d96ad49cd33edd446aa3e4e65a347c08b887eb9b0eb4f4765795137d0296d5f37891706bbe9c13d2c19ad956fa";
+      sha512 = "5772a034ba84844656c8d93286a514e49608e5fc1a2546d9b70631562e0c3da79f57cc36be1a4aec72f9ddfd187017db588bfc63af3142afc92ca331b23f32e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/bn-BD/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/bn-BD/firefox-57.0b6.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "282f309019a3d45fc2ed339b1e958bfe6e332f679c27d34a6c5e6b3fa5a45412f4aa7b0cbc7f520c1ee5135d95010007cea79fbfe35965c0d7263107c971714a";
+      sha512 = "6334057dd3661daa8434c1e3069b7a4e143fb148db821900b9f7c71f152777f77741c7dc720ef6f1513e4402abe83d51bb580354fc3355393b75488aa8969d64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/bn-IN/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/bn-IN/firefox-57.0b6.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "cd8a2fba1a2d5c550bec9287204d2c456e9c3ab8cdafa04455b6b2e706f2906786dde1183d58f7a84a7ccba7a2f4242dc4b13b30fadaf1071fef47f781e7cd39";
+      sha512 = "e73a7fa1b76cf4fc112319fa09685edb2a64a3048afcf4ca4f6fb278a9a10a7571fd8566968d7e9b1a86fbe4e262d9be5c8052a6a2a31097e2aa16a3657848f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/br/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/br/firefox-57.0b6.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "aa057d1d35a386d21732a235d558177dd9b2b0cd52d416bbbbb482eb62d181f69e981cc7174ad4805da0b06325bb1cbc7a9abaf050ec713e3c4b49e8a40da9de";
+      sha512 = "6f52057beeb18dbaa99e2762ffbdef7f3da69cc1ec4801fbfbae4c3f8fa12619faa0086dc21abd92c656d7117022f241a70be18798e93bd33eb8ef9625070ed4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/bs/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/bs/firefox-57.0b6.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "39392bb6e4dbc8d359545ce996193e22187ac14f795221231f0d9e74c3022b4757599e03d1862cfadab10f78d8f944651b73a64c8c16226ba1bb9e559fa1bcc1";
+      sha512 = "0069bf5b9c5499d3e5424b9043ac5f61ce6d9cb34ddb329a40d30482bdb79d1a0db4f00b14409690af4f0b9afca9f87cf65daee313da6343bae5e8684c1de266";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/ca/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/ca/firefox-57.0b6.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "c046f0dd88b706277781fdd9f88ba2014438b25a99e136ce7f3dd34e2d7df18496398f5bec5aded25a7eaa219c176f874e6bbc4e9ecad80800bfaaae24db2207";
+      sha512 = "0cb95a2b288f7042c1f6767feb1cab88d345e0f0298f3fbe3385e58c5466bdfb59a2c28683deb3a8fc3f4936dc991486295b1a920d1bc09df96cb77f58ecc4ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/cak/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/cak/firefox-57.0b6.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "532fbb953baa06ce5a3a6bf2ec1a4a2e0ee81ef297e4a02b00cb27aa2207143d40efb230f090225157a2a0c47dbc6bd939d819f9e5644ab3b84740ff9eef01a6";
+      sha512 = "4b9ad14926a3c952ce3dc5aafc1a04036c6ec45a7a68835f512221ddef13d67c6473d40fc0993cdafa6d8ba6927910c20c089b331233b1b6f493c048770d7e53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/cs/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/cs/firefox-57.0b6.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "78d880bd4ba71c8b83949e51d3396e2d192e825fcb61bb2146376605e4924cd10b4757fcdc2e55547300473527612c00327625e4c2a848afef22794d26837b8f";
+      sha512 = "e7e748aaecb30b7ada664474f8b2f2f9a3632d58b195f895094de2d4ecc5952948cb688dce1a151cb2e3832bdae335ef74017241d29400d237c828369bb9c392";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/cy/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/cy/firefox-57.0b6.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "f55d56221c3457f934dc4133a1c9c962e5c270f93edd78b5e815d8b8269f34296107c9eb576ad9eec75f1663fc111324cf4134ff18cf7ca93c0f7e5e7fa5a348";
+      sha512 = "4799a27cb22216e9ab2f8b2c18b18edb6eeb101995e804d78e86a1c79738f8c9a6cae0a3ae2caa1b1b104d4eed2218560c80d0be53b3e453419e576ea3eb5312";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/da/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/da/firefox-57.0b6.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "329cf5c3d30ad87f38a47385f94752580fb3a2cab3ab1e01fc6557277df101dc0f73b752fa896b0bc065ede104e7a2906501f3a4c7d52e2b9df952f3cff491e8";
+      sha512 = "fd26938de7e4df391edfbaca4b7d536bd3ef96ff53d85bb26b62fc8e9e1ebdaa344d69856a217f004ccb0a2a9f5aa18eded9f62f5ca4196ac07d845a80f74043";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/de/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/de/firefox-57.0b6.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "d5e5854a87894d5f1ad032494da40f9c35177f9743a3106d26aa14fa700539aa5770d99b33a0f9cf9162a0c249929f48b5a78451096d7b22e2f3838033a2cf5e";
+      sha512 = "bd753ea3bbfc389028316f76784bb0e4216777e34606b415bbcb6efe45095536bc5e45d6bce6bdb632cd59a3d99df18abb4579219d6fb1745ab81ad32c9d3939";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/dsb/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/dsb/firefox-57.0b6.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "03213881f204cf41bbe822160bb14fc309cf75b69efc41e70a589a0512f03ed668a3c73ef0048779405105cacaf1c08bcff222cee6e04ad095c5d082315a858b";
+      sha512 = "c5f8ee1bb7de2db1a6310b49c951749a0779f14fb3dba73fa4e925b69c7c6740330578e7762a796bb313c43ef3cd9175441e7494ccea719d1e904a7d06aa4947";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/el/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/el/firefox-57.0b6.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "024b78db62a30c9f353451ab01cb88849e900cf9dbd4850537fed1ac55d99fa3f454cef1488c84a5e990fd38227fa62c161dafbe4c6968d733507fdcf4610b10";
+      sha512 = "20d34d89e99653649766cd6f7ca49c0cecda2b0af76654fd077fc8287c730c49fc1050f7e30095a0d83e16a4f64e1c78e9a9119048d57f531968044d9ae50295";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/en-GB/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/en-GB/firefox-57.0b6.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "8433c61dadc56ef837c6ea20820e992fd1b0eddb95ae372dcfd7d27a10b830f83ce7ac84262fde306e07daca94c7d431cf4951b8f043dd673dd5114dcc9bcf7b";
+      sha512 = "543c4cc7ae137bccd1e4f765ae9c4422605a584d939ab919d481e761d29cefebfa664e63ae1c40b78b12da9cc185a887480c93b5af64449a4b321ebedc81abf0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/en-US/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/en-US/firefox-57.0b6.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "045c2bdcaa471988fb83f979d4ad4beb78002cbb26a40291a2239bb8de1059b07dd648e52f4164b2b2bcee1eb6512573172ec50d0b03aff665fa1a3c5aa67a6e";
+      sha512 = "e678f84ff6b82c989217f1c911a0d3c1e923785a8f0f65afaa4689bfe44a591d3b20066c93b5ab3c594e3330056435c5df86e1bec47c5d9ce6de0dfc68c65192";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/en-ZA/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/en-ZA/firefox-57.0b6.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "3d7e0668083a7abcc4fca09e8def3d5e1b9de8d66c6836443f453bb9ab9dc191e2a3fd680d2b68348fa9803958700b070a6865cab93351c9a3bfe655880ad887";
+      sha512 = "117868c399d9f41bea55441fadae9f6b7af7dcba2f6063a05ca7f2bf8f9197814f9314fec06cd63f3976cf389ef2f3c6425fb0890fd08cb036e8612c68f02ca7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/eo/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/eo/firefox-57.0b6.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "d041ad8f78878f32e52c970ed2b739ad159a36cfed882bf7aee5dbe24e0d7259bd72c2416465a69b65ac78dc77257ccef74a8136796b2b4a8b02333bdd803333";
+      sha512 = "e2f496ccc935fe978d05675e1152e518bb1c7a4b3cd393dd8d30a2f93cd586953df027d06c108f3531e9228c25844e7fd83d81a7caadfdec11f1bb5fb7dfa3de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/es-AR/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/es-AR/firefox-57.0b6.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "34c4653f3d76e079c125c19d0773ce34ac8d0602b178ea23ec46d17ec599f31483ecfdc778a55c33fffd98a6ecde556055ef22ea002c421699d8ee03fbc97b2b";
+      sha512 = "d56dd6fc221ec085864c50fefb57a8b4a5c11d6dad5bc5a3a24ed2b968eda816ec1fff83b00bf89e5fec2272467147ab5a6e14b5e6f5f0be25b5550aba908870";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/es-CL/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/es-CL/firefox-57.0b6.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "5a7acacc43917c20fd3cd15c855afad9bdbed7225f8fa710821ac779fc53f32ce593d176b1d06ebfcb4b16eadcd61a7192efeedc500f387f14936753fc6aa2ad";
+      sha512 = "ecbb9f624aaca6a02762ad0c0c15b9b6e4732efea4bdfe90f3557e4b242cdfece657d4bd71a369901b4866a36e6a95534d237f661c897c5375cb627d371ad3b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/es-ES/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/es-ES/firefox-57.0b6.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "07daaf5a0d8b80c83baaab94820931f3490bcfe7ff49e7bd370dae076f9a07f0f723b39a2abac02790e8e8dda6ae1438657e68fa6220b7ff92ee4790fd4d5db8";
+      sha512 = "2112e809b6109d9367f9257a24b0c4b66add2c63ca456647712e9ef4ff04ea0c38990e334381c4b822789b86b4bd9949e68ea323b95d626f1a5deebace4286d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/es-MX/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/es-MX/firefox-57.0b6.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "3d3ae9664ad67a04a533d57b587e1f05eeb2d5466ac8e8eb1f54d613c1dbbd85f9a1a261bd79699e3d97f2413c86db4f765e205435081e778213ade6eb453d6d";
+      sha512 = "4291992b179e7d2c07d38b7bb0c41b6b78007929a535f6689e3cee287cbb11662c6e94e9e1d64dd20efa5e8b5f3d5df5f554d196d1e6a8606ea53dad2157093e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/et/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/et/firefox-57.0b6.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "ab9ec19dd588e8d2875648ed8b53cbc6a26e3f5971dd89133729095b72f320f31e5e215814c6725ccd6a1abfe08c005ba0b23a304aedd3f6300116f756446c6c";
+      sha512 = "bc2cfa0b6729b1bba629db9bfaddeaf1e15ba6820ccf694ba2b468700b047e22ec8d8aad47a032af514e602023bbc45a9c94e80ca251b6f70fb5aa832491637c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/eu/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/eu/firefox-57.0b6.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "41b31072034bf9eadb52e12b78590ff986439d68e5c3b7a5a56fd0a8b1d1cadd7b2fb9dc53ec1245ac99dae359d829af697a542b6fc18511b02ce4a6a96595e0";
+      sha512 = "f0021641ac2079869d698650bba26f3c3d9a265defbe17fbf27f7cbaa7be2ca76f37ba4e03f3adad453d093ddf768155df5ee53774dcc47cc4fa79eca3cbf613";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/fa/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/fa/firefox-57.0b6.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "8d53470688b6130c501dc6aa2e500f14512bca8d61a17d60e71e19f2f6326c52a641bb041895c477645776c5b42d4da846e99aa81bb8baffaafd0f57b0c1f57b";
+      sha512 = "169d6be0a9e344353976f16c860e8fdd68b75ab94800926ba63e6efb108c6af9116d18f48485d462ce441f2bb1d484a934756ca16d5f365c9280ff0f1894f832";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/ff/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/ff/firefox-57.0b6.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "164f772a9b4e34eed65d22afa4d28c8860c13101da5866612ea981009bbb0ec849f3b5325b0c0ae6de55cdbcc0d09e18c10ff3504f8150a5182927f74376d046";
+      sha512 = "798be99da60a0ca0582b98dc3dd4e3f9c152e0f85f82a0f14adb7029905a206a801339d2565bac19c4acccdbb4617cc7d9f5b36df0497c3f33ca3f76c9fbb520";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/fi/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/fi/firefox-57.0b6.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "df43ce6144f4e51ab6933073ea52ef0cba29d882eb1daefab298d1e111ba89b2574357262e8d0fd0d7a61c69c1b350b1e8ff72077c7aa02138fe364d784025d6";
+      sha512 = "8659e136e27aea77acc9c73b679dfe0ed8c93176b70b69783b46828806ba41c3fb2f9e5b4679dcc554d7896c74589a86d8c9b35fa521ca84f051062f884fd501";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/fr/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/fr/firefox-57.0b6.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "9631b7e8f058be5fd77e34263fabb6666e6777c518340c53dfcf5b777f7254d91aecd4a27b7202c2020eb7652501b7d7334b1b5320edcbfc343460b93018de0f";
+      sha512 = "effc8f5ff352e6690ed32fe5ccf0c47d136c43a083fe8223687e6c0526a772b9120a15d3418cda8a061d1964260a9d203c552dd0f5a030f0431e62dc8304f8a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/fy-NL/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/fy-NL/firefox-57.0b6.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "6c6e36e93525ab0e486f1ec2b602af62c4b4b63447c5ab2ec963c4fe40ff788dfe8c64b2967c092e4c86ace117c13126de213b3b94ebbb79b20284db02bbc89e";
+      sha512 = "bff1f5d37a33d863fba0dab07d29fdf963c7be207cae27ad15c08657627896597c96bb6311aaedb8ce797e7d5adb3a7918512ef611836bdb0c083005d534a1c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/ga-IE/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/ga-IE/firefox-57.0b6.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "eaa680920e3ed60be14053f58dff4745aad29626e37e79bccb62f2e3a2892fb1fa07687581644a9b870b49b7c2e86a02f0a86f22257686fd66097808cbadb96a";
+      sha512 = "a27f0f158d2384207448016e0f9a3a9752388303772b5765707b6dfe936f66890705849b490e00c8330254f872813da064639e666e4122cd1b6d8978ddaf87fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/gd/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/gd/firefox-57.0b6.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "d5adf080364623705822087ff79432ded2c1ff2e7005a4bbcbbb6198f3d02ec072e3a266d72bf7aefeaac5ff208beda38c5976804d396b29315faf9447abd249";
+      sha512 = "d1ba5363a6629dbc62cbc9671ad8920a1c29ac9f23ac22c42af085ad862aa924d650a6349f5ae8ea1ecfd8a285205e48d7701a0ee72b16fb7c64aad4d30d497f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/gl/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/gl/firefox-57.0b6.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "a4ee4f5c0a8c8f99263e114e49526270235a304176bb75a987509ed4c3a4c0550e6277eedd7418755fa14854ce781c62cb7fc3340a711e2d2499d514a766a9d4";
+      sha512 = "f6c5c318369dad3651d0e65c79ccf7f3dffada3b6ba93455069aefd6b2346e3fdb630821146d1067ef64199e6ce737101caed5e474344a1e62780304c12dfe3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/gn/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/gn/firefox-57.0b6.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "a59541befa9ce1ae2e24a55b9bc80fea54175628db4eeb3557b101f715a84c985afa1c95958882841e76713ab5e237742ee427be1c1151f0abea1394bb486e91";
+      sha512 = "bd40bd6294cecaf72be721def4e26a0a5b6056e561a0980f2945202f77bb44dfbfad339f246f73159a83a4abd46732fd59916408c922dcd7232318147f321ee4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/gu-IN/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/gu-IN/firefox-57.0b6.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "252814b7efe0ffc063142fc05741fc3a06ab0416fae0f9e3f0a73b0c320a46ef94732b71af936f11486d1689a9baf12a56bbc0d8a6d23b25a8926fe3a4065ae7";
+      sha512 = "6d679736a588fd52af304764277c50466e296dab724654f928888d615b7a11254a96ac60b5350d2d35d4d6d534a4d94b684afc90c52fc1942a3521907c009eed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/he/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/he/firefox-57.0b6.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "3692e92dc7cd18798d3360365b8936228056cc385b2021dd18f84635b9e3975c8767ccc006d5e4d47021c8bf38945141ac4c1bda8c07999339bc4cecf08b6446";
+      sha512 = "0c45ac0a18279e10ac6864f917ebb98fb1e199cf14ef5cab1cccf333c0f7daa29ef8784bf55faae82fb7b9ea2d53384415e84a166ffc13c0ed0928834372cdb1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/hi-IN/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/hi-IN/firefox-57.0b6.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "592c242e76d81ff06276c35660fec84705b0bad72afe78732be27aece21b27073966c0dd5d227c29ce33f020cc3eb9520b11e914741cbc5b1c95cf46b0655a28";
+      sha512 = "d021986f8d7cd98910a1ba7f1b057f5dd20b3c3ae652876be69e948f29c03515e417953a4c091511beca1a06d7fcf1df8dcacba4f32653601b0fdc1fc619d5f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/hr/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/hr/firefox-57.0b6.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "012812399e63eb6628b78f91a8311511d16186d510198cc77bc0b7fa191a636875f9a1bb83fa350a4ee43e2cc23db412548246451a7fcae571d1787ffd557ee5";
+      sha512 = "e112cf30bb21c7c30dcacd6fc214863070b4a3395fd02701e3914a4a2bfed59d82234b5f1f1e22fee9824e8a731f0afba52be71c468f2323982fbd6408d558c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/hsb/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/hsb/firefox-57.0b6.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "82617b5ee0e3fa396d72cae69221af535255c602e8c0f220c15b5b88a47bc7b2326dbefb21b13dede02effc0c8731dd2a7739a941fd9d03aa4ca1dd0eeee0336";
+      sha512 = "f648acd408ceb7637851ddf05b3174dd7a1a201dd07856138025a22a181e17904d15f357cfc2d3bca0a027c7f43baa0891d347a65d0b80f1869ff1c951021400";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/hu/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/hu/firefox-57.0b6.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "e71308ac39d241bf5a52cde9c0b355c07687ce7e0aec67c8a6c63f01d4ebb26bd877ae7ff3ad1d96f3c823c0ded0a4b4bf454a5de92dd2f88cf9f83051dcc758";
+      sha512 = "3b8418ee8dfd195db7826a476613b47dd4ddb6e8b2b372f85e68a588ee13de89e89c3fc2e233f144c2199b75f7d18b245c4402f111f301b44be5c75f1eec262c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/hy-AM/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/hy-AM/firefox-57.0b6.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "79f56fd662bbb07de614023d2bf8ec4fbd767c4bb537f39aaf2152ff166822cb90ad32c47a6e9a7d90f5563fab7366e2014cf82225c06d6597e6d7ad0e13c31c";
+      sha512 = "a7be85d807202a0abf9704b43707a1bba75bd45f60e0d5e1cdeecfd1c2a0e932dfa0e16142e411ae2cbd8c3446a14c04766e50cc3ce8586a641c3f897172671d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/id/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/id/firefox-57.0b6.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "9c0cc4344081da052aea438682f28e79912b35d687e47865965962b723f07c5cd1ddbb68c11316bb24f0f9f9585eed6add1829e54d7da300791bd5c35dfac0e9";
+      sha512 = "eb1dd05c6c09998b020e21e344c0ac3303bf7fccfc65a0d73b6bdd3d7d371507a6b3fbf0814d621944d5b9ce57cb4e19379ef317e6151416a9f6cd1286825be8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/is/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/is/firefox-57.0b6.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "806d61c3d2366cbd8dba8e5744f00873cd2be08041b24e32ea023dff3dea21041336729e95ee007c0476f15f5617ddaa97462e5fd1d3d119b81619b7d193535c";
+      sha512 = "bdbb17aa801fea8a3e70ae75d197872a35114ef7a49c7ee56cf95763e26e2bb44a815563b2fe9e630843543599812015224c6634646915864ecfcadfed9ac978";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/it/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/it/firefox-57.0b6.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "c04444e7473ad6587e97441e56bc9a4c17755e3a641e5bc9e841d411fdbe64e876d0c17c374e891ab2d30d35d79189ef1e3161d9dec98378aeaa40752abd22b3";
+      sha512 = "915552b680051884db4a177ff17e19515352ef90ef4ae88b39abdda5db955bfc34cb92c65ac8ec4ff4a5ab69baccc42a91b3b079c0a58a93587468277d620da3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/ja/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/ja/firefox-57.0b6.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "c68fbd385f01ce1609d4a5dc0e111bb8b8cc85b4c500acf894750ed630749e5c6061e901d9a08c3f690b429ce1adbbad2b448778a8d746805ef7a47dd35b2a96";
+      sha512 = "1b3ab8420f3f18731385942f1e8012096708c49d7dd1614ee1439b80f5a742ec0fc481a55295d6f6989da4346940c58503fb67d13eb71dabfd332f84fb99c524";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/ka/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/ka/firefox-57.0b6.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "64d4a987a2e41b3c3c198786c55dfe0fa092d4e0d79dc081a5b155951d1ca80305c2af8862fa1fffa60529d7f2b3104d9eab6e87260f7883195fdd2d2afb9fac";
+      sha512 = "7d20045d38c471aa368401f0e65f31c08744953c96d15aedbcf306ee3d0b7e01a80ed0a6e207115565ab2bf1400312e9e7a8da1048af299f9b74c9e99ca5dffa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/kab/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/kab/firefox-57.0b6.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "91670abf15f57cace174d2d580135b4747f3de559e09c73671268c398317c069062e68f1be6e022eef12f593eb74eb59dcd47a91ed63aeabd0e0b52b11af0443";
+      sha512 = "7364dcdabe219ba4f72355e74d9e8be9bd5a08990910190753df3a6de346964558e17840367780e61b1647d507ebb204ea11beea703586aeca2145bb8a9cf9f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/kk/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/kk/firefox-57.0b6.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "519cfc6cc264ce83663076db8b0cdcc70c4838b2ebb920160199847e013ccc207cfa25e3e286e80f56fe8a57544b61692c1cd4496681c6115e18b57dc9d4b086";
+      sha512 = "12c3c49f0f9d80cd03a32fbc20f329fa7c34cbadc1ae625946a567b1b17b53fe1149ff92e6b5be22c5949a65024f9b24693a865a38bd8b458203329025fbeba9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/km/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/km/firefox-57.0b6.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "2bae5050a2c2e5f474fa97c27b75a2b159726f6950dd46a3ea133579f55036aefc4058b577aec477b23185cc17486ca7cad8516d8441743c372c8d30f59956d4";
+      sha512 = "808673a5345e56c6206f116fa3b9319de2fd3bb4560884236dbdd133de03e4b065059066ba6d6490a16bd6d2dfc5007f5ec00149b2cdade6fe91034fe4b2f9b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/kn/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/kn/firefox-57.0b6.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "7805f1df1fd0d7bf8f907a9175fa45731a0ff5e7a4a80635580940938e3bcb2deea0b858da2f3a41f1edfeea4b43a5555f309759413d9533992ba38836a6126e";
+      sha512 = "15f0103356a44255c523db8c5dd6703997b18ff0a965beac32324180c631bcc3c57de1ce65f1ba98820af1c4c2c0db293333eef71b33e3806dafd654223cbf0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/ko/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/ko/firefox-57.0b6.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "1f4786150f422b77ce36205bb82a36b59fb670c4a7c040c53ab92c9740826af11aa1a7b8fd9884603ffe84968154e1e5a213674ec4b7286ddf74794a767df04a";
+      sha512 = "fb8803093663addd2137bb336277bea3ff021dbfee15ec29da92ec92eea62c714f7a23248bf3804b276b58f82985eb34e28da64be6eea516aed32842ed621406";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/lij/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/lij/firefox-57.0b6.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "12da11c8d947b7a29d7a3213996c02cd13576b0dc1d906c133f28d4a58d6ed4f06fdcab2552915630dc9c4379d81334985ef4270078e71cee853a0fa6ca18a7d";
+      sha512 = "161085ad5441331f70de49afac1d4d22ba7de31259d8675a828b36eadd36a0cfa97a800881a99fd3f8fe8a11e03b57d0aa7e4dbd15948457760f25cce0b76278";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/lt/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/lt/firefox-57.0b6.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "9e417f4f5a4b983f74764f29f17452218541604a84b171be1e9cf0f2dd9fc9823893724a32505cc539126d85c41dd7df2155be43e260b7d0f7ddaf300a2a9327";
+      sha512 = "f5cc1ca615966721bad7e1c440621d9a09c1589ca0aca4b755aa8818c958b0e9f5e2b496aade5927dc0e7061c566794022a1ca38dd07a79683e38902afe124d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/lv/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/lv/firefox-57.0b6.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "479e8048db0f5f5adb0daf99ec2f026866d252826ab83bb403f520cec6a26c0bbe6f3b5f53bdabca2e9d84441af692a4183f0e3d84973af54db1ac9a4d32ba22";
+      sha512 = "f1ebc2d348dd8dd908b84351f51403b069c3b531134289c03240746927a46830dd47a54b15235ae86dc2cd5aa01d2c3bc94bc9b3efe45d35e8c4bc7123839852";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/mai/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/mai/firefox-57.0b6.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "6d74a33de4bfba330ab6fc3be8857cd93765955670d416051d1ca6dc8b1dc6ff0cc16e02971739383b0002b2f2a105f6e4e1253214a83a8dab3ea1f253a9b68d";
+      sha512 = "b6facd8e1d5ec870468ff024f4e6d454dd45e35561d5c4f3cd1c58e025c2868922d1b44a2f7520c82eb5911b7a887c98a614e7785f6ed052ecffb0039720b649";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/mk/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/mk/firefox-57.0b6.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "be1053acc188e7507bc8c4c3dbd775c80d9fd39efa2abede643a087220ffcee2f4bd10e3f3eb24946ac03710adfe9de14faf25cacfaff8d28e0f4317c6a6c826";
+      sha512 = "dd08da071d273041c6e442938d0957a0eed3b19b228c8e83ed4f38cbd481aec8759fd65639cedb2de8f698a79ac6b803dad3e9939fc30a327222a651034dbbe0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/ml/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/ml/firefox-57.0b6.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "8158b89b1daa8ef0c5cf219ff273f9b2867c2ed1149be2d5ccaf9b599909fb1650c8a4209e24ebb93b207a32f3ffcda08cbd898b726ac7ba4a8fafebfb332cc3";
+      sha512 = "be151a11954741b6fabf0c083f708f2063aaef2ca6ed3c63eb887c48e3e1d7599dcca4de4af946251a01bfd5e4c9d32f85fad749c1d345879ed54b829eac3f4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/mr/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/mr/firefox-57.0b6.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "e6c8d2bccc2ed6a19ca6e088a3d80989f5ef588151c58c84103fe27bc45f5cdbf3d0be04d5543b36be398e509f84b42e81049f48abc45f2ba3b133acb24cd3f3";
+      sha512 = "75b069efe46f4d47434cb1f0c12fa19d51138e383ac1aebf83d4e2261942b7eee769b1a1a29a9b4e28450382d47206a8649b12fbb470c9a594141062f5e2528c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/ms/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/ms/firefox-57.0b6.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "3a420608088a0590ceb5b63365e2281f3abb9838eb925dd0624ed31fc74fd784da437c7fddc4fd0c839a27f54d217d74232d25b7f0f0e763b5ee656f63fed323";
+      sha512 = "77858037401e6a92662f488cce07849f4074c084c9b2b3b30652d3555efd11c20beb2ad1ea927ecdc8daa368f89b02aeae4db7579b7dbd89b5fcf91a82197aa2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/my/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/my/firefox-57.0b6.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "6bc734753dbfb769cbd886f8f8a5e284cec8b11081edfb75f52f7ac0f735f1c4fe29e1024354326ab4484b810d1725cf8319a4a0f33385ddbbcef789e53cd362";
+      sha512 = "3ce9fd601346a4552d9ea7da3a3c8048ff72e1f18577b8eab156adb1b8e174e686866f52369108d1351520354fc6bf6af2ed9e3f1fa6e64255948cae9bcbe068";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/nb-NO/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/nb-NO/firefox-57.0b6.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "b0837d6a815bcd1e2625040ad6f0795ac8739991fdb52d98cb7c0883f2244c4421625e40ac96a121159e06a9533e29c283822f51d13775f4ee2680baad87b8da";
+      sha512 = "24a72fda7378ab7a6ddbc4cc1a0cc8a37af81cd75516858cd5a8f659e14b2528937c846252d44f379a08f7d041509b829c29857dce37f247d5bf810208cda144";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/nl/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/nl/firefox-57.0b6.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "744112471e0f11b9191ea191e553cdf5d023e20dab705910ce0038c60610755b4264aa6ef2edabf70db827b11267f8c5fa8643314242aef2bc517beaf76dc54d";
+      sha512 = "0d826036fd6dd68b787b748e34e7bf304b4233fc5203bde7581b771725ac3144c6aaa2d50fe854d01999b44a5e064c63247ddd02dba351cc6c89fd4facf70720";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/nn-NO/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/nn-NO/firefox-57.0b6.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "ef0e94a3d93128247354e3a3f3215e5ca27e664a24726dc9b98a064bd5885c7d775f1350ebe2976317ea0eb2db2c166844c1271e39752e10fa1165d214a96f31";
+      sha512 = "606aff032cc8fcb7d1739e1d6adfe3d2b05f1a0de6b5613269c5a3c2410976542bf2faa9105f122abc5d8891aba51f69b2fcd4d8dbd88b43112e37bb532131b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/or/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/or/firefox-57.0b6.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "dc33270b8760552d2c7f0d66aedab9f50ca0d1967978313ed18f9f66dcba4f2c8fd7aacf2b2de91223841ed1d2fdb051e581ade6376bbf65d95968eede0d04c7";
+      sha512 = "974eb2e7fd4ef1e93dd96a36199afa518a421fb3fbc59780bbd815014a84533cde3a76908af3f051f3be7eda8dbaf6041750faa44d264385f33169130b5a4174";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/pa-IN/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/pa-IN/firefox-57.0b6.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "06106c42f7bdca21a3340fedea95c29adbdad4fb5d3ce22bbb9b3437dcebca9c6a7efd01701164dbbe25119482a386bfe523c3d5cde2d5121c0af3855cb6f963";
+      sha512 = "d6136d9049d9d19025c7c47c9268f1a93a5ee96bfa993078b3488ad23a9e29fc00c9450ba97e25608b7ae27d84cc3b40dfe50016db83658be6bc300b3be7cf04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/pl/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/pl/firefox-57.0b6.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "037947aadb6ab54c07cefe7fe4b5de205c3f490121073b478dc9f211736916a853b47202e865b3160a849afd512a6901d20d1b356684c79be6022f08252bb3c8";
+      sha512 = "5aec655cce588bde2465b5d827a3d8966e588ca083bbbb452a2a6f3c3366478ae565a4f9162fd0d5045beed76f3aebfd3f44233e46275eb0a53e33efb079d1a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/pt-BR/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/pt-BR/firefox-57.0b6.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "3b3ba0892942e5cf11dc42c9eff31984c20edbb41ccd838373c18a62300142c66b0bb8184b0f4cfc5ed8805b88dc779f9f470ddaef4a0fb06e61999f6faecc0a";
+      sha512 = "40663403f97dd5a89d1853c7cd5ac0f48c761c23c6823314cdb7e821f83e1ff48f7eb3cb123784d55b7771dcbc6a2c2c4ce3e691642d25685817eede03947bde";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/pt-PT/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/pt-PT/firefox-57.0b6.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "451e2af4b83b8d3596520d4d9a5ede869afca4794d88493167a87ba8a2ad8835ef1ff57eccf4cd575c78386e262ef7995f43f6f4c2f2edcd98fdac07537d4a61";
+      sha512 = "46600e098ee503aaecf43e161a54ba0b60c79bbbd61de65f391937de3659af2520c013ad7360b9ab1e3aaada63ad371667bbb5633e46f8942410ecbb22cf4f66";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/rm/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/rm/firefox-57.0b6.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "7879a286d2c96cf0d08b308e96a84094cfbc475abc63dc0255749aaaadc372351f2480e71d9aab4d88c909d31c6a68f21d15360627fc16e2a79aada9ddf3ce14";
+      sha512 = "23e08b80859f6482fd8fad3d2a43961fb12a44827b5fa149c006508d3778ca0a3e307522e777535ec693ef365b0e2957344ac26a18bf05381c69f9dca509a9f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/ro/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/ro/firefox-57.0b6.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "7113b1b7d951eb43ad6722961aad26f83ba5640e18653b527571298cac311bad5a41c87611127d158ecd643090e517941c1e90a5578d9fbe9f7878ece23ce0f0";
+      sha512 = "54433c53212ad816d27fcc176f45242d275cca2e84fe68f985404471929c2907e95002a85f9c6141f8cf494bf6844940081e44e8046ede30ed6dee0b72a9eb68";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/ru/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/ru/firefox-57.0b6.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "4610a0f666f2b20eb35472abcdc450c8c24baa6388d731446d04fba13cbe9c48066860169bc5212abb823ce85c6fe485388dd77d61beaad9942b8b329d2adaba";
+      sha512 = "ee04e06bcf36056a876e9c4eb2e1d130b6b882653aa7ff1a313e4a21054741a7fe46a8f74ef179abd52b03d02fb4af94e4b7cdbaa885a4c1f019636c2b4cc02f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/si/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/si/firefox-57.0b6.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "2e1024a432300ac42ad00b6b5ffdc5ed53040a29556ca9ee98c64c4ac544b85f3542261519056949649fdd7525b5f83bf16fdb844b956bf2ef3f569029dac8ee";
+      sha512 = "0cb344cb274b27088af5d7ed41c76db40bec19c11abbbc421bf9efc7acd303156efdc5cdf8140bb022bd9607932fb636e678bdad16e8ea0b8f9a929be68ee081";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/sk/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/sk/firefox-57.0b6.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "c45e1dd1da621d4a5765b448f8836215cb2087f8633d987f269fcc5a67f5ee06fbeb1b08416eaf2e5720c778e272bb83c9e08294f6be0f148c0fe15dd042082d";
+      sha512 = "23a5f4c49993cc8727583028b1bd982845482261b793d50b8ce8779d3a4351549eb046ca35cac2d7edb6f3b40deddf077f6964d3e4a56837649fe86670452988";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/sl/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/sl/firefox-57.0b6.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "ba45ef8690f54996e55ec723732f17a4fe846d37c35d96b733d775c7888499cdd7ed73370238746a7911c3e773ba04d3d1ac8dc25959b2172a1940949fab2cd0";
+      sha512 = "7052a71800b2a5a3f9ed89db3638f30207da4f55887f4ce65c722dc326ad42663051384f195611cab20f86855a5b2289bf9c5fe2fc3c78c740afdc5a435f4b3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/son/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/son/firefox-57.0b6.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "9ed0e3c645f3c2884b6f9efc10571906cf39ceb295269468a553d5b4b3afe8d92073d7eac285f8b6c66b1b0d885fa1c80ab66ea320ccdecdea28bd0a82862f42";
+      sha512 = "6eea9ccac2c6100d7d7c9f80af4cca596cc4e3a0f3128beb22c7414ce0ef8a8e9f5aeb9e22c9fc8cf30db93eebe065e80d835d2927325fdc7af9b359e7b55b89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/sq/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/sq/firefox-57.0b6.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "c14c8cb330449c98090ca76dc2d834b3f048dd242414678450aa9abae8597ea23b527d51d5354325395c3321a755088762d32c69a387375ff0e32be807068d11";
+      sha512 = "049cb4f60f812673bf912b7ac06e440e40bbcc90f42fbd3e12f5d7ac08bd5e4a4897a435a1481201762d9fd4b99db954e838385953d9f458b80f86ce66b02ff1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/sr/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/sr/firefox-57.0b6.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "82b25e641b5a072d050c5216624dd62883fa5b4f84d407997598cbe366a04cd869fc54a4b9383a65f78a5e317bb3f4e198f919fdfd56bcb205852a13ad5edee3";
+      sha512 = "fb7db4165ff21463fd798246f18f7b9337b167c67e54d521d3d7e5bb5433b5cfaeeddf57619cea4079e852573bf109c57554cf574615232de86cb5ca922263ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/sv-SE/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/sv-SE/firefox-57.0b6.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "de4b5582acbb4ebc82bdf6677f53bcf73784d376fe63df298e1ec599ee0975e91fb9b9d548d2c0213ff7b99c6c123278eac4070e6f85c58c2e91a4b94add1347";
+      sha512 = "c8dbf8652a5a4be2325ef28a43e5cb8b464fcd552d62ca5241b072b9450ceb54d70bf5ac30e1136d03dca58410107c7d70f11539a7b712e3e2cf0da43c33eb75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/ta/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/ta/firefox-57.0b6.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "6e1c1d84b4b3987d31d8cf70fc292a7670b15bccf0c308a1222c72d3fa22fb426313b19c4feef3c9db1cdfb7a1fa267066ff533a3a0ba45594b443f10b8f710b";
+      sha512 = "66f1d6cd06e96d8835404446becc6f38516f43562d56a66991f1a73ff9915e0dff9ec31611e89c5596154a2c4b582d84bed30186691353ddaed914244575a27e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/te/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/te/firefox-57.0b6.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "2804c3891c386c3342bf464731aa5aa05e34d29bae17d766fa037866cfed2560893af86866db3018d3ecddcbb4fe63928ec95c86cb3a8355c86ecf470a2505e2";
+      sha512 = "aebf87f18e27e8acaa0c8956e7f90bd88da408aa266aa96285ef0d3fd85d3f25751eeeaae58e86948d4ff8abf295babc23e3d3a021e50d7c1329b2712306f64e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/th/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/th/firefox-57.0b6.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "64e0dc9fb2451dae0ad9d41cce0609a0ff499e049d130f7a867da90fb66d4243282dded80d58e40a41a32769862e9d82e6cf1af3b8fd8849f6b29eed114d3df9";
+      sha512 = "ff444997ab3a90cd5c4afd83a95d25c0d4d04d9dc82451bb8d33209433287cc4c31dd9f7887635ef4553776fe1be7407bac4a1fe7e5603679d209afa6717e2b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/tr/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/tr/firefox-57.0b6.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "a81c8e534f9956ec2c5e56f8fc8952d24e5cccc18536243fb1a3585e3c6cf899c7a9cd01a6e8da9f79725d5da602b1e47f37668c7069bc187530625619ecdd94";
+      sha512 = "8d5c1cb8ec1123cbf79cf156b54c86c28101078bed678b41dc996f42cad0b9d1fbbd83b02970a90f265e3839c2aecc9641d7231375146917b671411b02c913ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/uk/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/uk/firefox-57.0b6.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "75566f095dcada1f87815d25f5233ff93f28c557e8c38cc9a97b7ab066d6560afcf1e9de510f5d8bc924c6b78fb7ca11d68264ef689af06f52e0840985c95f02";
+      sha512 = "452eb08a1fbd0c27a382707c8417717c3728aadf5eec774fc3a020d46f4bc598ada9ace6ce49661f14398ae5b618491c070b52cd4d5fb3cd304ad2946a870757";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/ur/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/ur/firefox-57.0b6.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "ed2ceeed7e3a839e42cec5cf37883e44fc33e4f61ea8d1d044ea78f53b94cd293ef53a886be617292b70ffc96f62056948da4fff66c8483d99aac594961d94dd";
+      sha512 = "379362f6fa4162fbed19994490183200ad4af8603ae0f8809637953332b811cd754027636f9cb49b5e5b851057320b5f936d09d1193930c6b400098dbf5440f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/uz/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/uz/firefox-57.0b6.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "1b9e9d4bd792cae670ac5a5f4142aa735ad50a36ee055e4dfba2aa7f1e55328b1d178322a71ab4e7ffc98a502c13e9ab2a66f16d6e06d12c8f941c2efb076ce2";
+      sha512 = "ff457ccd5f435de9b03208a285d1c0e6ea942ff61592e26fa61e4946df1efec988f9f1d94091618c7b5d0b223c45ccf67773e4513445ee96bd1cf1e354034986";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/vi/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/vi/firefox-57.0b6.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "0d71e2d690cbceaa228d0ec56ff0773f7e78b5301a12c6599185fb0858f5fd325b9858adf55f3903ef44fa503f0d4b5cb66ac1185e07933620633fc0464f7024";
+      sha512 = "848ec90aa86f0761587082720b607c4b3c463300dbe2b97d7a59eb4eecae3263016a3dbcae2e92baff971ab2c4180f6a68abad52f3f74f72c0dc99d9865a0e25";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/xh/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/xh/firefox-57.0b6.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "9c11daa146e69343cd8c35d00c1c7dd3987bc0fe5e272a9fc33ae5a2b6d7791018649a3eed9a369cb6c810a9d6730039e12e6ae80727bffa4edfe5a7a1982f4f";
+      sha512 = "f0b0d4f81021010cefbb2734859eb771d0943d8bee301064d11e222c625bda65f12a322e066a363a1215514cf6ef7eb601bc22959a6e1fa9f29ef8da0c02bc89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/zh-CN/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/zh-CN/firefox-57.0b6.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "af35074fd3cbd9a0238fc8d37ada63d9b1b107c0859b52a53649f9b53a2ef561215e090127efc01537a5abbe942ed7485b13769ce74545a81ab68f4989697ca0";
+      sha512 = "0ca9911452654086037a09bb49aa7b5b200f42c40af7b94ecb55ba527518587cd5f345c88295cb43d9df8391a0f975cd35945416dd48057dbe8d4138cc3ef37e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b5/linux-i686/zh-TW/firefox-57.0b5.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b6/linux-i686/zh-TW/firefox-57.0b6.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "04f7f76d05b9c4edd61773719353893acef39beeaca96088620a8ca78bb1f13550bd9363148947923769b28e0a1904e2d239e4800ee1a1c4ba8088b5bc3775d4";
+      sha512 = "c643582dbc92145a9ade0d8763c8f30e1fc0fe3b9cb55dc6e1b88dae3001a3dc4b05eeabbe9b0fc040fd37f30f2d8cb07dbb7fa801d55a8e273bbd61eab69261";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,955 +1,955 @@
 {
-  version = "57.0b4";
+  version = "57.0b6";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/ach/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/ach/firefox-57.0b6.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "89c24fdc8c2f6890239c9cf907a52ff18a20d46286aef8397ca0ea70ad3ef213286728e80c1bdc288f9f3f5ddde6177c0573f3e25e18cd88169bf4509ce1f647";
+      sha512 = "32572bd7029c8123909c35c36d8790efec84b57ffe1607cdbe4b7f9ebf3d09d5b4e750d1c347094790647eddfc3ec20f083576033b2fe5ee147787247d316a1a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/af/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/af/firefox-57.0b6.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "d262ac9e5f477afdcec1244d2e70684e308cf9783f94da76d2401a0dc24223d19f1ed7e9deb51dd682292213f1cbcf70439275387aab509205b5f618414d9563";
+      sha512 = "edfda6b78cc45d7f78f59f23e074abc605a7776b27b89b7bd8d0c171eab9843716af28bdc81b53c993ea16d0e057611fdbc4c3fad7c2d6781ee1847e759057c8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/an/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/an/firefox-57.0b6.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "bc8ba4a5732591680a8a7cfe6bf56f23fb40782ec439a1a8eadd822b11d6ffd830b82a67e4b99b60a607907597abeebb35ea838695f75c48fd6e3b9341d577ab";
+      sha512 = "0a6b80080457500b2b0757491d74696eca3132123f146c17b75ceeb5478bf8ff6a4fbc6e397bd08424ca1df36b82f3b9903bd5f7d5b57d52cb82d9e19ecb8d78";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/ar/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/ar/firefox-57.0b6.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "23093e975a8401e306a876f47aa5c1afd93e1d17e5d9f915e967397f1c920456fc63fec2312aff23d076105cc4f567050317f3d48a1d32a016313a51df7e7f4b";
+      sha512 = "07001d159fb27773b16a8b8a38d9f6585b2304dfd9f02c9210b0dfabaebc8437ff7ecbe6d86d4f9065ebf67a89206ca870c339e0dcb70c1ee265660bfa060f08";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/as/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/as/firefox-57.0b6.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "8c179446514b3ff29e708064418c035c5a138776c8dfd957562302e192829994813ebf27fb491e0cd204399dc1ccc04f6eb5598c87dcca53e507db7656557f8c";
+      sha512 = "caf3f545e2bccf5566d2b5913ace96ebd304951a1428790219b74d8fa4461fe8fcae97af30c60c6fddd4cea88f5ad65251db656774acb8bad730ccb75b2ee425";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/ast/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/ast/firefox-57.0b6.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "4a2bb2543e66936dbe1bb5d80c3478ebeb00eb11fb8a83c8aab18440b93e4cb59c24fb7b14687f940d19cff4c9a36e255766ae712c224a02635e41e5e2e84a18";
+      sha512 = "b1660d8c853fa8a322d112241c926f48f63e244baa8fde8e7fe5f703a65656c1c33ef33c6ffe77c9f9f2147f8d27f2cf24782c794670034719fbd5b78a9bcc04";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/az/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/az/firefox-57.0b6.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "cb2cfa9956725d58eacb6b5d9317cb050ef959cd92b64fe2de5c3390855e0976d5a79805c134f36d80bad1c2aa71204bc04163c0a1bebf6977a96449f603d0fd";
+      sha512 = "2d299a7a9aa0e8eadb47cbe2651f4fddb09c21984396d3f41d3d65faa05324768c4a7d88c273dbb3c937aa65086124919f77b0f4a1541d48534a70a01d7077dd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/be/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/be/firefox-57.0b6.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "33555541b57d1e056bd2706834ca47f9b93ca70a1a81535189a49e50633f164372ffa5b36a0d47607edadc93b0e1b502ccec22aa6956764e0461cd5ffad133de";
+      sha512 = "75a7456d7e7b43118363d0ca7ce24ae6e2727c23542808731a3351c97e2d7fcf2aae44aeb9fdc460dce7ab582d4c8e1a59abbef51284f4fc85e8402307510dc6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/bg/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/bg/firefox-57.0b6.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "6a829c951817812dc021f76267dfe86c2e1ab81640f1538754b894ce8ffa4d0bafbe19cab81bb96d1b3177ee2c65312f7ec70fc68effe06f9a5a79884b69a951";
+      sha512 = "ca4be119b8cad3fc84eef3eaa0dc86ce9f6322ad39fa815449866ea13c343ca421c0d2de47de91e5f6ffba0be3d3e04af4442e55b8ef44b4b6ef48fd6ec8bfbd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/bn-BD/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/bn-BD/firefox-57.0b6.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "f1e96e42d57ecde22ebf14534a96b7253dee92cfae55fa6d9c5570060abb9f25a871ff73357f84f1b015d31b792b77568d5aee434f74576ddf15f9e62110fb74";
+      sha512 = "4b423a596cdf870b17c2744ba440e0cd7cba5218f76c1a1c9d088c4f1743f5d6f34dd7b0798221b26796afc5e888bdcd2246a84c446d543753c6bb80a9fce701";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/bn-IN/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/bn-IN/firefox-57.0b6.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "ade99a45c062478797b570e5887e8702544f6bf47cee57df6b6493d05c099fa274c335ed84723df8a699aed58996bef3379ea76b7d6290212cd5a532c2158c35";
+      sha512 = "ef308ca2bc4eae44d95bf791b42e1950fc969b750e5945b1fd2b1241d1768d0262065ef5f2a5afd8eb422291977e797c7f6fc65a2e81c88bf9f8c6b092be02bf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/br/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/br/firefox-57.0b6.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "cd7cfec9f80673147b07118e71608f3486b8f53b3d9b0fdf4052c9afd2d93e6dbe87f6d10d68a658e7d958a832961d47aa663d2d08e1e2c217f5dacc446f9221";
+      sha512 = "37660bc33778bbbb6831710fe34e28d07a52fd1f2a5a3f003d32e89f7f3506bd69f97c45546816f2737ff21a280274f1e3b68ede955820a127941b293aaf5f71";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/bs/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/bs/firefox-57.0b6.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "01bd5f3a28f24441f41f06becd22e4f5c409b2c7f4eaa19685ce49606e26f598874268adf7a579aafdd17159ec4ede03cedaba37a3168bdd19162f10af7ccbfd";
+      sha512 = "fb60c35fd1782d5553f8d479613bd037c6014f7bc15797835bd63537df86146e075879cbe5a144b7f2aa9c2a171f6fd13abe7ea6376cb431f6733305aae79594";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/ca/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/ca/firefox-57.0b6.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "dffb22850e7ec4b98484de8c1e92faf62dfad8c8a221ac96d393e11e53c2bdc638fc1d3d1bff2987e483f6a7784eb812d9a1aed79278b1c371bca27d23904551";
+      sha512 = "abc66fc5ab47aaf90325df0f699df3db0161fea9ea72d19437e9345b0d3740e80c8e435455941c3eb60aada521c1690dc05f22f833e2ef340677aa85960b46a6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/cak/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/cak/firefox-57.0b6.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "52906187bc01333ff67bc6ce4f493412ed77bf85b6bb18d06520acac5fed6790db9fe23c2c4bbc751706a6232e42ca62a566523ef4d074410b96a54651023315";
+      sha512 = "7df49494bc2bb59c42f025e89081a3825ec27cf17a27deca9c7aa2757ff8c2e6b5598bed06af0699fbd3d15d0e15aa88c38908ca0a96008a8382a5b4fb058c4c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/cs/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/cs/firefox-57.0b6.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "749d3d5781f266324aaa8c7d3bab777ac23518fc69bd3f1e1f4b3dbeb28cab17372327ca5622aad3841a56c52458c7cb4cff1d43b4fcc47a0e071f4c83f07fbe";
+      sha512 = "316884a24ba4aab3f65df9703ec7b4f201f9536e8b3f8648addc274fd99bb4d5a930e4499be319e040a90097c6b0450a3434a2b1f264625baea5f27b87271233";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/cy/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/cy/firefox-57.0b6.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "ed5cdd72190aaa2a7cb762bf5ed3c5e1fa7f6b2e0b168810b4f229421965520ad796ed27ca6c0c4e221d63c43c8034ee1bdecf46caa913d48c6e5eec1c132613";
+      sha512 = "929f32656a4c0ced25edc962d43d4baf4119ae75601cb8b5babc88cff953721edda2ac3e300762a8201a161db0d28abf2823de01b96dee4b36721a986d1cfded";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/da/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/da/firefox-57.0b6.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "84194c9496c0f74a4880a4d1d18c9c1c9b82a684cc9b1316d8f31980e8bed40125b68eea826063a6c12e04f7d55128fd34a954dfaaa37182f56eeb485867c3e2";
+      sha512 = "a8591c86d85a02c146b4695ccd9839eb311e371db420d05301359c833dbc462bbf33886926c602dcf21f8dd69d76fadb5aba875307b24e5553005fcdd47e0cf1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/de/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/de/firefox-57.0b6.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "57e129dac6eea631934e1c0be296fa8cbb54dfef73d5a2233655a5a08589dfdb4794eaff22515f000f6fdfa761b9c24e6d72dbdd406153047eaccc57328cea42";
+      sha512 = "8156fa17843960aa2913a1f12a59e6f3827dad26d4547cc5758888c7586e1a04360a5f41087356002c110f9ac60fade703291b7fd462cdf11cf00858dd45edb4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/dsb/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/dsb/firefox-57.0b6.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "b3c00e1aef9f55d75a93d7c5c48b6e02bad615c893394055d82a1aefab32e1a5edd82d48f8e0c0c9b550c390b543ffd91a5ef104ab39562025c3fb3992ba1802";
+      sha512 = "8d79d413a486073329f40caacffda50f8dc0675dc7d99d48fec9b79b7463cda180e6717fb15cdcb6c4f5aa89984a17c77f3703feb6865d802fbccefc66eb4452";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/el/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/el/firefox-57.0b6.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "1031ec1f99f03fbb52da4dcf7022bd056fb4a59e15211eb90465cb7a38b42733621bccabbef26d582e9c9fbef20b5d8df4d2c1b96892653220abb02a2e026758";
+      sha512 = "17619db107b1a35c0fb8cd0130517529e9cae38730aed31fc92340379228df3435b45b88038bfe421bf4833eb78ed995997456529e15fbf3ef9c823738dfda5a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/en-GB/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/en-GB/firefox-57.0b6.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "92ddb6e3253d09be9869bf43f46cc438a179a8548011c28f034100aacd4c7c713b3235beca9aca6c8cd3374fe30924b47706f848f9db4ff48faa1b40b83f96b0";
+      sha512 = "5d699c809ea1dac35a73fdfcc3c7c7be5e7f35a34dff1c8e1c5a7e536d72b445c3bc3197ec53cfdcf22a9d9ae43326c958b5d0820218356beafc95690d702860";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/en-US/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/en-US/firefox-57.0b6.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "039bbed397137d411448f4090ee7df8b32e119e844547d209105e3d30782c68ef4fc6ebff5d4747efb897dddf3d07d21201d42a6084821ccc82b98b3d6588cf1";
+      sha512 = "521728456d45ceba010ba8c8dcdcb581d08d64aad0f40294a0f1ecb1fef702e669cca37e35d35a89ef1b9e5bf891d72853aacf225a866c0e0e26ee9d61841efd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/en-ZA/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/en-ZA/firefox-57.0b6.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "3cddea06dbfd115013f3c29d7dbbab73fbb4546b6aa16db708c88dd1a042e885e262e1eafcce76091b881cf74a4e55479d0362acc8b0fcb06fdbbee3ff4c2b97";
+      sha512 = "f86a0034a310fe26d276fcf867c85647bda35f07bca2cfbac289523a618493e7200668bccf2928f0e56f6f789be4db76f2e344cb3a92c63b6af15a3b682f0cbf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/eo/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/eo/firefox-57.0b6.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "0ba19868f136b4a621df3990a784993f78ccdff291ba61aff85e1db692d090e9e5bf1721cf71dd61714d8ebb78c8b6f9bf1ea423075a69ae21415bae93f4b7e4";
+      sha512 = "89ea9fff345bcb88bd67eb1c10afb08efb68988c95aa2e489ed706acef083dfb9a1d0c91f00247f7a0afa92592208f356f8539ead8286b4f722014792bfac2a2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/es-AR/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/es-AR/firefox-57.0b6.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "d4bfe8cc057abfe1ad51ce4e2aa76bfab5db4fe9fc256d7d4fe6810f434ec7c5068f9c9f07dba7b358978d733176c3eff7986a96856b0bc662a92a73727d1578";
+      sha512 = "89c07f845771e87e434b36fcf5e9dae459d6b47dfe74715581972ba65cf78418c354eaeb28547de532ae7e53869bff6e94feb9fcf37c7eaead54282e883b0a16";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/es-CL/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/es-CL/firefox-57.0b6.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "7a17c0314dab8e29163a18d7e14d5963d908b8b290d5f8fc3f34c4b2b4eecb036d5f41d9f2d1ac4334c4a9c082831ecf01f8d0540573caf4c611b2da3658f4ce";
+      sha512 = "c03d76db5d9f8f312077fab403712eebe364ac0f25aa57c754f2c2ef42082a475c0fa8e7447f1bd3bbb72aa0849d1604371c63bd28444db568d42c9f2829ccc1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/es-ES/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/es-ES/firefox-57.0b6.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "27c859d93a32cbc1501243b975eccbcef0e7b0b41d3149ed941197e61b1d48d85247a8c5bd22e3cfa445d42ca2f8d44e7b95ddc165e703d3afaf41a499b158ad";
+      sha512 = "570b824ca0671c8444e5dff3a837c1726f47b2cb033099d051a1853215c80b928c2a54b129e0d75fa888fff3115e1a51383444737f739f98076b53c44ce6a2a1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/es-MX/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/es-MX/firefox-57.0b6.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "6f570232aaaa41332f69b7df59ec3822870e53e8f8c012dddefb36bcd2c6252677e63d8be837d0f6007a72ced19b88b5e9b1f837a72a97ba271e086e1f7c43b4";
+      sha512 = "1c40abca0e01db35a53afd628e7eb15a9448c6fcf1ad1655f2c201373ee8526c2ebd749715f068254757218be91d25d00c3016132841612c9d5b1fe0ded792f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/et/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/et/firefox-57.0b6.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "7c5b92e5801824f3e3174dc5d9bd4604689520d7c466658d0c987eb0351bb0c24ae4fbed019aa71e57309d2458cee38bfa4aaf6a6f122e8ae73493c44f177156";
+      sha512 = "4df4f29036d1f536b88a95fe78936beff16f0b7ff1c2394b0c10af6f12b0b6594866816d162d700d8ba28307b52cdec46090dfe77dcf161716bfc1266173b05e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/eu/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/eu/firefox-57.0b6.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "9717f966ef2d75666258ea45c100645c2a078b4ca2ce0e9090058b65e4eb605f1715ef834251032bec627ee66e63ff11c85af6e7cdb97ee74285a0853bcf6d85";
+      sha512 = "6474ed745f607d8b989ae1bc72c47717fadb63875a706349269d26ed1aae990e4784e2c5147dc93b6e2339562c568f5539d74522b66f94843dc9373b41e1b7b0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/fa/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/fa/firefox-57.0b6.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "44e20e83215619ff639ec12c5e60d5435d617438a7934d7e6d5cc6e865c3b6caba184fa8a786576c127eead4d87cc37cb6ba9cae72d59ee822d746d5790d2381";
+      sha512 = "6f9c61132f2310c4c0b08ab7356712acae16cca16e66d82cbd77cb9c45e90868b1f901b68334d9e462dd2598e95c3c05b74c5026ede1f01e69ea8090d7fa6e26";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/ff/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/ff/firefox-57.0b6.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "c2fc1b3b865652b90c8ac44322369b2278cbf4d95531111d4bc29735878660d8c4bdc58d8a2217454ec3880222a3d695b874d06173536217a5391314f087dcf6";
+      sha512 = "9551db4c78847a6f8a0431ee47522a7923f9029fcabfdcdf05bad26b238af9926a6b6a1c21bda2b38e87b67ae90b0a33a09c2477504b865c41854b38acef1a1f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/fi/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/fi/firefox-57.0b6.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "8253a890bb6db0eb278d828c51cbeae4331c55b2b4e36ce089249567ae74570008feb72929534750bc47b8ccacd64802e63faf00c354622a548a5fd1377b49e8";
+      sha512 = "8d86d0feff634ffdae2be5c691a0da072e86a255addaccc93d9e6ab849fc58b43c2b0bf5b01ecdb28711e88721ef87b772118f096d2da5c893d95acc804ac4fe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/fr/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/fr/firefox-57.0b6.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "df0483afb1bc2b2981290fe6a0789ad153ca529700b86a7f995303b22331b5faf17ca3bcc916f2bfe5efadf66d0b08d315c6c8cfea0073e1a31e35769cd00761";
+      sha512 = "7784d578af3cc764409f52f72a8de78866088485037512f2d0ed6d7abe6c2881fb14474e4a17e9829d6185a185df9519e7449170af4223c93a0277a2b6264783";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/fy-NL/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/fy-NL/firefox-57.0b6.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "38ea18ffd76eb89f317696c9bdd2bdf3061579b277680d86a85f655f915c75d9b0452bd320f8818a890e1b6332c22eca98c5c0fa2180d25586ccb278019df67b";
+      sha512 = "3d986bc10f2a4ae11319e08db71cd50cf8aed27550831a399a99709a73abda01bc2bb85857bdffe5cbea06470c8e78d5ceec94bd93b5c5e714620b975260b53a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/ga-IE/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/ga-IE/firefox-57.0b6.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "86c90f9f4dacd8111337341dfce981edf919c176c9ce08747619380de2ee1ed1ebd8b1f15d18e7d96f7db3b89fec6012421dd8d6c4f84707ddf98d30bd019db6";
+      sha512 = "8b6728c64452d533f59a899fff367ad03b5b0309fd908086125ddf9c924bb6acbc3a48b35c9787b69e598ef1046a179c0ddc0dc7735fed3fb2176e4c875a054f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/gd/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/gd/firefox-57.0b6.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "eafb289aa4e7f6979a9578794c6f119eff119ed606b576ef732a2f6838455b0358f4c7acc6103ffee35a0dd5cda6e5438ae83b73dfc9ba0d65dba95e38e274d7";
+      sha512 = "d511fca44339a41bb9c1e9d72ac333793ebd3b0dbc3a1331b1d230246aa6bd109905aa3fca44212328c3c710868b1de3dba3a2ed4d1f98f2916c14841eba9c6d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/gl/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/gl/firefox-57.0b6.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "bc52599558f41f399ce45449ecfff16f8a053f56808c85714a8c9e58187e440411a80b8047e46ee4cbf364e4e32eab16a13e31276b1d6d4380f3da5ebaee6fc0";
+      sha512 = "a817aa07f4ecb4d20a14ac7a69a8163c16a9916cc3315c27240356fcad2ee9ae1fd284d6c28b7f6cf587f45959788c2354e3625e83fbf6ea1051d932473ff8d0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/gn/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/gn/firefox-57.0b6.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "c4e521fa548e7fa0e5210f419fe5d76d357eff83e64b2755a708a3126d2404e31e929858eb216ef7891dc39870e8599f9f18b2743678f392275f589f90af8cd4";
+      sha512 = "fda261cf0d175e9304dee206f2aa9874dea15422098e2701a269e66a72191167bc56c18c80399a5b703337ab2171925b7ef0410f54bbb265e3245fe4683a42a8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/gu-IN/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/gu-IN/firefox-57.0b6.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "5981274b6889b5e21ecd80a37f14b1c41ea217a7fe59d68e8d545fd6ab0aa8b3af0b3caf242f9aac9cc67eeae4f6b989050a17f180ec5594558fdf10cab21825";
+      sha512 = "90c0219912fbed11ef6ecd620fbc1ebbb3324bbb36f049c97fa18402e1a71667c74e5aeab81efbad6093a477fbc0f1a8a96b9d43efc514cc3a8fc657dda063da";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/he/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/he/firefox-57.0b6.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "7f321af8d6c3dabd58afdfdb30f2f8bc77b8bd6c1824016464d1713e570d90ddc3e07c77b46972aff603ce804e0181090ba0a2993a838cf82244bcace82734ad";
+      sha512 = "bc8e3a2ce6c6cde3193469247f666159a9f5581a739e20f89d0c9f05d83eda48a6e4211b057df0e201797c7d235ca5b48b56b27a3d7ff9e5b3a80e3f120b4848";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/hi-IN/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/hi-IN/firefox-57.0b6.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "79764ad66fb22cd375b121ccc2f5ef4673a9a589fb2c4a1f58185b80f84d1dfa33e960475faebbcdecef95d7aed16bd6cc9f064a48e0db81d1732d31ee7e6aea";
+      sha512 = "f69208237376f4a4f129c15f4f05fd7f2bdceddf0a78cb5498f7bd3db9a466cea6a25429e7a164716cf42bcc4b7c2030ecd452a2dcde4763f2eaa9f1a698d991";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/hr/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/hr/firefox-57.0b6.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "77dd03a3c6328c38e022cee9e101ab8114dc8632067737c937313cd45e9fb669ac7bc88d5dde2733a0461c7e4bdf8dba65524cee4e5ba3cfec704e3b205406ea";
+      sha512 = "a7cf9db82a924d3a7579fbeccc93b31bbeffe9d044bb71813b3e493d0de40e646860f7fbacca8424d6977cb750c1bd3766ab0ef032113908bf4f4d010c91494e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/hsb/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/hsb/firefox-57.0b6.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "0b916b5b97acba7674e1fd6dca9c437cb5feb352cd6e98f31fd9f9e24b532d5309b9dba2e2936b2c2775488f0e0262f849ac08d4878d6a8329115e781f46ce4f";
+      sha512 = "3c6f7fc20aa02c3701d8155dcbab0df13e6692760613ad87f27df2ca0ff5615b927bca9b7359914f07f976354d697b54d5ae306644a7e7aa312500df28353204";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/hu/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/hu/firefox-57.0b6.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "48564c044d224ab4a02d0b33479a824b1e3d801a0d9e310b1ef2b8d2fe27dc392553af688b213be013c2b12bf22bec6cd69482682c9290dfb301187d0af03db8";
+      sha512 = "4f581f0f917fefffd6b7df0c570e3107d36232a9feaf5f5bb9b63bdcb51a0b8f8ec27a6d54a7a73ab17ca579fa95d3be601beca35eca2765ce019f3fda8d9f1a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/hy-AM/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/hy-AM/firefox-57.0b6.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "93b53ce5a08bfc9bcb7e9c59ae9a50891778625e6b716d317097ab2af5cc972df270e205b37b41801eb315f2a73d469b5922a753e838e7fff4e6cc827ce682c4";
+      sha512 = "1a088aa909fe0feef415698a03665567665f37e1dcf3fe033c45cd7d591a4708f392439b11ec7b96922139575d4edc8442ba08a8974c36255c7a7c349d4ed059";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/id/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/id/firefox-57.0b6.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "dba243ba98ee8674bb9a252e88c6970efbe68e27ab363eea8d69769925139d2f71dc34816ae6738992b5bb07b715d6ad82be19fe7db886b366558051e7b25cdb";
+      sha512 = "d185592907cda25a41dc8003b2bad9389dc1b56f5d6bf584e3f248abe0bde5ab548c055a039127b18960635338ccf28eea0fd8fd9c1c60f394a8df44f1644fc4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/is/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/is/firefox-57.0b6.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "9f997a155617259f13117e5be74c286e66ef8c0440869ccb6e2c531185a26c6c64c6c4c4d6a0adb49a589d85ac3a7e90ed1df602dcee594e6a84f1c9f245ed40";
+      sha512 = "ab1fce5528ef7ca3b08eb21d1a653a91403952165a2a16ab0c270a0e799a616858017e2fa8015952556bb8bc132971453e799b01861e078e8774d3db0686b1cb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/it/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/it/firefox-57.0b6.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "185fa90e5dc1a755e2bc109b8867433b8dceb4caa00451d4358f694b6e3be4778cc1fde187e092a0bb37051eb65f0b8209dad709d87233c604d53124650e94ab";
+      sha512 = "3b0bb483fdbdae0895ab60032ec09ddc40cd5db4b414fe440e8a449cf06c1b28eafee0aba0f8b05bd7fe278dbef8039ad5d44f9c627198ab1d7aedb483f6e2dc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/ja/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/ja/firefox-57.0b6.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "a3ea11ce5fac0039b08b14f7b83ca00265c6f26e0504b5a0d74d234f9c214e44394253165a01e82fce416a998034b2bc121cf79e9cf28d7795dc2cd9ab48b0af";
+      sha512 = "4acec36fe9193d742dac566677526eb0fbf028aaa3f3ba7226667d1ed6e74dd372f7493f01fe0a289aa0ed8ff3ddb27e6fe069777f6412cca6043d66a284e9b9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/ka/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/ka/firefox-57.0b6.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "aa1eb7803bb9aa61629ed349100e5912311802eb0e1b55ca4691e3411ba2dd5b583a6b6b7a027de26ed9753d1498086c0ff2c7f831a21cf0d7f0e8f8a5a9557e";
+      sha512 = "c2a7dd888e9ab06d2e3da86473a91ca12d25e496d58f5899de51aec2e6e8e8087fb65673af7990931c71439f8445ec040c514729d6d5dc45724130dab5056b45";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/kab/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/kab/firefox-57.0b6.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "a9f6086b6d0eb2c5e9d7d78821f1d1ff6f8139c63d31828bfb42a0946011235f4748688cdd1142428439d34d106dd746cf34fc393aeab8ac34e84ce0516b427c";
+      sha512 = "dfa0132593d19f2a68c15a3d7a7f9fc42aaf297c4fb8ff7eb6d88df0a569b10da6d52e5a3eaa8e51e48e890f946bf3015df053f4474466a3207768f0a9f28117";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/kk/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/kk/firefox-57.0b6.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "d0a7a3c4e9f71f3c9741f2f3ef68effec78551559a7c836d6b87c6dd52aab5f2b49db07f7528cb4e7de53b3d505bf82cb961cdaf517ed14cb322fb09e20fbea8";
+      sha512 = "9ca2aa99f561812ea2420a86b28858d62da2f9f91867c93f5605a9a46354c02b2cee873f828225e5c9f78a5bf147d071b9b6fe9307eed42ea950f0a16cc4047b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/km/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/km/firefox-57.0b6.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "c9086ca7ffb62ddeda314a5bc48819391cafb891b8e674383199893741ed9bbf03ae283e2c9b3d391c6184be4a2ec779517ccbd000926d964513f6aaa9db02e9";
+      sha512 = "2152dacb572481fe9ed51e45799bd6f723a80a4efb79d1b351cf1cbccc0674874091add0321630fc3f354707e91c042bba43bf9cd6538c3d18743bd887dfaf01";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/kn/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/kn/firefox-57.0b6.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "c530a3dcbf4f75239ef7c7b63736b9cdb2f2014c284e8d920552cc7ee4bc0dbb623f84c98d24dd169a5ed3683c816fdeb151c7d383f800682b5ff5e55af90ade";
+      sha512 = "046895dc39db3e2f373de35dee990700d30d47fc0e0e9cf4287fad6b55c23dbda107b95b0a1675c897f09d2ec4249cc16fefeec33b1a8e655d334b19e7786320";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/ko/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/ko/firefox-57.0b6.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "d57ec107d152b081bf112e7576d3b205f50f802b26b9723b8906dea4c5222a5c84a81185a64332ea1552e6db30bf5a1b4e5826ccd490e4eca79892ad879068c4";
+      sha512 = "c87597a98b2c8c46fac817939128353bf9d1b270f5e467c013b7181aed4210527338994c4913d1b902280e6c3a042a3414f518a2e0a716d25db0a12c0b605af3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/lij/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/lij/firefox-57.0b6.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "8bf173b76a2a63ff7201ee31a7738f928ac9809fc27c650d16c755808f7c3c00d60abb2733b40da993a6b3a02908c788ebd73b99ba4ae68c626101060e2dc311";
+      sha512 = "3edf7e1e21ff356fc20be6bc82253535caa76696b9672ea3f4f29b4880b4ac9c1e6747f2953d6e9526abb4e5262b14f7b931bf9845a3b59bb1ab21facfc858e0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/lt/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/lt/firefox-57.0b6.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "07306c0631bb5bcdc188b68c458c85cc02caef0544014acd1238a06bd5efb92e78fd6c3de7e15ec38b186861277160f65673fba3f7f7ea0a825f7e13cc514b21";
+      sha512 = "7139a914d655ccf53a0cab44fbc3c3ea46e3dac9d1834e6acea59c74329143cdcac5365b828bd21b907e3d3c143a7345ea660c6c4d469418674626c971d9c9ac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/lv/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/lv/firefox-57.0b6.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "d11cadcaaaffc61d62f4dbee9991c0a4f11fcf7ac279223d33bbc2ddfca0243bbbe136e5e19736f206dca5b4da2b71e31700f2b1dc9b15339163c68ea3ea128b";
+      sha512 = "05e98b288b71b2260b9bd8fa2aca1851c3131849b9868c1cbf42bf6b5ed622f4ef2f851db39977d77b3135cfe7cf282d7058d96e68fb5e39d95cdd12cc3deb84";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/mai/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/mai/firefox-57.0b6.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "f29cad32380d7c11627a8f839c882feb8a9af9d6bac0a0270b3a660f7d216474dd4a54b9a06a6f84c8b94b0d01fccbb8e2cd298a66e3a1af1af5abefe9afaff4";
+      sha512 = "0a84fcead91325eae96026f9a3439806bef6f589205f42859b3f9515c7fdbb29f37903c93f6e9e86b972eaa3e9b1e682b441753afbf529063dde307c2987ea91";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/mk/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/mk/firefox-57.0b6.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "47835be1baaff9a1943d5171e6a6c9d44279760348af1ff172fbf8c3ba27d50236883acc92a69a8df0764064f186a401895fd38ff0f73b6b19dfbc5fed85b14f";
+      sha512 = "c6d3dd3a1123d7094796466fafc9cb7e994824c95204728f7e255abd12004ba9db79ce69c50a3648659217d0c38863010c556bb4075a11883548bd47a51d2212";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/ml/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/ml/firefox-57.0b6.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "864d4cf9f2bcb40d2c178620e621df1450750bd305eb0386e7471c57396f5453607664c177790ef2177042a269c034e5f2a3c0789a761d83152bf8d1b9407846";
+      sha512 = "778885c609688d163fbbba87227ce79e7df0c9e7db0553f4754e23ab87f0cff0f64f7013b861bf8d96f7f6bf715786ac763e5104c983a46b1a3c23a57178a3fb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/mr/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/mr/firefox-57.0b6.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "040bfd4ac501aae9bc8e05cc58563eb8804590c286fab7e30614de0df0aad6f7f09ad87e5b808fb5211fc97bb64eb9046e6f3daec96a38e952bd83011d09b17f";
+      sha512 = "929c6fe735b94f52a26559525f3b846c7a9a1cd95c67ace534f19fa78246ed7faeaa817c004c23ff3ecd78352f9dda7a315e9f8ca1f895bde56b1f53ba8ce005";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/ms/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/ms/firefox-57.0b6.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "ef093c216bb6d7c7a9b6bc200739d678ad042f19bb98ae734fab9f7592405b80c1a8111ad76722615850781f97355a5788a089bef4d088bc76ad592212aeac95";
+      sha512 = "3e5f73d7934edc570b9a617075ed8deef45dfea01dcf057c712c121302a95cd6e19b0dd5de0529ba38e4b7e08edcae06e4652f462c1c2fdbf423d7c5c8c75c79";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/my/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/my/firefox-57.0b6.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "a1e6a303c084df5bfc74e7951de8bd59ea3ab58e25fa880afe7cb12be6399bd6f65db0f517e0656b165ed3083354943dc751d7f77e4dbe4abfea329553b4e28d";
+      sha512 = "98debb77674a17ce8d918e5db0171436dfe62a1633f3a7ddd7df79f1e7e5d1252826ce02f86a231a94158d21f672b40e1714db443f6eecc218e910ffdd3880e8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/nb-NO/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/nb-NO/firefox-57.0b6.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "848b504eadb4db1597a5722a42cc163af2fde27796644d4a3595883d7d5a86d19ca341b651a2825d8cac442a14688c3e1bf6b9da947f747ed20f9e9f269fdb41";
+      sha512 = "06ee63a1f1a87c50b8960962a987cd1b91052815bf8b3acd495c9cab6a8f2c7ca70d1aa551269df3a53708e8e2ac48fe3324fb333a11330072b5c0fd3ee9fe7a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/nl/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/nl/firefox-57.0b6.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "26c55fc46b96087acb71a7750cf6105afc07050f3779c53618d537e7dd009863add11d6ed8ca021f5a56eb3d3ba08a2928228f2b5b72e2d49af76e00c465e40a";
+      sha512 = "978085f2e33c3adf8d540b5ba144e2f1090795758ee3b97367f1392e4a4c96dafd6f76f62d7daae9341b1637a9d6dd52c02fd43e204dac0bdc7fb0db40fef182";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/nn-NO/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/nn-NO/firefox-57.0b6.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "28fd2fd88780cbcc8ae4a0d6a6958ce0b90ee33338061d6626419be50753f69816d9eab758279566472fccdb7ca5abc8ff257e32e93c3d7cbdd37c4f2f5f14c5";
+      sha512 = "c62f38b2855a3ee3fd53461dfd9988ed3be866cea6351dc08f2cdf579313aaf238b3cae066b52d823f5c42f7628ff2158fc8e4d914f9372b804b475b5a2803ae";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/or/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/or/firefox-57.0b6.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "cbdf442439fb2c6c2c673cfc7def6262961bee951cd07259a4a39ff453dfc2323dd7653208bb1fa6e72c768935079e71d11afc22779f9eacd529feb6e03ce125";
+      sha512 = "2094a90bba5a6795dcdd2c56324a8b517460f690194e0f7c1fb0f278dcdc108d6e2b9ed3f50810e86ade74cd5267367874d32011fbad1a52874454fb965882d0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/pa-IN/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/pa-IN/firefox-57.0b6.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "5df8c198c9a9e2a3acc8bcf19587b0ac40adad2cdda6a2b4ba040eb1e7e7274ab9753a28d07059b1d3d30c6b9f2efd35419bac560b856dd8afe45aecd1650ec2";
+      sha512 = "01e4fecff221daf211b9ec2b28ff40c6f8077c1bc06509bb78618ae866e26fafb23d060b3a92e397edb47e5fa291ea0a624ea7b51f3a17255ef56c9969dd74e8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/pl/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/pl/firefox-57.0b6.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "9406068dabf1382437a42db3da95e16909c768841294b5582091222bc3c81c62775c27865bbf8e0966edf0dad915693fc7b8250aec9a5f1218966564149c18ec";
+      sha512 = "c216423e6c6739e2f557b0542f5823e356ca4e494c257a138780f07a27c7173173f3e3a93f5c7e11076ad013d12aad5e4a67dee4845e351a00333e48b34f1edd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/pt-BR/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/pt-BR/firefox-57.0b6.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "d4eb83f228582cb2bafdce1427940fe86b3f2de3d66be9df269ac7211f203b19d09ac93be085420883ef89b196ba560627f929a5ad898ddac59a6260fc97dc5f";
+      sha512 = "b949fad120650718d99450a5c5a09b0badc7bf142c5c2a37fdbc97039dacacac2f384e3168ad23811356da1c4768bf23c0a3be5bce50a12dd9915b5777c45369";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/pt-PT/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/pt-PT/firefox-57.0b6.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "acb5a7f161fe869084e1ac75c6939b3f9d6ed60512aeb4677646d6dec08b6875092ae7ae403bbcb928fe7377d0c2a94b1cbe701e02dbddbd895bbe44aff5db31";
+      sha512 = "aa6ab4f994e4d6049c5d658cbe2b9bf8523fe862c7be632a261caba1a651b12db4e11f160bb18b368234ed8b3c480af7cee1ec7e468551308f4bfdeb6b0a22e4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/rm/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/rm/firefox-57.0b6.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "ff2b2d89336b08eee804ac057cddb5e0891328cb1ef9809357de670fb2d0bee84106f2030afe78972a4343de5f1cecba8e3db1cd7ace38a96a41527b410abdc2";
+      sha512 = "cb3fbc1954157236c92f884539b38d369ad718ea9004f3b05c4b70cc4588e25ffed97ad68391ad37713740fdf87966c039ecbae97984d89f01555a492c2debec";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/ro/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/ro/firefox-57.0b6.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "610685ebc89753f4f23b46f84a916c7ecc2e541eaddc41161d34ba04d30a9d896a090f3bf1a1ea192b7c2bee59c3acd552af62ef46e6d79db135cb2cd23bb073";
+      sha512 = "9ff1f5706e058f72b8fa57c35cda62e14809bb502e648df00bdb37f899a7e3b46ec34fe4fd556343ff11139cfac1e658076cb3c3132acd6bc447044e04adcccf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/ru/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/ru/firefox-57.0b6.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "46b57a8e73f14ac0ab75c578f948765b672e0f1aaa8c26b299864bf675f636e5e41b0cd62bcc56d67adccef2bced28da29bc3d45d5d78bfe1edbb91ed10bdaec";
+      sha512 = "4ab5bf3f84aa8223e24fa3996148ae9fed8fb98b2ba2e7a1e9c035db7521f9590a437e1861cd6e248c63c790163a04fdd87a3eca5a76b9450317ae7c315c9ba0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/si/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/si/firefox-57.0b6.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "1e07f52ad4ced6963287f873eadbbabf901bfa55910dbf768e32d2887786471ac34322ba12529182e9258d1565b07746393f4b472d4e67f031d59ff40c699143";
+      sha512 = "a54194765e1169219f050ff4d3404a45197029b4a7201125764a52c18de109b252c05321e18c2ef33b7478168c36cb3025629c0deef24fd297a4bc8937c51b6e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/sk/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/sk/firefox-57.0b6.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "45af02b4c15440f7d036e3f76c3335629041235511bc6b10eff4d1c1e65e98db3d94ab76724145a45bafc7662fe74efce0b2f192d17bfaccc76d725b89163011";
+      sha512 = "10551c3d57167b66b3a5a9368cb8b6c298471a43a8a9b144c5ea82f2dcc111b840e273821a42194bde0c793e1c217f7d39f54ffe907a706823b411c307ea0f5f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/sl/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/sl/firefox-57.0b6.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "b578a153dedb4a2c522a1b03c8cf6a2b0666c0302977bbe32522bc1967c786ce61280ac5c7e9db74aadae60820faf71047119656450f36ed83a2abf184c18aad";
+      sha512 = "cfebbc1438c649a543b5aaecd377a20153917c3f1a07771a3f246c60fe2139f5e3529e26ca507648ffcf062eab301cc3a95f1251df2b586f2f112f9b04aea20f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/son/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/son/firefox-57.0b6.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "c01bdcb4fb0c3d492011cafd64e44f5becede34a71168d3b774e6732fdc7cb615a42ccd7710a76e728a1cd874cfe56fcddd57dd7c4d538b05f30e1acc8294d85";
+      sha512 = "d2f71c72c5c1aadaa76ed17adbb81c3c72f59407279fb2b4670fc2e21604d8c7eafa0b247b30df3ddf2923f023d6ee3d9d1c36b7033d77b3b7b9f4a37a6656b6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/sq/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/sq/firefox-57.0b6.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "c589f7b55591fa412e643c7a3cd51067051302711ecae0a1d9a288e86cb5fa62a06b792a7a0b632e11f937c2bd0ba16738e14783fb2dfa54ea3a8eeeda4697d6";
+      sha512 = "03833bb8e39665ddee4cf0163123b52fb7184fc6210622597e7fe2084388a662d380a760bb381609b70679217461fa1c6bf69ea4cdbd872528f7bb0ca2e4500d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/sr/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/sr/firefox-57.0b6.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "cb10eeda85968b9454a45850bdb99c25f96baab18f8b797c5bc5fca959126cf61d6ac21017d65169668e1884bb0bb9ec8b6e49c6b3a5cbc8ab917c001dad9573";
+      sha512 = "3150fc381b81b4903837fb0b076cee1f425dff20dd449899ccc3b540095d80317727600db4b9abe7607ce7e3d280a86bb730ec665525b2efaa4d72d31ef0ec1e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/sv-SE/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/sv-SE/firefox-57.0b6.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "2df553437b2eb792fbbeaed55282c97e56bb613431aaa832dc11748c5e4797e8666cdd9d2e2ad58c95d284c8bf7ae09504ee99b38673b9cbfa99eeb0a1aa6cd8";
+      sha512 = "0d144a98d41dd6372d97c8720cb5a7a28d002f26355379bbd1778446a6ff73670d95d5420940634006dc860e585f26118c20a571ec52bce361a2278ab107b495";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/ta/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/ta/firefox-57.0b6.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "50c923efb24cdd29cec576b60d24d6796ae2ba5c747de80228c5eb462e2dabf38b8ff652d2300e82205e1f455a5204e5637a859224c21b6c2235b5249aba399e";
+      sha512 = "c609df57bfc5c637c0da9ac1a7418278ba8856bc7b9a283133d6570a3fb99cb9c517a131406dcf01b111a9d69a8624dce34db6e5db73f6bce715b28ecaf2b6b8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/te/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/te/firefox-57.0b6.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "21c35afee798548eeb4d0cd6d06c304b642bb023e2a17684d689dbba131301030aefaa66c875f4be80626b628de7235d240c24cb84d171ff6c87368668f85758";
+      sha512 = "8e1eeb91b97f93c9ef8ac1ca7020dd05ae89ff4a42849654411f991e483bf64bdd4b8305d2b1de01b5ed2da53ae3136a2cfd3393be1d27cb64c87f6bc52dd840";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/th/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/th/firefox-57.0b6.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "0c8e1493da42c336a5b10ac353d82d052c8229a61b60b9cdfa234bee50eb3a48fb4f987caf9f66097d9b41a4bd68e8f301d2176c74466cf2cda8e92c63aabb90";
+      sha512 = "68deab0e83db3fc69526c0ea86a97fcafc2a87c9ef116c7f8ff54bc78a647dcaae8ac164017d46cfb63248cf0bdc531898dec4d8db883d78fb0ce897fed7614d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/tr/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/tr/firefox-57.0b6.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "df48a1bb19a27ca16b3e3a5c1193073467fc543a2f9e05ebefeebbc8c9de98b34c0616b5a5b2366bd768d6f8898c42b20427a3582d8d6fdbd5647d58f50af620";
+      sha512 = "d48dc92b7bfa0dc0cba2ca5013acc2a5ff4c58eec365b5f80b70b2174624dd94eb199008720c799d5a0a6229e3c2b67a9ba4f93363310de3bb52b62136f3cc3c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/uk/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/uk/firefox-57.0b6.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "d85e2dc562e6f47bd169d61716798cece411853f57e777b2ad9349a822680c763a12fb130c851283e4dc9a838cde3c20165124f5d1d3672f897b2da4059ee98e";
+      sha512 = "a726dd6c12914e95c7a2707e050fff8e671e2c01e31ca964aa6f32eb89768b7ddd1039d20986baee54a746d67615fa4e4a327219816ae52356b1c6224a149690";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/ur/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/ur/firefox-57.0b6.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "8ac48e7f20342d7d662b163c0bc4452ff8b3d826f12d8fddc3356518c6f4d8bc7eb21935dba982023089823df67956a2eac0a18609c7f455fd91667727c8ad5e";
+      sha512 = "f8a0dc9e7e831e72a570bebfefba136e014a27d224537e7eb752a197261b0334cddb28661018c94d41b5c870642288b99d2fca2af3ad64679c7fc41367e8f090";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/uz/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/uz/firefox-57.0b6.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "6f25afef779901e9c61c0c0d8d7596174a0c98e9bef33e78d6f22d20da4e5c0d05196f9d8fa46e71d2f2c049c517a37fa46af2fa52302ac0b67ccc64ff89d820";
+      sha512 = "644ccd2c71a2409e840d87a4e9451b454e6223c83f49f398871acbbd3da9f8e1065ba7ff40aa6c81dc7aaee921c4247e462d49649a042e1fb5f79a6fe786782a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/vi/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/vi/firefox-57.0b6.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "74a2fe96d21c7963333209f4907d542165eb6db0e764e66b9b9854b0417cc7b308dcb7b05445d2ea53259e6dd71348439badc210bbb3977f9cab860e337827bb";
+      sha512 = "0a439df7d97e4e6dfead990da08f5a62aefb8e8938ae717b64fbe0d0fc83e9e0aede01060a30016a406af6eb91de1c05e10f71fbc4883fe679a9988858b8d488";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/xh/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/xh/firefox-57.0b6.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "1b060fef0a070434a94abc728993e2c1203b98886d7ae288b15d32eda082d647c321cd29e38cdbd160fa8123e3661b702d280807761fd46e5666f44861001993";
+      sha512 = "8a777c355641cdd14f9b23ed16f139853a7b338dd6d1f66e8c3971cb1a20745ba49aa12bd68ef26e3900b68112333a86988514f91b196127ae7d6e5bc5533770";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/zh-CN/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/zh-CN/firefox-57.0b6.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "2f12263c8fd4cedf9969eb25f24e6c211d95a764022eb0c793f25a5e071dcc7faa5c91c91441750ce0ab3f8e76cd317732ff661ea16c1d31e683eab30238b9ae";
+      sha512 = "17103974a976021fe921600d8a5fd697d65a8e90a595779be256e2d0350f4f5fcf51f8f16906b3b355b990ba12dab8cc1684a4268a0425e68d3421699618f480";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-x86_64/zh-TW/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-x86_64/zh-TW/firefox-57.0b6.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "25ac9e23f8f82b6baf9e8dc50361732ac18edb286e6ac673f82c0bd592fe26a61b2a1db012a904f48599fdf62d877f76b10262c0a293f0dc32de148a7417633b";
+      sha512 = "904aa9865d7f235cc60176e6dff01fa2842178ba812017cc23011f57baf23089da8feb74cfab15968bddd029ee5f161f10bdd2efead5bea33edc53ee27838052";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/ach/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/ach/firefox-57.0b6.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "a0d4648b606e7862db1bd144a68d6bdbd8e926675e58d431ab6dd444eb73b2d5d4bdf7ec83dc3604377166f6ffd2f5ab8e009ac2b64649194f5d3474d101d153";
+      sha512 = "6e0076d906a20021a3a161c685404efe584927d39b7e72ea6645a61571c14469b9de07cda7921c24123790fe8f7bfe7b1cf1f644a09f72b86161c3d57be49b7a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/af/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/af/firefox-57.0b6.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "c745a2b46f5eb4da7cf10400186913dc69b18284402f491334ab9f335296f60a6781cc09491cab174eb92c6eb6c65f8ab2fc556eaec7dd13be37ef4328084c47";
+      sha512 = "a36ba7a0838b00beba5f598281631bc2de5a6cef7399c48c32091cd901abe12356eca4e509e964ba8eb6db011bedce802d060502dcb948de00a57eb754182466";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/an/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/an/firefox-57.0b6.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "7aeb7e50e14ac323d68f0ac48fd702be8b3f30b56619b5213498701b4868d90e7ccbe46343cdd0cf950b67f9d51da6413d89445d4ab77f4ec465fb74a1623831";
+      sha512 = "262f3a4a7d7007ba22f155e994bd7fc6b69f92efb6932b96e1d07d4a7923b0eb1ca1b4ca60c93e9e1c9feef5c8aba282b4d9af6ad4dc21e8c83cfdc6f4854238";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/ar/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/ar/firefox-57.0b6.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "177da0fb662a99226889d4ad063b5af18f1cf8816a685d60c767b90dc2db0c460bd62c239d3045bae92bd1f4df129337e278bf95d5db103cbb6028ccf869c070";
+      sha512 = "6fc5c1e07b4d31e8f5cb21f325e282875ed481de67168b43506c5083741c117d690cf681400778d96b291dc925aa6fd866645bbbe5cd477c1c7254cecc940bb0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/as/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/as/firefox-57.0b6.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "dcfd4127df6b3f0d0ceef142c209223e7ef74e5fdc971072d6d43d5db1545b7d9f155185752688168bc1e461fb201d3d01246dd3c18ae006304144771f555483";
+      sha512 = "381032696886a2839d927c81abf0bfb48452ab2da37a57290e2f50daeba947fc17fa8bc8e95461f981980bf67cdbd022c7fbbf17cf631f27555fc92174c1c4f6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/ast/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/ast/firefox-57.0b6.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "ec31d580e6b8e5ae6e06e1a713a42f3712fc3253d64cff1a1c957211cd01ee09929643e0a8637bd11d51283cd99ad46e26568ae6cbcc4812720ec1ddb48832d5";
+      sha512 = "5eecf58f91ad77de3f9c4afe211138c79aed460d35f0b4f1a7297b27f72400355e0c1ade4fb2c457ae26d8da114ad711c3c0b2a374e5ba6bc33d107c28b3c3aa";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/az/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/az/firefox-57.0b6.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "e053d3b208023d799beb3be82944e9fe6b3ab8bee83e6e0a39f2e0739c77aa267d80096557e191d9b0dadad385ccdd55256ba875fa3bcca4cc3a850a1acf6908";
+      sha512 = "de90f1e9d1950d1f194d0c5da3bc25bba00da5dd4094c6944b035aa660cd56827183714d9dcc8bb9e7ea4c115792bfb969a218034fc743fe85b65921838db610";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/be/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/be/firefox-57.0b6.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "1e6f1e36a0b48994026da658cefa8cfde0f1f2c0eee66fb14c7f7beb18a485eaf14c47d22c4586659399dde7c6e352d8ecf4d3ebb3393ea3dd2c3796a4b69b2f";
+      sha512 = "f043a6e2c6499aac4c9b2df0ac0c2d62207a79a34eb727668a42942a4a4027ff545484212c88c0fcd9ab91c66921daa3846c294bc3260db3a0f8f35dc9a8c2cc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/bg/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/bg/firefox-57.0b6.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "68ba57eece50ece15eb6856593dc09496e2e120c76dc21d7dd0b00eddb8a15308cbee2e42995b530024fb0934323a7a0437c2bf5b5a6a9de22105abd023b04bc";
+      sha512 = "cdad058ee575bf2b4acfd3882769b067959ab8215b351add7558d8a6b6898fdce951db35e23e18c7e7d3fec170a78cf71bf61d20c4ef3c42c23a96e66686f59d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/bn-BD/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/bn-BD/firefox-57.0b6.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "96f300f3ce1920260426bae867f53a2bdca2fab085bd6f47e39f804ab298df1301ec58666a849e3c2d718c57ebd0c3bd5dc5da3e80884958dd4b4ec2287ce86a";
+      sha512 = "ac4e823c753a7b765f1bee0cfc8cc0fb216b5b9e70e147866100d4b90fab0b413850ed15f02585170c3a6dc39b4fd5e7906547626379a70d5d5abe67eac0956c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/bn-IN/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/bn-IN/firefox-57.0b6.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "887638fdcd191d2c073a4a5b7c3989b47af586a912864d0adac7b00c062ce6699a579e7362862c2f98d29c088db2e85e41f724939d04c1e496f1e48bacb76efb";
+      sha512 = "15b12cb32ea9be780dcc68ce75d54afbd16c011fee06a15130e2d1844746ac2cc66dd61397facb083c478f4a754385afc62fe4355442aad31e8ca87dd5270fc4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/br/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/br/firefox-57.0b6.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "c8b1391f54fb128a59ce1b0d4e506b27510e1c117d0f0044b67cea248ab82014e8f64d937f4c703a39d3603d8341f34d36e650ecc3a8dc10002943187545b77b";
+      sha512 = "493c260aca10b349b860492b5756814868520f79dc9853745af8e1989f645f2eb17446af9bb5309d21fc79d9139c7e7560dc5a5a1753bfc32ab3df07e5fe729e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/bs/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/bs/firefox-57.0b6.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "b7d89d6ff57f44c61693991eb67f0ee30a8e8daf0935be51a3ef5953e38ad3706bf16ca13e344038016a77fdae7566796f60a285304ab14638264449c25780d2";
+      sha512 = "ea865333358b245703fbbaaf621ebab603aa9db3a7c579e244f229696ed1c7176ed44158de6a01817cd410576e69c354d2091704af8dc30b4eed2b2f2f3a0629";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/ca/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/ca/firefox-57.0b6.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "ee829172889a002199f07ac806d512f9753b565fa992931039cffce764ae53495446cc55b3a1b3c68a805cee09db1249e06296b847928cda9773bc0d670d4445";
+      sha512 = "0961c13ae053299c8f0e0c1d704c0825215c1e77b43abd83ba86709448f22e6ee40c6a1b8d858e4f2d801d7c024b293631ab28ae9fa30553790187896a96da1e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/cak/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/cak/firefox-57.0b6.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "8bfd9a39d151410dac0e2479e3918d74604cf9773db63d077281aa94d29db102c14ec86fe24d00187a0a790e4bc2beb8af467fda205d69c5b3c918c22b7327a5";
+      sha512 = "3a8dc71fc212a35f83d10ecfc8c8f97381699431964d34fa7a278259b1cdd15b4e92fef33cc9c1f37868baff0f6ff1064599ba632ad718ae2d39dd3b044f758f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/cs/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/cs/firefox-57.0b6.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "c6fcbbaeeb39f1a842045b9a919fced5dfc5e13aa760504599a376692c7b84254365d50e4cc02af5d5bae378c8503dc02f755a8594eeff0e78c79726b44422d6";
+      sha512 = "eecb76deb0c420790a37ef24c0956574a4a881cc429f8f78d6ee207b4b9f6c12b8c890e6ebd4f69e9cf4ba120728a319ffba6f90a3eb42affac86fd27dc015d3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/cy/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/cy/firefox-57.0b6.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "e404cd8e0f699ff3a09f398ca29800739afd23e5a0ef6299ec47c65771de295d2f071454111fc3596eb77656ff92cba088620084f41e21e4e2a44706957a23c0";
+      sha512 = "7ca940188627a439f3a3e401075e3dfec2c4082eaa8aa65fc7a58bc669f4e4a4835095225bcba541c3cc8562dc611fefc4a7e1f7089a8d291b4986d557901cb7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/da/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/da/firefox-57.0b6.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "e9902fbad8c46b156f3331c7578a8223ed8b167db7e83333bb57fcd292fc2010fc1be16cdffb611238e0d2a310c6cb25f11317c100ecd5ba140d86890ba563b3";
+      sha512 = "366f786e96bbd5c4eb1ae247e2cbe567a7e94b76124a2a78062528daf1aa72236c91aeb2213f623a8214fadb920d10f1ec49a8bdad4a5a855ca23f06665d68dc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/de/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/de/firefox-57.0b6.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "0ed09f934f6d9b862ccf8dad186d510d380f9fa9afcdaf3093badee786c17db3d7baa1061370f4c505af10b4541af2fe368e9fe5a274778e54128999bd88c585";
+      sha512 = "43d46c88a8d58f36ebc832afd6b03eea5afaa58bd3eacde85eed36725f248529169f6d396a3580b2d9483d36bdcae3dd9ad53cc1aa69264231b53285915e3d3c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/dsb/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/dsb/firefox-57.0b6.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "c126ae75872980e5172b5b47813643ad9ea7d1d9e78e15aeea6bf0e4701ec21c83715a5313d570d121dd184751b8c7a0bee708f628ec2bd470c781719707f1e6";
+      sha512 = "16006a1e4ac7662e9d343cf31dae5d3032948a90a7eab1bf1122ea2f45b4f3477c53d8f0fbfb860e4725cb3a58678890c5de186ecc0cb76106153edefb011eff";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/el/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/el/firefox-57.0b6.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "5560e090a6c9a1d0b48fc16d983fc9c5321137202826cc14cdd6dccffbcaf202724eb2629162fa7ed8acb0537c8839a904df69778a0dd77b2caf78976fb9de80";
+      sha512 = "d5f74e30fc7da9c9765bbdff4f946ef5de3c64ae4626833d31161e62de106485f9246efe0b1866d47c52ba7d236880c648a438e1602f0552774573c76e2c79bd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/en-GB/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/en-GB/firefox-57.0b6.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "85ad619fa280092dd6674a35e95e07d6f590be9d26dfb48249092d5687c06770854d83c09e36ba22a4c8d1dd8bfdef104276c6a761ca3d26d5b1acc104c8e5ac";
+      sha512 = "4a6ebf46697c02c9a3953cfee25d761254cc79b12a88a049b8477806b3d1cd978e46295124e7afb3770b7d4c01bd2e002e1e8a092ddf252f6c22f6f9afb4c9c6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/en-US/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/en-US/firefox-57.0b6.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "db935918745a225db24499444723443437d1c68f17a83c7e524620328872f58d702ce6e16f7f0e641e7f67a53846804f5d49ba324ed66905ae4f019256225053";
+      sha512 = "f5f1af68ea08cc95b449595d9f15f346a8562e4c27529bba6453b0fb713d65d1b4cfb66c9054f25d8a8b6aa2d7029592a7d00a2a68ee5c2fa8cb7d06174f9f41";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/en-ZA/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/en-ZA/firefox-57.0b6.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "0dd3ef914cd5ff9ed64e475f8881bc6b0897193771f9faf0429105c21d5dface47f643c298dea8d539ed1f362b59a4f15d3097e623063f49968dd5aadaef35eb";
+      sha512 = "554221102e16a5ed426afc41b75be680a6d28012bb66a12c094a719c7d7ea61d0ea378a3eab758b907ad407de78063888b687cab8ef5dabe19f3a54d2bc722ee";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/eo/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/eo/firefox-57.0b6.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "0d85aec2cbce71e7dd30808df937bcae92f806dcb41e6e22283add504333538561deb7377454946e61ee9ce8e2366cc0be926f5d6f032f3f09fb6183eeaa7d3d";
+      sha512 = "bb31a3422a0d86970649485bad7f78588653ee91551fda7babc9214e9855e7a363eb010ddcfe6d353e292410421bf99c2fcde0aef4113b688dfd3843d1f0377d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/es-AR/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/es-AR/firefox-57.0b6.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "6b0d3bfbb399d444b18d42c8dede4c9f8adea846fe89931112eca0196fc2bf924e767d849d37a1ab599e27a39c02403d5df15bfd814fae91d2aa4094723ddbb2";
+      sha512 = "a47626bef5d9cc8df045d0a38350f0470f5426f4de8ef45bbcb6a60922532656f60f4fa41c4ef4706af82e5c099af5d5020e6d51ee1d61f8275eced5935ec2d8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/es-CL/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/es-CL/firefox-57.0b6.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "accee76187bd35e36b282f6187ab6ef93399e1d703b29c3c60deea9572c28c00f2430b26a5b94d9d894b9ade20e547a1330a68f0e5f05c433b20a0e969f3bff4";
+      sha512 = "cd93d2b921c3fbadd2862f0fd8d1cc628bf5da469d86bcf619c35940560024bf9b461b2fb405a2fde39e7910b6c0367e31e44c8217971f9a82391dfa5a869094";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/es-ES/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/es-ES/firefox-57.0b6.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "471326ae89d980943c8a2f110c57352c0e1498f131454d019ef1a3ff63414649a9a2d894a114a802c508db1117b95b7f09a0e5296633f6be8c3fe5bc140aadaa";
+      sha512 = "1c911d2898749ab249ddbf7747b7cabda4a33a2b4e426c88aef71055b8483e0e9b408511a14b400ee332358f2e92d3a83817cdb73d8edb9b85ada94538f1bffb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/es-MX/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/es-MX/firefox-57.0b6.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "c6af789d6db42cbab5b1524d35cdfc781ae4e836c81aa98eaba72c43b8aaee2e8eea1383c1be71e6816cca1278bc7d6809bbbb2503625e682d4a2ca00f509c71";
+      sha512 = "bc7aebfaefba4a4df95d1c60a85b6f961e0bf0a31249caedfd0653f1c1bcdc3f7c27c6f52f45b7cdcca54562a556bf99581e79ecfee9488094327af69b909c47";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/et/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/et/firefox-57.0b6.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "c72c23482222ee411f0781d5a3c93561d2b8234e7797570dfda0b69e92f7593b1ce7083676be8d8fa720f2b05d6cd052be2202782a7fb72fc30b85fd742df45b";
+      sha512 = "b1871f409cb4a9b1b85215e49ab4620fdd7eeb3db11e5a0145dd40a923ee4192ab6ddd8aaac82c1d28153722973a15c1fe80c822075dfa4baf50204228ea3db6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/eu/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/eu/firefox-57.0b6.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "2a6718e8f2d3803e61169813fcef9d016b672f7f8358ece119ae71b2535f3933d032bf133e1c36305cf7e02bc94c53d1ab8998f53aeb775c3056b8449ad971d7";
+      sha512 = "f3bf362364479ea07a0c681d79987f9c80c9e3c06a54eb82a0c0308ad195aef257845e73f72f86dfb45ec36551c9a6afa9b32958c28066e626ca33e2c3c8d628";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/fa/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/fa/firefox-57.0b6.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "c0980b33767e2bc99a42741b9d35d2b7841a637975759731bc9c8be6a34932a01006453e19e487fa06f37ad9dd97d4b3fcc9563f4a6dcf8998576db5262df999";
+      sha512 = "f7976eeb893f7fa4cf51b2ebb3c6442e731f4a96a2d833d532dbda87412789f044491b3239a7302972664c17dc08606648b011263d63e01e7a51e430ca1f243a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/ff/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/ff/firefox-57.0b6.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "5e6aafab13381f2c5c4f26dbd3bdb56296b3d92e9f9b9989f09adf1163edb587eacac2a63a9fc1283dc0ce9620fde08af50ac4558faace09675f6256523329ef";
+      sha512 = "6381ad86b9ccb65b4aae7359554a49cf630e8f898cca26479b327e9bb14695f87f566da9bd8a31af05c9781fee65dfaa8e23cd0588e4441ce6fb8fb25f7d7fa5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/fi/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/fi/firefox-57.0b6.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "94b3734bff09df66782f2cda93015be2d8f7ba90cadc272560ff232b8c01612cc733476ab3f6b3e27f52625102684ac11ecf58571a11f06806abadcf1c1e95f3";
+      sha512 = "1a80fef046318667a0306cd8870e697ab246df3f1ff7fba30ef3a24c25551b2e265e6b52a13514fe216dc5bbf237df7f04106bca87e0506a53caad9856c1c426";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/fr/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/fr/firefox-57.0b6.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "f4f9202c458171026c5770b3b471882df609dc029313b0914856e445dbed38da598bd96291a44dfeafb0dda82adb4ead3b9e5443e1493b8d861b11b1cdd92480";
+      sha512 = "26b25a2fdb514cca9638748ec8481f7c36e38f1d3953cd5a45025861145d7851a4441b2a2a472f07620c170864a278dffad3e2d625a31cefc0c348cdfb3ff4ee";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/fy-NL/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/fy-NL/firefox-57.0b6.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "72c71addde606c99df99f0b405f61e0b1cbebb10cc1a9467a3dce9092d3c17fc76fa8a737f8140db00fb03da513751b7518e7521fbff2ff36b4df36a8fbf1ee9";
+      sha512 = "d0a322d815f08e4cb1b7f49de22dd21401e1871b13272ef33f4e311f52436e97f863943511190b0dd2bb3c99ddc0a0b8acf95740e367a34bd78be3425af6e3bc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/ga-IE/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/ga-IE/firefox-57.0b6.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "1b23e5ccb911a0a683e356c413fb1c2b853e9e14c3415c0c11da72939107d4294f9f3abc579e2da7de613c32c65a4e8d6e05e6d7d65076619d18dcb38056ec86";
+      sha512 = "a736609a8a10782273b79a83cee0929bd2d82958edf6e266245c1a4631c4d4656b128789779806d6c9500f914c749beeac52df3c6c85e149f5357f182603f878";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/gd/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/gd/firefox-57.0b6.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "59b0ab5d6a04f2d9cc818b7184ec727d95cdf061095111878af58448739481f94e98d7818647d03a302815ea77e0832471ff072c6caa106227849eba56de75ab";
+      sha512 = "66e110faabe9a6ee1cc3aad8e471301aa636e00f3c7cd01d49b3aac5dc96ff117aca8c4b0dc2a7d23a8122bbcb152d82200a505a9e534c9a9dc93da8237afa13";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/gl/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/gl/firefox-57.0b6.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "36c45ed8de93cda743a5d054f3273db4878ce2ecc9d78cdabba4be93f2e466e111a344a05977cfa52b52ee905b0d053b5f509bde6e2e26f14a3391b37eb054af";
+      sha512 = "5b115d289497efd2c706bdd2f6337b6f3afb57f4fd95178b7a5953b92a5191dbdbdda54fa3324dab23661c49bd5c8992bb1e2bf6afd12dd6e61ccb2900e53d98";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/gn/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/gn/firefox-57.0b6.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "d658ab947e261a3eac0ffcd9f4d56eba634bb964799202e3717f5c41936e64de5523ab16b8b35daba1de7c625c8eb31101596fc73056065e4f8bcc8af8de1197";
+      sha512 = "357bb746ad1f10118e13f439ae58052fb93bf89562eab0f78510c027f24276849df4a69789db6b274a66b5232c4a6794f2d3daf3a3ff35644b8ce1f137febd2f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/gu-IN/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/gu-IN/firefox-57.0b6.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "9faf44b19f5730dd09fd32b3109249cade91fe4c464dada869e11211bf7d3c2039c65bfe4729c488ed53159a08cec5250e7c2fb55139a8af3a40b1cba40413e0";
+      sha512 = "ee4af8b2880c16c55f09d9c2385502ef4b099854c123cb6d148df1d2024e267d7ef9b0ebd8f1b70449698dd3b25be8479c932dc27cccd38d8086d4ffb7c3bdb5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/he/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/he/firefox-57.0b6.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "0cc925fd0f9d2d89c49a195e4f568f5c9f570175f31f86154cff6875860bc11db0103508f5985d073dc7c37c9ab5fffc6f50b94e47a3f47f7fa02678f4afc33b";
+      sha512 = "d937ec20e10ce471f658717310b6d361df800eecf54b81156e412c0af1d98efffc33534492c46fbd600f9e5a4d85e0bcd80fc7f711b22b7eebf7182e78e05abf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/hi-IN/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/hi-IN/firefox-57.0b6.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "934c1a6d4f148fc2d87b2ff2be5a4a31ed463caaba84b9330f0cf8e7bc56630665ef4566f03bd8f7da5111400ede564ce8d4cf14a4a34c48877aa710962f3798";
+      sha512 = "39d55bfe0d78884fc6f27ddbabc3f80e3075ffb027e656ad07cc56fe39cf097f3c3cc501d123abd172c1d4116bd8fb8bb620a2af8a8ac5c48bba5225cdba58dc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/hr/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/hr/firefox-57.0b6.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "65c92cbe069e7b67be5b092c070741490a5fc409fd3d0e8a03e7346702398ce717f45e80c909851a4699cbea218a5e7a49049429fc54d850ccb28b23382681ca";
+      sha512 = "aef7a38ccc9ca3a98249bd4d325ec01dd8e12e7b95b9bddd5183bf8b4795f283f8cfc6c87f22e38647fe58c00d40e95e65e1994a21910f3661937042732f0c14";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/hsb/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/hsb/firefox-57.0b6.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "27df62d51e97a63beecf1d842280ada91619f18372679b25580f9248dcff5a45c19d64b2c2912f0daaf9c5169cc3c8f58ca5e7dfd360b292dd88d8dfe1b428dd";
+      sha512 = "daffc6eadeb9376b42fba1c96b759b3dfef0bbace76472df11b56fd3bcf47d05f85f58affcba193aad39bd58d194b72da32ed5ab7a7d9376adcd17c50d19836e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/hu/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/hu/firefox-57.0b6.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "1b84d77cf561041ce0b0213111b5830cd95e40dbd447e16b23bf93d241f0dd9cb5510c29ecaad63dd3818f6a8f6070eb8314af28311deb012d3e8f4ca2390da9";
+      sha512 = "bdeef0f11f48cff94a0a80033e2e6f63c12130729ab0af7e0ce7133871282a911936b7c1365319495235ee4336cf2683a84995dc05d424ab70f89553ac8d39d1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/hy-AM/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/hy-AM/firefox-57.0b6.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "691d45d0ac7c8db9da1f73fb466eabe56d1a70e7fe08293fc6ad95e5df1da461593e89bb06122fe4a29395f75f2cb6a1abb568ca798130f9b4d03795eb8b165f";
+      sha512 = "2d20876ba70cbbaf66f0f6653ca284f3472511377e9b4cbfc087b763fc96e1343fb4da014523b24731fee709d1d407596b01cf531b390d1c2f3ff5e47c3d3347";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/id/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/id/firefox-57.0b6.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "1592365d75275ed597342602625a591b2fd31d204c39a68dc216fd353d317d811e17549b73486de9a001015fe415c918b1057a7f85093906a9fc612b8eaddc34";
+      sha512 = "09305a81fcd0400239192fcfce0369ed49dd5eb2e014ea1bc12c1470b732e6aea3580d1d34285848e7c12f5017d321e29ea27705cb298fc147abb82d089ad6e6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/is/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/is/firefox-57.0b6.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "b7f33d0d15e2c6b53d0f43feb767967e49288e5b108f18de9a74acf289dc56f0c4b477594de02eed7402150f8df77d1194f140ed64c99a6ce7749b32dbf91ca5";
+      sha512 = "4151a950e6a4fe8a4c9c143ac47714e35d45639a00a3c03c21c7cb974aab46b56b69b4357ce2294abaa84df6b3c561708b74f5d8fc4139221a89d744689d531e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/it/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/it/firefox-57.0b6.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "d96117f473e639863766280a59ea5c944cf916ab7c796eb59d0701ff5096d0efd93ec49c1d790eb3e16db139e3ad482fc7be2a6c214104874030a16eeb882629";
+      sha512 = "3d776b488104b99992e718b2a41c8de09438140143de61625f01ce51cc8461fcc564da883510dd29c854bb181e906b095347c5b34d5b1964ed51c268469842dd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/ja/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/ja/firefox-57.0b6.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "a535bc29f4f97e223716dc7d3eca6dc3cb8e04fa79c0a3880d116275ef6eec41a9458007a33fbe527c664aec9fdac24d56db04c8547c93fcbcbf33fd461ce217";
+      sha512 = "2b0adf6bb4f4729ffa7a4e20e5c5b4973032a4416076cfbd5d1c9d0ca551a8a1ccb0fcbe1998bfa390373ecbb7d74faf163fef47c20d1f2b4d179a9a0f802957";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/ka/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/ka/firefox-57.0b6.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "3bfc8c1b414bf8f38caf7f29342024a09d56c34fb66ff2bde2ea953ea2f22891d85a014e6ff767dc895d692b45927ff45b63277dfaa72c8f90e78ca172daf4c5";
+      sha512 = "50b718fea376c16b586f1c54012e6215eea03391d2bdbf1227629d5aafdbd864cdcb3e9527fd2e4fe1486bf928392d7cd70ac147f1b35d626ba7072066cb8737";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/kab/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/kab/firefox-57.0b6.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "ec3672acb496fa5e19f148ceab4950f05286f73dc1a00ed41388f14ac8945ca23b9c2d64f50826a49e2874b51b7b9fa61f8c345e968f77461d9daf9e8f616c8d";
+      sha512 = "ac3490642bfe48817d992706d441009ace6866ddcf38ee71b172eeacc3e7b3fe44d433b15fa9bfe238690078950514f7d5aa5c2ae7239e3698c04c71f725508b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/kk/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/kk/firefox-57.0b6.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "659663a9d889f31384e8734728de5ac7b0902587360a8da0ca596034d0f2f4a886d5c46a99a0103a9899f30078e384c1389886db8db5a657659d512fff8763a9";
+      sha512 = "62a6f73528c26264525fa2fb4e1c0a8e1f029c74eb5333c5912ef208146d24e2ce2e037e904bf83fb3f7c10fc81f969586a09c5cc3746213454f206fd6c1286d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/km/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/km/firefox-57.0b6.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "7c0e9cc3644bf38d042da7ce5ecc4d2c533c6215919def5be6a993daf7eba0f10a70f571361d0ccaa989e6a2abe3a273ea56099cff5bd47e0a6536066f23c824";
+      sha512 = "4dee68ffd5f306edc3e49321bb29edf435e7924371c37a2e1e239a1377e0f9be5cd6ee680aeba46465ebde9f8b090d467e93b0c65e75c9627413c5ff7c720589";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/kn/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/kn/firefox-57.0b6.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "150fcc5ba1aa0d9afb4ecb0ce9dda85a404c5aebabef5f0e3c00ea2fadfde52593a466c3582fe7545dcdd28fade62dd5947b7aff473b3d6e7060be67a78ecae6";
+      sha512 = "b0fc37707804ca6cad153528275076ad64b64685c2c34bebe27ce652c7385cef455da75420f0e8c543aaf20bc1358e080cce48b747a23c08b9c72b1f7640d0c4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/ko/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/ko/firefox-57.0b6.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "2e48ab21047dc311ab8db94ebe60c04b7bd61da5b56f39d56d6c7745efbe4d64f1ea54c370d197ca4c0bfada9a94afb96a33132b81148c18d8e69b31f0440108";
+      sha512 = "26534fd7779e1c29e2937399a4a79690fdafd8fe7aa735d4386fbb03d9e7be09ae83a3fb3d9c2691bbebe40f8f73ee18db24133ac4250b787a8e13263bc1ea2f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/lij/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/lij/firefox-57.0b6.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "6410f7bc134698e71dd8785885c470987afdb2d75ca5c0f49ea70c2cb0f4d1b1f93397b6974000082609b8d7007f304f917f9a3dc8d713f13968190b43a0f4e5";
+      sha512 = "2b42d3afa649bb48d3bef4d67f01fcae216f28d3d912ba096258ad1992914d99c8389abba60128e0198a8ea54ccd87239d857e29b44b297eecc288a08553a6ce";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/lt/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/lt/firefox-57.0b6.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "78e6f46015aeb56575c0c508f572fce65d1caa8af288d1db0dd157c54ecefcb821338f39e2c47021a4ec3be7c2bae0ebaa08c035d3755bc32e074a7ea87d7f9e";
+      sha512 = "ab7194527b65667938ba7e4dabce6ef67c075284b1795fa064a81e1970ff71e1d4e60687e202fb82ea4663f46dd4ebdfb0c7ae30734dbd5662c28499484618a4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/lv/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/lv/firefox-57.0b6.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "1972a6030332a571ae67b7856cff277101614b8e7d8f82dc204bf45a3a4838a214d00e23972cda731931f4dc202388896da6ffbb8c508cd4be45694ef1d934c8";
+      sha512 = "33d3fc939a464389fdb0345cd92c29a1c38e4418fa293d131f7bafd2f39444068ae7c168881076b9392019d77c5260ee670bf7131d9501127095441e43e7353b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/mai/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/mai/firefox-57.0b6.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "269841cbfa1b70b070cc619beeca5c4cb9c03a9d0643f5d1d95661e12153c66cdbd8f92807352ea9ddfd438cac8fc7da170c467a8f6712e1e00b152dfcaf15c9";
+      sha512 = "69816c5d46e84d0dd4b5fb1473e49875725ff4dce7d08c9a892f4119f6aabed29e30789a77a56585e2399918aea16a84dc94d3d9e04d3e29b85e1ecfd4289a52";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/mk/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/mk/firefox-57.0b6.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "948135fd1a957eb5b1f4731d684f37b0e7fb78d2861e5be55ee23fb03484cf59f2e66543aed1764fb66b69d4779e39dc0c5104f52feeceb602285bf4b6e46d09";
+      sha512 = "93e41429afa3095ec8cd903f7c942ac46b65a39566c7bffaea937b2ad72d219d755fec27d58e351cd70cd697149433b43f26753b389f8f70ddcac9ba9fab78f5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/ml/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/ml/firefox-57.0b6.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "db7eb47a5d357a67b5522361cabd690455eb17d25a9de290c79885fb3a0334a5149eac03e92af9e0dbb25fafb18dab73dc49ad0f0ef7451e7f1ec360bfd6ca4d";
+      sha512 = "911e36c834c35664b38c14748f146499bc74217ab7ab6dc3c318df8dc115bf8a5f09ab24f3c650f01d664b85e9edb90b2515f4f4d413fe2c0663a3ec4714df1b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/mr/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/mr/firefox-57.0b6.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "a416334034eb327d9affb8eef3331fb9627d4eed9b680c312bb4adb1ea64438f95b89117ad1db8ba1e8e8f2d5408668bc7ff6e1cd2b241641221cf591eb847ad";
+      sha512 = "8ea055ece43abe41c21b726df13587f86987b6a836055fc3bc525adc04e5d360db2e3b5104587546f3192868cc10b02fdf08540644e1d5ccc03e963920220286";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/ms/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/ms/firefox-57.0b6.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "2c486e99e052065705c3f49f743e703a1cd49083b08df6170c58eb1155a1a30c56418263adef4acd4677a0a812c9682a87d470ef0e0907057bb14ec10447f36a";
+      sha512 = "b3da22c39ba71e28fe6c5f36cf5b99d63014e68f5a1cae4dfe94846393321a15188358e4cda263f4fab2c2c578c78739e3338345d2e7b761286836db435df868";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/my/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/my/firefox-57.0b6.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "31718e334380c9937aa8003d3586931de21bf0ced0b28db57baab82d2e0328e64c1b390676ae4949c622544918aae727e925ddba04abb97b756f601ad22c13fe";
+      sha512 = "4ad4201d56fcacd6c238a3b60a36238cf5c635f7fa601ab4342516e7860e2966b449113632c9b1047f1721d31e211a67987bc2ef5a439db9cc09ab437afff2ce";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/nb-NO/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/nb-NO/firefox-57.0b6.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "051209a5d65615732d7353e24a500dabd3cfa4a3f5f8dd4ef61c1d4a11236cbf59915fe3ae14cd7c524898f01bfc40f1565ecbe6998b9061657db4a330eb6a28";
+      sha512 = "f167d00296e36ea498df7b331a48161d613cc395c16cd63b83580933a776829cf492213158c22eec1e6df9f2dd1a811ced289046ba404e40230bef5ca28bd4b5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/nl/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/nl/firefox-57.0b6.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "ea61e410ce32be3bb5c9bcc2463ca1eb6855b18c1b6511cda81b4203d86e1cce6d01329d60ee60b96340f9d6abe17e2ed567c5a7cb96797ba88525404b5dcb5a";
+      sha512 = "b53257382aa247d4b6745b0abfbc25c1c015f2c770f5ff2bb619e208ccbc4b499d2a60c9b9ce5d345dd65517a41f6cc4041d948ec8af5a43ebef417efeb91505";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/nn-NO/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/nn-NO/firefox-57.0b6.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "db9c3a1ee0630afded4ec215880050973dbeb2bb98995743497f01c79f90c1609846f4dc03f6f1da4b1274b23f95ce69f4ad6de0f2f94acf10df21615d00532e";
+      sha512 = "b7b50ef1127a07a4bf7aaf3c5e3eb2621c502e660528841dc92c4a937b78aea003fd6eba763374990563a63774e0041893ef952f02a387b4c2916b5a3c18fcc7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/or/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/or/firefox-57.0b6.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "9d8408c76a2dd72273827f0fce70b3346a910ee73df52b1c5129bcd6e79d7b768d311f5ce4b4867af5a32d6491b75f816793ccbc3da6e0d7ba2f06a7e2386d30";
+      sha512 = "ba55767451edc408b92d21fc74133a13151c5f1faa532dba0bb27d8ed79f73aebbd76c3acddd2b689023b649665f4b70f72a9495805ffa8de888bb35c1898e78";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/pa-IN/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/pa-IN/firefox-57.0b6.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "fabf259bb80a312ab1ed6997f7c2b605e5c19fc87adff388fa8188181038d1ba719075a23cc4195efca5c8ed4f8066277b2db0b581d10f64f1d6d206b29a624f";
+      sha512 = "97babdc8ea4541d2a2fe07b0c258d636329a03643ff411c1ed752ec949946b6459f7fd21ddd2a688653f788e30fc166c381dbfef238c0437ce276a0fca80323e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/pl/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/pl/firefox-57.0b6.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "35b31f5c5979ff0e30f52d3012db119abac393fb6948ae930e8efc17047235b06bc6bb0a2546677c943933a600e04d037e443b6c225893082802d5d876f900ee";
+      sha512 = "733b22d43c15bc0eba1918a3177654b0742d480bb8891f3ed817c7dcc70e084feb505b6b1c12fed103b73136a74138771fb3a23a0018786cd4cf16f9b745c281";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/pt-BR/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/pt-BR/firefox-57.0b6.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "cb118f08e74101373a3d1f586b5b7ed47d9f4bdd89e922ca430a92797e3cb141bc847b827b579412487ef5d8bd1ad933656db9929a14a91512af61d23b897a2d";
+      sha512 = "fff3d62b5d85448f8ae5ad30deff720912a5d8efa5838d908a68d97b3bce84164df57f387068b0e10b51469c5bbec9cbb1602279d0937f6cd211072a1222c8a8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/pt-PT/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/pt-PT/firefox-57.0b6.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "b561940da41b9d88819d7a86402d0b5973950f2d90789540c2be6a0b1981e80f2e2d163dc1b2d0a1e1e0fdbcef9927223b2d85b364126ec894e6f715d054956e";
+      sha512 = "c49d00cf50d5e6cc8c46e43aa2ef7879c7cdd92783a6834fce58450c8c93553062af060995a2fa8d3e9b5c288fed3522704213d482b60014091569bf12815f81";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/rm/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/rm/firefox-57.0b6.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "41ed27048f63ff77be3ec90144e94ef5a7ec846e88c1d90729cb00518eb1f9de5fd3e94975ab49954aab98850e8930b97f59bc6c1bff8b69520e81d94bed46ba";
+      sha512 = "5a5e383a1e8f95f938b12ae6509076c595709c737a02f8ca40838e638ecc79112aa25c9277086d13c6d7a00d6bc316c809273c8157cf7970c8b4481c5fd7ca4a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/ro/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/ro/firefox-57.0b6.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "c5c2359a7f183ddd7275b64ccd3a7f8fa48435d8595db1b7f388e557f02669c12aaa746756fe77ebbd83496d36cec3cfeaa8baf6dc8eeb731af1ad970ff0e325";
+      sha512 = "48392338e19fe9bd0b0094b0247e9d9272fc6ca518e1fadfe628e9607d2e1aa2db9e11895fc835dd4cc1bb6e196960afe601354a24885a3ddeef211f2632af04";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/ru/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/ru/firefox-57.0b6.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "1711a76df67b6ba5bfcac6015d92cdd5fa51643e3955487fc6df6176840ab910aec593b6bb041e2ad0259bd45d8aa0da7a6ef75bbdd38b0821b2524ea7de9452";
+      sha512 = "6543a2002291a87f91d224d223a8f292da4f8137b5916db7bb6d2182fbc23b3047133d3cce311275938317bc85ca992d3158d845797509ebdb765c4db76a5324";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/si/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/si/firefox-57.0b6.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "57c49bab469d7b17c6f9d79003b52a778c40d5dfb27cc238168809041aff849c843cc6442b1dba1503a6e89f1f2168ed191e0256aceb38fe990f9806bd4f2870";
+      sha512 = "1aa8bb875f28bbb99c8ba228485e612f8eb2d449d6518cb88268ae8cf31b572762353a210ad532ac9328bc5266b2710946aebbc39070ed98df633ad5b15ee589";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/sk/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/sk/firefox-57.0b6.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "be5dce90f29f97c0670531b58d3199e22e2638169d2deb62e9ac2c294d7ee768445e47661e7b4bef40b0e9dd6d526581b072f808c005722f9640d980a5a1da1f";
+      sha512 = "ef926b5a984d0f2027cebb405fd48486f1a79595f16f26f74a2f13083453ce5b94e5b123c959101e8b63a9af558f816a2af806cc9f2c87b9f2c3278369e52411";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/sl/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/sl/firefox-57.0b6.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "7dd6e621e4ca75d22d97ffb7649223eb31785d140058ac9d245f76e45d8c0fb85c7cc3da0b47fbf678e014e5a81c162df80a9e2d9c9700f9121cd9bfd49c7be3";
+      sha512 = "1447deb0e0d97e1a06d795cf66c604301b0c88fb248e96dcee23ffe6954effe11c12bb41706728c4b69f0f807b9f8e7aba6c9535b779a701ce41fbf26cd6a3c5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/son/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/son/firefox-57.0b6.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "00963fcbfd0fe449387c4b2bd7106df566641454b1988eed3f5a9ff285793c6fe9777b23836b2fb7b5ed6db2cfd4219b8cdcbd67339b453e6ed0fc7534547f29";
+      sha512 = "94c4c28b782268f37601188013957d95fda818d56b242bcd9d4575a787f4aca057c5970bafeebd31a6f31dfc72dd48c07b50fcc20d70ed9926e280b23661ec84";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/sq/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/sq/firefox-57.0b6.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "5a5e2531c75c4f120babe6ef575939b29e5b49363cf2788a14440e628009f7a2d32911b1ba16f88b55e85af8eb754aed0790471efdd834c1ab0bfff827b86b99";
+      sha512 = "7fb22a303bb016c37322bbbc3d4170b96d54cdac6e1ce61e48dabd868800b01009263ad69052d919823eb2c104ca41ebadebd00808c581c7eebbd3e82e2ff810";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/sr/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/sr/firefox-57.0b6.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "5b35e346cb017076a5ddde6a9a4a3a8de572e6799e194fa6ea358ce50a8df22f8ca5bbb316b4f17a8ea5260fd3e025af00f7c362263f84efe64254f1977c8d78";
+      sha512 = "991f3c6aeb48db23a4a569a5f51f22aebaa60b5ed6da149818c2a01dd40256eaebecc738e8623d3662ee9633e04581c4c4033461ac23694f81360e980b2ab406";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/sv-SE/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/sv-SE/firefox-57.0b6.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "6f52f537acd049e0602028fc1a852bb4a5adaa0649cb85a4361011e544f08ba5e1ad5917abc9a405a30f4fbf9eaf0acab1aaaabfddb4d5e1b4d030a600052bc6";
+      sha512 = "381667c64722d04fb102d3d1deee0c13805d4271adb801b5176b9fe842c3916a4ae926dc56256552cc309729e5a0a16d82188b79210c4901e8c4f6d4e2930260";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/ta/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/ta/firefox-57.0b6.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "a24286bccc8408833d689549e59792d12e16d985a0eb0eab386a2c220f5d01f9bcbef6862d7115154586fbf711df08fca0383978793d5d672c196e17a82830a3";
+      sha512 = "099d94a7f35bb7a6c59e34c0ea500ca4f98a473ee52b3e33e10a085693d09ad0904c4dff4097b0d80cfd43f31cf9e05e300c40482aaecb83ee59d6fdb21d20fb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/te/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/te/firefox-57.0b6.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "0e16d70eeb4f89ae7d02326053f1be58768213f4c50e60b4160e54b79b2b80beef8c2d161190b3276350b7b47dbfe44bc59e63bc95e9b0ad08491a0876574f06";
+      sha512 = "506c2538ed1a421631f9492894941ecd022ac3f085673c1447bac8f7c52c7dbe91854ff76efc7964f875444fdb83b54bbabf5c96f217cac6f61107af3ec65545";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/th/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/th/firefox-57.0b6.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "1145d91d10339ec6fe757f366d59568f76b1ade1be456547dc80719a85dc8bdf4e5f1be943335496c489891c3f18cefd9bf83ce2239a25890ba7de8981400319";
+      sha512 = "61ee3a8271478647e2d957e5a8304d88a68438043f6ffdb006c5935700856f7fb16d9ffe65785fde03926743c4c5713bde934383887d81d7e684ae6da14e8776";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/tr/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/tr/firefox-57.0b6.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "60031ede41569676d339df3abdc391c581ab01d4feed901346e77b33fc8d441bf501c521344caabc3dc59b6b537f8ef3f3edc0ec32f94b1c5386730b4b17b29d";
+      sha512 = "2204991ea8ff6f06bf9a4aa9de2f395fc7cb88fcbb837476c5dbe2556cfcbcf361934f840b293e09d11e33427d22cd8fec44821779ee671a19e0aa577d9bb2cb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/uk/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/uk/firefox-57.0b6.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "7c0554464057c27ac32ed1fea09a7bb05e5008b84ff5c1db0029a32fa7df0d4b5a47df7928bd138c8a8285c4a3146b8eb77b349c4352ca6b87ee8e804aba36f5";
+      sha512 = "d550a3637e8a135b750e0932be53b40adcd2b17073a08dee6d02357b679a088d04f8ca1ddee41cd6370da2d611fe4981a70b2f38caf7e8a5bf1145ce94923307";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/ur/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/ur/firefox-57.0b6.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "7f504ebcd65f30b2aa5fec962498457abb48a77fcbe5e9b50290500f7a78cc2cd8ede0395529d2edc081124fc980c85d37628529f10ab011f70eb40c9533385d";
+      sha512 = "606f376a7fbfce145cc911fa126b3c4bf7d67d5eda3ad6b82b846e6580b2bdaeed7b2ef4a72d5175a1fb7f5f3327b24d028186ce409d82d5b33f2bdc6bbff336";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/uz/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/uz/firefox-57.0b6.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "84f281673ed51f8c36ac72bd2a8a6d5109023a30110e70c1afc1befa0553f3a06c0718a45ba878e0d0609585e9041eb22ca0c67b8b9754be2fd4300b2c4ef1b3";
+      sha512 = "aa13daf900c1f1557c3c481bf3bfd0eaed7af46b6a1e9c42da6c1c2be160882a02be9eaf62ada680a1f1124e4afff032c4d50057564cc5b2a5b8985039cbb260";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/vi/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/vi/firefox-57.0b6.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "c9ba75084be67969c6eaed06cd33565f61bf86a2adee935b63ffe85a3ec225fd2a5188d7e29a4dc8a42c2fabaca574c1e3024bd06be758786aead5d27ed51d0e";
+      sha512 = "faa306348b89a9434a3a9068a3a128a9583ebbe647a9d22e5ef9d9b581efee8520f6f76b7590d27d0347c2db34f3d35770f2bdea5c1b6ba73f2c849f228212bc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/xh/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/xh/firefox-57.0b6.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "cb8adfe92c17479f9d99d8d96ec4f67020f302256f0971efc710fcaa83acf6340dc5a4ae9bc687abf875b38809fd201a1be0e6b1b88504b26b9086941e6a92d9";
+      sha512 = "b15a5f62c4dab9e44c620b18d23879886f13807ce8d0008fec028d40f652ba11c75c13cf6f86dbe044afc855d24694872d1ff5502cc82dbc31b75454321a755b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/zh-CN/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/zh-CN/firefox-57.0b6.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "765196a4790be391b11e58402127138041c3911d19c4f6f8d6fd06ce7f281724c321c031b190732f9e3e0ed966bf1e447627228f67847ef7144124c82018c04a";
+      sha512 = "92deabe9058262a81c465b370b128b08872dabd87b527dc524ff3035d2b5068d40f15705449f5fac8df2e1ca291b91af795844154cb7ee37d5d620f952b7d4a2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b4/linux-i686/zh-TW/firefox-57.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b6/linux-i686/zh-TW/firefox-57.0b6.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "c1e0fa2fe1e2929b3f1eff68f1960743cd149f2dd023c830fe9585302f7eb8f8ca4e4d33657ac08a144cd4171154d5d78a106d1d921970df541dd994e534db6e";
+      sha512 = "dd7266ba6bda17fd0194edd2855f1e1484758182a1c5c4ce14cabb046af31b277b2b385b47f6b368c6ba9840a3138416a0a787494cf7382827ff9bcb39b23655";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,955 +1,955 @@
 {
-  version = "56.0";
+  version = "56.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ach/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ach/firefox-56.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "5e91b737751e62f34d2d138956c115120993cd6e8f4f86b7e59dbbcd38f6dc30f7550cac45d3a8ed866cf24c566d042c4ca43bf1e14c8f8452db428a78d167a0";
+      sha512 = "8c6f9261a614b353e20b2b4a07f21eae8aa86cde092544ca924c5501bed8b4c26d8a1dcc2abd91c57704ba3c99b43014483c8f58a0aba2e0d515d8de2df93682";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/af/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/af/firefox-56.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "7e523a24713b84e182ac060562827778d99d9c6125410ba9dffc151e53fa87774943a4dd3ce2c4afc9d17340ab08fd951832af35d5715d143303dbc94bf95d87";
+      sha512 = "826b056547856e7a18b7e352123462491850d10699cd33b9dac696cbe3112aea3fc445db77f1f10392ac56f400967f9b4de6433d9d24f3e756b1edffa72259cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/an/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/an/firefox-56.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "410b11e1bf797a5bbde80fdca6ec0b223e5fb4404441636b633379d42c1bf337faf00f70ac71da2b44c71ef9a1e7fe9aaea0e71184640d5e5f20335d46b9ae03";
+      sha512 = "7bc420dbea0fd02c1ba03b6e4f8b17a9bf053dbebc2a9a91a07a725299f0b976eaeff55f3918a7dfd30828d47d02e266e3eebdbd4a431a5fbff9e066d6065604";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ar/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ar/firefox-56.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "82b390cb188629f0942c8c23db1c84a377ee6e6046add935faa036c93d7d0e9da50ffdb6f7bd0cee540781fd05fd28e9f5799c6970607e412659a625f850d262";
+      sha512 = "2dd2226eb5318e42d54a03eb51c0929b18431661e567ad8524a1229445ac399e2dabd63e4abde3af5eeeca6ffbccae37c38b31f5a35c6828de297538216310b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/as/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/as/firefox-56.0.1.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "d321a7b25d3b06ae356ce875b10d42082ada5673ed73edea419a1b021853fc7079c356d8e7a352b248d470bff90adc0ccfdbcfbd886945c219106bfb00b47931";
+      sha512 = "5616393b8a26383b24113f6b14c95dc96a9d1ec5778995325e48284e1299a4eceb4715e2488570c1ccbac3f38c286efb65afeb128d3489320dfebb86d32fd6a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ast/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ast/firefox-56.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "9ea303a429ce7e3c33e306c5c3cf9e8ba30e9c1441b8beddf3480a488fc99fc95f996f3b38763c04539f9438bdecafb77fa019d4b3a81edbcafd024d4afbe32c";
+      sha512 = "84105f28470ca3b173ef7d569942243f206e8d438e76166ed0ddd9b4d08e3d725447d44a846132a9fdefcfb35a869f0d765732e9662b4513f3da0aee8fdc93ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/az/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/az/firefox-56.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "6fd4196be196b6770635499c1f4eac4b3b1f67073c8a4c2d78fa89bb50ddf64248e8722bcf2367987bd8eddac93663f7f75790985afd39e1399b71121e73f26f";
+      sha512 = "05c402cd86b8b133487e012f1abb4ccab4a90756415fa9f7421e8a50482bf2fa853034d4f779120b6d8fb9c124df2f16b9a4ef65d3eb38698db90d612da58f12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/be/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/be/firefox-56.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "3be882b52db840e9d16976a8596877b1266e83bf1523e32467ba914a1295dccd5b578368bd19eb6a2c864a34e0deb06d75ac798b65e8d4216923c9e60826f0ee";
+      sha512 = "fa1135d28c23475a0184336067bbcfcdf7b707b5424896b9a0766fefc92a8f5fafd4e50ed0064f8e4acf698738672b089c284fb427ab6db2ffce63baadbce3d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/bg/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/bg/firefox-56.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "f5e04004f3ae5944e3b2cfd8922a670bf41c962135a6e65fcee7feef70b4e8de9c159bdb823f9819065b4225de621347066a9dc863aab6bec2bebd05b8fc74eb";
+      sha512 = "d470db1e995fa104b7504cd9f4b3f86851b130f5743235848a12725b294e4bf5a66327b93a0e6ebaeb8273711033a8b69f9493ed48b3c09c3dfa4899e8f09148";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/bn-BD/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/bn-BD/firefox-56.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "6383795dbc65a2d63485bb9014b6119259bf07cdd9e0240fbbf3101b9c955d2008739dc8a7cea4e98ae17212ffb867cfc88ec781935a27d2a8e009e3f2bdb66b";
+      sha512 = "4c2c612bafd1cc5db227d98e215e261546368391b2d3a5f13992f0704790a3bc0768b664fcb913418a31c97ff3f04019057634becbe62e357a8ceea48d31c28e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/bn-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/bn-IN/firefox-56.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "0233366e72f24498be112a584180181401b3bd5dd9dbfdd5b5a320ae2fb7e96c283e0b142c8e3a46e8f3a1ad9958833f7ce3f4a85add5f5b70a3b0e7ca29d996";
+      sha512 = "776dc919081b9ba8de3613614654371b34ae1e31134bce63afe8fb05eea9133cc27e8214ff41046708bc5d812e9046605ffbbbfe8740ab795d908dd714c93cc7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/br/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/br/firefox-56.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "667ade9dae138550defba527024f0900ae78a84d98f427ab5d767140d3bb0636677390ca0365dde4b526e2b0b318ab87aaf6c39f85818fc9f2dc671fb7a4a39b";
+      sha512 = "17d0fd5524a52ce8a81acc3799235e2e6cda905df6b40f70dbc837353fba96a4304a46078f887825f381adc6f5b0c519c71d2ac2fc848a7a5e96bf55d37e2cbd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/bs/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/bs/firefox-56.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "0addc663903145e6a95350ee23c734e7fc42156c07d27e60efc0228da0e4b20f230f76e7802edc795b95c8ba7c1db3133896f4bc3e56221a782eeb78ca57409f";
+      sha512 = "667a7384d89e1ef3b1dede6a6c362104957937352e49406852e6be76e615b1d093e6a8db700e9658cad7e56297d56e46baa0cf0fdb2188ef9d744e44683ee30b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ca/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ca/firefox-56.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "3a9b9622324528b7c7196269cd76ef6e15063ffd1944277ff4ec7cec8f972001718368154a5edbe7af8247262218aed697db46296a13e5861432848d3a29475a";
+      sha512 = "32f87cd6f5bfc8b9dbf10ab1339bc525b80ba50e24881797cb244b7b7079fe25a28ba6934cd7534802baa3e672b9b78ba36b973b264c1d00988669491b23b5e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/cak/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/cak/firefox-56.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "b691c0828637e13cb73ff281a939030effd78c7760cdd5826f723ea7b13f4c7b63bfddcfb27b61aab414f1621291756f5b98ca966efeac368e21e780147affeb";
+      sha512 = "ec9cc56a2cd7b4a9f9849124df9179184facccab1abe062b0e5f05410704562bef4dde4bfef5ed10187b5f1edf86033b5f94b077d8d48169e037c3b17514f038";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/cs/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/cs/firefox-56.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "d99ac651fb417674cbc0750e5e1250d2e622275eead4d9709107f05359d1f62b248295e9120cc0ef1d5de61d22c0f3a889470b1b7fd4c04440d0f1a4730071d9";
+      sha512 = "cdf3b7123c4b69d22f2aee8dcc816833ed876fbca1e0c0995180a170d7859fc10344384ca4c8150e6d0334978e5123371df2da3ef2d726eb39792307d76150ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/cy/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/cy/firefox-56.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "68bab0e265332111a09f04d651bbfca5b462cfd0c4ecc81f7f09f5722f52bd9a089ac28303879681d9ddc7c0da7456f71cc1a67094d2165d3f722c25ccd8115f";
+      sha512 = "2d9e04aa36cfb0c05359a9d51706cd759dde52901d80f68601d3f7beaa06419432a3026c1c4b4a098d31253ec871df227d69ba9c79ddbd282a229376d2789774";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/da/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/da/firefox-56.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "694e988e88b8b111f4c47e75dd439b03edf5e6d3476a0aaf6ff6a64f3732f2b47bb5639a017e026b49d5cad28ff2d9beaa1fdf39571400cf64753a2830a162a5";
+      sha512 = "1e8dc3f4deb5d87d8c2b89c32311062c5c5fd2e374af249e84c247d438f0a3fae53f97e0134ab9a778a84a7f49ee3f44cbbb5057212cce95bc4e977fbf205095";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/de/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/de/firefox-56.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "9647ad2fb13dbbd3bf83c43acfd835fcabcfc27480f31798939065ddd6fa4559fd22d11b656a735f88f30895842059c34f6860b61945e96608756306c3447957";
+      sha512 = "0acba4c4c7905eba03d6752e4de2b901716e0050d896359cf7821ebb4dd197f80d5b261b1c7c6838ac6da663063b134990a7cd785fc13ac1928f78e9de926d29";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/dsb/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/dsb/firefox-56.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "0faa30e572a216576ea8ef60d0d23847fe731634cbe87873a4e7fbd74dbfef85f7ea1c46175d5519ee0265a36603a97c0641c564f72a89de623320137dffbdd5";
+      sha512 = "de51364f0b3fa5f9075ffb50613cd274685a6a9ffd9f665a658da352caab4268e6e1e1458b8c6158c6f511184f6546c0c7fb8f78eac36de6b514104e6bb543c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/el/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/el/firefox-56.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "754f1dd8cc5e229af2f66205054c60d6c5c78f92e8434a2c079a2e4f0ef28a4b29e1b5ffa0e1828c613b749fa0105874dea03bceb6b2e3a01fb910f1a91005f9";
+      sha512 = "0c5292a67bf838f975eddfddf27da2cf54905479a2a88ea8e558161a491cd681f137d2f147f875e449e06ee99685b96aaf73214813cd7c9dacfe425340a8a850";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/en-GB/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/en-GB/firefox-56.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "c16a44f0b057075193bcdad11220ab8e2a4f342980b5b04912bf00a4dd7c6f92d8367319422e27f96413f2aefbbd60b012d62909658a42cf62b5d12abc09ea19";
+      sha512 = "83fbd797a7a798985b8413228f99cf18ee7904295070fd46e00dc960e72a7a59106cbc1e1f92d613070a7ebc91912f41dcdcf1c36a537b26612d11110ee05db3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/en-US/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/en-US/firefox-56.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "8b92bd537c2f962855e7ee4b259c99f3ecdb9939c56da118f38063588de222fddd66ea72fe95ceca5895229804fcb946ece9fd5beb476be771be430804d06be1";
+      sha512 = "45f14c5c4d707b10b3e1803950389486a59543ab408d449f19f04718f50e17c29c00d51a48edf7cdaf05dc5b7037dd221e3902c3c4c64fa2ffaa97346ecfd87c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/en-ZA/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/en-ZA/firefox-56.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "bbe364ece5f1da652530684fa36d2e13051fc85f90c147046110acaf4266ae187067a7b1c59dd48cdbfc5e10ca8df478579e20d19ed1e00b839f4fa1e99c2608";
+      sha512 = "c863347c33335f480cceef6d3461cb44940f87816c7c0d9ddfcc2f1f0722333100acf766105eb97210796e0389df4374b8b0f99c0e4da021e8ecc605ea64b914";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/eo/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/eo/firefox-56.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "2098fcc0e8405a3ac148ab4aa6ea3fd686b4ca839a3102886de515234b06a246bf4c588e6e0b3ecb0ce5c053b4f42e1d01cce79249ca22e041ec35e151b58ffb";
+      sha512 = "e0f322497f5b5dbb274926ba65106437a054e524b7819b5adb134a4af7b67eec58ea5c5d0e098569c96cf842fd91e06901e31240459a309c62cb87f9d1f7ecb2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/es-AR/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/es-AR/firefox-56.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "868e89a57c7ec69ff936dfc3dc3042ababa7c703bbabf5c12044668de922f22f0fe395f792891c839739e859a570676605d17c3c86c362b78155089e9ebc2437";
+      sha512 = "a11866faa165e7c14f0a932681b1cbb4139b733225eb7e3fee7eb952a7c7fc8eb20ea2ce06e1201ce4a6e26835587bad025fec89366ec013de7a5e5c417df498";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/es-CL/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/es-CL/firefox-56.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "cab2543a4d0d2201f4d956a5a35593c0f52df8ebf03ab4872450c409b11ea9c13b794897d8f4bfab6d362d50e72823c57405f8d78d3204d5f621592e188e69dd";
+      sha512 = "07cef4339fcba4a24f9fe8023f78809f7d7d2fc5bad3ded7ee7d54776ec9aee0b4409664ac342cb75a309f3426111e9c0278e61feeacdaf9779647bac2fe7bf9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/es-ES/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/es-ES/firefox-56.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "4f48a78207b5bfafccd8c76f5d5e06a38e79fda36739ef3f2f6359cd392c02a79367eaf8c136ed56c8ead59dd176388de3bbab6146898939fa93db01cfbf53a8";
+      sha512 = "e3416bc824c1d342f50bb275f94c5a70b91877fda49d8efab2691e739e6cc8dc69d6c8b7da42227b28942e8fe235fb9cf56de52e1f2b3d34a3bf6e6cd37e74ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/es-MX/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/es-MX/firefox-56.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "deaf33a4da6e9caf88668d6ca1f634f581c258f8d2ae47d1631735e5311a2818ff951c5a95c6c555dcdc3a182872bd64efceaeea3350ec6229c5207366f8a928";
+      sha512 = "647dcdd35334f37ba558ba5b31ac984f0a48181387704932445a216ad4bb9e1941f93424d36be4dba6ceb4d42a2dcbff15b011f07eb342c413003fb91be00a8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/et/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/et/firefox-56.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "9ccdebf0492d629be1e6514cbb9422bbb224bd7894e05d6343fcec32dad2e6817727c9becc1df487b402a5e61880d073f3315f4fbe221905c60d5c8324bbd57d";
+      sha512 = "09bfbbdc62edc88417211067f4a73772605eb650d689be07df028dac9366dd268891f4ee8cf8f122fd109339739caa6be1a6eca1d35b1240bb89a763427316ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/eu/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/eu/firefox-56.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "2acea950147b6ccc824a42a0256730a6fa1e7226a4bb3ad093a555af5d8323c1a4cbf8affa20ffdedbb3a0c1e2629082dcd01a8c4a18490c1cec579f6546e371";
+      sha512 = "41c99bc9d6047b5a05ad564aac31e217cee3db42e66f6f5bc442034e3210b0732c8bb3d64600eacd16719360242c1991957d81cd0d24218535dfefee0b1397d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/fa/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/fa/firefox-56.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "e4694064bfc8e00b3afb3c83c5286e93010c2d9a90daf781bf141787190aa6314bcfec9ba542fa136efa653b7527ba7c264ff4cd8cf1e529f1402ec2abe90f3e";
+      sha512 = "16c8a8cfb2d87d6ad84180074d78790fe1edd59cf443638606b17178a453a810e78a3f8a393ce730ab65d31688ad0e0ded0b25012f0b74baade3bf6d2fe34788";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ff/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ff/firefox-56.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "93d864d355ebea2d8add77031f490edb13f1e1faaa65e4207a4013c5bab1b473f6fd8d7f5867cd5a3bc30aa23263911f4dab2552adf570675427bbd3e3e93268";
+      sha512 = "b56c8672b0004958277471e1fd7b97fe0fbf180ca4f272a90cabf7b5aeeb534845bf6d0086cb7ccf0ee61170a310f0db9a782cbf4e660034cc978179f7d0d343";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/fi/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/fi/firefox-56.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "2bbdbe8798e2050432bc53f655d533fde999c8081a8a7d494e48d482afb572a08b3c63840124dd50374cca813aae7e87629cfcd68ef9596eb749b5bcef0270d7";
+      sha512 = "206429b73399333fbb9e787132157a51096989e3cfc9cfcf2573ab5dc12de2d0d8b73fcbeeec6c08535ef4fa179899677a7beadaf698f661e3960a1e05edd617";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/fr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/fr/firefox-56.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "c3903b640f674f5da1a7097543e917ea7c56c2c8749a30776fdaeb518d7b0ac874533cca0aae643d24175fa6307ec5cf00ab457ce3dbcad52a02e4269c12550f";
+      sha512 = "837bbb752d18c6697c8fb357d228b9cb24eacd2b4f9d7ee58959639d165d06de585602ef30391a5110a4711a0c2ab8e104395cbe20a5671da67d3cf90947f73a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/fy-NL/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/fy-NL/firefox-56.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "246cc7102dd43351a6751f71b30e347a67db6997744fd6b94d2179706304a370a36bf31b00aec32a41cda37ec0b734cb93b759bc30369ebfecd20ab3680b0c74";
+      sha512 = "1d4fc9621b08e34c6dbc19c016a4ebfc503aba17d9f69d6d281a2937eeaef8dce4b6cc0ca7d5d39392f487c9d19556bc175bbfed798e946bc81325f111f45dec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ga-IE/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ga-IE/firefox-56.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "cf825c5e47045afdad04cce7622ff91e82c2ab10c14d6c7f0338f37221fffd1df86b79a6dd606a333c83e029a21421220616af6bf417c1a12dab8504ede297ac";
+      sha512 = "41f88d1026df2521498c5f78c5bb12cd4e91620c87966429bf26b23cbaf872c2aa3e0ba5fedff05458b8e885901e5978c260537a865964672f0bc558e615b769";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/gd/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/gd/firefox-56.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "82f09b004babae82f2e84ebc3d7aff0f556eddfc3be0ecc1abe90a18ac67e846304ce478fdb6c3a757ffefbef50fe733666796c4820c701f249c09cc246eb396";
+      sha512 = "67ec86420e978b7f30e3ceeab403e3901c50c5ed3baa4958e2e36cbd4db95645198c2df81ac9f68160342a09b882b21c397210a82eeb6c1243264e404e9b9fb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/gl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/gl/firefox-56.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "f5b6513b4dac92b02a4961febf7c734b5b9e1f9e235bda4749fb139c9c050116d1f1f222daa50c0bd6209b7958f8610800d4504d9a9d7ea255bc70ae7149f211";
+      sha512 = "81d2149fa9f1ba4f1b69c8f2973ba1f127f64f4bfeeea0dcb5451dc88f3b681f7ccee5fcae9bc8b7c1d36f85f000cd4210b54c360694d909f0cb66728553a0fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/gn/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/gn/firefox-56.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "de42e872ce6ce31c020a539c3c85c0ad568c720a2667964fcfc6adbc5725fb84c4d559902cd36f7daa42864c8c276d18bce57c994bb0a996727291ab29f43362";
+      sha512 = "93b576f861273b96bba97eea33598d421f0251a847e853f1506fca08d094922ff445ebc36468fa457181359afcf4a7e1f185057c2cad6826376e03a6b996c8d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/gu-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/gu-IN/firefox-56.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "a894ee96d15bbfcd81a596d0e1c3fe72b01c02250c54e85e7f66321db735c157a8cc971c0aa04fbfaba367817b360ee5b9acdd000d46f85ff035c5ab3762aed5";
+      sha512 = "c377fc5936257a8cbce11206b0668bae64c32693161472a2e568da00c662739873b2b409cdedf041efc7bc47956219c746c05c0e95654c2e4b553b384e40ca24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/he/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/he/firefox-56.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "fa3eeb6926593e77505583f5321d7fa21928642c900c9ea3147cd8967b36478e30a15069ebcf23212f82a32030713144fac0cb836808e7e3ddad4184f03629a6";
+      sha512 = "9d82c000a8a09f69c9daf8f04cacec5a9c333da22f42600259d75aee7e8ebb57f76854921b34f5de078caf03edccacb59831ccf9f8b3a885842fdd1e42761b83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/hi-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/hi-IN/firefox-56.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "1749903bceca3b06fede93fe4a3cc531cdfc65d9bd1ceec7cfba0fb0c1c6cf74118de4e5f8b59125f429ab0797fd308b511bb50087237a2b470ed164281fa143";
+      sha512 = "1bf8c4f4252ccae9bdeb6201e631ee178c9c33c17661f680a5688138ce875f05b17618935247dd614a99c8b4c59355300160efe3dce3ed4dc672ec1ebe301a21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/hr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/hr/firefox-56.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "244a2895a30d6f6cadb7de82c5b1fa193a41d7c255d27ad525f30e057a2571531999992f3b8735b5cc549ec4e0340d0027b59c4518992cedc4fc2ed89be4c73e";
+      sha512 = "67db04beb477b841f50125957f1354c597a4e02adfe3a95e0e177bbe436fb103ff99a68a384e8431894669cca72eb27f3250f7547696771eb9dbacfc6ea9d39d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/hsb/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/hsb/firefox-56.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "274ebe64c5e0395d26443ababf3c998f583024d979d498bdb6de65defe330bb862abb8b29202bf17c8c6f5d938623936dc9336d13e99c214027d9cfc261f2b74";
+      sha512 = "1e3420c4003335e238df8b2d1f1e8116f4aa6f134140f0c4201bc1641c854a716d5845b1cde494e9d7fa8842bbf8a6075e5cf0e06fa7c6e5730429e4543df2c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/hu/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/hu/firefox-56.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "4aeb33a804b88312fb68e1429627328accb82db368b017214c9dc9a8023dd2a702e787c03020a5047bccad9fbfa82b5f44a9079ba9235dc03393e1b766b88f7b";
+      sha512 = "81935ef98b9b92db81f2ee3cb32bc081890c6e72c5fad4fbf601e9fbdddf85983f4c2d39d4b3a75f01137e3864bce1deb029bc6d7e1c2fb3927f40c7e06e6232";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/hy-AM/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/hy-AM/firefox-56.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "92202f50142c2e0dd0384d5d65ed1d059f55ecdf583e37777017ca3fa428225e1ced4206140f268fa5eaca301414b217f5e46f435ada4ce1a70be87d5dc30cb6";
+      sha512 = "2505aa2f68de27a09a24bf1323a6bfb30eb35a60d4abb97451f5fe749d4a47a199a5f8ff8071beff19c9074627d68f5a3ad014694b6799c2a318b9547996b6a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/id/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/id/firefox-56.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "b2b109fda6ac076c933765698026d278da662bf026a4e38b351676d2c73fee10969f39650217ad225bab1ad387fce1f42b7c5152385f1779d98264e0403ed04d";
+      sha512 = "ae6d762a66edca161f9e4a547b3ca99b34f727961fc5ab7a57885d3b9ab78a0c0d1ef6b80fbf15451ad06b9f59d7bde4dbaffebadfa51bd8f89c7107da7296f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/is/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/is/firefox-56.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "b5d753de5f044b693345c0dbb112555baa0f84a385338780c99bf465fdc09410b920083ad160f4eb56db5e2b73e3571aed8f8ae3b3d57142b9e5e452c39836a9";
+      sha512 = "91cdf41d9433d20cb737833a006f7b0e3408de9dc80d689f14d4c8c2cb1ee1cfbdb37196ec8cfc68e6ebf56d53b437917ecd9d18f935aaae5f4cddb7ab277d94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/it/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/it/firefox-56.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "3c6017bcbaa10da0d8fae0c37713cd06c010b9940791f6f9f9aac3f8393d18406759c6ea0c12fec02c50d52e436d401d67839859d96322d7ef3c664063d380cc";
+      sha512 = "5d051cc24c2cd5811b0a6738902a232718d3a6458b372fe9ed7923a15b18329607e93f062b4ec08fff4eb270adefaf9e39498e22522c102ea23b1d0a50bf3f7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ja/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ja/firefox-56.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "ba0f3bc654e0a6cf96ac555733cba556c3725474df71be52af06741a6690c8213c604f1f04b2df048b756addb86b85593e8b91b0bac714925e53469c7701c067";
+      sha512 = "796535836414b3f676c0e037f03cda49feabcee5bda2bda64130d569881fc5da7eb6040ea5a534a7f8685720801fc0cc9196f7d7d4225315929198598995e239";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ka/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ka/firefox-56.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "2bce012298b2b80e4567923b99c96dc49a6d2282cdd24b464c98dd36c2a66915f8486aca673abf34df63cfdba2bd2bf6999397610ef64a55804fd589cb581517";
+      sha512 = "d597a777779ecda47c588208ff350512282af7b933a599014f65b8c7777f68baec93eebbce982e3d77fb42d77b26d533d63c67d2a96a5d4024b1f595a28c2204";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/kab/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/kab/firefox-56.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "b2e2c667d4551724cf9fddbcd8ed4029c4d91a6f7363804b9f1382d6f4463ba65887174cb44cd4f7a5be525db8699ef4f517dcc3f87018d65e9fa136219278ee";
+      sha512 = "2c60fbaaef100c38d4d95f986289d9cfdf4abb739aa3320a882d218b949d7e293d2b8cb52380cc4991a7115d12eddc9439d6894d862a631c6e3b274680cdc1bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/kk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/kk/firefox-56.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "3e3dda19c1f03c144cdabbb4f968eec57df764053655d0a5cb69476d6bbb312cac0f06555422c1d95985871f37525f1675bdd4575008fbed99cdba2f0e80a3e3";
+      sha512 = "aa8e9255072a1154dfb4230effc9ad6649b02931c24ef4ce8e979fe4bfd9c350aa9dba39a7d0b866e11e96be29e0fd7a15f8f7ff9708ce26e430491453b49c23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/km/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/km/firefox-56.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "ed50a3fe8f72d0391a3facaf08bfa34bf8227689fd74e2372bb78a2cd76a99f150669a0a30c01879096a6fb4e6b1bdbd15b41756cf41000a1f10f3e5b7038cac";
+      sha512 = "e5c38d3ce0adc014510f5557577a2bdeca238f9675f2cad90e42b4ee15bbc2315cd869ec4d3a6fa380203491699d1402f5aa59c1c8cd8cdb15caeedfbb7b7590";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/kn/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/kn/firefox-56.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "fc3d3adb8a3e92e2da7e3970ab3f45a1c8750acdc11d5f7c062249a6f025070ee631dec1f8ccc9237f00442b4c9c782f51d8f2ba420ef5a8c3c4e3601e292d27";
+      sha512 = "ec5bd88e09660e6b3e02fa34bd3f8f5b81be7a6dbadf55e56256535ddfeb5734aab85ac47d16a14c41ca8b0b66b697c50250178ed341347a6763ee2009173610";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ko/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ko/firefox-56.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "05e6a136e711d1b13adf78037dcbcc21a6af7aa8eebcfca0c839810d8df4e87fd951a12c705504a585e729af72b6f6bed8189d3c5f8919f68f2aea72cca2f1b5";
+      sha512 = "33f6b9850a1f2d5f6d363b5830305c498c50eb705b552301d34988e9a446d2b438e83ab29cac45fd1be3c7be016a0eaa631aeeedf4742de4f27957c02a804491";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/lij/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/lij/firefox-56.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "d0ad5add37962d986b6faf324a4e9faab8c0366c6c04b34bbc5829159ed7364d108c5b324cd6ee42de279bc58c414d347054218dad268132a2543913841b2846";
+      sha512 = "77d2cfa449fc522f314749aa3a0850591efe4862bbb9a8e9dc1abb9d99c2b16439f7845aff9686d201bd23c88725212d28b1837fe1f2b20aea3c78525a8e1ef2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/lt/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/lt/firefox-56.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "efb74c5479867061c9a8ae525893114d85d253322a4411a7d67f5d1bfd17843b371ff58167d8c9f199cdfe7f3b13592072ccfb5eb88ad62a511272ff6419b620";
+      sha512 = "6a7c041f241fb6302e7c67b0a920ff613170b716e02258def0c87fe9332a69318f962797ffed9ead3a60b8a951f517f07f201053ff4ff4dace188d737bcdbd0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/lv/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/lv/firefox-56.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "030e445cbb156c12d77c1858262b6261e73fecf3091478cc9de47c4867c53b7ef807ed8a15caf2d217ca00e2d90a05f8a86e4a1f836abc99731c9384d74a1c98";
+      sha512 = "ef9166f0826ebcbac5352e48a1ecd23a0d88b6dd1ce2d5ec24b0b71326e03a7b4b175eee299aa620862aca9000a00e98472e1a605d214616933512e73a439808";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/mai/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/mai/firefox-56.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "abe8c9eb6fc36fa2eeaac29f7d53c9ced228383d24cff0c43520aba9975c6b400aa6ba44584c05395c9a4fe156ad1ec2e348cb8ab813933f514729bc4eb3569b";
+      sha512 = "291aafdbc820b39b7473192a3781b96ec2fa3ddfd378c27674e18a24eda51b6aa112df86a68b6cde6c922c9567449d75942d470b09399424517cc818418b7219";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/mk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/mk/firefox-56.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "a8c268b53e392f147aa371a7c5e623352fe80689e5d65b325540a478e9b2015ed91bbb7cae309117b16677dff1cab99e64de171dba3936a01101579b49efcd3c";
+      sha512 = "9224e087bbd6b49630023dc92ae752e62cf0a9e4169dac65b07acc8dfe143b333f8840875da4b5f3ce119ee31987721c0cb8088c202cf42d6d24c773c1406415";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ml/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ml/firefox-56.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "655369ea9047c3715e7e46065fadc255516e170f1892f0e0a02aa6c77ab94927b43f0d125be3b886dc7295a43cec304baf3268d701bb9aa6cf263eeed2f95974";
+      sha512 = "e8fe9fda9253b20f898314839e8f70e3011fd3bc6d1a08c762c38363066452f854c530ada25bd5417a3f6eb0ea4ffac525bc5b0bd67b6e6eddca35c8eac9a6d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/mr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/mr/firefox-56.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "f944bc416068446084e9fddcbcfc44ff096e29c2feeb2b1a40530317f7fbabc1c3f31419d749fc859789be9188c875e7d769d3aa09e286eaef305623f5a49d70";
+      sha512 = "07ee71ab15cea520c5c1403be55a7f09eede71787f9a404bdd18882935112a7cf423850df7b5c5afd3e595b2bd3af053858a9bbc6f152583ecd03adb0cb56dd5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ms/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ms/firefox-56.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "25d47aa89a88da6932cced36e2d5ea5de7fa9e1d7dbfece462842daa65ff018d7af81c26659267f5a40bf621e79ca0df30f1ecc5abc5d5b159673c73d10b0e69";
+      sha512 = "ef839f697bb37a81f988d28d6195b33f7aa92b1f0c67cb40b04ef3820a2f86f024a34e964f4f2ce8bfd81cb2695e6875d8d72aa426db447c6e65c1a277eb1379";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/my/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/my/firefox-56.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "3611e75b8d4c838ce81320e4f72d8b3425959e1962bf1b147da081f23a6536ff4e28204d01154f7e2f4eef3dd48796180d42ad7a4467d66cfbb56089784b3fe7";
+      sha512 = "06e24ae1c4d86ed2677d776037378e5f50b3481f7e96cb0e32369574fb2a04c5d572c7478ba2054f3929a0714aa960c8d9ebc8d7b9559d7f294c31c775e9b70d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/nb-NO/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/nb-NO/firefox-56.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "1a1ebe6b9b118c89a3642504c5d1175e64aa37d652741255ab93e7ed8770a21e2208434d19f95bc01deaffab7e33a011352bac5783401add797ee4c9535055e1";
+      sha512 = "c2384749c1121cf7b184e49fb7ce535a2387ea32285ad52f63afa6a02746c556459f61d7f19a60552e63958aa9541c81bffe13c6a96f71c598bc4501bfa4024d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/nl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/nl/firefox-56.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "e5348a13c66e3b6f5dcd1765bdaee0adffd0dad195be0c52dadd99fe1dbe5e381e5aea7b9e48d4c77059d1fbb0b214c25d3b51f83de79c5dc33089e2629f7298";
+      sha512 = "b207a5f091f556dae81fe4d35a14e39ddb1eba9fe9ac4440d7335eaef561466f14d843d91fb8a312379a0c7ff039a763fd041088031cb48761aec6f58f681fbd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/nn-NO/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/nn-NO/firefox-56.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "fc7ebfebccd5c3be0a06a02b98da1d18eb6402e2b97a44a8a483845df0365a073260930eb7651ee481c5f788bd0b158e5b97017818427b9143772601ed7b1af0";
+      sha512 = "e5a6e1ecef59fae002c4605e7c838e00ccf6fa232427c42a29cf27f1bb4db7c84d4c4aa70eae84b5ad40eed109de11270d02574101eaf690a212b219448cf273";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/or/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/or/firefox-56.0.1.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "2e450311632a130b4fdeb1aca3be2073e22acc1016315663037b0ce5daece961a2ea276b96da06219f6a6259ced97d819e2feed745c38148e766d2a08896835a";
+      sha512 = "f259f88c0e4669c4d174fd011493883811042ecb4b4752c7c69dce61d7c6c28267428327f891c2eede911667807b6554373e8f2dcb8ba9e2f3d90472aa2ec960";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/pa-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/pa-IN/firefox-56.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "ab2ce9dca08d20bd9f389f04ef1b2049ef60cf98c0423a59202b623419714fc1a1a40210e11a73a804adbfec1d6bf142747b7a80e7c83e35d905b9c48d7bcf12";
+      sha512 = "cdc2cdd6902c86eab3098514b2b676db6d8a323d3b78b2da6104fe1be17cc15b3d38d5fdd1692a87521d6afce8c8bb8e0f78bb7d291145ebc05b5a76d47e34b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/pl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/pl/firefox-56.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "d9b75c4777f029eb9645a076de83b634f8ce003dc3bc2276c94f7e6434fb5d4b06eac0a2998b2e4abedeabfadbcd9410c9c6bbe58cdf5bb257601f3dc0dbf0db";
+      sha512 = "edc50ffc298fc92100faf0b529716e14dfed8e41965e3b4a8d040bb90a526309bbf52c60d8d8cb816e0db99bf09401b27602cbf0e7e947e3ecbdf61f5c53be59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/pt-BR/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/pt-BR/firefox-56.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "bfbbbf7c2f94fdb5a15b3170f7ee6489a4cedaca07385643f659e553923c0ac06b7e7d38f80ffff082a56c1f2f08fa883067d1a3fce1531f1e4160d9c8f7dd70";
+      sha512 = "9da419264035792c3e9f601bd9198e77e0fae17a7ff2e34b6322667cd95bb79ba064a59b6336ef33571f6cb5f721a7f4f35e1f9ccc94e68196c310a683410846";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/pt-PT/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/pt-PT/firefox-56.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "5033151554eff19cbd1b9c66cf5338a20a8855e677761f89cbee022b8a2cef962161a91a7e67b85c34ab3b44ec4f4a1a638e5f7955e998bc29dc55ba072b905f";
+      sha512 = "b151504acc244ad3b80c2dd7ec87fc04682e06bb53338bc39aae164ba1a279c316eb84e33d1b41f4261135c39f0a0830a7f74f5ad7d0d3b9ea0bb458d628a9a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/rm/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/rm/firefox-56.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "12426599187b70240624401aed139c9c61ca58d3bc721bcad01d253942b30ef3beee77cd8d76c17c9204ed8a6b919cfa9709e775c520654c7570f26a1e5234f0";
+      sha512 = "480b46a34d36fc03107af64caa5c6f0cff95021cdd094e7c0641f28938f5f21aab8e50b8985e0b42c3cec2650dd4c9538df93570afbffa399241ca8b757c2ad0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ro/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ro/firefox-56.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "3eb917db04503d692883d621d783d6df623ece55da12769fed51634457ab9dcc4c879b79c232054e504d266cfd167a208e728c0b9bdfb2b9a80e0edc60ed0524";
+      sha512 = "3d257170a028575739fea107cdd55a39bce7c534244b4701716e0ae8930e79f04a9fad14c5123c1799fc7ff0d1e98b563e338621408c7e9fed1fd1b84c72a930";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ru/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ru/firefox-56.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "a839398c7afcbcc7e4902106a980675ef46123c7c8466da61586db623bf559e4238448003c722594d8b0a39b1da1efceb93d923d5160ae20e5d3bb6230005d4b";
+      sha512 = "954853d2f0adf078eb840b02be69500b0abe8d76947d1e71dc48492473492e3c3162b1dacfb1089397e2a4985af4ec71b57a01d86fa7cc3f22515aa5f772dd04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/si/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/si/firefox-56.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "c37aabe213ba6eb7bf12d56cdb65ce8b95fe95c40fdb0edb58e9abac064e4ef232fc75787d2b44647cd1887f117d6144d00d495dc196fade8bcc96ef06c6af82";
+      sha512 = "3cadc96524cb58a02aea721a7ae54fd81e660faddebeaa7f2a1b498fc5fc4341ea04093743270121af5757bbe9f6e80c9dead96c03a3e576b530ed3ad4edf7df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/sk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/sk/firefox-56.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "b79303551562b52e1fcec89819ea2ab04e1c5dcf41b9dde067da2d2e0a51307ceb45e0417c94c1f446bb80ee2c7f0e1f61479d33088c843423d5b195a6df4ebd";
+      sha512 = "b800b287c876bc0512295ea2f797e0c330604a9bb9ea5d8ba37b23f79d78701721bf98a329bd58c157d7e8866352fbf9a9508e0959ebbec2f05eef6534eb9c72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/sl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/sl/firefox-56.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "c51c1a2a81e6644c144840ae3a671e74165add9244975f2671a17ba6beba9096219e630b4475b9a576cf0d0c2fe8001692903a984bfa1adf92b7c34bed46cd9c";
+      sha512 = "3a672e005fea767d6af13691c2799d95ec7ea6004e889119624d01d02643bd73a2ae7c6a2b7c96b80572366ea54b77a4d83aa02370a884f18e86e6633f774a9f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/son/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/son/firefox-56.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "f40f28d3774c528e0b8043e30e9b4f88b46b1e3a296934d155c9b340e099937804f7d5b80c845df251f70401099dd089a09169c55b9f39f7b22a02261381ab73";
+      sha512 = "01a506d12757586c61a100755d2610686f2623c9ec7c60bcd1908fa02b16ac129ad0be7d38a43de1cb7fb402860a55595f87ff6b16e80360f26832dbf2c897bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/sq/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/sq/firefox-56.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "728941b8eafc179e5100add0d2489a418b28973e2427586cb662c34e7ff080bf528ae7037835b7c8965b68c6cab3fa5883cd6bc8f1b849937a5d37cf069765c0";
+      sha512 = "e5ea656718a965bb86d826a1989bae6c20f3722f3d7a2b2937fdca06422133b94fc0845c7dcf7577527399b8ef6e78c13e4f37c3109061dfe62ae12f4338c27e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/sr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/sr/firefox-56.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "3108a89eedd792e44334b232a127c7c8896d1a9fe389acb206118f341a747f65924798e99c36bc1be19c215988785fbd1cecd20f2707afe63a9b0664e23051a8";
+      sha512 = "c436c4df233230f0cc848bb29e36c2715d7d6bef09bcf3fee60e35277b2dfbaf5d0556507c5853daffd823c7ac3af47e9733746302e98cd55c5a45eb68477fa2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/sv-SE/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/sv-SE/firefox-56.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "a59983dae6d6814e45564dfd7b199412b7d7ea76afa0b0fcdad9019ea047b3c45d49317af4624d99a2375a525dcf72b92af0f34a51d955543fcaff8f407c6f23";
+      sha512 = "62f2e7154161ab18902e107d83d437fbab65de3195e49ed009eafbfe2a4f82bc1960f4343c52121edd8c36a57200fd5a6468706bbdbeac9b60416988964e548b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ta/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ta/firefox-56.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "458033fe202c3191cf6c8930ea8697aca2c534bb4c86c7f0a85925ca830086120d4bc3a8148530b8f04c621c5da6d2674321ad6b4f9af7fff0b7c02770550ed2";
+      sha512 = "3c125c9c03646ab80a65a5f84b14c5a2cdd0419cfa0356fc1f28a77b3df463653d369e9aafafeb90a4281333f9ce270097a6aef6b25ad4408312360fc751f5ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/te/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/te/firefox-56.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "ce7dd880adf34db123f85dd1e8d28dd3219e9db59177ae8f4e978efddec67b82025d4a2a2d90b7e8acd4f093b3d019e4b4e8203c70e1e8a41756bbd1c8eb95ab";
+      sha512 = "4642cd96dc68b059b6790ad1313f499126d0b68fad49fdc369f7c70b3ecdaceec3fb4572dcac0f75a415566b6de04ac6086dba1c57e8d5db4f5c360ff5b8bdb5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/th/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/th/firefox-56.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "7c23001e41e8e09f7468c74c79dcfbdaf655894f1c9a20bd87357e39f970faefdc1601b4d0ac2e442d4ee490362f17a4817269509280e180a2cfc31f8ebb1e64";
+      sha512 = "593768af7dc80b1a5850c493f80f2c538fa76e1b5d3b288d74c6be2bb3736cab29a6a1f68902074b0a3c3813eb29f0b461dcf0130ad7fa4f620917a8c1e2b738";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/tr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/tr/firefox-56.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "27bfd7c5d3cc45be0d29d4ffd4d449a0c564bf5eb7d7f86b808429bfc4cd54cffa9b7dab213122930b2b666ccdc99d09f8641670f79a1d1250988a1db4079a2d";
+      sha512 = "8314f255717a1dd56949075a8ac915e816d7647c39027ac636f79bbc2f6d7b9d1bb593a1ce03a9feb1ba41d4cf2a9613a9e64a42db448813b874fd0906267b2b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/uk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/uk/firefox-56.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "4073153ae727ba314dcb77ef8d8fadebb5e397a4c379d028ab381194a0c9a325ee2573ee22ce407c7d774758d74644f033f5e17f1ec402026bbb1b1c4b806520";
+      sha512 = "bf6ab16560f18a8e2eecc010f6838839561c0255beb6fcdd9a13767a34edffbce58fa2911ef13f5d6767cf19c96e0df520d6682d3441bf860d0654357bdc8f83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ur/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ur/firefox-56.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "e0ab4125e4d46529eb27a5d1e2039f36463b88b87370151955fe33d602bd1c72ee4fbe79cf669beea81444f340df3da1a3ac4acc73ef47162acc7240fe230841";
+      sha512 = "0a6f44415b465597fc58bda25f371da6cf7f31718a310c96ce1f1096c75f627391e62d10086d6816d64e4199ab0d971f1fb8759f6509967f0a7f79d8b6b08f16";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/uz/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/uz/firefox-56.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "628af5328deb486ebac3c3e631a3314c39e3a3cd4d76610c640ae60b5a827b62a4364898c895aa2f7bb300146451b3d21a1eadd484ec77665828591b111b40f5";
+      sha512 = "57b40355881e13373f3d122585c6e7fbe48ebcf86bbaaa78756e75c669d359b1948a5a42715d32ad4cb9569008be271e15ea2f8a998dfd15f7db36ef92453386";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/vi/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/vi/firefox-56.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "2e4117e805227dbbd96f2b5af658971018000e7dd89859f5f68369e45885125b60810a19f5d62affb98290b0846fe18ac7e96552fc8500369ae10ad1a2ee245c";
+      sha512 = "3f16a785a361dad4e395882cd2a72bb8dacd5c58c47b75d18d9406602a0b23ef227788652656398de09278f9fbb52dc61b7a9c649d5382a1fac663510f228a71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/xh/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/xh/firefox-56.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "b915c86aa00d09bb02424f93b6135e3f407daf73d8cead602682e13e78d6eefbdafa5116f8ed8683f3d42a2eaeaf3bc63660acbf9c4104fe99a8d80ca1ebe695";
+      sha512 = "e2792d9bc89033739104f8c14111dd07c28dc49be4ffa820ccdf88023d93ab7598f1b954183ee3abbb47b78ba05e596dbc7f458cc7c77cda91bae64ce561e5cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/zh-CN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/zh-CN/firefox-56.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "27491f5c075c2a9ab48cadbea211be12d4cd1a4b110d7e0f211a7255cc5109f9b1bdeadca1606afb0fccbf70351aef6ad7fcb251a49280e46fca546e28df9e04";
+      sha512 = "6ed90f1a4b157484c4f1fd0a171d948afbf2af06ec8141ce34285c521861f2bd3c3ca231feb4b8b69146c84bfcc83a675b4b69f1889476844d3cfb4626dcea6a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/zh-TW/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/zh-TW/firefox-56.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "46c370fb51c1691b06ff026b9ae5a9682713c3c564b077bee4e3fed9ea80c796787a37dfb79babb095c05ae49db364ab552913a43e48ce43a628b3747a15f68a";
+      sha512 = "e953cbc61b8b30de35dcb73407f817651fad295633ae52d299d6205668c49ed4e432ca2e5c8bdf411317c3dda1c4d71a3472cbccba94489573f96c42c09e6345";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ach/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ach/firefox-56.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "d8524970684dde392a393ecdff1897af03835ac07a529a643050e49a53e12dee472f33697bd66cccfb1f2ed78a261dd479d4aa25f3a56ac953579f6c6d5621d2";
+      sha512 = "386e84934aad44376173c7ce27e732e81612d231a4e527f4765cc7cfc1843badffc8caa1526cecfc546507f2e370fe55a85c6cf55b9b750d98a70514301c4da8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/af/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/af/firefox-56.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "3624bad2947f43d9aa89a4a5867d7a406fb34dba9aa06bfbfbb44405fef3b3f78e4ba64789cb02cae561c8112b65d81ec291460522602798ede3408b7127e1d7";
+      sha512 = "708c0012276f2473853efda705cb982d809edcdd300a08c105eb848be95efda784720bd2042f7d352c3b6ad96f5a63f53a70b98c9db29dbd93f14ce40f44390c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/an/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/an/firefox-56.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "ad7ee2ba36ac9a84ee44a16ffaf39cffaa10325c54fb573565780ebf3d176b7f7652349bcd02f0d7d1d4f51b8fd6e010f081f770bd0393e10225ac8ef4262f5a";
+      sha512 = "630d51145d27671fc739bf8ed45286bcd3884a0afc15f39c837fa213f0fe9bfd0213e6d8269fdd1887844bf07302ccf2bd8cce38e7f7d4f2f706486487736561";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ar/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ar/firefox-56.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "4796be96acf7b5a52844e52cf86f0bd90c8b6f3b4c8cc116578529371a77a44fe4a1176a1b4832aa4046a3e9a6291b13bd57c63b0df31cc6b2ba7f4fc58905e5";
+      sha512 = "07a668a25ab4faac23a4a2adfef2b6482261b22cbaccd4121a510af96958443e4ae35d6e83bac15ee0e64aafdf5a5d4e4c21cded777ec65f0c333f9474cab397";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/as/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/as/firefox-56.0.1.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "26c69f994389ebc7a0ed737c5f925f812e0ce0a1d2222406a17801891cc6ba8150c99aed0636f6585415d8ec6e7b4e51d39b39dbdfce1e0326af89faa8ab6179";
+      sha512 = "46263df53558751c587f1e6f6c4a9f3fe5c4833d3c984fb507f7bece693da7d85298a85a21eff38527a81cb1f24f6cd1c8292ebd280238f70e076a4da7748e95";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ast/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ast/firefox-56.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "511f7e3cb28b888c45fbe31e398d3b66192f8e6498021e34c10298096bdd16c839a0aac8db6a103efab12978f099ee3c414028ac4966bd7626556c8eb6f2ac99";
+      sha512 = "92daf3ec9160505501af044b1122a544f6a6e744ed262b5e7e9fa7d1d303e68dcfe7333970b97df9add69d8dcd4b29f8bbe1dfa47301ee16da677486c73d8e77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/az/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/az/firefox-56.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "2694b535a2bce0c5049a143b2a8c9d62bf1dd29e4ce18d7e686df43e87aa745b284c6272a6b1fc5bab58b023427120bd694f7e8e681320aaf0f9bb41bde0e7ec";
+      sha512 = "d8bfe731b8d80ccdd85f3f389fadd76fae2691ef2b02527cb96f2bead142e35fc74f7a904d62e25672eeabc51ba746e18fae70876c8c86efb22b05fe9137593f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/be/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/be/firefox-56.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "77d586ba3244e6fbedf354ad3b71edfdc20b7ec35ae520769aec4037bc45dd9d1a4ae858121c869a9e0f888f0d94d43ed0e0b4a25703d8cd0f0d8537b9631bd7";
+      sha512 = "8a27be65f3e5c586411534990cb948e995e69dc0d6f7cb52afc13c47b42e42507771e3665da57ad86ee5ae532130fd176b10cd17770cab7b2ea50b0121b35ab4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/bg/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/bg/firefox-56.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "eddb4223b62e2bc1e54f27ffd1df85696b9bd169f65b75dbc8f96cccbfd59d110b262f0a149a88b584d4a02c9cda81ced7ea4884be8edd4888d50fb26a850eb5";
+      sha512 = "2c2136346ca821f96300c59705ff077d9b3fccc097bb0da9732554b07278064d92a9238ee0a99cbbed354dcd13422b65334b03ec4a0bd0656b61e5bc8a1ed51d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/bn-BD/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/bn-BD/firefox-56.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "d5ac79231ef0f559059b62cc2b7b438fad544ebc4f44f8a88a1e2503c36547de70a485c4aa0ec575835be54657ff102d2f8d5ea5b009a5f4ee3ab9bc1c8553cf";
+      sha512 = "8c53e006d3d7cec66d5fba1eeb1ff8c0beda661f1033b2e648ff84f6a41e9496d08d90763c0356e5cf9139c699851b878bc1ee3f1f40aabd3d26a42d17554395";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/bn-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/bn-IN/firefox-56.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "ff104d3271479d8df7c5d63ecaa03ce67bcfce839e155bb8b7f12b0f4ce7eb950f0b36f542e6c87402b070ba23d7154124bfe51a10c560bb7d756cef9ba0db85";
+      sha512 = "696a769b55ed6beac2d7f61248deecdad88b85b048c6fea3bd8da1a7cadc792eaeef816ab83b184b0c65b3bae315bc7acc96e8415c69b4d92e50f40f96621471";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/br/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/br/firefox-56.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "5c25ffd7d5a7cc974c924e04103fa81f3d4bae58b2d00a9fe57b6c849de91e29be73533e2dfa49b07ccd45f1bfa7f80861fb6736beb5deeaa55460192ca3c231";
+      sha512 = "3eff8fe64026f8d337ac279193aed4f79320c35d4f5269900517c21bde2075595ad1b4afc68e05f64c8993517e832d1c34e39fc60d5eb6d1b1b6184fa912c416";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/bs/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/bs/firefox-56.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "63ad8bf0161537029da342ed24784c08daa7934c40231402ba867d9812ec0d01d93db251f5c253592de53b69300f669754fbe530ae4cc5f4a7043031a7dcaa32";
+      sha512 = "b964f5d6540f4d70f50cf0ac3858539f58ac50b691758568a5dceb3045b7acef99af65f9d1873f01a7e633b101ee37cdfd8382ea35c8719d35e5a89006883570";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ca/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ca/firefox-56.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "09ba0756946a02bbaf697f452275d3ae908e7fdb5af166e7586b84d1ae0983db0ca9008c48be93f409a56485a189da957f5ea9c18f9fb68c2c09621e16a1faff";
+      sha512 = "309ad23f3b042434c3c0779d59838c920063e64734d42075581ed3aab88de947e5fe2d74dab5ee17feb1462fa7125dee6b114087cae68fdd6c402207f248d1ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/cak/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/cak/firefox-56.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "eeab51af57e52689003339d3f02e60da8bbc13ead89343330328eeab34cbd55c4cdab4706075aced5b440378b83e84be7d9a62182fc76f47d7945a1b1f0fa337";
+      sha512 = "9454a093f4fbb2466fa63a565461f209783f24919c970e95ccb25d8c9b56260fcabbdd9bcb6ca5fa4a1e1098fef4fe50882e923954363c83cc3536f98f95e078";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/cs/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/cs/firefox-56.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "938cef9e5f0e7bbb6b3fc87bc71ddf5b71e97c89a53aa959b940f48345876ca0c8d368f4b630776fef51a1cd64496c96c1f75f32cb7d6ad0d92bb0a3c01cffe7";
+      sha512 = "b487d98f8f060d34164d78ca77d7e3f28cad212c2c9a8788a6f8f13939a8fba5bd6501765e0bcfeb3c57ce82076187cd158cead63f06b27657018e9b1c63ec6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/cy/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/cy/firefox-56.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "f70dc0dd9c92b9789d8de307a7151836729fb98c55666d13beb66958f3824493adec8a409109be6ee076a26a723e5b9da1c4e6363a881f1546a739978e78e7be";
+      sha512 = "3a3fe1ceb21e39bc5ae1f7a33afbdaef00a3fa2e713a8bb094c7ccdb4d724ea3a09907d427f55cefad987482f91db48e8e988b6847132ef2083c65851a95eb88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/da/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/da/firefox-56.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "4b9d83ec54935a6249111ef8605c184e3226223038b65cd709b7207d46d5342665fac40bd2672c40f8207a0436fe38be96bc762573d0a6453cd6dec15683df3f";
+      sha512 = "c9a9073ba8fe937853feddb194c1168e188aa22fc8cecfce619c0eebc6168feea1b18201bb5cc5bd0ae758b2468dc99444a6c2bd3f248814218af5777e848853";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/de/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/de/firefox-56.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "ba2d976917ab0559f4c70140231c2df3c372d7363f897ba92bfecb67f7c58ac6ae4dfbd43724b3404dc8aaf8c72828ea89108c8fd11792a30e34ce9969a3b3af";
+      sha512 = "12f5dd9ba04c6986e2764663648e34dbb21f8008919d6834acada2d6c6d409de4d12df026612ad6945be11836ef7db325e6e39e75fef38bd4eba95655e4f3c0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/dsb/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/dsb/firefox-56.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "706d77a27896c711fb5660203fee10f22fc902ee5b0dc8d26c95e61c49b8fcd39049fde234143af86b0be562ae162894a9a97613b326ae7011cae9f583a8b08f";
+      sha512 = "7e77a0af3a68facd2147d315f8fb0af7ba3defb712b15b1e21591ae2574d7881ceb8fce934b7ad4fe7ed341e5db6697cfcf5b901069771c8475359b4551a24b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/el/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/el/firefox-56.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "da683e296a10a6e548a6838c62d3ffeb26e1ae3e89c5aaad76b10cecdf5712421f2a2cda90105ea1da815c883d5c52da805eb31dc241bd93aa9199201efc9b8e";
+      sha512 = "7e577a58a549b67c2c9d1d85750d2f371b1b280555efcf48d16a4ec931f51474a14a424887abbb2de09bc182553d394777496b7abcf34226e63cf43cc4c874cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/en-GB/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/en-GB/firefox-56.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "61f6f0646daa9c530d098b3dd5679fda75161cb26e3b39b69616629ff1674b0cceaa4aa2d6b56826e54f6f4dfe2038b9186637980facfc63abf247765cdf1bd4";
+      sha512 = "b7c892f50bdc51e9fde38cef564edc44190adce6b8b36a1d5a301b5677b8ca46b68a31b5caef490e691320e76e8f712ecd7e9d963effca203464a2396345f380";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/en-US/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/en-US/firefox-56.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "c6c0573e967681e19667060f239aba9910648213f77d9c7b38b0d9318944ce89062235cbda54e55e0901a23f2a9aa7fdf1a7f02ae94217f6ad554f3ee9010f23";
+      sha512 = "52eb7a5344c457535c263c68a6e3b4714a513bf0c3fd5f8796e8bcd0ef9d86346a7757afaf8193a8de41635b88dcb8d5b666dba86e92f75ce267f14c8adcd356";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/en-ZA/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/en-ZA/firefox-56.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "7e288b18a6c85549c4239972a2d162ea1288fc5939494f612a9fe2a4ee7f39954506618e354dd3965cbbe221467cf1f74227a42c43f8cef96045defe958fd6d2";
+      sha512 = "4a086746611b98886a83759f546738c814577698f92b4d443bc4f0da0f1a8f5956461839bb7c3cf662d9c7386ce8d0828572abe96d17d490ced06257b311bc14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/eo/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/eo/firefox-56.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "9f3074cbcc973fd5bed0ce0b6f6090da9a7ebd05c543a065466a3b0968e58afff473d1637242fadee31840d5cc0504f6001e7cd2849dace0eff4edfd4411349e";
+      sha512 = "b65e271afc2cc1da1c9f3b9a6cfc00f6b1dd5e63043ab9c1f17eab024603869269d55efc4bcd713cd8a860f0b79fd77dc21e165e7d8690a720e7faf1c804cded";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/es-AR/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/es-AR/firefox-56.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "ef56e3dbd4f13b49b05db59e5f89ba3e3188dc7df4d2f340401510cd59620363a3294ef2b95c01e7c3cbb511f2ece013130a09445c314390679401d369067d6f";
+      sha512 = "bce196c4e86e0d2dbdcf42f4ef7d876c5afa1b407513a294c98e052ba9c320a4155ef1d41d67fc6ae089e3a57e5402c1fa7092b1efe47f95765d44ee519163d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/es-CL/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/es-CL/firefox-56.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "85b0284aa6ce08609ae6e7c874c02a8332ab723debff8bb6d1b500b8da791090b44742908683ca64405dcd85dbfc474b4157f873daedfdb9e678e0bc908e2a63";
+      sha512 = "9de7fb8363a8f4c632694de52b86ddf467427e64f4e92fb00c7001b8fa6df8b23ff43d77b74a4277cc1ebede986fbe4d387cf694ba82e35db0f4578382cfe77c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/es-ES/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/es-ES/firefox-56.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "36519bebb0e79a405610bac938c8a0183ba857fd733b71bb50f82f9fb16883a52818596f9bd776a56798829cf9d4761658d498069bae228ccb123da266459642";
+      sha512 = "9516ec93d60e4b5c6067148d9b9da6b40defba7cd1fe72d4a1b44bd59bc4f0d503dd6a29151aa14404b32d3cd3a95daf05660853ebb3d484845452c852362140";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/es-MX/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/es-MX/firefox-56.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "93d40e3df17392b4268e4efa1cd9c23d3da1f702b0e0a2305a05a31f80af0ed26738dc4eb6a4db60a7f43e7de13662ddbcae8ceaad972aaeae40a21856d9fb42";
+      sha512 = "8d4e0b0f9ad6b3875317e3e7fc0f249b239e1816a4dc335d444433b521460ad16a0374851caee132e58eba3b46005c5a294fb84774ca56084df108d861dbc335";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/et/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/et/firefox-56.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "bbbc7dac5d3a122a9a77790d570a8943bacf4bdf1595e1297d26a23cc99efc88de088aae9533b86d573bd10f81fa741ab765177bbf86f2920232ea3a832509a1";
+      sha512 = "ef60fa3a4c2933dff4fba6d8bf3f8f79faca16768802fccb4e1ce161bad315acd78abc09f998fc516683fd72fe9187b6a523961210d8629a2efa4f1102469322";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/eu/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/eu/firefox-56.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "a36172e47a17109d2790961f3317dc0a23404856224411393d4bc0a238ff3ea8ef9af46098f215beef85c35a20bc7d515e764ed3a5c4a1cf0da31c019788933f";
+      sha512 = "3bf28fe5886583c920da5ba845899674ed06586ac0b36ca353bd40cac4de2ff76d833da55b5d96c45d87e9ae66c33017a20817d4f2761a152750767b6957ae11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/fa/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/fa/firefox-56.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "c735cf60f7726485fd10d7da09bbd75f0ecb47c84f03fd4b2ed75efa32e906867cd5c99945cb4354792bd7a978c48f61fccb7634e931c370db8c28479023354d";
+      sha512 = "c56e142399445b45322a68cef53cecb063a37d24a697509da1333de4817ce1870a18e76745c113b6c3689fae28ec66f60806f478d2e88d2e213e31115558403b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ff/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ff/firefox-56.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "bf54987c9cc48218793e68580fba1f906d9168afa4adaf340c50c21d36859ed01cfc0b0485ba7aa835b1de78afaadee8c137e767589186090308316a4c0aefd8";
+      sha512 = "7f868d56a29ef7d03be1fbce98ae4bf7af96db7f7bc4f1729e7d5f0758bdb2e0d0471c3f46046fd21937dd410bf0ae822dc035ebdd27b1f8df3b92032ac5ffff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/fi/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/fi/firefox-56.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "597cd931f7a639e4e1c0cee220968269a03cb54bf72da2c658803c5ff2707523c6d1cfd9cd301b2b5df7db63f1d6d78b873b709003b67add35108d02a7011596";
+      sha512 = "449a103aedbb4596afc4a8b2ddfba5d9885756c7fa6983c25fb609ff3e280a83af4e28b04279b8f5243b46f366b8808b3e6d43286eeb60415d662ebe487e1c03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/fr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/fr/firefox-56.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "54dd3162f6783703b7ebbff0a15d4d733cee206feb59e131cc974cd431f9a83e8fd703c2ea03149dfd2d06289ca0db18e91a95c53a757b6b04abca506240c1f6";
+      sha512 = "c171d03ca2b067236087978b86c4e69f6253f1b73b34b198607c4f501893d0fe9baddbcdb28ce033fa796982a8a08885cad361dea673dc572594edfa49c906ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/fy-NL/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/fy-NL/firefox-56.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "cb9dd1f14d61068f74d7cb1d5368bdffadedc7f53059a66ea845cc7a0118ad01041b4d1b23f038b388fce9df91f962e2db8dc7ae13d35c472d9a2f19ef7f39b9";
+      sha512 = "8592c501f694fcbc478670f892bc239e0a7ec152ff386d418d8852cd7489b94665f7bbaccce6bb43ecc376525f23417c6ff7899ab1c30d4276d9b4495612f930";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ga-IE/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ga-IE/firefox-56.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "d54a01a07aa3d4c5b66f8fa2653ad06715ebe473756d56e685ccf23596854c1190b871cab8827507b2da0f42b0843d2d696633cdd173a155596ffacf2b8e9a08";
+      sha512 = "5e9b9fc017bda23d0a0336054fd5f8e04abc7fcd4c2bd165d27e01e76053ef19e074b83cb547949212c49c3efbfc2c620b0df3841fe46efcd4e269da4bdeff09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/gd/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/gd/firefox-56.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "bf8e248055b68eb8b04a37aca7711aaeb30401c126e911fd36658ae4fb140bf006f818291fad4dd1d82951ffed74f94d1174420254ef6ea19925276dbe660062";
+      sha512 = "500d0360a5b6310f6616343fbfa4ffc5d6dab8e16f99ce1963d7818d9b4fa99c5d93e6d062b9a27ce6b495c0cb6152bf9bd10c677a4a15c912a563ac20066283";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/gl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/gl/firefox-56.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "527d0febe7c58b7205cfbb21cf2e054bc8f390c28fb6a8e2f317c6bc8d58092b92f9f285dad6da1e01722da5cb198d9cb2f60ec36aef9f03cb87b48674f67b27";
+      sha512 = "8cf6391df871e5d8eba58ffdccb4bcc40f97310b880603fb6633053d5b6332b347bc0819b281fed6c0370c15cab63aa78cad92a0791fc7b694ea327c5d265ca5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/gn/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/gn/firefox-56.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "1599e5a6a242884d9fc13568d4ee48ba925c0d3f9ea6ca4ca1254ed39cd8187813efa86d1f65b8d7aa570f4d35420edf9a6412fe66bac34b748bde4ca9973022";
+      sha512 = "23d7ea2d103190f5b6052d06e92fbd56b410301bd2546d55b56d797e02f2d3591d6d9009b8d9b6527219e0ea118811b01b9b97dc85ce9ee6cfd4952e0d442197";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/gu-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/gu-IN/firefox-56.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "f6f1cc145a65c1ecce6e5e5b3293af37e731a24d1d15fb1c8e8c87d37745f823f8156f934931db0542106365a960cc81000cce8df37c863f6db47a48ce2dc382";
+      sha512 = "14234d0cab5c8e90385616d7d97b9e9107e4681469cf85fb21b8e4dea052d66fdd99b71b2da3e948cff4a5419f2c609c7b92b03883cb8eb86524f84a137d4c10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/he/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/he/firefox-56.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "fa56346e138b1981a125a5815b880ebdc192e9eba2af5348dbbab3cd601c35e61bb22bfaede27647705c7bfbf11fcec5e0773838dfe50e14cefa716d7f843304";
+      sha512 = "d2bd55a5ce635e0355a9639d9f4299b078f30a7a3111df5904c45f7c2751075adf9ae6096fed8e5344d96468f1e3f7eb0a40077609a26636d8071dd2d75cc910";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/hi-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/hi-IN/firefox-56.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "9176dfa4d5207108217fc9df663797bfb97ddccdb43762db85247f42f3d2c6f2ef309f68cd157f9f4972c80546d131d81c5780dd6ed92d267d8567a7d9420aee";
+      sha512 = "634fb324bb4df03e5ecdff8c01ac0cc108b42269652ec76606ba47a5b90d3f9a6ff7cc28c1d1fe0995ab5e36c6124ab10351059f369a0b4e91627aaedb49080c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/hr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/hr/firefox-56.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "0c1b1845e6aff8cd81dac114b2654ecfdf3176b7b9995c839fabb07fa52cf1ab5ed0cd93cafa969e98ce7fdc7883b7d40fa19e688c7b2e0850db69f71e13e146";
+      sha512 = "dfb13315937377347bb8d8804bbbbd1402525739be2b21f01536c04c210d9e4cf6bfb6e1e9a64b4b04bc8001066d0bdbf74873e55cafb2e5008c0e6302c7d967";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/hsb/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/hsb/firefox-56.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "88a6e49f8346f566db7a6807a5999a01ae3b843a2cb16051a7d82b250e8bb7169818ca4fd34893cc8c111ab00d62d7fedba651ba813b3bcdf639e1dc196cac3d";
+      sha512 = "4a5df6642eb981bdc27dc3473dd6e267d605e3ac9df350aa13d82350d2e58be6f0bae314371532922fcc9c8d4086678cb744c2502b38305d99c0c6cb010e8146";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/hu/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/hu/firefox-56.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "0fc08455d35212d8beb1097f7ce7c1ddc5519cc6faa62c9fc6294abe4cc3a020d13d514fb2b4e1b27eebbd351aabda70a1de68bcc3865f85c782bae7a19b0fb8";
+      sha512 = "39d9c881d9ff91cb5458a307d04a21e74ab57d653b08b81303f5a0cf72002b128894e6be4f4d1101df4004f2481fad4c6f63d3fe771d5e7dff31a9428f840522";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/hy-AM/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/hy-AM/firefox-56.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "89c3f56d2f6b4efbdc44e3fcadebbff7ac77b845eaa2f6220e1855f547c6aa14a727a493736f7e913602c6c354f259085bdc66eaa0ba3bdae9ce53a37de991ae";
+      sha512 = "0d4e2486577213e7a390d2f4b2d48b54e693748c19fb01c021e356ccf186db25e976324bb589da5040f394a4c5463f4c6f71c691ffcc900644e9996d01ff7cc3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/id/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/id/firefox-56.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "6ac431518cdaf8e2bbad23f44793b46c87e205513a3df8c092bdc4b25729ed7355779edd2bf154f9d49fae48747518aa12acb6ef55a3206e0f52ffa53dd2aa5e";
+      sha512 = "4c60276f146358a9de2b6c98cd54e0a10c9ae19ca20c2f4e5a6f86b0ca7f9b180604b58e085fda97be9e9457b3f7a1d36ce05ae2010e8a9b5a782679152cc4ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/is/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/is/firefox-56.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "b4fde08b7dfb09bedb2fd9fb7e3a1876dbe07ad2eaf7a706bbcda18728d997dac192f736ebcec4c0f3cf0ca2b49804f49030222ce25612987b73539acd98bbf1";
+      sha512 = "0c0ad6ed37d5ba059cda0fdf8c8cfbbdb3cb671a81c434d76feda7572d5f71ed4e05884d583d6ffc9a168f8176fabcf1de030d19f018a28e24a341bfe6ac5dd6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/it/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/it/firefox-56.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "ab91f86b0f8458e00fad441799056c396600d714316c0a1bf332253ad476c8a00a8b3c5634396fd70d60ff0ba32d6adb1a8ae3b2a01f42d1458b7796b0f09d84";
+      sha512 = "80f9a72be17b90f7e81650246c6338bba58ddfeaf911e1f9b3b81137751b32ff90e2945cf700850a72951c582f2a6b1c2e20b024fc5589d0316f583e1c3040d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ja/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ja/firefox-56.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "0b7e8d83b677ff51e8ab1c335d9befe05f3cee0444b0dce063b99516381697a985e5ce3d3b80b45ef563766166c65e7ff7d503c04240c44798a8a847ff66e05a";
+      sha512 = "f4af35418ef0e77dd7deff58041775097ffdbffd98c0b6b8da5da672535db33caf30648aad020e3be360232105020fbdaa254bbb141166fbc4065446c828a915";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ka/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ka/firefox-56.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "c09b1b11629f242918d231a27a3dba59fc8198c0c0a4c5ac2e648be6caf08c0644e89c9452c47b5ab4690f967a67054c4637cc83db6bf64eb6d9d796d5927cd8";
+      sha512 = "11f32a5b7a6b0e96728154769a71cc47741f7791610c327acf6e3e9929b09dc0d37feffa00d95d220e0fbed6c7daf4cc040bca86e3368523583f3b15affba9f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/kab/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/kab/firefox-56.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "b78db07da52542eb646c484c567f36c3d56b8613c6ee183ab02735a45397e28dc8cf1da3d42bd5ed0326554c93a4e53f85993f27193df05ea383873ca9767252";
+      sha512 = "80ed0a4fa480e89c8925c810bb80f1e43b8f26ed5fef4a8f641081ca59437b6069cca82f27d4437016c1767df00c307d48325a76dccf77d1cb434eecbdb41184";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/kk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/kk/firefox-56.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "dcb8a95db799748531fec235d1c348a5feb04b5a6ae86b93e3adb23b7f1142c4ce12f19c0007b34a9c0a7ecbf8760c476cf99398fb001810fb852c67883cec75";
+      sha512 = "639eac112c2a1471d4178304371996314c4eef6567fb205b586bb3e1eb94f87e30e7b10e81027a620a4def25c5e71412f6ba6fa00414d38843873df80745811b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/km/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/km/firefox-56.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "23565ee1f7f0ba89821efdffae8bf2a615e11d8ff74b56425097ee4cdc6abe2795d81513cb7066165c445cbb44f4f8b0bbc1add77f23b797a372cd9068f8794a";
+      sha512 = "f6c535a31dda743fa54985b5eeb97e3091243434923ebb75ed75ffb62350133f068251a17e1b2172ddc92dd3520e7d29af7276bfdc711760df855e850d6bcb5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/kn/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/kn/firefox-56.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "4646c1431dbcd96f943268a1a80e87ecb94db9c9d71eca80383c26f02ff8e117b22aba03f4d829b0a381ec04e249b2533fb104a2609437bca7f6b78e143a5d41";
+      sha512 = "07b371373494feca79ccba78df2706a9442a6d7ed743e8bdd94619ae1f0c814f66776d4d7f37fdc98a1d157d71a2d22450b5c3d6a39a84a15b63fd9911639f15";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ko/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ko/firefox-56.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "efd5b303fec5ab0be91dc457f383fd9cd14ba7f877d2be5b0133d9a8e7fc03b67cc0ebe9414c4ffa3859fa022656185cb78be955483bd749ffce258197b2ba64";
+      sha512 = "a39ef1b093a707f1e6e1bd7bfd9affe4684b19bfba33a88e81f51040bb7bde29e9c4ed12a7d49c30959f9a0201a5504fbb3e8300cf738767739d93d92553651c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/lij/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/lij/firefox-56.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "611d457dee0be03eace5e51160466748770e82b4d71617f7cd4aa0e48935c73fbe4334a786d1055be869b32c61cc1c189138650062408e66a382dab12bf9afa9";
+      sha512 = "9b4636d1520d94b5955e3f3feeb2aa91463f4e7bfae4cd63e102ff29a6ddbca091e7c27a45b31e14db00b3c2e3b49fff32abd7edbe5cbe6447a4544aadef9f20";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/lt/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/lt/firefox-56.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "c8760630354790f3c4d9964b594f4813d690ff30d62234c748c7c38758e4428873d55f7b54e5ba7f3c6008b0d5d14ff0b3e4de51d564d9c52b056eaf31753bc3";
+      sha512 = "8196df53989aae3ad1ad326ae85b9e24d717e2668b28958e7478a40408aa12dfdebc0df77bee73b7d7bb60ff593d45e650b772b71c17446d38875c2157b61918";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/lv/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/lv/firefox-56.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "6b074f3f4ef5e1c349db0ddb5e9bdb275af226d10768eb40322c14ec8b4c8d0c6f300d89b20911350ed1bbf84d9e7c28d3d4ed74f7f5944a2a60e13460c1eb3c";
+      sha512 = "288f37186f690c21e858cd89c0cffd0dacf1ae8a93b0c3edc9ef9a6438733dbd03f0418c14d9a779723acbbbe4c37a8f587d6ee64375de8d5b1a966df7962b0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/mai/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/mai/firefox-56.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "4e9e84e48187535075a0a424c99c5a7d2b5ef1a30e5b86662e295b8116d64a5448588bb9e262edeaa03138ecad46ccaf388ef9d3b053315b3dc77efd08ab2c9f";
+      sha512 = "5eee203c914db080e4809df94156f2d431f68c9bab5664c854cb66306e566ca6a45c4b6d683e7e543ceddc91d60964959b661d0a2da9b26f9b461a2e099a37f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/mk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/mk/firefox-56.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "adf41bac2ede4a91ffb3f107ecbfd40e945ad1fe23b44cfd0907400c12e526b8181ade5155ffb669a5f9a3c2ce08d06a5feb49d7faddb51494b6c404372ed083";
+      sha512 = "a5ad175c42bf938100b75012732053724edc1940e8ee759e2c248f8c394f5a23f3ec7964ffa282702a6d2eb5831c618457f823490b01c21723e4101b53a29024";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ml/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ml/firefox-56.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "b7d2c89c066cb142ad45098c7580268c4ef6e53588a1cdda100d195047efb33b62ad0ae0c6092810b69799647201526bca3654f3256f82692a678ad357dbd950";
+      sha512 = "dd45c351fc34dfc331c4ef9b475ed119dad87ea97be0d33dcafd013a3dfcc6b3975b4305fb4e3734a54b5378ebb8b354b7e91a4d89673f12c5b13ea4adab3287";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/mr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/mr/firefox-56.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "932431c5cccbccf0bea43ba18e4463721c78a2d0b87bb53f89b2e3ce7d1d98ff0c22af78e1643010f7ad3a1c74c1ecfc302841b522d24000960711aa469835e5";
+      sha512 = "19e6fb31009faed74fde46a969af17090629e5d32963cfc3e041ca0e77fcda09987b96fc109e8a399127794aec531d13a3406309bf84c29c27d8f8f3423de194";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ms/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ms/firefox-56.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "594ea2dcf622aff32d66a8d7336ccfc96abf50429214ae0503c05377c9fc79ba35bad70e05f713b44127e6aba2ef09ae29c7187ec17470645d413b1d1a30924f";
+      sha512 = "f34afc4cdfe9fe3d9c2836bbf0588fb39fa11c5b07a4acaddcd3ae44fb9c427f97b49b5579fe84b71b5f64ac3449fa8da9aff89de7395cf65c55b860d1148109";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/my/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/my/firefox-56.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "f7135ab56d292beeec62f075eb8e2a958adc95af848408b6d051992ca4def002ed6bbebd6f3733577ee9853bee99d346e6e749ef455aac4646bac3de9812c33d";
+      sha512 = "f10f83c008ae871a53598232c6e1a524a21efd9eb669639d16229e340713a6959c0fedd01179c40cb91dccf33af2dc0e21c58ae901aea63d9c334e0a96d9f7a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/nb-NO/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/nb-NO/firefox-56.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "82d1317e251b5c93b8c913a7a0a54b8582ad8a80fa242cf0d4e997f5d09615779a5b1a544a55a68feec2a49144f3a8e13be37a3f32caacfd7ffaae150ab8a4a6";
+      sha512 = "0d09dbc8d16648108560f4a45d93b5ebf0ab008e920d060e5cf031cb3c734ac4e0bc0510daca96f016dd729f759a66b6c0ba856256110a47c015511bb203f732";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/nl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/nl/firefox-56.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "d3ee1e58a46266688aab03a55846bd5cbc9ef96188cbc0c6a723088a71637390d14feb62dc5b1af48659b4bf41466ead9504d8c086eaf1a775d50f30d23982f4";
+      sha512 = "4413018700d0040be812f9082e9502fdb56db522a06df336b9a070189c7ef0938a5d830a9072db3bb5e721d25a9a63d3b5105222ff6a808d3dc6fccb1ef193f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/nn-NO/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/nn-NO/firefox-56.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "0a07cec43e602baa4fba8ba23c76d820c3fb0a7698968d6324d49b3a2cd88541f9c54998a090be173bcb5b31f0de85c0e5700e83cfc91ca9e448a4886503a346";
+      sha512 = "07a6fa48cee70d0cc97b6f6928e70b37be4e9de05e800a95aa1bcb733239129791568a11d75e1e2a647c6e08cb3ecec02979bf75b487ffc54fd11b46fc4d8a3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/or/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/or/firefox-56.0.1.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "5fbc52e53d63561249da9c3c33b28504fe7278bf91b218bb683d9d35fbd20ec94ffbb359e9d8ee2c3afa00f1f9bda0f13b07bcf266ccf1f19f647747b5b40b1b";
+      sha512 = "4dd3449deedca5a13a26e05a6d13a3d4e2e414f9997f4873668daa03d09873e674ea98f79c98c48fbab86c9a3f32820f8e17eb1fc6111e5bc1ce73da5584eaed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/pa-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/pa-IN/firefox-56.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "a91a0569b9dd8f5cbbfa66b67f7d737a4cc5cd2178eaee9d5b243230672813caaa17483f10d831c0aba89a2dc97945588a7b06d016aed7c4f6ca5e4ba80cd0c1";
+      sha512 = "b09bcd351a39c9c9cae213f18cd3ec49af8dd7d203a37f0ece99b54d7ad81aa711fc54b1b772502bcc071fa18a0a7f6af8d99b62bdc00437a0ef667d459426b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/pl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/pl/firefox-56.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "fd2dd21020116fc81e91c2ad92827e58803d06ecb63069953f7a6d49321152dbbee83d84aee280f9a2306220986a4e56dca36f0df771e61e950389b0981b6058";
+      sha512 = "910f5f8b9b34b20b4ed86f444c905171d23f459cc4a37f6fc700d5386a22758b51ffd8a9b3f747fe339f4be3a4967318c0bfb6f618c0602e8daf2369b6f95f07";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/pt-BR/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/pt-BR/firefox-56.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "e1eacb5b8da228b881503b0e1e43de40b7dd6808690011fbef6c5b367ec7d9edf1ae7df8d2e65ce6239a00a5b20296739dccc8086fbbd3634ae7153f2704a847";
+      sha512 = "ea5b6fcde8864aad6a3e005e5cd46e9e4c26b6de1b1bca8490e10ed2f7c7bbf44d93105c64c280327485b3537ca1354e8ea2749328a536a06fd0e34b70990ee9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/pt-PT/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/pt-PT/firefox-56.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "240094ce50b49a3537cb5b6e80dd2381309ea7684eacd5b7fa207f097b75728d48041ed0ce7eced5ae6da20ab769d4d8730eef0dacf534d5b1dc701730937503";
+      sha512 = "4bf071edcbd35a2b556d3593a70df66024f871a49abf32812c2e25cf3a9fb466ae87e6a958a5299c54972c68807b8154995eb7bc268bdb8cfffe32cd80f96b88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/rm/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/rm/firefox-56.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "78191dbb18f1cd6ab2425ad6ba38402fe98e20888fea662b3b6c347751de512439bb3cf349ffb2daaba93011cd33a2cecd6e383a45800224ccf9443ca4c2075b";
+      sha512 = "7dfe47e52cc71504cd1f4682bfed645a1fa1b622cf75f07cb650f8c42863cc9b5cb0d4b10c74e1e075c95155df8a52a08ddd4b13da45fc99e4c453a0c46845f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ro/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ro/firefox-56.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "b62b8c628864e176eddf410a402dcb5e39bec295ce97891b054b13727591cdf4ccd2973825e513929808c67a7519cd3aa550040eb359dea18b97bb4f01ea3dd8";
+      sha512 = "25fc42b92545f9219bd4d1502bd05b3ab848b590118fbc9d44dde00cd64e033016aba7eb2918de1d5a80e307b9743cd508567f076bc3de1eec2af966b126f574";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ru/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ru/firefox-56.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "51e61b637de95df9a400416546003fa5105390acd48aa1f8a3511b39fab76c83a6ba3d41cd5b15148837ea2df295dff06ef7baabaf44994130f0be73af4e13d7";
+      sha512 = "fdb9d2c7fd6708231b2b5b617a7d89698d77167a53e21cea7bd0da47b32bdfb5858e8c74c616e7265cac7095652829eb26e73d91c0949c3a11f238637bba56d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/si/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/si/firefox-56.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "3ff9503a991fc935cc7f0afbf69f76b1cb0ad68c21348bb9034c6af6e262fc87f49ffc0025702846b0c85d72b371cd573ad3147fa9dadf04ba846b22033aac62";
+      sha512 = "60663c3a8e66d416015dcb80b01eb991b28f7e0715a24d1fa3f1725bacd7d02360eaec1b7e75257a06cfc8bb9a7a960d654e52a9a128490df5c1821514388d94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/sk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/sk/firefox-56.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "4d574e1381c689f847b1d2be8f8f8e5d31d9e3e7765da00ae44d801716bfad56c1cdf18824bc203b6ca8124e9ab598b938c9082b57482146cbb7dfd6607bdb3c";
+      sha512 = "c0774271d098dc55be6154d2f687b4dc0018b359a4fab9a073818f0333c9a513a4f5934aa33948d40f59f10f79812741206eca43804ef3e1c9bba5a386355db0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/sl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/sl/firefox-56.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "a960a47cd5349e6c7073052672273c8a889e3d8650453f99ff118313ad692e9a0ae5ff8777ac52fc69a40e24665064d03e4cff4942796d554b75a1e4168f5790";
+      sha512 = "8a87e18213b70b0e25ba89fded209d2d0782f844f492fdf8f0d3beaa35d3c67ed3a537418c14c2e68ee3b20fd829475bfa763ccadad0b4ff06046dd0127927ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/son/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/son/firefox-56.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "c2a18b625ca95c4e4070409bf7a4bf42d0338c6b4c8065938297b4c0834c7018271e8d6001b8fde382719ca313d5ebae9dd811499e84e1ee917c8b3a512f8534";
+      sha512 = "bd84d6da25363521111b7dbe1153cfdc1b17a5eced2ade76a841c60cbe11a00d274b9a556f5320698a1ee846faaad5ceb42bd79e0164e14efadcf31796244bf3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/sq/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/sq/firefox-56.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "588076f33cab37b746ef25362a55c1cd8455a1c4ebf55dcf079b16b19cd7dd77a9c1cd57496117b5c3fb3907b1b047649f4e6f6eb0ed2e0e034ffa291e6f9b91";
+      sha512 = "955f7b8b8bc497325dfdfea24264c6784907f86340cdec78ffa01a79a10bd58154341960f0e6fcdc1504d9b5cd7d44b7b3ef9be348695b47089701a7e1c832b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/sr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/sr/firefox-56.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "995b5a57fdb617f1b8ceecbdd22ee408e4d83b73ed5b2cc49abda0a4de5d6ca0d5bd54346efcbb2d181b5a77d978e4611e7235bf66b3c501dc25785a4afb737b";
+      sha512 = "85562676547412364aa8043b9e4cada72b46e078628686fddab5444c7a8d5fd8d363d0429efa67478d290cc1671b52948095a75566e98993f49c04cda3f20881";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/sv-SE/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/sv-SE/firefox-56.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "050c87742013c5de08d072171a10ff365ac50f2900c65039f3ed699b206a684323bd08c7941027eb6f6f7862ba8bd7011054e83f92fb0a9e9a3f208bd1e4617a";
+      sha512 = "4a7aae7ae216e3db74f2f77bb747e06f69abbda483e2cb59bf7906e23b18b612461e08b5360abadec61ccb5ad39d536453376db35dd130df5d5173807a9ecc06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ta/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ta/firefox-56.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "8ba9e5eceb691c34c067a620167de35a130c3cbf67f0dd5417c27915b507891939d9080c9b7b3616ce939a17c153c8204639b7e3b431d564d43f79783a61b857";
+      sha512 = "510eec52d5d41e3ac7e7759d78e572ce2b7d7235d39e3cd01925dbc43c71f46d6b90493db27a45f6a36a50089173f70a301591b00ade07372ee08a2fcdeba2f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/te/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/te/firefox-56.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "c57380183538fd0a54a98f6fc9a9ad2a37c8a26f7beea65967b18ace44b88d2231a3509e643204322bd2c8111b8e9edd176a0712a32b34e4078c686a3b138bb9";
+      sha512 = "8c0936ccc1a92126573495e5747f6739c0995fb7280e686b31fa62e6c2c7a6527aba36c9ec1043cb5a3244fac368c899b9ac5afa30b0d121fbe97d1a9a41d7ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/th/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/th/firefox-56.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "bb9c8c108ba03016bffbcdc66dd5972df779c55349db431acc289ce2e8d299b930e9f17c8e3eac04b17a50e3e226eb73df91b8de0ee690915de8b3dccd7ddb2d";
+      sha512 = "ca7f55274ff6171f297904d9be0451294cfdf9fef93bccf51f8880e3b69237daa9058de6f8e272b754d85fedbd69144cb1337b653f47029a212fbc938bcca9b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/tr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/tr/firefox-56.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "2bb15f16c35021a319ea79b653185fc87e81fb55764eda65f78d049dfc876c3b95828fab69bbf7521738cb2107e8cf16c2bae40332d2ce891aefc086ec582b30";
+      sha512 = "b82558a077b562b485984d3864966135d5be8fd27a1b266d59beb4e2f1cc556b40d29133c63f3666eaf22f7eeb174fdf4f16e0e0804ae73a68e57f16f5d900aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/uk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/uk/firefox-56.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "bcb377c223a8f969b78832ce581dd4f21c4ef08409445faf3409651ec28f66361d8fda763104a6e39590e2e02ced75d7d0554d643e96a33784d471e9f1aba06a";
+      sha512 = "7f291c45f4b5569b3cac12f91538073a1c4e52be473c2e6b9c7974dfddaf85696c78f3b08849d960f1fbbac7d6f750d1e1cfd22993daeca1ebb2cbe3c98b0002";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ur/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ur/firefox-56.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "dfe75ccf52fa8a9d96309162e6499074446c609664a2d0971b9a7a0d64ccd4923494975af8d9b1710d7d5093b259d4ec56f43faeca331fbaf2c435f3cd5ed406";
+      sha512 = "733a8362e3abe0b7cd6fa94bec4dec3f317ccb08cece1c495ef712f0764f732878880a3cb5b90c54fa67bbf9531b1e4ceb8cf888e3b505f955252ee7f9e46390";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/uz/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/uz/firefox-56.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "81618bda3809d1c489fdd03be8aeb440a7963464efc381664d6ebeae5d106cc36008977592a16ad629711a00a731f25cd651f789f84260add8f272cb7f6d39e0";
+      sha512 = "d5e35145dc54462297e48fe8f4ef1e743ee9b164c9cf45604f293cd2d1433908ef26b3460d961669472c061a2572c655beee9d9c44ecadb153e1ad5bcc161e97";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/vi/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/vi/firefox-56.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "08d962b2ba18586e8bfc32d55ff800ce86125d59a7bdf6e6cb554b76d069aca86835cbe3985ff23c0462ab9f65758a12a0bcece39ce192d37d2eb2b66db8eaa6";
+      sha512 = "428950b7fb6152de6fe8beb1b1e8f42a5d0d112b20be1a502fed6534441c4fb3fdf2e30b45e71f2d463aa622657ef3784730204af8e853de0847a68332450144";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/xh/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/xh/firefox-56.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "fdf12790a573445cd48c5313579cb3d4016cde9ff8283c5adb63c7e51b6e2b42aa855f331842ecaf62c99c30641ed7b8531e9b2fefa3de1ee03530bafb12ee30";
+      sha512 = "6127dac54537eb2fcc689acb20ce1ecfa8c8ace6f9c62b6f096b2bb4d9c7d47a70fedb9891afc1f5e0ec286ae8d04e677ab833e6fa534a8f8d4a728977624694";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/zh-CN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/zh-CN/firefox-56.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "e828b745ee8526a2acea5a701982240172050342e0df0efc15dd87dfaea0271d42f7bc06435d4bc4af657f725462de49df8232d985debe15514d19d50b184663";
+      sha512 = "648ba81769c529476ef7a5875a518ce5aeb49466af86b5d07e411adf7abbab4f90134ae994e3009dd62767aee0376973b08247c8222bfc6359e4cff6b8a19918";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/zh-TW/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/zh-TW/firefox-56.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "c1b058d91c7b8d242238bd8411bfb339e2712b6c550329bd06fac837faf453320310cf0d11597e9ca6d5d9abf084ad761a6701deeb6673547fcd60a094c6452f";
+      sha512 = "230ea83c02b46c856f35ff15c6e9ece08e55b4407dc9e65411e92e1f6a8db15fadc3da44ae8a610b9ab96bf29a052c1d42a8b75d7346d242e8a9135b62e5ab09";
     }
     ];
 }


### PR DESCRIPTION
###### Motivation for this change
Upstream updates, devedition was lagging behind a bit more than the rest.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

