### PR TITLE
Qt4: Fix Darwin build

### DIFF
--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -183,10 +183,38 @@ stdenv.mkDerivation rec {
     sed -i 's/^\(LIBS[[:space:]]*=.*$\)/\1 -lobjc/' ./src/corelib/Makefile.Release
   '';
 
-  postInstall =
-    ''
+  installPhase = optionalString stdenv.isDarwin ''
+    runHook preInstall
+    cp -r lib $out
+
+    mkdir -p $out/Applications
+    mv bin/*.app $out/Applications
+    rm -rf bin/*.app
+
+    cp -r bin $out
+
+    mkdir -p $out/share/doc/${name}
+    mkdir -p $out/lib
+    mkdir -p $out/lib/qt4/plugins
+    mkdir -p $out/lib/qt4/imports
+    mkdir -p $out/bin
+    mkdir -p $out/include
+    mkdir -p $out/share/${name}
+
+    cp -r mkspecs $out/share/${name}
+    cp -r translations $out/share/${name}
+    cp -r tools/linguist/phrasebooks $out/share/${name}
+    cp tools/porting/src/q3porting.xml $out/share/${name}
+
+    cp -r plugins $out/lib/qt4
+    cp -r imports $out/lib/qt4
+    cp -r doc/* $out/share/doc/${name}
+    runHook postInstall
+  '';
+
+  postInstall = optionalString (!stdenv.isDarwin) ''
       rm -rf $out/tests
-    '';
+  '';
 
   crossAttrs = {
     # I've not tried any case other than i686-pc-mingw32.


### PR DESCRIPTION
###### Motivation for this change
This PR fixes qt4 on Darwin. At some point, the qmake-generated installer broke, despite the buildPhase compiling the library correctly. This PR manually copies the files to the required directories on Darwin. I realize this isn't ideal.
I've tested this with qjson, which built and linked with no issue.

###### Things done
- installPhase overridden on Darwin
- enableParallelBuilding on Darwin
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing (`relaxed`)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

fixes #28385 which has more details and logs on the actual error