### PR TITLE
pythonPackages.shapely: 1.5.15 -> 1.6.1

### DIFF
--- a/pkgs/development/python-modules/shapely/default.nix
+++ b/pkgs/development/python-modules/shapely/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     libc = if stdenv.isDarwin then "libc.dylib" else "libc.so.6";
   in ''
     sed -i "s|_lgeos = load_dll('geos_c', fallbacks=.*)|_lgeos = load_dll('geos_c', fallbacks=['${geos}/lib/libgeos_c${stdenv.hostPlatform.extensions.sharedLibrary}'])|" shapely/geos.py
-    sed -i "s|free = load_dll('c').free|free = load_dll('c', fallbacks=['${stdenv.cc.libc}/lib/${stdenv.cc.libc}']).free|" shapely/geos.py
+    sed -i "s|free = load_dll('c').free|free = load_dll('c', fallbacks=['${stdenv.cc.libc}/lib/${libc}']).free|" shapely/geos.py
   '';
 
   # tests/test_voctorized fails because the vectorized extension is not

--- a/pkgs/development/python-modules/shapely/default.nix
+++ b/pkgs/development/python-modules/shapely/default.nix
@@ -6,11 +6,11 @@
 buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "Shapely";
-  version = "1.5.15";
+  version = "1.6.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0lfqxb3kpdn0g9zzlhzg79yc8iyy4fpsk0p5nd80gar1mmhr8pg7";
+    sha256 = "1iyhrkm6g233gwbd20sf4aq4by0kg52cz1d2k7imnqgzjpmkgqas";
   };
 
   buildInputs = [ geos glibcLocales cython ];


### PR DESCRIPTION
###### Motivation for this change

@Mic92 once this is accepted, I’ll backport 85011d70845f5705d6b06ba2a3c2a10eb352fcd7 and 953ce94 to `release-17.09`. In its current state, shapely is not functioning in the stable channel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

