### PR TITLE
lambda-mod-zsh-theme: 2017-07-05 -> 2017-10-08

### DIFF
--- a/pkgs/shells/lambda-mod-zsh-theme/default.nix
+++ b/pkgs/shells/lambda-mod-zsh-theme/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  name = "lambda-mod-zsh-theme-unstable-2017-07-05";
+  name = "lambda-mod-zsh-theme-unstable-2017-10-08";
 
   src = fetchFromGitHub {
     owner = "halfo";
     repo = "lambda-mod-zsh-theme";
-    sha256 = "03kdhifxsnfbly6hqpr1h6kf52kyhdbh82nvwkkyrz1lw2cxl89n";
-    rev = "ba7d5fea16db91fc8de887e69250f4e501b1e36d";
+    sha256 = "13yis07zyr192s0x2h04k5bm1yzbk5m3js83aa17xh5573w4b786";
+    rev = "61c373c8aa5556d51522290b82ad44e7166bced1";
   };
 
   buildPhases = [ "unpackPhase" "installPhase" ];


### PR DESCRIPTION
###### Motivation for this change

`lambda-mod-zsh-theme` hasbeen updated today :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

