### PR TITLE
qt5: 5.9.1 -> 5.9.2

### DIFF
--- a/pkgs/development/libraries/qt-5/5.9/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.9/fetch.sh
@@ -1,2 +1,2 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.9/5.9.1/submodules/ \
+WGET_ARGS=( https://download.qt.io/archive/qt/5.9/5.9.2/submodules/ \
             -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-5/5.9/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtbase/default.nix
@@ -3,7 +3,7 @@
   src, version, qtCompatVersion,
 
   coreutils, bison, flex, gdb, gperf, lndir, patchelf, perl, pkgconfig, python2,
-  ruby,
+  ruby, which,
   # darwin support
   darwin, libiconv, libcxx,
 
@@ -73,7 +73,7 @@ stdenv.mkDerivation {
     ++ lib.optional (postgresql != null) postgresql;
 
   nativeBuildInputs =
-    [ bison flex gperf lndir perl pkgconfig python2 ]
+    [ bison flex gperf lndir perl pkgconfig python2 which ]
     ++ lib.optional (!stdenv.isDarwin) patchelf;
 
   outputs = [ "out" "dev" "bin" ];

--- a/pkgs/development/libraries/qt-5/5.9/srcs.nix
+++ b/pkgs/development/libraries/qt-5/5.9/srcs.nix
@@ -3,275 +3,283 @@
 
 {
   qt3d = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qt3d-opensource-src-5.9.1.tar.xz";
-      sha256 = "15j9znfnxch1n6fwz9ngi30msdzh0wlpykl53cs8g2fp2awfa7sg";
-      name = "qt3d-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qt3d-opensource-src-5.9.2.tar.xz";
+      sha256 = "10q7npsl087sja0g2n3v0cg4n75y7sbrs3mfjcsg1wpkw8psjmf9";
+      name = "qt3d-opensource-src-5.9.2.tar.xz";
     };
   };
   qtactiveqt = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtactiveqt-opensource-src-5.9.1.tar.xz";
-      sha256 = "07zq60xg7nnlny7qgj6dk1ibg3fzhbdh78gpd0s6x1n822iyislg";
-      name = "qtactiveqt-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtactiveqt-opensource-src-5.9.2.tar.xz";
+      sha256 = "1kz59ns6afnd8s73ys7hqffg9ki9g7px009b2ab72nq7f8cqsib0";
+      name = "qtactiveqt-opensource-src-5.9.2.tar.xz";
     };
   };
   qtandroidextras = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtandroidextras-opensource-src-5.9.1.tar.xz";
-      sha256 = "0nq879jsa2z1l5q3n0hhiv15mzfm5c6s7zfblcc10sgim90p5mjj";
-      name = "qtandroidextras-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtandroidextras-opensource-src-5.9.2.tar.xz";
+      sha256 = "1hsx16v17iqjhs20xn7an2ad7g8djwrmxachscjhji1dvk4682nl";
+      name = "qtandroidextras-opensource-src-5.9.2.tar.xz";
     };
   };
   qtbase = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtbase-opensource-src-5.9.1.tar.xz";
-      sha256 = "1ikm896jzyfyjv2qv8n3fd81sxb4y24zkygx36865ygzyvlj36mw";
-      name = "qtbase-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtbase-opensource-src-5.9.2.tar.xz";
+      sha256 = "16v0dny4rcyd5p8qsnsfg89w98k8kqk3rp9x3g3k7xjmi53bpqkz";
+      name = "qtbase-opensource-src-5.9.2.tar.xz";
     };
   };
   qtcanvas3d = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtcanvas3d-opensource-src-5.9.1.tar.xz";
-      sha256 = "10fy8wqfw2yhha6lyky5g1a72137aj8pji7mk0wjnggh629z12sb";
-      name = "qtcanvas3d-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtcanvas3d-opensource-src-5.9.2.tar.xz";
+      sha256 = "1siyzgm1mjx90rwyzzq9vw2s2xzyf6n7q0vn8gw7mdim5indda44";
+      name = "qtcanvas3d-opensource-src-5.9.2.tar.xz";
     };
   };
   qtcharts = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtcharts-opensource-src-5.9.1.tar.xz";
