### PR TITLE
Firefox: do not crash on print dialog.

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -116,13 +116,13 @@ let
             --prefix-contents PATH ':' "$(filterExisting $(addSuffix /extra-bin-path $plugins))" \
             --suffix PATH ':' "$out/bin" \
             --set MOZ_APP_LAUNCHER "${browserName}${nameSuffix}" \
-            --set MOZ_SYSTEM_DIR "$out/lib/mozilla" \
-            ${lib.optionalString (!ffmpegSupport)
-                ''--prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH"''
-            + lib.optionalString (browser ? gtk3)
-                ''--prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
-                  --suffix XDG_DATA_DIRS : '${gnome3.defaultIconTheme}/share'
-                ''
+            --set MOZ_SYSTEM_DIR "$out/lib/mozilla"${
+              lib.optionalString (!ffmpegSupport) '' \
+              --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH"''
+            }${
+              lib.optionalString (browser ? gtk3) '' \
+                --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
+                --suffix XDG_DATA_DIRS : "${gnome3.defaultIconTheme}/share"''
             }
 
         if [ -e "${browser}/share/icons" ]; then


### PR DESCRIPTION
Firefox sometimes crashes when requested to print a page.
The issue is that related gsettings are not found.

I know this should be handled by the gnome3 desktop-manager environment, but for some reason it is not.
Considering how fragile that method is, and that all the similar packages are already wrapped,
I think we should also wrap firefox.
It's a pretty trivial change as it only affects the wrapper.

/cc @vcunat for this ehances 700d6186a30