### PR TITLE
aspell: added new patch data-dirs-from-nix-profiles.patch

### DIFF
--- a/pkgs/development/libraries/aspell/aspell-with-dicts.nix
+++ b/pkgs/development/libraries/aspell/aspell-with-dicts.nix
@@ -1,5 +1,9 @@
 # Create a derivation that contains aspell and selected dictionaries.
 # Composition is done using `pkgs.buildEnv`.
+# Beware of that `ASPELL_CONF` used by this derivation is not always
+# respected by libaspell (#28815) and in some cases, when used as
+# dependency by another derivation, the passed dictionaries will be
+# missing. However, invoking aspell directly should be fine.
 
 { aspell
 , aspellDicts

--- a/pkgs/development/libraries/aspell/data-dirs-from-nix-profiles.patch
+++ b/pkgs/development/libraries/aspell/data-dirs-from-nix-profiles.patch
@@ -1,0 +1,38 @@
+diff --git a/common/info.cpp b/common/info.cpp
+index 8291cc7..6216326 100644
+--- a/common/info.cpp
++++ b/common/info.cpp
+@@ -36,6 +36,7 @@
+ #include "strtonum.hpp"
+ #include "lock.hpp"
+ #include "string_map.hpp"
++#include "file_util.hpp"
+ 
+ #include "gettext.h"
+ 
+@@ -495,6 +496,25 @@ namespace acommon {
+     lst.clear();
+     lst.add(config->retrieve("data-dir"));
+     lst.add(config->retrieve("dict-dir"));
++    if (config->lookup("data-dir") == NULL && config->lookup("dict-dir") == NULL) {
++        const char* cprofiles = getenv("NIX_PROFILES");
++        if (cprofiles != NULL) {
++            char* profiles = strdup(cprofiles);
++            char* profile = profiles;
++            char* end = profile;
++            while (*end != '\0') {
++                if (*end == ' ') {
++                    *end = '\0';
++                    lst.add(add_possible_dir(profile, "lib/aspell"));
++                    profile = ++end;
++                } else {
++                    ++end;
++                }
++            }
++            lst.add(add_possible_dir(profile, "lib/aspell"));
++            free(profiles);
++        }
++    }
+   }
+ 
+   DictExt::DictExt(ModuleInfo * m, const char * e)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7769,7 +7769,9 @@ with pkgs;
 
   aspellDicts = recurseIntoAttrs (callPackages ../development/libraries/aspell/dictionaries.nix {});
 
-  aspellWithDicts = callPackage ../development/libraries/aspell/aspell-with-dicts.nix { };
+  aspellWithDicts = callPackage ../development/libraries/aspell/aspell-with-dicts.nix {
+    aspell = aspell.override { searchNixProfiles = false; };
+  };
 
   attica = callPackage ../development/libraries/attica { };
 


### PR DESCRIPTION
Aspell will search for dictionaries in all nix profiles even when used as library.
Setting data-dir or dict-dir in ASPELL_CONF will disable this behavior.

###### Motivation for this change
The ASPELL_CONF variable is used only by aspell binary so any application using aspell API will never see any dictionaries (like in #28815). Internal code of aspell allows multiple data/dict search paths so is possible to add all `lib/aspell` subdirectories from all nix profiles, unlike when using ASPELL_CONF.
Any application using `libaspell` will be able use any dictionary installed without any modification.

I have looked on `aspellWithDicts` derivation, but I don't think it could solve this problem.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

