### PR TITLE
ocamlPackages.camlp5: 7.01 -> 7.02

### DIFF
--- a/pkgs/development/tools/ocaml/camlp5/default.nix
+++ b/pkgs/development/tools/ocaml/camlp5/default.nix
@@ -6,11 +6,11 @@ in
 
 stdenv.mkDerivation {
 
-  name = "camlp5${if transitional then "_transitional" else ""}-7.01";
+  name = "camlp5${if transitional then "_transitional" else ""}-7.02";
 
   src = fetchzip {
-    url = https://github.com/camlp5/camlp5/archive/rel701.tar.gz;
-    sha256 = "1gxhj7y30f1hbcqnqgg80wz0ymbslsfh09kl2kiackp49fywl606";
+    url = https://github.com/camlp5/camlp5/archive/rel702.tar.gz;
+    sha256 = "1m2d55zrgllidhgslvzgmr27f56qzdahz2sv56bvjs3bg7grmhnc";
   };
 
   buildInputs = [ ocaml ];


### PR DESCRIPTION
###### Motivation for this change

Camlp5 version 7.01 does not work with OCaml 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distribution
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

