### PR TITLE
fwupd: 0.9.6 → 1.0.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -226,6 +226,7 @@
   ./services/hardware/bluetooth.nix
   ./services/hardware/brltty.nix
   ./services/hardware/freefall.nix
+  ./services/hardware/fwupd.nix
   ./services/hardware/illum.nix
   ./services/hardware/interception-tools.nix
   ./services/hardware/irqbalance.nix

--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -1,0 +1,76 @@
+# fwupd daemon.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.fwupd;
+  originalEtc =
+    let
+      isRegular = v: v == "regular";
+      listFiles = d: builtins.attrNames (filterAttrs (const isRegular) (builtins.readDir d));
+      copiedDirs = [ "fwupd/remotes.d" "pki/fwupd" "pki/fwupd-metadata" ];
+      originalFiles = concatMap (d: map (f: "${d}/${f}") (listFiles "${pkgs.fwupd}/etc/${d}")) copiedDirs;
+      mkEtcFile = n: nameValuePair n { source = "${pkgs.fwupd}/etc/${n}"; };
+    in listToAttrs (map mkEtcFile originalFiles);
+in {
+
+  ###### interface
+  options = {
+    services.fwupd = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to enable fwupd, a DBus service that allows
+          applications to update firmware.
+        '';
+      };
+
+      blacklistDevices = mkOption {
+        type = types.listOf types.string;
+        default = [];
+        example = [ "2082b5e0-7a64-478a-b1b2-e3404fab6dad" ];
+        description = ''
+          Allow blacklisting specific devices by their GUID
+        '';
+      };
+
+      blacklistPlugins = mkOption {
+        type = types.listOf types.string;
+        default = [];
+        example = [ "udev" ];
+        description = ''
+          Allow blacklisting specific plugins
+        '';
+      };
+    };
+  };
+
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.fwupd ];
+
+    environment.etc = {
+      "fwupd/daemon.conf" = {
+        source = pkgs.writeText "daemon.conf" ''
+          [fwupd]
+          BlacklistDevices=${lib.concatStringsSep ";" cfg.blacklistDevices}
+          BlacklistPlugins=${lib.concatStringsSep ";" cfg.blacklistPlugins}
+        '';
+      };
+    } // originalEtc;
+
+    services.dbus.packages = [ pkgs.fwupd ];
+
+    services.udev.packages = [ pkgs.fwupd ];
+
+    systemd.packages = [ pkgs.fwupd ];
+
+    systemd.tmpfiles.rules = [
+      "d /var/lib/fwupd 0755 root root -"
+    ];
+  };
+}

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -1,31 +1,56 @@
 { stdenv, fetchurl, gtk_doc, pkgconfig, gobjectIntrospection, intltool
-, libgudev, polkit, appstream-glib, gusb, sqlite, libarchive
-, libsoup, docbook2x, gpgme, libxslt, libelf, libsmbios, efivar
-, fwupdate, libyaml, valgrind, meson, libuuid, pygobject3
-, pillow, ninja, gcab
+, libgudev, polkit, appstream-glib, gusb, sqlite, libarchive, glib_networking
+, libsoup, docbook2x, gpgme, libxslt, libelf, libsmbios, efivar, glibcLocales
+, fwupdate, libyaml, valgrind, meson, libuuid, pygobject3, colord
+, pillow, ninja, gcab, gnutls, python3Packages, wrapGAppsHook
 }:
