### PR TITLE
ruby_2_2: 2.2.7 -> 2.2.8

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -196,11 +196,11 @@ in {
     };
   };
 
-  ruby_2_2_7 = generic {
-    version = rubyVersion "2" "2" "7" "";
+  ruby_2_2_8 = generic {
+    version = rubyVersion "2" "2" "8" "";
     sha256 = {
-      src = "199xz5bvmp26c7vyzw47cpxkd8jk826kc8nlpavqzj5vqp388h9p";
-      git = "0i0nsm9ldjp39m9xq47v8w6wlg821ikczz530493cs150qkqa0a1";
+      src = "12i6v5i0djl4xx3x7fq12snqb5d4drqjmnwqs05fby4bagcbjdwg";
+      git = "16nw0795nhrj13crp5x4jis8hmi3gsyjl96pwk698wlrb89lf9bw";
     };
   };
 

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -24,7 +24,7 @@ rec {
     "${patchSet}/patches/ruby/2.1.8/railsexpress/08-funny-falcon-method-cache.patch"
     "${patchSet}/patches/ruby/2.1.8/railsexpress/09-heap-dump-support.patch"
   ];
-  "2.2.7" = ops useRailsExpress [
+  "2.2.8" = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.2/head/railsexpress/01-zero-broken-tests.patch"
     "${patchSet}/patches/ruby/2.2/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.2/head/railsexpress/03-display-more-detailed-stack-trace.patch"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6700,7 +6700,7 @@ with pkgs;
   inherit (callPackage ../development/interpreters/ruby {})
     ruby_2_0_0
     ruby_2_1_10
-    ruby_2_2_7
+    ruby_2_2_8
     ruby_2_3_5
     ruby_2_4_2;
 
@@ -6708,7 +6708,7 @@ with pkgs;
   ruby = ruby_2_3;
   ruby_2_0 = ruby_2_0_0;
   ruby_2_1 = ruby_2_1_10;
-  ruby_2_2 = ruby_2_2_7;
+  ruby_2_2 = ruby_2_2_8;
   ruby_2_3 = ruby_2_3_5;
   ruby_2_4 = ruby_2_4_2;
 


### PR DESCRIPTION
For multiple CVE's:

- CVE-2017-0898
- CVE-2017-10784
- CVE-2017-14033
- CVE-2017-14064

See https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-2-8-released/

###### Motivation for this change

A follow up on https://github.com/NixOS/nixpkgs/pull/29417 & https://github.com/NixOS/nixpkgs/commit/85049c5aad2ad3b82260019c205821f64b71c9e3 to address the same issues in 2.2 branch of Ruby.

/cc @manveru @zimbatm 

As an aside - would it be appropriate to backport https://github.com/NixOS/nixpkgs/commit/85049c5aad2ad3b82260019c205821f64b71c9e3 to stable as was done with https://github.com/NixOS/nixpkgs/pull/29417 (with 2_3 being default Ruby version AFAICT)?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

