### PR TITLE
kmplayer: 0.11.3d -> 0.12.0b

### DIFF
--- a/pkgs/applications/video/kmplayer/default.nix
+++ b/pkgs/applications/video/kmplayer/default.nix
@@ -1,30 +1,41 @@
-{ stdenv, fetchurl
-, automoc4, cmake, gettext, makeWrapper, perl, pkgconfig
-, kdelibs4, cairo, dbus_glib, mplayer
+{
+  mkDerivation, lib, fetchurl,
+  extra-cmake-modules, makeWrapper,
+  qtsvg, qtx11extras, ki18n, kdelibs4support, kio, kmediaplayer, kwidgetsaddons,
+  phonon, cairo, mplayer
 }:
 
-stdenv.mkDerivation {
-  name = "kmplayer-0.11.3d";
+mkDerivation rec {
+  majorMinorVersion = "0.12";
+  patchVersion = "0b";
+  version = "${majorMinorVersion}.${patchVersion}";
+  name = "kmplayer-${version}";
 
   src = fetchurl {
-    #url = http://kmplayer.kde.org/pkgs/kmplayer-0.11.3d.tar.bz2;
-    url = "mirror://gentoo/distfiles/kmplayer-0.11.3d.tar.bz2";
-    sha256 = "1yvbkb1hh5y7fqfvixjf2rryzm0fm0fpkx4lmvhi7k7d0v4wpgky";
+    url = "mirror://kde/stable/kmplayer/${majorMinorVersion}/kmplayer-${version}.tar.bz2";
+    sha256 = "0wzdxym4fc83wvqyhcwid65yv59a2wvp1lq303cn124mpnlwx62y";
   };
 
-  buildInputs = [ kdelibs4 cairo dbus_glib ];
+  patches = [
+    ./kmplayer_part-plugin_metadata.patch # Qt 5.9 doesn't like an empty string for the optional "FILE" argument of "Q_PLUGIN_METADATA"
+    ./no-docs.patch # Don't build docs due to errors (kdelibs4support propagates kdoctools)
+  ];
 
-  nativeBuildInputs = [ automoc4 cmake gettext makeWrapper perl pkgconfig ];
+  nativeBuildInputs = [ extra-cmake-modules makeWrapper ];
+
+  buildInputs = [
+    qtsvg qtx11extras ki18n kdelibs4support kio kmediaplayer kwidgetsaddons
+    phonon cairo
+  ];
 
   postInstall = ''
     wrapProgram $out/bin/kmplayer --suffix PATH : ${mplayer}/bin
   '';
 
-  meta = {
+  meta = with lib; {
     description = "MPlayer front-end for KDE";
-    license = "GPL";
-    homepage = http://kmplayer.kde.org;
-    broken = true; # Also unavailable on this mirror
-    maintainers = [ stdenv.lib.maintainers.sander ];
+    license = with licenses; [ gpl2 lgpl2 fdl12 ];
+    homepage = https://kmplayer.kde.org/;
+    maintainers = with maintainers; [ sander zraexy ];
   };
 }

--- a/pkgs/applications/video/kmplayer/kmplayer_part-plugin_metadata.patch
+++ b/pkgs/applications/video/kmplayer/kmplayer_part-plugin_metadata.patch
@@ -1,0 +1,11 @@
+--- a/src/kmplayer_part.h
++++ b/src/kmplayer_part.h
+@@ -36,7 +36,7 @@
+ 
+ class KMPlayerFactory : public KPluginFactory {
+     Q_OBJECT
+-    Q_PLUGIN_METADATA(IID "org.kde.KPluginFactory" FILE "")
++    Q_PLUGIN_METADATA(IID "org.kde.KPluginFactory")
+     Q_INTERFACES(KPluginFactory)
+ public:
+     KMPlayerFactory();

--- a/pkgs/applications/video/kmplayer/no-docs.patch
+++ b/pkgs/applications/video/kmplayer/no-docs.patch
@@ -1,0 +1,12 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -79,9 +79,6 @@
+ 
+ add_subdirectory(src)
+ add_subdirectory(icons)
+-if (IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/doc" AND KF5DocTools_VERSION)
+-  add_subdirectory(doc)
+-endif(KF5DocTools_VERSION)
+ add_subdirectory(data)
+ 
+ if (IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/po")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15240,7 +15240,7 @@ with pkgs;
 
   kiwix = callPackage ../applications/misc/kiwix { };
 
-  kmplayer = kde4.callPackage ../applications/video/kmplayer { };
+  kmplayer = libsForQt5.callPackage ../applications/video/kmplayer { };
 
   kodestudio = callPackage ../applications/editors/kodestudio { };
 


### PR DESCRIPTION
###### Motivation for this change

Update KMPlayer to the latest version which uses KF5

Resolves #22959

@svanderburg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