-let version = "0.9.6";
-in
-  stdenv.mkDerivation
-    { name = "fwupd-${version}";
-      src = fetchurl
-        { url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-          sha256 = "0h3y4ygckvkjdx7yxwbm273iv84yk37ivlcf4xvq95g64vs8gfhf";
-        };
-      buildInputs =
-        [ gtk_doc pkgconfig gobjectIntrospection intltool libgudev
-          polkit appstream-glib gusb sqlite libarchive libsoup
-          docbook2x libxslt libelf libsmbios fwupdate libyaml valgrind
-          meson gpgme libuuid pygobject3 pillow ninja gcab
-        ];
-      patches = [ ./fix-missing-deps.patch ];
-      preConfigure = ''
-        export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${efivar}/include/efivar"
-      '';
-      mesonFlags = [ "-Denable-colorhug=false" "-Denable-man=false" "-Denable-tests=false" "--localstatedir=/var" "-Denable-doc=false" "-Dwith-bootdir=/boot" ];
-      enableParallelBuilding = true;
-      meta =
-        { license = [ stdenv.lib.licenses.gpl2 ];
-          platforms = stdenv.lib.platforms.linux;
-        };
-    }
+let
+  version = "1.0.1";
+in stdenv.mkDerivation {
+  name = "fwupd-${version}";
+  src = fetchurl {
+    url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
+    sha256 = "1k627rja7df51dkzqvkzgbwrrj4049k6408d01m34n66zwr2fp59";
+  };
+
+  nativeBuildInputs = [
+    meson ninja gtk_doc pkgconfig gobjectIntrospection intltool glibcLocales
+    valgrind gcab docbook2x libxslt pygobject3 python3Packages.pycairo wrapGAppsHook
+  ];
+  buildInputs = [
+    polkit appstream-glib gusb sqlite libarchive libsoup libelf libsmbios fwupdate libyaml
+    libgudev colord gpgme libuuid pillow gnutls glib_networking
+  ];
+
+  LC_ALL = "en_US.UTF-8"; # For po/make-images
+
+  NIX_CFLAGS_COMPILE = [
+    "-I${efivar}/include/efivar"
+    # warning: "__LIBELF_INTERNAL__" is not defined
+    "-Wno-error=undef"
+  ];
+
+  patches = [
+    ./fix-missing-deps.patch
+  ];
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  mesonFlags = [
+    "-Denable-man=false"
+    "-Denable-tests=false"
+    "-Denable-doc=false"
+    "-Dwith-bootdir=/boot"
+    "-Dwith-udevdir=lib/udev"
+    "-Dwith-systemdunitdir=lib/systemd/system"
+    "--localstatedir=/var"
+  ];
+
+  enableParallelBuilding = true;
+  meta = {
+    homepage = https://fwupd.org/;
+    license = [ stdenv.lib.licenses.gpl2 ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/firmware/fwupd/fix-missing-deps.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/fix-missing-deps.patch
@@ -1,86 +1,99 @@
-diff -Naur fwupd-0.9.6-orig/data/meson.build fwupd-0.9.6/data/meson.build
---- fwupd-0.9.6-orig/data/meson.build	2017-08-03 05:45:02.000000000 -0400
-+++ fwupd-0.9.6/data/meson.build	2017-09-02 19:58:37.324596487 -0400
-@@ -20,7 +20,7 @@
+--- a/data/builder/meson.build
++++ b/data/builder/meson.build
+@@ -1,3 +0,0 @@
+-install_data('README.md',
+-  install_dir : join_paths(get_option('localstatedir'), 'lib', 'fwupd', 'builder')
+-)
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -7,16 +7,12 @@
+   subdir('installed-tests')
+ endif
+ 
+-install_data(['daemon.conf'],
+-  install_dir : join_paths(get_option('sysconfdir'), 'fwupd')
+-)
+-
+ install_data(['org.freedesktop.fwupd.metainfo.xml'],
+   install_dir: join_paths(get_option('datadir'), 'metainfo')
  )
  
- install_data(['90-fwupd-devices.rules'],
--  install_dir : join_paths(udev.get_pkgconfig_variable('udevdir'), 'rules.d')
-+  install_dir : join_paths(get_option('prefix'), 'lib', 'udev', 'rules.d')
+ install_data(['org.freedesktop.fwupd.conf'],
+-  install_dir : join_paths(get_option('sysconfdir'), 'dbus-1', 'system.d')
++  install_dir : join_paths(get_option('prefix'), 'etc', 'dbus-1', 'system.d')
  )
  
- con2 = configuration_data()
-@@ -52,7 +52,7 @@
-     output : 'fwupd-offline-update.service',
-     configuration : con2,
-     install: true,
--    install_dir: systemd.get_pkgconfig_variable('systemdsystemunitdir'),
-+    install_dir: join_paths(get_option('prefix'), 'lib', 'systemd', 'system'),
+ install_data(['metadata.xml'],
+--- a/data/pki/meson.build
++++ b/data/pki/meson.build
+@@ -3,13 +3,13 @@
+       'GPG-KEY-Hughski-Limited',
+       'GPG-KEY-Linux-Vendor-Firmware-Service',
+     ],
+-    install_dir : join_paths(get_option('sysconfdir'), 'pki', 'fwupd')
++    install_dir : join_paths(get_option('prefix'), 'etc', 'pki', 'fwupd')
+   )
+ 
+   install_data([
+       'GPG-KEY-Linux-Vendor-Firmware-Service',
+     ],
+-    install_dir : join_paths(get_option('sysconfdir'), 'pki', 'fwupd-metadata')
++    install_dir : join_paths(get_option('prefix'), 'etc', 'pki', 'fwupd-metadata')
    )
  endif
  
-@@ -63,6 +63,6 @@
-     output : 'fwupd.service',
-     configuration : con2,
-     install: true,
--    install_dir: systemd.get_pkgconfig_variable('systemdsystemunitdir'),
-+    install_dir: join_paths(get_option('prefix'), 'lib', 'systemd', 'system'),
+@@ -17,12 +17,12 @@
+   install_data([
+       'LVFS-CA.pem',
+     ],
+-    install_dir : join_paths(get_option('sysconfdir'), 'pki', 'fwupd')
++    install_dir : join_paths(get_option('prefix'), 'etc', 'pki', 'fwupd')
+   )
+   install_data([
+       'LVFS-CA.pem',
+     ],
+-    install_dir : join_paths(get_option('sysconfdir'), 'pki', 'fwupd-metadata')
++    install_dir : join_paths(get_option('prefix'), 'etc', 'pki', 'fwupd-metadata')
    )
  endif
-diff -Naur fwupd-0.9.6-orig/libdfu/meson.build fwupd-0.9.6/libdfu/meson.build
---- fwupd-0.9.6-orig/libdfu/meson.build	2017-08-03 05:45:02.000000000 -0400
-+++ fwupd-0.9.6/libdfu/meson.build	2017-09-02 19:58:37.325596508 -0400
-@@ -23,6 +23,10 @@
-   giounix,
-   libm,
-   gusb,
-+  uuid,
-+  libarchive,
-+  soup,
-+  libgcab
- ]
  
- if get_option('enable-libelf')
-diff -Naur fwupd-0.9.6-orig/meson.build fwupd-0.9.6/meson.build
---- fwupd-0.9.6-orig/meson.build	2017-08-03 05:45:02.000000000 -0400
-+++ fwupd-0.9.6/meson.build	2017-09-02 19:59:07.406216716 -0400
-@@ -124,6 +124,7 @@
- if polkit.version().version_compare('>= 0.114')
-   conf.set('HAVE_POLKIT_0_114', '1')
- endif
-+libgcab = dependency('libgcab-1.0')
- gudev = dependency('gudev-1.0')
- appstream_glib = dependency('appstream-glib', version : '>= 0.6.9')
- gusb = dependency('gusb', version : '>= 0.2.9')
-@@ -200,7 +201,7 @@
-                         'fwupd-plugins-2')
- conf.set_quoted('PLUGINDIR', plugin_dir)
- 
--conf.set_quoted('SYSCONFDIR', get_option('sysconfdir'))
-+conf.set_quoted('SYSCONFDIR', '/etc')
- conf.set_quoted('BINDIR',
-                 join_paths(get_option('prefix'),
-                            get_option('bindir')))
-@@ -227,6 +228,9 @@
- plugin_deps += gmodule
- plugin_deps += gusb
- plugin_deps += soup
-+plugin_deps += libarchive
-+plugin_deps += uuid
-+plugin_deps += libgcab
- 
- subdir('data')
- subdir('docs')
-@@ -255,6 +259,3 @@
-   endif
+--- a/data/remotes.d/meson.build
++++ b/data/remotes.d/meson.build
+@@ -3,7 +3,7 @@
+       'lvfs.conf',
+       'lvfs-testing.conf',
+     ],
+-    install_dir : join_paths(get_option('sysconfdir'), 'fwupd', 'remotes.d')
++    install_dir : join_paths(get_option('prefix'), 'etc', 'fwupd', 'remotes.d')
+   )
  endif
  
