### PR TITLE
pythonPackages.ofxclient: 1.3.8 -> 2.0.3

### DIFF
--- a/pkgs/development/python-modules/ofxclient/default.nix
+++ b/pkgs/development/python-modules/ofxclient/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchPypi,
+ ofxhome, ofxparse, beautifulsoup, lxml, keyring
+}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  version = "2.0.3";
+  pname = "ofxclient";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0jdhqsbl34yn3n0x6mwsnl58c25v5lp6vr910c2hk7l74l5y7538";
+  };
+
+  patchPhase = ''
+    substituteInPlace setup.py --replace '"argparse",' ""
+  '';
+
+  # ImportError: No module named tests
+  doCheck = false;
+
+  propagatedBuildInputs = [ ofxhome ofxparse beautifulsoup lxml keyring ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/captin411/ofxclient;
+    description = "OFX client for dowloading transactions from banks";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -24776,22 +24776,7 @@ EOF
     };
   };
 
-  ofxclient = buildPythonPackage rec {
-    name = "ofxclient-1.3.8";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/o/ofxclient/${name}.tar.gz";
-      sha256 = "99ab03bffdb30d9ec98724898f428f8e73129483417d5892799a0f0d2249f233";
-    };
-
-    patchPhase = ''
-      substituteInPlace setup.py --replace '"argparse",' ""
-    '';
-
-    # ImportError: No module named tests
-    doCheck = false;
-
-    propagatedBuildInputs = with self; [ ofxhome ofxparse beautifulsoup keyring ];
-  };
+  ofxclient = callPackage ../development/python-modules/ofxclient {};
 
   ofxhome = buildPythonPackage rec {
     name = "ofxhome-0.3.1";


### PR DESCRIPTION
###### Motivation for this change

Update to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

