### PR TITLE
shutter: 0.93.1 -> 0.94

### DIFF
--- a/pkgs/applications/graphics/shutter/default.nix
+++ b/pkgs/applications/graphics/shutter/default.nix
@@ -11,20 +11,12 @@ let
     ];
 in
 stdenv.mkDerivation rec {
-  name = "shutter-0.93.1";
+  name = "shutter-0.94";
 
   src = fetchurl {
-    url = "http://shutter-project.org/wp-content/uploads/releases/tars/${name}.tar.gz";
-    sha256 = "09cn3scwy98wqxkrjhnmxhpfnnynlbb41856yn5m3zwzqrxiyvak";
+    url = "https://launchpad.net/shutter/0.9x/0.94/+download/shutter-0.94.tar.gz";
+    sha256 = "943152cdf9e1b2096d38e3da9622d8bf97956a08eda747c3e7fcc564a3f0f40d";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "http://svnweb.mageia.org/packages/cauldron/shutter/current/SOURCES/CVE-2015-0854.patch?revision=880308&view=co";
-      name = "CVE-2015-0854.patch";
-      sha256 = "14r18sxz3ylf39cn9b85snjhjxdk6ngq4vnpljwghw2q5430nb12";
-    })
-  ];
 
   buildInputs = [ perl makeWrapper gdk_pixbuf librsvg ] ++ perlModules;
 


### PR DESCRIPTION
###### Motivation for this change
Upstream update to 0.94

Ref:
http://shutter-project.org/2017/09/after-a-long-time-a-new-bug-fix-release-0-94/
https://launchpad.net/shutter/+download
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

