### PR TITLE
atom-beta: 1.21.0-beta0 -> 1.22.0-beta0

### DIFF
--- a/pkgs/applications/editors/atom/beta.nix
+++ b/pkgs/applications/editors/atom/beta.nix
@@ -1,12 +1,12 @@
 { stdenv, pkgs, fetchurl, lib, makeWrapper, gvfs, atomEnv}:
 
 stdenv.mkDerivation rec {
-  name = "atom-${version}";
-  version = "1.21.0-beta0";
+  name = "atom-beta-${version}";
+  version = "1.22.0-beta0";
 
   src = fetchurl {
     url = "https://github.com/atom/atom/releases/download/v${version}/atom-amd64.deb";
-    sha256 = "1syxlyb62vp9hmjdiazhmvq8w52b90l8mvf502xkdav4vi3yxzfz";
+    sha256 = "0xsj0vvaxjw60gg6niaws2lf9lkrh1sz7ypk41g6l4hdgmqyg6fi";
     name = "${name}.deb";
   };
 


### PR DESCRIPTION
###### Motivation for this change
Update, fix derivation name to not collide with stable Atom.

Fix #30198 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@domenkozar @FRidh @TerkiKerel
