### PR TITLE
deja-dup:add dconf dependency

### DIFF
--- a/pkgs/applications/backup/deja-dup/default.nix
+++ b/pkgs/applications/backup/deja-dup/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
    at_spi2_core dbus gnome3.gnome_online_accounts libgpgerror
   ];
 
-  propagatedUserEnvPkgs = [ duplicity ];
+  propagatedUserEnvPkgs = [ duplicity gnome3.dconf ];
 
   postInstall = ''
     glib-compile-schemas $out/share/glib-2.0/schemas


### PR DESCRIPTION
without dconf deja-dup can only display the configuration interface,without being able to do anything with said interface

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

