### PR TITLE
escrotum: Init at 2017-01-28

### DIFF
--- a/pkgs/tools/graphics/escrotum/default.nix
+++ b/pkgs/tools/graphics/escrotum/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchFromGitHub, buildPythonApplication
+, pygtk
+, numpy ? null
+}:
+
+buildPythonApplication {
+  name = "escrotum-2017-01-28";
+
+  src = fetchFromGitHub {
+    owner  = "Roger";
+    repo   = "escrotum";
+    rev    = "a51e330f976c1c9e1ac6932c04c41381722d2171";
+    sha256 = "0vbpyihqgm0fyh22ashy4lhsrk67n31nw3bs14d1wr7ky0l3rdnj";
+  };
+
+  propagatedBuildInputs = [ pygtk numpy ];
+
+  meta = with lib; {
+    homepage = https://github.com/Roger/escrotum;
+    description = "Linux screen capture using pygtk, inspired by scrot";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ rasendubi ];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1902,6 +1902,10 @@ with pkgs;
 
   epsxe = callPackage ../misc/emulators/epsxe { };
 
+  escrotum = callPackage ../tools/graphics/escrotum {
+    inherit (pythonPackages) buildPythonApplication pygtk numpy;
+  };
+
   ethtool = callPackage ../tools/misc/ethtool { };
 
   ettercap = callPackage ../applications/networking/sniffers/ettercap { };


### PR DESCRIPTION
###### Motivation for this change
scrot has bugs with region selection and is unmaintained upstream.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