--if get_option('enable-systemd')
--  meson.add_install_script('meson_post_install.sh', systemd.get_pkgconfig_variable('systemdsystemunitdir'), localstatedir)
--endif
-diff -Naur fwupd-0.9.6-orig/po/make-images.sh fwupd-0.9.6/po/make-images.sh
---- fwupd-0.9.6-orig/po/make-images.sh	2017-08-03 05:45:02.000000000 -0400
-+++ fwupd-0.9.6/po/make-images.sh	2017-09-02 19:58:37.328596570 -0400
+@@ -19,12 +19,12 @@
+   output : 'fwupd.conf',
+   configuration : con2,
+   install: true,
+-  install_dir: join_paths(get_option('sysconfdir'), 'fwupd', 'remotes.d'),
++  install_dir: join_paths(get_option('prefix'), 'etc', 'fwupd', 'remotes.d'),
+ )
+ configure_file(
+   input : 'vendor.conf',
+   output : 'vendor.conf',
+   configuration : con2,
+   install: true,
+-  install_dir: join_paths(get_option('sysconfdir'), 'fwupd', 'remotes.d'),
++  install_dir: join_paths(get_option('prefix'), 'etc', 'fwupd', 'remotes.d'),
+ )
+--- a/meson_post_install.sh
++++ b/meson_post_install.sh
+@@ -11,6 +11,4 @@
+     echo 'Updating systemd deps'
+     mkdir -p ${DESTDIR}${SYSTEMDUNITDIR}/system-update.target.wants
+     ln -sf ../fwupd-offline-update.service ${DESTDIR}${SYSTEMDUNITDIR}/system-update.target.wants/fwupd-offline-update.service
+-    echo 'Creating stateful directory'
+-    mkdir -p ${DESTDIR}${LOCALSTATEDIR}/lib/fwupd
+ #fi
+--- a/po/make-images.sh
++++ b/po/make-images.sh
 @@ -7,6 +7,7 @@
  #
  install -m 0755 -d ${MESON_INSTALL_DESTDIR_PREFIX}/share/locale/
