### PR TITLE
nixos/zsh-syntax-highlighting: refactor

### DIFF
--- a/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
+++ b/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
@@ -5,74 +5,74 @@ with lib;
 let
   cfg = config.programs.zsh.syntaxHighlighting;
 in
-  {
-    options = {
-      programs.zsh.syntaxHighlighting = {
-        enable = mkEnableOption "zsh-syntax-highlighting";
+{
+  options = {
+    programs.zsh.syntaxHighlighting = {
+      enable = mkEnableOption "zsh-syntax-highlighting";
 
-        highlighters = mkOption {
-          default = [ "main" ];
+      highlighters = mkOption {
+        default = [ "main" ];
 
-          # https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/docs/highlighters.md
-          type = types.listOf(types.enum([
-            "main"
-            "brackets"
-            "pattern"
-            "cursor"
-            "root"
-            "line"
-          ]));
+        # https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/docs/highlighters.md
+        type = types.listOf(types.enum([
+          "main"
+          "brackets"
+          "pattern"
+          "cursor"
+          "root"
+          "line"
+        ]));
 
-          description = ''
-            Specifies the highlighters to be used by zsh-syntax-highlighting.
+        description = ''
+          Specifies the highlighters to be used by zsh-syntax-highlighting.
 
-            The following defined options can be found here:
-            https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/docs/highlighters.md
-          '';
-        };
+          The following defined options can be found here:
+          https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/docs/highlighters.md
+        '';
+      };
 
-        patterns = mkOption {
-          default = {};
-          type = types.attrsOf types.string;
+      patterns = mkOption {
+        default = {};
+        type = types.attrsOf types.string;
 
-          example = literalExample ''
-            {
-              "rm -rf *" = "fg=white,bold,bg=red";
-            }
-          '';
+        example = literalExample ''
+          {
+            "rm -rf *" = "fg=white,bold,bg=red";
+          }
+        '';
 
-          description = ''
-            Specifies custom patterns to be highlighted by zsh-syntax-highlighting.
+        description = ''
+          Specifies custom patterns to be highlighted by zsh-syntax-highlighting.
 
-            Please refer to the docs for more information about the usage:
-            https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/docs/highlighters/pattern.md
-          '';
-        };
+          Please refer to the docs for more information about the usage:
+          https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/docs/highlighters/pattern.md
+        '';
       };
     };
+  };
 
-    config = mkIf cfg.enable {
-      environment.systemPackages = with pkgs; [ zsh-syntax-highlighting ];
+  config = mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [ zsh-syntax-highlighting ];
 
-      programs.zsh.interactiveShellInit = with pkgs; with builtins; ''
-        source ${zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+    assertions = [
+      {
+        assertion = length(attrNames cfg.patterns) > 0 -> elem "pattern" cfg.highlighters;
+        message = ''
+          When highlighting patterns, "pattern" needs to be included in the list of highlighters.
+        '';
+      }
+    ];
 
-        ${optionalString (length(cfg.highlighters) > 0)
-          "ZSH_HIGHLIGHT_HIGHLIGHTERS=(${concatStringsSep " " cfg.highlighters})"
-        }
-
-        ${let
-            n = attrNames cfg.patterns;
-          in
-            optionalString (length(n) > 0)
-              (assert(elem "pattern" cfg.highlighters); (foldl (
-                a: b:
-                  ''
-                    ${a}
-                    ZSH_HIGHLIGHT_PATTERNS+=('${b}' '${attrByPath [b] "" cfg.patterns}')
-                  ''
-              ) "") n)
-        }
-      '';
-    };
-  }
+    programs.zsh.interactiveShellInit = with pkgs;
+      lib.concatStringsSep "\n" ([
+        "source ${zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+      ] ++ optional (length(cfg.highlighters) > 0)
+        "ZSH_HIGHLIGHT_HIGHLIGHTERS=(${concatStringsSep " " cfg.highlighters})"
+        ++ optionals (length(attrNames cfg.patterns) > 0)
+          (mapAttrsToList (
+            pattern: design:
+            "ZSH_HIGHLIGHT_PATTERNS+=('${pattern}' '${design}')"
+          ) cfg.patterns)
+      );
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
Refactored to add a message to the assertion, which makes the error more obvious when the condition is not met.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested functionality on my system :)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
