### PR TITLE
translate-toolkit: Init at 2.2.5

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4738,6 +4738,8 @@ with pkgs;
 
   translate-shell = callPackage ../applications/misc/translate-shell { };
 
+  translate-toolkit = python3Packages.translate-toolkit;
+
   trash-cli = callPackage ../tools/misc/trash-cli { };
 
   trickle = callPackage ../tools/networking/trickle {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20710,6 +20710,36 @@ in {
 
   transaction = callPackage ../development/python-modules/transaction { };
 
+  translate-toolkit = buildPythonPackage rec {
+    name = "translate-toolkit-${version}";
+    version = "2.2.5";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "translate";
+      repo = "translate";
+      rev = version;
+      sha256 = "05mh5h92w4h4899javn6grf5plbc9s6s968l7b77s912v8rsjy1r";
+    };
+
+    propagatedBuildInputs = with self; [
+      six diff-match-patch lxml python-Levenshtein chardet pycountry
+    ];
+    checkInputs = with self; [ pytest ];
+
+    # test_xliff_conformance requires network
+    checkPhase = ''
+      py.test -k 'not test_xliff_conformance' tests
+    '';
+
+    meta = {
+      description = "Useful localization tools for building localization & translation systems";
+      homepage = http://toolkit.translatehouse.org/;
+      license = stdenv.lib.licenses.gpl2;
+      maintainers = with stdenv.lib.maintainers; [ phile314 ];
+      platforms = with stdenv.lib.platforms; unix;
+    };
+  };
+
 
   transmissionrpc = buildPythonPackage rec {
     name = "transmissionrpc-${version}";


### PR DESCRIPTION
###### Motivation for this change

Add the translation-toolkit tools:
http://toolkit.translatehouse.org/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

