### PR TITLE
radare2: 1.6.0 -> 2.0.0

### DIFF
--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -34,10 +34,6 @@ stdenv.mkDerivation rec {
     substituteInPlace shlr/Makefile --replace CS_RELEASE=0 CS_RELEASE=1
     cp ${capstone} shlr/capstone-${cs_ver}.tar.gz
 
-    # make compiler happy (fixed in upstream 2017-08-11)
-    substituteInPlace libr/asm/arch/hexagon/gnu/hexagon-dis.c --replace \
-      '(*info->fprintf_func) (info->stream, errmsg);' \
-      '(*info->fprintf_func) (info->stream, "%s", errmsg);'
   '';
 
   buildInputs = [pkgconfig readline libusb libewf perl zlib openssl]

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -13,14 +13,14 @@ let
   inherit (stdenv.lib) optional;
 in
 stdenv.mkDerivation rec {
-  version = "1.6.0";
+  version = "2.0.0";
   name = "radare2-${version}";
 
   src = fetchFromGitHub {
     owner = "radare";
     repo = "radare2";
     rev = version;
-    sha256 = "0kb7y0b5kw2p1kxpzjgc8pnwdkqyzkijzp5d2a9zs2ira96668zd";
+    sha256 = "1ahai9x6jc15wjzdbdkri3rc88ark2i5s8nv2pxcp0wwldvawlzi";
   };
 
   postPatch = let


### PR DESCRIPTION
###### Motivation for this change

bump to latest version of r2

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

