### PR TITLE
devtodo: adjust platforms

### DIFF
--- a/pkgs/development/tools/devtodo/default.nix
+++ b/pkgs/development/tools/devtodo/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     description = "A hierarchical command-line task manager";
     license = licenses.gpl2;
     maintainers = [ maintainers.woffs ];
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/unicode/default.nix
+++ b/pkgs/tools/misc/unicode/default.nix
@@ -26,5 +26,6 @@ python3Packages.buildPythonApplication rec {
     homepage = https://github.com/garabik/unicode;
     license = licenses.gpl3;
     maintainers = [ maintainers.woffs ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
devtodo: adjust platforms
unicode: adjust platforms

###### Motivation for this change

devtodo does not build on darwin
https://hydra.nixos.org/build/62408869/nixlog/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

