### PR TITLE
nixos/config/timezone: Disallow spaces

### DIFF
--- a/nixos/modules/config/timezone.nix
+++ b/nixos/modules/config/timezone.nix
@@ -5,6 +5,9 @@ with lib;
 let
 
   tzdir = "${pkgs.tzdata}/share/zoneinfo";
+  nospace  = str: filter (c: c == " ") (stringToCharacters str) == [];
+  timezone = types.nullOr (types.addCheck types.str nospace)
+    // { description = "null or string without spaces"; };
 
 in
 
@@ -15,7 +18,7 @@ in
 
       timeZone = mkOption {
         default = null;
-        type = types.nullOr types.str;
+        type = timezone;
         example = "America/New_York";
         description = ''
           The time zone used when displaying times and dates. See <link


### PR DESCRIPTION
###### Motivation for this change

#20115 causes a very strange and hard to debug error, and it's easy to accidentally write "New York" instead of "New_York"

I would have preferred a check morally equivalent to `tz: lib.pathExists "${pkgs.tzdata}/share/zoneinfo/right/${tz}"`, but I can't figure out how to do so in a pure manner without hardcoding an enum with all the contents.

This should prevent the most frequent mistake anyway.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

