### PR TITLE
Warn about default ZNC mutability change

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -71,6 +71,7 @@ following incompatible changes:</para>
 <itemizedlist>
   <listitem>
     <para>
+      ZNC option <option>services.znc.mutable</option> now defaults to <literal>true</literal>.
     </para>
   </listitem>
 </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -72,6 +72,7 @@ following incompatible changes:</para>
   <listitem>
     <para>
       ZNC option <option>services.znc.mutable</option> now defaults to <literal>true</literal>.
+      That means that old configuration is not overwritten by default when update to the znc options are made.
     </para>
   </listitem>
 </itemizedlist>


### PR DESCRIPTION
The option now defaults to true. This requires a warning in the release notes. See https://github.com/NixOS/nixpkgs/pull/30155

/cc @Mic92 

