### PR TITLE
newsbeuter: fix CVE-2017-12904

### DIFF
--- a/pkgs/applications/networking/feedreaders/newsbeuter/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsbeuter/default.nix
@@ -36,6 +36,11 @@ stdenv.mkDerivation rec {
       url = "https://github.com/akrennmair/newsbeuter/commit/26f5a4350f3ab5507bb8727051c87bb04660f333.patch";
       sha256 = "1jjxj4z3s4f1n8rfpwyd42a40gjnziykqas6a26s1lsdkklnbp6q";
     })
+    # https://github.com/akrennmair/newsbeuter/issues/591 / CVE-2017-12904
+    (fetchpatch {
+      url = "https://github.com/akrennmair/newsbeuter/commit/d1460189f6f810ca9a3687af7bc43feb7f2af2d9.patch";
+      sha256 = "1a8k73ckziszsbdwdhcmkfvlmgy955gssg9v4sqvg20v91l5rmai";
+    })
    ];
 
   installFlags = [ "DESTDIR=$(out)" "prefix=" ];


### PR DESCRIPTION
###### Motivation for this change

> Improper Neutralization of Special Elements used in an OS Command in bookmarking function of Newsbeuter versions 0.7 through 2.9 allows remote attackers to perform user-assisted code execution by crafting an RSS item that includes shell code in its title and/or URL.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

