### PR TITLE
mesa: 17.1.10 -> 17.2.2

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, fetchpatch, lib
 , pkgconfig, intltool, autoreconfHook, substituteAll
-, file, expat, libdrm, xorg, wayland, openssl
+, file, expat, libdrm, xorg, wayland, wayland-protocols, openssl
 , llvmPackages, libffi, libomxil-bellagio, libva
-, libelf, libvdpau, valgrind-light
+, libelf, libvdpau, valgrind-light, python2
 , grsecEnabled ? false
-, enableRadv ? false
+, enableRadv ? true
 # Texture floats are patented, see docs/patents.txt, so we don't enable them for full Mesa.
 # It's overridden for mesa_drivers.
 , enableTextureFloats ? false
@@ -67,7 +67,7 @@ let
 in
 
 let
-  version = "17.1.10";
+  version = "17.2.2";
   branch  = head (splitString "." version);
   driverLink = "/run/opengl-driver" + optionalString stdenv.isi686 "-32";
 in
@@ -82,7 +82,7 @@ stdenv.mkDerivation {
       "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
       "https://launchpad.net/mesa/trunk/${version}/+download/mesa-${version}.tar.xz"
     ];
-    sha256 = "cbc0d681cc4df47d8deb5a36f45b420978128522fd665b2cd4c7096316f11bdb";
+    sha256 = "10jplvxg7rlbp7569w08z0igwlsjjfb7q3n07zgfr8d5sr224lng";
   };
 
   prePatch = "patchShebangs .";
@@ -150,9 +150,9 @@ stdenv.mkDerivation {
     autoreconfHook intltool expat llvmPackages.llvm
     glproto dri2proto dri3proto presentproto
     libX11 libXext libxcb libXt libXfixes libxshmfence
-    libffi wayland libvdpau libelf libXvMC
+    libffi wayland wayland-protocols libvdpau libelf libXvMC
     libomxil-bellagio libva libpthreadstubs openssl/*or another sha1 provider*/
-    valgrind-light
+    valgrind-light python2
   ];
 
 


### PR DESCRIPTION
###### Motivation for this change

The 17.1.10 version in master hangs my graphics card (works fine on the release-17.09 branch though).

I have enabled the `enableRadv` option by default, since it seems to work just fine with my RX480.  At least the smoketest demo runs at 1kFPS:
```
$(nix-build -A vulkan-loader.demos)/bin/smoketest
```

I'll merge this on Monday if there are no objections.
cc @vcunat @eduarrrd 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

