### PR TITLE
xcbuild: add SDKROOT by default to the wrappers

### DIFF
--- a/pkgs/development/tools/xcbuild/wrapper.nix
+++ b/pkgs/development/tools/xcbuild/wrapper.nix
@@ -58,11 +58,14 @@ stdenv.mkDerivation {
     wrapProgram $out/bin/xcodebuild \
       --add-flags "-xcconfig ${xcconfig}" \
       --add-flags "DERIVED_DATA_DIR=." \
-      --set DEVELOPER_DIR "$out"
+      --set DEVELOPER_DIR "$out" \
+      --set SDKROOT ${sdkName}
     wrapProgram $out/bin/xcrun \
-      --set DEVELOPER_DIR "$out"
+      --set DEVELOPER_DIR "$out" \
+      --set SDKROOT ${sdkName}
     wrapProgram $out/bin/xcode-select \
-      --set DEVELOPER_DIR "$out"
+      --set DEVELOPER_DIR "$out" \
+      --set SDKROOT ${sdkName}
   '';
 
   inherit (xcbuild) meta;


### PR DESCRIPTION
This fixes #30269 and lets us do things like `xcrun -find cc`, for example.

cc @matthewbauer 

###### Motivation for this change

#30269 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