-      sha256 = "180df5v7i1ki8hc3lgi6jcfdyz7f19pb73dvfkw402wa2gfcna3k";
-      name = "qtcharts-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtcharts-opensource-src-5.9.2.tar.xz";
+      sha256 = "193a3imkgryw42s0gbwaj9gpqd673h3jrg86jvmy33l2fc5gfyjf";
+      name = "qtcharts-opensource-src-5.9.2.tar.xz";
     };
   };
   qtconnectivity = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtconnectivity-opensource-src-5.9.1.tar.xz";
-      sha256 = "1mbzmqix0388iq20a1ljd1pgdq259rm1xzp9kx8gigqpamqqnqs0";
-      name = "qtconnectivity-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtconnectivity-opensource-src-5.9.2.tar.xz";
+      sha256 = "1k7kjmlny0ykm40qx796wbsg3310v6b8hqizkbr597cmxjbrax9c";
+      name = "qtconnectivity-opensource-src-5.9.2.tar.xz";
     };
   };
   qtdatavis3d = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtdatavis3d-opensource-src-5.9.1.tar.xz";
-      sha256 = "14d1q07winh6n1bkc616dapwfnsfkcjyg5zngdqjdj9mza8ang13";
-      name = "qtdatavis3d-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtdatavis3d-opensource-src-5.9.2.tar.xz";
+      sha256 = "1cmjjbbmdqdix1f8b7qyc2vwhj9pvchc8r4lp65qw11dhycmdbh6";
+      name = "qtdatavis3d-opensource-src-5.9.2.tar.xz";
     };
   };
   qtdeclarative = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtdeclarative-opensource-src-5.9.1.tar.xz";
-      sha256 = "1zwlxrgraxhlsdkwsai3pjbz7f3a6rsnsg2mjrpay6cz3af6rznj";
-      name = "qtdeclarative-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtdeclarative-opensource-src-5.9.2.tar.xz";
+      sha256 = "020bha6q8byxc8cj5zw7gms5rgsjg71hv31hv1rr2fy7x56zsh0d";
+      name = "qtdeclarative-opensource-src-5.9.2.tar.xz";
     };
   };
   qtdoc = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtdoc-opensource-src-5.9.1.tar.xz";
-      sha256 = "1d2kk9wzm2261ap87nyf743a4662gll03gz5yh5qi7k620lk372x";
-      name = "qtdoc-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtdoc-opensource-src-5.9.2.tar.xz";
+      sha256 = "0dfva8h8f9wpszih285qcxlfcijy52qcbfy1zy20gxh72nfi86c9";
+      name = "qtdoc-opensource-src-5.9.2.tar.xz";
     };
   };
   qtgamepad = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtgamepad-opensource-src-5.9.1.tar.xz";
-      sha256 = "055w4649zi93q1sl32ngqwgnl2vxw1idnm040s9gjgjb67gi81zi";
-      name = "qtgamepad-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtgamepad-opensource-src-5.9.2.tar.xz";
+      sha256 = "0lm5v43psf7r8zc79dcjdmmdnz4jm30ylgkvsyv8k88mj06yklbn";
+      name = "qtgamepad-opensource-src-5.9.2.tar.xz";
     };
   };
   qtgraphicaleffects = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtgraphicaleffects-opensource-src-5.9.1.tar.xz";
-      sha256 = "1zsr3a5dsmpvrb5h4m4h42wqmkvkks3d8mmyrx4k0mfr6s7c71jz";
-      name = "qtgraphicaleffects-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtgraphicaleffects-opensource-src-5.9.2.tar.xz";
+      sha256 = "0xpvigfiqfqvf05ywj8x69y57rp8dwq2hs1kpxlxs15pniz4wn8l";
+      name = "qtgraphicaleffects-opensource-src-5.9.2.tar.xz";
     };
   };
   qtimageformats = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtimageformats-opensource-src-5.9.1.tar.xz";
