### PR TITLE
xfce4-session: Backport querying lock command in xflock4

### DIFF
--- a/pkgs/desktops/xfce/core/xfce4-light-locker.patch
+++ b/pkgs/desktops/xfce/core/xfce4-light-locker.patch
@@ -1,16 +1,25 @@
 --- ./scripts/xflock4.orig	2017-08-06 23:05:53.807688995 +0100
 +++ ./scripts/xflock4	2017-08-06 23:09:06.171789989 +0100
-@@ -24,10 +24,11 @@
+@@ -24,12 +24,19 @
  PATH=/bin:/usr/bin
  export PATH
-
+ 
 -# Lock by xscreensaver or gnome-screensaver, if a respective daemon is running
-+# Lock by xscreensaver, gnome-screensaver or light-locker, if a respective daemon is running
++# First test for the command set in the session's xfconf channel
++LOCK_CMD=$(xfconf-query -c xfce4-session -p /general/LockCommand)
++
++# Lock by xscreensaver, gnome-screensaver, or light-locker, if a respective daemon is running
  for lock_cmd in \
++    "$LOCK_CMD" \
      "xscreensaver-command -lock" \
 -    "gnome-screensaver-command --lock"
 +    "gnome-screensaver-command --lock" \
 +    "light-locker-command -l"
  do
-     $lock_cmd >/dev/null 2>&1 && exit
+-    $lock_cmd >/dev/null 2>&1 && exit
++    if [ ! -z "$lock_cmd" ]; then
++        $lock_cmd >/dev/null 2>&1 && exit
++    fi
  done
+ 
+ # else run another access locking utility, if installed


### PR DESCRIPTION
###### Motivation for this change
Up until xfce 4.13, xflock4 only had support for "whitelisted" (*cough* hardcoded *cough*) locks screens. Version 4.13 added the ability for the user to specify the lock command via the xfce settings. This PR backports that functionality 
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

