### PR TITLE
solvespace: remove stray newline escape

### DIFF
--- a/pkgs/applications/graphics/solvespace/default.nix
+++ b/pkgs/applications/graphics/solvespace/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     substituteInPlace $out/share/applications/solvespace.desktop \
-      --replace /usr/bin/ $out/bin/ \
+      --replace /usr/bin/ $out/bin/
   '';
 
   meta = {


### PR DESCRIPTION
Apparently, when I wrote this derivation, I deleted a line and forgot to take out the escape. Doesn't seem to hurt the build, but it shouldn't be there either.