### PR TITLE
pypcap: init at 1.1.6

### DIFF
--- a/pkgs/development/python-modules/pypcap/default.nix
+++ b/pkgs/development/python-modules/pypcap/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, writeText, buildPythonPackage, fetchPypi, isPy3k, libpcap, dpkt }:
+
+buildPythonPackage rec {
+  pname = "pypcap";
+  version = "1.1.6";
+  name = "${pname}-${version}";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1cx7qm0w2a91g5z8k3kmlwz0b8dkr0h8dlb64rwgyhp2laa33syi";
+  };
+
+  patches = [
+    # The default setup.py searchs for pcap.h in a static list of default
+    # folders. So we have to add the path to libpcap in the nix-store.
+    (writeText "libpcap-path.patch"
+      ''
+      --- a/setup.py
+      +++ b/setup.py
+      @@ -27,7 +27,8 @@ def recursive_search(path, target_files):
+
+       def get_extension():
+           # A list of all the possible search directories
+      -    dirs = ['/usr', sys.prefix] + glob.glob('/opt/libpcap*') + \
+      +    dirs = ['${libpcap}', '/usr', sys.prefix] + \
+      +        glob.glob('/opt/libpcap*') + \
+               glob.glob('../libpcap*') + glob.glob('../wpdpack*') + \
+               glob.glob('/Applications/Xcode.app/Contents/Developer/Platforms/' +
+                         'MacOSX.platform/Developer/SDKs/*')
+      '')
+  ];
+
+  buildInputs = [ libpcap dpkt ];
+
+  meta = {
+    homepage = https://github.com/pynetwork/pypcap;
+    description = "Simplified object-oriented Python wrapper for libpcap";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ geistesk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17594,6 +17594,8 @@ in {
     };
   };
 
+  pypcap = callPackage ../development/python-modules/pypcap {};
+
   pyplatec = buildPythonPackage rec {
     name = "PyPlatec-${version}";
     version = "1.4.0";


### PR DESCRIPTION
###### Motivation for this change
This PR adds the [python libpcap module](https://github.com/pynetwork/pypcap).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

