### PR TITLE
biboumi: init at 6.1

### DIFF
--- a/pkgs/servers/xmpp/biboumi/catch.patch
+++ b/pkgs/servers/xmpp/biboumi/catch.patch
@@ -1,0 +1,30 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -273,27 +273,6 @@ foreach(file ${source_all})
+ endforeach()
+ 
+ #
+-## Add a rule to download the catch unit test framework
+-#
+-include(ExternalProject)
+-ExternalProject_Add(catch
+-  GIT_REPOSITORY "https://lab.louiz.org/louiz/Catch.git"
+-  PREFIX "external"
+-  UPDATE_COMMAND ""
+-  CONFIGURE_COMMAND ""
+-  BUILD_COMMAND ""
+-  INSTALL_COMMAND ""
+-  )
+-set_target_properties(catch PROPERTIES EXCLUDE_FROM_ALL TRUE)
+-ExternalProject_Get_Property(catch SOURCE_DIR)
+-if(NOT EXISTS ${CMAKE_SOURCE_DIR}/tests/catch.hpp)
+-  target_include_directories(test_suite
+-    PUBLIC "${SOURCE_DIR}/include/"
+-    )
+-  add_dependencies(test_suite catch)
+-endif()
+-
+-#
+ ## Add some custom rules to launch the tests
+ #
+ add_custom_target(check COMMAND "test_suite"

--- a/pkgs/servers/xmpp/biboumi/default.nix
+++ b/pkgs/servers/xmpp/biboumi/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, cmake, libuuid, expat, sqlite, git, libidn,
+  libiconv, botan2, systemd, pkgconfig, udns } :
+
+stdenv.mkDerivation rec {
+  name = "biboumi-${version}";
+  version = "6.1";
+
+  src = fetchurl {
+    url = "https://git.louiz.org/biboumi/snapshot/biboumi-${version}.tar.xz";
+    sha256 = "1la1n502v2wyfm0vl8v4m0hbigkkjchi21446n9mb203fz1cvr77";
+  };
+
+  buildInputs = [ cmake libuuid expat sqlite git libiconv libidn botan2
+    systemd pkgconfig udns ];
+
+  preConfigure = ''
+    grep -lr /etc/biboumi . | while read f
+    do
+      substituteInPlace $f --replace /etc/biboumi $out/etc/biboumi
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Modern XMPP IRC gateway";
+    platforms = platforms.unix;
+    homepage = https://lab.louiz.org/louiz/biboumi;
+    license = licenses.zlib;
+  };
+}

--- a/pkgs/servers/xmpp/biboumi/default.nix
+++ b/pkgs/servers/xmpp/biboumi/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, cmake, libuuid, expat, sqlite, git, libidn,
-  libiconv, botan2, systemd, pkgconfig, udns } :
+{ stdenv, fetchurl, fetchgit, cmake, libuuid, expat, sqlite, libidn,
+  libiconv, botan2, systemd, pkgconfig, udns, pandoc } :
 
 stdenv.mkDerivation rec {
   name = "biboumi-${version}";
@@ -10,20 +10,34 @@ stdenv.mkDerivation rec {
     sha256 = "1la1n502v2wyfm0vl8v4m0hbigkkjchi21446n9mb203fz1cvr77";
   };
 
-  buildInputs = [ cmake libuuid expat sqlite git libiconv libidn botan2
-    systemd pkgconfig udns ];
+  louiz_catch = fetchgit {
+    url = https://lab.louiz.org/louiz/Catch.git;
+    rev = "35f510545d55a831372d3113747bf1314ff4f2ef";
+    sha256 = "1l5b32sgr9zc2hlfr445hwwxv18sh3cn5q1xmvf588z6jyf88g2g";
+  };
+
+  patches = [ ./catch.patch ];
+
+  nativeBuildInputs = [ cmake pkgconfig pandoc ];
+  buildInputs = [ libuuid expat sqlite libiconv libidn botan2 systemd
+    udns ];
 
   preConfigure = ''
     grep -lr /etc/biboumi . | while read f
     do
       substituteInPlace $f --replace /etc/biboumi $out/etc/biboumi
     done
+    cp $louiz_catch/single_include/catch.hpp tests/
   '';
+
+  enableParallelBuilding = true;
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "Modern XMPP IRC gateway";
     platforms = platforms.unix;
     homepage = https://lab.louiz.org/louiz/biboumi;
     license = licenses.zlib;
+    maintainers = [ maintainers.woffs ];
   };
 }

--- a/pkgs/servers/xmpp/biboumi/default.nix
+++ b/pkgs/servers/xmpp/biboumi/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchgit, cmake, libuuid, expat, sqlite, libidn,
-  libiconv, botan2, systemd, pkgconfig, udns, pandoc } :
+  libiconv, botan2, systemd, pkgconfig, udns, pandoc, procps } :
 
 stdenv.mkDerivation rec {
   name = "biboumi-${version}";
@@ -20,14 +20,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkgconfig pandoc ];
   buildInputs = [ libuuid expat sqlite libiconv libidn botan2 systemd
-    udns ];
+    udns procps ];
 
+  inherit procps;
   preConfigure = ''
-    grep -lr /etc/biboumi . | while read f
-    do
-      substituteInPlace $f --replace /etc/biboumi $out/etc/biboumi
-    done
+    substituteInPlace CMakeLists.txt --replace /etc/biboumi $out/etc/biboumi
+    substituteInPlace unit/biboumi.service.cmake --replace /bin/kill $procps/bin/kill
     cp $louiz_catch/single_include/catch.hpp tests/
+    # echo "policy_directory=$out/etc/biboumi" >> conf/biboumi.cfg
+    # TODO include conf/biboumi.cfg as example somewhere
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11447,6 +11447,8 @@ with pkgs;
     inherit (lua51Packages) luasocket luasec luaexpat luafilesystem luabitop luaevent luazlib;
   };
 
+  biboumi = callPackage ../servers/xmpp/biboumi { };
+
   elasticmq = callPackage ../servers/elasticmq { };
 
   eventstore = callPackage ../servers/nosql/eventstore {


### PR DESCRIPTION
TODO: integrate config in NixOS

The config file referenced in the systemd service file is not existent atm and its options should be integrated into configuration.nix, but I am a newbie :-)

###### Motivation for this change

Provide my favourite XMPP IRC gateway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