-      sha256 = "0iwa3dys5rv706cpxwhmgircv783pmlyl1yrsc5i0rha643y7zkr";
-      name = "qtimageformats-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtimageformats-opensource-src-5.9.2.tar.xz";
+      sha256 = "1wwxxcl24mk1p4w6knyfai09axmwqsm6cgsbkjsmdz3zmjh6qqis";
+      name = "qtimageformats-opensource-src-5.9.2.tar.xz";
     };
   };
   qtlocation = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtlocation-opensource-src-5.9.1.tar.xz";
-      sha256 = "058mgvlaml9rkfhkpr1n3avhi12zlva131sqhbwj4lwwyqfkri2b";
-      name = "qtlocation-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtlocation-opensource-src-5.9.2.tar.xz";
+      sha256 = "033b6l6jbvmc0k5qvbgh5vkzvfga7npqcphrywrrqkmx9vj446n8";
+      name = "qtlocation-opensource-src-5.9.2.tar.xz";
     };
   };
   qtmacextras = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtmacextras-opensource-src-5.9.1.tar.xz";
-      sha256 = "0096g9l2hwsiwlzfjkw7rhkdnyvb5gzjzyjjg9kqfnsagbwscv11";
-      name = "qtmacextras-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtmacextras-opensource-src-5.9.2.tar.xz";
+      sha256 = "0f14xkardmidvwljccrv6adcs4nyn8rzry9k74mwqn0ikvycs3my";
+      name = "qtmacextras-opensource-src-5.9.2.tar.xz";
     };
   };
   qtmultimedia = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtmultimedia-opensource-src-5.9.1.tar.xz";
-      sha256 = "1r76zvbv6wwb7lgw9jwlx382iyw34i1amxaypb5bg3j1niqvx3z4";
-      name = "qtmultimedia-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtmultimedia-opensource-src-5.9.2.tar.xz";
+      sha256 = "0815hi3cxy5zy6yc5fkdpx2xd6rk7968j1ziwl2g4wa80802g9n9";
+      name = "qtmultimedia-opensource-src-5.9.2.tar.xz";
     };
   };
   qtnetworkauth = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtnetworkauth-opensource-src-5.9.1.tar.xz";
-      sha256 = "1fgax3p7lqcz29z2n1qxnfpkj3wxq1x9bfx61q6nss1fs74pxzra";
-      name = "qtnetworkauth-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtnetworkauth-opensource-src-5.9.2.tar.xz";
+      sha256 = "16i33m8x5yii22ciq97bpfmnw0lwhvgv84i2az30a1ikm9dg00x0";
+      name = "qtnetworkauth-opensource-src-5.9.2.tar.xz";
     };
   };
   qtpurchasing = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtpurchasing-opensource-src-5.9.1.tar.xz";
-      sha256 = "0b1hlaq6rb7d6b6h8kqd26klcpzf9vcdjrv610kdj0drb00jg3ss";
-      name = "qtpurchasing-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtpurchasing-opensource-src-5.9.2.tar.xz";
+      sha256 = "04f28y7qcr4kd0pw26mm515qj7haxr0i8lijn1q47wkikxyhawca";
+      name = "qtpurchasing-opensource-src-5.9.2.tar.xz";
     };
   };
   qtquickcontrols = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtquickcontrols-opensource-src-5.9.1.tar.xz";
