### PR TITLE
Cleanup typoed `propagateBuildInputs` that are probably not needded

### DIFF
--- a/pkgs/applications/networking/cluster/kanif/default.nix
+++ b/pkgs/applications/networking/cluster/kanif/default.nix
@@ -4,8 +4,6 @@ stdenv.mkDerivation rec {
   version = "1.2.2";
   name = "kanif-${version}";
 
-  propagateBuildInputs = [ perl taktuk ];
-
   src = fetchurl {
     url = "http://gforge.inria.fr/frs/download.php/26773/${name}.tar.gz";
     sha256 = "3f0c549428dfe88457c1db293cfac2a22b203f872904c3abf372651ac12e5879";

--- a/pkgs/tools/filesystems/irods/common.nix
+++ b/pkgs/tools/filesystems/irods/common.nix
@@ -9,8 +9,6 @@ with stdenv;
 
   buildInputs = [ bzip2 zlib autoconf automake cmake gnumake help2man texinfo libtool cppzmq libarchive avro-cpp jansson zeromq openssl pam libiodbc kerberos gcc boost libcxx which ];
 
-  propagateBuildInputs = [ boost ];
-
   cmakeFlags = [
     "-DIRODS_EXTERNALS_FULLPATH_CLANG=${stdenv.cc}"
     "-DIRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME=${stdenv.cc}"

--- a/pkgs/tools/filesystems/irods/default.nix
+++ b/pkgs/tools/filesystems/irods/default.nix
@@ -62,8 +62,6 @@ in rec {
 
      buildInputs = common.buildInputs ++ [ irods ];
 
-     propagateBuildInputs = [ boost ];
-
      preConfigure = common.preConfigure + ''
        patchShebangs ./bin
      '';


### PR DESCRIPTION
###### Motivation for this change

While digging around in the code I found these 3 occurrences of `propagateBuildInputs` which is not an attribute that is evaluated. The authors probably meant `propagatedBuildInputs` but since there is no bug about them not working / the authors (hopefully) verified the packages before uploading. I do not expect any kind of breakage due to this change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

