### PR TITLE
locatedb: fix startup fail due to systemd path capabilities

### DIFF
--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -147,8 +147,8 @@ in {
         serviceConfig.PrivateTmp = "yes";
         serviceConfig.PrivateNetwork = "yes";
         serviceConfig.NoNewPrivileges = "yes";
-        serviceConfig.ReadOnlyDirectories = "/";
-        serviceConfig.ReadWriteDirectories = dirOf cfg.output;
+        serviceConfig.ReadOnlyPaths = "/";
+        serviceConfig.ReadWritePaths = dirOf cfg.output;
       };
 
     systemd.timers.update-locatedb =

--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -125,13 +125,16 @@ in {
     warnings = optional (isMLocate && cfg.localuser != null) "mlocate does not support searching as user other than root"
             ++ optional (isFindutils && cfg.pruneNames != []) "findutils locate does not support pruning by directory component"
             ++ optional (isFindutils && cfg.pruneBindMounts) "findutils locate does not support skipping bind mounts";
-  
+
+    # directory creation needs to be separated from main service
+    # because ReadWritePaths fails when the directory doesn't already exist
+    systemd.tmpfiles.rules = [ "d ${dirOf cfg.output} 0755 root root -" ];
+
     systemd.services.update-locatedb =
       { description = "Update Locate Database";
         path = mkIf (!isMLocate) [ pkgs.su ];
         script =
           ''
-            mkdir -m 0755 -p ${dirOf cfg.output}
             exec ${cfg.locate}/bin/updatedb \
               ${optionalString (cfg.localuser != null && ! isMLocate) ''--localuser=${cfg.localuser}''} \
               --output=${toString cfg.output} ${concatStringsSep " " cfg.extraFlags}
@@ -148,6 +151,11 @@ in {
         serviceConfig.PrivateNetwork = "yes";
         serviceConfig.NoNewPrivileges = "yes";
         serviceConfig.ReadOnlyPaths = "/";
+        # Use dirOf cfg.output because mlocate creates temporary files next to
+        # the actual database. We could specify and create them as well,
+        # but that would make this quite brittle when they change something.
+        # NOTE: If /var/cache does not exist, this leads to the misleading error message:
+        # update-locatedb.service: Failed at step NAMESPACE spawning …/update-locatedb-start: No such file or directory
         serviceConfig.ReadWritePaths = dirOf cfg.output;
       };
 


### PR DESCRIPTION
###### Motivation for this change
On fresh NixOS 17.09 installs, `update-locatedb.service` continuously fails with:
```
update-locatedb.service: Failed at step NAMESPACE spawning /nix/store/bad6dlkkpkbk6qjdw8qhfbr1710bl0f9-unit-script/bin/update-locatedb-start: No such file or directory
```
This is because of the `ReadWritePaths=/var/cache` namespace restriction, as on new installs, `/var/cache` does not exist and therefore results in the `no such file or directory`. To reproduce this, delete your `/var/cache` directory.

I try to fix this by pulling out the mkdir part in a separate service. Note that this still fails on the *first* invocation with the same error, but creates the directory and then works on all subsequent invocations. I don't know why that happens. Maybe because the namespace restrictions are evaluated instantly when the unit is started, or because I did something wrong with the depency specification?

In any case, working the second day after being enabled is an improvement over always failing until the user creates `/var/cache` manually.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