-      sha256 = "0bpc465q822phw3dcbddn70wj1fjlc2hxskkp1z9gl7r23hx03jj";
-      name = "qtquickcontrols-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtquickcontrols-opensource-src-5.9.2.tar.xz";
+      sha256 = "07xxhkfsljwdwlp9jfp88pwkrig02y2pnwhdsaz8mkcackwfq2az";
+      name = "qtquickcontrols-opensource-src-5.9.2.tar.xz";
     };
   };
   qtquickcontrols2 = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtquickcontrols2-opensource-src-5.9.1.tar.xz";
-      sha256 = "1zq86kqz85wm3n84jcxkxw5x1mrhkqzldkigf8xm3l8j24rf0fr0";
-      name = "qtquickcontrols2-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtquickcontrols2-opensource-src-5.9.2.tar.xz";
+      sha256 = "1ln83afxyp5dmvdnq6n7as82xrd5k3xvfx7b1jxnljivslyxsm9b";
+      name = "qtquickcontrols2-opensource-src-5.9.2.tar.xz";
     };
   };
   qtremoteobjects = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtremoteobjects-opensource-src-5.9.1.tar.xz";
-      sha256 = "10kwq0fgmi6zsqhb6s1nkcydpyl8d8flzdpgmyj50c4h2xhg2km0";
-      name = "qtremoteobjects-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtremoteobjects-opensource-src-5.9.2.tar.xz";
+      sha256 = "1ylphdwis34y4pm9xiwh2xqfd0hh2gp8kkawlps2q5mh2bm11376";
+      name = "qtremoteobjects-opensource-src-5.9.2.tar.xz";
     };
   };
   qtscript = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtscript-opensource-src-5.9.1.tar.xz";
-      sha256 = "13qq2mjfhqdcvkmzrgxg1gr5kww1ygbwb7r71xxl6rjzbn30hshp";
-      name = "qtscript-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtscript-opensource-src-5.9.2.tar.xz";
+      sha256 = "1wa0rnbphkhgydnwkf5bjwn0llskl6hgs0964nh0jik8qaspv027";
+      name = "qtscript-opensource-src-5.9.2.tar.xz";
     };
   };
   qtscxml = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtscxml-opensource-src-5.9.1.tar.xz";
-      sha256 = "1m3b6wg5hqasdfc5igpj9bq3czql5kkvvn3rx1ig508kdlh5i5s0";
-      name = "qtscxml-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtscxml-opensource-src-5.9.2.tar.xz";
+      sha256 = "0pdimqwdrj8hckm81lwy1z58ji4bdv0bzgv336m0a8v3pj914awx";
+      name = "qtscxml-opensource-src-5.9.2.tar.xz";
     };
   };
   qtsensors = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtsensors-opensource-src-5.9.1.tar.xz";
-      sha256 = "1772x7r6y9xv2sv0w2dfz2yhagsq5bpa9kdpzg0qikccmabr7was";
-      name = "qtsensors-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtsensors-opensource-src-5.9.2.tar.xz";
+      sha256 = "1lxmhi19dbb8vjhpjph0l0ss6zh72hb4908lp4s1pgf8r641ai3r";
+      name = "qtsensors-opensource-src-5.9.2.tar.xz";
     };
   };
   qtserialbus = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtserialbus-opensource-src-5.9.1.tar.xz";
-      sha256 = "1hzk377c3zl4dm5hxwvpxg2w096m160448y9df6v6l8xpzpzxafa";
-      name = "qtserialbus-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtserialbus-opensource-src-5.9.2.tar.xz";
+      sha256 = "025yv7zajz5scrmkjkmgkyvxpgkliqvrzc88is0gr481zpd4phmv";
+      name = "qtserialbus-opensource-src-5.9.2.tar.xz";
     };
   };
   qtserialport = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtserialport-opensource-src-5.9.1.tar.xz";
-      sha256 = "0sbsc7n701kxl16r247a907zg2afmbx1xlml5jkc6a9956zqbzp1";
-      name = "qtserialport-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtserialport-opensource-src-5.9.2.tar.xz";
+      sha256 = "0hndc9z7qzxazzjvc6k5yd58afw13444plk70b05nqdi5p19rvah";
+      name = "qtserialport-opensource-src-5.9.2.tar.xz";
     };
   };
   qtspeech = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtspeech-opensource-src-5.9.1.tar.xz";
