### PR TITLE
scudcloud: 0.58 -> 0.63

### DIFF
--- a/pkgs/applications/networking/instant-messengers/scudcloud/default.nix
+++ b/pkgs/applications/networking/instant-messengers/scudcloud/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, python3Packages }:
 
-let version = "1.58";
+let version = "1.63";
 in python3Packages.buildPythonPackage {
   name = "scudcloud-${version}";
 
   src = fetchurl {
     url = "https://github.com/raelgc/scudcloud/archive/v${version}.tar.gz";
-    sha256 = "1j84qdc2j3dvl1nhrjqm0blc8ww723p9a6hqprkkp8alw77myq1l";
+    sha256 = "08hd6n6vwv88qgx869lpa3i8zbaq2pjqplljvcbxl3sx25rcplg0";
   };
 
   propagatedBuildInputs = with python3Packages; [ pyqt5 dbus-python ];


### PR DESCRIPTION
###### Motivation for this change

Just a regular update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @jagajaga 