### PR TITLE
ghcjs/ghcjsHEAD: Use separate patch files to fix build of ghcjs

### DIFF
--- a/pkgs/development/compilers/ghcjs/ghcjs-head.patch
+++ b/pkgs/development/compilers/ghcjs/ghcjs-head.patch
@@ -46,24 +46,6 @@ index db8b12e..7b815c5 100644
        mapM_ patchPackage =<< allPackages
        preparePrimops
        buildGenPrim
-@@ -1141,7 +1132,7 @@ cabalStage1 pkgs = sub $ do
-   globalFlags <- cabalGlobalFlags
-   flags <- cabalInstallFlags (length pkgs == 1)
-   let args = globalFlags ++ ("install" : pkgs) ++
--             [ "--solver=topdown" -- the modular solver refuses to install stage1 packages
-+             [ "--allow-boot-library-installs"
-              ] ++ map ("--configure-option="<>) configureOpts ++ flags
-   checkInstallPlan pkgs args
-   cabal_ args
-@@ -1162,7 +1153,7 @@ cabalInstall pkgs = do
- -- uses somewhat fragile parsing of --dry-run output, find a better way
- checkInstallPlan :: [Package] -> [Text] -> B ()
- checkInstallPlan pkgs opts = do
--  plan <- cabal (opts ++ ["-v2", "--dry-run"])
-+  plan <- cabal (opts ++ ["-vverbose+nowrap", "--dry-run"])
-   when (hasReinstalls plan || hasUnexpectedInstalls plan || hasNewVersion plan) (err plan)
-   where
-     hasReinstalls = T.isInfixOf "(reinstall)"   -- reject reinstalls
 @@ -1201,14 +1192,14 @@ cabalInstallFlags parmakeGhcjs = do
             , "--avoid-reinstalls"
             , "--builddir",      "dist"

--- a/pkgs/development/compilers/ghcjs/head.nix
+++ b/pkgs/development/compilers/ghcjs/head.nix
@@ -45,4 +45,6 @@ bootPkgs.callPackage ./base.nix {
     "unix"
   ];
   stage2 = import ./head_stage2.nix;
+
+  patches = [ ./ghcjs-head.patch ];
 }


### PR DESCRIPTION
###### Motivation for this change

In #29696 I removed the patch for building `ghcjs` using cabal-install 2.0 since it had been merged upstream into `GHCJS 8.0` (`ghcjsHEAD` in `nixpkgs`). However, I’ve missed that this is also used for `ghcjs` which still needs this patch and is currently broken due to this change (sorry about this).

###### Things done

Separate the patch files for `ghcjsHEAD` and `ghcjs` and include the `cabal-install 2.0` patch for `ghcjs`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