-      sha256 = "00daxkf8iwf6n9rhkkv3isv5qa8wijwzb0zy1f6zlm3vcc8fz75c";
-      name = "qtspeech-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtspeech-opensource-src-5.9.2.tar.xz";
+      sha256 = "0cq33dffi7q7dnvzhdivky5prakb8xnwap0b76fwgirhbbn88ypg";
+      name = "qtspeech-opensource-src-5.9.2.tar.xz";
     };
   };
   qtsvg = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtsvg-opensource-src-5.9.1.tar.xz";
-      sha256 = "1rg2q4snh2g4n93zmk995swwkl0ab1jr9ka9xpj56ddifkw99wlr";
-      name = "qtsvg-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtsvg-opensource-src-5.9.2.tar.xz";
+      sha256 = "020icrl9vi8jh8ygsssqrx2bl8bx28m15dwmf9a969qdnvxyp5ms";
+      name = "qtsvg-opensource-src-5.9.2.tar.xz";
     };
   };
   qttools = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qttools-opensource-src-5.9.1.tar.xz";
-      sha256 = "1s50kh3sg5wc5gqhwwznnibh7jcnfginnmkv66w62mm74k7mdsy4";
-      name = "qttools-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qttools-opensource-src-5.9.2.tar.xz";
+      sha256 = "06nqsa5mj0mc9w9xbm7mgdkb66x4wlvkhnas32f97sb8ic8rdf9b";
+      name = "qttools-opensource-src-5.9.2.tar.xz";
     };
   };
   qttranslations = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qttranslations-opensource-src-5.9.1.tar.xz";
-      sha256 = "0sdjiqli15fmkbqvhhgjfavff906sg56jx5xf8bg6xzd2j5544ja";
-      name = "qttranslations-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qttranslations-opensource-src-5.9.2.tar.xz";
+      sha256 = "0byi4s07lfnzzlr2c4sc5qg3hrysswmakwmf80q2mx50kpgnvwax";
+      name = "qttranslations-opensource-src-5.9.2.tar.xz";
     };
   };
   qtvirtualkeyboard = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtvirtualkeyboard-opensource-src-5.9.1.tar.xz";
-      sha256 = "0k79sqa8bg6gkbsk16320gnila1iiwpnl3vx03rysm5bqdnnlx3b";
-      name = "qtvirtualkeyboard-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtvirtualkeyboard-opensource-src-5.9.2.tar.xz";
+      sha256 = "1z66chp5746cb0rwy2isnpbvwjj44qvp2hg56n3g47dj901wldp8";
+      name = "qtvirtualkeyboard-opensource-src-5.9.2.tar.xz";
     };
   };
   qtwayland = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwayland-opensource-src-5.9.1.tar.xz";
-      sha256 = "1yizvbmh26mx1ffq0qaci02g2wihy68ld0y7r3z8nx3v5acb236g";
-      name = "qtwayland-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtwayland-opensource-src-5.9.2.tar.xz";
+      sha256 = "1ipn4xh0dj1kjg5i4vfl4gpx3hg2377w5gls47xpv1ikz41lshzn";
+      name = "qtwayland-opensource-src-5.9.2.tar.xz";
     };
   };
   qtwebchannel = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwebchannel-opensource-src-5.9.1.tar.xz";
-      sha256 = "003h09mla82f2znb8jjigx13ivc68ikgv7w04594yy7qdmd5yhl0";
-      name = "qtwebchannel-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtwebchannel-opensource-src-5.9.2.tar.xz";
+      sha256 = "09iss70c1iqgf8qpik35qlgrdw5y9935v0fm2ppgkmxdxkpls6ww";
+      name = "qtwebchannel-opensource-src-5.9.2.tar.xz";
     };
   };
   qtwebengine = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwebengine-opensource-src-5.9.1.tar.xz";
