### PR TITLE
ffmpegthumbnailer: build with jpeg support

### DIFF
--- a/pkgs/development/libraries/ffmpegthumbnailer/default.nix
+++ b/pkgs/development/libraries/ffmpegthumbnailer/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, fetchFromGitHub, stdenv, ffmpeg, cmake, libpng, pkgconfig
+{ pkgs, fetchFromGitHub, stdenv, ffmpeg, cmake, libpng, pkgconfig, libjpeg
 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ ffmpeg libpng ];
+  buildInputs = [ ffmpeg libpng libjpeg ];
 
   meta = with stdenv.lib;  {
     homepage = https://github.com/dirkvdb/ffmpegthumbnailer;


### PR DESCRIPTION
###### Motivation for this change
jpeg support is required for ranger video previews (https://github.com/ranger/ranger/wiki/Video-Previews)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

