### PR TITLE
tnef: 1.4.14 -> 1.4.15

### DIFF
--- a/pkgs/applications/misc/tnef/default.nix
+++ b/pkgs/applications/misc/tnef/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  version = "1.4.14";
+  version = "1.4.15";
   name = "tnef-${version}";
 
   src = fetchFromGitHub {
     owner  = "verdammelt";
     repo   = "tnef";
     rev    = version;
-    sha256 = "0p7yji5hqq7k4pcba1cnv4jkl0fkg7jd77c1q164wk0vwinpmsc2";
+    sha256 = "0wm5ylppkjg518ldb9kzlx58a9l8z66gpz9ljalmyq6a77khd7pj";
   };
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change

Update to latest upstream release that fixes CVE-2017-8911 - https://github.com/verdammelt/tnef/commits/1.4.15

/cc @peterhoeg

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