-      sha256 = "00b4d18m54pbxa1hm6ijh2mrd4wmrs7lkplys8b4liw8j7mpx8zn";
-      name = "qtwebengine-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtwebengine-opensource-src-5.9.2.tar.xz";
+      sha256 = "0251qk04yif4lsn8qvkc2kmzzmaw1v3pfh5ypr06d04zb3j6kc6a";
+      name = "qtwebengine-opensource-src-5.9.2.tar.xz";
+    };
+  };
+  qtwebsockets = {
+    version = "5.9.2";
+    src = fetchurl {
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtwebsockets-opensource-src-5.9.2.tar.xz";
+      sha256 = "0x0nx1ampqsgj9qlc3l32z3ham1a5vq7m2lnxk5pr92yj6yw3pdg";
+      name = "qtwebsockets-opensource-src-5.9.2.tar.xz";
     };
   };
   qtwebkit = {
@@ -290,44 +298,36 @@
       name = "qtwebkit-examples-opensource-src-5.9.1.tar.xz";
     };
   };
-  qtwebsockets = {
-    version = "5.9.1";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwebsockets-opensource-src-5.9.1.tar.xz";
-      sha256 = "0r1lya2jj3wfci82zfn0vk6vr8sk9k7xiphnkb0panhb8di769q1";
-      name = "qtwebsockets-opensource-src-5.9.1.tar.xz";
-    };
-  };
   qtwebview = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwebview-opensource-src-5.9.1.tar.xz";
-      sha256 = "0qmxrh4y3i9n8x6yhrlnahcn75cc2xwlc8mi4g8n2d83c3x7pxyn";
-      name = "qtwebview-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtwebview-opensource-src-5.9.2.tar.xz";
+      sha256 = "1cdqw6pjfqagnwxrha0s18zadjnm65dsildxj07h2qiwqxwyrjpw";
+      name = "qtwebview-opensource-src-5.9.2.tar.xz";
     };
   };
   qtwinextras = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwinextras-opensource-src-5.9.1.tar.xz";
-      sha256 = "1x7f944f3g2ml3mm594qv6jlvl5dzzsxq86yinp7av0lhnyrxk0s";
-      name = "qtwinextras-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtwinextras-opensource-src-5.9.2.tar.xz";
+      sha256 = "07qq9rxl6hhl300w7qxsjjbdd5fwpszfk3rbinxklg20f6c6ixml";
+      name = "qtwinextras-opensource-src-5.9.2.tar.xz";
     };
   };
   qtx11extras = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtx11extras-opensource-src-5.9.1.tar.xz";
-      sha256 = "00fn3bps48gjyw0pdqvvl9scknxdpmacby6hvdrdccc3jll0wgd6";
-      name = "qtx11extras-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtx11extras-opensource-src-5.9.2.tar.xz";
+      sha256 = "1ias745j5lfnrfkgyk0pr8n8zlkqs08gq7yyzaj1c645sh54b1fv";
+      name = "qtx11extras-opensource-src-5.9.2.tar.xz";
     };
   };
   qtxmlpatterns = {
-    version = "5.9.1";
+    version = "5.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtxmlpatterns-opensource-src-5.9.1.tar.xz";
-      sha256 = "094wwap2fsl23cys6rxh2ciw0gxbbiqbshnn4qs1n6xdjrj6i15m";
-      name = "qtxmlpatterns-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/archive/qt/5.9/5.9.2/submodules/qtxmlpatterns-opensource-src-5.9.2.tar.xz";
+      sha256 = "0knk4bplqhvsxar1wv16bzfw57q0aja12gdaxz7m8mvx121sm9ha";
+      name = "qtxmlpatterns-opensource-src-5.9.2.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change
For qtwebkit there is no 5.9.2, so this sticks to 5.9.1.

@ttuegel 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

