### PR TITLE
easyloggingpp: init at 9.95.0

### DIFF
--- a/pkgs/development/libraries/easyloggingpp/default.nix
+++ b/pkgs/development/libraries/easyloggingpp/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, gtest }:
+stdenv.mkDerivation rec {
+  name = "easyloggingpp-${version}";
+  version = "9.95.0";
+  src = fetchFromGitHub {
+    owner = "muflihun";
+    repo = "easyloggingpp";
+    rev = "v${version}";
+    sha256 = "0gzmznw6ffag9x55lixxffy6x7mvb7691x0md4q9rbh88zkws7kq";
+  };
+  nativeBuildInputs = [cmake];
+  buildInputs = [gtest];
+  cmakeFlags = [ "-Dtest=ON" "-Dbuild_static_lib=ON"];
+  NIX_CFLAGS_COMPILE = "-std=c++11" +
+    stdenv.lib.optionalString stdenv.isLinux " -pthread";
+  meta = {
+    description = "C++ logging library";
+    homepage = https://muflihun.github.io/easyloggingpp/;
+    license = stdenv.lib.licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [acowley];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8027,6 +8027,8 @@ with pkgs;
 
   dxflib = callPackage ../development/libraries/dxflib {};
 
+  easyloggingpp = callPackage ../development/libraries/easyloggingpp {};
+
   eccodes = callPackage ../development/libraries/eccodes { };
 
   eclib = callPackage ../development/libraries/eclib {};


### PR DESCRIPTION
###### Motivation for this change
Adding a package definition for a small C++ logging framework

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