@@ -89,26 +102,3 @@ diff -Naur fwupd-0.9.6-orig/po/make-images.sh fwupd-0.9.6/po/make-images.sh
  for x in ${MESON_INSTALL_DESTDIR_PREFIX}/share/locale/*/LC_IMAGES/*.bmp ; do
      gzip -f ${x}
  done
-diff -Naur fwupd-0.9.6-orig/src/meson.build fwupd-0.9.6/src/meson.build
---- fwupd-0.9.6-orig/src/meson.build	2017-08-03 05:45:02.000000000 -0400
-+++ fwupd-0.9.6/src/meson.build	2017-09-02 19:58:37.329596590 -0400
-@@ -24,6 +24,9 @@
-     polkit,
-     soup,
-     sqlite,
-+    uuid,
-+    libarchive,
-+    libgcab
-   ],
-   link_with : fwupd,
-   c_args : [
-@@ -73,6 +76,9 @@
-     gpgme,
-     gpgerror,
-     valgrind,
-+    uuid,
-+    libarchive,
-+    libgcab
-   ],
-   link_with : fwupd,
-   c_args : [


### PR DESCRIPTION
###### Motivation for this change

I cherry-picked from GNOME 3.26, where it builds sandboxed. Then I updated again (to 1.0.0), added a nixos service and hopefully fixed the problems from #24376. The new version contains some backwards incompatible changes but we do not depend on it anywhere.

There are several issues:
* ~~mesonFlags variable does not interpolate variables so I had to modify it in preConfigureHook.~~
* ~~The sysconfdir and localstatedir are inside the nix store, i.e. not writeable, making any operation impossible. I also had to remove `ReadWritePaths` from systemd service file to prevent “Failed at step NAMESPACE spawning” error.~~ Solved by NixOS module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @shlevy 