### PR TITLE
Fix dockerTools.pullImage

### DIFF
--- a/pkgs/build-support/docker/pull.nix
+++ b/pkgs/build-support/docker/pull.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, docker, vmTools, utillinux, curl, kmod, dhcp, cacert, e2fsprogs }:
+{ stdenv, lib, docker, vmTools, utillinux, curl, kmod, dhcp, cacert, e2fsprogs, jq }:
 let
   nameReplace = name: builtins.replaceStrings ["/" ":"] ["-" "-"] name;
 in
@@ -14,7 +14,7 @@ let
 
       builder = ./pull.sh;
 
-      buildInputs = [ curl utillinux docker kmod dhcp cacert e2fsprogs ];
+      buildInputs = [ curl utillinux docker kmod dhcp cacert e2fsprogs jq ];
 
       outputHashAlgo = "sha256";
       outputHash = sha256;

--- a/pkgs/build-support/docker/pull.sh
+++ b/pkgs/build-support/docker/pull.sh
@@ -33,4 +33,17 @@ done
 rm -r $out
 
 docker pull ${imageId}
-docker save ${imageId} > $out
+
+# Save & extract the image. We need to fix the timestamps of the _outer_ layer.
+mkdir archive
+docker save ${imageId} | tar -x -C archive
+
+LAST_LAYER_ID=$(jq '.[0].Layers[-1]' -r < archive/manifest.json | awk -F'/' '{ print $1 }')
+
+# Reset that outer layer's timestamp to 1
+# Use -h to change the symlink in the outer layer to the layer.tar.
+touch -h -t 197001010000.01 archive/$LAST_LAYER_ID{,/*}
+
+# Repackage
+cd archive
+tar -c * > $out


### PR DESCRIPTION
The `docker save` command does include the current timestamp at it's
'outer layer'. By unpacking, resetting the timestamps to 1 and repacking
we can work around this impurity.

### What went wrong / how to reproduce.
```
$ nix-repl
Welcome to Nix version 1.11.6. Type :? for help.

nix-repl> :l <nixpkgs>
Added 7812 variables.

nix-repl> :b dockerTools.pullImage { imageName = "kubernetes/pause"; sha256 = "139mcmylkljrqg16z4c5mc0li5zljws3alibd8c9fnz5i5v10k4i"; }
these derivations will be built:
  /nix/store/84i0rc6vsk0waw8v6868lks0jf5k7p38-docker-image-kubernetes-pause-latest.tar.drv

...
 
latest: Pulling from kubernetes/pause
a3ed95caeb02: Pull complete 
f72a00a23f01: Pull complete 
Digest: sha256:2088df8eb02f10aae012e6d4bc212cabb0ada93cb05f09e504af0c9811e0ca14
Status: Downloaded newer image for kubernetes/pause:latest
[    6.623318] reboot: Power down
output path ‘/nix/store/5z6fb9fwa62ac0ppvhq5v89pji9iypcx-docker-image-kubernetes-pause-latest.tar’ has sha256 hash ‘1r8hdgrkskwbridrq6q5bm4s8811biy533ljnvbrvi75am2pwnql’ when ‘139mcmylkljrqg16z4c5mc0li5zljws3alibd8c9fnz5i5v10k4i’ was expected
error: build of ‘/nix/store/84i0rc6vsk0waw8v6868lks0jf5k7p38-docker-image-kubernetes-pause-latest.tar.drv’ failed
```
found hash = `1r8hdgrkskwbridrq6q5bm4s8811biy533ljnvbrvi75am2pwnql`

```
nix-repl> :b dockerTools.pullImage { imageName = "kubernetes/pause"; sha256 = "139mcmylkljrqg16z4c5mc0li5zljws3alibd8c9fnz5i5v10k4i"; }
these derivations will be built:
  /nix/store/84i0rc6vsk0waw8v6868lks0jf5k7p38-docker-image-kubernetes-pause-latest.tar.drv

...
output path ‘/nix/store/5z6fb9fwa62ac0ppvhq5v89pji9iypcx-docker-image-kubernetes-pause-latest.tar’ has sha256 hash ‘1160s5v645h3n0r9rhmpccwg2ddb0x76w98x7xyq05y1lxf6kdgz’ when ‘139mcmylkljrqg16z4c5mc0li5zljws3alibd8c9fnz5i5v10k4i’ was expected
error: build of ‘/nix/store/84i0rc6vsk0waw8v6868lks0jf5k7p38-docker-image-kubernetes-pause-latest.tar.drv’ failed
```
found hash = `1160s5v645h3n0r9rhmpccwg2ddb0x76w98x7xyq05y1lxf6kdgz`

### Output after fix
```
$ nix-repl
Welcome to Nix version 1.11.6. Type :? for help.

nix-repl> :l .
Added 7941 variables.

nix-repl> :b dockerTools.pullImage { imageName = "kubernetes/pause"; sha256 = "139mcmylkljrqg16z4c5mc0li5zljws3alibd8c9fnz5i5v10k3i"; }
these derivations will be built:
  /nix/store/xfw1lncaix5fh0rbpvhdb9dg6iqsydya-docker-image-kubernetes-pause-latest.tar.drv

.....

this derivation produced the following outputs:
  out -> /nix/store/if4kdlkany0sk7k9431zy3gcs9jwj838-docker-image-kubernetes-pause-latest.tar

nix-repl> 
```