### PR TITLE
selenium-server-standalone: 2.53.0 -> 3.6.0

### DIFF
--- a/pkgs/development/tools/selenium/htmlunit-driver/default.nix
+++ b/pkgs/development/tools/selenium/htmlunit-driver/default.nix
@@ -4,11 +4,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "htmlunit-driver-standalone-${version}";
-  version = "2.21";
+  version = "2.27";
 
   src = fetchurl {
-    url = "https://github.com/SeleniumHQ/htmlunit-driver/releases/download/${version}/htmlunit-driver-standalone-${version}.jar";
-    sha256 = "1wrbam0hb036717z3y73lsw4pwp5sdiw2i1818kg9pvc7i3fb3yn";
+    url = "https://github.com/SeleniumHQ/htmlunit-driver/releases/download/${version}/htmlunit-driver-${version}-with-dependencies.jar";
+    sha256 = "1sd3cwpamcbq9pv0mvcm8x6minqrlb4i0r12q3jg91girqswm2dp";
   };
 
   unpackPhase = "true";

--- a/pkgs/development/tools/selenium/selendroid/default.nix
+++ b/pkgs/development/tools/selenium/selendroid/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     makeWrapper ${jdk}/bin/java $out/bin/selendroid-selenium \
       --add-flags "-Dfile.encoding=UTF-8" \
       --add-flags "-cp \"$out/share/lib/selendroid/${name}.jar:${selenium-server-standalone}/share/lib/${selenium-server-standalone.name}/${selenium-server-standalone.name}.jar\"" \
-      --add-flags "org.openqa.grid.selenium.GridLauncher"
+      --add-flags "org.openqa.grid.selenium.GridLauncherV3"
   '';
 
   meta = {

--- a/pkgs/development/tools/selenium/server/default.nix
+++ b/pkgs/development/tools/selenium/server/default.nix
@@ -4,17 +4,19 @@
 with stdenv.lib;
 
 let
+  minorVersion = "3.6";
+  patchVersion = "0";
   arch = if stdenv.system == "x86_64-linux" then "amd64"
          else if stdenv.system == "i686-linux" then "i386"
          else "";
 
 in stdenv.mkDerivation rec {
   name = "selenium-server-standalone-${version}";
-  version = "2.53.0";
+  version = "${minorVersion}.${patchVersion}";
 
   src = fetchurl {
-    url = "http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-${version}.jar";
-    sha256 = "0dp0n5chl1frjy9pcyjvpcdgv1f4dkslh2bpydpxwc5isfzqrf37";
+    url = "http://selenium-release.storage.googleapis.com/${minorVersion}/selenium-server-standalone-${version}.jar";
+    sha256 = "11v340nm8vzqc2bkmbjfm9a7j4dj0bi9bfk8wdpfan0fb8prf772";
   };
 
   unpackPhase = "true";
@@ -25,9 +27,9 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/share/lib/${name}
     cp $src $out/share/lib/${name}/${name}.jar
     makeWrapper ${jre}/bin/java $out/bin/selenium-server \
-      --add-flags "-cp ${htmlunit-driver}/share/lib/${htmlunit-driver.name}/${htmlunit-driver.name}.jar:$out/share/lib/${name}/${name}.jar" \
+      --add-flags "-cp $out/share/lib/${name}/${name}.jar:${htmlunit-driver}/share/lib/${htmlunit-driver.name}/${htmlunit-driver.name}.jar" \
       --add-flags ${optionalString chromeSupport "-Dwebdriver.chrome.driver=${chromedriver}/bin/chromedriver"} \
-      --add-flags "org.openqa.grid.selenium.GridLauncher"
+      --add-flags "org.openqa.grid.selenium.GridLauncherV3"
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Package update.

###### Things done

htmlunit driver has been updated as well.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

