### PR TITLE
ansible: Init 2.4 and set to default

### DIFF
--- a/pkgs/tools/admin/ansible/2.4.nix
+++ b/pkgs/tools/admin/ansible/2.4.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, fetchurl
+, pythonPackages
+, windowsSupport ? false
+}:
+
+pythonPackages.buildPythonPackage rec {
+  pname = "ansible";
+  version = "2.4.0.0";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "http://releases.ansible.com/ansible/${name}.tar.gz";
+    sha256 = "0xkwnx817rygb1922gncv9ivgvb7hjg8g53r39hfdm3jgzp6y9qs";
+  };
+
+  prePatch = ''
+    sed -i "s,/usr/,$out," lib/ansible/constants.py
+  '';
+
+  doCheck = false;
+  dontStrip = true;
+  dontPatchELF = true;
+  dontPatchShebangs = false;
+
+  propagatedBuildInputs = with pythonPackages; [
+    pycrypto paramiko jinja2 pyyaml httplib2 boto six netaddr dns
+  ] ++ stdenv.lib.optional windowsSupport pywinrm;
+
+  meta = with stdenv.lib; {
+    homepage = http://www.ansible.com;
+    description = "A simple automation tool";
+    license = with licenses; [ gpl3] ;
+    maintainers = with maintainers; [
+      jgeerds
+      joamaki
+    ];
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6845,8 +6845,9 @@ with pkgs;
   ansible_2_1 = callPackage ../tools/admin/ansible/2.1.nix {};
   ansible_2_2 = callPackage ../tools/admin/ansible/2.2.nix {};
   ansible_2_3 = callPackage ../tools/admin/ansible/2.3.nix {};
-  ansible  = ansible_2_3;
-  ansible2 = ansible_2_3;
+  ansible_2_4 = callPackage ../tools/admin/ansible/2.4.nix {};
+  ansible  = ansible_2_4;
+  ansible2 = ansible_2_4;
 
   antlr = callPackage ../development/tools/parsing/antlr/2.7.7.nix { };
 


### PR DESCRIPTION
Ansible tends to have many version quirks, so I've left 2.3 in instead
of simply bumping it.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

