### PR TITLE
pkgs.yabause: fix typo

### DIFF
--- a/pkgs/misc/emulators/yabause/default.nix
+++ b/pkgs/misc/emulators/yabause/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "An open-source Sega Saturn emulator";
     homepage = https://yabause.org/;
     license = licenses.gpl2Plus;
-    maintainers = with maintaines; [ AndersonTorres ];
+    maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
s/maintaines/maintainers/

###### Motivation for this change
This was breaking the Travis CI build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

