### PR TITLE
powertop module: add kmod to path

### DIFF
--- a/nixos/modules/tasks/powertop.nix
+++ b/nixos/modules/tasks/powertop.nix
@@ -16,6 +16,7 @@ in {
       powertop = {
         wantedBy = [ "multi-user.target" ];
         description = "Powertop tunings";
+        path = [ pkgs.kmod ];
         serviceConfig = {
           Type = "oneshot";
           RemainAfterExit = "yes";


### PR DESCRIPTION
###### Motivation for this change

powertop attempt to load some kernel modules like msr by calling
modprobe. This is the counterpart to
88e43eb39bcda5f8fdf41d566bc6799596177cd0 which has the powertop
executable search PATH for modprobe rather than hardcoding /sbin, and
actually adds the directory containing modprobe to its PATH for the
systemd service.

Not tested!

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).