### PR TITLE
fcron module: fix use with hardlink-optimized store

### DIFF
--- a/nixos/modules/services/scheduling/fcron.nix
+++ b/nixos/modules/services/scheduling/fcron.nix
@@ -146,7 +146,7 @@ in
           --group fcron \
           --directory /var/spool/fcron
         # load system crontab file
-        /run/wrappers/bin/fcrontab -u systab ${pkgs.writeText "systab" cfg.systab}
+        /run/wrappers/bin/fcrontab -u systab - < ${pkgs.writeText "systab" cfg.systab}
       '';
 
       serviceConfig = {


### PR DESCRIPTION
Fixes an issue with the same symptoms as https://github.com/NixOS/nixpkgs/issues/25072 when the nix store is optimized with hardlinks.

fcron apparently checks for security reasons that the file isn't hardlinked anywhere when reading it, according to fcron's source code, subs.c:151 on commit 7afed73.

So the solution is to just pass it via stdin.

Tested by hand via `disabledModules` and import of the updated module file on an up-to-date 17.09.