### PR TITLE
php couchbase: remove warnings on php startup

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -33,7 +33,7 @@ let
     name = "couchbase-${version}";
     version = "2.3.4";
 
-    buildInputs = [ pkgs.libcouchbase pcs ];
+    buildInputs = [ pkgs.libcouchbase pkgs.zlib igbinary pcs ];
 
     src = pkgs.fetchFromGitHub {
       owner = "couchbase";
@@ -57,8 +57,29 @@ let
                if test -r $i/include/libcouchbase/couchbase.h; then
                  LIBCOUCHBASE_DIR=$i
                  AC_MSG_RESULT(found in $i)
+        @@ -154,6 +154,8 @@ COUCHBASE_FILES=" \
+             igbinary_inc_path="$phpincludedir"
+           elif test -f "$phpincludedir/ext/igbinary/igbinary.h"; then
+             igbinary_inc_path="$phpincludedir"
+        +  elif test -f "${igbinary.dev}/include/ext/igbinary/igbinary.h"; then
+        +    igbinary_inc_path="${igbinary.dev}/include"
+           fi
+           if test "$igbinary_inc_path" = ""; then
+             AC_MSG_WARN([Cannot find igbinary.h])
       '')
     ];
+  };
+
+  igbinary = buildPecl {
+    name = "igbinary-2.0.4";
+
+    configureFlags = [ "--enable-igbinary" ];
+
+    makeFlags = [ "phpincludedir=$(dev)/include" ];
+
+    outputs = [ "out" "dev" ];
+
+    sha256 = "0a55l4f0bgbf3f6sh34njd14niwagg829gfkvb8n5fs69xqab67d";
   };
 
   imagick = buildPecl {


### PR DESCRIPTION
**WIP!**

###### Motivation for this change

On PHP Startup you got following warnings:
```
[cb,WARN] (pcbc/ext L:418) igbinary serializer is not found
[cb,WARN] (pcbc/ext L:425) zlib compressor is not found
```

I want to remove these,

###### Things done

I've added the `igbinary` package and add `igbinary` and `zlib` as `buildInputs`.
With these changes, I get the following warning:
```
PHP Warning:  PHP Startup: Unable to load dynamic library '/nix/store/ssib4rawawan5h3wc2h8r9mc56q0gy66-php-couchbase-2.3.4/lib/php/extensions/couchbase.so' - /nix/store/ssib4rawawan5h3wc2h8r9mc56q0gy66-php-couchbase-2.3.4/lib/php/extensions/couchbase.so: undefined symbol: igbinary_unserialize in Unknown on line 0
```
I really don't know how to fix this, so I thought a PR would be the best place to get good help on this. I have been googling and testing around a week now and don't have any ideas how to fix this.
Maybe anyone could help me out :)

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

