### PR TITLE
sxhkd: 0.5.6 -> 0.5.8

### DIFF
--- a/pkgs/applications/window-managers/sxhkd/default.nix
+++ b/pkgs/applications/window-managers/sxhkd/default.nix
@@ -1,11 +1,15 @@
-{ stdenv, fetchurl, asciidoc, libxcb, xcbutil, xcbutilkeysyms, xcbutilwm }:
+{ stdenv, fetchFromGitHub, asciidoc, libxcb, xcbutil, xcbutilkeysyms
+, xcbutilwm
+}:
 
 stdenv.mkDerivation rec {
   name = "sxhkd-${version}";
   version = "0.5.6";
 
-  src = fetchurl {
-    url = "https://github.com/baskerville/sxhkd/archive/${version}.tar.gz";
+  src = fetchFromGitHub {
+    owner = "baskerville";
+    repo = "sxhkd";
+    rev = version;
     sha256 = "15grmzpxz5fqlbfg2slj7gb7r6nzkvjmflmbkqx7mlby9pm6wdkj";
   };
 

--- a/pkgs/applications/window-managers/sxhkd/default.nix
+++ b/pkgs/applications/window-managers/sxhkd/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ asciidoc libxcb xcbutil xcbutilkeysyms xcbutilwm ];
 
-  makeFlags = ''PREFIX=$(out)'';
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "Simple X hotkey daemon";

--- a/pkgs/applications/window-managers/sxhkd/default.nix
+++ b/pkgs/applications/window-managers/sxhkd/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     description = "Simple X hotkey daemon";
     homepage = "https://github.com/baskerville/sxhkd";
     license = licenses.bsd2;
+    maintainers = with maintainers; [ vyp ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/window-managers/sxhkd/default.nix
+++ b/pkgs/applications/window-managers/sxhkd/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "sxhkd-${version}";
-  version = "0.5.6";
+  version = "0.5.8";
 
   src = fetchFromGitHub {
     owner = "baskerville";
     repo = "sxhkd";
     rev = version;
-    sha256 = "15grmzpxz5fqlbfg2slj7gb7r6nzkvjmflmbkqx7mlby9pm6wdkj";
+    sha256 = "0vnm0d2ckijsp8kc2v8jz4raamb487vg62v58v01a3rb9gzzgl06";
   };
 
   buildInputs = [ asciidoc libxcb xcbutil xcbutilkeysyms xcbutilwm ];

--- a/pkgs/applications/window-managers/sxhkd/default.nix
+++ b/pkgs/applications/window-managers/sxhkd/default.nix
@@ -13,10 +13,10 @@ stdenv.mkDerivation rec {
 
   makeFlags = ''PREFIX=$(out)'';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Simple X hotkey daemon";
-    homepage = https://github.com/baskerville/sxhkd/;
-    license = stdenv.lib.licenses.bsd2;
-    platforms = stdenv.lib.platforms.linux;
+    homepage = "https://github.com/baskerville/sxhkd";
+    license = licenses.bsd2;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

