### PR TITLE
gnome3.geary: 0.11.3 → 0.12.0

### DIFF
--- a/pkgs/desktops/gnome-3/core/libgee/default.nix
+++ b/pkgs/desktops/gnome-3/core/libgee/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, autoconf, vala_0_32, pkgconfig, glib, gobjectIntrospection, gnome3 }:
+{ stdenv, fetchurl, autoconf, vala, pkgconfig, glib, gobjectIntrospection, gnome3 }:
 let
-  ver_maj = "0.18";
+  ver_maj = "0.20";
   ver_min = "0";
 in
 stdenv.mkDerivation rec {
@@ -8,15 +8,15 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libgee/${ver_maj}/${name}.tar.xz";
-    sha256 = "16a34js81w9m2bw4qd8csm4pcgr3zq5z87867j4b8wfh6zwrxnaa";
+    sha256 = "1fy24dr8imrjlmsqj1syn0gi139gba6hwk3j5vd6sr3pxniqnc11";
   };
 
   doCheck = true;
 
   patches = [ ./fix_introspection_paths.patch ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ autoconf vala_0_32 glib gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig autoconf vala pkgconfig gobjectIntrospection ];
+  buildInputs = [ glib ];
 
   meta = with stdenv.lib; {
     description = "Utility library providing GObject-based interfaces and classes for commonly used data structures";

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -366,10 +366,7 @@ let
 
   california = callPackage ./misc/california { };
 
-  geary = callPackage ./misc/geary {
-    # https://bugzilla.gnome.org/show_bug.cgi?id=728002
-    webkitgtk = pkgs.webkitgtk24x-gtk3;
-  };
+  geary = callPackage ./misc/geary { };
 
   gfbgraph = callPackage ./misc/gfbgraph { };
 


### PR DESCRIPTION
Geary requires newer libgee so I cherry picked it from GNOME 3.26. There should be no backwards-incompatible changes according to [changelog](https://github.com/GNOME/libgee/blob/0.20.0/NEWS).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @grahamc 