### PR TITLE
fish: always set up the basic Nix env during shell initialization

### DIFF
--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -165,6 +165,12 @@ in
 
     # For resetting environment with `. /etc/set-environment` when needed
     # and discoverability (see motivation of #30418).
+    #
+    # The set-environment.sh script is also exposed here for use by shells in
+    # loading the essential Nix environment variables. It is loaded automatically
+    # by Nixpkgs' fish package, but it can by used by other shells in and
+    # outside of Nixpkgs. This is meant to be a path which can be used in common
+
     environment.etc."set-environment".source = config.system.build.setEnvironment;
 
     system.build.setEnvironment = pkgs.writeText "set-environment"
@@ -181,6 +187,9 @@ in
         # ~/bin if it exists overrides other bin directories.
         export PATH="$HOME/bin:$PATH"
       '';
+
+   # among different Nix module systems, for example NixOS and nix-darwin.
+    environment.etc."nix/support/set-environment.sh".source = "${system.build.setEnvironment}";
 
     system.activationScripts.binsh = stringAfter [ "stdio" ]
       ''

--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -102,28 +102,16 @@ in
     environment.etc."fish/foreign-env/shellInit".text = cfge.shellInit;
     environment.etc."fish/foreign-env/loginShellInit".text = cfge.loginShellInit;
     environment.etc."fish/foreign-env/interactiveShellInit".text = cfge.interactiveShellInit;
-
-    environment.etc."fish/nixos-env-preinit.fish".text = ''
-      # This happens before $__fish_datadir/config.fish sets fish_function_path, so it is currently
-      # unset. We set it and then completely erase it, leaving its configuration to $__fish_datadir/config.fish
-      set fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions $__fish_datadir/functions
-
-      # source the NixOS environment config
-      if [ -z "$__NIXOS_SET_ENVIRONMENT_DONE" ]
-          fenv source ${config.system.build.setEnvironment}
-      end
-
-      # clear fish_function_path so that it will be correctly set when we return to $__fish_datadir/config.fish
-      set -e fish_function_path
-    '';
-
     environment.etc."fish/config.fish".text = ''
       # /etc/fish/config.fish: DO NOT EDIT -- this file has been generated automatically.
 
       # if we haven't sourced the general config, do it
       if not set -q __fish_nixos_general_config_sourced
         set fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions $fish_function_path
-        fenv source /etc/fish/foreign-env/shellInit > /dev/null
+        # source the NixOS environment config
+        if [ -z "$__NIXOS_SET_ENVIRONMENT_DONE" ]
+            fenv source ${config.system.build.setEnvironment}
+        end
         set -e fish_function_path[1]
 
         ${cfg.shellInit}


### PR DESCRIPTION
###### Motivation for this change
Setting up Nix and Fish together can be a stumbling block for new users and an annoyance for experienced ones. It involves setting up a shell framework, installing a plugin, pointing that plugin to a POSIX shell script, deciding whether and how to suppress certain expected error messages, and figuring out how early in shell initialization this stuff needs to be sourced.

Moreover, Fish integrations (vendor-provided in some of our packages) currently only work for NixOS users. This makes them available to all Nix users, with no configuration at all.

It also locates all the logic for using `fenv` to set up the basic Nix environment in a single place, where it is usable by non-NixOS Nix users as well as NixOS users and nix-darwin users. It even places that logic in a separate file so that it can be used in combination with Fish from other sources, like Homebrew or APT, so at the very least the configuration of the essential NIX_* variables and placing the `/bin` directories of the NIX_PROFILES on the PATH happens, even for non-Nixpkgs versions of Fish.

Note that this PR also avoids reproducing #18946 on non-NixOS by preventing PATH clobbering in the same way as it is currently done on NixOS.

###### Things done
This is only partially tested! It's up for comments at the moment, not merging. Please do play with it and test it , though.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

