### PR TITLE
Rely on XML_CATALOG_FILES variable for DocBook

### DIFF
--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, which, autoreconfHook, ncurses, perl
-, cyrus_sasl, gss, gpgme, kerberos, libidn, notmuch, openssl, lmdb, libxslt, docbook_xsl }:
+, cyrus_sasl, gss, gpgme, kerberos, libidn, notmuch, openssl, lmdb, libxslt, docbook_xsl, docbook_xml_dtd_42 }:
 
 stdenv.mkDerivation rec {
   version = "20170912";
@@ -12,18 +12,11 @@ stdenv.mkDerivation rec {
     sha256 = "0qndszmaihly3pp2wqiqm31nxbv9ys3j05kzffaqhzngfilmar9g";
   };
 
-  nativeBuildInputs = [ autoreconfHook docbook_xsl libxslt.bin which ];
+  nativeBuildInputs = [ autoreconfHook docbook_xsl docbook_xml_dtd_42 libxslt.bin which ];
   buildInputs = [
     cyrus_sasl gss gpgme kerberos libidn ncurses
     notmuch openssl perl lmdb
   ];
-
-  postPatch = ''
-    for f in doc/*.xsl ; do
-      substituteInPlace $f \
-        --replace http://docbook.sourceforge.net/release/xsl/current ${docbook_xsl}/share/xml/docbook-xsl
-    done
-  '';
 
   configureFlags = [
     "--enable-debug"

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.1.2.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.1.2.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, unzip}:
+{stdenv, fetchurl, unzip, findXMLCatalogs}:
 
 let
 
@@ -12,7 +12,7 @@ let
 in
 
 import ./generic.nix {
-  inherit stdenv fetchurl unzip;
+  inherit stdenv fetchurl unzip findXMLCatalogs;
   name = "docbook-xml-4.1.2";
   src = fetchurl {
     url = http://www.docbook.org/xml/4.1.2/docbkx412.zip;

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.2.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.2.nix
@@ -1,7 +1,7 @@
-{stdenv, fetchurl, unzip}:
+{stdenv, fetchurl, unzip, findXMLCatalogs}:
 
 import ./generic.nix {
-  inherit stdenv fetchurl unzip;
+  inherit stdenv fetchurl unzip findXMLCatalogs;
   name = "docbook-xml-4.2";
   src = fetchurl {
     url = http://www.docbook.org/xml/4.2/docbook-xml-4.2.zip;

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.3.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.3.nix
@@ -1,7 +1,7 @@
-{stdenv, fetchurl, unzip}:
+{stdenv, fetchurl, unzip, findXMLCatalogs}:
 
 import ./generic.nix {
-  inherit stdenv fetchurl unzip;
+  inherit stdenv fetchurl unzip findXMLCatalogs;
   name = "docbook-xml-4.3";
   src = fetchurl {
     url = http://www.docbook.org/xml/4.3/docbook-xml-4.3.zip;

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.4.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.4.nix
@@ -1,7 +1,7 @@
-{stdenv, fetchurl, unzip}:
+{stdenv, fetchurl, unzip, findXMLCatalogs}:
 
 import ./generic.nix {
-  inherit stdenv fetchurl unzip;
+  inherit stdenv fetchurl unzip findXMLCatalogs;
   name = "docbook-xml-4.4";
   src = fetchurl {
     url = http://www.docbook.org/xml/4.4/docbook-xml-4.4.zip;

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.5.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.5.nix
@@ -1,7 +1,7 @@
-{stdenv, fetchurl, unzip}:
+{stdenv, fetchurl, unzip, findXMLCatalogs}:
 
 import ./generic.nix {
-  inherit stdenv fetchurl unzip;
+  inherit stdenv fetchurl unzip findXMLCatalogs;
   name = "docbook-xml-4.5";
   src = fetchurl {
     url = http://www.docbook.org/xml/4.5/docbook-xml-4.5.zip;

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, src, name, postInstall ? "true", meta ? {} }:
+{ stdenv, fetchurl, unzip, src, name, postInstall ? "true", meta ? {}, findXMLCatalogs }:
 
 assert unzip != null;
 
@@ -6,6 +6,7 @@ stdenv.mkDerivation {
   inherit src name postInstall;
   builder = ./builder.sh;
   buildInputs = [unzip];
+  propagatedBuildInputs = [ findXMLCatalogs ];
 
   meta = meta // {
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
+++ b/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, findXMLCatalogs }:
 
 let
 
@@ -9,6 +9,8 @@ let
       url = "mirror://sourceforge/docbook/${name}.tar.bz2";
       inherit sha256;
     };
+
+    propagatedBuildInputs = [ findXMLCatalogs ];
 
     dontBuild = true;
 

--- a/pkgs/development/libraries/drumstick/default.nix
+++ b/pkgs/development/libraries/drumstick/default.nix
@@ -15,25 +15,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # Prevent the manpage builds from attempting to access the Internet.
-  prePatch = ''
-    substituteInPlace cmake_admin/CreateManpages.cmake --replace \
-      http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl \
-      ${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl
-
-    for xml in doc/*.xml.in; do
-      substituteInPlace "$xml" --replace \
-        http://www.docbook.org/xml/4.5/docbookx.dtd \
-        ${docbook_xml_dtd_45}/xml/dtd/docbook/docbookx.dtd
-    done
-  '';
-
   #Temporarily remove drumstick-piano; Gives segment fault. Submitted ticket
   postInstall = ''
     rm $out/bin/drumstick-vpiano
     '';
 
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ cmake pkgconfig docbook_xsl docbook_xml_dtd_45 docbook_xml_dtd_45 ];
   buildInputs = [
     alsaLib doxygen fluidsynth qt5.qtbase qt5.qtsvg
   ];

--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, perl, python, libxml2Python, libxslt, which
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, perl, python, libxml2Python, libxslt, which
 , docbook_xml_dtd_43, docbook_xsl, gnome_doc_utils, dblatex, gettext, itstool }:
 
 stdenv.mkDerivation rec {
@@ -10,28 +10,19 @@ stdenv.mkDerivation rec {
     sha256 = "0hpxcij9xx9ny3gs9p0iz4r8zslw8wqymbyababiyl7603a6x90y";
   };
 
+  patches = [
+    ./respect-xml-catalog-files-var.patch
+  ];
+
   outputDevdoc = "out";
 
-  # maybe there is a better way to pass the needed dtd and xsl files
-  # "-//OASIS//DTD DocBook XML V4.1.2//EN" and "http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl"
-  preConfigure = ''
-    mkdir -p $out/nix-support
-    cat > $out/nix-support/catalog.xml << EOF
-    <?xml version="1.0"?>
-    <!DOCTYPE catalog PUBLIC "-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN" "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
-    <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-      <nextCatalog  catalog="${docbook_xsl}/xml/xsl/docbook/catalog.xml" />
-      <nextCatalog  catalog="${docbook_xml_dtd_43}/xml/dtd/docbook/catalog.xml" />
-    </catalog>
-    EOF
-
-    configureFlags="--with-xml-catalog=$out/nix-support/catalog.xml --disable-scrollkeeper";
-  '';
-
+  nativeBuildInputs = [ autoreconfHook ];
   buildInputs =
    [ pkgconfig perl python libxml2Python libxslt docbook_xml_dtd_43 docbook_xsl
      gnome_doc_utils dblatex gettext which itstool
    ];
+
+  configureFlags = "--disable-scrollkeeper";
 
   meta = with stdenv.lib; {
     homepage = https://www.gtk.org/gtk-doc;

--- a/pkgs/development/tools/documentation/gtk-doc/respect-xml-catalog-files-var.patch
+++ b/pkgs/development/tools/documentation/gtk-doc/respect-xml-catalog-files-var.patch
@@ -1,0 +1,28 @@
+diff --git a/m4/gtkdoc_jh_check_xml_catalog.m4 b/m4/gtkdoc_jh_check_xml_catalog.m4
+index 618c1c9..1842a0d 100644
+--- a/m4/gtkdoc_jh_check_xml_catalog.m4
++++ b/m4/gtkdoc_jh_check_xml_catalog.m4
+@@ -10,7 +10,21 @@ AC_DEFUN([JH_CHECK_XML_CATALOG],
+ 		AC_MSG_RESULT([found])
+ 		ifelse([$3],,,[$3])
+ 	else
+-		AC_MSG_RESULT([not found])
+-		ifelse([$4],,[AC_MSG_ERROR([could not find ifelse([$2],,[$1],[$2]) in XML catalog])],[$4])
++		jh_check_xml_catalog_saved_ifs="$IFS"
++		IFS=' '
++		for f in $XML_CATALOG_FILES; do
++			if [[ -f "$f" ]] && \
++				AC_RUN_LOG([$XMLCATALOG --noout "$f" "$1" >&2]); then
++				jh_found_xmlcatalog=true
++				AC_MSG_RESULT([found])
++				ifelse([$3],,,[$3])
++				break
++			fi
++		done
++		IFS="$jh_check_xml_catalog_saved_ifs"
++		if ! $jh_found_xmlcatalog; then
++			AC_MSG_RESULT([not found])
++			ifelse([$4],,[AC_MSG_ERROR([could not find ifelse([$2],,[$1],[$2]) in XML catalog])],[$4])
++		fi
+ 	fi
+ ])

--- a/pkgs/os-specific/linux/conky/default.nix
+++ b/pkgs/os-specific/linux/conky/default.nix
@@ -80,10 +80,6 @@ stdenv.mkDerivation rec {
     # Drop examples, since they contain non-ASCII characters that break docbook2x :(
     sed -i 's/ Example: .*$//' doc/config_settings.xml
 
-    substituteInPlace cmake/Docbook.cmake \
-      --replace "http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl" "${docbook_xsl}/xml/xsl/docbook/html/docbook.xsl"
-    substituteInPlace doc/docs.xml \
-      --replace "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" "${docbook_xml_dtd_44}/xml/dtd/docbook/docbookx.dtd"
     substituteInPlace cmake/Conky.cmake --replace "#set(RELEASE true)" "set(RELEASE true)"
   '';
 
@@ -91,7 +87,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ glib cmake libXinerama ]
-    ++ optionals docsSupport        [ docbook2x libxslt man less ]
+    ++ optionals docsSupport        [ docbook2x docbook_xsl docbook_xml_dtd_44 libxslt man less ]
     ++ optional  ncursesSupport     ncurses
     ++ optional  x11Support         xlibsWrapper
     ++ optional  xdamageSupport     libXdamage

--- a/pkgs/os-specific/linux/criu/default.nix
+++ b/pkgs/os-specific/linux/criu/default.nix
@@ -12,14 +12,13 @@ stdenv.mkDerivation rec {
   };
 
   enableParallelBuilding = true;
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig docbook_xsl ];
   buildInputs = [ protobuf protobufc asciidoc xmlto libpaper libnl libcap python ];
 
   patchPhase = ''
     chmod +w ./scripts/gen-offsets.sh
     substituteInPlace ./scripts/gen-offsets.sh --replace hexdump ${utillinux}/bin/hexdump
     substituteInPlace ./Documentation/Makefile --replace "2>/dev/null" ""
-    substituteInPlace ./Documentation/Makefile --replace "--skip-validation" "--skip-validation -x ${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl"
     substituteInPlace ./criu/Makefile --replace "-I/usr/include/libnl3" "-I${libnl.dev}/include/libnl3"
     substituteInPlace ./Makefile --replace "tar-name := $(shell git tag -l v$(CRIU_VERSION))" "tar-name = 2.0" # --replace "-Werror" ""
     ln -sf ${protobuf}/include/google/protobuf/descriptor.proto ./images/google/protobuf/descriptor.proto

--- a/pkgs/tools/package-management/apt/default.nix
+++ b/pkgs/tools/package-management/apt/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     cmake perl curl gtest lzma bzip2 lz4 db dpkg libxslt.bin
   ] ++ lib.optionals withDocs [
-    doxygen Po4a w3m
+    doxygen Po4a w3m docbook_xml_dtd_45
   ] ++ lib.optionals withNLS [
     gettext
   ];
@@ -44,15 +44,6 @@ stdenv.mkDerivation rec {
       -DWITH_DOC=${if withDocs then "ON" else "OFF"}
       -DUSE_NLS=${if withNLS then "ON" else "OFF"}
     )
-
-    for f in doc/*; do
-      if [[ -f "$f" ]]; then
-        substituteInPlace "$f" \
-          --replace \
-            "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" \
-            "${docbook_xml_dtd_45}/xml/dtd/docbook/docbookx.dtd"
-      fi
-    done
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
Previously DocBook DTD and XSL files were not added to XML_CATALOG_FILES variable, so the path had to be adjusted manually in the configuration script for each derivation if we did not want `xmllint` and `xsltproc` to download them from network.

I cherry picked this from [GNOME 3.26 PR](https://github.com/NixOS/nixpkgs/pull/29392) since it overloaded the hydra jobset there.

###### Things done

I successfully compiled flatpak and gnome-dictionary with the patched gtk-doc, the documentation was built without any attempts to access network. The other modified packages also built without any problem.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @pSub (`gtk_doc`), @edolstra (`docbook_xsl`)