### PR TITLE
Semi-automated Emacs package updates

### DIFF
--- a/pkgs/applications/editors/emacs-modes/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/elpa-generated.nix
@@ -28,10 +28,10 @@
     ada-mode = callPackage ({ cl-lib ? null, elpaBuild, emacs, fetchurl, lib, wisi }:
     elpaBuild {
         pname = "ada-mode";
-        version = "5.2.2";
+        version = "5.3.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ada-mode-5.2.2.tar";
-          sha256 = "0c0lrj4vgsbawyshqbfb7gvndf0yb97wybqb0b34z7kan7q0xgvd";
+          url = "https://elpa.gnu.org/packages/ada-mode-5.3.1.tar";
+          sha256 = "0srna7w3y2nq0y80a01bcx8mg6gvind7nzvsbk9bd7rrr05njrd9";
         };
         packageRequires = [ cl-lib emacs wisi ];
         meta = {
@@ -95,10 +95,10 @@
     ahungry-theme = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
     elpaBuild {
         pname = "ahungry-theme";
-        version = "1.4.0";
+        version = "1.5.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ahungry-theme-1.4.0.tar";
-          sha256 = "1n8k12mfn01f20j0pyd7ycj77x0y3a008xc94frklaaqjc0v26s4";
+          url = "https://elpa.gnu.org/packages/ahungry-theme-1.5.0.tar";
+          sha256 = "0xxzmqawd7cwafzb9z6c7hjlh6adc5sj7hfcqxf30b7b7ragqn19";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -149,10 +149,10 @@
     ascii-art-to-unicode = callPackage ({ elpaBuild, fetchurl, lib }:
     elpaBuild {
         pname = "ascii-art-to-unicode";
-        version = "1.9";
+        version = "1.11";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ascii-art-to-unicode-1.9.el";
-          sha256 = "0lfgfkx81s4dd318xcxsl7hdgpi0dc1fv3d00m3xg8smyxcf3adv";
+          url = "https://elpa.gnu.org/packages/ascii-art-to-unicode-1.11.el";
+          sha256 = "1z1vjpskvhynja41cv5z6xrz3rmpdzz51avv2gzrpxxa4k6iaz8s";
         };
         packageRequires = [];
         meta = {
@@ -281,10 +281,10 @@
       }) {};
     captain = callPackage ({ elpaBuild, fetchurl, lib }: elpaBuild {
         pname = "captain";
-        version = "1.0.1";
+        version = "1.0.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/captain-1.0.1.el";
-          sha256 = "1jqbgzcgq4kxpcsma9ia6w6rjy9sdn51lz2f4rfjjy3qgy4fqjx5";
+          url = "https://elpa.gnu.org/packages/captain-1.0.2.el";
+          sha256 = "0rslksfwzf5bngmbfgv2mwmls5dpwmz7rs9av9p60y7k848haqf1";
         };
         packageRequires = [];
         meta = {
@@ -700,10 +700,10 @@
     ebdb = callPackage ({ cl-lib ? null, elpaBuild, emacs, fetchurl, lib, seq }:
     elpaBuild {
         pname = "ebdb";
-        version = "0.3.1";
+        version = "0.3.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ebdb-0.3.1.tar";
-          sha256 = "1g8chkw302nhjj8n6v7j3xfcw24wpn43pcp8f3bh4s4haw1l75q3";
+          url = "https://elpa.gnu.org/packages/ebdb-0.3.4.tar";
+          sha256 = "1jj7s0646wqg9ykmpi52cc6m6m0gk2inqc2h6h7cr7gr4v7n2l00";
         };
         packageRequires = [ cl-lib emacs seq ];
         meta = {
@@ -728,10 +728,10 @@
     ebdb-i18n-chn = callPackage ({ ebdb, elpaBuild, fetchurl, lib, pyim }:
     elpaBuild {
         pname = "ebdb-i18n-chn";
-        version = "1.1";
+        version = "1.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ebdb-i18n-chn-1.1.el";
-          sha256 = "0pf7qp15z9wp41dazvi4bhdz7y13h9k5nnghhsb0nvknn6if0k4m";
+          url = "https://elpa.gnu.org/packages/ebdb-i18n-chn-1.2.el";
+          sha256 = "1qgrlk625mhfd6n1mc0kqfzbisnb61kx3vrrl3bzlz4viq3kcc10";
         };
         packageRequires = [ ebdb pyim ];
         meta = {
@@ -1556,10 +1556,10 @@
       }) {};
     org = callPackage ({ elpaBuild, fetchurl, lib }: elpaBuild {
         pname = "org";
-        version = "20170911";
+        version = "20171009";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/org-20170911.tar";
-          sha256 = "0w91f5lx64klwbpym0b73z919dagzakykkmx6g13iscsh7fflx06";
+          url = "https://elpa.gnu.org/packages/org-20171009.tar";
+          sha256 = "03j7vcj5rihhdh1mmy667s1jy39wfs0kf4gc0gmqxldml062gcpm";
         };
         packageRequires = [];
         meta = {
@@ -2068,10 +2068,10 @@
       }) {};
     tramp-theme = callPackage ({ elpaBuild, emacs, fetchurl, lib }: elpaBuild {
         pname = "tramp-theme";
-        version = "0.1.1";
+        version = "0.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/tramp-theme-0.1.1.el";
-          sha256 = "0l8i625h9sc6h59qfj847blmfwfhf9bvfsbmwfb56qzs535fby3y";
+          url = "https://elpa.gnu.org/packages/tramp-theme-0.2.el";
+          sha256 = "1q1j0vcdyv5gnfbnfl08rnwd5j4ayc1gi1vpinr99ny70wsv7gbf";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2293,10 +2293,10 @@
     wisi = callPackage ({ cl-lib ? null, elpaBuild, emacs, fetchurl, lib }:
     elpaBuild {
         pname = "wisi";
-        version = "1.1.5";
+        version = "1.1.6";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/wisi-1.1.5.tar";
-          sha256 = "1q0dbykh9gvh0355vc1lwpriwlqq07jaydqx8zdrs6s0zyffx3a4";
+          url = "https://elpa.gnu.org/packages/wisi-1.1.6.tar";
+          sha256 = "0p7hm9l4gbp50rmpqna6jnc1pss2axdd6m6hk9ik4afbz0knzwnk";
         };
         packageRequires = [ cl-lib emacs ];
         meta = {

--- a/pkgs/applications/editors/emacs-modes/melpa-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-generated.nix
@@ -127,12 +127,12 @@
     abc-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "abc-mode";
-        version = "20140225.944";
+        version = "20171001.403";
         src = fetchFromGitHub {
           owner = "mkjunker";
           repo = "abc-mode";
-          rev = "1dd6e1217136a6f986917a3e5f41c1007bac908d";
-          sha256 = "1h4gwp2gyd4jhbkb8ai1zbzhhmlhmihbwzr0wsxg5yq074n72ifs";
+          rev = "161de34bc9e13bb094da0e99233b496a16f890fd";
+          sha256 = "0dqn2y6afn36jry2lb96v8w6hwlzcln3d314j5n4sl4lh5ba2s5f";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/aaee9dc5de06747374f311d86a550d3cc15beed1/recipes/abc-mode";
@@ -355,25 +355,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    ac-dabbrev = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "ac-dabbrev";
-        version = "20130905.2218";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/ac-dabbrev.el?revision=9";
-          sha256 = "0q0lbhdng5s5hqa342yyvg02hf2bfbwq513lj1rlaqz4ykvpd7fh";
-          name = "ac-dabbrev.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/4327b4dd464ebb00c2acdd496274dedf912cdf92/recipes/ac-dabbrev";
-          sha256 = "03lndw7y55bzz4rckl80j0kh66qa82xxxhfakzs1dh1h9f1f0azh";
-          name = "ac-dabbrev";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/ac-dabbrev";
-          license = lib.licenses.free;
-        };
-      }) {};
     ac-dcd = callPackage ({ auto-complete, fetchFromGitHub, fetchurl, flycheck-dmd-dub, lib, melpaBuild }:
     melpaBuild {
         pname = "ac-dcd";
@@ -398,12 +379,12 @@
     ac-emacs-eclim = callPackage ({ auto-complete, eclim, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "ac-emacs-eclim";
-        version = "20170104.743";
+        version = "20170924.1339";
         src = fetchFromGitHub {
           owner = "emacs-eclim";
           repo = "emacs-eclim";
-          rev = "ebb844d1ebdd7eb347e89063a9b6e9f890a1ff57";
-          sha256 = "18q4blnxf7p2kvgh1rhr7pizga06z97hv1lxjgzv0dc2dll2zwmd";
+          rev = "322a796be1619fb2ade6de6d51111e5f3f5776d0";
+          sha256 = "05sil1pazr7rdg6hq34p5ba7rnp3rp2lfnhsjpr26fisfhkbbaic";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1e9d3075587fbd9ca188535fd945a7dc451c6d7e/recipes/ac-emacs-eclim";
@@ -759,8 +740,8 @@
         src = fetchFromGitHub {
           owner = "xcwen";
           repo = "ac-php";
-          rev = "9e9c126397c3d2c7160e38eb72b9317c515678f3";
-          sha256 = "14qnbfxm9k870qi53krg6lmmfzcbhnv0yslhv66p40rwh9wjslwd";
+          rev = "59e11170c3e3d037ed3ccf183a856cae3cc9e531";
+          sha256 = "02z0z0mxj44zlgzd0dx7v7v02fpbnz655nszc2dfmvd5m9q8bg3z";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ac283f1b65c3ba6278e9d3236e5a19734e42b123/recipes/ac-php";
@@ -776,12 +757,12 @@
     ac-php-core = callPackage ({ dash, emacs, f, fetchFromGitHub, fetchurl, lib, melpaBuild, php-mode, popup, s, xcscope }:
     melpaBuild {
         pname = "ac-php-core";
-        version = "20170831.802";
+        version = "20170925.821";
         src = fetchFromGitHub {
           owner = "xcwen";
           repo = "ac-php";
-          rev = "9e9c126397c3d2c7160e38eb72b9317c515678f3";
-          sha256 = "14qnbfxm9k870qi53krg6lmmfzcbhnv0yslhv66p40rwh9wjslwd";
+          rev = "59e11170c3e3d037ed3ccf183a856cae3cc9e531";
+          sha256 = "02z0z0mxj44zlgzd0dx7v7v02fpbnz655nszc2dfmvd5m9q8bg3z";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ac283f1b65c3ba6278e9d3236e5a19734e42b123/recipes/ac-php-core";
@@ -822,8 +803,8 @@
         src = fetchFromGitHub {
           owner = "Andersbakken";
           repo = "rtags";
-          rev = "2af4d6a32e8194f8fbcc23fd94395e3d595a3c25";
-          sha256 = "0091w529lvbjlw1fdb3qjgb8fd5fcwxhqyr4ps5cvxl5bqnwlw39";
+          rev = "12636847b1ea512ce2d0c1075a74465f38555e69";
+          sha256 = "12v3wr2103293fkglbkhp20m2z72n66qka2s5zpcgc3jwqyqnnf9";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3dea16daf0d72188c8b4043534f0833fe9b04e07/recipes/ac-rtags";
@@ -1028,12 +1009,12 @@
     ace-link = callPackage ({ avy, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "ace-link";
-        version = "20170904.340";
+        version = "20170925.723";
         src = fetchFromGitHub {
           owner = "abo-abo";
           repo = "ace-link";
-          rev = "34eefe3c94042a20abf4d340fdae71955a087926";
-          sha256 = "02lh4kmjwf8d67b33ha4shwkkfvy9igvg88v5xq7282wxp6y3lx7";
+          rev = "eee81e6f75b078a207a547e0e8cff8c3d4f0b07c";
+          sha256 = "03p8cdakbx5pz9f8s01chd0bzmgsz50zi433k6gh0vw553y8vcmi";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/68032f40c0ce4170a22db535be4bfa7099f61f85/recipes/ace-link";
@@ -1216,12 +1197,12 @@
     add-node-modules-path = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "add-node-modules-path";
-        version = "20170501.151";
+        version = "20170914.1912";
         src = fetchFromGitHub {
           owner = "codesuki";
           repo = "add-node-modules-path";
-          rev = "8eef7fa6765af1716fc21db08f19f3d3e9b68998";
-          sha256 = "1dm2gdhs9zy5jqhbqipdgzfj24mrzxz064ax9l2dg0lqylk1dc0q";
+          rev = "6f7801b2c41e3711406b7e1654257ad5557f5bb3";
+          sha256 = "1pfgy1k7vp34k4zb9835y3x4jmf81na60vsf80wlgvfafwk170z6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/63e99d8fc0678d7b1831cae8940e9e6547780861/recipes/add-node-modules-path";
@@ -1321,12 +1302,12 @@
     ag = callPackage ({ cl-lib ? null, dash, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "ag";
-        version = "20170712.1549";
+        version = "20170915.1249";
         src = fetchFromGitHub {
           owner = "Wilfred";
           repo = "ag.el";
-          rev = "74d00c48a98211001c844ab4386d00420ccc850a";
-          sha256 = "1mjgl1pwaf0wl8hmzcwxq1g58mbi63ajbvhxljlysyfdkw15lvlq";
+          rev = "3b567902ccbec4ed9b8c5f5cd369be833e485e79";
+          sha256 = "1ihhmz4ww6iqbjbv1cvssixn01bkd2cl8pij7p32dxyyd8jdwlkq";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/67f410ac3a58a038e194bcf174bc0a8ceceafb9a/recipes/ag";
@@ -1346,8 +1327,8 @@
         src = fetchFromGitHub {
           owner = "davidshepherd7";
           repo = "aggressive-fill-paragraph-mode";
-          rev = "c5185ad673c01e5103ab4a078095c3e2ce7ab039";
-          sha256 = "11dppmpdv26m9l5cnnnylihiss2a09zyyb7kqdrk3djdqvqplqb4";
+          rev = "bcbc63d1c93cd8dc5bf2fc6eb4988fa76375c631";
+          sha256 = "042xvhfc7h571rdriixdf2s2aai8qz4w1wddbbbsq3ir0n814zp3";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/982f5936f2d83222263df2886ca0b629076366bb/recipes/aggressive-fill-paragraph";
@@ -1383,11 +1364,11 @@
       }) {};
     ahg = callPackage ({ fetchhg, fetchurl, lib, melpaBuild }: melpaBuild {
         pname = "ahg";
-        version = "20161110.455";
+        version = "20171003.39";
         src = fetchhg {
           url = "https://bitbucket.com/agriggio/ahg";
-          rev = "0e1d1b4142e7";
-          sha256 = "09606q8b9qhz1szshv8aapc7450j085rjf2fv769vbivr3kshqvh";
+          rev = "6a4cc7a7eee6";
+          sha256 = "09c3rawxqxxbl648bq1akawmgwiwppzd9g2sspza0k52adsb3rps";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5b7972602399f9df9139cff177e38653bb0f43ed/recipes/ahg";
@@ -1424,12 +1405,12 @@
     ahungry-theme = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "ahungry-theme";
-        version = "20170702.2226";
+        version = "20170926.1903";
         src = fetchFromGitHub {
           owner = "ahungry";
           repo = "color-theme-ahungry";
-          rev = "e3d7e22cb10582a443b0e245be68aca936cd6abf";
-          sha256 = "0fsip64bxs55kkqmpfcg4nr391b6wsd8hiq4fxvwww7n52lwsn5s";
+          rev = "85a1af27541f6a73a63120fac2cfbb7ba39531c9";
+          sha256 = "0z1kh8xj16lp7ydzw1fxypw37vlrcxcb8bpx96w6aj6zcd7pzwmn";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/520295978fd7de3f4266dd69cc30d0b4fdf09db0/recipes/ahungry-theme";
@@ -1508,12 +1489,12 @@
     alda-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "alda-mode";
-        version = "20170803.1852";
+        version = "20170913.926";
         src = fetchFromGitHub {
           owner = "jgkamat";
           repo = "alda-mode";
-          rev = "08556b3050c0bfc2d8f0a6d918610dbb2b85958f";
-          sha256 = "1f2m7pz3l62gk5ndfh49hm87ihz0lfk28izps9j3i68h4zclk3ls";
+          rev = "0e800594796ae283f5c0a6a374b9c2f8ebdfef56";
+          sha256 = "06j1imqknya3kglnmhsz2jg18mcbcycrjlgjzb9c1n68z43xglyh";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/2612c494a2b6bd43ffbbaef88ce9ee6327779158/recipes/alda-mode";
@@ -1613,12 +1594,12 @@
     all-the-icons = callPackage ({ emacs, fetchFromGitHub, fetchurl, font-lock-plus, lib, melpaBuild, memoize }:
     melpaBuild {
         pname = "all-the-icons";
-        version = "20170817.642";
+        version = "20170914.129";
         src = fetchFromGitHub {
           owner = "domtronn";
           repo = "all-the-icons.el";
-          rev = "d3550f8e0f8df6509e7f29a1ffbffc0f17144704";
-          sha256 = "09y1g4dphkhzrxym1bwxgx5f3hzvh1v4shbrr59bvdqymv93dagl";
+          rev = "8f269ae0ddec217db4ec643f8e167eb431091b72";
+          sha256 = "1wprrwv099w61blam6x8wfxym1dfx802ra7cddbkmh07vfi1w6bx";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/604c01aa15927bd122260529ff0f4bb6a8168b7e/recipes/all-the-icons";
@@ -1790,12 +1771,12 @@
     amx = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "amx";
-        version = "20170810.1842";
+        version = "20170923.835";
         src = fetchFromGitHub {
           owner = "DarwinAwardWinner";
           repo = "amx";
-          rev = "ba09f5ecf451d278a6cf5721b6942ad8d81ab911";
-          sha256 = "0xilab0v5qzvz6g8n10jdb9vz2pmlhgz6pc9cc3qsgg54r3igsv2";
+          rev = "88ab7ccb2a88b5cd3ecc4d703ae9373df3e4971c";
+          sha256 = "1n1zsrlj272scl4xcbys86d6gxnaq08vp5frd96i47c1an75p0xw";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c55bfad05343b2b0f3150fd2b4adb07a1768c1c0/recipes/amx";
@@ -1811,12 +1792,12 @@
     anaconda-mode = callPackage ({ dash, emacs, f, fetchFromGitHub, fetchurl, lib, melpaBuild, pythonic, s }:
     melpaBuild {
         pname = "anaconda-mode";
-        version = "20170405.301";
+        version = "20170924.704";
         src = fetchFromGitHub {
           owner = "proofit404";
           repo = "anaconda-mode";
-          rev = "0f9576791b86e0b315447e6823b3a7db131cd826";
-          sha256 = "1qqh1gg4sanh0vi624gys9wdncmvc92kly4zlwl6a9jhi3sr7w3s";
+          rev = "89fc16d50b889a17521084347b28f3011b84e113";
+          sha256 = "08wdci57vig88iy5kk57k5qjkzphbbzy8g7b87hxakfgdmcwpg3g";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/e03b698fd3fe5b80bdd24ce01f7fba28e9da0da8/recipes/anaconda-mode";
@@ -1847,26 +1828,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/anaphora";
-          license = lib.licenses.free;
-        };
-      }) {};
-    anchored-transpose = callPackage ({ fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "anchored-transpose";
-        version = "20080904.2254";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/anchored-transpose.el?revision=8";
-          sha256 = "1hklypbp79pgaf1yklbm3qx4skm3xlml0cm1r9b9js3dbqyha651";
-          name = "anchored-transpose.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/993271c9931170c3352daa3c1c0a8bcfa6915d9a/recipes/anchored-transpose";
-          sha256 = "19dgj1605qxc2znvzj0cj6x29zyrh00qnzk2rlwpn9hvzypg9v7w";
-          name = "anchored-transpose";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/anchored-transpose";
           license = lib.licenses.free;
         };
       }) {};
@@ -2041,12 +2002,12 @@
     ansible = callPackage ({ f, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "ansible";
-        version = "20161218.1707";
+        version = "20170926.1951";
         src = fetchFromGitHub {
           owner = "k1LoW";
           repo = "emacs-ansible";
-          rev = "a712d9b48809c975525cb059ea278cbe8a839f5a";
-          sha256 = "1jfksnk5fvr4h8mqb0mr2czyxnjmcdlrqdylvj0k0ks6xnskza91";
+          rev = "9da54a2a426dca259ec9c2a8a60fb58e954be5bc";
+          sha256 = "16z286gqy18s6bff1njkjpy0swrkfyarvb5xvik49pigd8hzh495";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/8e45bf58b980ff542a5e887707a6361eb5ac0492/recipes/ansible";
@@ -2415,25 +2376,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    aok = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "aok";
-        version = "20130824.427";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/aok.el?revision=13";
-          sha256 = "10vdmxzifxx3fkpyg76ngnj79k3d2pq0f322rd8ssc66alxhkz3g";
-          name = "aok.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/38eee4f0f7ad25d9b1de9011e63b82400177cdd5/recipes/aok";
-          sha256 = "1nkkbfwqp5r44wjwl902gm0xc8p3d2qj5mk1cchilr2rib52zd46";
-          name = "aok";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/aok";
-          license = lib.licenses.free;
-        };
-      }) {};
     aozora-view = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "aozora-view";
@@ -2602,26 +2544,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    apropos-fn-plus-var = callPackage ({ fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "apropos-fn-plus-var";
-        version = "20170221.748";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/apropos-fn+var.el";
-          sha256 = "0aa8d92ibbi1ix60j73nhvy16l8dkb3njn9d9z256jixmvzab7gr";
-          name = "apropos-fn+var.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/cd66a7c1a54ede8a279effeee5326be392058d1c/recipes/apropos-fn+var";
-          sha256 = "1s5gnsipsj7dhc8ca806grg32i6vlwm78hcxhrbs830vx9k84g5x";
-          name = "apropos-fn-plus-var";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/apropos-fn+var";
-          license = lib.licenses.free;
-        };
-      }) {};
     apropospriate-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "apropospriate-theme";
@@ -2640,25 +2562,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/apropospriate-theme";
-          license = lib.licenses.free;
-        };
-      }) {};
-    apu = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "apu";
-        version = "20170221.750";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/apu.el?revision=27";
-          sha256 = "15mq2b0df4hx53hqvgl3hcrbf9ww370byg90cail6rm50wamyik6";
-          name = "apu.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/ad04078221946c9d6b758809ec03ff88efce7322/recipes/apu";
-          sha256 = "0399rmjwcs7fykj10s9m0lm2wb1cr2bzw2bkgm5rp4n3va0rzaa2";
-          name = "apu";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/apu";
           license = lib.licenses.free;
         };
       }) {};
@@ -2701,6 +2604,27 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/archive-region";
+          license = lib.licenses.free;
+        };
+      }) {};
+    archive-rpm = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "archive-rpm";
+        version = "20171005.1548";
+        src = fetchFromGitHub {
+          owner = "legoscia";
+          repo = "archive-rpm";
+          rev = "830158cfb3b43c85cfcb4bd5b92d4457d015c80a";
+          sha256 = "18vmwffvxxg9clddmrkyv9lkjxiczaig69yyxzghigmzmg8wk557";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/e5f5653e62afdc022eac30bda3d21bd2d2625d2e/recipes/archive-rpm";
+          sha256 = "0s53zbn71lb008gw3f0b5w4q0pw0vgiqbffgnyib24sh03ijl7z7";
+          name = "archive-rpm";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/archive-rpm";
           license = lib.licenses.free;
         };
       }) {};
@@ -2830,25 +2754,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    ascii = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "ascii";
-        version = "20130824.500";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/ascii.el?revision=10";
-          sha256 = "05fjsj5nmc05cmsi0qj914dqdwk8rll1d4dwhn0crw36p2ivql75";
-          name = "ascii.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/ascii";
-          sha256 = "0f90anxrpnb8k1lqmz0iim4yp20riy19palwmdyl840hz69m98cd";
-          name = "ascii";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/ascii";
-          license = lib.licenses.free;
-        };
-      }) {};
     asilea = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "asilea";
@@ -2915,12 +2820,12 @@
     async = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "async";
-        version = "20170823.2116";
+        version = "20170916.2256";
         src = fetchFromGitHub {
           owner = "jwiegley";
           repo = "emacs-async";
-          rev = "5863eefbcd445f0fe917646f1326a9c86f067865";
-          sha256 = "16m1ykbjawia3nh6qkmp38yrdg58pc7k3vpfq364gf31qpsq6rwg";
+          rev = "87853ae35f19646f83f653b798e9f6d646de7113";
+          sha256 = "17q1x9nddjy14nbm3h343s8kv9y8p6kj7yvixa7vbf71396dwsxm";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/async";
@@ -3182,25 +3087,6 @@
         packageRequires = [ cl-lib es-lib ];
         meta = {
           homepage = "https://melpa.org/#/auto-auto-indent";
-          license = lib.licenses.free;
-        };
-      }) {};
-    auto-capitalize = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "auto-capitalize";
-        version = "20160415.1403";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/auto-capitalize.el?revision=19";
-          sha256 = "0xywyfpsi64g9lihm5ncmjrj06iq9s6pp9fmsgj1hdf9y0z65lg0";
-          name = "auto-capitalize.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/d4edbba637a27a641f53f8a51861b176cabaa286/recipes/auto-capitalize";
-          sha256 = "18fygc71n9bc0vrpymz2f7sw9hzkpqxzfglh53shmbm1zns3wkw0";
-          name = "auto-capitalize";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/auto-capitalize";
           license = lib.licenses.free;
         };
       }) {};
@@ -3501,12 +3387,12 @@
     auto-dim-other-buffers = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "auto-dim-other-buffers";
-        version = "20170911.307";
+        version = "20170925.1208";
         src = fetchFromGitHub {
           owner = "mina86";
           repo = "auto-dim-other-buffers.el";
-          rev = "90f6a6f0fba8dac1cfd5e4140638eceebc88bfab";
-          sha256 = "1z1d7gzfv573rw1kr3bb6viybj63zbfwad15gvgha9fld2jhmakz";
+          rev = "d1ee176652d7f5a77608e54175b7e67c31d41381";
+          sha256 = "1qqb051b16z2ay1xqx2ncy2p07cs29dv6wdy1x3n3w85yw9kh0mx";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/acc9b816796b9f142c53f90593952b43c962d2d8/recipes/auto-dim-other-buffers";
@@ -3561,34 +3447,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    auto-install = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "auto-install";
-        version = "20150418.1702";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/auto-install.el?revision=82";
-          sha256 = "043pb2wk7jh0jgxphdl4848rjyabna26gj0vlhpiyd8zc361pg9d";
-          name = "auto-install.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/7ad02a591b981518abd147475195f9484e4012fc/recipes/auto-install";
-          sha256 = "1gaxc2ya4r903k0jf3319wg7wg5kzq7k8rfy8ac9b0wfzv247ixk";
-          name = "auto-install";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/auto-install";
-          license = lib.licenses.free;
-        };
-      }) {};
     auto-minor-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "auto-minor-mode";
-        version = "20170716.717";
+        version = "20170917.1437";
         src = fetchFromGitHub {
           owner = "joewreschnig";
           repo = "auto-minor-mode";
-          rev = "06fa6975a9fb171b91a8b8234d65ef72374d64e2";
-          sha256 = "19r71hdgz367f6cgyqfdpilwlmhrjw5drmijpq8m0fxgysnmz2qd";
+          rev = "07ea9df59c5364d1938beef3dfbba24afd46c230";
+          sha256 = "007w6j6zhjv2647njh80vfbrhjzhmb8rx9yi9rf94fhf17z8pmk3";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b3ab5f048034777551e344101d8415cac92362c8/recipes/auto-minor-mode";
@@ -3751,12 +3618,12 @@
     auto-virtualenvwrapper = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild, s, virtualenvwrapper }:
     melpaBuild {
         pname = "auto-virtualenvwrapper";
-        version = "20170618.52";
+        version = "20170916.1304";
         src = fetchFromGitHub {
           owner = "robert-zaremba";
           repo = "auto-virtualenvwrapper.el";
-          rev = "516cb0406a98fd5a41d389f37544f11b28b1d027";
-          sha256 = "0y82n8354nri2qpz7bn58rbhpjkqiaf82q9izhl6jy12g63g416l";
+          rev = "0f2cc8ea8f211c7b88f852ae6ffe677914652b92";
+          sha256 = "1vm2nf7i9v56v57r7ckz8i1y3fk5s302bcfglywqysm4b8k36mp8";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/02a209ae8f9fc68feb3bb64d32d129fedef2b80b/recipes/auto-virtualenvwrapper";
@@ -3850,26 +3717,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/autodisass-llvm-bitcode";
-          license = lib.licenses.free;
-        };
-      }) {};
-    autofit-frame = callPackage ({ fetchurl, fit-frame, lib, melpaBuild }:
-    melpaBuild {
-        pname = "autofit-frame";
-        version = "20170221.752";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/autofit-frame.el?revision=48";
-          sha256 = "0c2b0d743w1c58iicg9r194zq2l5xxa08zyxj0nljw2dz9lhacwm";
-          name = "autofit-frame.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/autofit-frame";
-          sha256 = "0p24qqnfa1vfn5pgnpvbxwi11zjkd6f3cv5igwg6h0pr5s7spnvw";
-          name = "autofit-frame";
-        };
-        packageRequires = [ fit-frame ];
-        meta = {
-          homepage = "https://melpa.org/#/autofit-frame";
           license = lib.licenses.free;
         };
       }) {};
@@ -4020,6 +3867,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    avk-emacs-themes = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "avk-emacs-themes";
+        version = "20171001.235";
+        src = fetchFromGitHub {
+          owner = "avkoval";
+          repo = "avk-emacs-themes";
+          rev = "bf781eec7d46cce829ac5bdb114e728a110366e7";
+          sha256 = "0bj51ii8vsd2gwyykxp1hvkp4r9kbc0b7ajskf8i5vb8qvpvkali";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/ef362a76a3881c7596dcc2639df588227b3713c0/recipes/avk-emacs-themes";
+          sha256 = "0yimnfm50qsq505fc67b3qnxx2aiyz5a7bw87zkjrdnar12vv144";
+          name = "avk-emacs-themes";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://melpa.org/#/avk-emacs-themes";
+          license = lib.licenses.free;
+        };
+      }) {};
     avy = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "avy";
@@ -4086,12 +3954,12 @@
     avy-migemo = callPackage ({ avy, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, migemo }:
     melpaBuild {
         pname = "avy-migemo";
-        version = "20170907.955";
+        version = "20171004.925";
         src = fetchFromGitHub {
           owner = "momomo5717";
           repo = "avy-migemo";
-          rev = "0074b70fda731169888571013b4b618a6f0914e7";
-          sha256 = "153xv2k0v86k8c2w7cm68d6vs3xbrbhc660ka1dywprr7q1l3jrk";
+          rev = "dfb7d8eb4cb1e037e5a460b514b907306f8b845b";
+          sha256 = "157jbkzh0g7mmx94mj36lx137gzhzb9sqxjnjaissqn571p9ykay";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6a02db29eb3e4b76b4a9cdbc966df5a1bd35dec0/recipes/avy-migemo";
@@ -4122,25 +3990,6 @@
         packageRequires = [ avy ];
         meta = {
           homepage = "https://melpa.org/#/avy-zap";
-          license = lib.licenses.free;
-        };
-      }) {};
-    awk-it = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "awk-it";
-        version = "20130917.1148";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/awk-it.el?revision=10";
-          sha256 = "1r1vbi1r3rdbkyb2naciqwja7hxigjhqfxsfcinnygabsi7fw9aw";
-          name = "awk-it.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/awk-it";
-          sha256 = "0qic9m7c31sq4xgx7hnkhj0j0mfy26smghg266lrp5jii833qlz3";
-          name = "awk-it";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/awk-it";
           license = lib.licenses.free;
         };
       }) {};
@@ -4255,25 +4104,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    backup-each-save = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "backup-each-save";
-        version = "20130704.732";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/backup-each-save.el?revision=2";
-          sha256 = "0b9vvi2m0fdv36wj8mvawl951gjmg3pypg08a8n6rzn3rwg0fwz7";
-          name = "backup-each-save.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/88fd979eb479701303e65e68c581f8f847887842/recipes/backup-each-save";
-          sha256 = "1fv9sf6vkjyv93vil4l9hjm2fg73zlxbnif0xfm3kpmva9xin337";
-          name = "backup-each-save";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/backup-each-save";
-          license = lib.licenses.free;
-        };
-      }) {};
     backup-walker = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "backup-walker";
@@ -4358,27 +4188,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    baidu-life = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "baidu-life";
-        version = "20160426.519";
-        src = fetchFromGitHub {
-          owner = "lujun9972";
-          repo = "el-baidu-life";
-          rev = "5c4b3dbc016a2656cc2febaa2ac2268c05725b5c";
-          sha256 = "024gpdjr1lbqjg6md526g4wz2shpgfpdrrd2m1bn4fissbzj70i1";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/101ae6ea151df8d423f00cb6ac391374d0f7f3c8/recipes/baidu-life";
-          sha256 = "0rib50hja33qk8dmw5i62gaxhx7mscj2y0n25jmnds7k88ms8z19";
-          name = "baidu-life";
-        };
-        packageRequires = [ cl-lib ];
-        meta = {
-          homepage = "https://melpa.org/#/baidu-life";
-          license = lib.licenses.free;
-        };
-      }) {};
     bar-cursor = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "bar-cursor";
@@ -4403,12 +4212,12 @@
     base16-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "base16-theme";
-        version = "20170824.1656";
+        version = "20171005.1058";
         src = fetchFromGitHub {
           owner = "belak";
           repo = "base16-emacs";
-          rev = "bb4f204f51439fcf8ae45429d150861523d1f1d0";
-          sha256 = "1vkv5kqs9crbk2j4jynyrx2fzijhimnhm2fvgwcxsb6hx3g257id";
+          rev = "e7e646b79b5e3cebdf34f0ed775bceb8a5f3645a";
+          sha256 = "1lgg54cxl1zhv1gh7y5z99dwfb15w64gn05g8iwha2f37kmk22r4";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/30862f6be74882cfb57fb031f7318d3fd15551e3/recipes/base16-theme";
@@ -4424,12 +4233,12 @@
     bash-completion = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "bash-completion";
-        version = "20170909.650";
+        version = "20170924.1021";
         src = fetchFromGitHub {
           owner = "szermatt";
           repo = "emacs-bash-completion";
-          rev = "a789093cd32b2007cb64943de30aca51d5b3106b";
-          sha256 = "1fqkslxjdfqcwq1dj4fhw80naq58gpz3d50xar4wrxn76z7vkbcz";
+          rev = "31bc1c1c21691668c6cc16a46361490d5bec303a";
+          sha256 = "0iq9q0isaynrjhzgkm5hvw26162m52vbzwf12vic5nr9frxbxkv5";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/8b528544841995045fb1f8344aaaa38946bb3915/recipes/bash-completion";
@@ -4449,8 +4258,8 @@
         src = fetchFromGitHub {
           owner = "nick96";
           repo = "basic-c-compile";
-          rev = "335e96e19647ad7245fb68cf7e68cf86c5023d23";
-          sha256 = "1sq6mmg5361z30psn6x2ylpr8yxsbg3d47qai9px7p889p63384l";
+          rev = "0129786aeee50d7bb0020d9fc2b7508875d403e8";
+          sha256 = "0q6scyva1psyam7jzygqcr1wayf70vrp237hm01q5i9cin8j4j1z";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/basic-c-compile";
@@ -4460,6 +4269,27 @@
         packageRequires = [ cl-lib f ];
         meta = {
           homepage = "https://melpa.org/#/basic-c-compile";
+          license = lib.licenses.free;
+        };
+      }) {};
+    basic-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, seq }:
+    melpaBuild {
+        pname = "basic-mode";
+        version = "20171004.1218";
+        src = fetchFromGitHub {
+          owner = "dykstrom";
+          repo = "basic-mode";
+          rev = "d5f480fce6b25de4857e0f04c419cab5268185e3";
+          sha256 = "1kkqqi5ipbf5pyqdx1kzwxkn6gzgsmayg0dbyjzkdgc8zqihw4w3";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/71801bdc0720f150edeab6796487c753c6e7c3f5/recipes/basic-mode";
+          sha256 = "1l0ylzww7jg6l804fdrklhay4is0wx1drfi9l9wn7gcdjh76mr6g";
+          name = "basic-mode";
+        };
+        packageRequires = [ emacs seq ];
+        meta = {
+          homepage = "https://melpa.org/#/basic-mode";
           license = lib.licenses.free;
         };
       }) {};
@@ -4481,25 +4311,6 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://melpa.org/#/basic-theme";
-          license = lib.licenses.free;
-        };
-      }) {};
-    batch-mode = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "batch-mode";
-        version = "20140807.1350";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/batch-mode.el?revision=14";
-          sha256 = "1aa611jrzw4svmxvw1ghgh53x4nry0sl7mxmp4kxiaybqqvz6a1p";
-          name = "batch-mode.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/7fb675b865b8fa1497cdd33764bad051b2fd4d7e/recipes/batch-mode";
-          sha256 = "1p0rh5r8w00jag64sbjy8xb9g6lqhm2fz476v201kbrj9ggp643x";
-          name = "batch-mode";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/batch-mode";
           license = lib.licenses.free;
         };
       }) {};
@@ -4672,12 +4483,12 @@
     bbyac = callPackage ({ browse-kill-ring, cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "bbyac";
-        version = "20170815.28";
+        version = "20171007.722";
         src = fetchFromGitHub {
           owner = "baohaojun";
           repo = "bbyac";
-          rev = "e748e07bd77ef93f3c3110b5cde4e68f50b04efb";
-          sha256 = "1030gs02hb6kjd4w5iw0li8k7lcpklya37ybl62mkqhrzfri61bh";
+          rev = "584af0efa4809252bb37cf165df029410198327e";
+          sha256 = "17cmlc49y26j2salkmcsck9618s1p7y49phiy7hvzkipa13qmj9w";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/92c10c13a1bd19c8bdbca128852d1c91b76f7002/recipes/bbyac";
@@ -4756,12 +4567,12 @@
     beginend = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "beginend";
-        version = "20170810.624";
+        version = "20171003.548";
         src = fetchFromGitHub {
           owner = "DamienCassou";
           repo = "beginend";
-          rev = "bc608ef0735e5b7e34b320b899fd2b3ce2156d1b";
-          sha256 = "1vb9505lkzkl9ipczs3q0vmf70mzf9l1wk703g9b5aiss81r5w4i";
+          rev = "2762796b54c7fd8613b02c041b2b9afeb13eb9fa";
+          sha256 = "1g1mml0npypfk0vhicy4s7fa5df76xqpb80llxcfbnl2si9fzyfb";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/31c1157d4fd9e47a780bbd91075252acdc7899dd/recipes/beginend";
@@ -4834,25 +4645,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/better-defaults";
-          license = lib.licenses.free;
-        };
-      }) {};
-    better-registers = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "better-registers";
-        version = "20140813.119";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/better-registers.el?revision=23";
-          sha256 = "05dlhhvd1m9q642gqqj6klif13shbinqi6bi72fldidi1z6wcqlh";
-          name = "better-registers.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/2667829dfc72e848ab939be0602cbec1105671b0/recipes/better-registers";
-          sha256 = "01i0qjrwsc5way2h9z3pmsgccsbdifsq1dh6zhka4h6qfgrmn3bx";
-          name = "better-registers";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/better-registers";
           license = lib.licenses.free;
         };
       }) {};
@@ -5027,12 +4819,12 @@
     bifocal = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "bifocal";
-        version = "20170906.1948";
+        version = "20171004.1124";
         src = fetchFromGitHub {
           owner = "riscy";
           repo = "bifocal-mode";
-          rev = "5e89ad1a9a47e890ce080a79fd32c71eb128d1c4";
-          sha256 = "1rwxw1wniws31gbmpxgglxbc2g4jag19dvsjrym0f43yy4w2mbpw";
+          rev = "a8b222b069a6bd64531b4780905989797bad8abe";
+          sha256 = "0c6vzh35lj3pg9wd4v2fy6xdmcg9kq3n5br6rp4lx257gxglzpwh";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/79e71995bd8452bad2e717884f148ec74c9735fc/recipes/bifocal";
@@ -5094,8 +4886,8 @@
         src = fetchFromGitHub {
           owner = "jwiegley";
           repo = "use-package";
-          rev = "360df30683a711c443f87e495ba14cdd125a505d";
-          sha256 = "0nz0gk6gf9060hbyqr5vgzwr620k6l5sk9n6jbhfyrwmcscnmilc";
+          rev = "16abb66246170fe06325ff32a4889e4b51bfd979";
+          sha256 = "1fav32ax7qykclvrimlf00pyp534yfngizm697mbr9346va1zqm6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d39d33af6b6c9af9fe49bda319ea05c711a1b16e/recipes/bind-key";
@@ -5297,25 +5089,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    blank-mode = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "blank-mode";
-        version = "20130824.459";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/blank-mode.el?revision=40";
-          sha256 = "1wdplnmdllbydwr9gyyq4fbkxl5xjh7220vd4iajyv74pg2jkkkv";
-          name = "blank-mode.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/7e687f3d3945bdff0e8e36bcff1f629d8ad921fc/recipes/blank-mode";
-          sha256 = "1pyx5xwflnni9my5aqpgf8xz4q4rvmj67pwb4zxx1lghrca97z87";
-          name = "blank-mode";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/blank-mode";
-          license = lib.licenses.free;
-        };
-      }) {};
     blgrep = callPackage ({ clmemo, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "blgrep";
@@ -5403,12 +5176,12 @@
     blog-admin = callPackage ({ cl-lib ? null, ctable, f, fetchFromGitHub, fetchurl, lib, melpaBuild, names, s }:
     melpaBuild {
         pname = "blog-admin";
-        version = "20170430.721";
+        version = "20170923.709";
         src = fetchFromGitHub {
           owner = "CodeFalling";
           repo = "blog-admin";
-          rev = "98e397c4014f7c81c42722028778726cbf9baf8c";
-          sha256 = "0fj0yri8hayqb6fwgj5i6bw7yx4jsdq7jh9aqd5zdpmyfc6lshzr";
+          rev = "b5f2e1dad7d68ec903619f7280bb0bcb7e398a1e";
+          sha256 = "0fgzmmjxhl8i9yqx1bvb7hgkk9w4ylx73xy990qf1bl7fg21v636";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/7fabdb05de9b8ec18a3a566f99688b50443b6b44/recipes/blog-admin";
@@ -5529,12 +5302,12 @@
     bonjourmadame = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "bonjourmadame";
-        version = "20160112.156";
+        version = "20170919.434";
         src = fetchFromGitHub {
           owner = "pierre-lecocq";
           repo = "bonjourmadame";
-          rev = "4b4baaec19d8893268a2c93b3c35ac2581d02ba4";
-          sha256 = "06cpbjbv8ysz81szwgglgy5r1aay8rrzw5k86wyqg9jdzwpmilpn";
+          rev = "d3df185fce78aefa689fded8e56a654f0fde4ac0";
+          sha256 = "1acn63hd7s2z8viy52hmhncdic7m86rcqczxnz9aivikqy4hfnsi";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/34c4cfd7bbf5b442a9304598ba0a23ba9b8dfae4/recipes/bonjourmadame";
@@ -5565,25 +5338,6 @@
         packageRequires = [ cl-lib company dash flycheck yasnippet ];
         meta = {
           homepage = "https://melpa.org/#/boogie-friends";
-          license = lib.licenses.free;
-        };
-      }) {};
-    bookmark-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "bookmark-plus";
-        version = "20170731.1658";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/bookmark+.el";
-          sha256 = "0iqvlwqilwpqlymj8iynw2miifl28h1g7z10q08rly2430fnmi37";
-          name = "bookmark+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/4327b4dd464ebb00c2acdd496274dedf912cdf92/recipes/bookmark+";
-          sha256 = "0121xx7dp2pakk9g7sg6par4mkxd9ky746yk4wh2wrhprc9dqzni";
-          name = "bookmark-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/bookmark+";
           license = lib.licenses.free;
         };
       }) {};
@@ -5716,12 +5470,12 @@
     bpr = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "bpr";
-        version = "20170823.1636";
+        version = "20170930.642";
         src = fetchFromGitHub {
           owner = "ilya-babanov";
           repo = "emacs-bpr";
-          rev = "392de473664fbf319e3585a15f7f8abd34b3dbb6";
-          sha256 = "1ngz76j9mf9a1gvmwdy1r1jqxl8g4d3md95lqxq5dqbwz9076im2";
+          rev = "314b0d6f69ff5a9c2d25a1ce5a2109d67d4d9bb3";
+          sha256 = "02qj8gnhxv39y8kvlw491cbiaknll3hg03pk4xx15rffl7dyrbds";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/05eed39bae37cc8359d2cc678052cbbcc946e379/recipes/bpr";
@@ -5839,26 +5593,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    browse-kill-ring-plus = callPackage ({ browse-kill-ring, fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "browse-kill-ring-plus";
-        version = "20170221.757";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/browse-kill-ring+.el";
-          sha256 = "01cnh9i09b7i97aqjh8m7s18js85wm7cs25dxlkcrhy112pjb1nq";
-          name = "browse-kill-ring+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/e700f4066e67991dd67f6476c783e0a5134723db/recipes/browse-kill-ring+";
-          sha256 = "1flw7vmqgsjjvr2zlgz2909gvpq9mhz8qkg6hvsrzwg95f4l548w";
-          name = "browse-kill-ring-plus";
-        };
-        packageRequires = [ browse-kill-ring ];
-        meta = {
-          homepage = "https://melpa.org/#/browse-kill-ring+";
-          license = lib.licenses.free;
-        };
-      }) {};
     browse-url-dwim = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, string-utils }:
     melpaBuild {
         pname = "browse-url-dwim";
@@ -5877,25 +5611,6 @@
         packageRequires = [ string-utils ];
         meta = {
           homepage = "https://melpa.org/#/browse-url-dwim";
-          license = lib.licenses.free;
-        };
-      }) {};
-    bs-ext = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "bs-ext";
-        version = "20130824.459";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/bs-ext.el?revision=8";
-          sha256 = "1yslzlx54n17330sf6b2pynz01y6ifnkhipz4hggn1i55bz8hvrw";
-          name = "bs-ext.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/74c4861e76bb806ec4c4fd3482162bf0d95530a8/recipes/bs-ext";
-          sha256 = "0dddligqr71qdakgfkx0r45k9py85qlym7y5f204bxppyw5jmwb6";
-          name = "bs-ext";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/bs-ext";
           license = lib.licenses.free;
         };
       }) {};
@@ -6049,12 +5764,12 @@
     buffer-manage = callPackage ({ choice-program, dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "buffer-manage";
-        version = "20170912.1621";
+        version = "20170916.957";
         src = fetchFromGitHub {
           owner = "plandes";
           repo = "buffer-manage";
-          rev = "7a37c2ffa3d8ff446fe9cb5adc693095696b8341";
-          sha256 = "0shxy0apdmyajlhssxkgpzcch02c1ffbpgajddbr68m8npilq6p5";
+          rev = "4a0d526ca45264971796efe67c6e41d8aa659e4c";
+          sha256 = "15p089qfz8ra6f2lhny492hiricgs39w7w5iak2zlqm6k88cl1j8";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/28f8f376df810e6ebebba9fb2c93eabbe3526cc9/recipes/buffer-manage";
@@ -6105,25 +5820,6 @@
         packageRequires = [ cl-lib ];
         meta = {
           homepage = "https://melpa.org/#/buffer-sets";
-          license = lib.licenses.free;
-        };
-      }) {};
-    buffer-stack = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "buffer-stack";
-        version = "20101223.220";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/buffer-stack.el?revision=2";
-          sha256 = "0d87cl7a4rcd6plbjyf26vaar7imwd18z24xdi4dz734m9zbkg6r";
-          name = "buffer-stack.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/buffer-stack";
-          sha256 = "0lnd5mh20b4isa6m930dzibw3v4jyzp1ryvmz8irca28xfn0hjln";
-          name = "buffer-stack";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/buffer-stack";
           license = lib.licenses.free;
         };
       }) {};
@@ -6403,12 +6099,12 @@
     buttercup = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "buttercup";
-        version = "20170901.422";
+        version = "20170929.512";
         src = fetchFromGitHub {
           owner = "jorgenschaefer";
           repo = "emacs-buttercup";
-          rev = "11d7fdce9f46eec62ed86f4f9617e04d2c204b3a";
-          sha256 = "0vaq5dgajilysn720sgd294rhzvxbr7q2nyf71m74gf42pxf791d";
+          rev = "c1187b34c11cdf4030c57427261f3af4d6374b15";
+          sha256 = "0sk9s29521kh4qhi4px917vql6ba07ijvp7vrc0dzr1gdpm0b3w2";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d4b187cb5b3cc5b546bfa6b94b6792e6363242d1/recipes/buttercup";
@@ -6466,12 +6162,12 @@
     c-eldoc = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "c-eldoc";
-        version = "20170618.845";
+        version = "20170917.1502";
         src = fetchFromGitHub {
           owner = "nflath";
           repo = "c-eldoc";
-          rev = "0899f497e98e285d7d2e9cf897e305587b4b0790";
-          sha256 = "0yw59pm25a5xrcdl6mv30i08wnhljy6gndvnlpi09vp2dln37kbq";
+          rev = "79d09769362228058246f5e6fa183d121f7fb322";
+          sha256 = "1398lfd18zn2xym36p71yavgggqbb15xz9m7gah4w4k2bk15aczk";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/cae2ac3513e371a256be0f1a7468e38e686c2487/recipes/c-eldoc";
@@ -6841,17 +6537,19 @@
           license = lib.licenses.free;
         };
       }) {};
-    caml = callPackage ({ fetchsvn, fetchurl, lib, melpaBuild }: melpaBuild {
+    caml = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
         pname = "caml";
-        version = "20151009.845";
-        src = fetchsvn {
-          url = "https://caml.inria.fr/svn/ocaml/trunk/emacs/";
-          rev = "16561";
-          sha256 = "16qw82m87i1fcnsccqcvr9l6p2cy0jdhljsgaivq0q10hdmbgqdw";
+        version = "20170930.722";
+        src = fetchFromGitHub {
+          owner = "ocaml";
+          repo = "ocaml";
+          rev = "8eef73ea8d0a4994cb1c7210b83ba58e00d80144";
+          sha256 = "03c5cc0xh1azqqj7119g5yiy7w1jr3qddinqc30m7db1jrjsg3nq";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/caml";
-          sha256 = "1s05s3dqxlz2qhvjr3j9akb56finpmpbnsjb5pmjnzflhc4y01cf";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/d5a3263cdcc229b11a3e96edbf632d56f32c47aa/recipes/caml";
+          sha256 = "1ixs0626nsg1ilqdwj5rd8kicjy7mprswwy0kprppmpmc8y7xf7c";
           name = "caml";
         };
         packageRequires = [];
@@ -6947,12 +6645,12 @@
     cask = callPackage ({ cl-lib ? null, dash, epl, f, fetchFromGitHub, fetchurl, lib, melpaBuild, package-build, s, shut-up }:
     melpaBuild {
         pname = "cask";
-        version = "20161024.1205";
+        version = "20170917.1107";
         src = fetchFromGitHub {
           owner = "cask";
           repo = "cask";
-          rev = "07d8c963a4d349d856c51a471c60689734ebeda0";
-          sha256 = "15fyfzd0ssjyq8n77s8h8n0by33j5q0m4hs0v5k7m8zb3ca0w7mc";
+          rev = "bf52c3ecb1356657cae12fe3229c0827181c1ed9";
+          sha256 = "0g4vnvbfvr9c2rjf0fbbvzw1ipvwgsp11sn0rjrpx5cwszghvy0w";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b86c666ee9b0620390a250dddd42b17cbec2409f/recipes/cask";
@@ -6989,12 +6687,12 @@
     cask-package-toolset = callPackage ({ ansi, cl-lib ? null, commander, dash, emacs, f, fetchFromGitHub, fetchurl, lib, melpaBuild, s, shut-up }:
     melpaBuild {
         pname = "cask-package-toolset";
-        version = "20170411.1430";
+        version = "20170921.1556";
         src = fetchFromGitHub {
           owner = "AdrieanKhisbe";
           repo = "cask-package-toolset.el";
-          rev = "aed1f12b6072a2467e0efa23c3265aaa9f414425";
-          sha256 = "1as3fxs1h4gq6mv7gdsjqa59prrgzzs22c9qky8q47dr20sc9q6s";
+          rev = "2c74cd827e88c7f8360581a841e45f0b794510e7";
+          sha256 = "1hk5q6p1j7cqg5srr3v21xfyy7aas4hfj1a66h21c2xvfjra3hxw";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ed71e45389626e700b93b29d5e2659b6706274d8/recipes/cask-package-toolset";
@@ -7216,26 +6914,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    centered-cursor-mode = callPackage ({ fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "centered-cursor-mode";
-        version = "20151001.634";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/centered-cursor-mode.el?revision=30";
-          sha256 = "15psyizjz8wf9wfxwwcdmg1bxf8jbv0qy40rskz7si7vxin8hhxl";
-          name = "centered-cursor-mode.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/centered-cursor-mode";
-          sha256 = "1sq0hfvnm8sbqyxzr0znq0lwrhbqm961wi13yywjcwxd3x0ar3z0";
-          name = "centered-cursor-mode";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/centered-cursor-mode";
-          license = lib.licenses.free;
-        };
-      }) {};
     centered-window-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "centered-window-mode";
@@ -7327,8 +7005,8 @@
         src = fetchFromGitHub {
           owner = "cfengine";
           repo = "core";
-          rev = "83fd2b5014d2eb5d685941bed1ee64bf750e4f94";
-          sha256 = "1ffdscvp624gh8vgb01nsdbafynw7b2r83mr1nqf356jpn43ah7a";
+          rev = "4097e6453093b7aa8cb96e47d23847cc65b3fbe0";
+          sha256 = "01irq5g2n55s5arj7b3clnq50ym38qwghg20mdwhij1zljp42zb1";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c737839aeda583e61257ad40157e24df7f918b0f/recipes/cfengine-code-style";
@@ -7386,12 +7064,12 @@
     cframe = callPackage ({ buffer-manage, dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "cframe";
-        version = "20170828.919";
+        version = "20170917.1509";
         src = fetchFromGitHub {
           owner = "plandes";
           repo = "cframe";
-          rev = "8b60c482a5888464caf6d05b2a0079340bdd7be8";
-          sha256 = "0skms8cwniddpns1fmpqjnhyrn1fjvv6zknzjfganpv0h10gypgk";
+          rev = "bb99672502046e87c8f029ce98c637f762a4fc54";
+          sha256 = "088px3wlvr4km913y7hajrjqnxnv6n325rk6353bkbah2d75vxq4";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6e39555b2538cc8a955766c5533871396e8fe712/recipes/cframe";
@@ -7425,17 +7103,19 @@
           license = lib.licenses.free;
         };
       }) {};
-    cg = callPackage ({ fetchsvn, fetchurl, lib, melpaBuild }: melpaBuild {
+    cg = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
         pname = "cg";
         version = "20170911.610";
-        src = fetchsvn {
-          url = "https://beta.visl.sdu.dk/svn/visl/tools/vislcg3/trunk/emacs";
-          rev = "12362";
+        src = fetchFromGitHub {
+          owner = "emacsorphanage";
+          repo = "cg";
+          rev = "f5d74973d2cf19fd31db485ee6bfaaebcf96af2d";
           sha256 = "0bmydpv3slv5fvy1admgsm1qlkfp4sdsd0caik48dn7bnghifggz";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/caaa21f235c4864f6008fb454d0a970a2fd22a86/recipes/cg";
-          sha256 = "0xj4yqjg0r9m9cvwgs60lsid6qm1fi8lmb068dj6xaga11n70si5";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/30de78c9cf83de30093a5647976eeaf552d4b2cb/recipes/cg";
+          sha256 = "0yl2w48953vym4gxcxvjfaq3jgsv5jlya9vq3iwlfxqpapd3r3k9";
           name = "cg";
         };
         packageRequires = [];
@@ -7447,12 +7127,12 @@
     challenger-deep-theme = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "challenger-deep-theme";
-        version = "20170623.311";
+        version = "20171007.300";
         src = fetchFromGitHub {
           owner = "MaxSt";
           repo = "challenger-deep";
-          rev = "22022667437e94c2309c7c77a14268970de16146";
-          sha256 = "1prvdrc8wjb7dy8dqj5gvjzzdiz6hqv252inlwcyjrqiq4apipxz";
+          rev = "b4cd8550dd6a26c4efd226156dff33e261e7a8cc";
+          sha256 = "1m0ackx5wvwff0qpy9204rmpq7yr6hd3bfkwahjy6kwfrjavkfbv";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/7942f539d025c1e2b059d49e1984716cbbc90a67/recipes/challenger-deep-theme";
@@ -7843,34 +7523,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    chm-view = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "chm-view";
-        version = "20110616.1019";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/chm-view.el?revision=5";
-          sha256 = "1r274pf0xrcdml4sy2nhhp3v5pr3y3s4lvk45hd3pmw1i4pw2fd8";
-          name = "chm-view.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/8688cd57fca1974403c0e36d6289845059adac5c/recipes/chm-view";
-          sha256 = "1acz0fvl3inn7g4himq680yf64bgm7n61hsv2zpm1k6smrdl78nz";
-          name = "chm-view";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/chm-view";
-          license = lib.licenses.free;
-        };
-      }) {};
     choice-program = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "choice-program";
-        version = "20170828.616";
+        version = "20171004.931";
         src = fetchFromGitHub {
           owner = "plandes";
           repo = "choice-program";
-          rev = "5a803216d1d7a7ac6fd0f89f04ba4c126182a852";
-          sha256 = "0iah71kcrzi22mi1jvyyaiflsx0ry24hqb0wd2w0nbgzc8s5ycqb";
+          rev = "27607ec1fe241c58fbc1f861454a8e2ec1fd7b15";
+          sha256 = "0q8krgsydrc2xc29y60qljifdvxfmxnvbncxsh64xhrzsnrgwmq5";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6e39555b2538cc8a955766c5533871396e8fe712/recipes/choice-program";
@@ -7928,12 +7589,12 @@
     cider = callPackage ({ clojure-mode, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, pkg-info, queue, seq, spinner }:
     melpaBuild {
         pname = "cider";
-        version = "20170913.434";
+        version = "20171001.112";
         src = fetchFromGitHub {
           owner = "clojure-emacs";
           repo = "cider";
-          rev = "8a9eab32646abcaaf31fe83b2d897c01971b98f1";
-          sha256 = "0ddkm87l9ann05a6j57r0x59qqgfavwrvlzhkc5xhak1nmk5556h";
+          rev = "c60d1ae5802ec1dba90f5e4b51579488bbda55c6";
+          sha256 = "15r4lbb2wraadi27300gw9yarfpgwnclhjfvgr8vgiy1pqg1y5bi";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/55a937aed818dbe41530037da315f705205f189b/recipes/cider";
@@ -8114,15 +7775,36 @@
           license = lib.licenses.free;
         };
       }) {};
+    circadian = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "circadian";
+        version = "20170924.1440";
+        src = fetchFromGitHub {
+          owner = "GuidoSchmidt";
+          repo = "circadian.el";
+          rev = "6412eca0dfd5030ccd18f949066f1352ed89b44d";
+          sha256 = "0y62c3cfsz439x7pp7s4zzfhavyasv07y4gkn37383p38k56xqdf";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/3440905a20bc91bb2637a87c04ff8410379f150d/recipes/circadian";
+          sha256 = "13797y1w1636bibisz5i5p2xp0smd3apnhc1nx8ijm75smx679id";
+          name = "circadian";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/circadian";
+          license = lib.licenses.free;
+        };
+      }) {};
     circe = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "circe";
-        version = "20170728.638";
+        version = "20170929.1635";
         src = fetchFromGitHub {
           owner = "jorgenschaefer";
           repo = "circe";
-          rev = "452dfb407b640ba6eb288ff25a9de27446a409c4";
-          sha256 = "1yqnpvk5ib754bkb8gcd8skf0d3rqxkqwcsbibr052ilrp5ampcl";
+          rev = "6b110d4c2c6447c4ed65cfa5b7e8676620081ee2";
+          sha256 = "01llr34y9mvgpbz3y10l7gmp40qvislwhm6jb2fvcb7vdn9k9gmz";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a2b295656d53fddc76cacc86b239e5648e49e3a4/recipes/circe";
@@ -8138,12 +7820,12 @@
     circe-notifications = callPackage ({ alert, circe, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "circe-notifications";
-        version = "20160902.42";
+        version = "20171001.2258";
         src = fetchFromGitHub {
           owner = "eqyiel";
           repo = "circe-notifications";
-          rev = "80c44441ecd3ae04ae63760aa20afa837c1ed05b";
-          sha256 = "0s0iw5vclciziga78f1lvj6sdg84a132in39k4vz0pj598ypin1w";
+          rev = "4b93112b715714fc7b0ac2637df93adb90f35b40";
+          sha256 = "1hfic3qrlskcf0zmd3w76sl1qgrd6myf6mwg06mnc9jy76backqk";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/76c0408423c4e0728789de7b356b2971d6c446c7/recipes/circe-notifications";
@@ -8198,18 +7880,19 @@
           license = lib.licenses.free;
         };
       }) {};
-    clang-format = callPackage ({ cl-lib ? null, fetchsvn, fetchurl, lib, melpaBuild }:
+    clang-format = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "clang-format";
         version = "20170120.137";
-        src = fetchsvn {
-          url = "https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format";
-          rev = "313143";
+        src = fetchFromGitHub {
+          owner = "emacsorphanage";
+          repo = "clang-format";
+          rev = "1fc9ffb08a71d8747c26037a133fbd811673adc0";
           sha256 = "0zldh5nk5i3y41q70kwlhf576xmv0baim3q4jam01d41p4p040mq";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/1e2a0e4698d4e71ec28656594f6a83504a823490/recipes/clang-format";
-          sha256 = "1s7xbq1xczzz24gi6wlv9ihzs7cbsn3g16rrhdpxwaadagbasgk7";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/30de78c9cf83de30093a5647976eeaf552d4b2cb/recipes/clang-format";
+          sha256 = "1w2w8hhyxp73s1ziyd0n7f1yi0x46v93630xxpjnf9bgr1psfk5f";
           name = "clang-format";
         };
         packageRequires = [ cl-lib ];
@@ -8225,8 +7908,8 @@
         src = fetchFromGitHub {
           owner = "pmarinov";
           repo = "clean-aindent-mode";
-          rev = "9ae15997cd75c5625a4f759a3aff39bf202fc36f";
-          sha256 = "1h6k6kzim1zb87y1kzpqjzk3ip9bmfxyg54kdh2sfp4xy0g5h3p0";
+          rev = "78d917761b7f47f41dd1452e5a6fd783115913c9";
+          sha256 = "01jh561gpicw3wf8nvmw0ggc08gjg8zfzvqhjidpjn6sk4za9fhb";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ee9dac7c10e652f026643620418dfea9237a0d23/recipes/clean-aindent-mode";
@@ -8590,12 +8273,12 @@
     clojure-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "clojure-mode";
-        version = "20170819.2159";
+        version = "20171008.743";
         src = fetchFromGitHub {
           owner = "clojure-emacs";
           repo = "clojure-mode";
-          rev = "a6f0592e9cabeb4e039e654bd30890a20208950e";
-          sha256 = "0sr34679371b89qz93z88b6l0ii4lfh8lm91clpl6in4lp4daj93";
+          rev = "35f5d71b196b1a4b147a56a82b723d0383cb7282";
+          sha256 = "11im686bjh97vm67325zkm7q8mzd575s0rl7r8kd0kz837gywbh6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5e3cd2e6ee52692dc7b2a04245137130a9f521c7/recipes/clojure-mode";
@@ -8615,8 +8298,8 @@
         src = fetchFromGitHub {
           owner = "clojure-emacs";
           repo = "clojure-mode";
-          rev = "a6f0592e9cabeb4e039e654bd30890a20208950e";
-          sha256 = "0sr34679371b89qz93z88b6l0ii4lfh8lm91clpl6in4lp4daj93";
+          rev = "35f5d71b196b1a4b147a56a82b723d0383cb7282";
+          sha256 = "11im686bjh97vm67325zkm7q8mzd575s0rl7r8kd0kz837gywbh6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5e3cd2e6ee52692dc7b2a04245137130a9f521c7/recipes/clojure-mode-extra-font-locking";
@@ -8695,12 +8378,12 @@
     closql = callPackage ({ emacs, emacsql-sqlite, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "closql";
-        version = "20170629.921";
+        version = "20170919.455";
         src = fetchFromGitHub {
           owner = "emacscollective";
           repo = "closql";
-          rev = "73e68bcfbe076e152beed1b8e5f894ca438f9770";
-          sha256 = "0vj18784x6cdl39sbfpsksmxln5yj31ah250q5n7ivh54vk2hvjl";
+          rev = "66597831248bbe14ebc7bbf24b24cafebb5fd362";
+          sha256 = "0jxf7k95l2j6rjyafq3zj6bxaa2xn4zmi4zg1n04sachcdrcgh3l";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/2df16abf56e53d4a1cc267a78797419520ff8a1c/recipes/closql";
@@ -8821,12 +8504,12 @@
     cmake-ide = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, levenshtein, lib, melpaBuild, s, seq }:
     melpaBuild {
         pname = "cmake-ide";
-        version = "20170818.907";
+        version = "20170922.231";
         src = fetchFromGitHub {
           owner = "atilaneves";
           repo = "cmake-ide";
-          rev = "6489aabba8d124445ba72f55db9ef3bb2212b1b0";
-          sha256 = "0wh0z28nfb5kpm3jlkkgkxbhzyc8akyc6hs1fm8i7bxrslrj6ll0";
+          rev = "37950c45f6a61383c70286bbecea305e6f1daf51";
+          sha256 = "1si544nsjzwbikv3m17x2k4l0cnjrshpld28fzfhjv336p9jw25q";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/17e8a8a5205d222950dc8e9245549a48894b864a/recipes/cmake-ide";
@@ -8846,8 +8529,8 @@
         src = fetchFromGitHub {
           owner = "Kitware";
           repo = "CMake";
-          rev = "a763cffd6b65bbe5572527e39969981bf31d5aca";
-          sha256 = "1jrvsqcb123z1r84c074qz1z6ljz6psc7ysabzsxkrkcs3f66v58";
+          rev = "cb8f26f199e18be231f40f523bfe64375e749e35";
+          sha256 = "13zywybi3r9pzwlqvailgafqc68v62adkrkca1lm7mjrr33jdsfn";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/598723893ae4bc2e60f527a072efe6ed9d4e2488/recipes/cmake-mode";
@@ -8902,25 +8585,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    cmds-menu = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "cmds-menu";
-        version = "20170221.1557";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/cmds-menu.el?revision=10";
-          sha256 = "0ladkkydypf08mn3j749fv46blpzyvh45kx52qdzhwxjiz7nlmfs";
-          name = "cmds-menu.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/de6366e4b3e72a5e68b960d6bf4bab2683ad6800/recipes/cmds-menu";
-          sha256 = "12s75y9d75cxqgg3hj0s4w0d10zy8y230b5gy09685ab5lcajfks";
-          name = "cmds-menu";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/cmds-menu";
-          license = lib.licenses.free;
-        };
-      }) {};
     cmm-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "cmm-mode";
@@ -8939,27 +8603,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/cmm-mode";
-          license = lib.licenses.free;
-        };
-      }) {};
-    cn-outline = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "cn-outline";
-        version = "20100321.914";
-        src = fetchFromGitHub {
-          owner = "mori-dev";
-          repo = "cn-outline";
-          rev = "47d33a99b7ae26b1cd456441970b4bab2173d981";
-          sha256 = "1635k51ppivq6v2702fihq8dvi33445smds9zhqm0drnpv9rv5cr";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/bf843cbcfc5806d9089000f08c72433dc8c12e17/recipes/cn-outline";
-          sha256 = "0cw1rr56hdngvhmx59j76hvkfzgybasn0fwhd6vwm709jqiiiwiz";
-          name = "cn-outline";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/cn-outline";
           license = lib.licenses.free;
         };
       }) {};
@@ -9152,26 +8795,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    col-highlight = callPackage ({ fetchurl, lib, melpaBuild, vline }:
-    melpaBuild {
-        pname = "col-highlight";
-        version = "20170510.1541";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/col-highlight.el?revision=31";
-          sha256 = "0wi4xz8n5ib65spyrgqsp8l6zafnvxdiw3hy918fs0xjj7ziy6qc";
-          name = "col-highlight.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/2a16dca0068d9d4f25ad6b699ec8cb8da6ba17e5/recipes/col-highlight";
-          sha256 = "1kycjdlrg7a5x37b0pzqhg56yn7kaisryrk303qx1084kwq9464i";
-          name = "col-highlight";
-        };
-        packageRequires = [ vline ];
-        meta = {
-          homepage = "https://melpa.org/#/col-highlight";
-          license = lib.licenses.free;
-        };
-      }) {};
     colemak-evil = callPackage ({ evil, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "colemak-evil";
@@ -9256,18 +8879,19 @@
           license = lib.licenses.free;
         };
       }) {};
-    color-theme = callPackage ({ fetchbzr, fetchurl, lib, melpaBuild }:
+    color-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "color-theme";
-        version = "20080305.34";
-        src = fetchbzr {
-          url = "https://bzr.savannah.gnu.org/r/color-theme/trunk";
-          rev = "57";
+        version = "20070910.1007";
+        src = fetchFromGitHub {
+          owner = "emacsorphanage";
+          repo = "color-theme";
+          rev = "eeb07560b30aaf7934dfd21f5c2518a479905cd9";
           sha256 = "17bidzq9kiz250gal1fn9mg8gf8l749nz69z0awpc4x2222wxxiz";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/caaa21f235c4864f6008fb454d0a970a2fd22a86/recipes/color-theme";
-          sha256 = "1ds098v50p4g6ji0zy7m5nyj2kadm3l3v0pnb01wkjjx6anh3qsy";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/30de78c9cf83de30093a5647976eeaf552d4b2cb/recipes/color-theme";
+          sha256 = "1c1n0m4hhj2sxi08vjvayypf9g5i2hyng53ry950yfdqgzq7nk8i";
           name = "color-theme";
         };
         packageRequires = [];
@@ -9363,12 +8987,12 @@
     color-theme-sanityinc-tomorrow = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "color-theme-sanityinc-tomorrow";
-        version = "20170908.216";
+        version = "20171003.235";
         src = fetchFromGitHub {
           owner = "purcell";
           repo = "color-theme-sanityinc-tomorrow";
-          rev = "6c9b01bb5268f00d0e65fb8351a7ad87abbfb127";
-          sha256 = "1gr1iab6dyyx47v2fbx7g1lf8x1hm9vppra9ypf8957fxzi99l2n";
+          rev = "c5855d0906c672150dc2b00486dda633823d9477";
+          sha256 = "1p2qjgwxj969hffawc8h1zikl5zgqj91qii7fv31n2h4sqxxybks";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/cae2ac3513e371a256be0f1a7468e38e686c2487/recipes/color-theme-sanityinc-tomorrow";
@@ -9423,6 +9047,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    colormaps = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "colormaps";
+        version = "20171008.1524";
+        src = fetchFromGitHub {
+          owner = "lepisma";
+          repo = "colormaps.el";
+          rev = "19fbb64a6288d505b9cf45c9b5a3eed0bfb135e2";
+          sha256 = "0kbhy8bpxqdr1kjczz2vm7chfpjprx2frpbh1gh9i1gwwx5k4myp";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/f4c795d9e323b08bc8354a6933a061644705a2ec/recipes/colormaps";
+          sha256 = "16plhgpfz1wb58p6h8wxjhplhgv0mbj3f2xj34p6vydh44l8w8q2";
+          name = "colormaps";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/colormaps";
+          license = lib.licenses.free;
+        };
+      }) {};
     column-enforce-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "column-enforce-mode";
@@ -9441,25 +9086,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/column-enforce-mode";
-          license = lib.licenses.free;
-        };
-      }) {};
-    column-marker = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "column-marker";
-        version = "20121128.43";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/column-marker.el?revision=13";
-          sha256 = "05bv198zhqw5hqq6cr11mhz02dpca74hhp1ycwq369m0yb2naxy9";
-          name = "column-marker.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/5f629b6b44fae3191f58e007c39b75bbb880d517/recipes/column-marker";
-          sha256 = "1xgfsiw46aib2vb9bbjlgnhcgfnlfhdcxd0cl0jqj4fjfxzbz0bq";
-          name = "column-marker";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/column-marker";
           license = lib.licenses.free;
         };
       }) {};
@@ -9568,6 +9194,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    comment-tags = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "comment-tags";
+        version = "20170910.1035";
+        src = fetchFromGitHub {
+          owner = "vincekd";
+          repo = "comment-tags";
+          rev = "7d914097f0a03484af71e621db533737fc692f58";
+          sha256 = "0s86a7078arck9z4gzkp2hnxyklprl0zh5hsw7nkyyscjydly80i";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/6ac71f4ffc19bce4f571001f9270d5be855dfc3c/recipes/comment-tags";
+          sha256 = "13slv150zch0b7zpxa2dbqjzpqh0iy559m6rc0zs0dwdagzryp3i";
+          name = "comment-tags";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/comment-tags";
+          license = lib.licenses.free;
+        };
+      }) {};
     commenter = callPackage ({ emacs, fetchFromGitHub, fetchurl, let-alist, lib, melpaBuild }:
     melpaBuild {
         pname = "commenter";
@@ -9613,12 +9260,12 @@
     common-lisp-snippets = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, yasnippet }:
     melpaBuild {
         pname = "common-lisp-snippets";
-        version = "20170522.2147";
+        version = "20170918.356";
         src = fetchFromGitHub {
           owner = "mrkkrp";
           repo = "common-lisp-snippets";
-          rev = "46f1de08c8d86b72b474c2f8e1c1b313ac70f23d";
-          sha256 = "148ach1p3iqch3a6r1y8wkr1avyprg47jjz3a31vjvqgcwgs3ynw";
+          rev = "cd46223fbc6ee99372a25ba455ffec4354895e45";
+          sha256 = "0xii63fw3gx1hhx57yh8gr9mhkgb2vjkfs2sl5z9010myi9504is";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/48d0166ccd3dcdd3df4719349778c6c5ab6872ca/recipes/common-lisp-snippets";
@@ -9634,12 +9281,12 @@
     company = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "company";
-        version = "20170828.414";
+        version = "20171006.1442";
         src = fetchFromGitHub {
           owner = "company-mode";
           repo = "company-mode";
-          rev = "c0098afab0719c633ea9984e62a240f542ab8c49";
-          sha256 = "0vm4rl7xkqpbi1dh2ds45smbyk25x16w0x99ri1nzvfbana5w7j5";
+          rev = "d033112748440e772f0173b28356e956ce57d8a0";
+          sha256 = "0qabdz95wa4gqag212gcfys4kpnvdcv0kmq2kiwc6znyp6xicnd1";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/96e7b4184497d0d0db532947f2801398b72432e4/recipes/company";
@@ -9789,12 +9436,12 @@
     company-cabal = callPackage ({ cl-lib ? null, company, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "company-cabal";
-        version = "20151216.720";
+        version = "20170917.617";
         src = fetchFromGitHub {
           owner = "iquiw";
           repo = "company-cabal";
-          rev = "05886d6f2621b019fafb40cff4d2567e5d8045b4";
-          sha256 = "1yxp6l8a16d6g2sfwrpfx97ds7nfrgk2akwydal1dzr2bjq02pc6";
+          rev = "62112a7259e24bd6c08885629a185afe512b7d3d";
+          sha256 = "1gf45xwjzdm8i4q6c6khk4dbg1mmp2r0awz2sjr4dcr2dbd1n7mg";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ee888b1ba57b6af3a3330607898810cd248862db/recipes/company-cabal";
@@ -9926,8 +9573,8 @@
         src = fetchFromGitHub {
           owner = "emacs-eclim";
           repo = "emacs-eclim";
-          rev = "ebb844d1ebdd7eb347e89063a9b6e9f890a1ff57";
-          sha256 = "18q4blnxf7p2kvgh1rhr7pizga06z97hv1lxjgzv0dc2dll2zwmd";
+          rev = "322a796be1619fb2ade6de6d51111e5f3f5776d0";
+          sha256 = "05sil1pazr7rdg6hq34p5ba7rnp3rp2lfnhsjpr26fisfhkbbaic";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1e9d3075587fbd9ca188535fd945a7dc451c6d7e/recipes/company-emacs-eclim";
@@ -10027,12 +9674,12 @@
     company-ghc = callPackage ({ cl-lib ? null, company, emacs, fetchFromGitHub, fetchurl, ghc, lib, melpaBuild }:
     melpaBuild {
         pname = "company-ghc";
-        version = "20160315.710";
+        version = "20170918.133";
         src = fetchFromGitHub {
           owner = "iquiw";
           repo = "company-ghc";
-          rev = "ff2205c0b309467eea763521d30220e7849c75b0";
-          sha256 = "1a93q5q91xjyvfxbf5q57ndjarqdm9av11bb3dmc72v9bmwgpi7s";
+          rev = "dab111cb5067c545ccdc6b2d0ba70c1c4bbce060";
+          sha256 = "0ygw3dhlz247qzmcsbnkkdry2w2ni60j1rbyqprnzp8sd5yk97r1";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/28f6a983444f796c81df7e5ee94d74c480b21298/recipes/company-ghc";
@@ -10073,8 +9720,8 @@
         src = fetchFromGitHub {
           owner = "nsf";
           repo = "gocode";
-          rev = "c7fddb39ecbc9ebd1ebe7d2a3af473ed0fffffa1";
-          sha256 = "0qx8pq38faig41xkl1a4hrgp3ziyjyn6g53vn5wj7cdgm5kk67nb";
+          rev = "1a78dd6c36d7f37cbb60073523c2e9ca3f6519fa";
+          sha256 = "1bcd62rggq3sk96n3dlpidrv4pbx6x385x17knfnp35avgrhsv4b";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/04867a574773e8794335a2664d4f5e8b243f3ec9/recipes/company-go";
@@ -10283,8 +9930,8 @@
         src = fetchFromGitHub {
           owner = "travisbhartwell";
           repo = "nix-emacs";
-          rev = "ace629f7645d12778c96ff7b5cf4b1e41a98af29";
-          sha256 = "11infdrdjc30kxvfg5rh1zn4idvkhf9s0c6v60qn441m1d5bnavq";
+          rev = "7007363e773a419203a69798fb0e0731b2eb0f73";
+          sha256 = "00hv8fhyahkdh1vfy1qkahqvsik6d81c7mqh4gjiqxrmb2l1vbcb";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6846c7d86e70a9dd8300b89b61435aa7e146be96/recipes/company-nixos-options";
@@ -10304,8 +9951,8 @@
         src = fetchFromGitHub {
           owner = "xcwen";
           repo = "ac-php";
-          rev = "9e9c126397c3d2c7160e38eb72b9317c515678f3";
-          sha256 = "14qnbfxm9k870qi53krg6lmmfzcbhnv0yslhv66p40rwh9wjslwd";
+          rev = "59e11170c3e3d037ed3ccf183a856cae3cc9e531";
+          sha256 = "02z0z0mxj44zlgzd0dx7v7v02fpbnz655nszc2dfmvd5m9q8bg3z";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ac283f1b65c3ba6278e9d3236e5a19734e42b123/recipes/company-php";
@@ -10315,6 +9962,27 @@
         packageRequires = [ ac-php-core cl-lib company ];
         meta = {
           homepage = "https://melpa.org/#/company-php";
+          license = lib.licenses.free;
+        };
+      }) {};
+    company-plsense = callPackage ({ cl-lib ? null, company, dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
+    melpaBuild {
+        pname = "company-plsense";
+        version = "20171001.1200";
+        src = fetchFromGitHub {
+          owner = "CeleritasCelery";
+          repo = "company-plsense";
+          rev = "8a72677fcd7f8abef4fb1f046b6b424d5482aadd";
+          sha256 = "02b7pfrz5k31bfq23m71hq8pzxsl2w43wjxaqx154g2bb8wkfdkr";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/9cf9d671d81e07c704676c557a9f0d686067ce5c/recipes/company-plsense";
+          sha256 = "0k8k2vpkknd4nyxzwdj7698lgm5d85byxd49x7w5nrxmh2h1w3c7";
+          name = "company-plsense";
+        };
+        packageRequires = [ cl-lib company dash emacs s ];
+        meta = {
+          homepage = "https://melpa.org/#/company-plsense";
           license = lib.licenses.free;
         };
       }) {};
@@ -10409,8 +10077,8 @@
         src = fetchFromGitHub {
           owner = "iquiw";
           repo = "company-restclient";
-          rev = "7b41cd58ffdf965480f1cf52d58d718009ba6fe7";
-          sha256 = "0j6b9jqs4i05rxx6fs7rvim1snf33fi1l6dkm9lskchbykzz4adq";
+          rev = "ef67ba2f613ce3d61b70011c9d0a303a754ffc5b";
+          sha256 = "0af1h6n1rgyni686hrrakmmbgymjg8dc1i9g2jc27dxkxz0nk454";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3dd063bc3789772fdcc6a8555817588962e60825/recipes/company-restclient";
@@ -10432,12 +10100,12 @@
     company-rtags = callPackage ({ company, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, rtags }:
     melpaBuild {
         pname = "company-rtags";
-        version = "20170829.2022";
+        version = "20170924.2244";
         src = fetchFromGitHub {
           owner = "Andersbakken";
           repo = "rtags";
-          rev = "2af4d6a32e8194f8fbcc23fd94395e3d595a3c25";
-          sha256 = "0091w529lvbjlw1fdb3qjgb8fd5fcwxhqyr4ps5cvxl5bqnwlw39";
+          rev = "12636847b1ea512ce2d0c1075a74465f38555e69";
+          sha256 = "12v3wr2103293fkglbkhp20m2z72n66qka2s5zpcgc3jwqyqnnf9";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3dea16daf0d72188c8b4043534f0833fe9b04e07/recipes/company-rtags";
@@ -10621,12 +10289,12 @@
     company-ycmd = callPackage ({ company, dash, deferred, f, fetchFromGitHub, fetchurl, let-alist, lib, melpaBuild, s, ycmd }:
     melpaBuild {
         pname = "company-ycmd";
-        version = "20170622.146";
+        version = "20170926.2252";
         src = fetchFromGitHub {
           owner = "abingham";
           repo = "emacs-ycmd";
-          rev = "fd037efae08628e41480e9dad705dcc1f64e498d";
-          sha256 = "06scz0d3jzgbr919lkjjfq9x1dyr5nqkhblvfpyk5bdp8l6j06d6";
+          rev = "393724d0d36a8269e57a0e4c2b3723071caf0a3c";
+          sha256 = "02pm3x9frscgz5szddvbir0i7amnkzfj7pl4lgiah57bhcg1lhd0";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/company-ycmd";
@@ -10765,18 +10433,19 @@
           license = lib.licenses.free;
         };
       }) {};
-    confluence = callPackage ({ fetchsvn, fetchurl, lib, melpaBuild, xml-rpc }:
+    confluence = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, xml-rpc }:
     melpaBuild {
         pname = "confluence";
         version = "20151020.1828";
-        src = fetchsvn {
-          url = "https://svn.code.sf.net/p/confluence-el/code/trunk/";
-          rev = "173";
-          sha256 = "18859zi60s2y79add998vxh084znbdxxq31m12flg7makxlamyh7";
+        src = fetchFromGitHub {
+          owner = "emacsorphanage";
+          repo = "confluence";
+          rev = "4518d270a07760644c4204985c83d234ece4738b";
+          sha256 = "1lrq23cxlp2vkyv7g56r06bp7chhw10kii3ymkydf24y4pyn1zpg";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/cf9110cd142ece0a8d63815bf00a89574b947bb4/recipes/confluence";
-          sha256 = "0hplpqaxjg34pf75p9sf97wlbq4rz9f8qvn4cfpjxf16if078ls3";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/30de78c9cf83de30093a5647976eeaf552d4b2cb/recipes/confluence";
+          sha256 = "0xa2g168mm31kh5h7smhx35cjsk1js88nzs19yakjljf56b1khlf";
           name = "confluence";
         };
         packageRequires = [ xml-rpc ];
@@ -11037,15 +10706,36 @@
           license = lib.licenses.free;
         };
       }) {};
+    cosmo = callPackage ({ emacs, fetchFromGitLab, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "cosmo";
+        version = "20170922.44";
+        src = fetchFromGitLab {
+          owner = "montanari";
+          repo = "cosmo-el";
+          rev = "dd83b09a49a2843606b28279b674b2207040b36b";
+          sha256 = "0phcg81g3dy67s1hfymvj0lkcpwygwql8iixf940nv31qllgzvd7";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/3ab914dfefcddf6ecd65261bc11bd3eb12929c79/recipes/cosmo";
+          sha256 = "1pk34d0kv1jm2fq72qa5lj0y39x1yf2nbkjjg8jcj8ari28h9vfk";
+          name = "cosmo";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/cosmo";
+          license = lib.licenses.free;
+        };
+      }) {};
     counsel = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, swiper }:
     melpaBuild {
         pname = "counsel";
-        version = "20170911.1121";
+        version = "20171007.231";
         src = fetchFromGitHub {
           owner = "abo-abo";
           repo = "swiper";
-          rev = "0a1d361b926291874124f8c63a653d83ead64a36";
-          sha256 = "0ssbsllpv0lyr7dhnipwd7zgpxvfm36rldr7vkxh5maajdkamls7";
+          rev = "6827edffb70890f2e94c3d146ed129bde581992d";
+          sha256 = "0xwf8q73xisi1072dkkvf181sf9a7a6j9b9g24ismc3fn0q7216k";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/06c50f32b8d603db0d70e77907e36862cd66b811/recipes/counsel";
@@ -11145,12 +10835,12 @@
     counsel-projectile = callPackage ({ counsel, fetchFromGitHub, fetchurl, lib, melpaBuild, projectile }:
     melpaBuild {
         pname = "counsel-projectile";
-        version = "20170911.1304";
+        version = "20171001.641";
         src = fetchFromGitHub {
           owner = "ericdanan";
           repo = "counsel-projectile";
-          rev = "20557b47a963cc5304ac2bc3ea4800c3a7da7feb";
-          sha256 = "0cszbczgpsm6l2pwh8pci3md0aranilqw6j0519vr6aaj5j6g15p";
+          rev = "88a16cb75301ae95f21a71e8838a49590d011e73";
+          sha256 = "155yvmyyg99znxnb3viagmd3hmii44fww68g857l7msw4q9ki1gy";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/389f16f886a385b02f466540f042a16eea8ba792/recipes/counsel-projectile";
@@ -11478,26 +11168,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    crosshairs = callPackage ({ col-highlight, fetchurl, hl-line-plus, lib, melpaBuild, vline }:
-    melpaBuild {
-        pname = "crosshairs";
-        version = "20170626.1548";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/crosshairs.el?revision=40";
-          sha256 = "1dcynm83a3ixdccw3cqy533d9xwzswyi67cydaqmv35q88dg2nqw";
-          name = "crosshairs.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/crosshairs";
-          sha256 = "0s7gh5zrb46hzybmpydb0pad7jinvcwds7i03ndhzwx89rxg3019";
-          name = "crosshairs";
-        };
-        packageRequires = [ col-highlight hl-line-plus vline ];
-        meta = {
-          homepage = "https://melpa.org/#/crosshairs";
-          license = lib.licenses.free;
-        };
-      }) {};
     crux = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, seq }:
     melpaBuild {
         pname = "crux";
@@ -11585,12 +11255,12 @@
     csharp-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "csharp-mode";
-        version = "20170502.158";
+        version = "20170927.816";
         src = fetchFromGitHub {
           owner = "josteink";
           repo = "csharp-mode";
-          rev = "628a4e2afa0e9c4672e8654c86240cb7f7bdf444";
-          sha256 = "0gnl7nddgy7b83p70ybr41s3f6ybs383hdbzhp9jvxb21g665hn6";
+          rev = "331b45df9c6e84601cea323638f82ce5e4a68b03";
+          sha256 = "00i53c5a85n1i48jyxg78ab2yicx8maybfc6mzxw8s12j9hbw75i";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/736716bbcfd9c9fb1d10ce290cb4f66fe1c68f44/recipes/csharp-mode";
@@ -11606,12 +11276,12 @@
     csound-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, multi, shut-up }:
     melpaBuild {
         pname = "csound-mode";
-        version = "20170911.1412";
+        version = "20170923.807";
         src = fetchFromGitHub {
           owner = "hlolli";
           repo = "csound-mode";
-          rev = "c5243852d20e54e43a4a7fc19c58bbd10fa8570b";
-          sha256 = "1wa4356xykkfmfp8pkk72r2s18l9vhv9mdhrq827fh6cgz64p4s8";
+          rev = "b5abcb68cedf1231c2e419bf87e875bfdb8fbc42";
+          sha256 = "0r5c8g3jjb4p3a21mjdi9xcmify0c2r61d5y7ycbia7rjv9xpgdh";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c940d29de11e43b4abf2901c466c94d426a21818/recipes/csound-mode";
@@ -11708,34 +11378,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    csv-nav = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "csv-nav";
-        version = "20130407.1120";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/csv-nav.el?revision=7";
-          sha256 = "15rfg3326xcs3zj3siy9rn7yff101vfch1srskdi2650c3l3krva";
-          name = "csv-nav.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/4327b4dd464ebb00c2acdd496274dedf912cdf92/recipes/csv-nav";
-          sha256 = "0626vsm2f5zc2wi5pyx4xrwcr4ai8w9a3l7gi9883smvayr619sj";
-          name = "csv-nav";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/csv-nav";
-          license = lib.licenses.free;
-        };
-      }) {};
     ctable = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "ctable";
-        version = "20140304.1659";
+        version = "20171005.1711";
         src = fetchFromGitHub {
           owner = "kiwanami";
           repo = "emacs-ctable";
-          rev = "cd673a09a80ce4e9e102ffe2e3d7e6bfb9d652b0";
-          sha256 = "07vasdlai49qs0nsmq2cz1kcq1adqyarv8199imgwwcbh4vn7dqb";
+          rev = "b8830d1ca95abb100a81bc32011bd17d5ecba000";
+          sha256 = "0pg303pnqscrsbx9579hc815angszsgf9vpd2z2f8p4f4ka6a00h";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/8bc29a8d518ce7a584277089bd4654f52ac0f358/recipes/ctable";
@@ -11818,8 +11469,8 @@
         src = fetchFromGitHub {
           owner = "mortberg";
           repo = "cubicaltt";
-          rev = "c920475b9f9b50559d81d39ad177dbe22b258a35";
-          sha256 = "0s7az1j0dpi306j01wzw5ldy6cvpz56fk0x4jhb7bsnq01lkm7jy";
+          rev = "747f5bafad712b90da9eb7e6b893fff16683fe17";
+          sha256 = "1px9pycw44jvkl8gz1zz577hw61l7xvpmdl1bf1bl5wy72x13v42";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1be42b49c206fc4f0df6fb50fed80b3d9b76710b/recipes/cubicaltt";
@@ -11874,25 +11525,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    cursor-chg = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "cursor-chg";
-        version = "20170221.1610";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/cursor-chg.el?revision=21";
-          sha256 = "026x1mbjrf68xrv970jbf131d26rj0nmzi1x0c8r6qdr02pw2jy1";
-          name = "cursor-chg.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/cursor-chg";
-          sha256 = "1yam5hz1v16g2v19j3dmgbj7n2rj8dsqyr5hwfyc031s6q7f649x";
-          name = "cursor-chg";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/cursor-chg";
-          license = lib.licenses.free;
-        };
-      }) {};
     cursor-test = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "cursor-test";
@@ -11911,25 +11543,6 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://melpa.org/#/cursor-test";
-          license = lib.licenses.free;
-        };
-      }) {};
-    cus-edit-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "cus-edit-plus";
-        version = "20170604.1000";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/cus-edit+.el";
-          sha256 = "0awn3m16cyamb4h9i4iq9fzbwzl6qrkpbcr4v3dr7iwlcz7lw7jl";
-          name = "cus-edit+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/57370fc617f4f10cc67e9d3c6dc113ff0a18cace/recipes/cus-edit+";
-          sha256 = "1kazcdfajcnrzvhsgsmwwx96rkry0dglprrc02hbd7ky1fppp4sz";
-          name = "cus-edit-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/cus-edit+";
           license = lib.licenses.free;
         };
       }) {};
@@ -12017,25 +11630,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    cygwin-mount = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "cygwin-mount";
-        version = "20131111.1346";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/cygwin-mount.el?revision=17";
-          sha256 = "09my4gj3qm9rdpk8lg6n6ki8ywj7kwzwd4hhgwascfnfi1hzwdvw";
-          name = "cygwin-mount.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/f94fb69a954275ee4098c96495b8566d6ce7cbb9/recipes/cygwin-mount";
-          sha256 = "0ik2c8ab9bsx58mgcv511p50h45cpv7455n4b0kri83sx9xf5abb";
-          name = "cygwin-mount";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/cygwin-mount";
-          license = lib.licenses.free;
-        };
-      }) {};
     cyphejor = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "cyphejor";
@@ -12085,8 +11679,8 @@
         src = fetchFromGitHub {
           owner = "cython";
           repo = "cython";
-          rev = "e6315294395ad44e667a804710938ee799575296";
-          sha256 = "07lgc3g66w8ggmnhqn7vrck3vl9jcvwmg67mlb772kz9d5v4kn5x";
+          rev = "14b085980903fa5a172a118929aecbae2d1975c4";
+          sha256 = "0rpilj79a1kpd7z5pmq04pqc7gxaxlfj7br6gfsx2bs07mc0j6b8";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/be9bfabe3f79153cb859efc7c3051db244a63879/recipes/cython-mode";
@@ -12165,12 +11759,12 @@
     dad-joke = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "dad-joke";
-        version = "20170814.824";
+        version = "20170927.2358";
         src = fetchFromGitHub {
           owner = "davep";
           repo = "dad-joke.el";
-          rev = "92641503c7e93309db12380d5228f99dbe64a53c";
-          sha256 = "063cz5k264qbkb5g87xr6z68fjjnw3j1hpckdn6nqy8cin4qhagc";
+          rev = "bee47e7b746b403228fa7d7361cb095de19ac9ba";
+          sha256 = "14snnnjs28jg6k8x6g90m3dbcx10306ipcd256d3l6czk9p17vpd";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/484d571b2737f7c613816333afdde6460c64e635/recipes/dad-joke";
@@ -12228,12 +11822,12 @@
     danneskjold-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "danneskjold-theme";
-        version = "20170702.1007";
+        version = "20170928.1211";
         src = fetchFromGitHub {
           owner = "rails-to-cosmos";
           repo = "danneskjold-theme";
-          rev = "f4de0fa84bec756ea31419f8db0b900fd1603c83";
-          sha256 = "1wzwiahab6r8y772mg6268sh7l3b1fw4hxl10d38qv2khy641vlv";
+          rev = "b516cf4556bb2a1a898701d953374b96079678b3";
+          sha256 = "0ilzd6qwjjj5lfimv3b5him54yh7lpxhlm0hnsmk6zcrr6884vsl";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/557244a3b60c7cd3ca964ff843aa1e9d5a1e32ec/recipes/danneskjold-theme";
@@ -12249,12 +11843,12 @@
     dante = callPackage ({ dash, emacs, f, fetchFromGitHub, fetchurl, flycheck, haskell-mode, lib, melpaBuild, s }:
     melpaBuild {
         pname = "dante";
-        version = "20170901.525";
+        version = "20171004.1231";
         src = fetchFromGitHub {
           owner = "jyp";
           repo = "dante";
-          rev = "203dcd8b748d485d1c78d04d81db22fd00cb71d7";
-          sha256 = "1ywx46mm1zrj0hnx2zwyxlxlq7ysg46hsy5vi6hmfppwbrfmkyzv";
+          rev = "17961ec04dbe924a4c43ff0fe94bd72d044d9703";
+          sha256 = "14r1jhrrq4d5l0fsjacf619f4nhc86aq4jab8qzfkszi348r5g7j";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5afa8226077cbda4b76f52734cf8e0b745ab88e8/recipes/dante";
@@ -12264,6 +11858,27 @@
         packageRequires = [ dash emacs f flycheck haskell-mode s ];
         meta = {
           homepage = "https://melpa.org/#/dante";
+          license = lib.licenses.free;
+        };
+      }) {};
+    darcsum = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "darcsum";
+        version = "20140315.2110";
+        src = fetchFromGitHub {
+          owner = "emacsorphanage";
+          repo = "darcsum";
+          rev = "00c252b51cb24c25fb74f529960ebd631514a4c1";
+          sha256 = "1vbfdmc56ma2ycxhza681ninhdxgvxm9j5xb9374xiqmb6g0vykq";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/30de78c9cf83de30093a5647976eeaf552d4b2cb/recipes/darcsum";
+          sha256 = "0p3hwmwjjqwgkjws5b7gkad4yxh0gs2hr03ar18y43yahwgihvnv";
+          name = "darcsum";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://melpa.org/#/darcsum";
           license = lib.licenses.free;
         };
       }) {};
@@ -12459,12 +12074,12 @@
     dash = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "dash";
-        version = "20170810.137";
+        version = "20171009.105";
         src = fetchFromGitHub {
           owner = "magnars";
           repo = "dash.el";
-          rev = "dcb0ec1623517e54551b801846a272dd07fd55b2";
-          sha256 = "1wfky9gq0qw4x8i8wnssh2zn18i953pypw23j35ra03rfknha1zc";
+          rev = "8ef32875da21ea278002da823c05b7206cc1a81e";
+          sha256 = "1zci5bbc5s9m6dvgiypsxwkqiqd67la5wxrqny1qnsii5c4id1kc";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/57eed8767c3e98614259c408dc0b5c54d3473883/recipes/dash";
@@ -12505,8 +12120,8 @@
         src = fetchFromGitHub {
           owner = "magnars";
           repo = "dash.el";
-          rev = "dcb0ec1623517e54551b801846a272dd07fd55b2";
-          sha256 = "1wfky9gq0qw4x8i8wnssh2zn18i953pypw23j35ra03rfknha1zc";
+          rev = "8ef32875da21ea278002da823c05b7206cc1a81e";
+          sha256 = "1zci5bbc5s9m6dvgiypsxwkqiqd67la5wxrqny1qnsii5c4id1kc";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/57eed8767c3e98614259c408dc0b5c54d3473883/recipes/dash-functional";
@@ -12522,12 +12137,12 @@
     dashboard = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, page-break-lines }:
     melpaBuild {
         pname = "dashboard";
-        version = "20170901.2";
+        version = "20170923.719";
         src = fetchFromGitHub {
           owner = "rakanalh";
           repo = "emacs-dashboard";
-          rev = "8a555de891a83a9cd080c940dde183a8806479a9";
-          sha256 = "1w7f2fvnhqzcr6az4fkgb11k8qjzg81vwzx96qhym8d70sabahzh";
+          rev = "8594c4f55448148b720eda5b72d51667fb7a8a39";
+          sha256 = "1hhh1kfsz87qfmh45wjf2r93rz79rq0vbyxlfrsl02092zjbl1zr";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/e9a79341ccaa82a8c065e71c02fe6aee22007c66/recipes/dashboard";
@@ -12585,12 +12200,12 @@
     datetime = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "datetime";
-        version = "20170318.254";
+        version = "20170928.815";
         src = fetchFromGitHub {
           owner = "doublep";
           repo = "datetime";
-          rev = "3ecf9985250ecd441e91614b44cf12323af907c0";
-          sha256 = "1x8kj6d9p42lffk15m0c955ibwxxvfxhihij43alwq5xab2l16bv";
+          rev = "082d2c7b0e38c26a8c46af9c9956a2e100d88e71";
+          sha256 = "0fdswqi53qx924lib7nd9dazn0916xf1ybrh3bcn3f8cn6b8ikg5";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/fff9f0748b0ef76130b24e85ed109325256f956e/recipes/datetime";
@@ -12900,12 +12515,12 @@
     define-word = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "define-word";
-        version = "20150709.1223";
+        version = "20171001.1616";
         src = fetchFromGitHub {
           owner = "abo-abo";
           repo = "define-word";
-          rev = "64d98b7748686c51261fe6e8d42078c6284feb13";
-          sha256 = "02i621yq2ih0zp7mna8iykj41prv77hvcadz7rx8c942zyvjzxqd";
+          rev = "a425ffe44d62622b86477a622c6188a56bc2bd9a";
+          sha256 = "02v9yzvinapr6m7pjxr4kcgqnlm7j21ygh1dhkabarz83v43awh3";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/e318b30d8b2b89981f4b89d78e5a46e77d3de412/recipes/define-word";
@@ -12984,12 +12599,12 @@
     demangle-mode = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "demangle-mode";
-        version = "20170526.1508";
+        version = "20170923.1501";
         src = fetchFromGitHub {
           owner = "liblit";
           repo = "demangle-mode";
-          rev = "d3fce31974b1c9f659da427f3c69c2e6168df508";
-          sha256 = "0k4pacjjgxagsa8kgzvynvmvczhbb73waq3l6gld7v3h38js163a";
+          rev = "79231b05f97da147d66120f947656f856a3a64fb";
+          sha256 = "0whr18qwi5bmz39n8x836sjgky20qhw59qha59c11dvly1qs5nnq";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6ced9f4ffb051a8474d3f72695156416cf2dd8be/recipes/demangle-mode";
@@ -13128,18 +12743,40 @@
           license = lib.licenses.free;
         };
       }) {};
-    dic-lookup-w3m = callPackage ({ fetchsvn, fetchurl, lib, melpaBuild, stem, w3m }:
+    dhall-mode = callPackage ({ ansi-color ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "dhall-mode";
+        version = "20171006.1233";
+        src = fetchFromGitHub {
+          owner = "psibi";
+          repo = "dhall-mode";
+          rev = "181e5b0df73ce729cf4b711fa76bb43c2581d29d";
+          sha256 = "1jw4is9jxx60hsaqjkmravrkxdfn7ni6zl9wx9i7r2y2r5mmwx88";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/c7ab435077b2f47d75ddc0ff10c64ee2b46044e2/recipes/dhall-mode";
+          sha256 = "1zkspjwllcw9k4nlnif6jdwzl08ki39vmx90apw029n87xhvx7mp";
+          name = "dhall-mode";
+        };
+        packageRequires = [ ansi-color emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/dhall-mode";
+          license = lib.licenses.free;
+        };
+      }) {};
+    dic-lookup-w3m = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, stem, w3m }:
     melpaBuild {
         pname = "dic-lookup-w3m";
         version = "20170803.354";
-        src = fetchsvn {
-          url = "https://svn.osdn.jp/svnroot/dic-lookup-w3m/";
-          rev = "99";
+        src = fetchFromGitHub {
+          owner = "emacsorphanage";
+          repo = "dic-lookup-w3m";
+          rev = "79aca5eb9c78e67cb85a386060d48113caad5ec3";
           sha256 = "18l2s37bnnzbgw22mivgw5isxck2y0n3nk7735r4ir5y5wqx88mr";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/caaa21f235c4864f6008fb454d0a970a2fd22a86/recipes/dic-lookup-w3m";
-          sha256 = "1siqrarpyqjh1h350dsyca993fy6qin4apgyjm4vpp6awip8xfp0";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/30de78c9cf83de30093a5647976eeaf552d4b2cb/recipes/dic-lookup-w3m";
+          sha256 = "1kwbmzzf8sj4bn5kicmlp2hzv8ydcikwmdy7s40ggkgf1mk9zvqr";
           name = "dic-lookup-w3m";
         };
         packageRequires = [ stem w3m ];
@@ -13343,8 +12980,8 @@
         src = fetchFromGitHub {
           owner = "myrjola";
           repo = "diminish.el";
-          rev = "d5c61a14e1a5590a65f83c099a5bd42fcadff24d";
-          sha256 = "0c0p4b3nfnczmkjx64qz2w9dk0b7srfnhrnd902qn9z55k4n0wg8";
+          rev = "565a983a39d2e2cffab5df13b34f3b6116723208";
+          sha256 = "173lzj9l7a4wcfvdq6akvfyyyriy5c30b4vhhv51hs051dmn02d0";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1bfb4acb381cada46458cf60eae9b88d007294d5/recipes/diminish";
@@ -13427,8 +13064,8 @@
         src = fetchFromGitHub {
           owner = "Fuco1";
           repo = "dired-hacks";
-          rev = "325e2c5300b9acccf786c0cc46637c18d39790e7";
-          sha256 = "1p6m02d4j2wrnx7nlj5zqzc5q34d62ffc56hjhiw4r01vvvzm65j";
+          rev = "1c24048931c1fa8a7c54e80e2b3e9acc17e50dfb";
+          sha256 = "02chi7y41d3wqpdg91hdb51wdh4gvlbrhghsdz8zwc1ib3hvkxkl";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/568e524b7bdf91b31655bdbb30fe9481d7a0ffbf/recipes/dired-avfs";
@@ -13448,8 +13085,8 @@
         src = fetchFromGitHub {
           owner = "Fuco1";
           repo = "dired-hacks";
-          rev = "325e2c5300b9acccf786c0cc46637c18d39790e7";
-          sha256 = "1p6m02d4j2wrnx7nlj5zqzc5q34d62ffc56hjhiw4r01vvvzm65j";
+          rev = "1c24048931c1fa8a7c54e80e2b3e9acc17e50dfb";
+          sha256 = "02chi7y41d3wqpdg91hdb51wdh4gvlbrhghsdz8zwc1ib3hvkxkl";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6aab23df1451682ff18d9ad02c35cb7ec612bc38/recipes/dired-collapse";
@@ -13459,45 +13096,6 @@
         packageRequires = [ dash f ];
         meta = {
           homepage = "https://melpa.org/#/dired-collapse";
-          license = lib.licenses.free;
-        };
-      }) {};
-    dired-details = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "dired-details";
-        version = "20130824.458";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/dired-details.el?revision=15";
-          sha256 = "1ddrhj1kw0wl7jbs9jn067vfffsvqhz4izfw9f7ihxz34fdl2iza";
-          name = "dired-details.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/dired-details";
-          sha256 = "0kmcnx9zvfdwvq100nazgypkfwlgxgrbimprc5pysid8rrxyzws7";
-          name = "dired-details";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/dired-details";
-          license = lib.licenses.free;
-        };
-      }) {};
-    dired-details-plus = callPackage ({ dired-details, fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "dired-details-plus";
-        version = "20170903.1237";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/dired-details+.el";
-          sha256 = "03r7afjp376d0c34r1nj5hz914lbrk9y5ripar1w697bqk8kaxy3";
-          name = "dired-details+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/dired-details+";
-          sha256 = "0b4y01hk839z6m7fx5bwa80gwylvkp15niri8vrjak4vgj5g5cg9";
-          name = "dired-details-plus";
-        };
-        packageRequires = [ dired-details ];
-        meta = {
-          homepage = "https://melpa.org/#/dired-details+";
           license = lib.licenses.free;
         };
       }) {};
@@ -13609,12 +13207,12 @@
     dired-filter = callPackage ({ cl-lib ? null, dash, dired-hacks-utils, f, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "dired-filter";
-        version = "20170718.1145";
+        version = "20171006.711";
         src = fetchFromGitHub {
           owner = "Fuco1";
           repo = "dired-hacks";
-          rev = "325e2c5300b9acccf786c0cc46637c18d39790e7";
-          sha256 = "1p6m02d4j2wrnx7nlj5zqzc5q34d62ffc56hjhiw4r01vvvzm65j";
+          rev = "1c24048931c1fa8a7c54e80e2b3e9acc17e50dfb";
+          sha256 = "02chi7y41d3wqpdg91hdb51wdh4gvlbrhghsdz8zwc1ib3hvkxkl";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/568e524b7bdf91b31655bdbb30fe9481d7a0ffbf/recipes/dired-filter";
@@ -13634,8 +13232,8 @@
         src = fetchFromGitHub {
           owner = "Fuco1";
           repo = "dired-hacks";
-          rev = "325e2c5300b9acccf786c0cc46637c18d39790e7";
-          sha256 = "1p6m02d4j2wrnx7nlj5zqzc5q34d62ffc56hjhiw4r01vvvzm65j";
+          rev = "1c24048931c1fa8a7c54e80e2b3e9acc17e50dfb";
+          sha256 = "02chi7y41d3wqpdg91hdb51wdh4gvlbrhghsdz8zwc1ib3hvkxkl";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/568e524b7bdf91b31655bdbb30fe9481d7a0ffbf/recipes/dired-hacks-utils";
@@ -13735,12 +13333,12 @@
     dired-launch = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "dired-launch";
-        version = "20170409.1923";
+        version = "20171004.1027";
         src = fetchFromGitHub {
           owner = "thomp";
           repo = "dired-launch";
-          rev = "75745f2e40d060cae909f9e6f6ca2e5f725180b8";
-          sha256 = "1amsqbbjzjw07s40v8c63iw59qf5r1x7rqq2iq1jiybwsrp9s7v0";
+          rev = "f71826804221bafc4f9f2f75a800400a72c24b8b";
+          sha256 = "1cyg1bbn2jj101wz2jjzk832mfk5yhnc4a9m817lnalf73j0nkrs";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/31c9a4945d65aa6afc371c447a572284d38d4d71/recipes/dired-launch";
@@ -13760,8 +13358,8 @@
         src = fetchFromGitHub {
           owner = "Fuco1";
           repo = "dired-hacks";
-          rev = "325e2c5300b9acccf786c0cc46637c18d39790e7";
-          sha256 = "1p6m02d4j2wrnx7nlj5zqzc5q34d62ffc56hjhiw4r01vvvzm65j";
+          rev = "1c24048931c1fa8a7c54e80e2b3e9acc17e50dfb";
+          sha256 = "02chi7y41d3wqpdg91hdb51wdh4gvlbrhghsdz8zwc1ib3hvkxkl";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/8994330f90a925df17ae425ccdc87865df8e19cd/recipes/dired-narrow";
@@ -13781,8 +13379,8 @@
         src = fetchFromGitHub {
           owner = "Fuco1";
           repo = "dired-hacks";
-          rev = "325e2c5300b9acccf786c0cc46637c18d39790e7";
-          sha256 = "1p6m02d4j2wrnx7nlj5zqzc5q34d62ffc56hjhiw4r01vvvzm65j";
+          rev = "1c24048931c1fa8a7c54e80e2b3e9acc17e50dfb";
+          sha256 = "02chi7y41d3wqpdg91hdb51wdh4gvlbrhghsdz8zwc1ib3hvkxkl";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/568e524b7bdf91b31655bdbb30fe9481d7a0ffbf/recipes/dired-open";
@@ -13792,25 +13390,6 @@
         packageRequires = [ dash dired-hacks-utils ];
         meta = {
           homepage = "https://melpa.org/#/dired-open";
-          license = lib.licenses.free;
-        };
-      }) {};
-    dired-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "dired-plus";
-        version = "20170818.1411";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/dired+.el";
-          sha256 = "04yr4gwg5y6qjbjx2klharzf7s9n1akx2n14yddjrv7hr6rkxlrs";
-          name = "dired+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/4327b4dd464ebb00c2acdd496274dedf912cdf92/recipes/dired+";
-          sha256 = "1dmp6wcynran03nsa0fd26b9q0zj9wp8ngaafx1i1ybwn2gx32g5";
-          name = "dired-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/dired+";
           license = lib.licenses.free;
         };
       }) {};
@@ -13838,12 +13417,12 @@
     dired-rainbow = callPackage ({ dash, dired-hacks-utils, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "dired-rainbow";
-        version = "20170531.816";
+        version = "20170922.817";
         src = fetchFromGitHub {
           owner = "Fuco1";
           repo = "dired-hacks";
-          rev = "325e2c5300b9acccf786c0cc46637c18d39790e7";
-          sha256 = "1p6m02d4j2wrnx7nlj5zqzc5q34d62ffc56hjhiw4r01vvvzm65j";
+          rev = "1c24048931c1fa8a7c54e80e2b3e9acc17e50dfb";
+          sha256 = "02chi7y41d3wqpdg91hdb51wdh4gvlbrhghsdz8zwc1ib3hvkxkl";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/568e524b7bdf91b31655bdbb30fe9481d7a0ffbf/recipes/dired-rainbow";
@@ -13863,8 +13442,8 @@
         src = fetchFromGitHub {
           owner = "Fuco1";
           repo = "dired-hacks";
-          rev = "325e2c5300b9acccf786c0cc46637c18d39790e7";
-          sha256 = "1p6m02d4j2wrnx7nlj5zqzc5q34d62ffc56hjhiw4r01vvvzm65j";
+          rev = "1c24048931c1fa8a7c54e80e2b3e9acc17e50dfb";
+          sha256 = "02chi7y41d3wqpdg91hdb51wdh4gvlbrhghsdz8zwc1ib3hvkxkl";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c03f6f8c779c8784f52adb20b266404cb537113a/recipes/dired-ranger";
@@ -13884,8 +13463,8 @@
         src = fetchFromGitHub {
           owner = "jojojames";
           repo = "dired-sidebar";
-          rev = "9ac42bb6663e6c0c5e4e3dd2258b63e24cf33c90";
-          sha256 = "0x6gmpjm1rv38h6w5zv98vk86d7s0qvsa3pl5sab268dbhw0l9w2";
+          rev = "35e43797f037fc298b6478817d51be3ceff5b568";
+          sha256 = "1rizajqh96im8ygbfzrhn0ysh3r9qlk7njgn2rayk6a5krj6gn16";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/30e15c8361b01195f198197e704828fbcac0e8d6/recipes/dired-sidebar";
@@ -13919,64 +13498,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    dired-sort = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "dired-sort";
-        version = "20090208.2038";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/dired-sort.el?revision=1";
-          sha256 = "1dpxkxxfs14sdm3hwxv0j26lq0qzx4gryw42vrcdi680aj24962z";
-          name = "dired-sort.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/f1e4cd8274cdec74a9867060f72ec2025ed0150d/recipes/dired-sort";
-          sha256 = "1dzy2601yikmmbfqivf9s5xi4vd1f5g3c53f8rc74kfnxr1qn59x";
-          name = "dired-sort";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/dired-sort";
-          license = lib.licenses.free;
-        };
-      }) {};
-    dired-sort-menu = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "dired-sort-menu";
-        version = "20130824.507";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/dired-sort-menu.el?revision=9";
-          sha256 = "1i42r7j1c8677qf79ig33bia24d2yvcj26y92migfvrlbi03w4qi";
-          name = "dired-sort-menu.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/dired-sort-menu";
-          sha256 = "0n7zh8s3vdw3pcax8wkas9rykf917wn2dzikdlyrl5bbil9ijblb";
-          name = "dired-sort-menu";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/dired-sort-menu";
-          license = lib.licenses.free;
-        };
-      }) {};
-    dired-sort-menu-plus = callPackage ({ dired-sort-menu, fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "dired-sort-menu-plus";
-        version = "20170221.1630";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/dired-sort-menu+.el";
-          sha256 = "0f2z0nj51i27qqj0ws644k61dj9bp3hagi9phj9d41fcsqzzja4h";
-          name = "dired-sort-menu+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/dired-sort-menu+";
-          sha256 = "19ah8qgbfdvyhfszdr6hlw8l01lbdb84vf5snldw8qh3x6lw8cfq";
-          name = "dired-sort-menu-plus";
-        };
-        packageRequires = [ dired-sort-menu ];
-        meta = {
-          homepage = "https://melpa.org/#/dired-sort-menu+";
-          license = lib.licenses.free;
-        };
-      }) {};
     dired-subtree = callPackage ({ dash, dired-hacks-utils, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "dired-subtree";
@@ -13984,8 +13505,8 @@
         src = fetchFromGitHub {
           owner = "Fuco1";
           repo = "dired-hacks";
-          rev = "325e2c5300b9acccf786c0cc46637c18d39790e7";
-          sha256 = "1p6m02d4j2wrnx7nlj5zqzc5q34d62ffc56hjhiw4r01vvvzm65j";
+          rev = "1c24048931c1fa8a7c54e80e2b3e9acc17e50dfb";
+          sha256 = "02chi7y41d3wqpdg91hdb51wdh4gvlbrhghsdz8zwc1ib3hvkxkl";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d6a947ac9476f10b95a3c153ec784d2a8330dd4c/recipes/dired-subtree";
@@ -14037,6 +13558,27 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/dired-toggle-sudo";
+          license = lib.licenses.free;
+        };
+      }) {};
+    diredfl = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "diredfl";
+        version = "20171005.39";
+        src = fetchFromGitHub {
+          owner = "purcell";
+          repo = "diredfl";
+          rev = "2393653a1518b118180ff90ef2b66cfb7d0b555c";
+          sha256 = "04yykal90pc4nsdlk08z6svsnddjzaz1drwvs3bqfjw01fr50xcs";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/3da86e18d423198766455929da1dcb3a9a3be381/recipes/diredfl";
+          sha256 = "0cybq15yq07x2mnrnwapy020d598yymcy8y9wwf1m7f59p3h9hvn";
+          name = "diredfl";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/diredfl";
           license = lib.licenses.free;
         };
       }) {};
@@ -14169,12 +13711,12 @@
     disable-mouse = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "disable-mouse";
-        version = "20160630.1903";
+        version = "20170929.1353";
         src = fetchFromGitHub {
           owner = "purcell";
           repo = "disable-mouse";
-          rev = "f7d6f70a3c0a751a946613f997330fbc95a38c3e";
-          sha256 = "0d2hmaiz8v8kzkbdi281hyf3yfjwr03ngxr2qphgm7xk9298351v";
+          rev = "81639930bcaeedadbcc19728e91719afcac84613";
+          sha256 = "0l6mai68ns3qw3rlvjvzsnqwdy7bxqiy0vdwflq0l1plxb1vazyc";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/dbbc396373212fdf731e135cde391f27708ff015/recipes/disable-mouse";
@@ -14310,25 +13852,6 @@
         packageRequires = [ makey ];
         meta = {
           homepage = "https://melpa.org/#/discover-my-major";
-          license = lib.licenses.free;
-        };
-      }) {};
-    disk = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "disk";
-        version = "20081128.706";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/disk.el?revision=9";
-          sha256 = "1c0pgqvl1z2f5hprszln53pn2v2pqy110r3wx3g84v71w6378bbv";
-          name = "disk.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/edcafb4c459cf51fecc7c43a3e4dcbe377d68b46/recipes/disk";
-          sha256 = "0bij9gr4zv6jmc6dwsy3lb06vsxvmyzl8xrm8wzasxisk1qd2l6n";
-          name = "disk";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/disk";
           license = lib.licenses.free;
         };
       }) {};
@@ -14804,12 +14327,12 @@
     docker-compose-mode = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, yaml-mode }:
     melpaBuild {
         pname = "docker-compose-mode";
-        version = "20170910.1034";
+        version = "20170916.1438";
         src = fetchFromGitHub {
           owner = "meqif";
           repo = "docker-compose-mode";
-          rev = "372df2f0de34a4bd44d4a7274b9ab85117ac7392";
-          sha256 = "14vgjhy2j60xhf38zm5nlkr4d3r455kw6paw0wff4mqmdjcg3pds";
+          rev = "f3c06a43d69dfe80041a82a9365281bd5c65a105";
+          sha256 = "1fzz950wb95lp15ak8q4vzls21w9fc3qxqs5hlf50najdw36w52h";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/37dd4c1fc11d22598c6faf03ccc860503a68b950/recipes/docker-compose-mode";
@@ -14951,12 +14474,12 @@
     doom-themes = callPackage ({ all-the-icons, cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "doom-themes";
-        version = "20170912.726";
+        version = "20170927.1705";
         src = fetchFromGitHub {
           owner = "hlissner";
           repo = "emacs-doom-themes";
-          rev = "f7185cf7536e1f96e7cede2ce81c2b51205df850";
-          sha256 = "1wqa5b9ni8rci4h8m78h7cb3387gi45v1w6z5dbya4zvaw1gwx8p";
+          rev = "99a4c8691436b80ffb242512f026a8cc32b9539a";
+          sha256 = "0ww95dr3djxdwba0kark0d1j1q4vkjhnpiv5s5gc5zhgbc0421rb";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c5084bc2c3fe378af6ff39d65e40649c6359b7b5/recipes/doom-themes";
@@ -14966,84 +14489,6 @@
         packageRequires = [ all-the-icons cl-lib emacs ];
         meta = {
           homepage = "https://melpa.org/#/doom-themes";
-          license = lib.licenses.free;
-        };
-      }) {};
-    doremi = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "doremi";
-        version = "20170221.1634";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/doremi.el?revision=42";
-          sha256 = "03alkj4mxajsgmghw935hm3c95a12222zq1ig6kwmfrla5kg3b7q";
-          name = "doremi.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/doremi";
-          sha256 = "11i4cdxgrspx44p44zz5py89ypji5li6p5w77wy0b07i8a5gq2gb";
-          name = "doremi";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/doremi";
-          license = lib.licenses.free;
-        };
-      }) {};
-    doremi-cmd = callPackage ({ doremi, fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "doremi-cmd";
-        version = "20170221.1631";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/doremi-cmd.el?revision=47";
-          sha256 = "09iizx079y43qk3jd66n8i8ifm2s7jnc9g7831nv5f3c26rgl0w6";
-          name = "doremi-cmd.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/doremi-cmd";
-          sha256 = "1qzspirn1abqps0dn5z8w6ymffc6b02dyki5hr8v74wfs8fhzx05";
-          name = "doremi-cmd";
-        };
-        packageRequires = [ doremi ];
-        meta = {
-          homepage = "https://melpa.org/#/doremi-cmd";
-          license = lib.licenses.free;
-        };
-      }) {};
-    doremi-frm = callPackage ({ doremi, faces-plus, fetchurl, frame-fns, hexrgb, lib, melpaBuild }:
-    melpaBuild {
-        pname = "doremi-frm";
-        version = "20170221.1632";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/doremi-frm.el?revision=74";
-          sha256 = "0f9vwajgdm37krz55sv5c8ijfqhy5gsxj1zyxg8zbs6l33giynxd";
-          name = "doremi-frm.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/doremi-frm";
-          sha256 = "1rj3p665q32acsxxwygv1j5nbmjqrhi0b4glzrk88xki4lyz0ihz";
-          name = "doremi-frm";
-        };
-        packageRequires = [ doremi faces-plus frame-fns hexrgb ];
-        meta = {
-          homepage = "https://melpa.org/#/doremi-frm";
-          license = lib.licenses.free;
-        };
-      }) {};
-    doremi-mac = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "doremi-mac";
-        version = "20170221.1633";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/doremi-mac.el?revision=30";
-          sha256 = "002jhqk26ywiyci1r91aqbq0zhbxy6rsyw3h74ck04rxjfc49rxl";
-          name = "doremi-mac.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/doremi-mac";
-          sha256 = "0n9fffgxnpqc7cch7aci5kxbwzk36iljdz2r8gcp5y5n1p7aamls";
-          name = "doremi-mac";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/doremi-mac";
           license = lib.licenses.free;
         };
       }) {};
@@ -15341,34 +14786,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    dropdown-list = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "dropdown-list";
-        version = "20120329.936";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/dropdown-list.el?revision=5";
-          sha256 = "1szy46sk3nvlbb3yzk1s983281kkf507xr3fkclkki3d3x31n08a";
-          name = "dropdown-list.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/dropdown-list";
-          sha256 = "1zqqa4872r96fp377bcz6pd1djz59ami5k09abb62dw854sc5xfj";
-          name = "dropdown-list";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/dropdown-list";
-          license = lib.licenses.free;
-        };
-      }) {};
     drupal-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, php-mode }:
     melpaBuild {
         pname = "drupal-mode";
-        version = "20170112.1136";
+        version = "20170926.38";
         src = fetchFromGitHub {
           owner = "arnested";
           repo = "drupal-mode";
-          rev = "9d5808972f344a09dcf665d5113ae81e39ac1051";
-          sha256 = "0vz41jfkfir7ymyl5y0v836zclqfihrjdiyz3vnb081x0gara8l0";
+          rev = "b0ca2c39650136f7e5672461e64397b9add30b92";
+          sha256 = "1l2xc24y037b3z62yxmq2bx1x3qqv56d15bf3qmb3mpgm4gh85j6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/13e16af340868048eb1f51f9865dfc707e57abe8/recipes/drupal-mode";
@@ -15402,17 +14828,19 @@
           license = lib.licenses.free;
         };
       }) {};
-    dsvn = callPackage ({ fetchsvn, fetchurl, lib, melpaBuild }: melpaBuild {
+    dsvn = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
         pname = "dsvn";
         version = "20130120.1257";
-        src = fetchsvn {
-          url = "https://svn.apache.org/repos/asf/subversion/trunk/contrib/client-side/emacs/";
-          rev = "1808231";
-          sha256 = "016dxpzm1zba8rag7czynlk58hys4xab4mz1nkry5bfihknpzcrq";
+        src = fetchFromGitHub {
+          owner = "emacsorphanage";
+          repo = "dsvn";
+          rev = "17bce692e9bd5a43373d5cb1d66da50e1acb903b";
+          sha256 = "1bv4ivv9j5r0ax4vay1kmwv753y44qj6qprr38yh7ky0fpsml34c";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/dsvn";
-          sha256 = "1y55s187q2xiab31vs95jjjp1a3qzwkdwn7p5man666scbjrdyl5";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/30de78c9cf83de30093a5647976eeaf552d4b2cb/recipes/dsvn";
+          sha256 = "1kgc0b8as7w1h9dsknv2h7dzr6jcrs0j0p376050pshgzcm79nm6";
           name = "dsvn";
         };
         packageRequires = [];
@@ -15445,12 +14873,12 @@
     dtrt-indent = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "dtrt-indent";
-        version = "20170825.847";
+        version = "20171001.1233";
         src = fetchFromGitHub {
           owner = "jscheid";
           repo = "dtrt-indent";
-          rev = "69d0c5e143453708dbf0ebec4e368bc26fff683c";
-          sha256 = "154m53hhzjawmrg2vlqjcg9npgq1igw9f0fz6gh7vscmbxl5dnjq";
+          rev = "7fd55af3b0311ea24b68397054e705c835fa5ef1";
+          sha256 = "1sgmd1zqdwa1f6y8d6vaacyipkqn2ivvaim1xndbkihgmhyn4kf0";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/61bcbcfa6c0f38a1d87f5b6913b8be6c50ef2994/recipes/dtrt-indent";
@@ -15505,15 +14933,36 @@
           license = lib.licenses.free;
         };
       }) {};
+    dumb-diff = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "dumb-diff";
+        version = "20170924.2036";
+        src = fetchFromGitHub {
+          owner = "jacktasia";
+          repo = "dumb-diff";
+          rev = "205ea5fda371f296fd876e362c12a5b64c4724d9";
+          sha256 = "0gxrrhlhp1g679c1ygj8m0jy4pag55b957vyxm9845z4vx93wj1x";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/cf7fa0b4235247d82569ed078f92774f10afa45c/recipes/dumb-diff";
+          sha256 = "1h1dvxbj85kgi04lxh0bpx81f6sl1fd56lhjmq1cw9biwqw0sm0c";
+          name = "dumb-diff";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/dumb-diff";
+          license = lib.licenses.free;
+        };
+      }) {};
     dumb-jump = callPackage ({ dash, emacs, f, fetchFromGitHub, fetchurl, lib, melpaBuild, popup, s }:
     melpaBuild {
         pname = "dumb-jump";
-        version = "20170911.1951";
+        version = "20170918.2024";
         src = fetchFromGitHub {
           owner = "jacktasia";
           repo = "dumb-jump";
-          rev = "67928ef6449318a8653812167540aa5919301260";
-          sha256 = "0i7jyh0zzk4ifkqwi89bnnwgvaaphnf4n5z299mg0fj4walzx3rz";
+          rev = "0d39c148abd5c76e5b39847a794ab3a240a7e018";
+          sha256 = "0ksddljicrjx4cbx8ws31bskcirjvbsxz60f4xh8j8ywi3s7wj4b";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/dumb-jump";
@@ -15592,11 +15041,11 @@
     dyalog-mode = callPackage ({ cl-lib ? null, emacs, fetchhg, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "dyalog-mode";
-        version = "20170519.704";
+        version = "20170926.500";
         src = fetchhg {
           url = "https://bitbucket.com/harsman/dyalog-mode";
-          rev = "56fa34ea25d4";
-          sha256 = "1hk7i557m0m42zdg59z278cylglnp49dr8wa3zbdwzk2xzdg0m00";
+          rev = "023d2edde61d";
+          sha256 = "1izhlafsbxfav4jvl7bqg188d71895r1sqacxsblvcld8c0brsqp";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5b7972602399f9df9139cff177e38653bb0f43ed/recipes/dyalog-mode";
@@ -15906,12 +15355,12 @@
     easy-hugo = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "easy-hugo";
-        version = "20170819.347";
+        version = "20171008.9";
         src = fetchFromGitHub {
           owner = "masasam";
           repo = "emacs-easy-hugo";
-          rev = "108cc2347507ff8c92b10a817de0850e9eb99ab2";
-          sha256 = "1fcq6693cjl0lx67gwsk53lm20zznq9cc9widb3rzpwifns4x8ac";
+          rev = "8f16fb1f510a147e7ab846030057d4c74127ffb2";
+          sha256 = "15axmg6z1nlaz7xsf70arxazkkskkga2fa71iswpnhwqsrr90w8l";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/easy-hugo";
@@ -16071,34 +15520,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    echo-bell = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "echo-bell";
-        version = "20170221.1635";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/echo-bell.el?revision=8";
-          sha256 = "0000ya8y6v5xvl5qkrsamzwh1iikc3clhpdpdr2da6c4b9cznydh";
-          name = "echo-bell.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a81e339e9c7cf1ae5fe91ab4442164336a6fbf13/recipes/echo-bell";
-          sha256 = "0adhdfbcpmdhd9252rh0jik2z3v9bzf0brpzfvcjn5py2x6724ws";
-          name = "echo-bell";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/echo-bell";
-          license = lib.licenses.free;
-        };
-      }) {};
     eclim = callPackage ({ cl-lib ? null, dash, fetchFromGitHub, fetchurl, json ? null, lib, melpaBuild, popup, s, yasnippet }:
     melpaBuild {
         pname = "eclim";
-        version = "20170522.1354";
+        version = "20170921.1440";
         src = fetchFromGitHub {
           owner = "emacs-eclim";
           repo = "emacs-eclim";
-          rev = "ebb844d1ebdd7eb347e89063a9b6e9f890a1ff57";
-          sha256 = "18q4blnxf7p2kvgh1rhr7pizga06z97hv1lxjgzv0dc2dll2zwmd";
+          rev = "322a796be1619fb2ade6de6d51111e5f3f5776d0";
+          sha256 = "05sil1pazr7rdg6hq34p5ba7rnp3rp2lfnhsjpr26fisfhkbbaic";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1e9d3075587fbd9ca188535fd945a7dc451c6d7e/recipes/eclim";
@@ -16135,12 +15565,12 @@
     ecukes = callPackage ({ ansi, commander, dash, espuds, f, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "ecukes";
-        version = "20170810.305";
+        version = "20170922.656";
         src = fetchFromGitHub {
           owner = "ecukes";
           repo = "ecukes";
-          rev = "65f29ff764c3742cc1190371b1ac91f0812535f3";
-          sha256 = "16dypiczds89kpwqj7p29n5qcqpc1d7faci2f4glw1m60gnkgvqq";
+          rev = "e16dcb430cf05a28065ad26eab2b32e2f7af8705";
+          sha256 = "1x085idsgcfzagqm6jqqhgqzy1xqjkq40zl2q7a20v013n3rkbd8";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/14cf66e6929db2a0f377612e786aaed9eb12b799/recipes/ecukes";
@@ -16408,12 +15838,12 @@
     edit-indirect = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "edit-indirect";
-        version = "20170310.1002";
+        version = "20170928.430";
         src = fetchFromGitHub {
           owner = "Fanael";
           repo = "edit-indirect";
-          rev = "2fc8f382ee12fc8f7202288534258186bdf6068a";
-          sha256 = "1m40zi6dkq7m9386adrys5n7w8h9973svfmxl1c3n9vk9kjibb9k";
+          rev = "032ac0ec690d4999d564fd882588c7a197efe8dd";
+          sha256 = "0by1x53pji39fjrj5bd446kz831nv0vdgw2jqasbym4pc1p2947r";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/acc9b816796b9f142c53f90593952b43c962d2d8/recipes/edit-indirect";
@@ -16513,12 +15943,12 @@
     editorconfig = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "editorconfig";
-        version = "20170912.2223";
+        version = "20171005.2129";
         src = fetchFromGitHub {
           owner = "editorconfig";
           repo = "editorconfig-emacs";
-          rev = "f527731c0d24a094f6fc784366558e2bf3d0e201";
-          sha256 = "0im24f2h2n4ijdmkjkkphngk2sgj1g2rg0ygppq03rbzmqg0r6sm";
+          rev = "99bb6882d8ac708a066a9977cc4fa23f86c6b8f6";
+          sha256 = "0372s9xp8gjz6y0ix095r9gy8718jw1vkjszd12kz6vnxn4z4rmi";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/50d4f2ed288ef38153a7eab44c036e4f075b51d0/recipes/editorconfig";
@@ -16792,12 +16222,12 @@
     ein = callPackage ({ auto-complete, cl-generic, dash, deferred, fetchFromGitHub, fetchurl, lib, melpaBuild, request, request-deferred, s, skewer-mode, websocket }:
     melpaBuild {
         pname = "ein";
-        version = "20170903.829";
+        version = "20171003.817";
         src = fetchFromGitHub {
           owner = "millejoh";
           repo = "emacs-ipython-notebook";
-          rev = "213cea559e7a8fb50e303ea25e1626fefddaf4bd";
-          sha256 = "18ysd78pfyymqd0f6ipma9p9x61pw21f0jwk118r5yi00wnry9za";
+          rev = "e0e3fac0c41e8cf4efa2fea6dbb49d3ad80d6153";
+          sha256 = "11zw1gqzxzim6y6yrbbbsmmyadpagqk5f79vmx8ly0x1ivk87ldn";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/215e163755fe391ce1f049622e7b9bf9a8aea95a/recipes/ein";
@@ -17017,6 +16447,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    el-pocket = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, web }:
+    melpaBuild {
+        pname = "el-pocket";
+        version = "20170922.549";
+        src = fetchFromGitHub {
+          owner = "pterygota";
+          repo = "el-pocket";
+          rev = "a80abfb67efe68ada1d7d0a73aecee57e763baaa";
+          sha256 = "0q4nsgqpjmmxml5pcb6im1askk6q7c3ykzv6fgf1w8jgkvdifa6f";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/ef362a76a3881c7596dcc2639df588227b3713c0/recipes/el-pocket";
+          sha256 = "0fgylpfixsx5l1nrgz6n1c2ayf52p60f9q290hmkn36siyx5hixw";
+          name = "el-pocket";
+        };
+        packageRequires = [ emacs web ];
+        meta = {
+          homepage = "https://melpa.org/#/el-pocket";
+          license = lib.licenses.free;
+        };
+      }) {};
     el-spec = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "el-spec";
@@ -17098,25 +16549,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/el-spy";
-          license = lib.licenses.free;
-        };
-      }) {};
-    el-swank-fuzzy = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "el-swank-fuzzy";
-        version = "20130824.457";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/el-swank-fuzzy.el?revision=3";
-          sha256 = "1g2jhm9m5qcj6a231n5ch6b8bqwzq3kj275nd4s89p89v1252qhn";
-          name = "el-swank-fuzzy.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/2aecf6d476c7898478e6e5dcfc77d91935f07039/recipes/el-swank-fuzzy";
-          sha256 = "1m7y4c0r1w8ndmr1wgc2llrbfawbbxnvcvgjpsckb3704s87yxr1";
-          name = "el-swank-fuzzy";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/el-swank-fuzzy";
           license = lib.licenses.free;
         };
       }) {};
@@ -17204,25 +16636,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    eldoc-extension = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "eldoc-extension";
-        version = "20140306.645";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/eldoc-extension.el?revision=10";
-          sha256 = "13ncpp3hrwk0h030c5nnm2zfiingilr5b876jsf2wxmylg57nbch";
-          name = "eldoc-extension.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/2c59866b554def3f6cef997cc23254a560f3eb33/recipes/eldoc-extension";
-          sha256 = "0azkdx4ncjhb7qyhyg1a5pxgqqf2z1wq9iz802j0nxxnjzh9ny24";
-          name = "eldoc-extension";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/eldoc-extension";
-          license = lib.licenses.free;
-        };
-      }) {};
     eldoc-overlay-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, inline-docs, lib, melpaBuild, quick-peek }:
     melpaBuild {
         pname = "eldoc-overlay-mode";
@@ -17272,8 +16685,8 @@
         src = fetchFromGitHub {
           owner = "davidshepherd7";
           repo = "electric-operator";
-          rev = "9aa71d7b6b780242e4659fedfdb186d4ee422366";
-          sha256 = "03py67msf3cshg60zs6bdk71ksswi3vjf0nl88jhlgnzb3kjg4wm";
+          rev = "5800e90f5ce23663fe370e4ad8fb40f59a4f93f5";
+          sha256 = "0d3fakycfg7rfblp6wqxyynvnqnpnz4hvi812fp5v4wqz4slfjxh";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/906cdf8647524bb76f644373cf8b65397d9053a5/recipes/electric-operator";
@@ -17352,12 +16765,12 @@
     elfeed = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "elfeed";
-        version = "20170910.1453";
+        version = "20171001.1900";
         src = fetchFromGitHub {
           owner = "skeeto";
           repo = "elfeed";
-          rev = "b62a2d0040f1a8ad0a23a48e3843d2ed5cbc2a8c";
-          sha256 = "1fxxcdrm7138pb06wxk9k519kag03jllkwf2fyxh755x6fnxlgin";
+          rev = "f343cfa93b7d91024496b8b7f46280762fe86659";
+          sha256 = "0bysjh9626r2651n6vvq6mbbw36jrp41nmd45an6y9cl0z0wj58w";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/407ae027fcec444622c2a822074b95996df9e6af/recipes/elfeed";
@@ -17426,8 +16839,8 @@
         src = fetchFromGitHub {
           owner = "skeeto";
           repo = "elfeed";
-          rev = "b62a2d0040f1a8ad0a23a48e3843d2ed5cbc2a8c";
-          sha256 = "1fxxcdrm7138pb06wxk9k519kag03jllkwf2fyxh755x6fnxlgin";
+          rev = "f343cfa93b7d91024496b8b7f46280762fe86659";
+          sha256 = "0bysjh9626r2651n6vvq6mbbw36jrp41nmd45an6y9cl0z0wj58w";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/62459d16ee44d5fcf170c0ebc981ca2c7d4672f2/recipes/elfeed-web";
@@ -17611,12 +17024,12 @@
     elixir-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, pkg-info }:
     melpaBuild {
         pname = "elixir-mode";
-        version = "20170102.942";
+        version = "20170918.2231";
         src = fetchFromGitHub {
           owner = "elixir-lang";
           repo = "emacs-elixir";
-          rev = "384d8daf8ad563ebf2cb3437c71d30241adbe099";
-          sha256 = "0idgfjwd6116zaag0lmq2i9by2mr054nrqmpnsvyhk26hw71k3vn";
+          rev = "861788186f4dbd500209656dcf38a15b3efe74dd";
+          sha256 = "1py8slpda3vsw88v1wp1imnn3r17hz54621c6ks8xm75lnhn60ra";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6374ced0de38d83bf99147f702f30706615480ed/recipes/elixir-mode";
@@ -17653,12 +17066,12 @@
     elm-mode = callPackage ({ emacs, f, fetchFromGitHub, fetchurl, let-alist, lib, melpaBuild, s }:
     melpaBuild {
         pname = "elm-mode";
-        version = "20170903.221";
+        version = "20171001.26";
         src = fetchFromGitHub {
           owner = "jcollard";
           repo = "elm-mode";
-          rev = "ece63376b2a7a8f5e6d708bdb2061e13d6afb731";
-          sha256 = "1109si17ph8w90jcmzz72i0ha5va8ylh2y5jinabvsc3qs667bgy";
+          rev = "a0339b196760823a0f3bb0bcaf26daa62c356535";
+          sha256 = "0vsyibph08xcxinjri4lzy44ji3albwpcpb469q0h43jjd2jw2v4";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5d1a4d786b137f61ed3a1dd4ec236d0db120e571/recipes/elm-mode";
@@ -17881,15 +17294,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    elpy = callPackage ({ cl-generic, company, fetchFromGitHub, fetchurl, find-file-in-project, highlight-indentation, lib, melpaBuild, pyvenv, s, yasnippet }:
+    elpy = callPackage ({ company, fetchFromGitHub, fetchurl, find-file-in-project, highlight-indentation, lib, melpaBuild, pyvenv, s, yasnippet }:
     melpaBuild {
         pname = "elpy";
-        version = "20170903.143";
+        version = "20171005.1105";
         src = fetchFromGitHub {
           owner = "jorgenschaefer";
           repo = "elpy";
-          rev = "d1cfe9c87031a9fd4c9754afdc4c4d0b3b3128a6";
-          sha256 = "1zy24fp888i7xaplfnxznlw8hldfpcgh9ni0053m9sq8z28nld6j";
+          rev = "2d6dc9f31de8805f2b7630c874942fb7e8fb5bd3";
+          sha256 = "1mrda1kvwv0mzgxi8z28a9qynlkfzpw0wgvwc86pkq94fzr6l2pj";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1d8fcd8745bb15402c9f3b6f4573ea151415237a/recipes/elpy";
@@ -17897,7 +17310,6 @@
           name = "elpy";
         };
         packageRequires = [
-          cl-generic
           company
           find-file-in-project
           highlight-indentation
@@ -18060,12 +17472,12 @@
     elvish-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "elvish-mode";
-        version = "20170815.625";
+        version = "20170913.1939";
         src = fetchFromGitHub {
           owner = "ALSchwalm";
           repo = "elvish-mode";
-          rev = "d78a560b0aeba76ae09fb0885ca0cff2ee5b0d0d";
-          sha256 = "0fxmy0qfcapskbakin6p1hv9763yh4bxanlnak7p6dfmmw7mvz33";
+          rev = "9cf31b453ac79b011b84e83ca11c964c4e647649";
+          sha256 = "0ryg9c8pjw98a9l4hyjqwan7kcv492vzy0xxcrcfm69zn8vnw9k0";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/0fc724072702a565af471f9ae523a1e6e48e3f04/recipes/elvish-mode";
@@ -18480,11 +17892,11 @@
     emms = callPackage ({ cl-lib ? null, fetchgit, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "emms";
-        version = "20170901.1328";
+        version = "20170929.1427";
         src = fetchgit {
           url = "https://git.savannah.gnu.org/git/emms.git";
-          rev = "79793c0bb32620ad5b4db490c6e80ff8e5a20233";
-          sha256 = "13mk66vbrnzsy8bcz2wahn4hcqyiia6j0srpfffxsg49x9bssvff";
+          rev = "b1ea89a08da3f5953d55072fffed8f781b461315";
+          sha256 = "0kih2hvwrzjsw8k271hciwx4p2bxn4hgm4bsk9zdrsw9lxy0qqnm";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/caaa21f235c4864f6008fb454d0a970a2fd22a86/recipes/emms";
@@ -18584,12 +17996,12 @@
     emms-player-mpv-jp-radios = callPackage ({ cl-lib ? null, emacs, emms, emms-player-simple-mpv, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "emms-player-mpv-jp-radios";
-        version = "20170506.1024";
+        version = "20171002.723";
         src = fetchFromGitHub {
           owner = "momomo5717";
           repo = "emms-player-mpv-jp-radios";
-          rev = "43ef07db6e724847fdcff5f66d1806b3e8d315e4";
-          sha256 = "15wfr6qs4k6anm16zing0rgawpbrnk9589vr06fc6qvkald7ib3v";
+          rev = "dcf79a7570ff4031373991f9fc838ddc5f598006";
+          sha256 = "0mq6k6qgqv08k421wjk69ma8m7m29yfmwh2bsphxj1pa2h1y6h2n";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/09ba6da5057061f055d4a3212d167f9666618d4f/recipes/emms-player-mpv-jp-radios";
@@ -18605,12 +18017,12 @@
     emms-player-simple-mpv = callPackage ({ cl-lib ? null, emacs, emms, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "emms-player-simple-mpv";
-        version = "20160924.825";
+        version = "20170930.2216";
         src = fetchFromGitHub {
           owner = "momomo5717";
           repo = "emms-player-simple-mpv";
-          rev = "bcc056364df5f405716006a8b7bb90102a57f62f";
-          sha256 = "0kz31qsn3nrpi8r31nlxlkkkah0qcdkq9a9i9ypv4ky7pvnzx6m5";
+          rev = "1af7838037c86872e897bea872d279ff080c28c6";
+          sha256 = "1xgkpw89pyn4p37l5rz9dw8yg065slzq8l5z69n6nam9hndcnjsh";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/emms-player-simple-mpv";
@@ -18974,12 +18386,12 @@
     ensime = callPackage ({ company, dash, fetchFromGitHub, fetchurl, lib, melpaBuild, popup, s, sbt-mode, scala-mode, yasnippet }:
     melpaBuild {
         pname = "ensime";
-        version = "20170817.2325";
+        version = "20171005.347";
         src = fetchFromGitHub {
           owner = "ensime";
           repo = "ensime-emacs";
-          rev = "fe816d36bce96151f90b76887a69f44100bd12da";
-          sha256 = "19id9s3wvwlqvcfngw32rd9fnq74nwyl5zlmyvr6i268rk4gm4lq";
+          rev = "82de811bde723e78a702e98592e46514ac700f9d";
+          sha256 = "15n01ni833y9viccdcvhjj80yyavm1131njxwp0q13gqgbzj3n5f";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/502faab70af713f50dd8952be4f7a5131075e78e/recipes/ensime";
@@ -19087,12 +18499,12 @@
     epkg = callPackage ({ closql, dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "epkg";
-        version = "20170905.1210";
+        version = "20171006.353";
         src = fetchFromGitHub {
           owner = "emacscollective";
           repo = "epkg";
-          rev = "42528f4f1d3310361d84bb557c4b7270adb5fd5b";
-          sha256 = "1d14160l1w65a3klhd71972a726kzhcn07bljp5q57y1qxbq648m";
+          rev = "4258ca3457e9a7ac46d1f0bd7a80f1da51b360cb";
+          sha256 = "00v5ipcz642rrg4yicwmg1nam5n0yasqgrak13b3wqmzqx1qzf6f";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/2df16abf56e53d4a1cc267a78797419520ff8a1c/recipes/epkg";
@@ -19569,12 +18981,12 @@
     ergoemacs-mode = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, undo-tree }:
     melpaBuild {
         pname = "ergoemacs-mode";
-        version = "20170723.1921";
+        version = "20170915.1902";
         src = fetchFromGitHub {
           owner = "ergoemacs";
           repo = "ergoemacs-mode";
-          rev = "7b0600620fc64cdb92bb9a69144c68eaa088db5b";
-          sha256 = "05ihafhhjlq7b4zs58jaqssgqdha5kqv65hvk7946ba7l845fi83";
+          rev = "6231ee0ae7014bd8f8ef2a3adc13b4d3d403bf71";
+          sha256 = "1c3ryazy796zcxp550ic7a7qsgs4528sfqqywmwqpf8vl7p0p7xp";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/02920517987c7fc698de9952cbb09dfd41517c40/recipes/ergoemacs-mode";
@@ -19611,12 +19023,12 @@
     erlang = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "erlang";
-        version = "20170912.58";
+        version = "20170913.604";
         src = fetchFromGitHub {
           owner = "erlang";
           repo = "otp";
-          rev = "b36f0b6d381746a16c8d8c2bb3767d9ffb44c3f8";
-          sha256 = "1i0aqq3vwy10jbky6ahka2vqk55iqanq1liqj81r76l5v55flcz6";
+          rev = "e38c688d3961bedcd85f842fd052836cb345a902";
+          sha256 = "1izh0zblnyklhya72cz8rf8pwq8q5smm4yp520vrkplspcspwbva";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d9cd526f43981e0826af59cdc4bb702f644781d9/recipes/erlang";
@@ -19698,8 +19110,8 @@
         version = "20161018.1217";
         src = fetchgit {
           url = "https://bitbucket.org/olanilsson/ert-junit";
-          rev = "b8e23617bbd5228dfa37fdc00e7b5227fd6382df";
-          sha256 = "1f5r1ns2h53q5qmrr31xbwrsinnk4ialh4a7siz2n513znq6dq8w";
+          rev = "c4cd27b60f9e7ccd05fd8a2097cde947eb250599";
+          sha256 = "0zm71kv4wxs6yf70qwrfavxc1845bg4aqqk36zypy17g1x40bms7";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/27c627eacab54896a1363dbabc56250a65343dd8/recipes/ert-junit";
@@ -19778,12 +19190,12 @@
     es-mode = callPackage ({ cl-lib ? null, dash, fetchFromGitHub, fetchurl, lib, melpaBuild, request, s, spark }:
     melpaBuild {
         pname = "es-mode";
-        version = "20170823.957";
+        version = "20170915.801";
         src = fetchFromGitHub {
           owner = "dakrone";
           repo = "es-mode";
-          rev = "82c9d0e47f7f224d1248e3455ee10c0adea327bf";
-          sha256 = "1jb4b2cww6y3y0j3gf9n5v2hcmb9zsf1cz9rhr0x6vh169yvhjvr";
+          rev = "511eaf59123c2dc4f900cd31d3c30c5bf98599ea";
+          sha256 = "1ldyf39z7faizbg2nzh2myd5yld9iwxi9r5260sp1dv0ab2im4gy";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/9912193f73c4beae03b295822bf41cb2298756e2/recipes/es-mode";
@@ -19922,6 +19334,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    eshell-bookmark = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "eshell-bookmark";
+        version = "20170922.814";
+        src = fetchFromGitHub {
+          owner = "Fuco1";
+          repo = "eshell-bookmark";
+          rev = "deda4b848b2fb979dbe73ead2cb866610e3596ed";
+          sha256 = "14dmsnixf9vqdhsixw693sml0fn80zcf0b37z049fb40cmppqxdw";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/e7bf4702a907727990fcc676980f2b219e22ab0c/recipes/eshell-bookmark";
+          sha256 = "1bybxlq1h5chrjxqjb23kq8dmgw2xrjwkrnvpbphblqzpdy5ck0s";
+          name = "eshell-bookmark";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/eshell-bookmark";
+          license = lib.licenses.free;
+        };
+      }) {};
     eshell-did-you-mean = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "eshell-did-you-mean";
@@ -20009,12 +19442,12 @@
     eshell-prompt-extras = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "eshell-prompt-extras";
-        version = "20170713.11";
+        version = "20170914.1955";
         src = fetchFromGitHub {
           owner = "hiddenlotus";
           repo = "eshell-prompt-extras";
-          rev = "52a8ce66da2c5f419efd41f2a6b6d4af03f78acd";
-          sha256 = "1biandbijdngalbjvbfv894qjzmj0fndypa31rmd75c0r5mg2mnf";
+          rev = "7581c109673c40aceff278cd524273f50ffe170d";
+          sha256 = "1m1jisjz974cfz89i6l2zq666yzhsqipc6dmqlrm8mw81fxsfm1h";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/7fabdb05de9b8ec18a3a566f99688b50443b6b44/recipes/eshell-prompt-extras";
@@ -20139,8 +19572,8 @@
         src = fetchFromGitHub {
           owner = "ecukes";
           repo = "espuds";
-          rev = "31ffd83f6deccddfb8378fa2298d90d3fc5fdda1";
-          sha256 = "1l8c8g050av0hi5snini7igfrjaq8q0nb3g114ai1i8frzsrxgzn";
+          rev = "444285cde99860b50b4c9a2e1c6a25e4db8d9adf";
+          sha256 = "0nwgh9nrr85n6ix60r6z58rw2078wkzkqqfszq2sr7wmad6kxspx";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/14cf66e6929db2a0f377612e786aaed9eb12b799/recipes/espuds";
@@ -20198,12 +19631,12 @@
     ess = callPackage ({ fetchFromGitHub, fetchurl, julia-mode, lib, melpaBuild }:
     melpaBuild {
         pname = "ess";
-        version = "20170911.149";
+        version = "20171007.516";
         src = fetchFromGitHub {
           owner = "emacs-ess";
           repo = "ESS";
-          rev = "23e6d3ef5b314223043c9f03301b3e7018141385";
-          sha256 = "1fih6rphz5bsd2kvwblygaymp1mvz710xjvcqg52l9awlawgvbwb";
+          rev = "d559b3d0e7db97a74823c20fda4095d1a14d9209";
+          sha256 = "1cxq8k9m2m36zz3x04dranzg40k61qprhy4w91chl3384jf1rb39";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/12997b9e2407d782b3d2fcd2843f7c8b22442c0a/recipes/ess";
@@ -20303,12 +19736,12 @@
     esup = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "esup";
-        version = "20170729.1742";
+        version = "20170923.1328";
         src = fetchFromGitHub {
           owner = "jschaf";
           repo = "esup";
-          rev = "94e0d2bef2bcdbd9477e702f63148cc2de75ecb3";
-          sha256 = "0rz2a8ydr7jrsgz1mxgjk4wyf7rkz0w3qvx6jy8mygzhzhmniy24";
+          rev = "a589005a9a888537deef94d6fe38a9b8790c97c7";
+          sha256 = "04lxmd0h7mfjjl0qghrycgff0vcv950j1wqv0dbkr61jxp64n5fv";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b9d2948a42da5d4864404d2d11a924a4f235fc3b/recipes/esup";
@@ -20328,8 +19761,8 @@
         src = fetchFromGitHub {
           owner = "tali713";
           repo = "esxml";
-          rev = "08fcc5d76abb90c194e181f267cf1d2a149b7a7c";
-          sha256 = "034lxfqn5yh78hz7i568vw8kyv3hlb699z2d1dffjiigc1lblgip";
+          rev = "6d58e047b7c1e3e8cab87cf7ee15e039e8a22510";
+          sha256 = "0bkbp3bycb4vrk0y5n7013yqqzz7rjvfwkr9lppa6sixilhc8h66";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/db6556fe1b2403d1bcdade263986fd0faf0d9087/recipes/esxml";
@@ -20360,44 +19793,6 @@
         packageRequires = [ dash emacs interval-list ];
         meta = {
           homepage = "https://melpa.org/#/etable";
-          license = lib.licenses.free;
-        };
-      }) {};
-    etags-select = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "etags-select";
-        version = "20130824.500";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/etags-select.el?revision=21";
-          sha256 = "0gmlmxlwfsfk5axn3x5cfvqy9bx26ynpbg50mdxiljk7wzqs5dyb";
-          name = "etags-select.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/5875d00419666388acbcb8a4f392308e7576da0b/recipes/etags-select";
-          sha256 = "0j6mxj10n7jf087l7j86s3a8si5hzpwmvrpqisfvlnvn6a0rdy7h";
-          name = "etags-select";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/etags-select";
-          license = lib.licenses.free;
-        };
-      }) {};
-    etags-table = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "etags-table";
-        version = "20130824.457";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/etags-table.el?revision=4";
-          sha256 = "0apm8as606bbkpa7i1hkwcbajzsmsyxn6cwfk9dkkll5bh4vglqf";
-          name = "etags-table.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/c3efc1791df5658ca5bba4907f2a22c2cabfd3c8/recipes/etags-table";
-          sha256 = "1jzij9jknab42jmx358g7f1c0d8lsp9baxbk3xsy7w4nl0l53d84";
-          name = "etags-table";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/etags-table";
           license = lib.licenses.free;
         };
       }) {};
@@ -20572,12 +19967,12 @@
     evil = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, goto-chg, lib, melpaBuild, undo-tree }:
     melpaBuild {
         pname = "evil";
-        version = "20170904.1346";
+        version = "20171006.2359";
         src = fetchFromGitHub {
           owner = "emacs-evil";
           repo = "evil";
-          rev = "485bf5399bbad17ff0cbb3787de67b9a5a5665dd";
-          sha256 = "02zd9pk2x44lz9cb8cqy0apvdbb8vwlxgvrgfkfswvx34ww4rqmc";
+          rev = "b6ed94c9a531ba905b729e0c3dc89fc32d888f46";
+          sha256 = "0idp7wl22vzpy440jcrxspb47snk098h7gi7vn5fq5awc9pknwpi";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/440482c0edac8ee8bd4fe22f6bc5c1607f34c7ad/recipes/evil";
@@ -20698,12 +20093,12 @@
     evil-colemak-minimal = callPackage ({ emacs, evil, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "evil-colemak-minimal";
-        version = "20160922.226";
+        version = "20171006.617";
         src = fetchFromGitHub {
           owner = "bmallred";
           repo = "evil-colemak-minimal";
-          rev = "5f1db93959359d3efd57abb5a0d06e94dec92556";
-          sha256 = "08dfmny7z03h6hbj21f344jv9kpzlzk31j5sd78w1c68mgx9hj6b";
+          rev = "6d98b6da60f414524a0d718f76024c26dce742b3";
+          sha256 = "0pd05jq4qkw5xx7xqzxzx62fsm77vjz0ry9ayaqgqw5831rbp553";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/828c744062069027f19fe5f2f233179f9149dc16/recipes/evil-colemak-minimal";
@@ -20824,12 +20219,12 @@
     evil-escape = callPackage ({ cl-lib ? null, emacs, evil, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "evil-escape";
-        version = "20170115.1343";
+        version = "20170913.618";
         src = fetchFromGitHub {
           owner = "syl20bnr";
           repo = "evil-escape";
-          rev = "b4d44fc5015341e484495fc86b73d09b2ac062ec";
-          sha256 = "0s8lmmm25qabicwaj9jybpbd8mkc62yl7jnhk1lpablydjkv3w2i";
+          rev = "25920fb2f4ef48998eecea433c04096f8d124cfe";
+          sha256 = "1nbk0mlfrg8hbw119dpp2a1k2irgz811kcsrwmxv256gkx4pwmfk";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/evil-escape";
@@ -20929,12 +20324,12 @@
     evil-goggles = callPackage ({ emacs, evil, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "evil-goggles";
-        version = "20170913.59";
+        version = "20171002.2303";
         src = fetchFromGitHub {
           owner = "edkolev";
           repo = "evil-goggles";
-          rev = "221a5ed8ea0455e4274ef9ba14fe852cc512112d";
-          sha256 = "0qjzkg1cms6ska213n1ldm511ivdawxwpvn8qzl8l75yf3whzw05";
+          rev = "92d614e731d1f2b8cafa4bf211e560294e378c14";
+          sha256 = "006ny911qmxl7p1azdcf4d6daswglc06jh295glhn963sqkc2mgf";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/811b1261705b4c525e165fa9ee23ae191727a623/recipes/evil-goggles";
@@ -21328,12 +20723,12 @@
     evil-org = callPackage ({ emacs, evil, fetchFromGitHub, fetchurl, lib, melpaBuild, org }:
     melpaBuild {
         pname = "evil-org";
-        version = "20170911.1135";
+        version = "20170917.1447";
         src = fetchFromGitHub {
           owner = "Somelauw";
           repo = "evil-org-mode";
-          rev = "1b0cb009fcc593ba851d243d2e3291a8cfeb2fb0";
-          sha256 = "0qnb5vbsrwxsn2zjl6dy6gvc1y77ac9c8nqrhpzyvjbkby2gkwzh";
+          rev = "52bbb105a6a7fa9ead68c56746740b4343ecd6e9";
+          sha256 = "1k0akcqbr67lsrj5gkpr9b3nhrf53zd3ksv4sfrapn9xhv13brbi";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1768558ed0a0249421437b66fe45018dd768e637/recipes/evil-org";
@@ -21538,12 +20933,12 @@
     evil-surround = callPackage ({ evil, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "evil-surround";
-        version = "20170910.1952";
+        version = "20171004.600";
         src = fetchFromGitHub {
           owner = "emacs-evil";
           repo = "evil-surround";
-          rev = "7839abe0e04740e2928a6b799557d1b16460fa5f";
-          sha256 = "03lfn8clcbcmax5nzn6awzfd895inavzrn45n07hrq6abw98yjrd";
+          rev = "822a0f61c3fd7c55cda4e04c8590ae5144401c26";
+          sha256 = "0xd87whrznwk1hggb0jrx6n1m5sbj0014qv26qvvc3f11vrrda2x";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/2c9dc47a4c837c44429a74fd998fe468c00639f2/recipes/evil-surround";
@@ -21622,12 +21017,12 @@
     evil-test-helpers = callPackage ({ evil, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "evil-test-helpers";
-        version = "20170719.1445";
+        version = "20171002.135";
         src = fetchFromGitHub {
           owner = "emacs-evil";
           repo = "evil";
-          rev = "485bf5399bbad17ff0cbb3787de67b9a5a5665dd";
-          sha256 = "02zd9pk2x44lz9cb8cqy0apvdbb8vwlxgvrgfkfswvx34ww4rqmc";
+          rev = "b6ed94c9a531ba905b729e0c3dc89fc32d888f46";
+          sha256 = "0idp7wl22vzpy440jcrxspb47snk098h7gi7vn5fq5awc9pknwpi";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/87da8c50f9167ad9c3844b23becb6904f809611d/recipes/evil-test-helpers";
@@ -21853,12 +21248,12 @@
     ewmctrl = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "ewmctrl";
-        version = "20161104.1833";
+        version = "20170921.1917";
         src = fetchFromGitHub {
           owner = "flexibeast";
           repo = "ewmctrl";
-          rev = "ba1879cc803a63d5a4047ec6f2990e369ae5af3a";
-          sha256 = "12h2fgabfmaq1cpr7y7ckyyfgy53ww3v25p2kk5fq77rn40zbniy";
+          rev = "3d0217c4d6cdb5c308b6cb4293574f470d4faacf";
+          sha256 = "0ilwvx0qryv3v6xf0gxqwnfm6pf96gxap8h9g3f6z6lk9ff4n1wi";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b2a7679f0961b171bf23080e628ae80f50c446e4/recipes/ewmctrl";
@@ -21936,12 +21331,12 @@
     exotica-theme = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "exotica-theme";
-        version = "20170828.357";
+        version = "20171009.445";
         src = fetchFromGitHub {
           owner = "jbharat";
           repo = "exotica-theme";
-          rev = "0fcb6f3e5ef7d97a4ec049867a8d703ec60a89f5";
-          sha256 = "0i7pgdxrx2ijf67sy4x2xab416s458mgac261ng2522z87szddah";
+          rev = "086d1539e681e38829e3861cffdf62e49213ed58";
+          sha256 = "17prr6b5za43mahdfz355k1p1b2jkwd1csb6wlph5g4nmplh5c61";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/9182f92dd62e2f1775a76699a6c8f9c3e71e9030/recipes/exotica-theme";
@@ -22083,12 +21478,12 @@
     exwm-x = callPackage ({ bind-key, cl-lib ? null, counsel, exwm, fetchFromGitHub, fetchurl, ivy, lib, melpaBuild, swiper, switch-window }:
     melpaBuild {
         pname = "exwm-x";
-        version = "20170903.2138";
+        version = "20170916.2015";
         src = fetchFromGitHub {
           owner = "tumashu";
           repo = "exwm-x";
-          rev = "cee7cc0e6dd6d1c481480f1978b6487287b4f637";
-          sha256 = "0kwrm2bz09i8dj0zz7pznpv0hy08pxl4kzl46c470abvs2dzrp67";
+          rev = "abb210ff56134cc6a285d91b875f3115bc951ad0";
+          sha256 = "1l7578jfn3va6bpkjfbazygsn8asxhc7cpss32mnsrzkm1ix6sz8";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a0e6e23bcffdcd1e17c70599c563609050e5de40/recipes/exwm-x";
@@ -22175,12 +21570,12 @@
     eziam-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "eziam-theme";
-        version = "20170906.821";
+        version = "20171007.939";
         src = fetchFromGitHub {
           owner = "thblt";
           repo = "eziam-theme-emacs";
-          rev = "63395a2367d1d48983a9363d2d0bf518177297bd";
-          sha256 = "15vgv0z4vzdnc3vb98j2hy4bv5x83f4c1dzgx49r61vka7p5is0q";
+          rev = "909a84dc5959aac982d1c296e82d687d172d3ecd";
+          sha256 = "0mw9h55f708mv0ngixmdn7976yrhqjcnzac80f6mzddpwavgrhd6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/4e0411583bd4fdbe425eb07de98851136fa1eeb0/recipes/eziam-theme";
@@ -22277,72 +21672,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    face-remap-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "face-remap-plus";
-        version = "20170222.1742";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/face-remap+.el";
-          sha256 = "1p42wjzl2brbqv3vh3g1rcgh5m9a7bix5q80pg7r6515as8kykad";
-          name = "face-remap+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/face-remap+";
-          sha256 = "0vq6xjrv3qic89pxzi6mx1s08k4ba27g8wqm1ap4fxh3l14wkg0y";
-          name = "face-remap-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/face-remap+";
-          license = lib.licenses.free;
-        };
-      }) {};
-    facemenu-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "facemenu-plus";
-        version = "20170222.1744";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/facemenu+.el";
-          sha256 = "0nnaqmdsf6ksk6663924bpw3mrldybj6jjkgj0525nhpfjx7x4yq";
-          name = "facemenu+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/facemenu+";
-          sha256 = "0lbggalgkj59wj67z95949jmppmqrzrp63mdhw42r2x0fz1ir0iv";
-          name = "facemenu-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/facemenu+";
-          license = lib.licenses.free;
-        };
-      }) {};
-    faces-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "faces-plus";
-        version = "20170222.1745";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/faces+.el";
-          sha256 = "0a80027a78zad0nxlkmv69b2zzbz4b29rsn4ivgb313r4c24igzx";
-          name = "faces+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/faces+";
-          sha256 = "0k3m434f3d3061pvir0dnykmv6r9jswl7pzybzja3afiy591hh92";
-          name = "faces-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/faces+";
-          license = lib.licenses.free;
-        };
-      }) {};
     faceup = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "faceup";
-        version = "20170126.1305";
+        version = "20170925.1246";
         src = fetchFromGitHub {
           owner = "Lindydancer";
           repo = "faceup";
-          rev = "688b487ad0a78c8707c5aded50e1d85551270034";
-          sha256 = "1wmmj69wgzgac5y7gnrz84dvwjzd45h3rr434vv4dxnam0j0lj40";
+          rev = "6c92dad56a133e14e7b27831e1bcf9b3a71ff154";
+          sha256 = "1yzmy7flrhrh0i10bdszx8idx6r8h6czm4vm4q0z6fp5fw94zwrx";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a10bf2928b93c3908e89ca8ad9649bb468ebca05/recipes/faceup";
@@ -22592,8 +21930,8 @@
         version = "20170908.658";
         src = fetchgit {
           url = "https://bitbucket.org/yassinphilip/faustine";
-          rev = "feb938af3a5363e0e0210aa98a447e1896ceca47";
-          sha256 = "1c0xc1nk9djjk39ksysszliphibnpm7c472p4lvgkmrsmg28i23k";
+          rev = "ae67cd9d1a2625d80726dace9dd83539e71d1b36";
+          sha256 = "1wvf37g2bb9xbxi0qxn1sfq0ygaqxfzsnzdbnail6f29qyl541al";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b298e399335efbbdbc6e9bb06ab915fc07909faa/recipes/faustine";
@@ -22609,12 +21947,12 @@
     fcitx = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "fcitx";
-        version = "20170812.1131";
+        version = "20170913.1900";
         src = fetchFromGitHub {
           owner = "cute-jumper";
           repo = "fcitx.el";
-          rev = "6d552ab44234ed78ce9a50f2412f56197266bc9f";
-          sha256 = "08l859rw1lwj6hdxrlxqlxf1cfxv8yv9h1jsgs5zfis3hp7nq39j";
+          rev = "095332fbeb994c908c533fe2ad068c0728211c3d";
+          sha256 = "01sm50rqajylah2hx6n5ig0xmrrhxbamzs4bg97qzxzr4nlnjcaz";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/e8c40f09d9397b3ca32a7ed37203f490497dc984/recipes/fcitx";
@@ -22751,44 +22089,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    files-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "files-plus";
-        version = "20170222.1746";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/files+.el";
-          sha256 = "1ch7k4gpfcb5k6z656rprdcvxp75wsfjhw5l6x8f05qbmm0cbimv";
-          name = "files+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/files+";
-          sha256 = "1m1pxf6knrnyc9ygmyr27gm709ydxf0kkh1xrfcza6n476frmwr8";
-          name = "files-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/files+";
-          license = lib.licenses.free;
-        };
-      }) {};
-    filesets-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "filesets-plus";
-        version = "20170222.1748";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/filesets+.el";
-          sha256 = "0i9nc9zhpj208as9pynnh6xvr0qk53y7bpg2gw4gak9xr9xywbpg";
-          name = "filesets+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/filesets+";
-          sha256 = "06n8pw8c65bmrkxda2akvv57ndfijgbp95l40j7sjg8bjp385spn";
-          name = "filesets-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/filesets+";
-          license = lib.licenses.free;
-        };
-      }) {};
     fill-column-indicator = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "fill-column-indicator";
@@ -22873,25 +22173,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    find-dired-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "find-dired-plus";
-        version = "20170409.1832";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/find-dired+.el";
-          sha256 = "0zfqkw9vghbzvdh3iyqkkdq777bb1yhfgqk7p28dxz861z13cmfs";
-          name = "find-dired+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/find-dired+";
-          sha256 = "190cj41b6s1l6gk1m0rbwfsdciw4my39ncppdxf9pi7gzhcjpznr";
-          name = "find-dired-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/find-dired+";
-          license = lib.licenses.free;
-        };
-      }) {};
     find-file-in-project = callPackage ({ emacs, fetchFromGitHub, fetchurl, ivy, lib, melpaBuild }:
     melpaBuild {
         pname = "find-file-in-project";
@@ -22973,25 +22254,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/find-things-fast";
-          license = lib.licenses.free;
-        };
-      }) {};
-    finder-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "finder-plus";
-        version = "20170222.1752";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/finder+.el";
-          sha256 = "0h1jsgb7vivmbay35s9bx8dpl7l88zdh1f6ymdm16b0alpiv4p14";
-          name = "finder+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/finder+";
-          sha256 = "1ichxghp2vzx01n129fmjm6iwx4b98ay3xk1ja1i8vzyd2p0z8vh";
-          name = "finder-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/finder+";
           license = lib.licenses.free;
         };
       }) {};
@@ -23160,25 +22422,6 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://melpa.org/#/fish-mode";
-          license = lib.licenses.free;
-        };
-      }) {};
-    fit-frame = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "fit-frame";
-        version = "20170222.1754";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/fit-frame.el?revision=63";
-          sha256 = "1wm2jc7h5zhv695wf21l3n9gjn31ddgd0vybx8brj1nbvavifs0x";
-          name = "fit-frame.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/e13c77f822db3c9eaeb3fd5fa95cc2dbe5133f2c/recipes/fit-frame";
-          sha256 = "1xcq4n9gj0npjjl98vqacms0a0wnzw62a9iplyf7bgj7n77pgkjb";
-          name = "fit-frame";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/fit-frame";
           license = lib.licenses.free;
         };
       }) {};
@@ -23420,6 +22663,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    flex-compile = callPackage ({ buffer-manage, dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "flex-compile";
+        version = "20171006.905";
+        src = fetchFromGitHub {
+          owner = "plandes";
+          repo = "flex-compile";
+          rev = "e2a2820282458cad5bcac4037baa6c2e76b1bdce";
+          sha256 = "15dlfayyrcy54davrha8vm87vbip01sbqxgdjfbri4y134fljrk8";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/259caeebc317e81ab9d532a371ea85656c2b1619/recipes/flex-compile";
+          sha256 = "1hlh4k7qgln87xajnjjhf1yyg6bgdwd0iczhlfw8gdwfj5xpjd38";
+          name = "flex-compile";
+        };
+        packageRequires = [ buffer-manage dash emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/flex-compile";
+          license = lib.licenses.free;
+        };
+      }) {};
     flex-isearch = callPackage ({ fetchhg, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "flex-isearch";
@@ -23482,25 +22746,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    fliptext = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "fliptext";
-        version = "20131113.1818";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/fliptext.el?revision=4";
-          sha256 = "1viigj04kla20dk46xm913jzqrmx05rpjrpghnc0ylbqppqdwzpw";
-          name = "fliptext.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/093046dfb39148d56681e9c8be8cccff23dd19cb/recipes/fliptext";
-          sha256 = "0cmyan9hckjsv5wk1mvjzif9nrc07frhzkhhl6pkgm0j0f1q30ji";
-          name = "fliptext";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/fliptext";
-          license = lib.licenses.free;
-        };
-      }) {};
     floobits = callPackage ({ fetchFromGitHub, fetchurl, highlight, json ? null, lib, melpaBuild }:
     melpaBuild {
         pname = "floobits";
@@ -23525,12 +22770,12 @@
     flow-minor-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "flow-minor-mode";
-        version = "20170729.1008";
+        version = "20170916.312";
         src = fetchFromGitHub {
           owner = "an-sh";
           repo = "flow-minor-mode";
-          rev = "75067baceed7d699dda43944da49dc58d22baeff";
-          sha256 = "0r1xs3vff3ng0h2w8nn7mxssdnipnrzwk9dh5f5v7prwk2q60byb";
+          rev = "93184633933b5aa62e6e92b7fe1311261012e591";
+          sha256 = "1laainsc5l4l4r5j17hblv7b1ppxrgfak73ama1qn7kb14y1jfrf";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/66504f789069922ea56f268f4da90fac52b601ff/recipes/flow-minor-mode";
@@ -23630,12 +22875,12 @@
     flycheck = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, let-alist, lib, melpaBuild, pkg-info, seq }:
     melpaBuild {
         pname = "flycheck";
-        version = "20170911.127";
+        version = "20171007.33";
         src = fetchFromGitHub {
           owner = "flycheck";
           repo = "flycheck";
-          rev = "eeb915b51f2fe9f7afe125b1028737b8c2b44712";
-          sha256 = "13dsjngb5lbhzrlcw3skk7v6j7c2k3vn596msin9f6ssjwmgc94k";
+          rev = "b339f0efd72db0fea00964c224c20c6ee8ef92c8";
+          sha256 = "0vyp9l8190xgy27jil0pfvc9j0hjwfiq0w0ia69flid0jxgirslz";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/649f9c3576e81409ae396606798035173cc6669f/recipes/flycheck";
@@ -23861,12 +23106,12 @@
     flycheck-color-mode-line = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild }:
     melpaBuild {
         pname = "flycheck-color-mode-line";
-        version = "20170512.1607";
+        version = "20170929.1513";
         src = fetchFromGitHub {
           owner = "flycheck";
           repo = "flycheck-color-mode-line";
-          rev = "b2b20727d133c05fd31eac7b9b5c0886bbca8f98";
-          sha256 = "1dgm9i2b9irp454ag9pv96hbacz1j3gsapk96xr45wjh4hblgwa3";
+          rev = "19947b81ddce6df4f10d3facb7c047538036a9df";
+          sha256 = "197knp91qx5y3kqbmnm4mcx61w73yr9xkvidvp96mfjzlldbjaz3";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/02b5b60b74581ff0d1815155223e0c6e94a851a1/recipes/flycheck-color-mode-line";
@@ -24344,12 +23589,12 @@
     flycheck-joker = callPackage ({ fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild }:
     melpaBuild {
         pname = "flycheck-joker";
-        version = "20170415.2009";
+        version = "20171003.2222";
         src = fetchFromGitHub {
           owner = "candid82";
           repo = "flycheck-joker";
-          rev = "43a25fe17ba6ade96fc865bd8ec3fb3c131aa419";
-          sha256 = "0m2msyyshbr6pgnjqybv8b1fj0axja3la0drbbbk0va1cn556wfs";
+          rev = "c34c3922a2e8bc918f250602e0ddf655cdcad456";
+          sha256 = "0fp7h0pmxk02x1kisqvnb9wkjjn9bl91capmnllrb7qmb24w6pd5";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/599bf33a5d4a4a590b355001e532cab4e1ee9ef6/recipes/flycheck-joker";
@@ -24428,12 +23673,12 @@
     flycheck-liquidhs = callPackage ({ fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild }:
     melpaBuild {
         pname = "flycheck-liquidhs";
-        version = "20150618.1922";
+        version = "20170412.1626";
         src = fetchFromGitHub {
           owner = "ucsd-progsys";
           repo = "flycheck-liquidhs.el";
-          rev = "ee0d3bd0d5e07a872e541d02c112f1cc204db922";
-          sha256 = "1wwn9dnzn4vrh747dgbcm944bp3z02gzxd32afjc9k2dsn32qvz2";
+          rev = "c27252ac24d77f4b6eec76a4ba9cd61761a3fba9";
+          sha256 = "1v5s252w2ai0rrci0rkq6wsx110pw8hp60n67990jg6l6lpvir2s";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d5921fde4068ff1bb288f6f9e2fe03f4a7fdbbda/recipes/flycheck-liquidhs";
@@ -24743,12 +23988,12 @@
     flycheck-pycheckers = callPackage ({ fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild }:
     melpaBuild {
         pname = "flycheck-pycheckers";
-        version = "20170810.1143";
+        version = "20170928.1808";
         src = fetchFromGitHub {
           owner = "msherry";
           repo = "flycheck-pycheckers";
-          rev = "220c551df591792d08fc9d149ab3329171743cb9";
-          sha256 = "0q1sz28nlnamcm4l587q94b7cyak9d4wpgpr33a05m9lw4a6z74i";
+          rev = "fedb4094976349da1449f821fd79cacd7537e80b";
+          sha256 = "0cxpcmx810zkrnqbzj064kgbsyj4qkr7dpps16xdk4ckbiih55rj";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/af36dca316b318d25d65c9e842f15f736e19ea63/recipes/flycheck-pycheckers";
@@ -24810,8 +24055,8 @@
         src = fetchFromGitHub {
           owner = "Andersbakken";
           repo = "rtags";
-          rev = "2af4d6a32e8194f8fbcc23fd94395e3d595a3c25";
-          sha256 = "0091w529lvbjlw1fdb3qjgb8fd5fcwxhqyr4ps5cvxl5bqnwlw39";
+          rev = "12636847b1ea512ce2d0c1075a74465f38555e69";
+          sha256 = "12v3wr2103293fkglbkhp20m2z72n66qka2s5zpcgc3jwqyqnnf9";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3dea16daf0d72188c8b4043534f0833fe9b04e07/recipes/flycheck-rtags";
@@ -24869,12 +24114,12 @@
     flycheck-status-emoji = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, flycheck, let-alist, lib, melpaBuild }:
     melpaBuild {
         pname = "flycheck-status-emoji";
-        version = "20170405.1600";
+        version = "20170923.1439";
         src = fetchFromGitHub {
           owner = "liblit";
           repo = "flycheck-status-emoji";
-          rev = "c4e891ad287c12b83b754ada27b4550fb763c07f";
-          sha256 = "12nlzs4fha1bmq1xbfgf5j4wg9llacl2m3jr8fbk8144pyss3kg5";
+          rev = "e85072a04f4277a48d90364b8e48fcb26a650d38";
+          sha256 = "12k0nakwv7z90fprpzfrsnmha0w5zsvpq7qiv0md3k3h41b5mgfv";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5abd6aaa8d2bf55ae75cd217820763531f91958b/recipes/flycheck-status-emoji";
@@ -24911,12 +24156,12 @@
     flycheck-swift3 = callPackage ({ emacs, fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild }:
     melpaBuild {
         pname = "flycheck-swift3";
-        version = "20170409.25";
+        version = "20170926.317";
         src = fetchFromGitHub {
           owner = "GyazSquare";
           repo = "flycheck-swift3";
-          rev = "6b0b7c6fffc86809d0535afebd6b0972059992d5";
-          sha256 = "0d411idv9ib1jhmdbjb8ycc8clmm1ygpwapaka3d50gkgrmfin4q";
+          rev = "756833425f51baa9eb0a2fa7493df6e68612c88d";
+          sha256 = "1hvrg717q0nlz4r8wby82gs3vdx8fdhf38rg4j77j3fqfmxdd3fi";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/f1fb8c731c118327dc0bbb726e046fec46bcfb82/recipes/flycheck-swift3";
@@ -25013,6 +24258,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    flycheck-yang = callPackage ({ fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild, yang-mode }:
+    melpaBuild {
+        pname = "flycheck-yang";
+        version = "20170915.1308";
+        src = fetchFromGitHub {
+          owner = "andaru";
+          repo = "flycheck-yang";
+          rev = "c5f65fe3f710f73d56e04d077868719afc1ebfaf";
+          sha256 = "00w91mif3wnxgj93qag51yyadnfcsyxik96vf91qlfvwh4wi6ii7";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/e58b4f4294d11424918b399898c0044f5b76ab14/recipes/flycheck-yang";
+          sha256 = "0agfmirjwlz13aq1jh94agav0y1rxkyhj7mngdgys7mwjxy0ac9h";
+          name = "flycheck-yang";
+        };
+        packageRequires = [ flycheck yang-mode ];
+        meta = {
+          homepage = "https://melpa.org/#/flycheck-yang";
+          license = lib.licenses.free;
+        };
+      }) {};
     flycheck-ycmd = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, flycheck, let-alist, lib, melpaBuild, ycmd }:
     melpaBuild {
         pname = "flycheck-ycmd";
@@ -25020,8 +24286,8 @@
         src = fetchFromGitHub {
           owner = "abingham";
           repo = "emacs-ycmd";
-          rev = "fd037efae08628e41480e9dad705dcc1f64e498d";
-          sha256 = "06scz0d3jzgbr919lkjjfq9x1dyr5nqkhblvfpyk5bdp8l6j06d6";
+          rev = "393724d0d36a8269e57a0e4c2b3723071caf0a3c";
+          sha256 = "02pm3x9frscgz5szddvbir0i7amnkzfj7pl4lgiah57bhcg1lhd0";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/flycheck-ycmd";
@@ -26003,12 +25269,12 @@
     folding = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "folding";
-        version = "20140401.3";
+        version = "20170925.838";
         src = fetchFromGitHub {
           owner = "jaalto";
           repo = "project-emacs--folding-mode";
-          rev = "f738e28cd90d794aff698bcd44bf4f5027c92839";
-          sha256 = "1z2dkyzj1gq3gp9cc3lhi240f8f3yjpjnw520xszm0wvx1rp06ny";
+          rev = "3bf134fd1ecfa8767ab7020c25281ea5ce9968a2";
+          sha256 = "0kcm4k71syz778cbwqf68a63k4vmhygaib3ylwxbm5dq1dmr7iry";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1912296b7879019bea5ba8353d511496e3a9ca2d/recipes/folding";
@@ -26018,25 +25284,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/folding";
-          license = lib.licenses.free;
-        };
-      }) {};
-    font-lock-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "font-lock-plus";
-        version = "20170222.1755";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/font-lock+.el";
-          sha256 = "0iajkgh0n3pbrwwxx9rmrrwz8dw2m7jsp4mggnhq7zsb20ighs30";
-          name = "font-lock+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/font-lock+";
-          sha256 = "1wn99cb53ykds87lg9mrlfpalrmjj177nwskrnp9wglyqs65lk4g";
-          name = "font-lock-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/font-lock+";
           license = lib.licenses.free;
         };
       }) {};
@@ -26127,16 +25374,16 @@
     forecast = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "forecast";
-        version = "20170618.1048";
+        version = "20170924.1440";
         src = fetchFromGitHub {
           owner = "cadadr";
-          repo = "forecast.el";
-          rev = "96e37ca81a42061f0e837cc3c4dec1844f682e91";
-          sha256 = "0hbz2q9sm70r7sxk56dlnzwh71ckrww7w43xxy3ys1r3p7b3j3aq";
+          repo = "elisp";
+          rev = "b3d8b45c76134e2248448d719c840776e41b747a";
+          sha256 = "0fy0b04mf3brx86xjnidkwg4zs4nh123nc6pgrl4mp6d6552vv98";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/e6ff6a4ee29b96bccb2e4bc0644f2bd2e51971ee/recipes/forecast";
-          sha256 = "0whag2n1120384w304g0w4bqr7svdxxncdhnz4rznfpxlgiw2rsc";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/a7ea18a56370348715dec91f75adc162c800dd10/recipes/forecast";
+          sha256 = "0zng8xdficpfccq484pghzg8yylihcy8aq0vpxd1w6l40m2qf6zn";
           name = "forecast";
         };
         packageRequires = [ emacs ];
@@ -26355,45 +25602,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    frame-cmds = callPackage ({ fetchurl, frame-fns, lib, melpaBuild }:
-    melpaBuild {
-        pname = "frame-cmds";
-        version = "20170819.1358";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/frame-cmds.el?revision=95";
-          sha256 = "169g11vs3d5gr8y1lwg7lgl21dpfca33m1c6w24mfmga4xr9042w";
-          name = "frame-cmds.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/8b528544841995045fb1f8344aaaa38946bb3915/recipes/frame-cmds";
-          sha256 = "0xwzp6sgcb5ap76hpzm8g4kl08a8cgq7i2x9w64njyfink7frwc0";
-          name = "frame-cmds";
-        };
-        packageRequires = [ frame-fns ];
-        meta = {
-          homepage = "https://melpa.org/#/frame-cmds";
-          license = lib.licenses.free;
-        };
-      }) {};
-    frame-fns = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "frame-fns";
-        version = "20170222.1759";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/frame-fns.el?revision=31";
-          sha256 = "1yl51wnmlmbirrhcf07rnqix62q7ijymwfbahwjsz2s18g2zyj6n";
-          name = "frame-fns.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/8b528544841995045fb1f8344aaaa38946bb3915/recipes/frame-fns";
-          sha256 = "1wq8wva9q1hdzkvjk582a3fgig0lpqz9ch1p2jd6p29kb1i15f5p";
-          name = "frame-fns";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/frame-fns";
-          license = lib.licenses.free;
-        };
-      }) {};
     frame-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "frame-mode";
@@ -26436,25 +25644,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    framemove = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "framemove";
-        version = "20130328.433";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/framemove.el?revision=4";
-          sha256 = "03ll68d0j0b55rfxymzcirdigkmxcy8556d0i67ghdzmcqfwily7";
-          name = "framemove.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/f075338369dbf0694205c1b2c35dc16821f6dc92/recipes/framemove";
-          sha256 = "10qf017j0zfnzmcs1i56pznhbvgw7mv4232p8znqaaxphgh6r0ar";
-          name = "framemove";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/framemove";
-          license = lib.licenses.free;
-        };
-      }) {};
     frames-only-mode = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "frames-only-mode";
@@ -26462,8 +25651,8 @@
         src = fetchFromGitHub {
           owner = "davidshepherd7";
           repo = "frames-only-mode";
-          rev = "dbe2725846ab9d90b309fe0f5e303e600a7d1661";
-          sha256 = "0c6xq2l9hzw2gavnwzwp5gg7nzvf7dl1x8qh7aabchd4a8c050rb";
+          rev = "d2e6a825e2079adb58012e9677c494d317494724";
+          sha256 = "1x8w2788yaqfi5ys541kp4wi3rcfa2lvbhnxgd8dwr9h0da332xa";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1e628416ad9420b3ac5bbfacf930a86d98958ac8/recipes/frames-only-mode";
@@ -26605,12 +25794,12 @@
     fsharp-mode = callPackage ({ company, company-quickhelp, dash, fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild, popup, pos-tip, s }:
     melpaBuild {
         pname = "fsharp-mode";
-        version = "20170617.1330";
+        version = "20170918.842";
         src = fetchFromGitHub {
           owner = "rneatherway";
           repo = "emacs-fsharp-mode-bin";
-          rev = "9766952bd7830cb0d319736961af8e42e67d42fe";
-          sha256 = "1krncbzdhp6kpypaqdn6fhvxhhc1pvy2ayn4w4ljmsd7wx6zazyi";
+          rev = "71435fdd100712d6894d8d72a5667b250a0d8eb7";
+          sha256 = "1c718gfms4zhzj06zmzdw71q6vhbf7mh3cgvq9vf8bnlv910p832";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/dc45611e2b629d8bc5f74555368f964420b79541/recipes/fsharp-mode";
@@ -26634,12 +25823,12 @@
     fstar-mode = callPackage ({ company, company-quickhelp, dash, emacs, fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild, quick-peek, yasnippet }:
     melpaBuild {
         pname = "fstar-mode";
-        version = "20170824.31";
+        version = "20171004.806";
         src = fetchFromGitHub {
           owner = "FStarLang";
           repo = "fstar-mode.el";
-          rev = "9ffad30f11e97aeec4c8dcd353da8e14f1d3a9f3";
-          sha256 = "15ij1i4a0g7vmb312cdsq70i76accijrjha6lr8bq9a4r167axcr";
+          rev = "0e438c206059d268d085bb94d64782d4e2ae46b7";
+          sha256 = "02wpp9q4aijv81vspvzgw9pjdmagflfnrd7w1m21xgw56hrg0mj5";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c58ace42342c3d3ff5a56d86a16206f2ecb45f77/recipes/fstar-mode";
@@ -26667,8 +25856,8 @@
         src = fetchFromGitHub {
           owner = "factor";
           repo = "factor";
-          rev = "705e7018c824e8160ecd8f0e81117dbebf6e90a0";
-          sha256 = "16j855qg046q8p8dbsry1nr4ljfn90wk36yqrbcklb93m1g0f9ny";
+          rev = "b8a0feea5cc28136d053888b45c50a6e0d3d07fd";
+          sha256 = "1rmfvvxgjdng1wybri8a2lqcimf4ywpl1wx9q04zzl8zmm5f2diq";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1e2a0e4698d4e71ec28656594f6a83504a823490/recipes/fuel";
@@ -26747,12 +25936,12 @@
     function-args = callPackage ({ fetchFromGitHub, fetchurl, ivy, lib, melpaBuild }:
     melpaBuild {
         pname = "function-args";
-        version = "20170822.1002";
+        version = "20171006.1056";
         src = fetchFromGitHub {
           owner = "abo-abo";
           repo = "function-args";
-          rev = "f4d2d1692f38f5acf6d209610371e008856357b5";
-          sha256 = "1s5ajgig4na5mvymbxk4ncs6nfa8qirzgkp15x8rjx5kj1m22rxa";
+          rev = "bb0f76412de0f791d82685b4131195e3127e2ccf";
+          sha256 = "137fdy398f6fwp96pi7zqm3fmjlvdwh4h1kiivf8xasgp235f92z";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/80688d85a34b77783140ad2b8a47ef60c762b084/recipes/function-args";
@@ -26793,8 +25982,8 @@
         src = fetchFromGitHub {
           owner = "HIPERFIT";
           repo = "futhark";
-          rev = "d4a741d1e87123c1691c3fcf9842895ba7d692f6";
-          sha256 = "1zvk5mp1hk6lq0bmisl3nzmqclm00qjr74j3zl66q56sxn4sgxwf";
+          rev = "a0ab1dc5d3f8e84e505d97041b3ce28a4cac94ce";
+          sha256 = "0fka2dpv2gib19czg2p4x69h1d7s3hdg8j102qgc3da8d9vvhng8";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/0607f01aad7e77d53595ad8db95d32acfd29b148/recipes/futhark-mode";
@@ -26825,44 +26014,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/fuzzy";
-          license = lib.licenses.free;
-        };
-      }) {};
-    fuzzy-format = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "fuzzy-format";
-        version = "20130824.500";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/fuzzy-format.el?revision=6";
-          sha256 = "1iv0x1cb12kknnxyq2gca7m3c3rg9s4cxz397sazkh1csrn0b2i7";
-          name = "fuzzy-format.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/154cb0a10c81ce4907029f0eddc51108961c65ae/recipes/fuzzy-format";
-          sha256 = "055b8710yxbi2sdqsqk6jqgnzky4nykv8jgqgwy8q2isgj6q98jb";
-          name = "fuzzy-format";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/fuzzy-format";
-          license = lib.licenses.free;
-        };
-      }) {};
-    fuzzy-match = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "fuzzy-match";
-        version = "20170222.1800";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/fuzzy-match.el?revision=23";
-          sha256 = "1wxl900wikkzykzp95v84kcyw3m1d16hklhyqqhsmg58ph4i6r94";
-          name = "fuzzy-match.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/fuzzy-match";
-          sha256 = "0c1f4q985ag5qhv15iw2jhmpsyy09fbj87srp4k58lspjf40acdj";
-          name = "fuzzy-match";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/fuzzy-match";
           license = lib.licenses.free;
         };
       }) {};
@@ -27119,12 +26270,12 @@
     geiser = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "geiser";
-        version = "20170827.1755";
+        version = "20170928.2221";
         src = fetchFromGitHub {
           owner = "jaor";
           repo = "geiser";
-          rev = "9581e61f9d8839281fe42344dd5fe885ea7359ea";
-          sha256 = "0nx86pzncab0b7700m8sc7k3nzml4v9frrq77lljjcjhw71gnvnn";
+          rev = "839dc555861dbb77ea2632b8dd4d58904f33a396";
+          sha256 = "1hykxw6a14d6xivin44bfbgr8dy4l5pr50cg0fk4n18a7dym7pjj";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b0fe32d24cedd5307b4cccfb08a7095d81d639a0/recipes/geiser";
@@ -27245,12 +26396,12 @@
     ggtags = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "ggtags";
-        version = "20170827.510";
+        version = "20170918.1838";
         src = fetchFromGitHub {
           owner = "leoliu";
           repo = "ggtags";
-          rev = "9d1ecf961dd964cbe8ea183eac23572bb4f8f4ee";
-          sha256 = "1iy7n39kjl8n5qhs2vc9vszq3ff8h883zd380d3g7zs9nw0xx7jf";
+          rev = "6293c438a4a7aae08b8f5dd5fc0082d3da0aa530";
+          sha256 = "0rb293wjnc36gjy1vvvqsy605nn0vli1b1w210vvcjbg7zgcsak1";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b158bb1bc2fbe3de61a6b21174eac7b1457edda2/recipes/ggtags";
@@ -27434,12 +26585,12 @@
     ghub-plus = callPackage ({ apiwrap, emacs, fetchFromGitHub, fetchurl, ghub, lib, melpaBuild }:
     melpaBuild {
         pname = "ghub-plus";
-        version = "20170819.1806";
+        version = "20171007.1056";
         src = fetchFromGitHub {
           owner = "vermiculus";
           repo = "ghub-plus";
-          rev = "d6ee1158676f6fb62601fc20f02f4cbb7f090085";
-          sha256 = "1r4zm1frbm2dwsnrfnsghfplxj81grwhhyjc421kjnfavkkflxnq";
+          rev = "ac973a806e79ec883a3d041e91d06745084a622e";
+          sha256 = "1063wh3h5vv17mmppwbpsi8l8qnph0203h1lr6lz5001xv9rih91";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/03a412fd25218ff6f302734e078a699ff0234e36/recipes/ghub+";
@@ -27623,12 +26774,12 @@
     git-commit = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, with-editor }:
     melpaBuild {
         pname = "git-commit";
-        version = "20170913.343";
+        version = "20171007.346";
         src = fetchFromGitHub {
           owner = "magit";
           repo = "magit";
-          rev = "ae72710292a94d9af92799d3ddeb86f365f34a56";
-          sha256 = "1344dcngdk899xi9wjipvngq50xggbv06fb1w09zjzs8ckpsh8gf";
+          rev = "12fc6cede637c7e2542e2225565366f2a0ad9fce";
+          sha256 = "0ap1x0dshfivc0zljp96r2s5fhhnirqisrk3xsa94n2aidsf3y0q";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/cec5af50ae7634cc566adfbfdf0f95c3e2951c0c/recipes/git-commit";
@@ -28274,12 +27425,12 @@
     glab = callPackage ({ emacs, fetchFromGitLab, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "glab";
-        version = "20160808.539";
+        version = "20170924.359";
         src = fetchFromGitLab {
           owner = "tarsius";
           repo = "glab";
-          rev = "5ced0214622450930bcea105b9aac785c594609d";
-          sha256 = "100lz4dqn9ggvlvdrp909cy44br9hnlaa62pj0kp1vdqqxfxwfyn";
+          rev = "9848182275e0448390ccdd8dcd8e1e3a1853950c";
+          sha256 = "1fw1ck85y9r6z331g1wj7rix29fwy6gwbm7vqj3wff0lszy208ba";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/9375cbae3ffe5bf4ba5606358860050f3005d9b7/recipes/glab";
@@ -28295,12 +27446,12 @@
     glsl-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "glsl-mode";
-        version = "20160209.833";
+        version = "20170927.736";
         src = fetchFromGitHub {
           owner = "jimhourihan";
           repo = "glsl-mode";
-          rev = "b4709644bb01b522ba9c8afe16ed2394783c481f";
-          sha256 = "14ziljq34k585scwn606hqbkcvy8h1iylsc4h2n1grfmm8ilf0ws";
+          rev = "384968506cf25c5c2df61b32fdfdbd041e3bf651";
+          sha256 = "0729s4w010vw4ajvh1zpni7szxv9rpm6jk2y9hp7qyi67zbgjjgc";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c416822d54df436f29dcf9a5f26398685fdc17a2/recipes/glsl-mode";
@@ -28526,12 +27677,12 @@
     gnus-desktop-notify = callPackage ({ fetchFromGitHub, fetchurl, gnus ? null, lib, melpaBuild }:
     melpaBuild {
         pname = "gnus-desktop-notify";
-        version = "20170305.1215";
+        version = "20171007.1235";
         src = fetchFromGitHub {
           owner = "wavexx";
           repo = "gnus-desktop-notify.el";
-          rev = "7d80d5e1894859e963584c55f570508fdf9c2ee0";
-          sha256 = "1slj86f8c4pkl30xkv43vqwijd49nxya1bmhb8mqadncp3wapwr0";
+          rev = "52e5de0961ce0f6890d5e7f26bc05152b99d9979";
+          sha256 = "0r28hrlkji8z62nra71p0q6gvh21w90pyvmgskzjldmj78yjqbdj";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/7fabdb05de9b8ec18a3a566f99688b50443b6b44/recipes/gnus-desktop-notify";
@@ -28562,25 +27713,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/gnus-select-account";
-          license = lib.licenses.free;
-        };
-      }) {};
-    gnus-spotlight = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "gnus-spotlight";
-        version = "20130901.735";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/gnus-spotlight.el?revision=2";
-          sha256 = "1r6bck1hsvk39ccri1h128jj8zd0fh9bsrlp8ijb0v9f6x3cysw4";
-          name = "gnus-spotlight.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/004d48a59063163bfe5fbc5311330893d1b3b41c/recipes/gnus-spotlight";
-          sha256 = "065jcix6a4mxwq8wc8gkr0x9lxmn6hlvf0rqmhi8hb840km1syjx";
-          name = "gnus-spotlight";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/gnus-spotlight";
           license = lib.licenses.free;
         };
       }) {};
@@ -28675,8 +27807,8 @@
         src = fetchFromGitHub {
           owner = "nsf";
           repo = "gocode";
-          rev = "c7fddb39ecbc9ebd1ebe7d2a3af473ed0fffffa1";
-          sha256 = "0qx8pq38faig41xkl1a4hrgp3ziyjyn6g53vn5wj7cdgm5kk67nb";
+          rev = "1a78dd6c36d7f37cbb60073523c2e9ca3f6519fa";
+          sha256 = "1bcd62rggq3sk96n3dlpidrv4pbx6x385x17knfnp35avgrhsv4b";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/04867a574773e8794335a2664d4f5e8b243f3ec9/recipes/go-autocomplete";
@@ -28822,8 +27954,8 @@
         src = fetchFromGitHub {
           owner = "dominikh";
           repo = "go-mode.el";
-          rev = "99b06da201afb91e8db0c525c0f3c3590fd92fa6";
-          sha256 = "0ss6fpjnz3h3g4d1rjv50sknzr112c2r5zwzy2aqp7sw24cz10r2";
+          rev = "7eb5b3dd0ac31d176e9d56da4172f66aef8fae47";
+          sha256 = "1gx8hpgj9pbhpqqg1n5lby03bkg0llbkvb6pnidnfayh338amiqp";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/0cede3a468b6f7e4ad88e9fa985f0fdee7d195f5/recipes/go-guru";
@@ -28864,8 +27996,8 @@
         src = fetchFromGitHub {
           owner = "dominikh";
           repo = "go-mode.el";
-          rev = "99b06da201afb91e8db0c525c0f3c3590fd92fa6";
-          sha256 = "0ss6fpjnz3h3g4d1rjv50sknzr112c2r5zwzy2aqp7sw24cz10r2";
+          rev = "7eb5b3dd0ac31d176e9d56da4172f66aef8fae47";
+          sha256 = "1gx8hpgj9pbhpqqg1n5lby03bkg0llbkvb6pnidnfayh338amiqp";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/0cede3a468b6f7e4ad88e9fa985f0fdee7d195f5/recipes/go-mode";
@@ -28948,8 +28080,8 @@
         src = fetchFromGitHub {
           owner = "dominikh";
           repo = "go-mode.el";
-          rev = "99b06da201afb91e8db0c525c0f3c3590fd92fa6";
-          sha256 = "0ss6fpjnz3h3g4d1rjv50sknzr112c2r5zwzy2aqp7sw24cz10r2";
+          rev = "7eb5b3dd0ac31d176e9d56da4172f66aef8fae47";
+          sha256 = "1gx8hpgj9pbhpqqg1n5lby03bkg0llbkvb6pnidnfayh338amiqp";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d806abe90da9a8951fdb0c31e2167bde13183c5c/recipes/go-rename";
@@ -29158,8 +28290,8 @@
         src = fetchFromGitHub {
           owner = "golang";
           repo = "lint";
-          rev = "c5fb716d6688a859aae56d26d3e6070808df29f7";
-          sha256 = "0bp9aarkinjr6m358qw9x4qxi3v9h06jvipyx1pg3pwsqh61vb12";
+          rev = "6aaf7c34af0f4c36a57e0c429bace4d706d8e931";
+          sha256 = "1z1j2l0j5175xvin5v56nsq7byg5nfpfvl9xgjszparchkyr8ndz";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/34f22d829257456abbc020c006b92da9c7a7860e/recipes/golint";
@@ -29221,8 +28353,8 @@
         src = fetchFromGitHub {
           owner = "google";
           repo = "styleguide";
-          rev = "520cd9f88cc4bb6fa47345d566fffd8dd95c7450";
-          sha256 = "1xghwnjl2wi78bcn4nhjdxhann18r1nczq47yia2rxl0yg61wwxk";
+          rev = "911d9f4a7e3020578f4609860d7e5ede422a8f28";
+          sha256 = "0x2wx34gvz4dab7gyzs1992pf1f8zl5s5n1q1b4ps1d4ralglq1d";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b4e7f5f641251e17add561991d3bcf1fde23467b/recipes/google-c-style";
@@ -29259,12 +28391,12 @@
     google-maps = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "google-maps";
-        version = "20161210.458";
+        version = "20171002.734";
         src = fetchFromGitHub {
           owner = "jd";
           repo = "google-maps.el";
-          rev = "956e6ad42bc3819bcaf4cc66a640f5079b385ed7";
-          sha256 = "0dqcs9dl3170zddh4npsqm1ql0n0a0378gyqxk0vi0ibzch537vk";
+          rev = "c0e5dccfdc9f7f77ff8f29177547be47833d7156";
+          sha256 = "1agsfmbd2zbn1xs05kxlb32hhkmrri3hdmcrvf0w1fcsgc5a9085";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/671afe0ff3889ae8c4b2d7b8617a3a25c16f3f0f/recipes/google-maps";
@@ -29406,12 +28538,12 @@
     gotham-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "gotham-theme";
-        version = "20170822.1030";
+        version = "20171007.0";
         src = fetchFromGitHub {
           owner = "wasamasa";
           repo = "gotham-theme";
-          rev = "417d61978d139cb5d089c5365fc8d3166d76d3ac";
-          sha256 = "0rc40cfj2mby1q7bk1pp1fxdi72nh9ip80spjdm1csvjjc4dbkwr";
+          rev = "393da2aa55054b3ad06d24bf6f09a90554b6d37c";
+          sha256 = "134cw4g0hj6msyxyni71hkhf8wa2v2fxr41zyamg8xf76j75jr5b";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/4b388de872be397864a1217a330ba80437c287c0/recipes/gotham-theme";
@@ -29424,17 +28556,19 @@
           license = lib.licenses.free;
         };
       }) {};
-    goto-chg = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
+    goto-chg = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
         pname = "goto-chg";
-        version = "20131228.659";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/goto-chg.el?revision=9";
-          sha256 = "078d6p4br5vips7b9x4v6cy0wxf6m5ij9gpqd4g33bryn22gnpij";
-          name = "goto-chg.el";
+        version = "20170917.1200";
+        src = fetchFromGitHub {
+          owner = "emacs-evil";
+          repo = "goto-chg";
+          rev = "81fca94d2592cf32bab451c39a9cd2d9b03fbd6b";
+          sha256 = "033msplvpahkva9ha09gsg9232fyz2bjihrdxaa2z9g4yzql8jkq";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/529897b0c076d9031e7ecd13c945d2104ce8c735/recipes/goto-chg";
-          sha256 = "0fs0fc1mksbb1266sywasl6pppdn1f9a4q9dwycl9zycr588yjyv";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/cf1fc176430fe3ab55ce537a0efc59780bb812be/recipes/goto-chg";
+          sha256 = "1yd4jq4zql4av9nr1sdk4nsnnk54c3brgjhpczndy1ipiaxlnydy";
           name = "goto-chg";
         };
         packageRequires = [];
@@ -29488,12 +28622,12 @@
     govc = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, json-mode, lib, magit-popup, melpaBuild, s }:
     melpaBuild {
         pname = "govc";
-        version = "20170801.942";
+        version = "20170919.645";
         src = fetchFromGitHub {
           owner = "vmware";
           repo = "govmomi";
-          rev = "17b8c9ccb7f8c7b015d44c4ea39305c970a7bf31";
-          sha256 = "0g1vd8g6kbmz5ni0hdqg4yjlisf1lcxnfhrzcnwim5pw8zj549k2";
+          rev = "456200c5d4982d6938b7ed14fc9bb72cc12b1576";
+          sha256 = "0i10i311fr7lc2mf7na1jwxfj2lmi3l4f1bx22f01q4yy32kv3ap";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/92d6391318021c63b06fe39b0ca38f667bb45ae9/recipes/govc";
@@ -29618,8 +28752,8 @@
         src = fetchFromGitHub {
           owner = "Groovy-Emacs-Modes";
           repo = "groovy-emacs-modes";
-          rev = "36cd834c9fb1e438dfae4ad15a3580c963dba29f";
-          sha256 = "0rkxchxjgpgbhng15knwxfv0bcysdbc6nlh61x8z793aj2m0whi9";
+          rev = "167311c6c270f1bbcf51d2181e4af578a34c1ce7";
+          sha256 = "17bvizl9m1wdv3k6b289la5q56iy6b0bd96axlhb0ff10n48y29h";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3fe318b4e51a280a55c01fa30455e4a180df8bd6/recipes/grails-mode";
@@ -29811,15 +28945,36 @@
           license = lib.licenses.free;
         };
       }) {};
+    grayscale-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "grayscale-theme";
+        version = "20171005.102";
+        src = fetchFromGitHub {
+          owner = "belak";
+          repo = "emacs-grayscale-theme";
+          rev = "53ad50e10e68f2f076ebfc96e10ecef7a932d38d";
+          sha256 = "034pa35cjl07bhqdyw3xrcl97xcdg7jg0jvgn034fs3hssmsyxgv";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/2993881c7285cfbfc590b4118db46bfd435817bc/recipes/grayscale-theme";
+          sha256 = "0jbzb1zxv5mg3pivii31d4kz75igm339nw4cmx9kgzia9zal5f1r";
+          name = "grayscale-theme";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://melpa.org/#/grayscale-theme";
+          license = lib.licenses.free;
+        };
+      }) {};
     green-is-the-new-black-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "green-is-the-new-black-theme";
-        version = "20170828.1056";
+        version = "20171005.1641";
         src = fetchFromGitHub {
           owner = "fredcamps";
           repo = "green-is-the-new-black-emacs";
-          rev = "2b1011836fc04940d542e9a783b99670a08b308b";
-          sha256 = "16v7l4ynj4p1hq243rqckfgppmj8cvm0lyybjjqaqblqjd1ki90d";
+          rev = "b9cdecd04691311c30c94ad4ec81124e63b9b122";
+          sha256 = "124q733rirc8a2d9xfparphcjrrbxhp4wxf070l8hqp3p2764bka";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3e42528d5677fd90515cad47266c07ea3d4363fb/recipes/green-is-the-new-black-theme";
@@ -29892,25 +29047,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/grep-a-lot";
-          license = lib.licenses.free;
-        };
-      }) {};
-    grep-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "grep-plus";
-        version = "20170223.728";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/grep+.el";
-          sha256 = "0jx2r21x8ndikvn8zvdnmwg8al56yi9gb0fcmplc3lnq4my6xcjr";
-          name = "grep+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/grep+";
-          sha256 = "1qj4f6d3l88bdcnq825pylnc76m22x2i15yxdhc2b6rv80df7zsx";
-          name = "grep-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/grep+";
           license = lib.licenses.free;
         };
       }) {};
@@ -29999,12 +29135,12 @@
     groovy-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "groovy-mode";
-        version = "20170828.1026";
+        version = "20170928.728";
         src = fetchFromGitHub {
           owner = "Groovy-Emacs-Modes";
           repo = "groovy-emacs-modes";
-          rev = "36cd834c9fb1e438dfae4ad15a3580c963dba29f";
-          sha256 = "0rkxchxjgpgbhng15knwxfv0bcysdbc6nlh61x8z793aj2m0whi9";
+          rev = "167311c6c270f1bbcf51d2181e4af578a34c1ce7";
+          sha256 = "17bvizl9m1wdv3k6b289la5q56iy6b0bd96axlhb0ff10n48y29h";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3fe318b4e51a280a55c01fa30455e4a180df8bd6/recipes/groovy-mode";
@@ -30062,12 +29198,12 @@
     gruvbox-theme = callPackage ({ autothemer, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "gruvbox-theme";
-        version = "20170828.144";
+        version = "20170923.2008";
         src = fetchFromGitHub {
           owner = "Greduan";
           repo = "emacs-theme-gruvbox";
-          rev = "4e1c2616a31f33191daf20c0f9f744af5dd14468";
-          sha256 = "1cgc8amxbj1839zx6vhpk96r1iag8mwnkdzd4wj6xabb59lvbjld";
+          rev = "4241935d9cc786d0b4a3a445830c395f2a9eeb90";
+          sha256 = "1x624xc2756pmb4h5ayls8r16zy33d9vxr0as4jm6q682h2swir6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/2bd48c87919f64ced9f3add4860751bb34cb5ecb/recipes/gruvbox-theme";
@@ -30104,12 +29240,12 @@
     gscholar-bibtex = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "gscholar-bibtex";
-        version = "20170713.1934";
+        version = "20170913.1457";
         src = fetchFromGitHub {
           owner = "cute-jumper";
           repo = "gscholar-bibtex";
-          rev = "655bccf0b12c9d95ec992ee4bfb5c7c9a4d0c99b";
-          sha256 = "1ivdq3mgym14v5hpv938248vifw1xk9z16d2f38d9xj01icik522";
+          rev = "ba4ce159e385d695d8560e8b06b3cbe48424861c";
+          sha256 = "0idnfhk17avp0r4706grjqqkz0xl98gs0bx7wrkvwym3y2gadlz2";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/9fa546d3dce59b07a623ee83e3befe139dc10481/recipes/gscholar-bibtex";
@@ -30209,12 +29345,12 @@
     guix = callPackage ({ bui, dash, emacs, fetchFromGitHub, fetchurl, geiser, lib, magit-popup, melpaBuild }:
     melpaBuild {
         pname = "guix";
-        version = "20170902.1128";
+        version = "20171005.137";
         src = fetchFromGitHub {
           owner = "alezost";
           repo = "guix.el";
-          rev = "54bd174b514c5de11e82c4263ac2723addb0fe87";
-          sha256 = "1i5kwzwlb6lx65rgixm8mbdi6x03n0hb4hbc7j76lar4j58ypwz2";
+          rev = "6927d5afd2c4543bc97785d3f35e06a8b0fe86f3";
+          sha256 = "1hyghwnnkl7fsq3wm7acp4ia7a7zp396wbmmyk3zw93lnpjhwkpn";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b3d8c73e8a946b8265487a0825d615d80aa3337d/recipes/guix";
@@ -30314,12 +29450,12 @@
     habitica = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, org }:
     melpaBuild {
         pname = "habitica";
-        version = "20170203.2122";
+        version = "20170924.857";
         src = fetchFromGitHub {
           owner = "abrochard";
           repo = "emacs-habitica";
-          rev = "f3e326b7342953ffd5d3ced9266b46387b2bf9ce";
-          sha256 = "0aixxlfp04vmipki7r7aqid2lsrzy7d38g09qc1hrjjdba7jrjlp";
+          rev = "752bd376bcf1db563d503d554802aa0ff6e2c054";
+          sha256 = "01g9kkfddn7lggbqw6s1vk3igbdjh0v6qslnlbp1llih8wa2vdlr";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/cf9543db3564f4806440ed8c5c30fecbbc625fa1/recipes/habitica";
@@ -30377,12 +29513,12 @@
     hackernews = callPackage ({ fetchFromGitHub, fetchurl, json ? null, lib, melpaBuild }:
     melpaBuild {
         pname = "hackernews";
-        version = "20170829.1044";
+        version = "20170930.1313";
         src = fetchFromGitHub {
           owner = "clarete";
           repo = "hackernews.el";
-          rev = "62442f76a0936047b5f66457298811c4f724a4f5";
-          sha256 = "0pz3w726485yqww674ydrc3ffd0wrm9w0dgan0qyg3ggjj1fvjvs";
+          rev = "520e8dca91b8c2bc1de852f577af46ed1b7cabcd";
+          sha256 = "0951vb08sjpxx28cpaa8njirjw6fml60m91wa146cnxpngd68w6b";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c43a342e47e5ede468bcf51a60d4dea3926f51bd/recipes/hackernews";
@@ -30482,12 +29618,12 @@
     haml-mode = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "haml-mode";
-        version = "20170624.2148";
+        version = "20170923.2153";
         src = fetchFromGitHub {
           owner = "nex3";
           repo = "haml-mode";
-          rev = "c7c96a269f9b1a0302ff81360e1b5e693d784774";
-          sha256 = "0lh9m0598rmwx9qacb6wjd12hf6njx7r1srl25bw60fs1l5bnvqd";
+          rev = "1cbb2de8f0fc25f35448c5cad04642f28078f3bb";
+          sha256 = "1045bf7bq914d3577kg9xakm4yciwwsvlh5qwfk4wnsraf7rld0r";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/cae2ac3513e371a256be0f1a7468e38e686c2487/recipes/haml-mode";
@@ -30796,12 +29932,12 @@
     hasky-stack = callPackage ({ emacs, f, fetchFromGitHub, fetchurl, lib, magit-popup, melpaBuild }:
     melpaBuild {
         pname = "hasky-stack";
-        version = "20170901.154";
+        version = "20170928.359";
         src = fetchFromGitHub {
           owner = "hasky-mode";
           repo = "hasky-stack";
-          rev = "38a33e2ed02d57afb6b38bf36741f5bf7e38e45b";
-          sha256 = "03zg58hrka2q7sqm3f14xgcs2mjxhlyybkf9w6pp8icr4wdsih4z";
+          rev = "a3f890fb8570369898ee9718b128d4e7123a6585";
+          sha256 = "0bc5i4s7aclwrsh8yrhfwwlfbcs5hdbzm31glikd487asv30jq9c";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c3faf544872478c3bccf2fe7dc51d406031e4d80/recipes/hasky-stack";
@@ -30960,25 +30096,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    header2 = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "header2";
-        version = "20170223.729";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/header2.el?revision=69";
-          sha256 = "0cv74cfihr13jrgyqbj4x0na659djfyrhflxni6jdbgbysi4zf6k";
-          name = "header2.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/header2";
-          sha256 = "1vvxb850njn921djvnf76q1p045sqr5hqk6v0p0amvjvih48v0zx";
-          name = "header2";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/header2";
-          license = lib.licenses.free;
-        };
-      }) {};
     headlong = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "headlong";
@@ -31003,12 +30120,12 @@
     helm = callPackage ({ async, emacs, fetchFromGitHub, fetchurl, helm-core, lib, melpaBuild, popup }:
     melpaBuild {
         pname = "helm";
-        version = "20170912.523";
+        version = "20171009.221";
         src = fetchFromGitHub {
           owner = "emacs-helm";
           repo = "helm";
-          rev = "20fd1fdc80c05b1b2c03a9dd02f4a8358d2ed883";
-          sha256 = "08rli1i3k1kvv7bavdb9s1y333cldxla9v0k3g7x72lyqncl25pr";
+          rev = "8529bbd8a850bc0c212c38120621f2b2cc8a7656";
+          sha256 = "1rav46bbw807cbv93ash7ah3azsxbrnnpcsfm14mmc9x3mmjygrk";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/7e8bccffdf69479892d76b9336a4bec3f35e919d/recipes/helm";
@@ -31234,12 +30351,12 @@
     helm-bibtex = callPackage ({ biblio, cl-lib ? null, dash, f, fetchFromGitHub, fetchurl, helm, lib, melpaBuild, parsebib, s }:
     melpaBuild {
         pname = "helm-bibtex";
-        version = "20170808.1124";
+        version = "20171003.131";
         src = fetchFromGitHub {
           owner = "tmalsburg";
           repo = "helm-bibtex";
-          rev = "8ed898fb5a68f18e9bb9973832a5c1f8abcfc463";
-          sha256 = "14lyx0vbqr97p3anzrsp7m3q0kqclyjcdwplpraim403fcklzbnz";
+          rev = "299090ecb376ba269f2ffe547a672d210ddaceb3";
+          sha256 = "07jym5zh07zksrn1f7x2j8m3agjzq06f9xchmiv7cic6x7b3shcj";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/f4118a7721435240cf8489daa4dd39369208855b/recipes/helm-bibtex";
@@ -31633,12 +30750,12 @@
     helm-core = callPackage ({ async, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "helm-core";
-        version = "20170906.141";
+        version = "20170929.2213";
         src = fetchFromGitHub {
           owner = "emacs-helm";
           repo = "helm";
-          rev = "20fd1fdc80c05b1b2c03a9dd02f4a8358d2ed883";
-          sha256 = "08rli1i3k1kvv7bavdb9s1y333cldxla9v0k3g7x72lyqncl25pr";
+          rev = "8529bbd8a850bc0c212c38120621f2b2cc8a7656";
+          sha256 = "1rav46bbw807cbv93ash7ah3azsxbrnnpcsfm14mmc9x3mmjygrk";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ef7a700c5665e6d72cb4cecf7fb5a2dd43ef9bf7/recipes/helm-core";
@@ -31948,12 +31065,12 @@
     helm-ext = callPackage ({ emacs, fetchFromGitHub, fetchurl, helm, lib, melpaBuild }:
     melpaBuild {
         pname = "helm-ext";
-        version = "20170411.1049";
+        version = "20170914.1348";
         src = fetchFromGitHub {
           owner = "cute-jumper";
           repo = "helm-ext";
-          rev = "fe50af14eebc9be72b026e823facfd0a80593248";
-          sha256 = "1pz7i1byscfq2j73cfgcjqdx8s14h9qxnfmvs5g00m0y3g25hhc0";
+          rev = "c2de41c4694ed606b321bcf83493dee93ad5635a";
+          sha256 = "0bnnzf7pwg0qyx8hafgx6ckcc7n3pvf5j1qbipkzgnqmfqfli0n7";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1ee74cb0aa3445bc9ae4226c2043ee4de3ac6cd3/recipes/helm-ext";
@@ -32725,12 +31842,12 @@
     helm-lastpass = callPackage ({ csv, emacs, fetchFromGitHub, fetchurl, helm-core, lib, melpaBuild }:
     melpaBuild {
         pname = "helm-lastpass";
-        version = "20170808.511";
+        version = "20170914.142";
         src = fetchFromGitHub {
           owner = "xuchunyang";
           repo = "helm-lastpass";
-          rev = "3d07a1d68586980ae33dd7f84be00eaace31f7d2";
-          sha256 = "1rn19hql62fgz1kiyxyw11h3h9m38nnhba9sghlrxj3wk11fm8gs";
+          rev = "ae5d1252d60450082a5c26af3ad2be43994201ec";
+          sha256 = "0qlcy8g9m3mfnr6p7kax6i1bq0dsxpz22vy5zjp24farx96mj5mi";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a39f1b0a5b22e91eb9e298949def6c29e7bc5755/recipes/helm-lastpass";
@@ -32827,18 +31944,19 @@
           license = lib.licenses.free;
         };
       }) {};
-    helm-ls-svn = callPackage ({ cl-lib ? null, emacs, fetchsvn, fetchurl, helm, lib, melpaBuild }:
+    helm-ls-svn = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, helm, lib, melpaBuild }:
     melpaBuild {
         pname = "helm-ls-svn";
         version = "20150717.39";
-        src = fetchsvn {
-          url = "https://svn.macports.org/repository/macports/users/chunyang/helm-ls-svn.el";
-          rev = "154482";
+        src = fetchFromGitHub {
+          owner = "emacsorphanage";
+          repo = "helm-ls-svn";
+          rev = "4d4dc1a272f27fba5fdd7cc47e5d309b53c63ae3";
           sha256 = "0b7gah21rkfd43mb89lrwaqrrwq646abh7wi4q74sx796gmpz4dz";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/99cc183c09b97264d243b4fe036574ce9c6b9687/recipes/helm-ls-svn";
-          sha256 = "08mwzi340akw4ar20by0q981mzmzvf0wz3mn738q4inn2kqgs60d";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/30de78c9cf83de30093a5647976eeaf552d4b2cb/recipes/helm-ls-svn";
+          sha256 = "0rqsy6gk114khqr28bp2fi0ixaa8wbqd952yxph517p1pbfwxy66";
           name = "helm-ls-svn";
         };
         packageRequires = [ cl-lib emacs helm ];
@@ -32850,12 +31968,12 @@
     helm-make = callPackage ({ fetchFromGitHub, fetchurl, helm, lib, melpaBuild, projectile }:
     melpaBuild {
         pname = "helm-make";
-        version = "20170430.1053";
+        version = "20171004.1018";
         src = fetchFromGitHub {
           owner = "abo-abo";
           repo = "helm-make";
-          rev = "8bb531fa77fe1259cccdc2fa7629d65989684f16";
-          sha256 = "1vvdk2f41aqhcb8hawk0x17ix1fyanvx3m2zd398lhv3r6mll0r4";
+          rev = "786104ac0c3cf4fe5b53f841eb9fe10bda2e4031";
+          sha256 = "0qdfk0p2j8jah7m0ngy2mm7775cn779m3a84yll86wqc74g331qs";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/0f25f066c60d4caff1fbf885bc944cac47515ec8/recipes/helm-make";
@@ -32980,8 +32098,8 @@
         src = fetchFromGitHub {
           owner = "travisbhartwell";
           repo = "nix-emacs";
-          rev = "ace629f7645d12778c96ff7b5cf4b1e41a98af29";
-          sha256 = "11infdrdjc30kxvfg5rh1zn4idvkhf9s0c6v60qn441m1d5bnavq";
+          rev = "7007363e773a419203a69798fb0e0731b2eb0f73";
+          sha256 = "00hv8fhyahkdh1vfy1qkahqvsik6d81c7mqh4gjiqxrmb2l1vbcb";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6846c7d86e70a9dd8300b89b61435aa7e146be96/recipes/helm-nixos-options";
@@ -33249,12 +32367,12 @@
     helm-projectile = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, helm, lib, melpaBuild, projectile }:
     melpaBuild {
         pname = "helm-projectile";
-        version = "20170613.14";
+        version = "20170926.1123";
         src = fetchFromGitHub {
           owner = "bbatsov";
           repo = "helm-projectile";
-          rev = "0e9ba276b3fbc420b8cbdc1b99262ccd5c750db7";
-          sha256 = "155df7jyhjgqdks3ba1ca1k8w8aqka9vv3nhzpkvgz7wj84c95pq";
+          rev = "4466adbcada8be19ec97b9dba52e12b8da3da849";
+          sha256 = "1a4s3vs2vh2dz31an7jjrbyli1dsqwl7qcd1r63ak87klzpqn98b";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/8bc4e3a5af7ba86d277c73a1966a91c87d3d855a/recipes/helm-projectile";
@@ -33547,8 +32665,8 @@
         src = fetchFromGitHub {
           owner = "Andersbakken";
           repo = "rtags";
-          rev = "2af4d6a32e8194f8fbcc23fd94395e3d595a3c25";
-          sha256 = "0091w529lvbjlw1fdb3qjgb8fd5fcwxhqyr4ps5cvxl5bqnwlw39";
+          rev = "12636847b1ea512ce2d0c1075a74465f38555e69";
+          sha256 = "12v3wr2103293fkglbkhp20m2z72n66qka2s5zpcgc3jwqyqnnf9";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3dea16daf0d72188c8b4043534f0833fe9b04e07/recipes/helm-rtags";
@@ -33669,12 +32787,12 @@
     helm-smex = callPackage ({ emacs, fetchFromGitHub, fetchurl, helm, lib, melpaBuild, smex }:
     melpaBuild {
         pname = "helm-smex";
-        version = "20161202.1252";
+        version = "20171004.1308";
         src = fetchFromGitHub {
           owner = "ptrv";
           repo = "helm-smex";
-          rev = "7af4e4b44671f739b39584fc50c20084700701ac";
-          sha256 = "1dhzglpd48mb47iyii8igb1dldvnr4alg18m7g8xb529dx8z9wni";
+          rev = "2269375dfa452b88b5170d1a5d5849ebb2c1e413";
+          sha256 = "0n2ki7g0hygsq4bi5zkhp3v772ld7niiajfznxmv11dgn949a52s";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/85568bd732da952053148e07b95e53f7caf5f62c/recipes/helm-smex";
@@ -33774,12 +32892,12 @@
     helm-swoop = callPackage ({ emacs, fetchFromGitHub, fetchurl, helm, lib, melpaBuild }:
     melpaBuild {
         pname = "helm-swoop";
-        version = "20160619.953";
+        version = "20170923.2127";
         src = fetchFromGitHub {
           owner = "ShingoFukuyama";
           repo = "helm-swoop";
-          rev = "6d3fdcfb6dea06242efc8ff4cafff9917e558bfc";
-          sha256 = "1pjpzccviz95zgl86yw2xda7lhlsfdddf8la8di8rka8sz79nw72";
+          rev = "66a951700e0ef0621cc705791bdd6699488ab121";
+          sha256 = "1j1qmbj4g5z891i1xyz8p34mk63ckpl1j80pznbhvb9ffl9aw976";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/helm-swoop";
@@ -33900,12 +33018,12 @@
     helm-w3m = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, helm, lib, melpaBuild, w3m }:
     melpaBuild {
         pname = "helm-w3m";
-        version = "20170904.711";
+        version = "20170918.1017";
         src = fetchFromGitHub {
           owner = "emacs-helm";
           repo = "helm-w3m";
-          rev = "57b8b0d3cad39abd02fab569ddd1c96336bbbad5";
-          sha256 = "059jlyljlp5g7jh6bjdjd157l35apnwvxal1r18pipwfk1fcscxq";
+          rev = "158f52abaa216cd64fc2c85f07722eceef508cec";
+          sha256 = "1kvvgrfjpifrph1fgn4jvrhsrq8qq9z3w0ag9wjx5lb595svn4vh";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/f683fc9c7990e9ecb8a94808a7d03eb90c5569b1/recipes/helm-w3m";
@@ -33936,27 +33054,6 @@
         packageRequires = [ cl-lib emacs helm ];
         meta = {
           homepage = "https://melpa.org/#/helm-wordnet";
-          license = lib.licenses.free;
-        };
-      }) {};
-    helm-words = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "helm-words";
-        version = "20150413.1318";
-        src = fetchFromGitHub {
-          owner = "pronobis";
-          repo = "helm-words";
-          rev = "637aa3a7e9cfd34e0127472c5b1f993a4da26185";
-          sha256 = "19l8vysjygscr1nsddjz2yv0fjhbsswfq40rdny8zsmaa6qhpj35";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/f8c5b91762d47a4d3024f1ed7f19666c6f2d5ce5/recipes/helm-words";
-          sha256 = "0l9mb7g3xzasna1bw2p7vh2wdg1hmjkff40p8kpqvwwzszdm9v76";
-          name = "helm-words";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/helm-words";
           license = lib.licenses.free;
         };
       }) {};
@@ -34044,72 +33141,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    help-fns-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "help-fns-plus";
-        version = "20170223.733";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/help-fns+.el";
-          sha256 = "0n7sdzvplcb0zivpjq9x75kaid59yxr7sl85w7z99irx3kgpy9y4";
-          name = "help-fns+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/help-fns+";
-          sha256 = "10vz7w79k3barlcs3ph3pc7914xdhcygagdk2wj3bq0wmwxa1lia";
-          name = "help-fns-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/help-fns+";
-          license = lib.licenses.free;
-        };
-      }) {};
-    help-mode-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "help-mode-plus";
-        version = "20170223.737";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/help-mode+.el";
-          sha256 = "00yx1rhp7akap63c3nqh766zkjvfarmvm0xvza40i167wc7xmydg";
-          name = "help-mode+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/help-mode+";
-          sha256 = "1pmb845bxa5kazjpdxm12rm2wcshmv2cmisigs3kyva1pmi1shra";
-          name = "help-mode-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/help-mode+";
-          license = lib.licenses.free;
-        };
-      }) {};
-    help-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "help-plus";
-        version = "20170223.731";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/help+.el";
-          sha256 = "0zypqsj940cmb8szbk5acv47kaj3czg6yplx1lg5dynhvab3p29f";
-          name = "help+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/help+";
-          sha256 = "1jx0wa4md1mvdsvjyx2yvi4hhm5w061qqcafsrw4axsz7gjpd4yi";
-          name = "help-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/help+";
-          license = lib.licenses.free;
-        };
-      }) {};
     helpful = callPackage ({ dash, elisp-refs, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "helpful";
-        version = "20170910.1046";
+        version = "20171008.1448";
         src = fetchFromGitHub {
           owner = "Wilfred";
           repo = "helpful";
-          rev = "62ede4c121c0a0a9917682f28adf746e21bbfa45";
-          sha256 = "1kp61f18l0ll9k1r72id2xgfdc857d5qhhh5pamp5ps6kjfpz6h6";
+          rev = "aec98ee3c44c911936a309b56510384b8e835ff2";
+          sha256 = "1x2f34bpzlckiyn2ndknm5gmra8xginsnavjqs4dn6n0knbcrq32";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/889d34b654de13bd413d46071a5ff191cbf3d157/recipes/helpful";
@@ -34119,6 +33159,27 @@
         packageRequires = [ dash elisp-refs emacs s ];
         meta = {
           homepage = "https://melpa.org/#/helpful";
+          license = lib.licenses.free;
+        };
+      }) {};
+    hemera-theme = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "hemera-theme";
+        version = "20170910.603";
+        src = fetchFromGitHub {
+          owner = "GuidoSchmidt";
+          repo = "emacs-hemera-theme";
+          rev = "354ae3b788c11ac08e6e2fe7c86adc621e2b16fd";
+          sha256 = "00cfi9gsn9fvjpgxkz931p02gs8dcgwwsaqz3anss9qadxxmi9xv";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/3440905a20bc91bb2637a87c04ff8410379f150d/recipes/hemera-theme";
+          sha256 = "0lxm06gv5f75s86320m8wh3dirdcspb6zd5n1a6l0pnn585xqkrn";
+          name = "hemera-theme";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/hemera-theme";
           license = lib.licenses.free;
         };
       }) {};
@@ -34206,25 +33267,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    hexrgb = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "hexrgb";
-        version = "20170304.1213";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/hexrgb.el?revision=75";
-          sha256 = "1aj1fsc3wr8174xs45j2wc2mm6f8v6zs40xn0r4qisdw0plmsbsy";
-          name = "hexrgb.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/hexrgb";
-          sha256 = "0b8lzmyv91f5bg7n2wj50p1pv6hpd2wygjcrffg4wwa52lp24dzk";
-          name = "hexrgb";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/hexrgb";
-          license = lib.licenses.free;
-        };
-      }) {};
     hfst-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "hfst-mode";
@@ -34309,25 +33351,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    hide-comnt = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "hide-comnt";
-        version = "20170223.739";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/hide-comnt.el?revision=25";
-          sha256 = "1shkq45vm60nh2kkvf284nck8jwxh7f7m4c5d53k66mxn214h53m";
-          name = "hide-comnt.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/hide-comnt";
-          sha256 = "0l3qvklyyc6hfinlzif7vfspl8b91ql0qdiwhixcilglyvad8r80";
-          name = "hide-comnt";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/hide-comnt";
-          license = lib.licenses.free;
-        };
-      }) {};
     hide-lines = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "hide-lines";
@@ -34346,25 +33369,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/hide-lines";
-          license = lib.licenses.free;
-        };
-      }) {};
-    hide-region = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "hide-region";
-        version = "20140201.314";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/hide-region.el?revision=6";
-          sha256 = "1zxrygpf47bzj6p808r3qhj3dfr3m8brp1xgxs33c7f88rinfval";
-          name = "hide-region.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/c5fc294a4d0cfa74530c98d81149fd0501ea7efe/recipes/hide-region";
-          sha256 = "0nsc6m3yza658xsxvjz8766vkp71rcm6vwnvcv225r2pr94mq7vm";
-          name = "hide-region";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/hide-region";
           license = lib.licenses.free;
         };
       }) {};
@@ -34389,25 +33393,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    hideshowvis = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "hideshowvis";
-        version = "20170227.1250";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/hideshowvis.el?revision=10";
-          sha256 = "02a6v2m54r5nfbi54h1502aqh7gnz827pfi1sq266qyzj3p6yz12";
-          name = "hideshowvis.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/881fd07512c417c0b98021af2a2c26eac4268a5f/recipes/hideshowvis";
-          sha256 = "1ajr71fch3v5g8brb83kwmlakcam5w21i3yr8df00c5j2pnc6v1f";
-          name = "hideshowvis";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/hideshowvis";
-          license = lib.licenses.free;
-        };
-      }) {};
     hierarchy = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "hierarchy";
@@ -34426,25 +33411,6 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://melpa.org/#/hierarchy";
-          license = lib.licenses.free;
-        };
-      }) {};
-    highlight = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "highlight";
-        version = "20170702.732";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/highlight.el?revision=149";
-          sha256 = "0kh72fmqsha25rz0g3ff983badh20clsig7blrhvl8c4bv3sqs56";
-          name = "highlight.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/603e9fc90e6e6cf7fe903cb3c38155c1a4f45278/recipes/highlight";
-          sha256 = "0clv4mzy9kllcvc0cgsbx3a9anw68dc2c7vzwbrv13sw5gh9skc0";
-          name = "highlight";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/highlight";
           license = lib.licenses.free;
         };
       }) {};
@@ -34469,44 +33435,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    highlight-chars = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "highlight-chars";
-        version = "20170223.740";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/highlight-chars.el?revision=18";
-          sha256 = "00rna5bs0ilgsdi5168djjpb3hg89yq20pp17sx5r3jcksm2fm4f";
-          name = "highlight-chars.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/highlight-chars";
-          sha256 = "19jawbjvqx1hsjbynx0jgpziap3r64k8s1xfckajrx8aq8m4c6i0";
-          name = "highlight-chars";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/highlight-chars";
-          license = lib.licenses.free;
-        };
-      }) {};
-    highlight-cl = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "highlight-cl";
-        version = "20091012.1030";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/highlight-cl.el?revision=3";
-          sha256 = "0r3kzs2fsi3kl5gqmsv75dc7lgfl4imrrqhg09ij6kq1ri8gjxjw";
-          name = "highlight-cl.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/7dc85d7fd8e4d7381850f4a379140c64506f86e8/recipes/highlight-cl";
-          sha256 = "164h3c3rzriahb7v5hk2pw4i0gk2vk5ak722bai6x4zx4l1xp20w";
-          name = "highlight-cl";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/highlight-cl";
-          license = lib.licenses.free;
-        };
-      }) {};
     highlight-context-line = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "highlight-context-line";
@@ -34525,26 +33453,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/highlight-context-line";
-          license = lib.licenses.free;
-        };
-      }) {};
-    highlight-current-line = callPackage ({ fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "highlight-current-line";
-        version = "20051013.1056";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/highlight-current-line.el?revision=4";
-          sha256 = "1aki7a7nnj9n7vh19k4fr0v7cqbwkrpc6b3f3yv95vcqj8a4y34c";
-          name = "highlight-current-line.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/e2768ed5917ec2e2339412d8fbd146ca5a8a5042/recipes/highlight-current-line";
-          sha256 = "01bga6is3frzlzfajpvpgz224vhl0jnc2bl2ipvlygdcmv4h8973";
-          name = "highlight-current-line";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/highlight-current-line";
           license = lib.licenses.free;
         };
       }) {};
@@ -34820,34 +33728,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    highlight-tail = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "highlight-tail";
-        version = "20140415.1841";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/highlight-tail.el?revision=5";
-          sha256 = "1bbiyqddqkrp3c7xsg1m4143611bhg1kkakrwscqjb4cfmx29qqg";
-          name = "highlight-tail.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/d033ff8cceb7e6d1e5a9f0ec7b706eb28bfe30f3/recipes/highlight-tail";
-          sha256 = "187kv3n262l38jdapi9bwcafz8fh61pdq2zliwiz7m7xdspp2iws";
-          name = "highlight-tail";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/highlight-tail";
-          license = lib.licenses.free;
-        };
-      }) {};
     highlight-thing = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "highlight-thing";
-        version = "20170207.2239";
+        version = "20170919.704";
         src = fetchFromGitHub {
           owner = "fgeller";
           repo = "highlight-thing.el";
-          rev = "c998172704ac4b96147d862a0eb4a0f97deb5e0a";
-          sha256 = "0s441ya0fcw7sv1ah13dh0b0m2rcvf68a442knvnf06a07hpr5sr";
+          rev = "4eadd178175772fb04ae50e1199d797a6375ad4d";
+          sha256 = "1h2ka1fi0pdh0mx3z8sh4fvwyiyc18d56nl9wd4c96h3n93f7py0";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/84b6cb403ff9a588771d051e472596f4e3cc974d/recipes/highlight-thing";
@@ -34930,8 +33819,8 @@
         src = fetchFromGitHub {
           owner = "chrisdone";
           repo = "hindent";
-          rev = "dde17a134ae99bd3c6e9b98ed04ad1740c2cd00b";
-          sha256 = "1piyzinjz0khfpl96rgxg0f5yy4han16zqj7lcjd9xfzdx9rg4yg";
+          rev = "4556ff94e6ed35eabdd28a061a07aadf436f0daf";
+          sha256 = "1w5hwy1lszwcgqz43hw2mq95v6qm6ghxrzgrrw9p3cj2c4cz0kis";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/dbae71a47446095f768be35e689025aed57f462f/recipes/hindent";
@@ -35133,25 +34022,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    hl-defined = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "hl-defined";
-        version = "20170223.744";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/hl-defined.el?revision=9";
-          sha256 = "0sj1ypfawb1pxblm11zbfyy96f2mbpnmif972yqfrxzf5h20ra1y";
-          name = "hl-defined.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/hl-defined";
-          sha256 = "1y7vbhvpwxz70kja5hfm4i57mdd1cv43m4y9fr978y3nk265p8xx";
-          name = "hl-defined";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/hl-defined";
-          license = lib.licenses.free;
-        };
-      }) {};
     hl-indent = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "hl-indent";
@@ -35173,34 +34043,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    hl-line-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "hl-line-plus";
-        version = "20170621.734";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/hl-line+.el";
-          sha256 = "03bgx651nrnwqbclbfaabkw4h2iaiswnndqgms0w6lp3jjfc10wc";
-          name = "hl-line+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/hl-line+";
-          sha256 = "16wlvi97wfkj36rnkbhzsky7sib3b76r2ng0lizp7ncr8d0vvhfv";
-          name = "hl-line-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/hl-line+";
-          license = lib.licenses.free;
-        };
-      }) {};
     hl-sentence = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "hl-sentence";
-        version = "20170812.646";
+        version = "20171007.755";
         src = fetchFromGitHub {
           owner = "milkypostman";
           repo = "hl-sentence";
-          rev = "1235ec94af083c3e43559ce0cac6db485aa938e0";
-          sha256 = "1b58d79pkakfz2l31lg8nfkb1dfzrnbw4p5cs8mlxpfa5j4z13af";
+          rev = "10cead52cb4da5dccfe30ba6756c11973d8ea094";
+          sha256 = "1kl38jzgws5mw67yzg4055988sza36sdd8bq1dw68p9wi6kqpdqw";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/cae2ac3513e371a256be0f1a7468e38e686c2487/recipes/hl-sentence";
@@ -35234,25 +34085,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    hl-spotlight = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "hl-spotlight";
-        version = "20170223.746";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/hl-spotlight.el?revision=15";
-          sha256 = "02x7p6hy1mkhbish55mzsdp6a1pnsdcfl4qi9cq48syg6cfm8fw3";
-          name = "hl-spotlight.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/adb008d2da35dbd3fca63555f04dd8a0009380c6/recipes/hl-spotlight";
-          sha256 = "1166g27fp2pj4j3a8904pzvp5idlq4l22i0w6lbk5c9zh5pqyyf3";
-          name = "hl-spotlight";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/hl-spotlight";
-          license = lib.licenses.free;
-        };
-      }) {};
     hl-todo = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "hl-todo";
@@ -35277,12 +34109,12 @@
     hledger-mode = callPackage ({ async, emacs, fetchFromGitHub, fetchurl, htmlize, lib, melpaBuild, popup }:
     melpaBuild {
         pname = "hledger-mode";
-        version = "20170807.1130";
+        version = "20171003.647";
         src = fetchFromGitHub {
           owner = "narendraj9";
           repo = "hledger-mode";
-          rev = "fb314edbb193a1c640ae8f13c0373c7de26e2c8e";
-          sha256 = "1gq6f1dhfwsm1xk5952nxv8j67bz230pnswf9s1zp21drxwgdk20";
+          rev = "588c6a2df2ff4b8f77df49894808cf4ad3de6cad";
+          sha256 = "18hjnha1imqiygydbbwwfldp0wvfhf02ffzhzd967nq6gvl0vzdf";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/hledger-mode";
@@ -35657,8 +34489,8 @@
         src = fetchFromGitHub {
           owner = "hniksic";
           repo = "emacs-htmlize";
-          rev = "88e2cb6588827893d7bc619529393887c264d15a";
-          sha256 = "09xpv8dsc39a7w9s6xnilc5kh1krs2jw8cklizxzz4gp36hrsj2n";
+          rev = "1f7bd7290e4698ac0b26b911fde7727fcb609bc7";
+          sha256 = "1cy1100qzdpkk7kcr54262jgc4zl9jqn66v51g72kmhc90ayj8bh";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/075aa00a0757c6cd1ad392f0300bf5f1b937648d/recipes/htmlize";
@@ -35842,12 +34674,12 @@
     hy-mode = callPackage ({ dash, dash-functional, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "hy-mode";
-        version = "20170908.922";
+        version = "20171008.1642";
         src = fetchFromGitHub {
           owner = "hylang";
           repo = "hy-mode";
-          rev = "d44dce8475cd1e8d14a533c604c3c32fcdcd4a9f";
-          sha256 = "19zv3xj4lzwv9vvlqsnn4nqxjhnq1hvl81qin1kr7z6bmhmidhns";
+          rev = "6d45ce89f26efe7ed0652415d2e999e5afcc5802";
+          sha256 = "0ycn3gn442ap6gc1z9snbmmlrwd97rsf10cr3agf1z3xhzz2jycn";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/fc9ab5cf16b61bb27559cd8ec5cf665a5aab2154/recipes/hy-mode";
@@ -35926,12 +34758,12 @@
     hydra = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "hydra";
-        version = "20170903.218";
+        version = "20170924.2259";
         src = fetchFromGitHub {
           owner = "abo-abo";
           repo = "hydra";
-          rev = "b12d37ac00d4f677b7684ed1af7d04d996167dbb";
-          sha256 = "1aw0zca0xrqig7pj5gqfsrz8cblplb4ljh7k3k1hqsl1wpxav9kg";
+          rev = "df3025f7e3cf3899168ae8ced1e9b734df2b32a0";
+          sha256 = "1sbj699956vxbzbdagw5hbx168sx9cfrc5vx6m6s89v2rkq8fw8k";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a4375d8ae519290fd5018626b075c226016f951d/recipes/hydra";
@@ -36110,44 +34942,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    icicles = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "icicles";
-        version = "20170910.1711";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/icicles.el?revision=1089";
-          sha256 = "10w1lghh9jqxxm5cszi2qyk24vnvazfywmyyz1v7zf6cyiwbndrz";
-          name = "icicles.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/ca7bf43ef8893bf04e9658390e306ef69e80a156/recipes/icicles";
-          sha256 = "15h2511gm38q14avsd86j5mnxhsjvcdmwbnhj66ashj5p5nxhr92";
-          name = "icicles";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/icicles";
-          license = lib.licenses.free;
-        };
-      }) {};
-    icomplete-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "icomplete-plus";
-        version = "20170303.1456";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/icomplete+.el";
-          sha256 = "00wy0jqk6jdfh9izdpqq4y6x2x8q1m38sy6nb4ygfg3055lbhkam";
-          name = "icomplete+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/fade28733f33e52a8622479de201f451c9a31c11/recipes/icomplete+";
-          sha256 = "0gxqkj4bjrxb046qisfz22wvanxx6bzl4hfv91rfwm78q3484slx";
-          name = "icomplete-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/icomplete+";
-          license = lib.licenses.free;
-        };
-      }) {};
     id-manager = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "id-manager";
@@ -36319,12 +35113,12 @@
     ido-completing-read-plus = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, memoize, s }:
     melpaBuild {
         pname = "ido-completing-read-plus";
-        version = "20170819.1045";
+        version = "20170820.3";
         src = fetchFromGitHub {
           owner = "DarwinAwardWinner";
           repo = "ido-completing-read-plus";
-          rev = "02f21215ce5ef2234c0e58dac9ec181cfc0900c1";
-          sha256 = "1hvimcd3wh5xbmj9awgv4imvmvjigpysrlgsbjxk6j848gll0ll3";
+          rev = "e2ea358725f03ae623ae03ed90715efb92a61030";
+          sha256 = "1bai04fz6ln4dbc3lgglv11g6mibg40wci5ylmc90wgd38iw9gkn";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6104efc035bcf469d133ab9a2caf42c9d4482334/recipes/ido-completing-read+";
@@ -36631,22 +35425,22 @@
           license = lib.licenses.free;
         };
       }) {};
-    ido-ubiquitous = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, ido-completing-read-plus, lib, melpaBuild }:
+    ido-ubiquitous = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, ido-completing-read-plus, lib, melpaBuild }:
     melpaBuild {
         pname = "ido-ubiquitous";
-        version = "20170819.1045";
+        version = "20170923.842";
         src = fetchFromGitHub {
           owner = "DarwinAwardWinner";
           repo = "ido-completing-read-plus";
-          rev = "02f21215ce5ef2234c0e58dac9ec181cfc0900c1";
-          sha256 = "1hvimcd3wh5xbmj9awgv4imvmvjigpysrlgsbjxk6j848gll0ll3";
+          rev = "e2ea358725f03ae623ae03ed90715efb92a61030";
+          sha256 = "1bai04fz6ln4dbc3lgglv11g6mibg40wci5ylmc90wgd38iw9gkn";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6104efc035bcf469d133ab9a2caf42c9d4482334/recipes/ido-ubiquitous";
           sha256 = "11sdk0ymsqnsw1gycvq2wj4j0g502fp23qk6q9d95lm98nz68frz";
           name = "ido-ubiquitous";
         };
-        packageRequires = [ cl-lib emacs ido-completing-read-plus ];
+        packageRequires = [ cl-lib ido-completing-read-plus ];
         meta = {
           homepage = "https://melpa.org/#/ido-ubiquitous";
           license = lib.licenses.free;
@@ -36760,12 +35554,12 @@
     iedit = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "iedit";
-        version = "20170909.423";
+        version = "20170916.1024";
         src = fetchFromGitHub {
           owner = "victorhge";
           repo = "iedit";
-          rev = "796ee5298dd3f4b7c51fbbcd9510a8631c5cbb4b";
-          sha256 = "0k70i4k8rrgcj3cl6k4nki3k55fsd4yz8fnwaazhckjr6pvrwz8w";
+          rev = "5b14cc9fcaef509c50f25cff872fba5d70b2c799";
+          sha256 = "1vlfqh616id2kh35diwig6jswq5q5z22zwrpbdxkginag3sq8732";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/iedit";
@@ -36838,25 +35632,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/ignoramus";
-          license = lib.licenses.free;
-        };
-      }) {};
-    igrep = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "igrep";
-        version = "20130824.507";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/igrep.el?revision=10";
-          sha256 = "0qiv69v7ig38iizif7zg8aljdmpa1jk8bsfa0iyhqqqrkvsmhc29";
-          name = "igrep.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/83c05578974289527082bb67338c35e70bbff8f2/recipes/igrep";
-          sha256 = "1vyhrziy29q6w8w9vvanb7d29r1n7nfkznbcd62il991n48d08i3";
-          name = "igrep";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/igrep";
           license = lib.licenses.free;
         };
       }) {};
@@ -36963,6 +35738,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    imake = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "imake";
+        version = "20171006.450";
+        src = fetchFromGitHub {
+          owner = "tarsius";
+          repo = "imake";
+          rev = "edd2e59f7996c35450987cf8f137ecb54777e9ca";
+          sha256 = "12mq1ki001jgjdfr3fx43z1xz4jrki18rb0wkb7n956dvl34w0fg";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/28de8f7f5302b27c7c6600ad65a998119518be43/recipes/imake";
+          sha256 = "0j732fi6999n9990w4l28raw140fvqfbynyh4x65yilhw95r7c34";
+          name = "imake";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/imake";
+          license = lib.licenses.free;
+        };
+      }) {};
     imapfilter = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "imapfilter";
@@ -37023,25 +35819,6 @@
         packageRequires = [ cl-lib ];
         meta = {
           homepage = "https://melpa.org/#/imenu-list";
-          license = lib.licenses.free;
-        };
-      }) {};
-    imenu-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "imenu-plus";
-        version = "20170303.1457";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/imenu+.el";
-          sha256 = "0dga9a61ckvd8w4nnz9z8z0iakaxminwn0lgmf8vfj2nwkd0m6hb";
-          name = "imenu+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/imenu+";
-          sha256 = "1v2h3xs5pnv7z5qphkn2y5pa1p8pivrknkw7xihm5yr4a4dqjv5d";
-          name = "imenu-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/imenu+";
           license = lib.licenses.free;
         };
       }) {};
@@ -37275,30 +36052,22 @@
           license = lib.licenses.free;
         };
       }) {};
-    indium = callPackage ({ company, emacs, fetchFromGitHub, fetchurl, js2-mode, lib, melpaBuild, memoize, seq, sourcemap, websocket }:
+    indium = callPackage ({ company, emacs, fetchFromGitHub, fetchurl, js2-mode, lib, melpaBuild, seq, sourcemap, websocket }:
     melpaBuild {
         pname = "indium";
-        version = "20170829.637";
+        version = "20171009.444";
         src = fetchFromGitHub {
           owner = "NicolasPetton";
           repo = "Indium";
-          rev = "d98a9e0cd11d8230c4c3d0b59c4ac60520e34ebb";
-          sha256 = "1q3yf45fmbjppv3ahb1gdb95pa3kyn18x5m23ihpxz1pziz3a074";
+          rev = "261f3a8f4ce7edb8fb04457896fe747013a926b5";
+          sha256 = "1yikx5b6yy138aplzpdxda5pssnchbkpp1xr9lsl869vi4q25igi";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/4292058cc6e31cabc0de575134427bce7fcef541/recipes/indium";
           sha256 = "024ljx7v8xahmr8jm41fiy8i5jbg48ybqp5n67k4jwg819cz8wvl";
           name = "indium";
         };
-        packageRequires = [
-          company
-          emacs
-          js2-mode
-          memoize
-          seq
-          sourcemap
-          websocket
-        ];
+        packageRequires = [ company emacs js2-mode seq sourcemap websocket ];
         meta = {
           homepage = "https://melpa.org/#/indium";
           license = lib.licenses.free;
@@ -37328,12 +36097,12 @@
     inf-clojure = callPackage ({ clojure-mode, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "inf-clojure";
-        version = "20170910.30";
+        version = "20171005.1130";
         src = fetchFromGitHub {
           owner = "clojure-emacs";
           repo = "inf-clojure";
-          rev = "864356a543cac50b24c67901d1d04c4e6160070a";
-          sha256 = "07z131rxmwz3gwdy40qczz4is20jqdjylky7rsrxij5da3g017si";
+          rev = "b048358406c24f5f22a3fc51c0a1348236bcfde1";
+          sha256 = "0hw8981pi5xkcvs5023nj91vjq3agdlqabinmrrl0mj4wfh2q32q";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5d6112e06d1efcb7cb5652b0bec8d282d7f67bd9/recipes/inf-clojure";
@@ -37448,25 +36217,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/info-buffer";
-          license = lib.licenses.free;
-        };
-      }) {};
-    info-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "info-plus";
-        version = "20170830.1104";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/info+.el";
-          sha256 = "0zxcqcd53fr0rf1s2fhax2a8kymk2mvg7vf7k92g8afvm888jnzj";
-          name = "info+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/e77aadd8195928eed022f1e00c088151e68aa280/recipes/info+";
-          sha256 = "0flpmi8dsaalg14xd86xcr087j51899sm8ghsa150ag4g4acfggr";
-          name = "info-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/info+";
           license = lib.licenses.free;
         };
       }) {};
@@ -37787,12 +36537,12 @@
     interleave = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "interleave";
-        version = "20170630.22";
+        version = "20171003.2324";
         src = fetchFromGitHub {
           owner = "rudolfochrist";
           repo = "interleave";
-          rev = "2c0458038bf0440f271f6e000039027be411eba7";
-          sha256 = "0rpw1ms80hr01s76av8cvid4gvkd3sapx0c3g3a05za0bq1jqacw";
+          rev = "87549df30cbc681baf86b238bd14c7cf7ec11fc4";
+          sha256 = "07430hsyq9q90rjzxq7ifq4mlfc8k8b7l6b31s7xk1xm2snbky6b";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6c43d4aaaf4fca17f2bc0ee90a21c51071886ae2/recipes/interleave";
@@ -37808,12 +36558,12 @@
     intero = callPackage ({ company, emacs, fetchFromGitHub, fetchurl, flycheck, haskell-mode, lib, melpaBuild }:
     melpaBuild {
         pname = "intero";
-        version = "20170912.648";
+        version = "20170926.911";
         src = fetchFromGitHub {
           owner = "commercialhaskell";
           repo = "intero";
-          rev = "7176857391c064e1f16a4f9fd0a51775cfedd42b";
-          sha256 = "10w2jgr4nq2iff9jlk2kjbjf3hpbhlwgjvnnpvxnrkz4y4ap0bdi";
+          rev = "2d3c04ce523674e79f9339189a79e6841e1fa587";
+          sha256 = "1dgdbfxhhcda7hn9njvsjygn59rdx9wv9cgpj3aysll52zri8lh3";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1b56ca344ad944e03b669a9974e9b734b5b445bb/recipes/intero";
@@ -37976,12 +36726,12 @@
     ipcalc = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "ipcalc";
-        version = "20160927.220";
+        version = "20170926.105";
         src = fetchFromGitHub {
           owner = "dotemacs";
           repo = "ipcalc.el";
-          rev = "e92afd8b96592b6e2d65ba073bf87c9dd2408e91";
-          sha256 = "1s17wpdbrbkbmkndbwm0byy11cmymhs6yn7w0v5lvw5l2cgicxjg";
+          rev = "2720f7e3e662e04e195f8338b81a499cf321296a";
+          sha256 = "1kmqbb9ca3sca59462ha21grbgxkl4wynz2lr4yqb4qk7cijgd6g";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/ipcalc";
@@ -38099,34 +36849,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    irfc = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "irfc";
-        version = "20130824.507";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/irfc.el?revision=45";
-          sha256 = "197ybqwbj8qjh2p9pkf5mvqnrkpcgmv8c5s2gvl6msyrabk0mnca";
-          name = "irfc.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/0b4f2dc79231b165bd3b03a728e2b872ed6c50c1/recipes/irfc";
-          sha256 = "0186l6zk5l427vjvmjvi0xhwk8a4fjhsvw9kd0yw88q3ggpdl25i";
-          name = "irfc";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/irfc";
-          license = lib.licenses.free;
-        };
-      }) {};
     irony = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, json ? null, lib, melpaBuild }:
     melpaBuild {
         pname = "irony";
-        version = "20170905.1316";
+        version = "20171002.1130";
         src = fetchFromGitHub {
           owner = "Sarcasm";
           repo = "irony-mode";
-          rev = "72e1e73f3c9da2ad04286e13bfc8fc401626b7a9";
-          sha256 = "155wvzsmhb8vz30jcd3xj91z74268pq7szax7jwd725ndx6x7ny8";
+          rev = "a571167eca2533343f523f0c9ee3886de2d7b917";
+          sha256 = "1jh2w800dgadmc1xgxrhmbs8i7bz4xh0h5bdrambnwl173ca23pf";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d2b6a8d57b192325dcd30fddc9ff8dd1516ad680/recipes/irony";
@@ -38178,44 +36909,6 @@
         packageRequires = [ cl-lib ];
         meta = {
           homepage = "https://melpa.org/#/isearch-dabbrev";
-          license = lib.licenses.free;
-        };
-      }) {};
-    isearch-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "isearch-plus";
-        version = "20170723.1826";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/isearch+.el";
-          sha256 = "0d7xsr71iadqzg81mv17dqyd0bdzkmljxlrpdlpycjyaf3z59aqr";
-          name = "isearch+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/isearch+";
-          sha256 = "0n9jh3bx2h6k4mvbwss16m34fxzlq6sb057rj16hgrlmbqknynhw";
-          name = "isearch-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/isearch+";
-          license = lib.licenses.free;
-        };
-      }) {};
-    isearch-prop = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "isearch-prop";
-        version = "20170303.1504";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/isearch-prop.el?revision=79";
-          sha256 = "0q18i76gq2pfnkqlbxlx2hndpy9mhbag302dvr8irk1kjwgngz5r";
-          name = "isearch-prop.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/isearch-prop";
-          sha256 = "1z9y88b23m4ffil8p3wcq61q1fiyqjxphyd3wacs5fnc53mdzad9";
-          name = "isearch-prop";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/isearch-prop";
           license = lib.licenses.free;
         };
       }) {};
@@ -38432,12 +37125,12 @@
     ivy = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "ivy";
-        version = "20170911.1034";
+        version = "20171007.224";
         src = fetchFromGitHub {
           owner = "abo-abo";
           repo = "swiper";
-          rev = "0a1d361b926291874124f8c63a653d83ead64a36";
-          sha256 = "0ssbsllpv0lyr7dhnipwd7zgpxvfm36rldr7vkxh5maajdkamls7";
+          rev = "6827edffb70890f2e94c3d146ed129bde581992d";
+          sha256 = "0xwf8q73xisi1072dkkvf181sf9a7a6j9b9g24ismc3fn0q7216k";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/06c24112a5e17c423a4d92607356b25eb90a9a7b/recipes/ivy";
@@ -38453,12 +37146,12 @@
     ivy-bibtex = callPackage ({ biblio, cl-lib ? null, dash, f, fetchFromGitHub, fetchurl, lib, melpaBuild, parsebib, s, swiper }:
     melpaBuild {
         pname = "ivy-bibtex";
-        version = "20170808.1124";
+        version = "20171003.131";
         src = fetchFromGitHub {
           owner = "tmalsburg";
           repo = "helm-bibtex";
-          rev = "8ed898fb5a68f18e9bb9973832a5c1f8abcfc463";
-          sha256 = "14lyx0vbqr97p3anzrsp7m3q0kqclyjcdwplpraim403fcklzbnz";
+          rev = "299090ecb376ba269f2ffe547a672d210ddaceb3";
+          sha256 = "07jym5zh07zksrn1f7x2j8m3agjzq06f9xchmiv7cic6x7b3shcj";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c23c09225c57a9b9abe0a0a770a9184ae2e58f7c/recipes/ivy-bibtex";
@@ -38562,8 +37255,8 @@
         src = fetchFromGitHub {
           owner = "abo-abo";
           repo = "swiper";
-          rev = "0a1d361b926291874124f8c63a653d83ead64a36";
-          sha256 = "0ssbsllpv0lyr7dhnipwd7zgpxvfm36rldr7vkxh5maajdkamls7";
+          rev = "6827edffb70890f2e94c3d146ed129bde581992d";
+          sha256 = "0xwf8q73xisi1072dkkvf181sf9a7a6j9b9g24ismc3fn0q7216k";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/06c24112a5e17c423a4d92607356b25eb90a9a7b/recipes/ivy-hydra";
@@ -38688,8 +37381,8 @@
         src = fetchFromGitHub {
           owner = "Andersbakken";
           repo = "rtags";
-          rev = "2af4d6a32e8194f8fbcc23fd94395e3d595a3c25";
-          sha256 = "0091w529lvbjlw1fdb3qjgb8fd5fcwxhqyr4ps5cvxl5bqnwlw39";
+          rev = "12636847b1ea512ce2d0c1075a74465f38555e69";
+          sha256 = "12v3wr2103293fkglbkhp20m2z72n66qka2s5zpcgc3jwqyqnnf9";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3dea16daf0d72188c8b4043534f0833fe9b04e07/recipes/ivy-rtags";
@@ -39060,12 +37753,12 @@
     java-imports = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, pcache, s }:
     melpaBuild {
         pname = "java-imports";
-        version = "20160311.1515";
+        version = "20170913.710";
         src = fetchFromGitHub {
           owner = "dakrone";
           repo = "emacs-java-imports";
-          rev = "f1631adacdd9fcb7a92ee4fdfb9e592a1a9c3b0b";
-          sha256 = "1wk9i43b147bjcvhq27vcqxi6y1yl6w3n4i2sw3krk4vxcm1mwnm";
+          rev = "e96ff44ed48b362ab6227b8b802b84d84f78bcaa";
+          sha256 = "0nryawj8v6gj6hnb81yf6966kjnydcz49zsg2k355gldryqf4v5p";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5f6f4e4c14c422c2066f2200bb9b8f35e2ecc896/recipes/java-imports";
@@ -39225,22 +37918,22 @@
           license = lib.licenses.free;
         };
       }) {};
-    jdee = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild, memoize }:
+    jdee = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild, memoize, s }:
     melpaBuild {
         pname = "jdee";
-        version = "20170506.1514";
+        version = "20171007.835";
         src = fetchFromGitHub {
           owner = "jdee-emacs";
           repo = "jdee";
-          rev = "e572d4889604c0b4e1d9180b8a68f9c0f99b99d2";
-          sha256 = "1vhwza7xak2im2xp7qzs8b6bmnf9yw2di86rav8wh5xapqr8x7mn";
+          rev = "ebe5d2e36a6a367376ed6cde590d5f805830ec9e";
+          sha256 = "0rq8vp3pmnyabqzzplc91dk2ka48k809is9v4q486xv7y43013jh";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a6d2c98f3bf2075e33d95c7befe205df802e798d/recipes/jdee";
           sha256 = "15n76w0ygjmsa2bym59bkmbbh0kpqx6nacp4zz32hlg48kgz1dx4";
           name = "jdee";
         };
-        packageRequires = [ dash emacs flycheck memoize ];
+        packageRequires = [ dash emacs flycheck memoize s ];
         meta = {
           homepage = "https://melpa.org/#/jdee";
           license = lib.licenses.free;
@@ -39432,25 +38125,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/jinja2-mode";
-          license = lib.licenses.free;
-        };
-      }) {};
-    jira = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "jira";
-        version = "20131210.1022";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/jira.el?revision=11";
-          sha256 = "18b6hdqk59gnqh4ibq8lj59kbsg5gbyfb7vfcvpgmxjikpl3cgkz";
-          name = "jira.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/jira";
-          sha256 = "1zrywkwzqn5ffzzk3rmy01vj6afm2p9gm81rpc7s86cj3ywfy4wx";
-          name = "jira";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/jira";
           license = lib.licenses.free;
         };
       }) {};
@@ -39751,12 +38425,12 @@
     js2-mode = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "js2-mode";
-        version = "20170815.1415";
+        version = "20170930.820";
         src = fetchFromGitHub {
           owner = "mooz";
           repo = "js2-mode";
-          rev = "df51992a648c7fb3e441106defdbffa2ef2f020d";
-          sha256 = "08k0szwbwsgx2q1qm356f88jif36yqz8lnpylib24jy2plx24j5s";
+          rev = "5cb52a7de8218bb2d50f67ba422fa7b2d51d1dc6";
+          sha256 = "1b4kq8qix2lqhcqabbyhl3rzm99dzjspqqs6srgsgwvb9726q25f";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/cae2ac3513e371a256be0f1a7468e38e686c2487/recipes/js2-mode";
@@ -39958,6 +38632,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    jsonnet-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "jsonnet-mode";
+        version = "20171005.24";
+        src = fetchFromGitHub {
+          owner = "mgyucht";
+          repo = "jsonnet-mode";
+          rev = "efe768fdcff25d746674fbbf229b9e1a7efea4f1";
+          sha256 = "1a52266y83z9i3sg7hhc8sw7rhjy5i9wdy2bv7s2fv00lnngaj29";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/ba17372732723f73e8eeb6e7c47abc0edeb20da4/recipes/jsonnet-mode";
+          sha256 = "1aadys887szlc924qr645lby9f8vzvxkwhq6byhppk1b01h911ia";
+          name = "jsonnet-mode";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/jsonnet-mode";
+          license = lib.licenses.free;
+        };
+      }) {};
     jss = callPackage ({ emacs, fetchFromGitHub, fetchurl, js2-mode, lib, melpaBuild, websocket }:
     melpaBuild {
         pname = "jss";
@@ -40043,12 +38738,12 @@
     julia-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "julia-mode";
-        version = "20170710.538";
+        version = "20170916.628";
         src = fetchFromGitHub {
           owner = "JuliaLang";
           repo = "julia-emacs";
-          rev = "edaaff2e971a527460f838bebc0ef679f9a571b0";
-          sha256 = "1sm57dq58fjbjjprl1bf7vibrvp6v5m4ipiq7r73c2bdg8rmaapm";
+          rev = "115d4dc8a07445301772da8376b232fa8c7168f4";
+          sha256 = "1is4dcv6blslpzbjcg8l2jpxi8xj96q4cm0nxjxsyswpm8bw8ki0";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/8522d197cb1b2c139959e7189765001c5ee7e61a/recipes/julia-mode";
@@ -40064,12 +38759,12 @@
     julia-repl = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "julia-repl";
-        version = "20170708.2324";
+        version = "20171005.123";
         src = fetchFromGitHub {
           owner = "tpapp";
           repo = "julia-repl";
-          rev = "93b9d515e6f5fbacd42069a2ae6da3bd80b7c4d0";
-          sha256 = "1xpdr343b5qa1pb92d5nz0m9lswq2s8nzg46msjnb1dvihqyb27w";
+          rev = "2c5d681ddd3bc6018c394f797cb01add805ed573";
+          sha256 = "0l8asipch5pfk90jzifw0jxwhsfq9kam8msxlxscvhfj7wphc038";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/9a2a494969a9caf2f4513b12504379c9685047dc/recipes/julia-repl";
@@ -40316,12 +39011,12 @@
     kakapo-mode = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "kakapo-mode";
-        version = "20160727.2136";
+        version = "20171003.2151";
         src = fetchFromGitHub {
           owner = "listx";
           repo = "kakapo-mode";
-          rev = "bb6de027fb578df31652e58daa92522884ecc274";
-          sha256 = "1y6ihk52jza07krz24l9axkwhi46fwi4h6bcjdck9q1qvdrcxw40";
+          rev = "67d516138172fd60782df94454b3d0bd247e84f3";
+          sha256 = "0r2n410arr48skcwm39c6mjhzsia117lb8xd7pc4854y0rbrvrvs";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a43f0f1f6a0773240a51d379ec786c20a9389e7b/recipes/kakapo-mode";
@@ -40419,16 +39114,16 @@
     kaolin-theme = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "kaolin-theme";
-        version = "20170905.1243";
+        version = "20171008.451";
         src = fetchFromGitHub {
-          owner = "0rdy";
+          owner = "ogdenwebb";
           repo = "kaolin-theme";
-          rev = "7bf265de58fe412d7f445ee84c460e6b90d7e0cf";
-          sha256 = "1zd8vgg54hj8jycixh3vr34pf8grb02hhk10y1xh0ddpxw3mpb1s";
+          rev = "bd105da4115d3685f14b511dbc975b22a1c94483";
+          sha256 = "1iz288qygwcsz2gmnbcp9l92hbqvn27vkk07ik4bxgziksxyf2l4";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/d2abf9d914cdc210bbd47ea92d0dac76683e21f0/recipes/kaolin-theme";
-          sha256 = "1316sn1xpli9aqbhn8sldyvsc2fwk1ql9aw4l0rgkfbivvcklp7c";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/a67c2a3ad82efcb32ba4943c7ac10fe2768d9d51/recipes/kaolin-theme";
+          sha256 = "009064hhn39f9w9qxa3m0kwqhj5a12j7hg4916j9hslpwy5ghc0c";
           name = "kaolin-theme";
         };
         packageRequires = [ emacs ];
@@ -40927,8 +39622,8 @@
         src = fetchFromGitHub {
           owner = "kivy";
           repo = "kivy";
-          rev = "f32bb16e5b477f5b54f3dc23ff048b490e906590";
-          sha256 = "05lr10wnwghzsi59y7spy8a2jps11dmpm7wndzaj62nkx0d09a73";
+          rev = "fed61946603baf381404ae74009f742ab277d848";
+          sha256 = "1gxav0a4934z53sdkfa4wllzcfc5cnz66xcjayrzb17g1dxr3yzj";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/688e2a114073958c413e56e1d117d48db9d16fb8/recipes/kivy-mode";
@@ -40944,12 +39639,12 @@
     kiwix = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "kiwix";
-        version = "20170508.1802";
+        version = "20170927.120";
         src = fetchFromGitHub {
           owner = "stardiviner";
           repo = "kiwix.el";
-          rev = "a62f9e7c17ab34b183b36ae63408123a75689a5b";
-          sha256 = "0v86haw2nfd7q4yylzd0ls6916l95960c15khjnv1cfyshhri5q7";
+          rev = "86dbead6c0017beefd92a0b64a0bb5f5d12c5b16";
+          sha256 = "142mm1wy8zvlkzairnc1rjdi1lsq1asfk4zdbs1aria1nxz1sx6x";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/kiwix";
@@ -41007,12 +39702,12 @@
     kodi-remote = callPackage ({ elnode, fetchFromGitHub, fetchurl, json ? null, let-alist, lib, melpaBuild, request }:
     melpaBuild {
         pname = "kodi-remote";
-        version = "20170818.2206";
+        version = "20171008.2226";
         src = fetchFromGitHub {
           owner = "spiderbit";
           repo = "kodi-remote.el";
-          rev = "a032d13a3f39f260d7d00d62f32dce0f8a5927ab";
-          sha256 = "0c883yprblda22jq3jjdz9nd6ha6dbwfn6n8y448qln8dzj9sd7p";
+          rev = "479075d96857696cf029cd1f482b9f2f31d82452";
+          sha256 = "0kvx43ny49j115kj6zpy1i5g87bjgiimfgj9xp2fn9830adymc24";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/08f06dd824e67250afafdecc25128ba794ca971f/recipes/kodi-remote";
@@ -41133,12 +39828,12 @@
     kpm-list = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "kpm-list";
-        version = "20160310.1050";
+        version = "20170924.652";
         src = fetchFromGitHub {
           owner = "KMahoney";
           repo = "kpm-list";
-          rev = "6fb7db35f7dac7fb8f956c67ee2eea9d3fa54034";
-          sha256 = "0hbzr5x9ykzrbwzfsf6rc4pbiw9m59ny3cgcx26nbi6ijbjl2fxj";
+          rev = "e0f5112e5ce8ec1b603f4428fa51681c68bb28f5";
+          sha256 = "1achcr3v0d85narnxqpbfxy9qfk537kl83wiq5lyfy3lwqqf7dmp";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6b7065d016e2da49277b165edf565bef5819d483/recipes/kpm-list";
@@ -41319,25 +40014,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    lacarte = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "lacarte";
-        version = "20170307.837";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/lacarte.el?revision=41";
-          sha256 = "0m3swrvxz0cy01pd4kag626fxqp4l2zzwpgr26yp5wpsfxl9avv8";
-          name = "lacarte.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/lacarte";
-          sha256 = "07rxgjax6ms0knjj5qplfy0hxzfhs6iqk4ny43566zzqv86n0bhi";
-          name = "lacarte";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/lacarte";
-          license = lib.licenses.free;
-        };
-      }) {};
     lang-refactor-perl = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "lang-refactor-perl";
@@ -41383,12 +40059,12 @@
     langtool = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "langtool";
-        version = "20170606.432";
+        version = "20170917.2154";
         src = fetchFromGitHub {
           owner = "mhayashi1120";
           repo = "Emacs-langtool";
-          rev = "d976e4f0cadb2309b798540429558936f8f45889";
-          sha256 = "1qlgd5i8jngsq754jm44gb46p5y6j2cccacg72aklvwajay0adyh";
+          rev = "bae4bdd240583b2253b4ff03af5295146e285103";
+          sha256 = "0zwaddpmvkq7v5nnyzacmx0ql5zjlisvkqwa2knw3pihngr160cd";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/503845e79e67c921f1fde31447f3dd4da2b6f993/recipes/langtool";
@@ -41928,12 +40604,12 @@
     leuven-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "leuven-theme";
-        version = "20170907.413";
+        version = "20170919.252";
         src = fetchFromGitHub {
           owner = "fniessen";
           repo = "emacs-leuven-theme";
-          rev = "b6889c336fc4f046138334ed700c5c9a13e39992";
-          sha256 = "0j8d6h61nvz2gpkbf73v246srjg6wm93giijc7f0rks9g0nlp1rc";
+          rev = "9d31a9d4ed763d6309e9d44985cd8b4a5a2fb500";
+          sha256 = "0vr535a32cgkna0h1z8ac9cb4al3jb01bybn956rz51qdbzm2d1h";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b09451f4eb2be820e94d3fecbf4ec7cecd2cabdc/recipes/leuven-theme";
@@ -41995,8 +40671,8 @@
         src = fetchFromGitHub {
           owner = "rvirding";
           repo = "lfe";
-          rev = "71d8e5bafc59424bacd23c8af4b368d5a6db686c";
-          sha256 = "1wdxi1fbhw6k4dyq91vg7j33hcxjbhb1ydb5qaq292iach525wrq";
+          rev = "2880c8a2a7fe998238b6490fe3e3c484b5c5985e";
+          sha256 = "1xcnh1hk815wizhp7h1mik3npm7zpbvg4554nwbj072gnbb9j1nx";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c44bdb00707c9ef90160e0a44f7148b480635132/recipes/lfe-mode";
@@ -42006,25 +40682,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/lfe-mode";
-          license = lib.licenses.free;
-        };
-      }) {};
-    lib-requires = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "lib-requires";
-        version = "20170307.855";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/lib-requires.el?revision=53";
-          sha256 = "04lrkdjrhsgg7vgvw1mkr9a5m9xlyvjvnj2aj6w453bgmnp1mbvv";
-          name = "lib-requires.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/lib-requires";
-          sha256 = "1a69qf9dlsq5r7nm32hd0srzka7crd08gl82w8hjfvdhn43n2h0c";
-          name = "lib-requires";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/lib-requires";
           license = lib.licenses.free;
         };
       }) {};
@@ -42136,12 +40793,12 @@
     link-hint = callPackage ({ avy, cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "link-hint";
-        version = "20170904.1442";
+        version = "20170923.855";
         src = fetchFromGitHub {
           owner = "noctuid";
           repo = "link-hint.el";
-          rev = "366bce32f8cb1aa5f0f1ce4eceb4d60cc802abd6";
-          sha256 = "09k1cz3l2ql2fdn3kx43q3bjlwqcz67fw2as6m59951lyd8fnmxp";
+          rev = "0294df85aee10b47fcf6c2c9bfe7e1038660fa21";
+          sha256 = "0ixfrp6pfljgy5ja79cka0fa6a9ganwhh5myz6czqj4ykjzlyi2c";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d24b48fe0bc127ae6ac4084be8059aacb8445afd/recipes/link-hint";
@@ -42288,34 +40945,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    lispxmp = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "lispxmp";
-        version = "20170110.1508";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/lispxmp.el?revision=17";
-          sha256 = "120wgxvckrgryfg2lvyx60rkcayii0g4ny2cdk3aiwsrpqcyhlyr";
-          name = "lispxmp.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/6fc8f86533402e4be8bac87ad66bc8d51c8d40f8/recipes/lispxmp";
-          sha256 = "02gfbyng3dh2445jfkasxzjc9dlk02dafbfkjm40iwmb8h0fzji4";
-          name = "lispxmp";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/lispxmp";
-          license = lib.licenses.free;
-        };
-      }) {};
     lispy = callPackage ({ ace-window, emacs, fetchFromGitHub, fetchurl, hydra, iedit, lib, melpaBuild, swiper, zoutline }:
     melpaBuild {
         pname = "lispy";
-        version = "20170911.1138";
+        version = "20171007.209";
         src = fetchFromGitHub {
           owner = "abo-abo";
           repo = "lispy";
-          rev = "134d815c843813950cbffc4516cabafd8ae75ed4";
-          sha256 = "1xw8j3hjahp6vl3qnfab0kyl20zxclnbfpy9x1zp344zic61n02m";
+          rev = "7de90475f922ea1ec757c16bc96d704b2d876198";
+          sha256 = "13rx0ywbcplnh6swkmzq5ypd8a9ymd4w198pkl97cw5s6vzskh62";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/e23c062ff32d7aeae486c01e29c56a74727dcf1d/recipes/lispy";
@@ -42412,26 +41050,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    list-processes-plus = callPackage ({ fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "list-processes-plus";
-        version = "20131117.1135";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/list-processes+.el";
-          sha256 = "1bssvyjgk1h1wiaxxdi2m5gjy6a790a9rwvi0r22hin7iskg300a";
-          name = "list-processes+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/d508d50d89c914c53211197afc758fc0e1154081/recipes/list-processes+";
-          sha256 = "10x7hkba2bmryyl68w769fggw65dl4f3a9g0gqdzmkdj80rcipky";
-          name = "list-processes-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/list-processes+";
-          license = lib.licenses.free;
-        };
-      }) {};
     list-register = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "list-register";
@@ -42523,8 +41141,8 @@
         src = fetchFromGitHub {
           owner = "Fuco1";
           repo = "litable";
-          rev = "4a57d7aeddca76448e4df2a46b42d49253e5e625";
-          sha256 = "1zryrc0d2avb27w6a6yzqcc73rsr2rp795vi10qhb04ixda4a8w4";
+          rev = "90a2dca14a6da9b24fe332a65cff899ab4a90810";
+          sha256 = "1xaixgjfpnqnsdkhfia107fq5xaq2l0gdb0zp730z97958136mm3";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/74f2190b653907985e49a96ded986ab11b4946d7/recipes/litable";
@@ -42645,12 +41263,12 @@
     live-py-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "live-py-mode";
-        version = "20170906.2104";
+        version = "20170928.2107";
         src = fetchFromGitHub {
           owner = "donkirkby";
           repo = "live-py-plugin";
-          rev = "4d972a859e6a56d969b075688b425ac246b40962";
-          sha256 = "0qzg5i9x9f5skp2bk5avxw30nhs44z4didk69prli6p6sfd4bgqg";
+          rev = "619a1b35b9a8151703421e2716ea0409162a4b84";
+          sha256 = "0dakcsdn6pax0q6wdvg23fg327nk35z3lzk2vlvc76780d0fi85h";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c7615237e80b46b5c50cb51a3ed5b07d92566fb7/recipes/live-py-mode";
@@ -42666,12 +41284,12 @@
     lively = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "lively";
-        version = "20170820.407";
+        version = "20171005.54";
         src = fetchFromGitHub {
           owner = "purcell";
           repo = "lively";
-          rev = "49cf43815c04f0b84d20b527f5d712544a13a4db";
-          sha256 = "02in5dj50c82h2bb7l47b00w3hpn3c2788aiyq2bln06vpj1qq4n";
+          rev = "348675828c6a81bfa1ac311ca465aad813542c1b";
+          sha256 = "1j8w63hhk1wcxcfqz0wimqijp7p1m8a2n947gwqv8nk1wm40aqg3";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3e4b01286dbc84f01b43955b693ca08e675ffa07/recipes/lively";
@@ -42753,8 +41371,8 @@
         version = "20150910.644";
         src = fetchgit {
           url = "https://llvm.org/git/llvm";
-          rev = "ae7945dc893db824632135ea16929e14ca185595";
-          sha256 = "0vsj8i29qkfl2a6fsdplzdh2kb9vrc2rkbbh7hak81ngn19q41l8";
+          rev = "f7ceddc7e61d486863a6bf9ddcf74bb87fd1b977";
+          sha256 = "1v0wwdg57l613s5zd47wri75pgbwh6n401q64mnyj8frfb2670j0";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1e2a0e4698d4e71ec28656594f6a83504a823490/recipes/llvm-mode";
@@ -43020,12 +41638,12 @@
     logview = callPackage ({ datetime, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "logview";
-        version = "20170705.1217";
+        version = "20170928.820";
         src = fetchFromGitHub {
           owner = "doublep";
           repo = "logview";
-          rev = "134b41557ab539219d9e3a1b3c8939df93676726";
-          sha256 = "1jfdm64r6rj7pl6270v084fvaga5csa4snvbfjdlhs5bshn1d0v2";
+          rev = "72b6c5349206172a146b2c730b8ac040a92ebc3f";
+          sha256 = "1f93iyxf8v0jazzh6jljrm7r28z00nn14wr90qrh9y9chyq72n63";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1df3c11ed7738f32e6ae457647e62847701c8b19/recipes/logview";
@@ -43188,12 +41806,12 @@
     lsp-haskell = callPackage ({ fetchFromGitHub, fetchurl, haskell-mode, lib, lsp-mode, melpaBuild }:
     melpaBuild {
         pname = "lsp-haskell";
-        version = "20170814.1358";
+        version = "20170919.626";
         src = fetchFromGitHub {
           owner = "emacs-lsp";
           repo = "lsp-haskell";
-          rev = "7c4caf7f87392146203ecd0616a059280deecd15";
-          sha256 = "1i5rpmz8kzcjgxwvy1g3mlxd4y1bnnjzlk6j2sz4i7c75g2aprn4";
+          rev = "a749bd017c293a7231639f75f024ee922f44818a";
+          sha256 = "1yynwf0m0mkm0xxbj3sgy0zhkxzfw1qhwyvfq5fcgpqw59xfps6w";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1a7b69312e688211089a23b75910c05efb507e35/recipes/lsp-haskell";
@@ -43227,15 +41845,36 @@
           license = lib.licenses.free;
         };
       }) {};
+    lsp-javacomp = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, lsp-mode, melpaBuild }:
+    melpaBuild {
+        pname = "lsp-javacomp";
+        version = "20171005.659";
+        src = fetchFromGitHub {
+          owner = "tigersoldier";
+          repo = "lsp-javacomp";
+          rev = "e45ac9ac18375d63fc068cbb466ed580ccd9476a";
+          sha256 = "0hpidswz1rfy8fmjw3m6jxhl4p9134521nj7fana5x3dl3v5c9kh";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/6b8a1c034554579a7e271409fa72020cfe441f68/recipes/lsp-javacomp";
+          sha256 = "1gp8dlcpik2lmpicccq2kya498pmw9m8vz9m1fbd725p7wk58fhi";
+          name = "lsp-javacomp";
+        };
+        packageRequires = [ emacs lsp-mode ];
+        meta = {
+          homepage = "https://melpa.org/#/lsp-javacomp";
+          license = lib.licenses.free;
+        };
+      }) {};
     lsp-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild }:
     melpaBuild {
         pname = "lsp-mode";
-        version = "20170905.1130";
+        version = "20171005.946";
         src = fetchFromGitHub {
           owner = "emacs-lsp";
           repo = "lsp-mode";
-          rev = "d69692651742b65398b4c1f9ee06d1670d9443d0";
-          sha256 = "1f09shdirq81c37sg2hdgj1wqqvwmg5m7bkprz28fych76xi8jgr";
+          rev = "252396b8631c5f6d5fc4725e9430feebe408568b";
+          sha256 = "0hbhv6ch23z2wyigsq3270x07kqr7j2kxz254ps6ym67dr3kka4x";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1a7b69312e688211089a23b75910c05efb507e35/recipes/lsp-mode";
@@ -43500,25 +42139,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    macros-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "macros-plus";
-        version = "20170307.842";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/macros+.el";
-          sha256 = "0x9fycqw234s1i0ndy7v0d7vn654id245pi0kwphbqgnga7w3l6p";
-          name = "macros+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/macros+";
-          sha256 = "0aihszxsjnc93pbbkmkr1iwzvii3jw8yh1f6dpnjykgvb328pvqi";
-          name = "macros-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/macros+";
-          license = lib.licenses.free;
-        };
-      }) {};
     macrostep = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "macrostep";
@@ -43627,12 +42247,12 @@
     magit = callPackage ({ async, dash, emacs, fetchFromGitHub, fetchurl, git-commit, lib, magit-popup, melpaBuild, with-editor }:
     melpaBuild {
         pname = "magit";
-        version = "20170913.343";
+        version = "20171009.314";
         src = fetchFromGitHub {
           owner = "magit";
           repo = "magit";
-          rev = "ae72710292a94d9af92799d3ddeb86f365f34a56";
-          sha256 = "1344dcngdk899xi9wjipvngq50xggbv06fb1w09zjzs8ckpsh8gf";
+          rev = "12fc6cede637c7e2542e2225565366f2a0ad9fce";
+          sha256 = "0ap1x0dshfivc0zljp96r2s5fhhnirqisrk3xsa94n2aidsf3y0q";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/68bb049b7c4424345f5c1aea82e950a5e47e9e47/recipes/magit";
@@ -43655,12 +42275,12 @@
     magit-annex = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, magit, melpaBuild }:
     melpaBuild {
         pname = "magit-annex";
-        version = "20170702.832";
+        version = "20170913.659";
         src = fetchFromGitHub {
           owner = "magit";
           repo = "magit-annex";
-          rev = "2aa23cd169166e92be3e874c723ff224a9d42c15";
-          sha256 = "1bjv8a38y75cpbxhzxsnvzpq2cvs80x8ai7pspsqf4pp3w1dj45n";
+          rev = "895c229c2b0d822a4debb302d8638105ecb4ee20";
+          sha256 = "0316csgc95dalqmkxj6qlb7inzcg4csfs9n3im1ygswcswpdaajh";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/cec5af50ae7634cc566adfbfdf0f95c3e2951c0c/recipes/magit-annex";
@@ -43760,12 +42380,12 @@
     magit-gitflow = callPackage ({ fetchFromGitHub, fetchurl, lib, magit, magit-popup, melpaBuild }:
     melpaBuild {
         pname = "magit-gitflow";
-        version = "20170425.128";
+        version = "20170929.124";
         src = fetchFromGitHub {
           owner = "jtatarik";
           repo = "magit-gitflow";
-          rev = "5bdcfe0a7bf4f5bb9a927baa4880233bf11a4a6b";
-          sha256 = "12pi6aw44lnzzcw0zgz5rxvcf4p700fkz4q2skbapwmds8gw3fg9";
+          rev = "cc41b561ec6eea947fe9a176349fb4f771ed865b";
+          sha256 = "0jz69wrrzvqadaphmjrr146nzvmphsbl7rmc3ccnpw1gw6gnz81f";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/dfaeb33dec2c75d21733b6e51d063664c6544e4d/recipes/magit-gitflow";
@@ -43844,12 +42464,12 @@
     magit-popup = callPackage ({ async, dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "magit-popup";
-        version = "20170913.343";
+        version = "20171009.258";
         src = fetchFromGitHub {
           owner = "magit";
           repo = "magit";
-          rev = "ae72710292a94d9af92799d3ddeb86f365f34a56";
-          sha256 = "1344dcngdk899xi9wjipvngq50xggbv06fb1w09zjzs8ckpsh8gf";
+          rev = "12fc6cede637c7e2542e2225565366f2a0ad9fce";
+          sha256 = "0ap1x0dshfivc0zljp96r2s5fhhnirqisrk3xsa94n2aidsf3y0q";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/cec5af50ae7634cc566adfbfdf0f95c3e2951c0c/recipes/magit-popup";
@@ -43970,12 +42590,12 @@
     magithub = callPackage ({ emacs, fetchFromGitHub, fetchurl, ghub-plus, lib, magit, melpaBuild, s }:
     melpaBuild {
         pname = "magithub";
-        version = "20170901.1234";
+        version = "20171008.917";
         src = fetchFromGitHub {
           owner = "vermiculus";
           repo = "magithub";
-          rev = "7051c1bf8e316b116430be63c55b3010578c3eb4";
-          sha256 = "0jga49kwp47m39nsp2a12vwaj5n54zgcjnfq214fjjdcdrqcl3n7";
+          rev = "50bb82d310d5720db82ad5b437ca47c0ff0d83a3";
+          sha256 = "10ri2kqzcq48xvdyz9pm9d5j5vlh6f7nx4095s4wwxf22swkpnr6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/magithub";
@@ -44156,27 +42776,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    maker-mode = callPackage ({ dash, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
-    melpaBuild {
-        pname = "maker-mode";
-        version = "20150116.354";
-        src = fetchFromGitHub {
-          owner = "fommil";
-          repo = "maker-mode";
-          rev = "335c43b08eff589040129dae1ea13c88793b069e";
-          sha256 = "0w3kar52yf8clf9801c4jzfrixi10clc8fs8ni2d4pzhdwwca2zw";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/ba7edfa6ab6b93c346f92859db706acb3fd5fc6e/recipes/maker-mode";
-          sha256 = "03q09jxmhwqy7g09navj08z9ir0rbh7w26c1av7hwhmq4i6xwg8a";
-          name = "maker-mode";
-        };
-        packageRequires = [ dash s ];
-        meta = {
-          homepage = "https://melpa.org/#/maker-mode";
-          license = lib.licenses.free;
-        };
-      }) {};
     makey = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "makey";
@@ -44327,12 +42926,12 @@
     mandm-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "mandm-theme";
-        version = "20170903.306";
+        version = "20170925.321";
         src = fetchFromGitHub {
           owner = "choppsv1";
           repo = "emacs-mandm-theme";
-          rev = "889cdcb8ea7234d2e6d9dad663e39bd5f872c28d";
-          sha256 = "0x7fhzsx7pcbyy5dkx9aa2qvpnn7psc3nf8mqv96mvnzr5q1xg53";
+          rev = "078d6d6f11bd48193c5de590cfb0e3d0d687ffc9";
+          sha256 = "070280438388q57lpzvd5wdk16abmxixiq01n68hdskfcipdkn2d";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/mandm-theme";
@@ -44348,12 +42947,12 @@
     mandoku = callPackage ({ fetchFromGitHub, fetchurl, git, github-clone, lib, magit, melpaBuild, org }:
     melpaBuild {
         pname = "mandoku";
-        version = "20170908.247";
+        version = "20171002.12";
         src = fetchFromGitHub {
           owner = "mandoku";
           repo = "mandoku";
-          rev = "14e2d3f7586001ae4b44582ef03728eaf8326643";
-          sha256 = "0c1n5lnllm9mqar68jxm9sr5kyzl4v4ckrdmms68a9rvcfrbn6lg";
+          rev = "77647573331c602847b06b9e21de69f72cd7bad5";
+          sha256 = "0yqxsls9phvd4dgzb908xds4x437rqpm3ddy07pq3qq7ghri1cnv";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1aac4ae2c908de2c44624fb22a3f5ccf0b7a4912/recipes/mandoku";
@@ -44524,12 +43123,12 @@
     markdown-mode = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "markdown-mode";
-        version = "20170830.2131";
+        version = "20171001.730";
         src = fetchFromGitHub {
           owner = "jrblevin";
           repo = "markdown-mode";
-          rev = "2d790a7c72546b96b3fdf57e7b7d6af1663fb721";
-          sha256 = "0jfldbw7wpy05rq7xzxm5w49pwcnsz97l1ajh3g526lbj76p2rnl";
+          rev = "bc79248c605a5ebd01d96b26e5d5dba39bddcdc7";
+          sha256 = "1d0c5l4g3miwzn51a3fsjqnv9shm8kw4inn2hwg2ff40jfrgfy1n";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/74610ec93d4478e835f8b3b446279efc0c71d644/recipes/markdown-mode";
@@ -44926,25 +43525,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    mb-depth-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "mb-depth-plus";
-        version = "20170307.844";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/mb-depth+.el";
-          sha256 = "1vqminlfc146c8wr00ck7drs5kf92fvdmhyqyh2hj6394cvqs7w9";
-          name = "mb-depth+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/mb-depth+";
-          sha256 = "031hh227rh7l818p3di4h34i4698yynw5g9a5sl2hj47c0734q6w";
-          name = "mb-depth-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/mb-depth+";
-          license = lib.licenses.free;
-        };
-      }) {};
     mb-url = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "mb-url";
@@ -45239,34 +43819,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    menu-bar-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "menu-bar-plus";
-        version = "20170720.710";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/menu-bar+.el";
-          sha256 = "0yq995jyfw3a1dj49a4wnavfb29amw575dajps6nbv0g1q0rnwkf";
-          name = "menu-bar+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/menu-bar+";
-          sha256 = "181jxjnzdckmvpsdknhm21xwimvsp0qxn8azfn58dz41gl4xcg90";
-          name = "menu-bar-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/menu-bar+";
-          license = lib.licenses.free;
-        };
-      }) {};
     merlin = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "merlin";
-        version = "20170731.907";
+        version = "20170917.430";
         src = fetchFromGitHub {
           owner = "the-lambda-church";
           repo = "merlin";
-          rev = "b53e4beeeb8da6d7cb035990a7e805fea5da0de6";
-          sha256 = "1lw0s78zwr8rd4q4pg34m9q8yd5swh1fff3c5p992a2qlzfb0hax";
+          rev = "a5dbf8e321ff162476555e62264468dd6f55c279";
+          sha256 = "0mq4ddr3g64dd4bhq812hb5xvlkswfmib1nw34f3m8sghmaxcd5z";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b1b9bfd3164e62758dc0a3362d85c6627ed7cbf8/recipes/merlin";
@@ -45300,25 +43861,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    message-x = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "message-x";
-        version = "20151029.718";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/message-x.el?revision=9";
-          sha256 = "05ic97plsysh4nqwdrsl5m9f24m11w24bahj8bxzfdawfima2bkf";
-          name = "message-x.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/b7bf124ec30fa5551b31c0e0d39be234f19e2e81/recipes/message-x";
-          sha256 = "0z12alizwrqp5f9wq3qllym9k5xljh904c9qhlfhp9biazj6yqwj";
-          name = "message-x";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/message-x";
-          license = lib.licenses.free;
-        };
-      }) {};
     messages-are-flowing = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "messages-are-flowing";
@@ -45326,8 +43868,8 @@
         src = fetchFromGitHub {
           owner = "legoscia";
           repo = "messages-are-flowing";
-          rev = "17a0d91658390ba8d38f325b3ece380e07e3cb49";
-          sha256 = "0600is9cynvppdy9vrnr1c0m3cyxim0ha4gq4wbhw9h0cvkz8i1b";
+          rev = "ef879726957c850c3a5afd7f1118604991e37e32";
+          sha256 = "1mryk48z92r4j8f3qg0j0q5iygv7vnk1k0wgza5pq6bhrl5w13hq";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/messages-are-flowing";
@@ -45822,25 +44364,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    minor-mode-hack = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "minor-mode-hack";
-        version = "20141226.1220";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/minor-mode-hack.el?revision=10";
-          sha256 = "0vwvvhzqiad82qvfwygb2arq1mdvh1lj6q2as0a92fg1vc95qcb0";
-          name = "minor-mode-hack.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/df182bfd8272f3ded761c90826c8cfe6bfd1a48b/recipes/minor-mode-hack";
-          sha256 = "1f2wy25iphk3hzjy39ls5j04173g7gaq2rdp2grkawfhwx0ld4pj";
-          name = "minor-mode-hack";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/minor-mode-hack";
-          license = lib.licenses.free;
-        };
-      }) {};
     mip-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "mip-mode";
@@ -45880,44 +44403,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/mips-mode";
-          license = lib.licenses.free;
-        };
-      }) {};
-    misc-cmds = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "misc-cmds";
-        version = "20170823.842";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/misc-cmds.el?revision=104";
-          sha256 = "1spds0fkbvk1br3lpaq3ifyvq0vk5rvyyx5x3cmrvpd0m5s01h87";
-          name = "misc-cmds.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/misc-cmds";
-          sha256 = "0bylb84icddgznmim18fwq1mhh3qz8yh8ch6lpadf9p3h420qgcl";
-          name = "misc-cmds";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/misc-cmds";
-          license = lib.licenses.free;
-        };
-      }) {};
-    misc-fns = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "misc-fns";
-        version = "20170307.848";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/misc-fns.el?revision=50";
-          sha256 = "0jjmd33z36dikkbskskgbdv8pflkwaxn4ifajq4ghrdprdhm6gbm";
-          name = "misc-fns.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/c2cbbe5a718ec961982a7f65de8f6ec1c9513696/recipes/misc-fns";
-          sha256 = "1spjbkcac33lyfsgkd6z186a3432x9nw3akmx194gaap2863xcam";
-          name = "misc-fns";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/misc-fns";
           license = lib.licenses.free;
         };
       }) {};
@@ -46007,12 +44492,12 @@
     mmm-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "mmm-mode";
-        version = "20170808.1814";
+        version = "20171004.336";
         src = fetchFromGitHub {
           owner = "purcell";
           repo = "mmm-mode";
-          rev = "c68cee0beaeb99c5bd178fab6fec995bce4e501f";
-          sha256 = "1k13q5hwb2p2bq5j84pln9kx18bs2x9zfnzgqm4acrxjp9hnknlc";
+          rev = "7661968fa6974996e58dfa28da33bca0cbde777d";
+          sha256 = "066qp884qw0bqcglncxvag89i1z5rmqjc73y7ksr7ll3309y1969";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/cae2ac3513e371a256be0f1a7468e38e686c2487/recipes/mmm-mode";
@@ -46235,44 +44720,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    modeline-char = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "modeline-char";
-        version = "20170307.854";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/modeline-char.el?revision=8";
-          sha256 = "1c6ij1c0d6r9chzwqcpgdjq1rb2h0m09fpck9rc9rg5jy7fgdc0d";
-          name = "modeline-char.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/modeline-char";
-          sha256 = "0ksi5vfcwbyhgpp59qdl7l536zw2rd33xf4r2gihcx2g2k52h2w9";
-          name = "modeline-char";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/modeline-char";
-          license = lib.licenses.free;
-        };
-      }) {};
-    modeline-posn = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "modeline-posn";
-        version = "20170307.856";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/modeline-posn.el?revision=43";
-          sha256 = "1cpab6k0p65nmw78y5v4lbpxw6pczkzk46zmkc76pi55yjpw6pbm";
-          name = "modeline-posn.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/c62008950ea27b5a47363810f57063c1915b7c39/recipes/modeline-posn";
-          sha256 = "0dngfcbcdh22fl6nd47dhg9z9iivj67six67zjr9j1cbngp10dwk";
-          name = "modeline-posn";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/modeline-posn";
-          license = lib.licenses.free;
-        };
-      }) {};
     modern-cpp-font-lock = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "modern-cpp-font-lock";
@@ -46318,12 +44765,12 @@
     moe-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "moe-theme";
-        version = "20170111.1838";
+        version = "20170914.2111";
         src = fetchFromGitHub {
           owner = "kuanyui";
           repo = "moe-theme.el";
-          rev = "70e71ef7404cc5c38254771695eee221090d5110";
-          sha256 = "1dpcffb6pyggg2lj7n9lnxyg2clwm4q7hnxvgc87r6b61vjr3a20";
+          rev = "b8f0206614ab40ffb75e50ce6c38675fb9c7cf2e";
+          sha256 = "0pn3a1rrj7ycxh91x3q008b6rmq7rbl8ir6diqzqfp6y465pn2w2";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/4efefd7edacf90620436ad4ef9ceb470618a8018/recipes/moe-theme";
@@ -46630,25 +45077,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    mouse-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "mouse-plus";
-        version = "20170307.859";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/mouse+.el";
-          sha256 = "1f49b10i1iqh0q2s2fa309dc617dzavah7fw0k1rpjk84kb001bd";
-          name = "mouse+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/01cbe9b5bb88f8c02fab67a269ac53c8aa4d8326/recipes/mouse+";
-          sha256 = "1fv7jnqzskx9iv92dm2pf0mqy2accl0svjl2kkb6v273n1day3f8";
-          name = "mouse-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/mouse+";
-          license = lib.licenses.free;
-        };
-      }) {};
     mouse-slider-mode = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "mouse-slider-mode";
@@ -46667,25 +45095,6 @@
         packageRequires = [ cl-lib emacs ];
         meta = {
           homepage = "https://melpa.org/#/mouse-slider-mode";
-          license = lib.licenses.free;
-        };
-      }) {};
-    mouse3 = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "mouse3";
-        version = "20170324.1050";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/mouse3.el?revision=39";
-          sha256 = "0rnpfz0d4spxkyssgf3j5kfajm54i1vism2q0giikd0savrh0a1c";
-          name = "mouse3.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/mouse3";
-          sha256 = "1rppn55axjpqwqm2lq4dvwi3z7xkd5jkyqi1x8jqgcsfc9w6m777";
-          name = "mouse3";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/mouse3";
           license = lib.licenses.free;
         };
       }) {};
@@ -46944,12 +45353,12 @@
     mtg-deck-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "mtg-deck-mode";
-        version = "20170904.2002";
+        version = "20170925.1338";
         src = fetchFromGitHub {
           owner = "mattiasb";
           repo = "mtg-deck-mode";
-          rev = "c1ab6dbfbe83d0c90f2c9ba4dfeb31b09f1fb875";
-          sha256 = "1xyd827b6wfdbhzj2ba4mywikfjwjs9xspn2aksbsl2bcby0n6zn";
+          rev = "546a62ada70aa89d325cc3941c8c9379a4c21553";
+          sha256 = "1gbgsfd04jdw6jrsp13h13jkkac5ndrn684pl18q0wjgx9kk11b6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/425fa66cffe7bfda71de4ff2b49e951456bdeae1/recipes/mtg-deck-mode";
@@ -47025,6 +45434,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    mu4e-query-fragments = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "mu4e-query-fragments";
+        version = "20170923.622";
+        src = fetchFromGitHub {
+          owner = "wavexx";
+          repo = "mu4e-query-fragments.el";
+          rev = "34ddad4e6785f575333efcc66153d892daa1c884";
+          sha256 = "0l5i3a88j9il2y0jq2sfzwi9q3czc1wi8n9nvgdysj5db5m4xsw6";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/21277a79a211b4d101809314bdb9963130a3d533/recipes/mu4e-query-fragments";
+          sha256 = "0h8rapfz9snvr722vr65gqa0xhgig81b2gvswjlzljwd2m98yzzn";
+          name = "mu4e-query-fragments";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/mu4e-query-fragments";
+          license = lib.licenses.free;
+        };
+      }) {};
     multi = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "multi";
@@ -47064,25 +45494,6 @@
         packageRequires = [ dash emacs ];
         meta = {
           homepage = "https://melpa.org/#/multi-compile";
-          license = lib.licenses.free;
-        };
-      }) {};
-    multi-eshell = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "multi-eshell";
-        version = "20120608.1135";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/multi-eshell.el?revision=9";
-          sha256 = "1w1jwfznpl214a1xx46zlgqbx9c5yjzpyqqrkn3xqjgnj485yhkl";
-          name = "multi-eshell.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a9069a6eb1e57bccb06d26577cac70765de8e52f/recipes/multi-eshell";
-          sha256 = "1i0mvgqxsc99dwp9qcdrijqxsxflrbxw846rgw89p1jfs8mp4l7d";
-          name = "multi-eshell";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/multi-eshell";
           license = lib.licenses.free;
         };
       }) {};
@@ -47256,12 +45667,12 @@
     mustache = callPackage ({ dash, fetchFromGitHub, fetchurl, ht, lib, melpaBuild, s }:
     melpaBuild {
         pname = "mustache";
-        version = "20131117.1407";
+        version = "20170923.533";
         src = fetchFromGitHub {
           owner = "Wilfred";
           repo = "mustache.el";
-          rev = "b0ea352813592424164520a49e86c04600242752";
-          sha256 = "1n2ymd92qpvsby6ms0l3kjhdzzc47rri2aiscc6bs07hm4mjpr9q";
+          rev = "5e39654b933a18131146a0f3b3e3dc55c5058124";
+          sha256 = "0ilsdrvqy9zn0yb1c8zh1zidag32rfb9xhm43qpfcg6n5w6c7r82";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d1bcf9599ca6d2c29333071a80f96808d4ab52e2/recipes/mustache";
@@ -47355,25 +45766,6 @@
         packageRequires = [ dash emacs ];
         meta = {
           homepage = "https://melpa.org/#/mutant";
-          license = lib.licenses.free;
-        };
-      }) {};
-    muttrc-mode = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "muttrc-mode";
-        version = "20090804.1552";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/muttrc-mode.el?revision=7";
-          sha256 = "1xihp3zdqs9054j3bfrd9wnahsvvxjk1ags1iy50ncv5850ppjis";
-          name = "muttrc-mode.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/7d3fd45af3345742cff7be99ad8210d7f8fd2a2f/recipes/muttrc-mode";
-          sha256 = "0ym6rfrhrmpnlqhkxv9ck5893qm0yhswslvgc9vb4nl9hyc1b5jn";
-          name = "muttrc-mode";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/muttrc-mode";
           license = lib.licenses.free;
         };
       }) {};
@@ -47563,25 +45955,6 @@
         packageRequires = [ cypher-mode emacs ];
         meta = {
           homepage = "https://melpa.org/#/n4js";
-          license = lib.licenses.free;
-        };
-      }) {};
-    naked = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "naked";
-        version = "20170418.1822";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/naked.el?revision=23";
-          sha256 = "1k3j6dyp8p47q43i4ba53krl06yx32rkjnh2f5x1zqk6nxnb1wf8";
-          name = "naked.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/naked";
-          sha256 = "06p6dzhn34dva3677mrvwq2a2x3bhw7f486y654hszla7i75pilq";
-          name = "naked";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/naked";
           license = lib.licenses.free;
         };
       }) {};
@@ -47812,25 +46185,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/naquadah-theme";
-          license = lib.licenses.free;
-        };
-      }) {};
-    narrow-indirect = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "narrow-indirect";
-        version = "20170820.1748";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/narrow-indirect.el?revision=14";
-          sha256 = "16knfw5h15f7al6sn1n40bcw2ahqsy9ipkvfk0h7r1vlpb92w2fq";
-          name = "narrow-indirect.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/38e5dd845c99acaae719562595059154a08a5f00/recipes/narrow-indirect";
-          sha256 = "10aq4gssayh3adw8yz2lza1xbypyffi8r03lsc0kiis6gd9ibiyj";
-          name = "narrow-indirect";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/narrow-indirect";
           license = lib.licenses.free;
         };
       }) {};
@@ -48362,12 +46716,12 @@
     nimbus-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "nimbus-theme";
-        version = "20170909.1336";
+        version = "20171003.1044";
         src = fetchFromGitHub {
           owner = "m-cat";
           repo = "nimbus-theme";
-          rev = "71b3a560e6d017907f43f7dd074d300653c1588b";
-          sha256 = "0ip330ylvy6rwgvqravm58qh8ssbrd8nw2rbd3gbhcwiqakawsjl";
+          rev = "f62edeb70cc19bc4c8de9b815c4e9d257acff35d";
+          sha256 = "04y10x36bfgcg22cazza13ildkcsc3vmrd0z8qcsc74yd05n09zf";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/fc0e6b456b76e2379c64a86ad844362c58146dc6/recipes/nimbus-theme";
@@ -48387,8 +46741,8 @@
         src = fetchFromGitHub {
           owner = "martine";
           repo = "ninja";
-          rev = "87111bff382655075f2577c591745a335f0103c7";
-          sha256 = "1rmh2a2q3lw3wmnlh5y7g06nzhcgnhz5libgsjfl3jvpxzdlck76";
+          rev = "b26168be150bd1cbdd6daca59f53755a56fe7939";
+          sha256 = "1g10scd55asi5mfkbj0mdi098nkhy0phvnllwbv52vy6p0amppq9";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/aed2f32a02cb38c49163d90b1b503362e2e4a480/recipes/ninja-mode";
@@ -48446,12 +46800,12 @@
     nix-sandbox = callPackage ({ dash, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "nix-sandbox";
-        version = "20170131.241";
+        version = "20171004.1006";
         src = fetchFromGitHub {
           owner = "travisbhartwell";
           repo = "nix-emacs";
-          rev = "ace629f7645d12778c96ff7b5cf4b1e41a98af29";
-          sha256 = "11infdrdjc30kxvfg5rh1zn4idvkhf9s0c6v60qn441m1d5bnavq";
+          rev = "7007363e773a419203a69798fb0e0731b2eb0f73";
+          sha256 = "00hv8fhyahkdh1vfy1qkahqvsik6d81c7mqh4gjiqxrmb2l1vbcb";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/66be755a6566e8c0cfb5aafa50de29b434023c7a/recipes/nix-sandbox";
@@ -48471,8 +46825,8 @@
         src = fetchFromGitHub {
           owner = "travisbhartwell";
           repo = "nix-emacs";
-          rev = "ace629f7645d12778c96ff7b5cf4b1e41a98af29";
-          sha256 = "11infdrdjc30kxvfg5rh1zn4idvkhf9s0c6v60qn441m1d5bnavq";
+          rev = "7007363e773a419203a69798fb0e0731b2eb0f73";
+          sha256 = "00hv8fhyahkdh1vfy1qkahqvsik6d81c7mqh4gjiqxrmb2l1vbcb";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6846c7d86e70a9dd8300b89b61435aa7e146be96/recipes/nixos-options";
@@ -48576,8 +46930,8 @@
         src = fetchFromGitHub {
           owner = "emacscollective";
           repo = "no-littering";
-          rev = "d1d649711c4ba63e458b229afdc64ed4639cf988";
-          sha256 = "0416i7gv89r46x30swvqhqf7na9rkpm0w9lw1v49kxqdrqqdci67";
+          rev = "a4b42b185b65e78bc3bb6523e23aefb1213eb3b2";
+          sha256 = "1yzcawvz3vbq6pgr0b3sk0qg24jx1fpkinwcmsdl283ib8msbc7g";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/57a2fb9524df3fdfdc54c403112e12bd70888b23/recipes/no-littering";
@@ -48740,12 +47094,12 @@
     nord-theme = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "nord-theme";
-        version = "20170506.2351";
+        version = "20171005.1039";
         src = fetchFromGitHub {
           owner = "arcticicestudio";
           repo = "nord-emacs";
-          rev = "eb7929e41606776a45817946b5d6f79426767a93";
-          sha256 = "1cb7la2al8124i4xfmripfzhabpnzh929qi1266p4c7jchyz2gxw";
+          rev = "be32879416bbed1d6524f7c30ac53fbfa5a0e024";
+          sha256 = "0q347f9bjayfl8y8vz83kjamf1lp58386nhy0iacjxsq4riwpric";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/31cb60069825abe3998c8b43bc9177b39a7f3659/recipes/nord-theme";
@@ -48779,11 +47133,11 @@
       }) {};
     notmuch = callPackage ({ fetchgit, fetchurl, lib, melpaBuild }: melpaBuild {
         pname = "notmuch";
-        version = "20170912.1817";
+        version = "20170927.415";
         src = fetchgit {
           url = "git://git.notmuchmail.org/git/notmuch";
-          rev = "f2ed177e6260d835b8a13d2a53e1c8d5fa76edf2";
-          sha256 = "0d4110cai0z2h2gggx93wfm8fj2av4dwk57gf835crsmv8y3wkj7";
+          rev = "54aef071590cb23f61da943daa29080cf7446696";
+          sha256 = "0hh7276br857a5s5wms2wxf24jz3vvdpqm2d3zrzdfgz54ix6cp7";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b19f21ed7485036e799ccd88edbf7896a379d759/recipes/notmuch";
@@ -48820,12 +47174,12 @@
     nov = callPackage ({ dash, emacs, esxml, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "nov";
-        version = "20170910.1145";
+        version = "20170924.512";
         src = fetchFromGitHub {
           owner = "wasamasa";
           repo = "nov.el";
-          rev = "91c4329f64ddc9a598fa6c58e1d9264aee073e72";
-          sha256 = "0x3ijjhjg2q8gdqf4hgr2d8wy32qhxy48kbz0slibkn9yik3pvlz";
+          rev = "19ab463864f137b43704b4f34173349c88e84d8e";
+          sha256 = "00f5hhw157nwdwy26yn6l3z2hgk6xxvx5xl0hasskj1l9rg0zgh2";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/cf543955ba2d5d0074fa2a5ba176f9415f6e006d/recipes/nov";
@@ -48835,25 +47189,6 @@
         packageRequires = [ dash emacs esxml ];
         meta = {
           homepage = "https://melpa.org/#/nov";
-          license = lib.licenses.free;
-        };
-      }) {};
-    novice-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "novice-plus";
-        version = "20170307.925";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/novice+.el";
-          sha256 = "1f49c0wv1zsi720g3a8ka3h17n7r81pzz7zfwalz0zxwxmh6jghb";
-          name = "novice+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/novice+";
-          sha256 = "0r4w4c6y4fny8k0kipzqjsn7idwbi9jq6x9yw51d41ra3pkpvfzf";
-          name = "novice-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/novice+";
           license = lib.licenses.free;
         };
       }) {};
@@ -48962,22 +47297,28 @@
           license = lib.licenses.free;
         };
       }) {};
-    nu-mode = callPackage ({ fetchFromGitHub, fetchurl, helm, help-fns-plus, lib, melpaBuild, transpose-frame, undo-tree }:
+    nu-mode = callPackage ({ ace-window, avy, fetchFromGitHub, fetchurl, help-fns-plus, lib, melpaBuild, transpose-frame, undo-tree }:
     melpaBuild {
         pname = "nu-mode";
-        version = "20170825.1300";
+        version = "20171007.1521";
         src = fetchFromGitHub {
           owner = "pyluyten";
           repo = "emacs-nu";
-          rev = "711b5bd53c77ba66987fe9807a4442084f67789e";
-          sha256 = "11iymqm51ky7k8ylwvcq770y8anaqn8giki63kf2a96f4rdglb1x";
+          rev = "4a3fe40585031a1c2b323e28f536a3840f0776bd";
+          sha256 = "01pl34cn6z1hky7gwh832vrkpyjsbc62ihbnqxj9rma5w9dfwarx";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/230d5f8fdd965a24b8ff3cc94acf378d04815fca/recipes/nu-mode";
           sha256 = "0nzv3p62k8yyyww6idlxyi94q4d07nis7ydypar8d01jfqlrybkn";
           name = "nu-mode";
         };
-        packageRequires = [ helm help-fns-plus transpose-frame undo-tree ];
+        packageRequires = [
+          ace-window
+          avy
+          help-fns-plus
+          transpose-frame
+          undo-tree
+        ];
         meta = {
           homepage = "https://melpa.org/#/nu-mode";
           license = lib.licenses.free;
@@ -49151,6 +47492,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    nyx-theme = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "nyx-theme";
+        version = "20170910.607";
+        src = fetchFromGitHub {
+          owner = "GuidoSchmidt";
+          repo = "emacs-nyx-theme";
+          rev = "afe2b8c3b5421b4c292d182dcf77079b278e93d8";
+          sha256 = "1qamw4x3yrygy8qkicy6smxksnsfkkp76hlnivswh7dm3fr23v6m";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/3440905a20bc91bb2637a87c04ff8410379f150d/recipes/nyx-theme";
+          sha256 = "17ajpsbwbal1rwgd38kckh1kvnd412h6fkvj2x4j5rqvjr9nhgr6";
+          name = "nyx-theme";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/nyx-theme";
+          license = lib.licenses.free;
+        };
+      }) {};
     o-blog = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "o-blog";
@@ -49294,6 +47656,27 @@
         packageRequires = [ org ];
         meta = {
           homepage = "https://melpa.org/#/ob-browser";
+          license = lib.licenses.free;
+        };
+      }) {};
+    ob-cfengine3 = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "ob-cfengine3";
+        version = "20170915.634";
+        src = fetchFromGitHub {
+          owner = "nickanderson";
+          repo = "ob-cfengine3";
+          rev = "f38f87256efcb2b02f5c7042900087be941c1ddc";
+          sha256 = "09xn84d2vy3kxk2xihjml8zzrhv2cz2jy20dg7w6ll9wn38gs33h";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/d068233c438e76cbcc6e9a97cbec9b2550a18ed6/recipes/ob-cfengine3";
+          sha256 = "1pp3mykc5k629qlqixpl2900m1j604xpp6agrngwagsvf7qkhnvl";
+          name = "ob-cfengine3";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://melpa.org/#/ob-cfengine3";
           license = lib.licenses.free;
         };
       }) {};
@@ -49510,12 +47893,12 @@
     ob-http = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "ob-http";
-        version = "20170411.1842";
+        version = "20170920.2251";
         src = fetchFromGitHub {
           owner = "zweifisch";
           repo = "ob-http";
-          rev = "5fd0e99630e07c5e64f2483c6d46aefdd37677d2";
-          sha256 = "1i5la27m36xfc8jwmz5i0yiim9ddmfaqjpahxgpbf63zks555vpk";
+          rev = "c4da6d47b3f96c31c00f9eaaf712b59afe00daef";
+          sha256 = "0rhxp7gw4d5yp6yvjcp80in22wckj4zl9siykalj0jm97hkwqmzz";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/950b02f76a04f453992b8720032e8c4cec9a039a/recipes/ob-http";
@@ -49531,12 +47914,12 @@
     ob-ipython = callPackage ({ dash, dash-functional, emacs, f, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "ob-ipython";
-        version = "20170902.1253";
+        version = "20171008.1733";
         src = fetchFromGitHub {
           owner = "gregsexton";
           repo = "ob-ipython";
-          rev = "ed1c2d580037c0592066e1f33c0581890dd09e2e";
-          sha256 = "0ciacp8llx0njkrcbzgs13srhjm2nxx0pr7v8ladlx0sfdsxj078";
+          rev = "4a181127000e43dd520e600880b49607747d8f08";
+          sha256 = "01gfj11pd97xp02bdal3c9wy77ha1dcym1ddrbpzkvck2ja1s6ib";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/557c36e86844c211f2d2ee097ce51ee9db92ea8b/recipes/ob-ipython";
@@ -49867,12 +48250,12 @@
     ob-swift = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, org }:
     melpaBuild {
         pname = "ob-swift";
-        version = "20151204.2311";
+        version = "20170921.625";
         src = fetchFromGitHub {
           owner = "zweifisch";
           repo = "ob-swift";
-          rev = "f376af0d86fb410e41289df59a0c2625954c9067";
-          sha256 = "071rl0bvhwh5vqbl7n84shvzgqgwg2f5l9vb8wfs4y24hsqfgxmz";
+          rev = "ed478ddbbe41ce5373efde06b4dd0c3663c9055f";
+          sha256 = "1vwg10d33mwb32bpdbpghfihy3ryiqbc4yydpb5hfv3v5k83vs0x";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b401383966398d3223032c59baa920ce594e5fef/recipes/ob-swift";
@@ -50329,12 +48712,12 @@
     omni-kill = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "omni-kill";
-        version = "20150526.2349";
+        version = "20171005.955";
         src = fetchFromGitHub {
           owner = "AdrieanKhisbe";
           repo = "omni-kill.el";
-          rev = "4c8dbb6b2c9f1afc0f82077c04eab022e5387e85";
-          sha256 = "1925mh47n4x9v780qp5l6cksl64v9mpyb87znsg93x6sxr0cvv4c";
+          rev = "192d51d843c6581d593a4eb01f1b49ad59d206cf";
+          sha256 = "0n24rhzl1zhlkdkjigsczyc0z3yrihz9qnn1icrk6nkms107qbnn";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c24df34d2fa5d908223379e909148423ba327ae2/recipes/omni-kill";
@@ -50350,12 +48733,12 @@
     omni-log = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, ht, lib, melpaBuild, s }:
     melpaBuild {
         pname = "omni-log";
-        version = "20170420.407";
+        version = "20170930.535";
         src = fetchFromGitHub {
           owner = "AdrieanKhisbe";
           repo = "omni-log.el";
-          rev = "60fd1b7ba77bd82787e43ce1aee2832f53981c68";
-          sha256 = "1s81qj4g8nhw6k4b7wi4ya9g51xbsqzyi659zs4zdxjxj7acdq8s";
+          rev = "11e959473c1bd9415d0cda785940c36ba6ad44ab";
+          sha256 = "081vq3wzl8w9yz1356np6h27d7yi5j8i3va9sc2flfwylmw1y9gr";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/47bb19bb7b4713c3fd82c1035a2fe66588c069e3/recipes/omni-log";
@@ -50392,12 +48775,12 @@
     omni-scratch = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "omni-scratch";
-        version = "20170416.329";
+        version = "20171008.1207";
         src = fetchFromGitHub {
           owner = "AdrieanKhisbe";
           repo = "omni-scratch.el";
-          rev = "0da549c1386f93ed4de201bf8779ba64ddc91347";
-          sha256 = "0qfi54z2jqrkrdzriandwc9myzc27sxsx7nf20jf5qvcdgn13cl1";
+          rev = "98cdc402c3663e30a2bd260911b2ac0c93f93129";
+          sha256 = "19pwhbg4db5g4nq3j7axdh81k6ikm2jirwdkl38nqyr0sb0s2w33";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6ba3e128a7fe4476d82266506b18ba9984c37944/recipes/omni-scratch";
@@ -50455,12 +48838,12 @@
     omnisharp = callPackage ({ auto-complete, cl-lib ? null, csharp-mode, dash, emacs, f, fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild, popup, s, shut-up }:
     melpaBuild {
         pname = "omnisharp";
-        version = "20170909.319";
+        version = "20171007.416";
         src = fetchFromGitHub {
           owner = "OmniSharp";
           repo = "omnisharp-emacs";
-          rev = "b425270bed93b427ff519d6f51ad1d97531a0a92";
-          sha256 = "0l9dk9idfsr21q0icx9fpgqyi4qlhnqal6sypak5zh8dgchrqif9";
+          rev = "40b6251a96057c80a958362a0886c06eea5bfd62";
+          sha256 = "176qfjd0qfgypj7pyi2p7v6zn7sic86gcgxz056k4y2akm6aa2p6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/e327c483be04de32638b420c5b4e043d12a2cd01/recipes/omnisharp";
@@ -50565,25 +48948,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/one-time-pad-encrypt";
-          license = lib.licenses.free;
-        };
-      }) {};
-    oneonone = callPackage ({ fetchurl, hexrgb, lib, melpaBuild }: melpaBuild {
-        pname = "oneonone";
-        version = "20170416.858";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/oneonone.el?revision=129";
-          sha256 = "0ag62z31mb5n50m9qph2ww945pr71j95c5xv7krna1iq01qr8ji1";
-          name = "oneonone.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/oneonone";
-          sha256 = "0v4nvhzgq97zbi18jd3ds57yh1fpv57b2a1cd7r8jbxwaaz3gpg9";
-          name = "oneonone";
-        };
-        packageRequires = [ hexrgb ];
-        meta = {
-          homepage = "https://melpa.org/#/oneonone";
           license = lib.licenses.free;
         };
       }) {};
@@ -50882,12 +49246,12 @@
     org-autolist = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "org-autolist";
-        version = "20150922.705";
+        version = "20170924.1201";
         src = fetchFromGitHub {
           owner = "calvinwyoung";
           repo = "org-autolist";
-          rev = "da332fadcd9be4c5eb21c5e98c392b89743750b2";
-          sha256 = "0j6fqgzvbmvvdh0dgwsxq004wxys2zwnq9wa3idm087ynp2a2ani";
+          rev = "c82d1e83e982b5f0c106b8800e5b0cfd5f73fdc1";
+          sha256 = "0ykiafbdjb2iy0s1gr6l51gddjbk08iwj4v13hgm8b675bl0cw56";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ca8e2cdb282674b20881bf6b4fc49af42a5d09a7/recipes/org-autolist";
@@ -50987,12 +49351,12 @@
     org-brain = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, org }:
     melpaBuild {
         pname = "org-brain";
-        version = "20170908.634";
+        version = "20171004.1305";
         src = fetchFromGitHub {
           owner = "Kungsgeten";
           repo = "org-brain";
-          rev = "9a84111f759c264bd6ab435995803d0f6234b78a";
-          sha256 = "00a92064bjlrjrmy7xcfc5ajajxviar82pjisdm4pxd3jcab8qcw";
+          rev = "35d46695ceffff4069e66fa2a4f039509f1a3c7e";
+          sha256 = "0c0jps0gxsk3m8s78yp8141wh7g2nx8acd1jc0v4ffmlr8qi2csj";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/47480fbae06e4110d50bc89db7df05fa80afc7d3/recipes/org-brain";
@@ -51075,8 +49439,8 @@
         src = fetchFromGitHub {
           owner = "IvanMalison";
           repo = "org-projectile";
-          rev = "48f621b595e748c5e03431f237facf258ffc9443";
-          sha256 = "00n2msmwcjjiibrhrvpawzgz6qcjjfy9qnii1iaass0038g4bd89";
+          rev = "d57062569e59f598fcad1107f463691ec5d07e5f";
+          sha256 = "1s5d9g8a8wgap0hsn5wqwzr20r6xr2jfm720zb404ixpkw4p939y";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6760daac1ef9d9d7ba07e2fc9668873020f901f1/recipes/org-category-capture";
@@ -51323,12 +49687,12 @@
     org-download = callPackage ({ async, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "org-download";
-        version = "20170605.23";
+        version = "20170924.2309";
         src = fetchFromGitHub {
           owner = "abo-abo";
           repo = "org-download";
-          rev = "131d2409b3639798ebac6d77c98eae446ea915dc";
-          sha256 = "1l04vs47pl63daz9n0d2xby43kr2ynbykvdr7hjbyizcg9l9fzp7";
+          rev = "14261c2619be224fc4c499624abc2cba3663e7f5";
+          sha256 = "0d8lcg9gnzf5bpn1z83i5nni444mzy6mlqggadsrdav9bdf8cfy2";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/edab283bc9ca736499207518b4c9f5e71e822bd9/recipes/org-download";
@@ -51491,12 +49855,12 @@
     org-evil = callPackage ({ dash, evil, fetchFromGitHub, fetchurl, lib, melpaBuild, monitor, org }:
     melpaBuild {
         pname = "org-evil";
-        version = "20170529.741";
+        version = "20171004.255";
         src = fetchFromGitHub {
           owner = "GuiltyDolphin";
           repo = "org-evil";
-          rev = "aff7bf3885e318287abf7d542916d21372496bdd";
-          sha256 = "1z6rj7nrjdmkc7skx2si7s462228bpka96p0zzmkg7wa82j7ywv9";
+          rev = "aae5688c15cef9f2f6105d395dab36b163d5af34";
+          sha256 = "01ablfw0prcb4bwsaa6fbqc80xz539a48psvnmddz98c8yjhb9g7";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/17a4772d409aa5dbda5fb84d86c237fd2653c70b/recipes/org-evil";
@@ -51616,12 +49980,12 @@
     org-iv = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, impatient-mode, lib, melpaBuild, org }:
     melpaBuild {
         pname = "org-iv";
-        version = "20160609.1854";
+        version = "20171001.322";
         src = fetchFromGitHub {
           owner = "kuangdash";
           repo = "org-iv";
-          rev = "40fa39ae680794cd493dfa8624e5eff4d04c2363";
-          sha256 = "1zn1bvk2kgd6a969m1d63v8ax52lanvb1h2w62ffpxlkap3kl6m8";
+          rev = "7f2bb1b32647655fd9d6684f6f09dcc66b61b0cd";
+          sha256 = "0s3fi8sk7jm5vr0fz20fbygm4alhpirv0j20jfi1pab14yhhf34h";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/e7db0c34f0f6fb9c3b9e581a74304cc9a26ed342/recipes/org-iv";
@@ -51658,12 +50022,12 @@
     org-journal = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "org-journal";
-        version = "20170712.657";
+        version = "20170928.231";
         src = fetchFromGitHub {
           owner = "bastibe";
           repo = "org-journal";
-          rev = "69b237d1b3c5cc0eb81fb5918df25d01e999b0f1";
-          sha256 = "1ss1lxxilbr177mlp4iygg8q74qfw68v8iap9fpj6lvlm7vawins";
+          rev = "cda1980b013afabd299e7a2294517897f6442d98";
+          sha256 = "1y6idbp74vrr3g0r10n09znky8ih94kzf5fyil47sjkqyzzmpk3s";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/7fabdb05de9b8ec18a3a566f99688b50443b6b44/recipes/org-journal";
@@ -51739,55 +50103,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    org-mac-iCal = callPackage ({ fetchgit, fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "org-mac-iCal";
-        version = "20140107.519";
-        src = fetchgit {
-          url = "git://orgmode.org/org-mode.git";
-          rev = "657302b97e222abb262070586c56fe5d64355035";
-          sha256 = "0myi67sdr62q0qxjijkxbpmyhxvnrxwjwpq2al1cds0bk8q7nzq4";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/ee69e5e7b1617a29919d5fcece92414212fdf963/recipes/org-mac-iCal";
-          sha256 = "1ilzvmw1x5incagp1vf8d9v9mz0krlv7bpv428gg3gpqzpm6kksw";
-          name = "org-mac-iCal";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/org-mac-iCal";
-          license = lib.licenses.free;
-        };
-      }) {};
-    org-mac-link = callPackage ({ fetchgit, fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "org-mac-link";
-        version = "20170105.1723";
-        src = fetchgit {
-          url = "git://orgmode.org/org-mode.git";
-          rev = "657302b97e222abb262070586c56fe5d64355035";
-          sha256 = "0myi67sdr62q0qxjijkxbpmyhxvnrxwjwpq2al1cds0bk8q7nzq4";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/b86c666ee9b0620390a250dddd42b17cbec2409f/recipes/org-mac-link";
-          sha256 = "02rmhrwikppppw8adnzvwj43kp9wsyk60csj5pygg7cd7wah7khw";
-          name = "org-mac-link";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/org-mac-link";
-          license = lib.licenses.free;
-        };
-      }) {};
     org-mime = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "org-mime";
-        version = "20170807.549";
+        version = "20171008.644";
         src = fetchFromGitHub {
           owner = "org-mime";
           repo = "org-mime";
-          rev = "8067e76eb1fb6a9c15229cc93015aba923120a19";
-          sha256 = "0r33y6l74i8n2fbqcazq4r2659lqva855mf5lm5yf7spjga2f9vw";
+          rev = "0a0aa9b11005ff620b447c75e15122f6c0f9d81b";
+          sha256 = "1m5qih09zyi8awwf2badis9czy0biwnpxrhd26an3ssb07i7ajgs";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/521678fa13884dae69c2b4b7a2af718b2eea4b28/recipes/org-mime";
@@ -51977,21 +50301,21 @@
           license = lib.licenses.free;
         };
       }) {};
-    org-parser = callPackage ({ dash, emacs, fetchhg, fetchurl, lib, melpaBuild }:
+    org-parser = callPackage ({ dash, emacs, fetchhg, fetchurl, ht, lib, melpaBuild }:
     melpaBuild {
         pname = "org-parser";
-        version = "20170814.2016";
+        version = "20171002.2136";
         src = fetchhg {
           url = "https://bitbucket.com/zck/org-parser.el";
-          rev = "f568dd98a8b2";
-          sha256 = "15lbanb14ip0xwcd3ddq5a0099f299blvf6j3g03hmnzfa4pm7cy";
+          rev = "105050acee08";
+          sha256 = "1y1ikk950awxhvx4d930ymqa8ds6a0wlywzx09jvrnkvbisd4l63";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/28d55005cbce276cda21021a8d9368568cb4bcc6/recipes/org-parser";
           sha256 = "06yb78mf486b986dhvqg3avflfyi271vykyars465qpk0v8ahq8h";
           name = "org-parser";
         };
-        packageRequires = [ dash emacs ];
+        packageRequires = [ dash emacs ht ];
         meta = {
           homepage = "https://melpa.org/#/org-parser";
           license = lib.licenses.free;
@@ -52104,12 +50428,12 @@
     org-projectile = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, org-category-capture, projectile, s }:
     melpaBuild {
         pname = "org-projectile";
-        version = "20170819.1047";
+        version = "20171006.1230";
         src = fetchFromGitHub {
           owner = "IvanMalison";
           repo = "org-projectile";
-          rev = "48f621b595e748c5e03431f237facf258ffc9443";
-          sha256 = "00n2msmwcjjiibrhrvpawzgz6qcjjfy9qnii1iaass0038g4bd89";
+          rev = "d57062569e59f598fcad1107f463691ec5d07e5f";
+          sha256 = "1s5d9g8a8wgap0hsn5wqwzr20r6xr2jfm720zb404ixpkw4p939y";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/9d7a7ab98f364d3d5e93f83f0cb3d80a95f28689/recipes/org-projectile";
@@ -52129,8 +50453,8 @@
         src = fetchFromGitHub {
           owner = "IvanMalison";
           repo = "org-projectile";
-          rev = "48f621b595e748c5e03431f237facf258ffc9443";
-          sha256 = "00n2msmwcjjiibrhrvpawzgz6qcjjfy9qnii1iaass0038g4bd89";
+          rev = "d57062569e59f598fcad1107f463691ec5d07e5f";
+          sha256 = "1s5d9g8a8wgap0hsn5wqwzr20r6xr2jfm720zb404ixpkw4p939y";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6760daac1ef9d9d7ba07e2fc9668873020f901f1/recipes/org-projectile-helm";
@@ -52257,12 +50581,12 @@
     org-ref = callPackage ({ dash, emacs, f, fetchFromGitHub, fetchurl, helm, helm-bibtex, hydra, ivy, key-chord, lib, melpaBuild, pdf-tools, s }:
     melpaBuild {
         pname = "org-ref";
-        version = "20170808.625";
+        version = "20170927.2056";
         src = fetchFromGitHub {
           owner = "jkitchin";
           repo = "org-ref";
-          rev = "0af19a6ed3ccde878c27c27f1413409fdc0de9f8";
-          sha256 = "0prwvc3yywivhap6rrji25afcxc553nginzxgrr7fbkxy5vfprzg";
+          rev = "5fcbd975523281e5bacaf0284af21b4387147a98";
+          sha256 = "0fc5kcz1xy819m960qn28hz9c13qpc542kzihmzkc3ykm5d96x3c";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/550e4dcef2f74fbd96474561c1cb6c4fd80091fe/recipes/org-ref";
@@ -52520,12 +50844,12 @@
     org-tfl = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, org }:
     melpaBuild {
         pname = "org-tfl";
-        version = "20161120.932";
+        version = "20170923.518";
         src = fetchFromGitHub {
           owner = "storax";
           repo = "org-tfl";
-          rev = "f0405e3ad62b90ea43489bdd6312adbd77edb9f3";
-          sha256 = "0cznw60ivaz42ass35sf9i62x7mf9in6z8kr8wc5i1mb7hafy2hk";
+          rev = "f0d7d39106a1de5457f5160cddd98ab892b61066";
+          sha256 = "1rwdibiq0w4nzccmvdkpwnmfga70y35lfg2xlkqxd02x7bfl7j3m";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d9e97f2fee577c7e3fb42e4ca9d4f422c8907faf/recipes/org-tfl";
@@ -52688,12 +51012,12 @@
     org-vcard = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "org-vcard";
-        version = "20161001.2202";
+        version = "20170929.410";
         src = fetchFromGitHub {
           owner = "flexibeast";
           repo = "org-vcard";
-          rev = "58f83784c580da893c214bd729aae3ab5d285f33";
-          sha256 = "122qxg0ji9c7zj52vqlf9d6276w7rdlxg4ippy6dayqs8bhkimbg";
+          rev = "dbe266b79df4fb31f1766010322bf4e383ce1c03";
+          sha256 = "1rcqcgxvjshbz3n1p376h618xapj03n6m7b3cxgv9gnryviyr6ax";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/df860814a09c376c9a6a2c5e7f528bbae29810b2/recipes/org-vcard";
@@ -52730,12 +51054,12 @@
     org-web-tools = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, org, s }:
     melpaBuild {
         pname = "org-web-tools";
-        version = "20170906.102";
+        version = "20171008.2128";
         src = fetchFromGitHub {
           owner = "alphapapa";
           repo = "org-web-tools";
-          rev = "9ae976aedacefdbe4a827bd66a4642f40bc878d4";
-          sha256 = "18hbcjg30fd342mvab3h7v8y5mja90g54823mnvmffhrp657z7qc";
+          rev = "dac686b18cddbf3af4632054b15ff53c1ae8d564";
+          sha256 = "1bw543dc0lbzf4s3sjwg6y8pszfpkby5dyj0pykg98pcii51agkj";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/f082bfb480649d21f586b7eb331c19d57e7a84cf/recipes/org-web-tools";
@@ -52856,12 +51180,12 @@
     org2web = callPackage ({ cl-lib ? null, dash, el2org, fetchFromGitHub, fetchurl, ht, htmlize, lib, melpaBuild, mustache, org, simple-httpd }:
     melpaBuild {
         pname = "org2web";
-        version = "20170809.411";
+        version = "20171005.1617";
         src = fetchFromGitHub {
           owner = "tumashu";
           repo = "org2web";
-          rev = "b14aaecd9e51b3cc4fa4530bfc6f07dd47c80616";
-          sha256 = "04f85kw7d5s8yszbm0270yyb49i3k5a9q35a6zdfhpmpfap48h90";
+          rev = "5243b399927a4c474bb3b8d1c8a00799df1f27d7";
+          sha256 = "0wsvfn409a2ivbich8b8zqza78sprirg4bl7igx536ydqclmi0n7";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/2864959163442165b9b1cd5471dc2649508decde/recipes/org2web";
@@ -53079,8 +51403,8 @@
         src = fetchFromGitHub {
           owner = "DamienCassou";
           repo = "orgtbl-show-header";
-          rev = "0b63ab4425b6e2af8ffb1f0b94839918d1720d09";
-          sha256 = "161bsmgrbdhb73k36gqb5b96mf0y0sl8q9sjg81vx86bs9sbkddw";
+          rev = "112d54a44682f065318ed0c9c89a8f5b8907342a";
+          sha256 = "1s2bgsm4s33w5275qghw1axdpmz6bbyhki53jr2giyk4f90822gi";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/9c5ea906b1d642405ca532d89dbb32cf79f53582/recipes/orgtbl-show-header";
@@ -53432,12 +51756,12 @@
     outshine = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild, outorg }:
     melpaBuild {
         pname = "outshine";
-        version = "20170904.1524";
+        version = "20171005.955";
         src = fetchFromGitHub {
           owner = "alphapapa";
           repo = "outshine";
-          rev = "a695215b47ca4a950c47a69a5c6e4c695892b1b3";
-          sha256 = "18c1iqfw2q9if6yhvgspcw5arhd549gcvwyphnsl9cl6q40q2vly";
+          rev = "75389b7104692f4f6a97dc72020d145f03affd25";
+          sha256 = "0j99wx48xq5vpla69yj5w255n3acbgc4bbig4kmbvayr2871ls7n";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/8edf78a0ecd2ff8e6e066b80751a31e11a068c3f/recipes/outshine";
@@ -53478,8 +51802,8 @@
         src = fetchFromGitHub {
           owner = "tonini";
           repo = "overseer.el";
-          rev = "3269801dc5145d41c11599430229340e6dfa6cc6";
-          sha256 = "1zjp1bw7ipg4ibabrc0wzzsvd4jydjq571768v2hdpzcdw36d8f7";
+          rev = "6be1f2a4df1b7a20298865b85502ee89e327898d";
+          sha256 = "0ipq5gflymvznb8xzfl524l09sj90787bzga9ymjjpc4rn9zmqlb";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/overseer";
@@ -53579,12 +51903,12 @@
     ox-epub = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, org }:
     melpaBuild {
         pname = "ox-epub";
-        version = "20170414.0";
+        version = "20171003.327";
         src = fetchFromGitHub {
           owner = "ofosos";
           repo = "ox-epub";
-          rev = "113300ed2c66cca10624e6d7bf5ff0a72e05653a";
-          sha256 = "1xj643jybrd6idn6bazp0canj8pm9v3gs199fa17hlag7151ancw";
+          rev = "c12467d1c6a2a3f89e1e271c44e29eb5409ed9df";
+          sha256 = "0qlnxqzc3xw12w62kgjmmkvm2l25z4rjz77dnl4y15pqrjl4ljak";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c3ac31dfef00e83fa6b716ea006f35afb5dc6cd5/recipes/ox-epub";
@@ -53642,12 +51966,12 @@
     ox-hugo = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, org }:
     melpaBuild {
         pname = "ox-hugo";
-        version = "20170912.1322";
+        version = "20170930.1905";
         src = fetchFromGitHub {
           owner = "kaushalmodi";
           repo = "ox-hugo";
-          rev = "a486141e4e2c3f9f67e799e20af150611d77f850";
-          sha256 = "1srrkc0bajmhp614avk4yr51zsp0gnmn47r1wi7qxkr6ybxwx8k1";
+          rev = "98346caff78f5e8740505bcade85e00914bc54a6";
+          sha256 = "0c1ajqybpcv0nc5fklq01lkz1f0320wnn43i0r22d4m8dflqfhy0";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1e1240bb7b5bb8773f804b987901566a20e3e8a9/recipes/ox-hugo";
@@ -53705,12 +52029,12 @@
     ox-jira = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, org }:
     melpaBuild {
         pname = "ox-jira";
-        version = "20170607.1513";
+        version = "20171001.216";
         src = fetchFromGitHub {
           owner = "stig";
           repo = "ox-jira.el";
-          rev = "a5e7c7166f5d4baf4b6487f44865f2636cda4698";
-          sha256 = "14qybj34wvpn91m9hvfmcrsj5d9zzq5pyzjc61gd0zn482bklxz4";
+          rev = "db2ec528f46c9e611624ba28611c440a99bff255";
+          sha256 = "04zz6359xkn4w7jmmadxyvjd8pw21gw12mqwch1l9yxc4m9q474l";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/e8a77d9c903acd6d7fdcb53f63384144e85589c9/recipes/ox-jira";
@@ -53894,12 +52218,12 @@
     ox-rst = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, org }:
     melpaBuild {
         pname = "ox-rst";
-        version = "20170418.758";
+        version = "20171004.1553";
         src = fetchFromGitHub {
           owner = "masayuko";
           repo = "ox-rst";
-          rev = "70f15591715796b1d96af660481739f019c295cb";
-          sha256 = "1q6qfgfajl103hsf5zp4zxpf4svypv0n1kiqkhjp12b0hy45n2l0";
+          rev = "6d1eab55ff7c8dc4bcf511c9483e69f2a840e928";
+          sha256 = "10z922lcg8hz517kg57knx2irfcac8plp9nsxayrbxpkjx7mmjlj";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3af3905e1ce36397645a54078280852a8a7eb1eb/recipes/ox-rst";
@@ -54083,12 +52407,12 @@
     package-build = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "package-build";
-        version = "20170910.124";
+        version = "20171008.2352";
         src = fetchFromGitHub {
           owner = "melpa";
           repo = "package-build";
-          rev = "46055de8792a1c7c01d06f74148dae6d700b00d6";
-          sha256 = "1x1kln1bdqxxgan1pkjs98a9d3737j4qfpza4r70va7wvsy3ndhj";
+          rev = "6c288fd22eef6332adc5680aa0843d1c678c4832";
+          sha256 = "1s2p5c1c8fyiwi6idjl4bw2cxikdim0maw6w5pf12k2j1bwm98qy";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/948fb86b710aafe6bc71f95554655dfdfcab0cca/recipes/package-build";
@@ -54125,12 +52449,12 @@
     package-lint = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "package-lint";
-        version = "20170907.201";
+        version = "20171006.1846";
         src = fetchFromGitHub {
           owner = "purcell";
           repo = "package-lint";
-          rev = "2fc3bc9530caea437a55e23c13d31d8803193107";
-          sha256 = "076da92vc86kdc7gdh8id7w8qadh0fbiz068qzk8kr8w5bw6zkr6";
+          rev = "ff64e1171e8330972c26bf547042429927aed7c7";
+          sha256 = "11hsxvla2vq944zfd8kr0wynvkr7n90jv714ll6f7yhn10nrraks";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/9744d8521b4ac5aeb1f28229c0897af7260c6f78/recipes/package-lint";
@@ -54332,25 +52656,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    palette = callPackage ({ fetchurl, hexrgb, lib, melpaBuild }: melpaBuild {
-        pname = "palette";
-        version = "20170307.936";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/palette.el?revision=84";
-          sha256 = "112b91z1f4p0j4kzrn8110w9pk2fyndjqiiyh0vkwah2ihpsw3pj";
-          name = "palette.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/2cdf2d07307007a95d1fe8dc8d2f105c34a26416/recipes/palette";
-          sha256 = "1s9lklvr1b0a496q0ljbhkl8zdx80d7bqvkdjnfp35z2s37f1zz3";
-          name = "palette";
-        };
-        packageRequires = [ hexrgb ];
-        meta = {
-          homepage = "https://melpa.org/#/palette";
-          license = lib.licenses.free;
-        };
-      }) {};
     palimpsest = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "palimpsest";
@@ -54396,12 +52701,12 @@
     pamparam = callPackage ({ emacs, fetchFromGitHub, fetchurl, hydra, lib, lispy, melpaBuild, worf }:
     melpaBuild {
         pname = "pamparam";
-        version = "20170910.537";
+        version = "20170927.1048";
         src = fetchFromGitHub {
           owner = "abo-abo";
           repo = "pamparam";
-          rev = "d452c3baa19d51fb04c5a52f550b560fe695eb0a";
-          sha256 = "02qrc3qxajzxm9lfrd33i9sbawh9nf4gz9i3drzhv11ca549paaq";
+          rev = "c840a8f941940bb8e694c635995566faee995c7b";
+          sha256 = "0wqnzgkcwhrgxdkrlk6i469gcas9477pbkv878cqq9ifsjwvf42n";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/067b5e3594641447478db8c1ffcb36d63018b1b2/recipes/pamparam";
@@ -54480,16 +52785,16 @@
     paper-theme = callPackage ({ emacs, fetchFromGitHub, fetchurl, hexrgb, lib, melpaBuild }:
     melpaBuild {
         pname = "paper-theme";
-        version = "20151231.932";
+        version = "20170924.1231";
         src = fetchFromGitHub {
           owner = "cadadr";
-          repo = "paper-theme";
-          rev = "15af5e31492f79dc0d47787150ef39d6318a2608";
-          sha256 = "1xh614czldjvfl66vhkyaai5k4qsg1l3mz6wd5b1w6kd45qrc54i";
+          repo = "elisp";
+          rev = "b3d8b45c76134e2248448d719c840776e41b747a";
+          sha256 = "0fy0b04mf3brx86xjnidkwg4zs4nh123nc6pgrl4mp6d6552vv98";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a35a0888a7a27174b5de58d99b01554769041f46/recipes/paper-theme";
-          sha256 = "04diqm2c9fm29zyms3hplkzb4kb7b2kyrxdsy0jxyjj5kabypd50";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/a7ea18a56370348715dec91f75adc162c800dd10/recipes/paper-theme";
+          sha256 = "1ph6c6g907cnxzl74byc754119qia8rs8y7wvaj8i6q3fz2658zr";
           name = "paper-theme";
         };
         packageRequires = [ emacs hexrgb ];
@@ -54526,8 +52831,8 @@
         src = fetchFromGitHub {
           owner = "Malabarba";
           repo = "paradox";
-          rev = "c508a52aee7f10f5e9b750b4724e264a3e694757";
-          sha256 = "1xbys48368a6vcyjqxn71lg6yf7zvb2k9dlf07dl6hvh0a7qlpqa";
+          rev = "dfdfbec8b4a3b71966c134f00c3f5edfa87b6245";
+          sha256 = "1l0rs49lbclq4ayhnx6vi6bxn37a0h2ylk73fjcbar2lbr1dhf9r";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1e6aed365c42987d64d0cd9a8a6178339b1b39e8/recipes/paradox";
@@ -54769,22 +53074,22 @@
           license = lib.licenses.free;
         };
       }) {};
-    pass = callPackage ({ emacs, f, fetchFromGitHub, fetchurl, lib, melpaBuild, password-store }:
+    pass = callPackage ({ emacs, f, fetchFromGitHub, fetchurl, lib, melpaBuild, password-store, password-store-otp }:
     melpaBuild {
         pname = "pass";
-        version = "20170911.456";
+        version = "20170928.1118";
         src = fetchFromGitHub {
           owner = "NicolasPetton";
           repo = "pass";
-          rev = "f811120c33279fb6881c0a70ae26862adefcd659";
-          sha256 = "07m80mscxfi5wmf0cvymlnpcp4aprzn8ynaxs6vxgpr11gwr8zvm";
+          rev = "adcafc25e1bbd43b70251305a07252cc46d20308";
+          sha256 = "0hbbqgj0vi5xlb48fjdy7yh8qx43hi6rw3jqrcmvlh3gnm47yhky";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/428c2d53db69bed8938ec3486dfcf7fc048cd4e8/recipes/pass";
           sha256 = "1vvyvnqf6k7wm0p45scwi6ny86slkrcbr36lnxdlkf96cqyrqzfr";
           name = "pass";
         };
-        packageRequires = [ emacs f password-store ];
+        packageRequires = [ emacs f password-store password-store-otp ];
         meta = {
           homepage = "https://melpa.org/#/pass";
           license = lib.licenses.free;
@@ -54874,18 +53179,19 @@
           license = lib.licenses.free;
         };
       }) {};
-    password-store = callPackage ({ emacs, f, fetchgit, fetchurl, lib, melpaBuild, s, with-editor }:
+    password-store = callPackage ({ emacs, f, fetchFromGitHub, fetchurl, lib, melpaBuild, s, with-editor }:
     melpaBuild {
         pname = "password-store";
         version = "20170829.1633";
-        src = fetchgit {
-          url = "https://git.zx2c4.com/password-store";
-          rev = "65cead8c0fdb07ce3821f6b97bdcb32684d0c3f7";
-          sha256 = "0rm364l9mg2gl16ng5zd02gkfq8592mhrp81sk1v0wwh8wlyrzrh";
+        src = fetchFromGitHub {
+          owner = "zx2c4";
+          repo = "password-store";
+          rev = "c1b3ff04425844ed88fac2a634232bdb8e2662bc";
+          sha256 = "07hfca1r09m5p5i8y62b54xmhw1ymcq68ys0gk579d7lvvy6s5qf";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/ceff76206bd44d92c00adc931236c4ae15db5583/recipes/password-store";
-          sha256 = "06l4xlvrjswy5kndn6h6swliqcp007nh4fyvma3jaac4f3x2qi65";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/207f8ec84572176749d328cb2bbc4e87c36f202c/recipes/password-store";
+          sha256 = "03r8j14l12yc42b51fzvn1jh8j85nyl1rg6c80r0a7ihwkj27jv6";
           name = "password-store";
         };
         packageRequires = [ emacs f s with-editor ];
@@ -54897,12 +53203,12 @@
     password-store-otp = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, password-store, s }:
     melpaBuild {
         pname = "password-store-otp";
-        version = "20170912.349";
+        version = "20170928.18";
         src = fetchFromGitHub {
           owner = "volrath";
           repo = "password-store-otp.el";
-          rev = "2965da7d8edd32bd4ef62f487ea6bcd08c599c89";
-          sha256 = "1svm6rlh4f0rjcl0fjy3x4bfakdn9npi8w7ak217ad2k08j44bzd";
+          rev = "a39a64a91de36e87b852339635bd3c5fb0e32441";
+          sha256 = "0gb48blvnn6ci2wl45z81p41ny7vbgl610hqy6b2hyr2171qjd60";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/fc89d02554a6ff150ad42634879073892f3e88be/recipes/password-store-otp";
@@ -55359,12 +53665,12 @@
     pdf-tools = callPackage ({ emacs, fetchFromGitHub, fetchurl, let-alist, lib, melpaBuild, tablist }:
     melpaBuild {
         pname = "pdf-tools";
-        version = "20170912.711";
+        version = "20170918.934";
         src = fetchFromGitHub {
           owner = "politza";
           repo = "pdf-tools";
-          rev = "c1b183f71e618693ac6ec20f051ca41270be3bce";
-          sha256 = "059fmrakfzwq4xqf246ksi9h7gfm37f29565w9mvlq4z7hhbf5z3";
+          rev = "52acd65c0db97a83e3f86ca97f9a3bf27135e8f3";
+          sha256 = "19d5nmy7kdlysxzig2akbxvg9h1vnjagp4xh1qpyw8iqgm3kpxxn";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/8e3d53913f4e8a618e125fa9c1efb3787fbf002d/recipes/pdf-tools";
@@ -55464,11 +53770,11 @@
     pelican-mode = callPackage ({ emacs, fetchgit, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "pelican-mode";
-        version = "20170818.1352";
+        version = "20171001.503";
         src = fetchgit {
           url = "https://git.korewanetadesu.com/pelican-mode.git";
-          rev = "9b2a64b9d57ee4eb95e40a309fbab4bcfa5b5fef";
-          sha256 = "19gqg2p56r0iz5l3p5y421c107f3jggwi60xk2wamx5jv9rbrn2d";
+          rev = "64d41f0ee5970b2d875880994eb287b97cad24a1";
+          sha256 = "0xivc8sdp6h3fajyj7g73xnyfqlkhfpm2cs9x3mpyr42502lmn2c";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/aede5994c2e76c7fd860661c1e3252fb741f9228/recipes/pelican-mode";
@@ -55498,48 +53804,6 @@
         packageRequires = [ cl-lib ];
         meta = {
           homepage = "https://melpa.org/#/per-buffer-theme";
-          license = lib.licenses.free;
-        };
-      }) {};
-    perl-completion = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "perl-completion";
-        version = "20090527.2336";
-        src = fetchFromGitHub {
-          owner = "imakado";
-          repo = "perl-completion";
-          rev = "f2ec91b88a8b7d97d40d6c90a89eaf8e595c2b89";
-          sha256 = "0fzypcxxd5zlkcybz0xppf09l0vf4vsfisr2y3ijsmxhg7yrwzj5";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/987c14a2c4a31e27382d05cdbca18a3d2661d2e1/recipes/perl-completion";
-          sha256 = "01p17mlkwjm60f14arda3ly8ng0r98nn3rly94ghn6jr7r7fv14b";
-          name = "perl-completion";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/perl-completion";
-          license = lib.licenses.free;
-        };
-      }) {};
-    perl6-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, pkg-info }:
-    melpaBuild {
-        pname = "perl6-mode";
-        version = "20160730.1455";
-        src = fetchFromGitHub {
-          owner = "hinrik";
-          repo = "perl6-mode";
-          rev = "14073feeb0f8ad2225616d550133f8f473a51b33";
-          sha256 = "1j6zgr9vfyqpdya8975sjh2ny70rqqyj9zbl63kldkirppnw995i";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/d4bbb2171c70958d5ab3730f974db3b07561a81b/recipes/perl6-mode";
-          sha256 = "0af1djypd8n0n1fq10sl8mrdg27354kg9g87d6xz4q5phvi48cqv";
-          name = "perl6-mode";
-        };
-        packageRequires = [ emacs pkg-info ];
-        meta = {
-          homepage = "https://melpa.org/#/perl6-mode";
           license = lib.licenses.free;
         };
       }) {};
@@ -55735,12 +53999,12 @@
     perspeen = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, powerline }:
     melpaBuild {
         pname = "perspeen";
-        version = "20170813.1754";
+        version = "20170916.404";
         src = fetchFromGitHub {
           owner = "seudut";
           repo = "perspeen";
-          rev = "6b3a3b0468199a8db10a73d119dfcd8833d181b6";
-          sha256 = "13rivw5rafl4pb68l500ksbzpz00yp7lx9wi9vy8nz0hwr80jd0p";
+          rev = "525f2f25358f17c7269c3750d56bfb8a6d59b5e6";
+          sha256 = "17nv33nl60jdn6cz6abbj6jxnvjcshaq4a22lkssxczp968k1qn3";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/perspeen";
@@ -55756,12 +54020,12 @@
     pfuture = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "pfuture";
-        version = "20170531.805";
+        version = "20170726.1502";
         src = fetchFromGitHub {
           owner = "Alexander-Miller";
           repo = "pfuture";
-          rev = "a6c32c69abdb9b91baf8036b88cc4f477f611bd5";
-          sha256 = "0ly38dzg754n4s2xs09kaisxs14ikm42d9sjhw9p9xirzqm7zd5j";
+          rev = "8b5cd8dfb8769d2b24484a313d3d21938afd3dfb";
+          sha256 = "1d63sfwy7qmldhq2xda9dglg91cy2kpjdr2rlmqb48w95wf0am3m";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5fb70c9f56a58b5c7a2e8b69b191aa2fc7c9bcc8/recipes/pfuture";
@@ -56908,25 +55172,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    plsql = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "plsql";
-        version = "20121115.243";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/plsql.el?revision=5";
-          sha256 = "1v0wvy9fd1qq3aq83x5jv3953n0n51x7y2r2ql11j0h8xasy42p1";
-          name = "plsql.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/eb457144c112a7a9de2fc4c634dfd6c2dda2e486/recipes/plsql";
-          sha256 = "1jvppmfdll34b8dav5dvbabfxiapv92p7lciblj59a707bbdb7l1";
-          name = "plsql";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/plsql";
-          license = lib.licenses.free;
-        };
-      }) {};
     plur = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "plur";
@@ -56972,8 +55217,8 @@
         version = "20170419.303";
         src = fetchgit {
           url = "https://git.savannah.gnu.org/git/gettext.git";
-          rev = "5ad8c92742daaf4434fded196ff23638cdaa621b";
-          sha256 = "1z3cy6n727lrsm8smksb48hbj2ckh4wri44c0423hdf84qp5ifg8";
+          rev = "b05d13f04990f6ed74637ee8bdb42fd1500974ac";
+          sha256 = "03bcknd6y6rhg6185bjga2idswq4p0d87jmyhkx2x56gdybpa9mr";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/caaa21f235c4864f6008fb454d0a970a2fd22a86/recipes/po-mode";
@@ -57007,6 +55252,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    pocket-lib = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, kv, lib, melpaBuild, request }:
+    melpaBuild {
+        pname = "pocket-lib";
+        version = "20171008.2135";
+        src = fetchFromGitHub {
+          owner = "alphapapa";
+          repo = "pocket-lib.el";
+          rev = "9f2a5dad867ef11d6629073ae4c8a43df1c03470";
+          sha256 = "1y97zlnxp0lxh21x51bdkvd8yxg59sxbq94s06vkvkbq2pjz86pp";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/71f17ce28f4fc8c2c100848be8aec15526ef8697/recipes/pocket-lib";
+          sha256 = "0v619blifmvm36dr773wjf35fjji4dj3pyck9nkz0m8zmpz0fg78";
+          name = "pocket-lib";
+        };
+        packageRequires = [ dash emacs kv request ];
+        meta = {
+          homepage = "https://melpa.org/#/pocket-lib";
+          license = lib.licenses.free;
+        };
+      }) {};
     pocket-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, pocket-api }:
     melpaBuild {
         pname = "pocket-mode";
@@ -57025,6 +55291,36 @@
         packageRequires = [ emacs pocket-api ];
         meta = {
           homepage = "https://melpa.org/#/pocket-mode";
+          license = lib.licenses.free;
+        };
+      }) {};
+    pocket-reader = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, kv, lib, melpaBuild, org-web-tools, ov, pocket-lib, rainbow-identifiers, s }:
+    melpaBuild {
+        pname = "pocket-reader";
+        version = "20171008.1411";
+        src = fetchFromGitHub {
+          owner = "alphapapa";
+          repo = "pocket-reader.el";
+          rev = "410add35782f037e4c42d3f740fb5623901ebf39";
+          sha256 = "1lchwlv32b5gfgkp2i3li3rk3w1xyz8axamz5mqs1imb6mkc1dws";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/835a7bf2f72987183e9d15ada7ae747fb5715c11/recipes/pocket-reader";
+          sha256 = "0gcgmz4mhjgvqbh2gmv8v09sy80cnfccjym455m0fbl31b8dczhf";
+          name = "pocket-reader";
+        };
+        packageRequires = [
+          dash
+          emacs
+          kv
+          org-web-tools
+          ov
+          pocket-lib
+          rainbow-identifiers
+          s
+        ];
+        meta = {
+          homepage = "https://melpa.org/#/pocket-reader";
           license = lib.licenses.free;
         };
       }) {};
@@ -57088,25 +55384,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/point-stack";
-          license = lib.licenses.free;
-        };
-      }) {};
-    point-undo = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "point-undo";
-        version = "20100504.129";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/point-undo.el?revision=6";
-          sha256 = "13c1iw77ccvrfrv4lyljg8fpm7xqhnv29yzvig8wr8b5j2vsd8bz";
-          name = "point-undo.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/ce31bd8f9a1ad4f3252f8cd4ef15984495df18bd/recipes/point-undo";
-          sha256 = "0by7ifj1lf0w9pp7v1j9liqjs40k8kk9yjnznxchq172816zbg3k";
-          name = "point-undo";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/point-undo";
           license = lib.licenses.free;
         };
       }) {};
@@ -57197,12 +55474,12 @@
     pomidor = callPackage ({ alert, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "pomidor";
-        version = "20170817.2253";
+        version = "20170925.2301";
         src = fetchFromGitHub {
           owner = "TatriX";
           repo = "pomidor";
-          rev = "58a4368d91d472aa47a83f498be82db8929cf41a";
-          sha256 = "1g6mwx6gq6zlzn06izic81qf2ppqprfmap5hgsksx1xbickkmwdx";
+          rev = "16bed77ff933cb5f8430b6eacf27509631d22072";
+          sha256 = "1w2ql67arjzzjakqm34gbs3vf6w9yzkw5kzi5vrvkcwajqq8qq56";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/4e0d4f313081594df23f357c40feb456847d8bd0/recipes/pomidor";
@@ -57302,12 +55579,12 @@
     pophint = callPackage ({ fetchFromGitHub, fetchurl, lib, log4e, melpaBuild, yaxception }:
     melpaBuild {
         pname = "pophint";
-        version = "20170403.701";
+        version = "20170917.1948";
         src = fetchFromGitHub {
           owner = "aki2o";
           repo = "emacs-pophint";
-          rev = "5d1db7c0b92862ba2cc5f3566b25840b8ce3ba59";
-          sha256 = "09av2krrmm8g3f3f31kl4j4agmmf8hx9irzrqyvgshljflk0nq1q";
+          rev = "909025c5a871ca4b9ec7aed7f1a27c819a94dba1";
+          sha256 = "0qbb36qijkzbzxlmqsvvddm7x2gk9rkafnyjbkxsl76rz1ajy6nz";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/0055c2887acbbd8a2803bf3f81ac2cc444cc805a/recipes/pophint";
@@ -57596,12 +55873,12 @@
     powerline = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "powerline";
-        version = "20170708.1442";
+        version = "20171008.2002";
         src = fetchFromGitHub {
           owner = "milkypostman";
           repo = "powerline";
-          rev = "8a246902e86a0c59015bb897a9c59be9729ef5c4";
-          sha256 = "1q90y0l0vdach8irb9cigw8w5nllvzv5hg8hd8ljpb4j9jhc5y5n";
+          rev = "b51217d52ea0b8b91b15783d364562b6668ac0d0";
+          sha256 = "0afhs8dpvlc29xpdgwm0jp1syyyraqipscxx89x1yi0idkgvxj29";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/f805053cd4dd9ed53ee0df17ad69429bc62325bb/recipes/powerline";
@@ -57653,44 +55930,6 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://melpa.org/#/powershell";
-          license = lib.licenses.free;
-        };
-      }) {};
-    pp-c-l = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "pp-c-l";
-        version = "20170307.939";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/pp-c-l.el?revision=25";
-          sha256 = "0q36bq82lp381jnzf8kapiiglqgibzkhsxlhpgfdg3ynbmw5i1cc";
-          name = "pp-c-l.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/pp-c-l";
-          sha256 = "0gbqxlrsh9lcdkrj8bqh1mpxyhdlwbaxz4ndp5s90inmisaqb83v";
-          name = "pp-c-l";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/pp-c-l";
-          license = lib.licenses.free;
-        };
-      }) {};
-    pp-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "pp-plus";
-        version = "20170307.938";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/pp+.el";
-          sha256 = "0a1dj9n3n81xal17djj15hqa71cqphjnf9k9z03vnpw8zq0m93lh";
-          name = "pp+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/pp+";
-          sha256 = "1ng5x7dp85y6yqj6q43h08qdnapg2j1ab8rmc47w4w79d1pryniq";
-          name = "pp-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/pp+";
           license = lib.licenses.free;
         };
       }) {};
@@ -57817,25 +56056,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/prettify-greek";
-          license = lib.licenses.free;
-        };
-      }) {};
-    pretty-lambdada = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "pretty-lambdada";
-        version = "20170307.940";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/pretty-lambdada.el?revision=15";
-          sha256 = "0b8m96hbqmgyqmv5f890fnyl9vl2wcsaz8w4b11wdprh82ravp4r";
-          name = "pretty-lambdada.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/pretty-lambdada";
-          sha256 = "16v5fgifz672c37xyzv557mm6za4rldvdrb26vdymxqg4fy62fd6";
-          name = "pretty-lambdada";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/pretty-lambdada";
           license = lib.licenses.free;
         };
       }) {};
@@ -58112,26 +56332,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    project-local-variables = callPackage ({ fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "project-local-variables";
-        version = "20080502.952";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/project-local-variables.el?revision=1";
-          sha256 = "1bb5b6hxg3gvwf0sqwkd97nnipsmr60py0rnsfhgvizn4cj3khhw";
-          name = "project-local-variables.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/project-local-variables";
-          sha256 = "1jys9nac2912jdv40fly1q4i30xa8b1v2ndbc50rk4ysarhbhdd9";
-          name = "project-local-variables";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/project-local-variables";
-          license = lib.licenses.free;
-        };
-      }) {};
     project-persist = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "project-persist";
@@ -58218,12 +56418,12 @@
     projectile = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, pkg-info }:
     melpaBuild {
         pname = "projectile";
-        version = "20170827.2053";
+        version = "20171008.135";
         src = fetchFromGitHub {
           owner = "bbatsov";
           repo = "projectile";
-          rev = "adf6ae2dbfbdca96aec49115ca35867006f326b1";
-          sha256 = "1x39v7lb63k2nfa4xyvkgvgxbd88jcqnwdmd78a86p5zc3m42zk9";
+          rev = "933fcbd849781ea5e0ace32b9dc655d00de7df06";
+          sha256 = "020j7cpa5ljblanf4y7xsr7gvz12b8cdgpy75k0hb4igc62qzkym";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ca7bf43ef8893bf04e9658390e306ef69e80a156/recipes/projectile";
@@ -58369,8 +56569,8 @@
         src = fetchFromGitHub {
           owner = "nlamirault";
           repo = "sift.el";
-          rev = "ef509ac4c579340e8d924c26d9e5858a9f4fb9de";
-          sha256 = "0i8gqzvpl3drzp031dqdpsi1ssr3az8fzb7xpbxnamzscfz6pdyc";
+          rev = "4ce8878a0fc396ded7521ce38852d93e1d863065";
+          sha256 = "1x78i6svi4cwah9xw85imhpncvxsx4xim4fzykpnd328mxkk07h6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a730e1331b0486c4bd2d309b85d2f8810489eb47/recipes/projectile-sift";
@@ -58428,12 +56628,12 @@
     projector = callPackage ({ alert, cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild, projectile }:
     melpaBuild {
         pname = "projector";
-        version = "20170717.1151";
+        version = "20171006.1258";
         src = fetchFromGitHub {
           owner = "waymondo";
           repo = "projector.el";
-          rev = "ec63167ee21d537f410c0971f82e2ffdfd6fa008";
-          sha256 = "155wnks7i73c3kvgysnfy0379d1fp78qv2b8lhsaxwx7jh356dbm";
+          rev = "03751fca880c95cf47e560c78cfc2aaa056cd455";
+          sha256 = "1yg9pcs6pbwd7a35q0jqjwnqwjqz4v5jd24msr51xh0v8kbs2v61";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/420ffea4549f59677a16c1ee89c77b866487e302/recipes/projector";
@@ -58642,8 +56842,8 @@
         src = fetchFromGitHub {
           owner = "google";
           repo = "protobuf";
-          rev = "06aa8dc9e730cc39c67d0ff9c0c95e645ccf03c9";
-          sha256 = "0na3apgapd78z57jfdwns35mflqgwjwbcj2lmspg9ipg0x191378";
+          rev = "77f64bb7779ec2195f9bc4dc82497d12c18fc6b7";
+          sha256 = "0176y1ikr6pi3paz4q588ka3c02al25fnbn0y09z10mi7nplrx85";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b4e7f5f641251e17add561991d3bcf1fde23467b/recipes/protobuf-mode";
@@ -58680,12 +56880,12 @@
     psc-ide = callPackage ({ cl-lib ? null, company, dash, dash-functional, emacs, fetchFromGitHub, fetchurl, flycheck, let-alist, lib, melpaBuild, s, seq }:
     melpaBuild {
         pname = "psc-ide";
-        version = "20170817.1206";
+        version = "20170923.250";
         src = fetchFromGitHub {
           owner = "epost";
           repo = "psc-ide-emacs";
-          rev = "fb3040a1204c4a6f7a54abc499fb88074627cb3e";
-          sha256 = "0fh2xv0rz5mkhqvcaj55wpx39f953qalz5v46v35nzmhc0fpmzab";
+          rev = "e577f84b938a1fb461a016540b06f5d5e399526a";
+          sha256 = "14q4bj7cfny1jwsvdjfsl88nhwh5al8hyvf4rxki9k2wim8lx2bv";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/384ffc463cc6edb4806f8da68bd251e662718e65/recipes/psc-ide";
@@ -58711,12 +56911,12 @@
     psci = callPackage ({ dash, f, fetchFromGitHub, fetchurl, lib, melpaBuild, purescript-mode, s }:
     melpaBuild {
         pname = "psci";
-        version = "20170818.1301";
+        version = "20170914.1048";
         src = fetchFromGitHub {
           owner = "purescript-emacs";
           repo = "emacs-psci";
-          rev = "875ea3231e4aceadf7718daef75a1426ff8e87e5";
-          sha256 = "11yihnlm7cawyhgava70xja8rf0gi6j1jf3z4x8ylf5wjj6fbbfc";
+          rev = "47a0ba79e7284c71bebd8abe753246badeb1251d";
+          sha256 = "1j2zbxk2d7yjpwhhv48j6qlsnmapk0858zrdiqpcicapddbsv66w";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3451719ce5096383db082917716a5ed8346fc186/recipes/psci";
@@ -58813,24 +57013,45 @@
           license = lib.licenses.free;
         };
       }) {};
-    pug-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    pug-mode = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "pug-mode";
-        version = "20170913.348";
+        version = "20171007.1642";
         src = fetchFromGitHub {
           owner = "hlissner";
           repo = "emacs-pug-mode";
-          rev = "3a3bdf96e64dc6f5d031bf0ed2b6002a600187ad";
-          sha256 = "02mx4gs8hlinrxm8jas9jy83kvglaqjz3sxn4m4hrrj07gz0si96";
+          rev = "971ccf8d380965a5268e499a8c8785f2fcdef6f4";
+          sha256 = "1zrs94vcp7yjz929x51243jf0lifb8kbxdzr3slkc5wbni5c5jk3";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b3710aac9f3df3a23238af1f969c462b3692f260/recipes/pug-mode";
           sha256 = "1njhr95y2rx7inpl9phxxz580844p2iadqlga1kj7xzvjz698x85";
           name = "pug-mode";
         };
-        packageRequires = [ emacs ];
+        packageRequires = [ cl-lib emacs ];
         meta = {
           homepage = "https://melpa.org/#/pug-mode";
+          license = lib.licenses.free;
+        };
+      }) {};
+    pulseaudio-control = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "pulseaudio-control";
+        version = "20171004.428";
+        src = fetchFromGitHub {
+          owner = "flexibeast";
+          repo = "pulseaudio-control";
+          rev = "f542adc0585e7890c11e478bf193ef6f3b1f6eac";
+          sha256 = "1h0li679pz683bsnbv08g8sr2q8slh12lad0v7qhyig1if3yh63w";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/7964f226e12c3a27ff856e28f4b030ebf304aea2/recipes/pulseaudio-control";
+          sha256 = "1vdhg85lbdx7sj1xg2vhhfmhrrp5q2x560agnsb0gxi2akp6z9r0";
+          name = "pulseaudio-control";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://melpa.org/#/pulseaudio-control";
           license = lib.licenses.free;
         };
       }) {};
@@ -58900,12 +57121,12 @@
     puppet-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, pkg-info }:
     melpaBuild {
         pname = "puppet-mode";
-        version = "20170719.752";
+        version = "20170928.1007";
         src = fetchFromGitHub {
           owner = "voxpupuli";
           repo = "puppet-mode";
-          rev = "fb1b683191d767eab312ea424de3517062d86420";
-          sha256 = "12kxxgm61myna4wf3hgai8dgrssc9dnv75fh2mbcgwqggbfv8wlv";
+          rev = "e04f041386ebfe29fc67c3407e85b577b820df4f";
+          sha256 = "0hcp7hmxri62qcx80zqphlhwrhzapzi0c07kk4l2cm75xfy20a2l";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1de94f0ab39ab18dfd0b050e337f502d894fb3ad/recipes/puppet-mode";
@@ -58921,12 +57142,12 @@
     purescript-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "purescript-mode";
-        version = "20161216.133";
+        version = "20170926.242";
         src = fetchFromGitHub {
           owner = "dysinger";
           repo = "purescript-mode";
-          rev = "c88126070c052d636f4dad5525846a1b200fce43";
-          sha256 = "1ndclsywvh5x06gmvk44zjlgfamdn55lygdgxf3x1vrznvr0jawy";
+          rev = "e2d6519a9669a1443db1040cf098bc3ea30ec861";
+          sha256 = "1k8q32ipa684hvk7iwpdzqwikimw8g3j6gkmz9yi5fxflq6z1swr";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/77175fa470e517fa134751fbb38e144eb5b979ff/recipes/purescript-mode";
@@ -59360,12 +57581,12 @@
     pyim = callPackage ({ async, cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, popup, pos-tip, pyim-basedict }:
     melpaBuild {
         pname = "pyim";
-        version = "20170901.2053";
+        version = "20170916.2024";
         src = fetchFromGitHub {
           owner = "tumashu";
           repo = "pyim";
-          rev = "54c05392e5a9523e34c7d54f8999632358f0ed89";
-          sha256 = "0cxyz8b1djsdd0pxy15aamxx8j4vxvakinmrrwm3k6saqx8frmr9";
+          rev = "d44db4cb74c1c0cf6f814ff14d0be8e733f8404a";
+          sha256 = "02b2aknx127xvl8amf74krvd7z33kyr049iw5h0665zkzsli4g8w";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/151a0af91a58e27f724854d85d5dd9668229fe8d/recipes/pyim";
@@ -59490,8 +57711,8 @@
         src = fetchFromGitHub {
           owner = "PyCQA";
           repo = "pylint";
-          rev = "e231a409a83a23c24c8b7dbbaca79314eee6d4c6";
-          sha256 = "0xkbhd2cgsmqkbkscaa758ngfg01cdym7qgh809wsa0j6xf058lp";
+          rev = "0b1b25a63f6d68a4dc21dbc47a0af79d3eed973e";
+          sha256 = "0n3ihw3p61y46a8njq1ah5gxb26m13aawqsciy944l203s305845";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a073c91d6f4d31b82f6bfee785044c4e3ae96d3f/recipes/pylint";
@@ -59633,12 +57854,12 @@
     python-mode = callPackage ({ fetchFromGitLab, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "python-mode";
-        version = "20170825.20";
+        version = "20171005.1620";
         src = fetchFromGitLab {
           owner = "python-mode-devs";
           repo = "python-mode";
-          rev = "e0fab065042a7e35b73928e94f32f649eac6a3af";
-          sha256 = "0vpzzfdr85zp2gsh148yp1b1aynwcgvva69r3qjj0cwm13f28492";
+          rev = "93345f0531b03c5bb2bf34417e9c25fc6fcda6d9";
+          sha256 = "016igycxn7h3gjklr24a7yhp49y4h55f4hpd05haq9raj7vaa6qf";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/82861e1ab114451af5e1106d53195afd3605448a/recipes/python-mode";
@@ -59696,12 +57917,12 @@
     python-x = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, folding, lib, melpaBuild, python ? null }:
     melpaBuild {
         pname = "python-x";
-        version = "20161029.531";
+        version = "20171006.336";
         src = fetchFromGitHub {
           owner = "wavexx";
           repo = "python-x.el";
-          rev = "ef749fe2d3e58d5f6d7f32453d06964786c085d5";
-          sha256 = "1nncinrwh0nqy8wn1q8yzi15nf15gj576ccsp5l28951gjgkc6s9";
+          rev = "9bf0d16cfe7b5f24b98d6b33cbc8763edaceb174";
+          sha256 = "0x255lnfyv2i7yz6ipx5adazqmvgmf4mdcixzs1wv85gazmbgfc5";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/87ed5ea4868945df1bf92d1eae5d3ebb83ece117/recipes/python-x";
@@ -59738,12 +57959,12 @@
     pyvenv = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "pyvenv";
-        version = "20170826.812";
+        version = "20171005.1106";
         src = fetchFromGitHub {
           owner = "jorgenschaefer";
           repo = "pyvenv";
-          rev = "fc1e9c1fbac00460a32435390b94a8ce4f5542ce";
-          sha256 = "0ckam3mkx44hrdykrhvm147xvw09rn328byl6dcpd3ygdqamwpdk";
+          rev = "9f528449dfc35516647118689a2104603f23b49c";
+          sha256 = "11yznfndkbyl6cmi7blxrr5yw9b32qw01abhvsj8jz1g1wnxhn45";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/e37236b89b9705ba7a9d134b1fb2c3c003953a9b/recipes/pyvenv";
@@ -60095,12 +58316,12 @@
     racket-mode = callPackage ({ emacs, faceup, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "racket-mode";
-        version = "20170913.509";
+        version = "20170913.534";
         src = fetchFromGitHub {
           owner = "greghendershott";
           repo = "racket-mode";
-          rev = "d57b3a6c64835fe334501bb2b1f8e370be777d90";
-          sha256 = "11mh94lcmwh0qb68lyqmdkannq9p9y3j32mmwc23q88z1z7vvbf6";
+          rev = "33877b1bb24faea68842e0396bd5718b84e47451";
+          sha256 = "0681mzwx08zwbh8qg3s26jw1jn4fw2ljp1akxqkhy08sxhafqvb1";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/7ad88d92cf02e718c9318d197dd458a2ecfc0f46/recipes/racket-mode";
@@ -60200,12 +58421,12 @@
     rainbow-delimiters = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "rainbow-delimiters";
-        version = "20160430.2358";
+        version = "20170929.432";
         src = fetchFromGitHub {
           owner = "Fanael";
           repo = "rainbow-delimiters";
-          rev = "93cd2dc873e7fedca7abc599cd97d46db4376ac7";
-          sha256 = "0vs9pf8lqq5p5qz1770pxgw47ym4xj8axxmwamn66br59mykdhv0";
+          rev = "19b93892afa0494ba749c2ca9c154e04447ad778";
+          sha256 = "0c2a8pbhzzy0bxx8gxz320r106k69hvwkn43j06i6sidbgjwh786";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d2cf11dbff76f0e3581b865f48bb44a307aa7f23/recipes/rainbow-delimiters";
@@ -60242,12 +58463,12 @@
     rake = callPackage ({ cl-lib ? null, dash, f, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "rake";
-        version = "20161114.605";
+        version = "20170921.801";
         src = fetchFromGitHub {
           owner = "asok";
           repo = "rake";
-          rev = "e680f1a8f2591af7c80cad188340601b101b5ddc";
-          sha256 = "1dk2clsnmjy3bfv6laxf8sslvdajjbwpk83ss8v9xm55dcxjvd7n";
+          rev = "a27322262ebcce7765574b577000f6f939400206";
+          sha256 = "1fzlll8s5vri5hmqsx5ilbrms73b0rsn3k6m5dgq6rhgn5z5k6r1";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/bf0f84698dda02a5b84a244ee29a23a6faa9de68/recipes/rake";
@@ -60557,12 +58778,12 @@
     rdf-prefix = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "rdf-prefix";
-        version = "20170514.859";
+        version = "20170915.1200";
         src = fetchFromGitHub {
           owner = "simenheg";
           repo = "rdf-prefix";
-          rev = "35129521d5b6035e5dd75d5b3481ce4971f46034";
-          sha256 = "1iy9385n8a2b7ph4wdf8p92n81slirsxxckrc3khbk5zrpp62z5k";
+          rev = "25cc3c8902f16191496b549705b00ffc7dff51f1";
+          sha256 = "00ycsqzgn5rq8r4r86z1j43i2a7wj4r3c2vcggdaizyf4parmgmy";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a5f083bd629697038ea6391c7a4eeedc909a5231/recipes/rdf-prefix";
@@ -60704,12 +58925,12 @@
     real-auto-save = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "real-auto-save";
-        version = "20150701.815";
+        version = "20170918.730";
         src = fetchFromGitHub {
           owner = "chillaranand";
           repo = "real-auto-save";
-          rev = "81bf61742ea553ccdee0e22d3abb43fcf07f82cf";
-          sha256 = "1kghhps8mqys5l59qwzv3fgy1fvb15cnyaxmk29v818a6khjc5l2";
+          rev = "780d6c1c219e1f1efde1159a99af97b1c54c005d";
+          sha256 = "1wcyvyc3nwr9a89v8i4wmqvy2fwf7x7f3kcj7a8kdnp2albkvwsa";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/525039a3dc29190829bf50d608ef09bc4a8557af/recipes/real-auto-save";
@@ -60725,12 +58946,12 @@
     realgud = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, load-relative, loc-changes, melpaBuild, test-simple }:
     melpaBuild {
         pname = "realgud";
-        version = "20170907.916";
+        version = "20171006.1840";
         src = fetchFromGitHub {
           owner = "rocky";
           repo = "emacs-dbgr";
-          rev = "f41b7a7f8eac0be5c4d8780af1d461f9e51e9cad";
-          sha256 = "1k3xsidc05dls9scsi7vvrrqlfgqk343crgh89amg066s5p55s6y";
+          rev = "081f7edc79a8e510d47e10c6ce4306b2f850df1f";
+          sha256 = "0nj95w5jfck0lhnrrnrl6h31cvgnpizbhnr52k7mf360vwrsjil6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/7ca56f05df6c8430a5cbdc55caac58ba79ed6ce5/recipes/realgud";
@@ -60875,25 +59096,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    recentf-ext = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "recentf-ext";
-        version = "20161210.840";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/recentf-ext.el?revision=5";
-          sha256 = "0pzimhqkrdg2s9zw7ysir740cmaycf6fjs08bmlfjads7vdbjfpg";
-          name = "recentf-ext.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/5a36ac5e0fc3599d50d7926cacf16b7a315f0e76/recipes/recentf-ext";
-          sha256 = "1m54w1n3ci5j7i1jhw6cs7dgzmxrj1hsrrarqlrd1d4iqhixjzbq";
-          name = "recentf-ext";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/recentf-ext";
-          license = lib.licenses.free;
-        };
-      }) {};
     recompile-on-save = callPackage ({ cl-lib ? null, dash, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "recompile-on-save";
@@ -60918,12 +59120,12 @@
     recover-buffers = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "recover-buffers";
-        version = "20150812.5";
+        version = "20171008.2137";
         src = fetchFromGitHub {
           owner = "tripleee";
           repo = "recover-buffers";
-          rev = "a1db7f084977697081da3497628e3514e032b966";
-          sha256 = "114ssmby614xjs7mrpbbsdd4gj5ra6klfh8h6z8iij8xn3kii83q";
+          rev = "81a5cb53099955ebc2a411a44cba5a394ee3f2d1";
+          sha256 = "07dfdvz5rn5l13xdycd7h75zaq0pw2afb9n1yiq01fqk6gvrhc5b";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/43b33cfb794c35de78fde6eabb71ffe01049d23d/recipes/recover-buffers";
@@ -61020,25 +59222,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    redo-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "redo-plus";
-        version = "20131117.351";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/redo+.el";
-          sha256 = "1jc4n60spzssa57i3jwrqwy20f741hb271vmmx49riycx1ybx3d3";
-          name = "redo+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/redo+";
-          sha256 = "0v7nrn6fbjx4mb0xsnkvqxk2hp35wfy83si5bavwwym4jcb5pl2r";
-          name = "redo-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/redo+";
-          license = lib.licenses.free;
-        };
-      }) {};
     redpen-paragraph = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, json ? null, lib, melpaBuild }:
     melpaBuild {
         pname = "redpen-paragraph";
@@ -61063,12 +59246,12 @@
     redprl = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "redprl";
-        version = "20170903.911";
+        version = "20171008.409";
         src = fetchFromGitHub {
           owner = "RedPRL";
           repo = "sml-redprl";
-          rev = "f96a5a50354cdc8a83b8fe347fafc49ad6c303a0";
-          sha256 = "0pq0730b8nxm4xhb3dilnmp7lhv8vb83q7860dc64mds3fl12fg0";
+          rev = "887d32fa14ec6e9e024e50077c119b95b22d91d3";
+          sha256 = "1ibrqnnnsqplgx2hdj3jf8jcg3dwc01d50pkfb75wwi1w2xvsjmk";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/06e7371d703ffdc5b6ea555f2ed289e57e71e377/recipes/redprl";
@@ -61078,26 +59261,6 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://melpa.org/#/redprl";
-          license = lib.licenses.free;
-        };
-      }) {};
-    redshank = callPackage ({ fetchgit, fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "redshank";
-        version = "20120510.1230";
-        src = fetchgit {
-          url = "http://www.foldr.org/~michaelw/projects/redshank.git";
-          rev = "f98e68f532e622bcd464292ca4a9cf5fbea14ebb";
-          sha256 = "1jdkgvd5xy9hl5q611jwah2n05abjp7qcy9sj4k1z11x0ii62b6p";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/f2cf21b79d47a4bc154ac15f8111794ca9eeac16/recipes/redshank";
-          sha256 = "07s4gja1w8piabkajbzrgq77mkdkxr0jy9bmy2qb9w2svfsyns9b";
-          name = "redshank";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/redshank";
           license = lib.licenses.free;
         };
       }) {};
@@ -61457,25 +59620,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    replace-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "replace-plus";
-        version = "20170801.1947";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/replace+.el";
-          sha256 = "0vlk2sjszzzkf94vfgb52ck4qbqp9ll1kdlxnmxixjxxl8iciwzj";
-          name = "replace+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/replace+";
-          sha256 = "1imsgr3v8g2p2mnkzp92ga3nvckr758pblmlha8gh8mb80089krn";
-          name = "replace-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/replace+";
-          license = lib.licenses.free;
-        };
-      }) {};
     replace-symbol = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "replace-symbol";
@@ -61770,25 +59914,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    reveal-next = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "reveal-next";
-        version = "20170101.1120";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/reveal-next.el?revision=7";
-          sha256 = "0vqacr3q9n772qmyyj35dxkqp79yqrpfhlf8zj70jzg04xzy6f0m";
-          name = "reveal-next.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/38e5dd845c99acaae719562595059154a08a5f00/recipes/reveal-next";
-          sha256 = "0fp6ssd4fad0s2pbxbw75bnx7fcgasig8xvcx7nls8m9p6zbbmh2";
-          name = "reveal-next";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/reveal-next";
-          license = lib.licenses.free;
-        };
-      }) {};
     reverse-im = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "reverse-im";
@@ -61873,41 +59998,22 @@
           license = lib.licenses.free;
         };
       }) {};
-    rfringe = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "rfringe";
-        version = "20110405.820";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/rfringe.el?revision=1";
-          sha256 = "02i5znln0aphvmvaia3sz75bvjhqwyjq1blf5qkcbprnn95lm3yh";
-          name = "rfringe.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/rfringe";
-          sha256 = "16a647gvvn5nzgng7a8pam4ay6aifvhldaxg2xfz9fcafzkvw967";
-          name = "rfringe";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/rfringe";
-          license = lib.licenses.free;
-        };
-      }) {};
-    rg = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, s, seq }:
+    rg = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "rg";
-        version = "20170908.2359";
+        version = "20170930.653";
         src = fetchFromGitHub {
           owner = "dajva";
           repo = "rg.el";
-          rev = "adfdf6230f02f469a1b508922b6837f95f6434d2";
-          sha256 = "0bk0caadn3wq2ck2acyvdssllw45l455binpm5i3i63nzs73v8r2";
+          rev = "1a4ebe8bf2e1052a1a8dde3dcbfedb802ca070fb";
+          sha256 = "1lpb22ggw17d8bx2gjmaxqk5rbf64gh8llvf9shl18r813d3srrb";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/9ce1f721867383a841957370946f283f996fa76f/recipes/rg";
           sha256 = "0i78qvqdznh1z3b0mnzihv07j8b9r86dc1lsa1qlzacv6a2i9sbm";
           name = "rg";
         };
-        packageRequires = [ cl-lib emacs s seq ];
+        packageRequires = [ cl-lib emacs s ];
         meta = {
           homepage = "https://melpa.org/#/rg";
           license = lib.licenses.free;
@@ -61983,8 +60089,8 @@
         src = fetchFromGitHub {
           owner = "wavexx";
           repo = "rigid-tabs.el";
-          rev = "d48ba58acbe8934700cd23db2acb574b09306238";
-          sha256 = "03dmyn5lnw0mj4ymgyxz6gksl2byw31plxn61qcggkj6gk8g500d";
+          rev = "eba84ceaba2e57e76ad2dfbb7a7154238a25d956";
+          sha256 = "18rba101m9vmjl4mf3x0k7wvbgn6qmay9la745vzpr3lx1f4nn98";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/689b0060ee5db505fc0ed4603aca204b2d3c63a2/recipes/rigid-tabs";
@@ -62000,12 +60106,12 @@
     rimero-theme = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "rimero-theme";
-        version = "20170819.648";
+        version = "20171001.821";
         src = fetchFromGitHub {
           owner = "yveszoundi";
           repo = "emacs-rimero-theme";
-          rev = "451b9d30f7ef711ee8c9c304677c7dcac6c57cfb";
-          sha256 = "0442s4pj8v4ympf8nk1zgrvk3d16djgdhknlvkwi296db3zixbc4";
+          rev = "2c15da5a4d56f1b29db2fc178d387eb86e7abd39";
+          sha256 = "0pvykjz0a2jgq2dghhshc4w7852jrlk0vy35ppbn956yp7rq9sx3";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c6d07b0c021001195e6e0951c890566a5a784ce1/recipes/rimero-theme";
@@ -62105,12 +60211,12 @@
     rjsx-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, js2-mode, lib, melpaBuild }:
     melpaBuild {
         pname = "rjsx-mode";
-        version = "20170808.634";
+        version = "20171009.608";
         src = fetchFromGitHub {
           owner = "felipeochoa";
           repo = "rjsx-mode";
-          rev = "39474fe464d76112e278445996cfd4ff84c39af8";
-          sha256 = "11wz3gqdyb4ffsy9qdria0515ry643g3yjzidvaqccx6g59g4d5x";
+          rev = "487ce00922571f84918e99ade678fe83d55bd6e0";
+          sha256 = "1q396gzpqba7a4knnnx5pjwgbdh7r4q8ac7f81z9mp624w2zlgam";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b83be7efdef2457e1320fe3dec46484fbd20263c/recipes/rjsx-mode";
@@ -62189,12 +60295,12 @@
     rope-read-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "rope-read-mode";
-        version = "20170620.237";
+        version = "20171003.719";
         src = fetchFromGitHub {
           owner = "marcowahl";
           repo = "rope-read-mode";
-          rev = "bbb67d54a31ce238e4a8b1aae677ef055aea27ba";
-          sha256 = "1l00km1rrnybskv0rv0kqxdrqimmfwz4mmil64m2d6vl0nqickb0";
+          rev = "77b183a6f5450138388509f54a6a2ce442766e50";
+          sha256 = "0ddm7gwr51ip8mc79jxkvp52sxhlvs0kyy59v7r7pf5mbadbpsbz";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/14a674559aa485e92357a8b941304ae8167b9c3e/recipes/rope-read-mode";
@@ -62336,12 +60442,12 @@
     rtags = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "rtags";
-        version = "20170903.1710";
+        version = "20171006.1343";
         src = fetchFromGitHub {
           owner = "Andersbakken";
           repo = "rtags";
-          rev = "2af4d6a32e8194f8fbcc23fd94395e3d595a3c25";
-          sha256 = "0091w529lvbjlw1fdb3qjgb8fd5fcwxhqyr4ps5cvxl5bqnwlw39";
+          rev = "12636847b1ea512ce2d0c1075a74465f38555e69";
+          sha256 = "12v3wr2103293fkglbkhp20m2z72n66qka2s5zpcgc3jwqyqnnf9";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3dea16daf0d72188c8b4043534f0833fe9b04e07/recipes/rtags";
@@ -62396,42 +60502,24 @@
           license = lib.licenses.free;
         };
       }) {};
-    ruby-additional = callPackage ({ emacs, fetchsvn, fetchurl, lib, melpaBuild, ruby-mode ? null }:
+    ruby-additional = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, ruby-mode ? null }:
     melpaBuild {
         pname = "ruby-additional";
-        version = "20161115.2259";
-        src = fetchsvn {
-          url = "https://svn.ruby-lang.org/repos/ruby/trunk/misc/";
-          rev = "59866";
-          sha256 = "05rkz2wvyr00rr6g5sc2jgx1v2m81cbf24gjazxw4i9b3sf55ykr";
+        version = "20171001.2106";
+        src = fetchFromGitHub {
+          owner = "emacsorphanage";
+          repo = "ruby-additional";
+          rev = "14f380893cb7c1d9ddbb4ed1a2fc280999c82fde";
+          sha256 = "07mbjnph72l52f0bgz6qn5pbnfiyjx5p1ranq5g4csbfpx9jcc3s";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/ruby-additional";
-          sha256 = "1x5574swmch89jz2jiq6g34igp94bivzld0lb1nhyb1i3v1msq6i";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/30de78c9cf83de30093a5647976eeaf552d4b2cb/recipes/ruby-additional";
+          sha256 = "1ivxn787k64q5jl0dxmxbj240ykcyvfhfam5fdvrwvc3yysk2dx7";
           name = "ruby-additional";
         };
         packageRequires = [ emacs ruby-mode ];
         meta = {
           homepage = "https://melpa.org/#/ruby-additional";
-          license = lib.licenses.free;
-        };
-      }) {};
-    ruby-block = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "ruby-block";
-        version = "20131210.1931";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/ruby-block.el?revision=12";
-          sha256 = "0c4vy9xsw44g6q9nc8aaav5avgp34h24mvgcnww468afiimivdcq";
-          name = "ruby-block.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/e2149ce3baef9ac01d5b2e8b1a933a3e1206015f/recipes/ruby-block";
-          sha256 = "0jfimjq1xpwxkxya452kp27h0fdiy87aj713w3zsm04k7l6i12hm";
-          name = "ruby-block";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/ruby-block";
           license = lib.licenses.free;
         };
       }) {};
@@ -62585,12 +60673,12 @@
     ruby-test-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, pcre2el, ruby-mode ? null }:
     melpaBuild {
         pname = "ruby-test-mode";
-        version = "20170515.1008";
+        version = "20171006.944";
         src = fetchFromGitHub {
           owner = "r0man";
           repo = "ruby-test-mode";
-          rev = "740ff1a7c81eb8380fd0f0cdb7c32238acf13dd1";
-          sha256 = "1a7lhx7ibh9rrxdamxwd107npnmsf9sxbksvy9rm8l3rnm8yjnvy";
+          rev = "9a686e6e18ac2d56be41020ed9d0814cdfe86330";
+          sha256 = "02m0kaw86p6qmn6jxcq6vqbbp2v57b2dnj75fqai1dz2f521dh0g";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/ruby-test-mode";
@@ -62642,6 +60730,27 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://melpa.org/#/rufo";
+          license = lib.licenses.free;
+        };
+      }) {};
+    run-stuff = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "run-stuff";
+        version = "20170813.1957";
+        src = fetchFromGitHub {
+          owner = "ideasman42";
+          repo = "emacs-run-stuff";
+          rev = "2e23a78c26f62141142c743febd57ec54c78c0e3";
+          sha256 = "04m7hpda5hbmr0dni4cnpdjxwzk3sygpr5m158gswhbwh2p4r0j4";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/0d6e9ce2acd859b887f7e161f4b9969be1a0b8ef/recipes/run-stuff";
+          sha256 = "0zx96m6cval5g4p0lhy9kpyycp2jygaq3y2njhkpij9gl4nb2ll2";
+          name = "run-stuff";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/run-stuff";
           license = lib.licenses.free;
         };
       }) {};
@@ -62711,12 +60820,12 @@
     rust-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "rust-mode";
-        version = "20170827.1300";
+        version = "20170920.1919";
         src = fetchFromGitHub {
           owner = "rust-lang";
           repo = "rust-mode";
-          rev = "c8280aea1d02ae84bff2a6f02f8dc7701309c8b6";
-          sha256 = "105ayzqkcd8q2zhny1x84gdry6mfp92zfa8ihfqlfvva6ax6v1vp";
+          rev = "eae291ab7b3e1a52e158261d1192ea1ca2b332f4";
+          sha256 = "0g68yy281v232f3f8k9r16nqxlirkb52yca1wknng57addma4cjv";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/8f6e5d990d699d571dccbdeb13327b33389bb113/recipes/rust-mode";
@@ -62795,12 +60904,12 @@
     s = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "s";
-        version = "20170906.1304";
+        version = "20170922.900";
         src = fetchFromGitHub {
           owner = "magnars";
           repo = "s.el";
-          rev = "3a95064647d1f39b90e65a56f1fdfceb7c329f75";
-          sha256 = "0n2c6islny418pfmaz1bjij1j2s1qailga0vha32qanx4fx7yf3v";
+          rev = "12f116d58ac03706496bd682c6449b452681874e";
+          sha256 = "1g8mqd13llj007al4nlxxx4z2lcsg3wk970mgjn0avwrhjjgdmmv";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/s";
@@ -62831,6 +60940,27 @@
         packageRequires = [ noflet s ];
         meta = {
           homepage = "https://melpa.org/#/s-buffer";
+          license = lib.licenses.free;
+        };
+      }) {};
+    s12cpuv2-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "s12cpuv2-mode";
+        version = "20170828.1901";
+        src = fetchFromGitHub {
+          owner = "AdamNiederer";
+          repo = "s12cpuv2-mode";
+          rev = "446696222fec364442fa7a52f523be10bb5cff68";
+          sha256 = "1l8950p4bakgxwd61n9agiyi15s1l09r1rnrijl4dnyv6vxmwghl";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/6c1b9bbdc4deb17636270c7f2be0b43b647c695a/recipes/s12cpuv2-mode";
+          sha256 = "0mrcf5s7vmkyrsdka7qd2vfcmdy8hzf6a6g14la88rxrv4chv29s";
+          name = "s12cpuv2-mode";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/s12cpuv2-mode";
           license = lib.licenses.free;
         };
       }) {};
@@ -62904,8 +61034,8 @@
         src = fetchFromGitHub {
           owner = "glynnforrest";
           repo = "salt-mode";
-          rev = "ea4980b9c9e8e7570086a2558fe7f66c62a528ad";
-          sha256 = "0ygi9kzkfqzizygaqwqpymn8s7kr8ci38v61qmy4n58n9c19fdwx";
+          rev = "a41c07660199cfad3f9dd928d5674d2727508035";
+          sha256 = "0y7z4lfvhd1aiyhy0yhrx9jdjsy2k1di6y747rjmf0rlwcq2gb2q";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/9dcf1a93a06fc42581521c88cfd988b03bedc000/recipes/salt-mode";
@@ -63484,25 +61614,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    screenshot = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "screenshot";
-        version = "20120509.405";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/screenshot.el?revision=8";
-          sha256 = "0q7yxaaa0fic4d2xwr0qk28clkinwz4xvw3wf8dv1g322s0xx2cw";
-          name = "screenshot.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/24f113097db4cc27a2e9c7b9086af6d263e6fcb7/recipes/screenshot";
-          sha256 = "0aw2343as38y26r2g7wpn1rq1n6xpw4y5c7ir8qh1crkc1y513hs";
-          name = "screenshot";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/screenshot";
-          license = lib.licenses.free;
-        };
-      }) {};
     scribble-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "scribble-mode";
@@ -63569,12 +61680,12 @@
     sdcv = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, popup, pos-tip, showtip }:
     melpaBuild {
         pname = "sdcv";
-        version = "20170801.2216";
+        version = "20171002.210";
         src = fetchFromGitHub {
           owner = "stardiviner";
           repo = "sdcv.el";
-          rev = "ebe45a5fb1e465cb4150e4dbe38a069b2a218219";
-          sha256 = "0pcbrzii9x7v3qqygr29yi6pg1gvzjbsgcfziispsf24n01lrrly";
+          rev = "1aad9defb871dc07e27f603092bb81413be54cf2";
+          sha256 = "1ij7inm1f59hmn9s1iqnywk1acfm0pqiim2s36vwrljy9lnb4ls8";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/173e233b2dacaaf54d92f3bcc06e54d068520dd4/recipes/sdcv";
@@ -63668,25 +61779,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/seclusion-mode";
-          license = lib.licenses.free;
-        };
-      }) {};
-    second-sel = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "second-sel";
-        version = "20170702.729";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/second-sel.el?revision=29";
-          sha256 = "1yq06a04j44r019cjv2jb3kfpfqhnxdf3b4hhz4d3fz7v1hsicwg";
-          name = "second-sel.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/second-sel";
-          sha256 = "1nzy5ms5qf5big507kg3z5m6d6zgnsv2fswn359r2j59cval3fvr";
-          name = "second-sel";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/second-sel";
           license = lib.licenses.free;
         };
       }) {};
@@ -63959,26 +62051,6 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://melpa.org/#/sequences";
-          license = lib.licenses.free;
-        };
-      }) {};
-    sequential-command = callPackage ({ fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "sequential-command";
-        version = "20151207.1403";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/sequential-command.el?revision=3";
-          sha256 = "0vg8rqzzi29swznhra2mnf45czr2vb77dpcxn3j0fi7gynx3wcwk";
-          name = "sequential-command.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/31db031dc8712e89042d4ce80438a4267a241739/recipes/sequential-command";
-          sha256 = "03qybacgy5fs3lam73x0rds4f68s173mhbah6rr97272nikd50v1";
-          name = "sequential-command";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/sequential-command";
           license = lib.licenses.free;
         };
       }) {};
@@ -64507,17 +62579,19 @@
           license = lib.licenses.free;
         };
       }) {};
-    shimbun = callPackage ({ fetchcvs, fetchurl, lib, melpaBuild }: melpaBuild {
+    shimbun = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
         pname = "shimbun";
-        version = "20170503.1327";
-        src = fetchcvs {
-          cvsRoot = ":pserver:anonymous@cvs.namazu.org:/storage/cvsroot";
-          module = "emacs-w3m";
-          sha256 = "6ef1dd834a16cf3b8a0ec7a7412ae7410f0392d616eb3329f78011039384fc6d";
+        version = "20171003.2158";
+        src = fetchFromGitHub {
+          owner = "emacsorphanage";
+          repo = "w3m";
+          rev = "284a4cdd394d2d52220c62c24ddbce00ea100471";
+          sha256 = "1fnxb3fn6a25sn41isf3frja5iwxi98cbs7rvp9mkzb4jq3bhb89";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/8bbb18b0db057b9cca78ae7280674fd1beb56443/recipes/shimbun";
-          sha256 = "05dxdyh8xvbpjmc19q733jmjd6kgv8rdahjd3bw5wwsb3smqig4x";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/30de78c9cf83de30093a5647976eeaf552d4b2cb/recipes/shimbun";
+          sha256 = "1rjykr0y5jfd6r3shm8x23yyra6qjsb55jrfc45rhpb89klyg1nk";
           name = "shimbun";
         };
         packageRequires = [];
@@ -64607,25 +62681,6 @@
         packageRequires = [ fm ];
         meta = {
           homepage = "https://melpa.org/#/show-marks";
-          license = lib.licenses.free;
-        };
-      }) {};
-    showkey = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "showkey";
-        version = "20170307.1528";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/showkey.el?revision=11";
-          sha256 = "143889knvy6ifvq759869gbjfg10k10mi2by2hajcgzqhby72h61";
-          name = "showkey.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/showkey";
-          sha256 = "04lw32k1imvpfc4dr5pz11sx74982xr13hcyblvrz1zxhgixb1z1";
-          name = "showkey";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/showkey";
           license = lib.licenses.free;
         };
       }) {};
@@ -64758,12 +62813,12 @@
     shx = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "shx";
-        version = "20170805.1619";
+        version = "20171004.1113";
         src = fetchFromGitHub {
           owner = "riscy";
           repo = "shx-for-emacs";
-          rev = "8166b02ebbab43d8a33d47b8221a94b69fc63487";
-          sha256 = "0n97iys2xyg1lzkn8bqsx0sgqpzci1pxg69v42cpzmyrz3h54bwp";
+          rev = "e53d798ba4a4c07a3ee1c194840c937b18c02087";
+          sha256 = "0sig9gpa2wn23skwny9jpvwxax0gbwp143anvgkc5gm87iw2jgrd";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/7a2ff78ae3c4289ebf9e06cdfd8f8082c395a16f/recipes/shx";
@@ -64804,8 +62859,8 @@
         src = fetchFromGitHub {
           owner = "nlamirault";
           repo = "sift.el";
-          rev = "ef509ac4c579340e8d924c26d9e5858a9f4fb9de";
-          sha256 = "0i8gqzvpl3drzp031dqdpsi1ssr3az8fzb7xpbxnamzscfz6pdyc";
+          rev = "4ce8878a0fc396ded7521ce38852d93e1d863065";
+          sha256 = "1x78i6svi4cwah9xw85imhpncvxsx4xim4fzykpnd328mxkk07h6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/sift";
@@ -64947,12 +63002,12 @@
     simple-httpd = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "simple-httpd";
-        version = "20170125.1910";
+        version = "20171004.938";
         src = fetchFromGitHub {
           owner = "skeeto";
           repo = "emacs-web-server";
-          rev = "348483efea6ec2752bc5aa4028a16087d19b2809";
-          sha256 = "191aq4zhg5a8g6ypkbh20rnqyk76lhxfhnq5ww0g5hzpig8srxaa";
+          rev = "e7775d3bc5c6b73255814d0a62dc954e23a12c15";
+          sha256 = "0pjhxhzzxrpcczwvd7b6a6q1nfmsr6m6mnlxn13nwf3r270grz87";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/7fabdb05de9b8ec18a3a566f99688b50443b6b44/recipes/simple-httpd";
@@ -64983,26 +63038,6 @@
         packageRequires = [ s ];
         meta = {
           homepage = "https://melpa.org/#/simple-mpc";
-          license = lib.licenses.free;
-        };
-      }) {};
-    simple-plus = callPackage ({ fetchurl, lib, melpaBuild, strings }:
-    melpaBuild {
-        pname = "simple-plus";
-        version = "20170307.1529";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/simple+.el";
-          sha256 = "061vw3w8gl1lcjy67ina4w496i91addsl5s3xbffk2q6k1qhjsdi";
-          name = "simple+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/simple+";
-          sha256 = "12fsgjk53fq2316j8nm6wvdckpyg9hq3v65j5c52i0g0cwmx62ra";
-          name = "simple-plus";
-        };
-        packageRequires = [ strings ];
-        meta = {
-          homepage = "https://melpa.org/#/simple+";
           license = lib.licenses.free;
         };
       }) {};
@@ -65261,12 +63296,12 @@
     slack = callPackage ({ alert, circe, emojify, fetchFromGitHub, fetchurl, lib, melpaBuild, oauth2, request, websocket }:
     melpaBuild {
         pname = "slack";
-        version = "20170903.2004";
+        version = "20170927.2004";
         src = fetchFromGitHub {
           owner = "yuya373";
           repo = "emacs-slack";
-          rev = "5df0ea55257b2c1f3a4e4352af4854fb81dee5cc";
-          sha256 = "0xrmsfi1nzm5yhmsxhn7xq87z70jkb68c3il4xf8r4lz6a0d8m4p";
+          rev = "5fabc901a316569ab84edaf7ea3aa7143ab91796";
+          sha256 = "076yk65wyqgcqd9w8d4pgada0hsdlb58gvcldhvirlqsbmvjp9wl";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/f0258cc41de809b67811a5dde3d475c429df0695/recipes/slack";
@@ -65324,12 +63359,12 @@
     slime = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, macrostep, melpaBuild }:
     melpaBuild {
         pname = "slime";
-        version = "20170828.451";
+        version = "20170929.1441";
         src = fetchFromGitHub {
           owner = "slime";
           repo = "slime";
-          rev = "f223388c78ea51ce7717e9bbae14c50ad2386c2c";
-          sha256 = "07jks9fnqjv2i9sjfpgj7r3a7g5aha4aipsffjbnw1qd930ygw83";
+          rev = "c5fa94f86b61f3a14a7348b4fa001a0e1c62cef2";
+          sha256 = "0y9n40knm1r3z0kx0xd5yda5191m5s2ibsxb2sa23qp1yj2qs6xm";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/14c60acbfde13d5e9256cea83d4d0d33e037d4b9/recipes/slime";
@@ -65366,12 +63401,12 @@
     slime-docker = callPackage ({ cl-lib ? null, docker-tramp, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, slime }:
     melpaBuild {
         pname = "slime-docker";
-        version = "20170718.1157";
+        version = "20171004.1151";
         src = fetchFromGitHub {
           owner = "daewok";
           repo = "slime-docker";
-          rev = "dc41f7c33de497bc622f037f33ea2a1ecfa1069f";
-          sha256 = "169vy9wjkf0vzqgdbm30rssl82xl2n73hipnaidncbw9sd8cpx1y";
+          rev = "13fa8be2fca516f3ff5fb70fa79dd8404bf86439";
+          sha256 = "005zkypg2hkyzpkcv1rzfrmg8amg1bp0534y13xjqq3rz1p602bx";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/15ec3f7208287161571c8fc3b29369ceabb44e5f/recipes/slime-docker";
@@ -65492,12 +63527,12 @@
     sly = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "sly";
-        version = "20170912.445";
+        version = "20170928.1829";
         src = fetchFromGitHub {
           owner = "capitaomorte";
           repo = "sly";
-          rev = "ac50082050df5274a5d71e182abca0d0b0fe71d1";
-          sha256 = "14cknfz1nnk82svdp92sq6cdpndd5d25l7fgd5zi2l4j5i57rj0b";
+          rev = "6f7d1c5e5d51100c573f3e5b6d3eb1eabe3dfaa2";
+          sha256 = "1684agg19nxc9mirpkr062z9ycri2d78nr9hg8y7kgkq814vbbsi";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/79e7213183df892c5058a766b5805a1854bfbaec/recipes/sly";
@@ -65953,12 +63988,12 @@
     smartparens = callPackage ({ cl-lib ? null, dash, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "smartparens";
-        version = "20170913.130";
+        version = "20171005.541";
         src = fetchFromGitHub {
           owner = "Fuco1";
           repo = "smartparens";
-          rev = "7d368051dec40e8e129d84bca5070bb7e83ad72a";
-          sha256 = "1rbwjmp71wh234qrjss00xgcnh8jcha19lmz15nwrrwvpmmspg0c";
+          rev = "456b78c5b7af52f84701aea0ad51a9d6d7de23d5";
+          sha256 = "1b5mp87qjyjs0d2mn9rz0iy6qmdmhkb8699ddlbjxrmid2s8g73h";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/bd98f85461ef7134502d4f2aa8ce1bc764f3bda3/recipes/smartparens";
@@ -66289,12 +64324,12 @@
     snakemake-mode = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, magit-popup, melpaBuild }:
     melpaBuild {
         pname = "snakemake-mode";
-        version = "20170430.1436";
+        version = "20170920.1454";
         src = fetchFromGitHub {
           owner = "kyleam";
           repo = "snakemake-mode";
-          rev = "8a4da1125dd284e55139084d62fb29af5bcbcc20";
-          sha256 = "1c85ycaqyrncp7pbax6mdnz1v91hpi1pc9jspd6irwhhs8b9jxfk";
+          rev = "9a29ca3f5c7302a67f969b10defeb75e2fda688a";
+          sha256 = "1hskg4llb0wfdmzgnanbvppbjj55zkifh2yan5rvzkkwma1vb2ry";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c3a5b51fee1c9e6ce7e21555faa355d118d34b8d/recipes/snakemake-mode";
@@ -66391,22 +64426,22 @@
           license = lib.licenses.free;
         };
       }) {};
-    snoopy = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    snoopy = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "snoopy";
-        version = "20170730.1951";
+        version = "20171008.1304";
         src = fetchFromGitHub {
           owner = "anmonteiro";
           repo = "snoopy-mode";
-          rev = "8adce636376812df99bd79f3fbb3d9ec19a02351";
-          sha256 = "04sq37bpvg6lqsqmjvdm9jzwrq4xhbakfzl5b2rcm3mlhzwnhs88";
+          rev = "ec4123bdebfe0bb7bf4feaac2dc02b59caffe386";
+          sha256 = "01l44lshw0zvykay9886s1vqryanagkd4ciw3ramchn0baqz11vl";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/4a882cd92964ac195a09469006c9a44dc202f000/recipes/snoopy";
           sha256 = "1wa8jykqyj6rxqfhwbiyli6yh8s7n0pqv7fc9sfaymarda93zbgi";
           name = "snoopy";
         };
-        packageRequires = [ emacs ];
+        packageRequires = [ cl-lib emacs ];
         meta = {
           homepage = "https://melpa.org/#/snoopy";
           license = lib.licenses.free;
@@ -66520,12 +64555,12 @@
     solarized-theme = callPackage ({ cl-lib ? null, dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "solarized-theme";
-        version = "20170831.1159";
+        version = "20170924.1440";
         src = fetchFromGitHub {
           owner = "bbatsov";
           repo = "solarized-emacs";
-          rev = "ae7bc3f102cff597092dad7fc0bfd49e1865b0cf";
-          sha256 = "0d4cs7s2k5plf2ya0df72pvpf30xdhdbfybm0179dma4fw9fx0is";
+          rev = "a2595627a793c57fa904ac210a6ca07fe1fef656";
+          sha256 = "1q65mrarmqxsvc27flr6wy6v3yrmpw5i6hax95hh6y50zx3hfsd1";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/cae2ac3513e371a256be0f1a7468e38e686c2487/recipes/solarized-theme";
@@ -66541,12 +64576,12 @@
     solidity-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "solidity-mode";
-        version = "20170712.1442";
+        version = "20171001.926";
         src = fetchFromGitHub {
           owner = "ethereum";
           repo = "emacs-solidity";
-          rev = "e4aa0190145d5cfad7d3f052ba44c88a1ebb6c7f";
-          sha256 = "1dh2av9grij2v179vfr2pric6bxibxbg34ij3488ki9crc2zpv4y";
+          rev = "d0a09c68912fcd03e384b0b2a9746f4e002d0df8";
+          sha256 = "0zs16af2j6l0vypgikvs78x82cq8m5yfdfpi550cymkv7mjydj4v";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/bb9df5ec0692352b6494d435d11166f4ea26c99e/recipes/solidity-mode";
@@ -66562,12 +64597,12 @@
     sonic-pi = callPackage ({ cl-lib ? null, dash, emacs, fetchFromGitHub, fetchurl, highlight, lib, melpaBuild, osc }:
     melpaBuild {
         pname = "sonic-pi";
-        version = "20170313.810";
+        version = "20171002.343";
         src = fetchFromGitHub {
           owner = "repl-electric";
           repo = "sonic-pi.el";
-          rev = "494981aa8f7828392a930ef8533698944738090e";
-          sha256 = "1x9qn6b4nbld9v0r7vi3mg6w7nsa76pzyn1fl118n14a8kkc0is7";
+          rev = "f4bb7abafea564c97d3b9a28b1b2c3858191674f";
+          sha256 = "1xdv94k830a70hi8cmvv2gxzybk16cfsf5my8c1b2kw7041a074q";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/sonic-pi";
@@ -66646,12 +64681,12 @@
     sotclojure = callPackage ({ cider, clojure-mode, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, sotlisp }:
     melpaBuild {
         pname = "sotclojure";
-        version = "20170512.612";
+        version = "20170921.1708";
         src = fetchFromGitHub {
           owner = "Malabarba";
           repo = "speed-of-thought-clojure";
-          rev = "84e2be5939c33d44f9518aea60cfccff4d6c9707";
-          sha256 = "1jz3lscjq8xfkrx464a1s8vyggnh5sjl8jvq8dvx0w7blny2jvz8";
+          rev = "ceac82aa691e8d98946471be6aaff9c9a4603c32";
+          sha256 = "1a6riq7ksk5m76dsgc75d8b992nyr50l48l8cpms9064m6b0r9jv";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3a2ccef8af91eada4449d9cd4bda6bd28272722e/recipes/sotclojure";
@@ -66905,12 +64940,12 @@
     spacemacs-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "spacemacs-theme";
-        version = "20170823.1658";
+        version = "20170918.1246";
         src = fetchFromGitHub {
           owner = "nashamri";
           repo = "spacemacs-theme";
-          rev = "30b198ce87a92777f74e34ddee775b99d05b46c3";
-          sha256 = "0a77y9njks44xx1c5j0cxpgkqwlz6lrzkbph3qwnbzkydnbyxgiy";
+          rev = "7900aca87f9d96bd6ebaa62886e4ab135bf449b3";
+          sha256 = "0kai39mqx0i2b46vcf5g2la8q65sp1pb8vnzfjwzv0qip4p9fd62";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6c8ac39214856c1598beca0bd609e011b562346f/recipes/spacemacs-theme";
@@ -67007,25 +65042,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    speck = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "speck";
-        version = "20160717.951";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/speck.el?revision=12";
-          sha256 = "0zn7gjrga1ly1za04jd4s61m1dwkyy960x7g3x9hn4szqvpcsvfa";
-          name = "speck.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/speck";
-          sha256 = "06x5543pwqazs4airj43208caw3sxw7zb148njbn33qgl09r1iv6";
-          name = "speck";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/speck";
-          license = lib.licenses.free;
-        };
-      }) {};
     speech-tagger = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "speech-tagger";
@@ -67074,8 +65090,8 @@
         src = fetchFromGitHub {
           owner = "parkouss";
           repo = "speed-type";
-          rev = "5d691f57743304db63b6afdc5bd79dabd282d390";
-          sha256 = "08qp2b80rh9k8h5vv141lfsg73rqqikhh7ygal789rr278ai1rjf";
+          rev = "9940383d94688e7f130b01f9872182ab59edf00f";
+          sha256 = "0gfiw3rmqyargc1prkrglmzvzxm03nszqqba1q9zd7cs0m315pmm";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d6c33b5bd15875baea0fd2f24ee8ec9414a6f7aa/recipes/speed-type";
@@ -67466,25 +65482,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    sqlplus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "sqlplus";
-        version = "20170710.150";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/sqlplus.el?revision=26";
-          sha256 = "19lrk1a9d9ljdnsiar5cgmp68c26b6aihi3rbgf3d5bcg9iqbp7q";
-          name = "sqlplus.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/41b1fc299cf8eeba1916a58ad8f50eb4560f0252/recipes/sqlplus";
-          sha256 = "1z9pf36b1581flykis9cjv7pynnp94fm4ijzjy6hvqyj81aikxpz";
-          name = "sqlplus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/sqlplus";
-          license = lib.licenses.free;
-        };
-      }) {};
     sqlup-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "sqlup-mode";
@@ -67635,12 +65632,12 @@
     ssh-deploy = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "ssh-deploy";
-        version = "20170907.305";
+        version = "20170926.315";
         src = fetchFromGitHub {
           owner = "cjohansson";
           repo = "emacs-ssh-deploy";
-          rev = "72a503394ee43023100a6f2624ad40a4325f5938";
-          sha256 = "0ss1q3ywznkj180rndpi3zrcxz3bgm3a87wx194xyq5dzijaydw5";
+          rev = "af7f33c85fe7d8e6c597fe5c674b1c7bf8ce2bfd";
+          sha256 = "0n1h510v1bkq4yrmfyhih2721yagfb2slm97b0vpjfp3f94m2nvz";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/ssh-deploy";
@@ -67845,12 +65842,12 @@
     steam = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "steam";
-        version = "20160427.231";
+        version = "20171008.1327";
         src = fetchFromGitHub {
           owner = "Kungsgeten";
           repo = "steam.el";
-          rev = "a0547487ccf40aa582af3dd0d433a1b153d25246";
-          sha256 = "142jamr8mi1nkjvivvkh2qgh5fch89xpg5wwi8q0b6hcqcsy8nqn";
+          rev = "476da75cce7def2f3323e4a112a500728178e71e";
+          sha256 = "1d23m611p001i846ypv9mz78hqn4wmjnh6cwa2yif9h6m44g1dsf";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/25a45eb6297168cd0ce4c4db5574362addad5c69/recipes/steam";
@@ -67902,25 +65899,6 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://melpa.org/#/stem-english";
-          license = lib.licenses.free;
-        };
-      }) {};
-    sticky = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "sticky";
-        version = "20101129.1852";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/sticky.el?revision=4";
-          sha256 = "18izyia1j3w2c07qhkp9h6rnvw35m5k1brrrjhm51fpdv2xj65fy";
-          name = "sticky.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/1c3a9689703b8c8edbffdc966cded9ea98fc8762/recipes/sticky";
-          sha256 = "1xjkdwphq3m4jrazsfnzrrcrqikfdxzph3jdzkpbzk3grd4af96w";
-          name = "sticky";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/sticky";
           license = lib.licenses.free;
         };
       }) {};
@@ -68068,25 +66046,6 @@
         packageRequires = [ list-utils ];
         meta = {
           homepage = "https://melpa.org/#/string-utils";
-          license = lib.licenses.free;
-        };
-      }) {};
-    strings = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "strings";
-        version = "20170307.1533";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/strings.el?revision=49";
-          sha256 = "08sq20ys4xkkg11jyrnlzibl5v73i7zlnj28ygivy3sqvp07z7iz";
-          name = "strings.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/strings";
-          sha256 = "0n3239y7biq3rlg74m7nqimhf654w4snnw2zm7z84isgwzz2dphk";
-          name = "strings";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/strings";
           license = lib.licenses.free;
         };
       }) {};
@@ -68298,25 +66257,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    subr-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "subr-plus";
-        version = "20170501.916";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/subr+.el";
-          sha256 = "1vrs390vqcsjwzf6pzcvqjc3mliac66g7g5kifvz9zp0v3bq6x7d";
-          name = "subr+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/subr+";
-          sha256 = "17i5sgsv8clh3pzpkv5zvhmm584m1rvsypd6nh6ks2jpidwgs8x1";
-          name = "subr-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/subr+";
-          license = lib.licenses.free;
-        };
-      }) {};
     sudo-edit = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "sudo-edit";
@@ -68383,12 +66323,12 @@
     suggest = callPackage ({ dash, emacs, f, fetchFromGitHub, fetchurl, lib, loop, melpaBuild, s }:
     melpaBuild {
         pname = "suggest";
-        version = "20170806.1414";
+        version = "20171007.930";
         src = fetchFromGitHub {
           owner = "Wilfred";
           repo = "suggest.el";
-          rev = "6ae090cab9bc16650c1788e83ccd2fe95a959de2";
-          sha256 = "1rnp7zwr5j345l569zhpskf7g6bkg0jmplzjwy79rlv3h3d6rv4d";
+          rev = "f9cd0db1c62073b5dacefad20483f181c2d8d019";
+          sha256 = "0xhj6x1c9r69sw6xw9kdvdhkvmr000mnmw7ihqmy6fkar945046f";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b9fd27e812549587dc2ec26bb58974177ff263ff/recipes/suggest";
@@ -68419,25 +66359,6 @@
         packageRequires = [ emacs popup ];
         meta = {
           homepage = "https://melpa.org/#/suggestion-box";
-          license = lib.licenses.free;
-        };
-      }) {};
-    summarye = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "summarye";
-        version = "20130328.327";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/summarye.el?revision=4";
-          sha256 = "0q5m8d6p9aqbfx17zgznkqw2jgh027xix4894wrdz91670zxd3py";
-          name = "summarye.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/85e28911e6b8173188f45331c6540681691223f2/recipes/summarye";
-          sha256 = "1znd96ixg1n90yjiny84igb7m8qsbiibn7s6bky8g6n2k7zzmq65";
-          name = "summarye";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/summarye";
           license = lib.licenses.free;
         };
       }) {};
@@ -68507,12 +66428,12 @@
     super-save = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "super-save";
-        version = "20160426.729";
+        version = "20171008.3";
         src = fetchFromGitHub {
           owner = "bbatsov";
           repo = "super-save";
-          rev = "701c98eef4b9b21cd6cfd31f190f9988d32353aa";
-          sha256 = "1frm90kssrp4s6x0g4vq4jkssh8rnrfjbgwa05igsjnsbnnfxxd1";
+          rev = "1c8fbd5e18277e4af0ada2678a854b1c9072db38";
+          sha256 = "0mh7xp71l9xybbv17b1rsbpa60bwjw79ql9krj1kzy2c2pv9hmff";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/9730b65787b26d3909952cf246a01bd349e5fbab/recipes/super-save";
@@ -68553,8 +66474,8 @@
         src = fetchFromGitHub {
           owner = "TheSuspiciousWombat";
           repo = "SusColors-emacs";
-          rev = "8f5cdf8de5e58db838ef0e803b60b7d74fc2a889";
-          sha256 = "1wc4l7zvb8zmh48cgrl7bkbyfj0sflzq28sc8jssghkcl2735cbg";
+          rev = "b946e7924aa02fa7441c970026898f17fe97601f";
+          sha256 = "0553fgiyjy2n3wa2agwzvadf6il85waf2vjpsy75ljj6lw8glhka";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6f26b8281f9bd05e3c8f2ef21838275711e622c9/recipes/suscolors-theme";
@@ -68672,25 +66593,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    swbuff-x = callPackage ({ fetchurl, lib, melpaBuild, swbuff }: melpaBuild {
-        pname = "swbuff-x";
-        version = "20130607.314";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/swbuff-x.el?revision=9";
-          sha256 = "1fkicyjvanh8yk2y27sq075sarcyqhsdz0r4xhillpnv34ji98r5";
-          name = "swbuff-x.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/42bac16fa83eb3df693835326444f4bd4255cf1d/recipes/swbuff-x";
-          sha256 = "1wglcxgfr839lynwsl8i7fm70sxxjidy3ib6ibz0kgiwr41rh49y";
-          name = "swbuff-x";
-        };
-        packageRequires = [ swbuff ];
-        meta = {
-          homepage = "https://melpa.org/#/swbuff-x";
-          license = lib.licenses.free;
-        };
-      }) {};
     sweetgreen = callPackage ({ cl-lib ? null, dash, fetchFromGitHub, fetchurl, helm, lib, melpaBuild, request }:
     melpaBuild {
         pname = "sweetgreen";
@@ -68715,12 +66617,12 @@
     swift-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, seq }:
     melpaBuild {
         pname = "swift-mode";
-        version = "20170909.430";
+        version = "20170918.51";
         src = fetchFromGitHub {
           owner = "chrisbarrett";
           repo = "swift-mode";
-          rev = "59dcd603848656c691f76cc5095ea354c307dbcf";
-          sha256 = "127xx6qmxlh81pylrvx60d280ginms09qv24xv5g8lg08bi9zmkx";
+          rev = "e8d9a5d7af59e8be25997b8b048d7c3e257cd0b0";
+          sha256 = "035478shf1crb1qnhk5rmz08xgn0z2p6fsw0yii1a4q5f3h85xrc";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/19cb133191cd6f9623e99e958d360113595e756a/recipes/swift-mode";
@@ -68757,12 +66659,12 @@
     swiper = callPackage ({ emacs, fetchFromGitHub, fetchurl, ivy, lib, melpaBuild }:
     melpaBuild {
         pname = "swiper";
-        version = "20170911.1036";
+        version = "20170926.937";
         src = fetchFromGitHub {
           owner = "abo-abo";
           repo = "swiper";
-          rev = "0a1d361b926291874124f8c63a653d83ead64a36";
-          sha256 = "0ssbsllpv0lyr7dhnipwd7zgpxvfm36rldr7vkxh5maajdkamls7";
+          rev = "6827edffb70890f2e94c3d146ed129bde581992d";
+          sha256 = "0xwf8q73xisi1072dkkvf181sf9a7a6j9b9g24ismc3fn0q7216k";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/e64cad81615ef3ec34fab1f438b0c55134833c97/recipes/swiper";
@@ -68799,12 +66701,12 @@
     switch-buffer-functions = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "switch-buffer-functions";
-        version = "20160702.2157";
+        version = "20171004.2056";
         src = fetchFromGitHub {
           owner = "10sr";
           repo = "switch-buffer-functions-el";
-          rev = "4778a2bc9ecfb71bb2b6a65c7108260ec8f30a37";
-          sha256 = "0xv57imh6w6kbh1i1ib9k9x2h01l4vdxs2i667a76ym6dmsjbx2x";
+          rev = "ce61a74a88bf64afa699d20ed27b8be4cc63f80a";
+          sha256 = "1bdcsgbnyabkrri296dgb5q42vjb1v0yji2la5ir6sfxmhw0mrb6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d37ebd28f4a2f770958bd9a2669cce86cc76cbe7/recipes/switch-buffer-functions";
@@ -69027,25 +66929,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    synonyms = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "synonyms";
-        version = "20170307.1537";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/synonyms.el?revision=63";
-          sha256 = "0456mmp3niljpghqcngknqkrxmpkba3n95ab4pf0b0021z2zjyxk";
-          name = "synonyms.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/synonyms";
-          sha256 = "1b000scgba310i7w27c8wj0iflqqgwik524ql084wpqvikwqnlzm";
-          name = "synonyms";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/synonyms";
-          license = lib.licenses.free;
-        };
-      }) {};
     synosaurus = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "synosaurus";
@@ -69088,22 +66971,22 @@
           license = lib.licenses.free;
         };
       }) {};
-    syntactic-close = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    syntactic-close = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "syntactic-close";
-        version = "20170907.6";
+        version = "20171004.1037";
         src = fetchFromGitHub {
           owner = "emacs-berlin";
           repo = "syntactic-close";
-          rev = "143faf5ecd6388f4ea76d668b4814415befcf883";
-          sha256 = "0dwanswsyxhi7izah9qm6jzl5yvfany62f5m80r9kfkhcq68hyx9";
+          rev = "e2cd1f332d111b0e90d9a72f35bc969c7638b7cf";
+          sha256 = "18fq9v1kb6bx0xxd1cic2f3gfwv82y4mjs5qg7q2ra1cz5d502w9";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/f2c15c0c8ee37a1de042a974c6daddbfa7f33f1d/recipes/syntactic-close";
           sha256 = "19lrzxxyzdj1nrzdgzandjz3b8b4pw7akbv86yf0mdf023d9as1f";
           name = "syntactic-close";
         };
-        packageRequires = [];
+        packageRequires = [ cl-lib emacs ];
         meta = {
           homepage = "https://melpa.org/#/syntactic-close";
           license = lib.licenses.free;
@@ -69195,12 +67078,12 @@
     systemd = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "systemd";
-        version = "20170911.625";
+        version = "20171006.1352";
         src = fetchFromGitHub {
           owner = "holomorph";
           repo = "systemd-mode";
-          rev = "a3d39214b70c3dde0be12a53260e3fa470530ad6";
-          sha256 = "1wvf7m6j73y0aavz14f0xjmqs7hxbw0ifzxw5hdvhsw8bsvagbmi";
+          rev = "22f024fe8f433af7b6a6b99520cea1e766894fe5";
+          sha256 = "11h1nr9gz0mw2gwlplv00i06s9ziw77a7zfcrrzd01rmanz1m4fa";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ca810e512c357d1d0130aeeb9b46b38c595e3351/recipes/systemd";
@@ -69467,12 +67350,12 @@
     tangotango-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "tangotango-theme";
-        version = "20150702.104";
+        version = "20170924.809";
         src = fetchFromGitHub {
           owner = "juba";
           repo = "color-theme-tangotango";
-          rev = "08c3b9270547970dbce2cb1e35e66f6ae380c8b2";
-          sha256 = "11xb7xpmxvgv7mrjd2vlbjz3h5fa541aydv6bdxngjq6y3qn6wsp";
+          rev = "e2f2ea9c35f06dfc43a29c91c14cf0cdb19f2144";
+          sha256 = "01gvsvha8z7pyr8c33gh3xmz47lh6b8g0nwf1gzdiw1gd0sfhs4z";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ebfcfa3ba4ca77443667a9478d59214810cd8cc2/recipes/tangotango-theme";
@@ -69513,8 +67396,8 @@
         src = fetchFromGitHub {
           owner = "phillord";
           repo = "tawny-owl";
-          rev = "f103ace956d5e7039cf0785d93c2956bd7bea4f4";
-          sha256 = "0w82lzig3fy4p59rjj5dgi15mlmx6v4s6vm3z58rj65ql7qfzf88";
+          rev = "a8fc8300481a1e033a3811ccda54e552392d1689";
+          sha256 = "1lkldr6rr21f97vp6kms2ha8hsszhmba4sn07is4k55lpvlnxd49";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ea9a114ff739f7d6f5d4c3167f5635ddf79bf60c/recipes/tawny-mode";
@@ -69933,8 +67816,8 @@
         src = fetchFromGitHub {
           owner = "davidshepherd7";
           repo = "terminal-here";
-          rev = "5e440c33a1d24762477863af5c9b7a896df4be1b";
-          sha256 = "0kqn3gzm5q37d2iz0wk2xcl7qlmqkblwy8zdc7plc6syldnh91aj";
+          rev = "b17f82e894d5b0f77cea04a64c4f398124eb3290";
+          sha256 = "0aawmlzy1w76lajz5lxaix793j3bni3fyb4sws3v765m1rxhnc5c";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/f8df6f7e23476eb52e7fdfbf9de277d3b44db978/recipes/terminal-here";
@@ -69950,12 +67833,12 @@
     tern = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, json ? null, lib, melpaBuild }:
     melpaBuild {
         pname = "tern";
-        version = "20161222.850";
+        version = "20170925.1333";
         src = fetchFromGitHub {
           owner = "ternjs";
           repo = "tern";
-          rev = "cbbc2167cabc185c151fcfb32b2094b93b387422";
-          sha256 = "02vwq91ra4yrx0davi6sri0hh7p3fbwwz8flqrk5kaxz1rwqgq20";
+          rev = "5c395b5d696aad5a185724f56c74a7f83349f3bd";
+          sha256 = "11sp1jz0fn8gnc28qvyrmc7qxr1gn5r3vxv6gp46p7cmgg9mflri";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/eaecd67af24050c72c5df73c3a12e717f95d5059/recipes/tern";
@@ -69975,8 +67858,8 @@
         src = fetchFromGitHub {
           owner = "ternjs";
           repo = "tern";
-          rev = "cbbc2167cabc185c151fcfb32b2094b93b387422";
-          sha256 = "02vwq91ra4yrx0davi6sri0hh7p3fbwwz8flqrk5kaxz1rwqgq20";
+          rev = "5c395b5d696aad5a185724f56c74a7f83349f3bd";
+          sha256 = "11sp1jz0fn8gnc28qvyrmc7qxr1gn5r3vxv6gp46p7cmgg9mflri";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/eaecd67af24050c72c5df73c3a12e717f95d5059/recipes/tern-auto-complete";
@@ -70136,6 +68019,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    tex-smart-umlauts = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "tex-smart-umlauts";
+        version = "20160427.58";
+        src = fetchFromGitHub {
+          owner = "emacsorphanage";
+          repo = "tex-smart-umlauts";
+          rev = "5261b931443558f4252489a1e6616034848aff02";
+          sha256 = "1rq1l52mgbasgwvjwpivjrfjf8l8r85wdkfpbw8213449qh9c9zh";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/30de78c9cf83de30093a5647976eeaf552d4b2cb/recipes/tex-smart-umlauts";
+          sha256 = "05q5mzl0pya682hdmjyp09hh121dc5y4d5vgqjffx3yfd5kgsy5w";
+          name = "tex-smart-umlauts";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://melpa.org/#/tex-smart-umlauts";
+          license = lib.licenses.free;
+        };
+      }) {};
     textile-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "textile-mode";
@@ -70241,25 +68145,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    tfs = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "tfs";
-        version = "20120508.1120";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/tfs.el?revision=9";
-          sha256 = "16byw8ix7bjh5ldr8rymisq2bhc5sh7db6rhpf0x28yd6mmzn73v";
-          name = "tfs.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/tfs";
-          sha256 = "0h38qd1xhfd0my26i6w5j1jr91r5qal8x4bp7ij1cym72yxspna6";
-          name = "tfs";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/tfs";
-          license = lib.licenses.free;
-        };
-      }) {};
     theme-changer = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "theme-changer";
@@ -70320,64 +68205,6 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://melpa.org/#/therapy";
-          license = lib.licenses.free;
-        };
-      }) {};
-    thesaurus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "thesaurus";
-        version = "20121125.1137";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/thesaurus.el?revision=6";
-          sha256 = "0zcyasdzb7dvmld8418cy2mg8mpdx01bv44cm0sp5950scrypsaq";
-          name = "thesaurus.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/thesaurus";
-          sha256 = "1cnna27dlragk4w3f59xbrwppp49r010qdn7n3n7wvhibv3cfyd7";
-          name = "thesaurus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/thesaurus";
-          license = lib.licenses.free;
-        };
-      }) {};
-    thing-cmds = callPackage ({ fetchurl, hide-comnt, lib, melpaBuild }:
-    melpaBuild {
-        pname = "thing-cmds";
-        version = "20170726.1355";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/thing-cmds.el?revision=58";
-          sha256 = "07z49csdlrf08h8d8p9n8j492r22s7wgpzjwafppbsm4mvgshmq9";
-          name = "thing-cmds.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/thing-cmds";
-          sha256 = "133bm2cw9ar6m2amj0rrq4wbj9c3zl61gaprx0vlasxj2cyxs7yw";
-          name = "thing-cmds";
-        };
-        packageRequires = [ hide-comnt ];
-        meta = {
-          homepage = "https://melpa.org/#/thing-cmds";
-          license = lib.licenses.free;
-        };
-      }) {};
-    thingatpt-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "thingatpt-plus";
-        version = "20170307.1539";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/thingatpt+.el";
-          sha256 = "1k9y354315gvhbdk0m9xpjx24w1bwrnzlnfiils8xgdwnw4py99a";
-          name = "thingatpt+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/thingatpt+";
-          sha256 = "0w031lzjl5phvzsmbbxn2fpziwkmdyxsn08h6b9lxbss1prhx7aa";
-          name = "thingatpt-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/thingatpt+";
           license = lib.licenses.free;
         };
       }) {};
@@ -70472,8 +68299,8 @@
         src = fetchFromGitHub {
           owner = "apache";
           repo = "thrift";
-          rev = "1744cdcb674a20c554ae9f23cb95c0c8eff63b90";
-          sha256 = "12zclwdqr1v2pbp0i4d5m2bgr7s20bm5yyjpakg61sx5nld2j9sg";
+          rev = "9f9e30b51e3912c0b63258badf5501d3cb2550be";
+          sha256 = "1pxjsql4d02igqzz4qk5mc1l8as9myfml28bg9q2bqcjsl6rh0s9";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/857ab7e3a5c290265d88ebacb9685b3faee586e5/recipes/thrift";
@@ -70483,26 +68310,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/thrift";
-          license = lib.licenses.free;
-        };
-      }) {};
-    thumb-frm = callPackage ({ fetchurl, frame-cmds, frame-fns, lib, melpaBuild }:
-    melpaBuild {
-        pname = "thumb-frm";
-        version = "20170307.1540";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/thumb-frm.el?revision=62";
-          sha256 = "1mfz4gkq71sp9q7pa8q0md36g7x0dpsqz0np507dx2kypzqhklpd";
-          name = "thumb-frm.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/thumb-frm";
-          sha256 = "1fjjd80drm8banni909lww9zqazr1kk9m40xwwa1ln2zicaf091c";
-          name = "thumb-frm";
-        };
-        packageRequires = [ frame-cmds frame-fns ];
-        meta = {
-          homepage = "https://melpa.org/#/thumb-frm";
           license = lib.licenses.free;
         };
       }) {};
@@ -70530,12 +68337,12 @@
     tide = callPackage ({ cl-lib ? null, dash, fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild, s, typescript-mode }:
     melpaBuild {
         pname = "tide";
-        version = "20170911.521";
+        version = "20171008.2022";
         src = fetchFromGitHub {
           owner = "ananthakumaran";
           repo = "tide";
-          rev = "af6adf6170e23a44ba773e07899ec602ae659663";
-          sha256 = "0y8kfibip9saa9mh1bhgnqjzkx0yyss1z1ssxq1qvndnq8sp4rpz";
+          rev = "e5d1d3852aaf63cbfb0abaec1792a62bed024a72";
+          sha256 = "1kwssyzbjwl2vyll0p49l57z41yv6k1jnzbsdnh0d1h81nixg5wk";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a21e063011ebbb03ac70bdcf0a379f9e383bdfab/recipes/tide";
@@ -70545,25 +68352,6 @@
         packageRequires = [ cl-lib dash flycheck s typescript-mode ];
         meta = {
           homepage = "https://melpa.org/#/tide";
-          license = lib.licenses.free;
-        };
-      }) {};
-    tidy = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "tidy";
-        version = "20111222.956";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/tidy.el?revision=9";
-          sha256 = "0psci55a3angwv45z9i8wz8jw634rxg1xawkrb57m878zcxxddwa";
-          name = "tidy.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/bf079dbd04675ecd5f511b940d7cc5f80ccc94c4/recipes/tidy";
-          sha256 = "09xb2k3k99hp3m725f31s6hlaxgl4fsaa1dylahxvdfddhbh290m";
-          name = "tidy";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/tidy";
           license = lib.licenses.free;
         };
       }) {};
@@ -70852,12 +68640,12 @@
     toc-org = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "toc-org";
-        version = "20170518.451";
+        version = "20171009.156";
         src = fetchFromGitHub {
           owner = "snosov1";
           repo = "toc-org";
-          rev = "5a8a3f9b3a1440eb207a031685b7f4d77ef05b76";
-          sha256 = "0cwc7l8vf6x62s7727a6zr099zxgbbgnqkb2y60js6bys2mxqv99";
+          rev = "4d259c9cea3f575e5210974c025ebe3d51cc317f";
+          sha256 = "04y7zib1wpxswkh7srxgh4bq25cpsybpi2aaynrwjms695ggh346";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1305d88eca984a66039444da1ea64f29f1950206/recipes/toc-org";
@@ -70873,12 +68661,12 @@
     todotxt = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "todotxt";
-        version = "20160919.2238";
+        version = "20170919.1141";
         src = fetchFromGitHub {
           owner = "rpdillon";
           repo = "todotxt.el";
-          rev = "c0d0e8320ba9284710d46941eaf6847f909b589e";
-          sha256 = "08fd5lk1gq9clxhz5i81qm5f0a20yrx49iy13bx1p59gj20f1z41";
+          rev = "afa4079f15f705a4fa34ea8e14b122e73028f285";
+          sha256 = "07rhjxl8kvsjf23kxyl6xj51a2z1r66h4bsdsfj7nncavvybzqn3";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/todotxt";
@@ -71101,44 +68889,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    tool-bar-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "tool-bar-plus";
-        version = "20170307.1542";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/tool-bar+.el";
-          sha256 = "09myj10ifjjc43invxbiinskv5xllkqvqfnzmc7893k2hp2miczm";
-          name = "tool-bar+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/tool-bar+";
-          sha256 = "07nsas600w5kxx7yzg52ax9avry8kq429mqlrs38jg5ycf3b1l6d";
-          name = "tool-bar-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/tool-bar+";
-          license = lib.licenses.free;
-        };
-      }) {};
-    top-mode = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "top-mode";
-        version = "20130605.1039";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/top-mode.el?revision=3";
-          sha256 = "0a5rl1cgznycqwx4r48mh69lgm8ixbnlfzbqdyvclgm8fldbannn";
-          name = "top-mode.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/8b528544841995045fb1f8344aaaa38946bb3915/recipes/top-mode";
-          sha256 = "0hrjlbiz827v9yf4086wlghw64rhvvlsbzv8lzs6pprdwbpr9pdx";
-          name = "top-mode";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/top-mode";
-          license = lib.licenses.free;
-        };
-      }) {};
     tornado-template-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "tornado-template-mode";
@@ -71246,12 +68996,12 @@
     traad = callPackage ({ deferred, fetchFromGitHub, fetchurl, lib, melpaBuild, popup, request, request-deferred, virtualenvwrapper }:
     melpaBuild {
         pname = "traad";
-        version = "20170713.2320";
+        version = "20170916.252";
         src = fetchFromGitHub {
           owner = "abingham";
           repo = "emacs-traad";
-          rev = "7a443ad17643060f9b4c2897abe185bb9221e304";
-          sha256 = "1n91a8bdrji0kca38bh6jzwjfsg90jqqa47vvazsqk072fjjbnkr";
+          rev = "bb9e86958a92cb5b6ca107f90d05c1890a47cf63";
+          sha256 = "0vjql7z5wda701s63x1h5m6m02342dw1pylngbbxxs29d70mzybn";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/2b3eb31c077fcaff94b74b757c1ce17650333943/recipes/traad";
@@ -71277,8 +69027,8 @@
         src = fetchFromGitHub {
           owner = "jorgenschaefer";
           repo = "circe";
-          rev = "452dfb407b640ba6eb288ff25a9de27446a409c4";
-          sha256 = "1yqnpvk5ib754bkb8gcd8skf0d3rqxkqwcsbibr052ilrp5ampcl";
+          rev = "6b110d4c2c6447c4ed65cfa5b7e8676620081ee2";
+          sha256 = "01llr34y9mvgpbz3y10l7gmp40qvislwhm6jb2fvcb7vdn9k9gmz";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a2b295656d53fddc76cacc86b239e5648e49e3a4/recipes/tracking";
@@ -71378,12 +69128,12 @@
     transmission = callPackage ({ emacs, fetchFromGitHub, fetchurl, let-alist, lib, melpaBuild }:
     melpaBuild {
         pname = "transmission";
-        version = "20170906.1911";
+        version = "20171005.1043";
         src = fetchFromGitHub {
           owner = "holomorph";
           repo = "transmission";
-          rev = "de23122e2c1d0c184e2439dd142ddedb0eb043b3";
-          sha256 = "0wa89zppxvr6cbaxn8qjdcqvnfsgq3bdzb45rbab8hwc4p8fv76f";
+          rev = "c8be91596420ca8d79de44602d836aa6d1cbe2fc";
+          sha256 = "1nbm3m00s5ayicqhymw1y2y7qck5m4sajw467cp4gnsq8qw6ri53";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/9ed7e414687c0bd82b140a1bd8044084d094d18f/recipes/transmission";
@@ -71480,22 +69230,22 @@
           license = lib.licenses.free;
         };
       }) {};
-    treemacs = callPackage ({ ace-window, cl-lib ? null, dash, emacs, f, fetchFromGitHub, fetchurl, lib, melpaBuild, pfuture, s }:
+    treemacs = callPackage ({ ace-window, cl-lib ? null, dash, emacs, f, fetchFromGitHub, fetchurl, hydra, lib, melpaBuild, pfuture, s }:
     melpaBuild {
         pname = "treemacs";
-        version = "20170911.819";
+        version = "20171004.631";
         src = fetchFromGitHub {
           owner = "Alexander-Miller";
           repo = "treemacs";
-          rev = "b967e5ac38625992a19e42eb680892f4fa18e88f";
-          sha256 = "18i9aj6ajl41mn2456g48wdpqm188vsc5cqiqsj27gqvpnqkkns3";
+          rev = "2e0351ee4f70db36e26b2c603ab8b00cb35ffc05";
+          sha256 = "14q5ac76scj0bvv0iypcgmkgh3lkdjcxygqpxgqc213znpik33x9";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/486f21e99856a77f470d246f3c71cd32d2e61ad6/recipes/treemacs";
           sha256 = "07npjnhn9a0b537h1wmvy57bmicd2cji7bslp4wbnrfmmg2jdc3a";
           name = "treemacs";
         };
-        packageRequires = [ ace-window cl-lib dash emacs f pfuture s ];
+        packageRequires = [ ace-window cl-lib dash emacs f hydra pfuture s ];
         meta = {
           homepage = "https://melpa.org/#/treemacs";
           license = lib.licenses.free;
@@ -71504,12 +69254,12 @@
     treemacs-evil = callPackage ({ evil, fetchFromGitHub, fetchurl, lib, melpaBuild, treemacs }:
     melpaBuild {
         pname = "treemacs-evil";
-        version = "20170625.1401";
+        version = "20170925.2232";
         src = fetchFromGitHub {
           owner = "Alexander-Miller";
           repo = "treemacs";
-          rev = "b967e5ac38625992a19e42eb680892f4fa18e88f";
-          sha256 = "18i9aj6ajl41mn2456g48wdpqm188vsc5cqiqsj27gqvpnqkkns3";
+          rev = "2e0351ee4f70db36e26b2c603ab8b00cb35ffc05";
+          sha256 = "14q5ac76scj0bvv0iypcgmkgh3lkdjcxygqpxgqc213znpik33x9";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a52c2770097fe8968bff7c31ac411b3d9b60972e/recipes/treemacs-evil";
@@ -71529,8 +69279,8 @@
         src = fetchFromGitHub {
           owner = "Alexander-Miller";
           repo = "treemacs";
-          rev = "b967e5ac38625992a19e42eb680892f4fa18e88f";
-          sha256 = "18i9aj6ajl41mn2456g48wdpqm188vsc5cqiqsj27gqvpnqkkns3";
+          rev = "2e0351ee4f70db36e26b2c603ab8b00cb35ffc05";
+          sha256 = "14q5ac76scj0bvv0iypcgmkgh3lkdjcxygqpxgqc213znpik33x9";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b694918c94e6311745776d451aa2519924beef2d/recipes/treemacs-projectile";
@@ -71733,12 +69483,12 @@
     tuareg = callPackage ({ caml, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "tuareg";
-        version = "20170912.206";
+        version = "20171008.1240";
         src = fetchFromGitHub {
           owner = "ocaml";
           repo = "tuareg";
-          rev = "928ed2a5153094d772ad5a0831f4bd84e819755d";
-          sha256 = "1844cqykzik3cn9wqas56h2mfh0wlxq53srdl6inx7j27mm1v7ga";
+          rev = "3ef5d4c4cad10b63fac200ece4604bf7370994b7";
+          sha256 = "09v32d9diky72hrixjqd5k5358wsvyyiwwawf99rziaa33qvyns9";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/01fb6435a1dfeebdf4e7fa3f4f5928bc75526809/recipes/tuareg";
@@ -72024,25 +69774,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    typing = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "typing";
-        version = "20121026.1418";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/typing.el?revision=13";
-          sha256 = "0mgvpdp3vlvjy32d163h2mzsf9j2ij2f542sdr3rsy8l80n6nx31";
-          name = "typing.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/1bc0c7b53431a9d2bc41c9a7a755bdad0fa0f5cf/recipes/typing";
-          sha256 = "0b72lbzji105wzvsi58l6pjc08qcwrm5ddf42irdxi956081pzp3";
-          name = "typing";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/typing";
-          license = lib.licenses.free;
-        };
-      }) {};
     typing-game = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "typing-game";
@@ -72088,12 +69819,12 @@
     typo = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "typo";
-        version = "20160121.330";
+        version = "20171005.1045";
         src = fetchFromGitHub {
           owner = "jorgenschaefer";
           repo = "typoel";
-          rev = "f7d07cedf90ce65f226a66c428c0788d2bd7b912";
-          sha256 = "0bn1bvs334wb64bli9h613zf1vzjyi0pz8bgyq1wy12qmbwwmfwk";
+          rev = "73c8d960e9dcbb77a4ad6166b4685122a0f208ee";
+          sha256 = "1zlnfjav11842am9n043j3hk23134hp92k1pg86jvnsj5mwmp9ij";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/typo";
@@ -72145,25 +69876,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/ubuntu-theme";
-          license = lib.licenses.free;
-        };
-      }) {};
-    ucs-cmds = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "ucs-cmds";
-        version = "20170308.1512";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/ucs-cmds.el?revision=23";
-          sha256 = "072swg5iyx9n4xpdm65ydh2z7g11jqi3jjwkhcd7a389lavfqnbw";
-          name = "ucs-cmds.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/ucs-cmds";
-          sha256 = "1n0f0qf8w8ark78fs67aaxnqpk0km97hy59pnxwfyahgjl2qz6d1";
-          name = "ucs-cmds";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/ucs-cmds";
           license = lib.licenses.free;
         };
       }) {};
@@ -72248,25 +69960,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/ukrainian-holidays";
-          license = lib.licenses.free;
-        };
-      }) {};
-    unbound = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "unbound";
-        version = "20160505.2355";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/unbound.el?revision=11";
-          sha256 = "0awmzz9cfr17ggpzsgxqqhz5946l7705vvkfaiz7qx9wg0pbch18";
-          name = "unbound.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/118e8df30e4caf2a5ef668af8970cfbfc2327004/recipes/unbound";
-          sha256 = "1ys6pgb3lhx4ihhv8i28vrchp1ad37md7lnana40macf5n72d77x";
-          name = "unbound";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/unbound";
           license = lib.licenses.free;
         };
       }) {};
@@ -72805,25 +70498,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    usage-memo = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "usage-memo";
-        version = "20110722.851";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/usage-memo.el?revision=12";
-          sha256 = "00g1zj5fjykdi6gh2wkswpwx132xa6jmwfnrgfg5r96zwb8pib4i";
-          name = "usage-memo.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/ae8f3adf42300fc0d8f0c5474edf839614d84978/recipes/usage-memo";
-          sha256 = "05n50adjnavl7ag24wfjwlnbv5x55qlhmplgsm8j57gjig01nd95";
-          name = "usage-memo";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/usage-memo";
-          license = lib.licenses.free;
-        };
-      }) {};
     use-package = callPackage ({ bind-key, diminish, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "use-package";
@@ -72831,8 +70505,8 @@
         src = fetchFromGitHub {
           owner = "jwiegley";
           repo = "use-package";
-          rev = "360df30683a711c443f87e495ba14cdd125a505d";
-          sha256 = "0nz0gk6gf9060hbyqr5vgzwr620k6l5sk9n6jbhfyrwmcscnmilc";
+          rev = "16abb66246170fe06325ff32a4889e4b51bfd979";
+          sha256 = "1fav32ax7qykclvrimlf00pyp534yfngizm697mbr9346va1zqm6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3f9b52790e2a0bd579c24004873df5384e2ba549/recipes/use-package";
@@ -73121,16 +70795,16 @@
     vc-fossil = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "vc-fossil";
-        version = "20170811.1453";
+        version = "20171008.1303";
         src = fetchFromGitHub {
-          owner = "emacsorphanage";
-          repo = "vc-fossil";
-          rev = "0aceef306726815a84e304253711bb6d3bdf497b";
-          sha256 = "1i50nyhb3qc404xilm5j31ifyrlh98mjxk98fl0gz1cpbygvklds";
+          owner = "venks1";
+          repo = "emacs-fossil";
+          rev = "7bb3121ccd89f1533c6b91d5f952755b358eb0eb";
+          sha256 = "1x2x59k3qxna32a8fjqb0vs6bykynii3i8qnlj770dn6drmnzlfd";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/91f2e615c887f353a82deee75990609d0dc66bbe/recipes/vc-fossil";
-          sha256 = "09pslw9gamjn1hly4l3bfci6rf4xw2xq42cr7na2rj0k8c1lvxcx";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/31c5ee4b625b90c1af66d7d11a25af8e1aa307b1/recipes/vc-fossil";
+          sha256 = "11ps2wrkjrjm1d984mf80wwj1hzskw5qrn0nv7md21lp75kxsvxb";
           name = "vc-fossil";
         };
         packageRequires = [];
@@ -73394,12 +71068,12 @@
     vhdl-tools = callPackage ({ emacs, fetchFromGitHub, fetchurl, ggtags, helm, lib, melpaBuild, outshine }:
     melpaBuild {
         pname = "vhdl-tools";
-        version = "20170701.1603";
+        version = "20170928.822";
         src = fetchFromGitHub {
           owner = "csantosb";
           repo = "vhdl-tools";
-          rev = "c08343904835cbae12f48e0758b0a6a014d76a74";
-          sha256 = "1skh9p5s9nbl6jvljj9bfn19fdzjx8lvx1q6rzldld07xwaif4qb";
+          rev = "d4178edf27cfd54a473d10d5adfa819c748dc801";
+          sha256 = "1cxfgb068sdlyr8i8r6hi0jm5capbsc58zrh5g7jyknya7z02ajp";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/69fe2f8fb98ac1af1d3185f62ae1c89e646cfebf/recipes/vhdl-tools";
@@ -73587,8 +71261,8 @@
         src = fetchFromGitHub {
           owner = "porterjamesj";
           repo = "virtualenvwrapper.el";
-          rev = "5649028ea0c049cb7dfa2105285dee9c00d189fb";
-          sha256 = "1xcjjs394vlaz94xh52kqaq94gkbmmjqmxlg7wly8vfn9vh34mws";
+          rev = "15af07004dba640df8202e76bea0b5dc82567f72";
+          sha256 = "0ahlp3yfh1yxrlyyhjf9k4qssg2z3192dw4ab8lk62xnxq99bjln";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/acc9b816796b9f142c53f90593952b43c962d2d8/recipes/virtualenvwrapper";
@@ -73748,25 +71422,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    vline = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "vline";
-        version = "20120108.445";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/vline.el?revision=17";
-          sha256 = "1ys6928fgk8mswa4gv10cxggir8acck27g78cw1z3pdz5gakbgnj";
-          name = "vline.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/aa860c2ccbaeb19d8b866919cdc45549d9cf9537/recipes/vline";
-          sha256 = "0p59xhyrv7fmcn3qi51sp8v9v2y71ray2s756zbhzgzg63h3nbjp";
-          name = "vline";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/vline";
-          license = lib.licenses.free;
-        };
-      }) {};
     vmd-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "vmd-mode";
@@ -73854,12 +71509,12 @@
     vue-html-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "vue-html-mode";
-        version = "20170904.1017";
+        version = "20170928.1057";
         src = fetchFromGitHub {
           owner = "AdamNiederer";
           repo = "vue-html-mode";
-          rev = "7358de66280435531dda4dd29dfbcef397edb628";
-          sha256 = "0pqjlszacpwrkr41l27d8zlyjm25b38l94plqjy4qk4p5r2zivvg";
+          rev = "9218c61ff1ab2bdc6a6711d21ad760198d3511a8";
+          sha256 = "1xpbr2fajn0nk53abb2x9m0qs0ygxfl62gdxd2iqfcwj56fswj9y";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/48588b163ab76204b9054340071e758045480e19/recipes/vue-html-mode";
@@ -73872,22 +71527,22 @@
           license = lib.licenses.free;
         };
       }) {};
-    vue-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, mmm-mode, ssass-mode, vue-html-mode }:
+    vue-mode = callPackage ({ edit-indirect, fetchFromGitHub, fetchurl, lib, melpaBuild, mmm-mode, ssass-mode, vue-html-mode }:
     melpaBuild {
         pname = "vue-mode";
-        version = "20170712.930";
+        version = "20171004.744";
         src = fetchFromGitHub {
           owner = "CodeFalling";
           repo = "vue-mode";
-          rev = "a680998d5e597e91be2e7e15e88bd83856a13c84";
-          sha256 = "1hmqwv4xdjmly1l4s1hkx1n28navnqy5nplas39pwywik2dlh2cs";
+          rev = "3b3cbbf6cb89380a721584dd62528cf3568ad9c7";
+          sha256 = "1nfxvfpiwqjyn6h53gwpifmrsv0l4az9fsv7mrvnvf67pk3jawg0";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/2e5e0a9fff332aeec09f6d3d758e2b67dfdf8397/recipes/vue-mode";
           sha256 = "0gy7a5sliaijq0666l55vbkg15anrw7k1828szdn1ppkraw14bn0";
           name = "vue-mode";
         };
-        packageRequires = [ mmm-mode ssass-mode vue-html-mode ];
+        packageRequires = [ edit-indirect mmm-mode ssass-mode vue-html-mode ];
         meta = {
           homepage = "https://melpa.org/#/vue-mode";
           license = lib.licenses.free;
@@ -73914,37 +71569,19 @@
           license = lib.licenses.free;
         };
       }) {};
-    w32browser-dlgopen = callPackage ({ fetchurl, lib, melpaBuild }:
+    w3m = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
-        pname = "w32browser-dlgopen";
-        version = "20170309.1433";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/w32browser-dlgopen.el?revision=25";
-          sha256 = "1fkkrqwhkg58jjjsjf0fzwabaaxarjylp22zng1id6hqfsm7r1cd";
-          name = "w32browser-dlgopen.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/w32browser-dlgopen";
-          sha256 = "0dnvsnahnbnvjlhfmb0q6agzikv9d42fbnfrwsz6hni92937gz39";
-          name = "w32browser-dlgopen";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/w32browser-dlgopen";
-          license = lib.licenses.free;
-        };
-      }) {};
-    w3m = callPackage ({ fetchcvs, fetchurl, lib, melpaBuild }: melpaBuild {
         pname = "w3m";
-        version = "20170503.1331";
-        src = fetchcvs {
-          cvsRoot = ":pserver:anonymous@cvs.namazu.org:/storage/cvsroot";
-          module = "emacs-w3m";
-          sha256 = "6ef1dd834a16cf3b8a0ec7a7412ae7410f0392d616eb3329f78011039384fc6d";
+        version = "20171003.2122";
+        src = fetchFromGitHub {
+          owner = "emacsorphanage";
+          repo = "w3m";
+          rev = "284a4cdd394d2d52220c62c24ddbce00ea100471";
+          sha256 = "1fnxb3fn6a25sn41isf3frja5iwxi98cbs7rvp9mkzb4jq3bhb89";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/8bbb18b0db057b9cca78ae7280674fd1beb56443/recipes/w3m";
-          sha256 = "17mzs126fvlnsvxgfpbil9wmka0i87psblq49phky7dywcwz27lc";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/30de78c9cf83de30093a5647976eeaf552d4b2cb/recipes/w3m";
+          sha256 = "0a4jql7ky62ickccbr2xnyggix5wf726d4pfz7mi3yxlw6i8m79s";
           name = "w3m";
         };
         packageRequires = [];
@@ -74081,12 +71718,12 @@
     wanderlust = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, semi }:
     melpaBuild {
         pname = "wanderlust";
-        version = "20170627.2306";
+        version = "20170916.37";
         src = fetchFromGitHub {
           owner = "wanderlust";
           repo = "wanderlust";
-          rev = "770d54fafb1a0a140b449e6132db22e70b4d6aa9";
-          sha256 = "1f6h5n42fwwby880wikh8fdlk2zqimkl7wdb8wvr5kq1nqfqpz3f";
+          rev = "0249c9b12dcd13df709441edff3c7fcc4efcb198";
+          sha256 = "1xcxg24jwazkvc5afnqnmqisql6cr1brsmbb754a70a0r374965r";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/426172b72026d1adeb1bf3fcc6b0407875047333/recipes/wanderlust";
@@ -74312,12 +71949,12 @@
     web-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "web-mode";
-        version = "20170906.214";
+        version = "20171002.1316";
         src = fetchFromGitHub {
           owner = "fxbois";
           repo = "web-mode";
-          rev = "80e6de3b249c565506e29b2f1eca4104867f989d";
-          sha256 = "127z1968znc6m1c5b819wjhiaxq6l6wkdhra5cwxfic4wzghdvbi";
+          rev = "c15743454d0de944e5872a2ac4c9111d8cd61940";
+          sha256 = "13hndf7ldw6nb2jkr3x1yxj374j2m116q0xl74ihk32vf8kb8j2a";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6f0565555eaa356141422c5175d6cca4e9eb5c00/recipes/web-mode";
@@ -74834,34 +72471,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    wid-edit-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "wid-edit-plus";
-        version = "20170309.1434";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/wid-edit+.el";
-          sha256 = "0w2hjahcq68inabjbdyh3a0wcxd6pdgsp81iqcikxzfvwpzm35a9";
-          name = "wid-edit+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/wid-edit+";
-          sha256 = "1wwrsk14hc0wrvy7hm94aw6zg50n2smlqwr6frwpi7yp8y394wiv";
-          name = "wid-edit-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/wid-edit+";
-          license = lib.licenses.free;
-        };
-      }) {};
     wide-column = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "wide-column";
-        version = "20120814.112";
+        version = "20170925.913";
         src = fetchFromGitHub {
           owner = "phillord";
           repo = "wide-column";
-          rev = "0b382e7a3ceecafcea6c9e7e742fb6d11641b04b";
-          sha256 = "0bq39sfipad16skh5q26gp7z24kk93hgnaxb378dzfq1306kmn8q";
+          rev = "ce9ef4675485a7bea381077866368ef875226b10";
+          sha256 = "0qh8hy4jl59bfg4323a8h4q4a78gn4hsglfk2h23hqssbv4mhsp2";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/8d29def44ae42dc4b60c1d254a57572bd09faf51/recipes/wide-column";
@@ -74902,8 +72520,8 @@
         src = fetchFromGitHub {
           owner = "foretagsplatsen";
           repo = "emacs-js";
-          rev = "7bc9ba691c838650bd74848c7ebf0bc1ed6c3f2b";
-          sha256 = "18wwp5pp6s18f253xy9z2dhkxv7z3fxkgc8ayr3ypp8fskv78l34";
+          rev = "597b3e1cab9f32591561a299670999260112afbe";
+          sha256 = "1ndxd5s3raw4630zfxp5iz0mmnc6rrim6lgpzp4wjipb4zryjlnk";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/78d7a15152f45a193384741fa00d0649c4bba91e/recipes/widgetjs";
@@ -74976,25 +72594,6 @@
         packageRequires = [ dash emacs s ];
         meta = {
           homepage = "https://melpa.org/#/wilt";
-          license = lib.licenses.free;
-        };
-      }) {};
-    wimpy-del = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "wimpy-del";
-        version = "20170309.1436";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/wimpy-del.el?revision=26";
-          sha256 = "0impy9kp1xnhs0834azzndx93p8q53dxdqd9hz0n1mg0h8331c13";
-          name = "wimpy-del.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/wimpy-del";
-          sha256 = "10qw5lfq2392fr5sdz5a9bc6rvsg0j4dkrwvdhip1kqvajznw49x";
-          name = "wimpy-del";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/wimpy-del";
           license = lib.licenses.free;
         };
       }) {};
@@ -75145,34 +72744,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    window-plus = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "window-plus";
-        version = "20170309.1437";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/window+.el";
-          sha256 = "1l6fwrd2f58xpf7cprp354bq2fz0hvl9bz73hrbrzyqvnd9kix61";
-          name = "window+.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/window+";
-          sha256 = "0fhzb0ay9g9qgcaxpb2qaw15dh0lfmv3x4akyipi3zx11446d06j";
-          name = "window-plus";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/window+";
-          license = lib.licenses.free;
-        };
-      }) {};
     window-purpose = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, imenu-list, let-alist, lib, melpaBuild }:
     melpaBuild {
         pname = "window-purpose";
-        version = "20170722.655";
+        version = "20170920.15";
         src = fetchFromGitHub {
           owner = "bmag";
           repo = "emacs-purpose";
-          rev = "00ddafcf4802e7430ca709769b888656a6eb421b";
-          sha256 = "1c3jf1cxfvja1v323wkxkd67n9nwzb57c79x4m010h2700xim8vs";
+          rev = "44d31e373ce95d133c560169eb225d2c16a32b7b";
+          sha256 = "0wpndc2p4pcq1z07r659pxv0db1g6hqkgdivjs5dxc75sb3mrrmw";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5813120ab674f6db7d0a486433d8faa6cfec1727/recipes/window-purpose";
@@ -75234,8 +72814,8 @@
         src = fetchFromGitHub {
           owner = "dgtized";
           repo = "winnow.el";
-          rev = "cbc06fb51883212a5169d33a689d14cd7b0a7c34";
-          sha256 = "1hprii3da7y758ihlv308hg9sbcn42jn2f6g4dzb30ql5g2vxcnr";
+          rev = "18cb6b94338f3b7b4f2cd0331dad22f82dd9e0d3";
+          sha256 = "1wp00zxxcibvl6vjwmvhkgcbi76dyb2g8c30wy4kp7876cpc8hgv";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/58891c2057ec834f999e3bf82af15e0617a4d4cf/recipes/winnow";
@@ -75317,8 +72897,8 @@
         version = "20160419.1232";
         src = fetchhg {
           url = "https://bitbucket.com/ArneBab/wisp";
-          rev = "7ce954278aef";
-          sha256 = "116cspnc4lhf6gk73yr9sy7013jp88vq5zayghzgnkbdlaw6zmz3";
+          rev = "4d41c0814bbc";
+          sha256 = "1xy9a27qdl7hm7x2gbhxql63paxi16441rczl2i8ps032l4ffdnj";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5b7972602399f9df9139cff177e38653bb0f43ed/recipes/wisp-mode";
@@ -75355,12 +72935,12 @@
     with-editor = callPackage ({ async, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "with-editor";
-        version = "20170817.1240";
+        version = "20171006.352";
         src = fetchFromGitHub {
           owner = "magit";
           repo = "with-editor";
-          rev = "241726118dee067a8d9880d53c6a781d580ba8a1";
-          sha256 = "0q06qfir64nib604f23gdmbzl23mcsnysfd0x36cx9nwik95wl0x";
+          rev = "ee39f232f2daf997498a4030d104c35ae397f457";
+          sha256 = "17m5b7g5sdh0iy6lpj2inv9akscyw83nyx9hl71disdk7diq15hn";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/8c52c840dc35f3fd17ec660e113ddbb53aa99076/recipes/with-editor";
@@ -75401,8 +72981,8 @@
         src = fetchFromGitHub {
           owner = "DarwinAwardWinner";
           repo = "with-simulated-input";
-          rev = "d0f779594243fe85e330fd3f47caeb80068f7134";
-          sha256 = "1iadgd99n1ilrdvybbrxj0f8n50sz76j3bji2nfpn3w32krj90w4";
+          rev = "af9a38ce28a741e6d8742750bef5d7b5afa13796";
+          sha256 = "0iann7zi9bgd3vmvxvg2n6x24hkyzbchbli1ymsmfrn8rif9byf7";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/e4ddf16e19f5018106a423327ddc7e7499cf9248/recipes/with-simulated-input";
@@ -75454,27 +73034,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/wolfram";
-          license = lib.licenses.free;
-        };
-      }) {};
-    wolfram-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "wolfram-mode";
-        version = "20170221.120";
-        src = fetchFromGitHub {
-          owner = "kawabata";
-          repo = "wolfram-mode";
-          rev = "d27a0f23791abde2bdda22e50108b99f11c13ed7";
-          sha256 = "0r82h3x1ggirgd0a03qr71pdcxgkc4s3307ggwy86j4asd308m79";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/299fe35d0a5a11d20f0b917bc8f406bd0f011c93/recipes/wolfram-mode";
-          sha256 = "1bq95lamzz45macpklnq1kxw9ak4x4f41kx16f472dn650ff0zlf";
-          name = "wolfram-mode";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/wolfram-mode";
           license = lib.licenses.free;
         };
       }) {};
@@ -75544,12 +73103,12 @@
     worf = callPackage ({ ace-link, fetchFromGitHub, fetchurl, hydra, lib, melpaBuild, swiper, zoutline }:
     melpaBuild {
         pname = "worf";
-        version = "20170818.1105";
+        version = "20171002.1118";
         src = fetchFromGitHub {
           owner = "abo-abo";
           repo = "worf";
-          rev = "bf812a47e44dfbf4e166dbdbed7a97197bc1fc1d";
-          sha256 = "11miqpdg0v27fi6ksrqkqfyi2qrsgsv8jsqfw15nyhqmi3sgxzqh";
+          rev = "cf2f382b368bcb3c8ba4785a7fac8ee9300e80b5";
+          sha256 = "0rnvmwdks8m4f6dwnyinv9rli58mlvlnrg7swpdjfh0g3bqgr7w5";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/f00f8765e35c21dd1a4b5c01c239ed4d15170ab7/recipes/worf";
@@ -75670,12 +73229,12 @@
     writegood-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "writegood-mode";
-        version = "20160802.1405";
+        version = "20170925.647";
         src = fetchFromGitHub {
           owner = "bnbeckwith";
           repo = "writegood-mode";
-          rev = "a99896531a260db11acb931b68dbdc45030832d7";
-          sha256 = "15g133ql8mgjchm6h255q77b6rks843lzva44kgjmfgwmgbfmc1b";
+          rev = "416453af5a44da52646052fa2ee3a63acfd7bf8a";
+          sha256 = "08z35gc3j25h02jmlkzsis4n7a6sy6zy2qykcnp8b3s8y51d0dg0";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/75c5a4304999fc3f5a02235a1c2c904238d2ce4f/recipes/writegood-mode";
@@ -75863,8 +73422,8 @@
         src = fetchFromGitHub {
           owner = "jobbflykt";
           repo = "x509-mode";
-          rev = "a34584f310f3d8afe57dc1950db52b2d079242b8";
-          sha256 = "07z0iyz7zgypqjv6izpdccllwrp7jgc86279rk0blf0vazj2927h";
+          rev = "240b5045dcce18190bdabd91d74f48d3610a6fe2";
+          sha256 = "0pi5hi0n6f2hif5hz1g04rk509rb4jlw6nrlhc8fg5k6x4n7ci3p";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/27145423eb4e68e006ef96868a35b99d119a3099/recipes/x509-mode";
@@ -75964,12 +73523,12 @@
     xah-fly-keys = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "xah-fly-keys";
-        version = "20170905.840";
+        version = "20171009.422";
         src = fetchFromGitHub {
           owner = "xahlee";
           repo = "xah-fly-keys";
-          rev = "0d0b3b96401af0d1e4ddea2713218bee08ab6a04";
-          sha256 = "09iyf2xrp3scxr67jm3gl067kb8vsrnrqdwz2sv6la41n04s9lm3";
+          rev = "15dc0360011eb8ec542db5e8e5bdfa1147366557";
+          sha256 = "0n8j36q16njkcyr23qc8zx19wn4qx7pjiankimgjp96bcxsfa9df";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/05eed39bae37cc8359d2cc678052cbbcc946e379/recipes/xah-fly-keys";
@@ -76147,6 +73706,27 @@
         packageRequires = [ dash emacs multiple-cursors s ];
         meta = {
           homepage = "https://melpa.org/#/xcode-mode";
+          license = lib.licenses.free;
+        };
+      }) {};
+    xcode-project = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "xcode-project";
+        version = "20170922.612";
+        src = fetchFromGitHub {
+          owner = "nhojb";
+          repo = "xcode-project";
+          rev = "ec5d503a51430205daa6f5f382d921b6412b4b55";
+          sha256 = "0m3262mqqhjcpzw8m4n403kr75m561kxvwf8clzwmv0fvkf8aazk";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/49b866ebf7e707bc74525f83dd5038e6e860fcef/recipes/xcode-project";
+          sha256 = "0igp30f6ypmp4l8zmdfpa5bza4avm7mq2gj8v7b3ii655v91n6vi";
+          name = "xcode-project";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/xcode-project";
           license = lib.licenses.free;
         };
       }) {};
@@ -76619,8 +74199,8 @@
         src = fetchFromGitHub {
           owner = "drdv";
           repo = "yahtzee";
-          rev = "09b18f248c957f74d219a6d1127923e9c786d650";
-          sha256 = "05hg6andy8wxrsxf939g77v6ml4rac239vkkfk0fh6723wgiz144";
+          rev = "18ee56bd687238be2bb6834062be3f04d9e9a283";
+          sha256 = "13a6qy22jwyxrlcxw2xmqw3dckzlkxa84babdwrgpdx7kx4hqa5h";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/200169fdabce0ae3a2ecb6f4f3255c15ec3ed094/recipes/yahtzee";
@@ -76759,25 +74339,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    yaoddmuse = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "yaoddmuse";
-        version = "20170325.1752";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/yaoddmuse.el?revision=104";
-          sha256 = "0vlllq3xmnlni0ws226pqxj68nshclbl5rgqv6y11i3yvzgiazr6";
-          name = "yaoddmuse.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/yaoddmuse";
-          sha256 = "1p68f3xjv55m8lnq5x27b8y87mq685hpm3n9kiga9qq8wxdf2rnf";
-          name = "yaoddmuse";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/yaoddmuse";
-          license = lib.licenses.free;
-        };
-      }) {};
     yapfify = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "yapfify";
@@ -76907,12 +74468,12 @@
     yasnippet = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "yasnippet";
-        version = "20170828.1908";
+        version = "20170923.1646";
         src = fetchFromGitHub {
           owner = "joaotavora";
           repo = "yasnippet";
-          rev = "89eb7ab64d67e96646576dc0d551e8c23d50438a";
-          sha256 = "1wr0d14yl3440hkdr436zxl9pk7nqhl76n9m3b3ia4lp6z5aj4jc";
+          rev = "35a4df769cbdebd10d043f16d680bdb16ee858ed";
+          sha256 = "0rkk39bm12d3d4gf8r99a2ipjaf1yb0b57rpg44bsqz5jada4a86";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5d1927dc3351d3522de1baccdc4ce200ba52bd6e/recipes/yasnippet";
@@ -76928,12 +74489,12 @@
     yasnippet-snippets = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, yasnippet }:
     melpaBuild {
         pname = "yasnippet-snippets";
-        version = "20170908.435";
+        version = "20171006.918";
         src = fetchFromGitHub {
           owner = "AndreaCrotti";
           repo = "yasnippet-snippets";
-          rev = "5c3bb7ad8f659cb6651cc9c90709528672dd2ad0";
-          sha256 = "1nbkgmqgrih99jgpzvmy0h8vdjgkrml9ck9wi19vw80d62b8m9p8";
+          rev = "29ce99b8412ef919b7f03f259a877c4111362410";
+          sha256 = "0xq3vjlsm4fvk809r69bln8i7fkqx49xi1gk1nff0v8y5b26vnxp";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/25b8d4efe2e7833eb95dfdf33aa3ecc34af7a687/recipes/yasnippet-snippets";
@@ -76964,6 +74525,25 @@
         packageRequires = [ emacs yasnippet ];
         meta = {
           homepage = "https://melpa.org/#/yatemplate";
+          license = lib.licenses.free;
+        };
+      }) {};
+    yatex = callPackage ({ fetchhg, fetchurl, lib, melpaBuild }: melpaBuild {
+        pname = "yatex";
+        version = "20170916.1826";
+        src = fetchhg {
+          url = "https://www.yatex.org/hgrepos/yatex/";
+          rev = "ca7cf34e959c";
+          sha256 = "19pczpzl0wvkdassskcssq5qrpica0bffqxxi8sqp1j35px6v4ma";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/e28710244a1bef8f56156fe1c271520896a9c694/recipes/yatex";
+          sha256 = "17np4am7yan1bh4706azf8in60c41158h3z591478j5b1w13y5a6";
+          name = "yatex";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://melpa.org/#/yatex";
           license = lib.licenses.free;
         };
       }) {};
@@ -77012,12 +74592,12 @@
     ycmd = callPackage ({ cl-lib ? null, dash, deferred, emacs, fetchFromGitHub, fetchurl, let-alist, lib, melpaBuild, pkg-info, request, request-deferred, s }:
     melpaBuild {
         pname = "ycmd";
-        version = "20170723.1458";
+        version = "20171009.702";
         src = fetchFromGitHub {
           owner = "abingham";
           repo = "emacs-ycmd";
-          rev = "fd037efae08628e41480e9dad705dcc1f64e498d";
-          sha256 = "06scz0d3jzgbr919lkjjfq9x1dyr5nqkhblvfpyk5bdp8l6j06d6";
+          rev = "dfb0b02d0e19a05c8712d1877834a3eaafe453d4";
+          sha256 = "10w5194lj6s5bvwl9r9zgw479f2a1i4lx87954xymcbridbcih6y";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/4b25378540c64d0214797348579671bf2b8cc696/recipes/ycmd";
@@ -77166,26 +74746,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    zeitgeist = callPackage ({ fetchgit, fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "zeitgeist";
-        version = "20131228.1009";
-        src = fetchgit {
-          url = "https://anongit.freedesktop.org/git/zeitgeist/zeitgeist-datasources.git";
-          rev = "cdd1c219ed3afa9500403c3c499f49583d599034";
-          sha256 = "0xg67asvgav5js03i3bqmh7apndrn0jy5vai0bsh22pq8wgvq083";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/1e2a0e4698d4e71ec28656594f6a83504a823490/recipes/zeitgeist";
-          sha256 = "0zbpmdf7fq3qph70m13giir58y1n5z6q6kqixjll5j4fk98k6bkz";
-          name = "zeitgeist";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/zeitgeist";
-          license = lib.licenses.free;
-        };
-      }) {};
     zen-and-art-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "zen-and-art-theme";
@@ -77272,12 +74832,12 @@
     zephir-mode = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, pkg-info }:
     melpaBuild {
         pname = "zephir-mode";
-        version = "20170906.320";
+        version = "20170917.2125";
         src = fetchFromGitHub {
           owner = "sergeyklay";
           repo = "zephir-mode";
-          rev = "6b54967c76244ba18040deffd52c03caa8fff49d";
-          sha256 = "0a48p08m1kdz1wxmwdcvv8lbph0by3lmxz4ccr6jrfsw3gxnixff";
+          rev = "c2c6b7451667e68e29c353616f54ef9195c3fffd";
+          sha256 = "1h5iv0ggh4jzv180mg8lz72d91b6kcqwy6ypgy3rn50bk6pz06kg";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5bd901c93ce7f64de6082e801327adbd18fd4517/recipes/zephir-mode";
@@ -77293,12 +74853,12 @@
     zerodark-theme = callPackage ({ all-the-icons, fetchFromGitHub, fetchurl, flycheck, lib, magit, melpaBuild }:
     melpaBuild {
         pname = "zerodark-theme";
-        version = "20170830.57";
+        version = "20170928.827";
         src = fetchFromGitHub {
           owner = "NicolasPetton";
           repo = "zerodark-theme";
-          rev = "37ec068e6a744274daf1ecd1a64b75db6a7b8a0c";
-          sha256 = "1yh1n6647a3fppjhhbs6ir7vgqn6nqhpghwnhlrl3amp74h6di78";
+          rev = "248e95616304e4eb1adde458bbb59442c11d1cb9";
+          sha256 = "1bckvqfid2acmn5xcxzflid7hqhflsjw51r9gws3vxb9hpj5qqyb";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d00b78ead693e844e35c760fe2c39b8ed6cb0d81/recipes/zerodark-theme";
@@ -77308,6 +74868,27 @@
         packageRequires = [ all-the-icons flycheck magit ];
         meta = {
           homepage = "https://melpa.org/#/zerodark-theme";
+          license = lib.licenses.free;
+        };
+      }) {};
+    zig-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "zig-mode";
+        version = "20170920.802";
+        src = fetchFromGitHub {
+          owner = "AndreaOrru";
+          repo = "zig-mode";
+          rev = "814657c5b6b0600ace78a7bbd216c3e90d611cfd";
+          sha256 = "0nhx2wsk3qpdplvwxmdzwlka9255x46ca9vcjb58zbpb5wbfckzx";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/33895b0ff559ffd18a62c04736597188f55419ee/recipes/zig-mode";
+          sha256 = "1rmvlsgx01h62imbksxl164d5p0caz49nlgg0z7spvvd9bmplr09";
+          name = "zig-mode";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/zig-mode";
           license = lib.licenses.free;
         };
       }) {};
@@ -77479,63 +75060,24 @@
           license = lib.licenses.free;
         };
       }) {};
-    zones = callPackage ({ fetchurl, lib, melpaBuild }: melpaBuild {
-        pname = "zones";
-        version = "20170802.1406";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/zones.el?revision=32";
-          sha256 = "02vvkj2nx5ha1ad1zn5jd91jakxwx1pkrysj07a8y2sg657d7nkk";
-          name = "zones.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/zones";
-          sha256 = "1l4qilawlgvanrz4ny4aaqzg011dlqh65g06d44pf6ha586rvzp2";
-          name = "zones";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/zones";
-          license = lib.licenses.free;
-        };
-      }) {};
-    zonokai-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    zoom = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
-        pname = "zonokai-theme";
-        version = "20160321.1925";
+        pname = "zoom";
+        version = "20171008.1325";
         src = fetchFromGitHub {
-          owner = "ZehCnaS34";
-          repo = "zonokai-emacs";
-          rev = "38ee819b711e848437ba6d563594129a0ecac598";
-          sha256 = "16ni0va1adpqdnrkiwmpxwrhyanxp5jwbknii2wnbhgq62s7gv43";
+          owner = "cyrus-and";
+          repo = "zoom";
+          rev = "a78361f6db1753ad749f5b865f2076579a276971";
+          sha256 = "1c2ww8a6q64w486hb0gp18hcxvxyjjw3qpkwqkx7rfj5smy12zim";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/80c7b1e01eb23f2f9b71fbeeea7d54ac36bae992/recipes/zonokai-theme";
-          sha256 = "1hrpgh03mp7yynqamgzkw7fa70c5pmyjfmfblkfhspnsif8j4v29";
-          name = "zonokai-theme";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/3fe094c99756ad29eda9bc51f31bb70c4ddc4131/recipes/zoom";
+          sha256 = "09bk0nnfj72an2b3rravd6qp21gdgcm1m55qnf2r8rzbgqymq5ls";
+          name = "zoom";
         };
-        packageRequires = [];
+        packageRequires = [ emacs ];
         meta = {
-          homepage = "https://melpa.org/#/zonokai-theme";
-          license = lib.licenses.free;
-        };
-      }) {};
-    zoom-frm = callPackage ({ fetchurl, frame-cmds, frame-fns, lib, melpaBuild }:
-    melpaBuild {
-        pname = "zoom-frm";
-        version = "20170309.1439";
-        src = fetchurl {
-          url = "https://www.emacswiki.org/emacs/download/zoom-frm.el?revision=44";
-          sha256 = "03f3clivm7nfgg16k9pcshdwbwmjaqk0lcdm9d0180dl1c1z2wvs";
-          name = "zoom-frm.el";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/8b528544841995045fb1f8344aaaa38946bb3915/recipes/zoom-frm";
-          sha256 = "111lr29zhj8w8j7dbzl58iisqxjhccxpw4spfxx08zxh4623g5mk";
-          name = "zoom-frm";
-        };
-        packageRequires = [ frame-cmds frame-fns ];
-        meta = {
-          homepage = "https://melpa.org/#/zoom-frm";
+          homepage = "https://melpa.org/#/zoom";
           license = lib.licenses.free;
         };
       }) {};
@@ -77668,11 +75210,11 @@
     zpresent = callPackage ({ dash, emacs, fetchhg, fetchurl, lib, melpaBuild, org-parser, request }:
     melpaBuild {
         pname = "zpresent";
-        version = "20170730.2055";
+        version = "20171008.2152";
         src = fetchhg {
           url = "https://bitbucket.com/zck/zpresent.el";
-          rev = "33b840f663b7";
-          sha256 = "1g9x257bg9mgg1impyk5s8lfhr4qmqf1fzc7iwfdzizvzmgdlas1";
+          rev = "eb6f5bf71b00";
+          sha256 = "1q3xz4gwqb7ac49w0nq7zvl4n790wk6r97by1kldv54y2fj0ja9g";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3aae38ad54490fa650c832fb7d22e2c73b0fb060/recipes/zpresent";

--- a/pkgs/applications/editors/emacs-modes/melpa-stable-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-stable-generated.nix
@@ -926,12 +926,12 @@
     add-node-modules-path = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "add-node-modules-path";
-        version = "1.1.0";
+        version = "1.2.0";
         src = fetchFromGitHub {
           owner = "codesuki";
           repo = "add-node-modules-path";
-          rev = "8eef7fa6765af1716fc21db08f19f3d3e9b68998";
-          sha256 = "1dm2gdhs9zy5jqhbqipdgzfj24mrzxz064ax9l2dg0lqylk1dc0q";
+          rev = "6f7801b2c41e3711406b7e1654257ad5557f5bb3";
+          sha256 = "1pfgy1k7vp34k4zb9835y3x4jmf81na60vsf80wlgvfafwk170z6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/63e99d8fc0678d7b1831cae8940e9e6547780861/recipes/add-node-modules-path";
@@ -1073,12 +1073,12 @@
     ahungry-theme = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "ahungry-theme";
-        version = "1.4.0";
+        version = "1.5.0";
         src = fetchFromGitHub {
           owner = "ahungry";
           repo = "color-theme-ahungry";
-          rev = "e3d7e22cb10582a443b0e245be68aca936cd6abf";
-          sha256 = "0fsip64bxs55kkqmpfcg4nr391b6wsd8hiq4fxvwww7n52lwsn5s";
+          rev = "85a1af27541f6a73a63120fac2cfbb7ba39531c9";
+          sha256 = "0z1kh8xj16lp7ydzw1fxypw37vlrcxcb8bpx96w6aj6zcd7pzwmn";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/520295978fd7de3f4266dd69cc30d0b4fdf09db0/recipes/ahungry-theme";
@@ -1292,12 +1292,12 @@
     anaconda-mode = callPackage ({ dash, emacs, f, fetchFromGitHub, fetchurl, lib, melpaBuild, pythonic, s }:
     melpaBuild {
         pname = "anaconda-mode";
-        version = "0.1.8";
+        version = "0.1.9";
         src = fetchFromGitHub {
           owner = "proofit404";
           repo = "anaconda-mode";
-          rev = "95fdfab07600171daccb0e9e98fb91c11237fd48";
-          sha256 = "0l5h6apjshr6drfak6j66m3rv26hkr2namj85k8isvalmn4dlrj2";
+          rev = "89fc16d50b889a17521084347b28f3011b84e113";
+          sha256 = "08wdci57vig88iy5kk57k5qjkzphbbzy8g7b87hxakfgdmcwpg3g";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/e03b698fd3fe5b80bdd24ce01f7fba28e9da0da8/recipes/anaconda-mode";
@@ -2809,12 +2809,12 @@
     bifocal = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "bifocal";
-        version = "0.0.2";
+        version = "0.0.3";
         src = fetchFromGitHub {
           owner = "riscy";
           repo = "bifocal-mode";
-          rev = "5e89ad1a9a47e890ce080a79fd32c71eb128d1c4";
-          sha256 = "1rwxw1wniws31gbmpxgglxbc2g4jag19dvsjrym0f43yy4w2mbpw";
+          rev = "a8b222b069a6bd64531b4780905989797bad8abe";
+          sha256 = "0c6vzh35lj3pg9wd4v2fy6xdmcg9kq3n5br6rp4lx257gxglzpwh";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/79e71995bd8452bad2e717884f148ec74c9735fc/recipes/bifocal";
@@ -3166,12 +3166,12 @@
     buffer-manage = callPackage ({ choice-program, dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "buffer-manage";
-        version = "0.5";
+        version = "0.6";
         src = fetchFromGitHub {
           owner = "plandes";
           repo = "buffer-manage";
-          rev = "1c63a3267bc7b790cebcea6308b64ca7ae08ef98";
-          sha256 = "1g4qchgf7gcy8mhynxklz3bh2nlrhshczpq6yzh7gpvgcaf2zg32";
+          rev = "44b26d5c17a4ecea3484727fa46c3d734569a018";
+          sha256 = "0c9hz2532vcbn69am7pd2zyraqgw0q139qsck9hs1vfxnsj4v8dc";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/28f8f376df810e6ebebba9fb2c93eabbe3526cc9/recipes/buffer-manage";
@@ -3376,12 +3376,12 @@
     buttercup = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "buttercup";
-        version = "1.8";
+        version = "1.9";
         src = fetchFromGitHub {
           owner = "jorgenschaefer";
           repo = "emacs-buttercup";
-          rev = "e6f97d0ee4da1d061c2ff5f3e3984a30956a9fbc";
-          sha256 = "1qizbnychsjv42h9r33l1jm0rylvkgddcwgwxxcckfkj6r75k9p5";
+          rev = "18a887957b0e22d3cc8873796bd27f06b2493a03";
+          sha256 = "0y0wg0yqmvqjyhjs4dx8yw44hl19k227krd9mds220w0dx8wmhay";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d4b187cb5b3cc5b546bfa6b94b6792e6363242d1/recipes/buttercup";
@@ -3646,6 +3646,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    caml = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "caml";
+        version = "4.6.0beta1";
+        src = fetchFromGitHub {
+          owner = "ocaml";
+          repo = "ocaml";
+          rev = "185bf236abb2bf10abfd3bff45c723ba10551c80";
+          sha256 = "0057iik539jfcw287vcacb8hfxdnyfk17cc0ymxxy3sk5y1mfjik";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/d5a3263cdcc229b11a3e96edbf632d56f32c47aa/recipes/caml";
+          sha256 = "1ixs0626nsg1ilqdwj5rd8kicjy7mprswwy0kprppmpmc8y7xf7c";
+          name = "caml";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://melpa.org/#/caml";
+          license = lib.licenses.free;
+        };
+      }) {};
     cargo = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, rust-mode }:
     melpaBuild {
         pname = "cargo";
@@ -3733,12 +3754,12 @@
     cask-package-toolset = callPackage ({ ansi, cl-lib ? null, commander, dash, emacs, f, fetchFromGitHub, fetchurl, lib, melpaBuild, s, shut-up }:
     melpaBuild {
         pname = "cask-package-toolset";
-        version = "0.9.1";
+        version = "0.9.2";
         src = fetchFromGitHub {
           owner = "AdrieanKhisbe";
           repo = "cask-package-toolset.el";
-          rev = "1e972739dbdf3af5b60a250c99414e76db238f78";
-          sha256 = "0padb1zfjkmx9kbqnqh744qvpd3ln0khwxifxld9cpcpdp5k04vc";
+          rev = "2c74cd827e88c7f8360581a841e45f0b794510e7";
+          sha256 = "1hk5q6p1j7cqg5srr3v21xfyy7aas4hfj1a66h21c2xvfjra3hxw";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ed71e45389626e700b93b29d5e2659b6706274d8/recipes/cask-package-toolset";
@@ -3938,6 +3959,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    cframe = callPackage ({ buffer-manage, dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "cframe";
+        version = "0.1";
+        src = fetchFromGitHub {
+          owner = "plandes";
+          repo = "cframe";
+          rev = "bb99672502046e87c8f029ce98c637f762a4fc54";
+          sha256 = "088px3wlvr4km913y7hajrjqnxnv6n325rk6353bkbah2d75vxq4";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/6e39555b2538cc8a955766c5533871396e8fe712/recipes/cframe";
+          sha256 = "0pngdaflk1pk2xmwbij4b520b3mlacnjab4r3jby0phah44ziv4l";
+          name = "cframe";
+        };
+        packageRequires = [ buffer-manage dash emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/cframe";
+          license = lib.licenses.free;
+        };
+      }) {};
     chapel-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "chapel-mode";
@@ -4088,12 +4130,12 @@
     choice-program = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "choice-program";
-        version = "0.2";
+        version = "0.4";
         src = fetchFromGitHub {
           owner = "plandes";
           repo = "choice-program";
-          rev = "5a803216d1d7a7ac6fd0f89f04ba4c126182a852";
-          sha256 = "0iah71kcrzi22mi1jvyyaiflsx0ry24hqb0wd2w0nbgzc8s5ycqb";
+          rev = "27607ec1fe241c58fbc1f861454a8e2ec1fd7b15";
+          sha256 = "0q8krgsydrc2xc29y60qljifdvxfmxnvbncxsh64xhrzsnrgwmq5";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6e39555b2538cc8a955766c5533871396e8fe712/recipes/choice-program";
@@ -4169,15 +4211,36 @@
           license = lib.licenses.free;
         };
       }) {};
+    circadian = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "circadian";
+        version = "0.2.3";
+        src = fetchFromGitHub {
+          owner = "GuidoSchmidt";
+          repo = "circadian.el";
+          rev = "0034de1551de9f420f42267f3ec081351c2b5d7f";
+          sha256 = "1khczk5lsiicyjra7g5m3dcl1rc6g43zbypigkj3izx2dsa47n5d";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/3440905a20bc91bb2637a87c04ff8410379f150d/recipes/circadian";
+          sha256 = "13797y1w1636bibisz5i5p2xp0smd3apnhc1nx8ijm75smx679id";
+          name = "circadian";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/circadian";
+          license = lib.licenses.free;
+        };
+      }) {};
     circe = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "circe";
-        version = "2.5";
+        version = "2.6";
         src = fetchFromGitHub {
           owner = "jorgenschaefer";
           repo = "circe";
-          rev = "13c605e639194c3da0c2e685056fac685f8c76a0";
-          sha256 = "0n7v0g332ml1ang2fjc8rjbi8h1f4bqazcqi8dlfn99vvv8kcd21";
+          rev = "59f1096238e6c30303a6fe9fc1c635f49e5946c6";
+          sha256 = "19h3983zy3f15cgs86irvbdzz55qyjm48qd7gjlzcxplr7vnnh0j";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a2b295656d53fddc76cacc86b239e5648e49e3a4/recipes/circe";
@@ -4499,12 +4562,12 @@
     closql = callPackage ({ emacs, emacsql-sqlite, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "closql";
-        version = "0.3.3";
+        version = "0.4.0";
         src = fetchFromGitHub {
           owner = "emacscollective";
           repo = "closql";
-          rev = "0bb0fa3dd1e545cbf025d42e253ddb00107156a3";
-          sha256 = "1mpycmj88gi62rhzxdv4933l318j3llphbc00b7rvzms55sgpcz5";
+          rev = "66597831248bbe14ebc7bbf24b24cafebb5fd362";
+          sha256 = "0jxf7k95l2j6rjyafq3zj6bxaa2xn4zmi4zg1n04sachcdrcgh3l";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/2df16abf56e53d4a1cc267a78797419520ff8a1c/recipes/closql";
@@ -4583,12 +4646,12 @@
     cmake-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "cmake-mode";
-        version = "3.9.2";
+        version = "3.10.0pre1";
         src = fetchFromGitHub {
           owner = "Kitware";
           repo = "CMake";
-          rev = "ffa164736ec78f27583ca4515ff3dfc7a82fc702";
-          sha256 = "09m6hwlzdrd884h8wcq8pfac098smk1xqjpqm3003bqs4aynm49p";
+          rev = "ecaddda2fea374089d867ad17b8b4700b189f397";
+          sha256 = "0j6zzirbx1pcb0hyih77w6dbjmz2axknib7aryrcm7pjwd9d0q23";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/598723893ae4bc2e60f527a072efe6ed9d4e2488/recipes/cmake-mode";
@@ -4619,6 +4682,27 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/cmake-project";
+          license = lib.licenses.free;
+        };
+      }) {};
+    cnfonts = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "cnfonts";
+        version = "0.9.1";
+        src = fetchFromGitHub {
+          owner = "tumashu";
+          repo = "cnfonts";
+          rev = "cbe1ddd49e33b790a568c55351146aa5b909f173";
+          sha256 = "11d44lf0m0kbzq1mvyqkl4aprys0xqaarp08nij57xnynin1rynx";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/0d5787ffeeee68ffa41f3e777071815084e0ed7a/recipes/cnfonts";
+          sha256 = "1pryn08fkdrdj7w302205nj1qhfbk1jzqxx6717crrxakkdqmn9w";
+          name = "cnfonts";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/cnfonts";
           license = lib.licenses.free;
         };
       }) {};
@@ -4748,6 +4832,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    colormaps = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "colormaps";
+        version = "0.1.2";
+        src = fetchFromGitHub {
+          owner = "lepisma";
+          repo = "colormaps.el";
+          rev = "3a88961ba66b09a49ea5aa92b2b8776b2c92d68c";
+          sha256 = "083hks2zzalizdsgabiwc1kd114r748v5i3w3kfk8pv37i2gay35";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/f4c795d9e323b08bc8354a6933a061644705a2ec/recipes/colormaps";
+          sha256 = "16plhgpfz1wb58p6h8wxjhplhgv0mbj3f2xj34p6vydh44l8w8q2";
+          name = "colormaps";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/colormaps";
+          license = lib.licenses.free;
+        };
+      }) {};
     commander = callPackage ({ cl-lib ? null, dash, f, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "commander";
@@ -4787,6 +4892,27 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/comment-dwim-2";
+          license = lib.licenses.free;
+        };
+      }) {};
+    comment-tags = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, pkg-info }:
+    melpaBuild {
+        pname = "comment-tags";
+        version = "0.1";
+        src = fetchFromGitHub {
+          owner = "vincekd";
+          repo = "comment-tags";
+          rev = "293a30026d7750f6657d6c2e6d6428abf1d7db5a";
+          sha256 = "06s0phgqpzkkv81gl0cm6x8rjs53lhs8b2j56xamflqiydq0fz7n";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/6ac71f4ffc19bce4f571001f9270d5be855dfc3c/recipes/comment-tags";
+          sha256 = "13slv150zch0b7zpxa2dbqjzpqh0iy559m6rc0zs0dwdagzryp3i";
+          name = "comment-tags";
+        };
+        packageRequires = [ emacs pkg-info ];
+        meta = {
+          homepage = "https://melpa.org/#/comment-tags";
           license = lib.licenses.free;
         };
       }) {};
@@ -4898,12 +5024,12 @@
     company-cabal = callPackage ({ cl-lib ? null, company, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "company-cabal";
-        version = "0.1.1";
+        version = "0.2.1";
         src = fetchFromGitHub {
           owner = "iquiw";
           repo = "company-cabal";
-          rev = "a570559ff92522598b5ed40e21c4539fffb3e976";
-          sha256 = "1pja44g15d11kl47abzykrp28j782nkbmb0db0ilpc96xf1fjlsw";
+          rev = "f458de88cad16ed48a605e8347e56433e73dcef8";
+          sha256 = "0ll9dxzsgrpy4psz3dqhzny990lfccn63swcyfvl8mnqgwbrq8k0";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ee888b1ba57b6af3a3330607898810cd248862db/recipes/company-cabal";
@@ -6206,12 +6332,12 @@
     cython-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "cython-mode";
-        version = "0.26.1";
+        version = "0.27.1";
         src = fetchFromGitHub {
           owner = "cython";
           repo = "cython";
-          rev = "39c71d912af541229d24da17987d65e65731d2bf";
-          sha256 = "02alpsgmm0csp9yfa4bhsf8yyhf0q9rc44yrss0020qg8n92xs06";
+          rev = "32538fc162be830bf01ff96e43a020bc4924a1ee";
+          sha256 = "03v4ig9zlh8dz9s0c31f5hz2wfpvjydiidb0zgghnrshlqacpyj3";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/be9bfabe3f79153cb859efc7c3051db244a63879/recipes/cython-mode";
@@ -6248,12 +6374,12 @@
     dad-joke = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "dad-joke";
-        version = "1.3";
+        version = "1.4";
         src = fetchFromGitHub {
           owner = "davep";
           repo = "dad-joke.el";
-          rev = "92641503c7e93309db12380d5228f99dbe64a53c";
-          sha256 = "063cz5k264qbkb5g87xr6z68fjjnw3j1hpckdn6nqy8cin4qhagc";
+          rev = "bee47e7b746b403228fa7d7361cb095de19ac9ba";
+          sha256 = "14snnnjs28jg6k8x6g90m3dbcx10306ipcd256d3l6czk9p17vpd";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/484d571b2737f7c613816333afdde6460c64e635/recipes/dad-joke";
@@ -6395,12 +6521,12 @@
     dashboard = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, page-break-lines }:
     melpaBuild {
         pname = "dashboard";
-        version = "1.2.3";
+        version = "1.2.4";
         src = fetchFromGitHub {
           owner = "rakanalh";
           repo = "emacs-dashboard";
-          rev = "f435fd394edc5ad9cf82065ef73b5821e3f93c58";
-          sha256 = "0f0ipnij69z90qv9lzl6x9id3f6nayrgqxppbcf4gkxh25pi5nkw";
+          rev = "8594c4f55448148b720eda5b72d51667fb7a8a39";
+          sha256 = "1hhh1kfsz87qfmh45wjf2r93rz79rq0vbyxlfrsl02092zjbl1zr";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/e9a79341ccaa82a8c065e71c02fe6aee22007c66/recipes/dashboard";
@@ -6458,12 +6584,12 @@
     datetime = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "datetime";
-        version = "0.2.1";
+        version = "0.3";
         src = fetchFromGitHub {
           owner = "doublep";
           repo = "datetime";
-          rev = "3ecf9985250ecd441e91614b44cf12323af907c0";
-          sha256 = "1x8kj6d9p42lffk15m0c955ibwxxvfxhihij43alwq5xab2l16bv";
+          rev = "082d2c7b0e38c26a8c46af9c9956a2e100d88e71";
+          sha256 = "0fdswqi53qx924lib7nd9dazn0916xf1ybrh3bcn3f8cn6b8ikg5";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/fff9f0748b0ef76130b24e85ed109325256f956e/recipes/datetime";
@@ -7085,6 +7211,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    diredfl = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "diredfl";
+        version = "0.3";
+        src = fetchFromGitHub {
+          owner = "purcell";
+          repo = "diredfl";
+          rev = "2393653a1518b118180ff90ef2b66cfb7d0b555c";
+          sha256 = "04yykal90pc4nsdlk08z6svsnddjzaz1drwvs3bqfjw01fr50xcs";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/3da86e18d423198766455929da1dcb3a9a3be381/recipes/diredfl";
+          sha256 = "0cybq15yq07x2mnrnwapy020d598yymcy8y9wwf1m7f59p3h9hvn";
+          name = "diredfl";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/diredfl";
+          license = lib.licenses.free;
+        };
+      }) {};
     diredful = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "diredful";
@@ -7172,12 +7319,12 @@
     disable-mouse = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "disable-mouse";
-        version = "0.2";
+        version = "0.3";
         src = fetchFromGitHub {
           owner = "purcell";
           repo = "disable-mouse";
-          rev = "d1c52d80ed2149d0751afd948ffc2d9f80f589ac";
-          sha256 = "1v1y5hf6k6ng7xsvgb27nh740d14m6l4krr0paccda8zgm4mw357";
+          rev = "81639930bcaeedadbcc19728e91719afcac84613";
+          sha256 = "0l6mai68ns3qw3rlvjvzsnqwdy7bxqiy0vdwflq0l1plxb1vazyc";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/dbbc396373212fdf731e135cde391f27708ff015/recipes/disable-mouse";
@@ -7347,12 +7494,12 @@
     docker-compose-mode = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, yaml-mode }:
     melpaBuild {
         pname = "docker-compose-mode";
-        version = "0.3.5";
+        version = "1.0.0";
         src = fetchFromGitHub {
           owner = "meqif";
           repo = "docker-compose-mode";
-          rev = "372df2f0de34a4bd44d4a7274b9ab85117ac7392";
-          sha256 = "14vgjhy2j60xhf38zm5nlkr4d3r455kw6paw0wff4mqmdjcg3pds";
+          rev = "ae25b0e01394f94995f4b0ceaab1e04eb4b9acbd";
+          sha256 = "14xri92dcj52vw1vhrnicibrn9y010zv8w7jw6j3q9lrpmr073lr";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/37dd4c1fc11d22598c6faf03ccc860503a68b950/recipes/docker-compose-mode";
@@ -7578,12 +7725,12 @@
     drupal-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, php-mode }:
     melpaBuild {
         pname = "drupal-mode";
-        version = "0.7.1";
+        version = "0.7.3";
         src = fetchFromGitHub {
           owner = "arnested";
           repo = "drupal-mode";
-          rev = "1e6f973ed5dfdbbfda96c4ab266bd8ef3d6436d7";
-          sha256 = "1c3krir3l04rwlyadnhra6kmbnmvdm95aj7iwspa6dssnry4vflj";
+          rev = "49ce63c659aa0af7a2daf0c9e74e58fbce6deb71";
+          sha256 = "1l2xc24y037b3z62yxmq2bx1x3qqv56d15bf3qmb3mpgm4gh85j6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/13e16af340868048eb1f51f9865dfc707e57abe8/recipes/drupal-mode";
@@ -7662,12 +7809,12 @@
     dumb-jump = callPackage ({ dash, emacs, f, fetchFromGitHub, fetchurl, lib, melpaBuild, popup, s }:
     melpaBuild {
         pname = "dumb-jump";
-        version = "0.5.0";
+        version = "0.5.1";
         src = fetchFromGitHub {
           owner = "jacktasia";
           repo = "dumb-jump";
-          rev = "c96467b3079495353350a6b00fd2e6052b3a3fd0";
-          sha256 = "04jhbapf84if54d648mx1fk7b9vwrnd0apyarwjv7p1azasm6vwl";
+          rev = "64c0759432334465ccea115d83600b468f86e3be";
+          sha256 = "00vhxd7z7fw2cwdzgvfbdzfp668dfaw83c95kkicmmdzlabiz50i";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/dumb-jump";
@@ -7686,8 +7833,8 @@
         version = "0.7";
         src = fetchhg {
           url = "https://bitbucket.com/harsman/dyalog-mode";
-          rev = "56fa34ea25d4";
-          sha256 = "1hk7i557m0m42zdg59z278cylglnp49dr8wa3zbdwzk2xzdg0m00";
+          rev = "023d2edde61d";
+          sha256 = "1izhlafsbxfav4jvl7bqg188d71895r1sqacxsblvcld8c0brsqp";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5b7972602399f9df9139cff177e38653bb0f43ed/recipes/dyalog-mode";
@@ -7871,12 +8018,12 @@
     easy-hugo = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "easy-hugo";
-        version = "1.7.7";
+        version = "1.9.11";
         src = fetchFromGitHub {
           owner = "masasam";
           repo = "emacs-easy-hugo";
-          rev = "108cc2347507ff8c92b10a817de0850e9eb99ab2";
-          sha256 = "1fcq6693cjl0lx67gwsk53lm20zznq9cc9widb3rzpwifns4x8ac";
+          rev = "8f16fb1f510a147e7ab846030057d4c74127ffb2";
+          sha256 = "15axmg6z1nlaz7xsf70arxazkkskkga2fa71iswpnhwqsrr90w8l";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/easy-hugo";
@@ -8165,12 +8312,12 @@
     edit-indirect = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "edit-indirect";
-        version = "0.1.4";
+        version = "0.1.5";
         src = fetchFromGitHub {
           owner = "Fanael";
           repo = "edit-indirect";
-          rev = "1d1dae842505e5ff09644529deec87c056e1b14e";
-          sha256 = "145knahvvxbm8qmcdb69ilrg14w7130vav2pqjd7anr1l8n2i6gz";
+          rev = "032ac0ec690d4999d564fd882588c7a197efe8dd";
+          sha256 = "0by1x53pji39fjrj5bd446kz831nv0vdgw2jqasbym4pc1p2947r";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/acc9b816796b9f142c53f90593952b43c962d2d8/recipes/edit-indirect";
@@ -8614,12 +8761,12 @@
     el2org = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "el2org";
-        version = "0.5.0";
+        version = "0.6.0";
         src = fetchFromGitHub {
           owner = "tumashu";
           repo = "el2org";
-          rev = "c85837d56ed8fe1b31927755294db49ac46f443e";
-          sha256 = "0znnvpngghd9z8a0cakpvrw261mnmxqa15lpjcxfm7w8wgb2d4f6";
+          rev = "4a33469cd305e581603d7ef63bc2a1f2156f2e2e";
+          sha256 = "0mzddqny6wpg1fv99xrvlv7rxmaifvmy5bvj4in4pldhm4cx4q1b";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/el2org";
@@ -8950,12 +9097,12 @@
     elpy = callPackage ({ company, fetchFromGitHub, fetchurl, find-file-in-project, highlight-indentation, lib, melpaBuild, pyvenv, s, yasnippet }:
     melpaBuild {
         pname = "elpy";
-        version = "1.16.0";
+        version = "1.16.1";
         src = fetchFromGitHub {
           owner = "jorgenschaefer";
           repo = "elpy";
-          rev = "c33794ae03fa787c7f93b93cc9427d864b63e25f";
-          sha256 = "1q8zjsl9zbgwqcbvzkdlqy28z4h1qr0kkhhrq037vab0w0l0zi6l";
+          rev = "1e65cb6e988df088c299572464335b6f149addcd";
+          sha256 = "01mfrn6mn8h9fkpkqg2shp21864ffjr7q5h3rpbnk6wpa3pmjc1m";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1d8fcd8745bb15402c9f3b6f4573ea151415237a/recipes/elpy";
@@ -9574,12 +9721,12 @@
     ensime = callPackage ({ company, dash, fetchFromGitHub, fetchurl, lib, melpaBuild, popup, s, sbt-mode, scala-mode, yasnippet }:
     melpaBuild {
         pname = "ensime";
-        version = "1.0.1";
+        version = "2.0.1";
         src = fetchFromGitHub {
           owner = "ensime";
           repo = "ensime-emacs";
-          rev = "2b4d4cd764b9fa4757738a6dae87f4d1e99686d6";
-          sha256 = "0j7zd3qxh4m5gv5s8pvfacad2mkzwwz1xdrvg1sa035xaxahqsyx";
+          rev = "34c7719c9739d1e5d55c3f776e8f32a417b4eea6";
+          sha256 = "1dpj31krw0vwrb1pimpbpdm3k2ivqmr6kbgaw8p2dwwwqk1s6nbg";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/502faab70af713f50dd8952be4f7a5131075e78e/recipes/ensime";
@@ -9645,12 +9792,12 @@
     epkg = callPackage ({ closql, dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "epkg";
-        version = "2.3.0";
+        version = "3.0.0";
         src = fetchFromGitHub {
           owner = "emacscollective";
           repo = "epkg";
-          rev = "deb9affaadce11c356df53b6b62ab376ef652d16";
-          sha256 = "1515gv9bhjwbmkbz6sivq5zhpalvfb0ias4qia9anz9npqfx24y0";
+          rev = "1768e91e02a2d6441c2d82a711912a9498d2316e";
+          sha256 = "02fknkqxqxzqdqa2vj7ql6swrl83v1xs5iym5r6yr6mpj69di8bd";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/2df16abf56e53d4a1cc267a78797419520ff8a1c/recipes/epkg";
@@ -9875,12 +10022,12 @@
     erlang = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "erlang";
-        version = "20.0.4";
+        version = "20.1.1";
         src = fetchFromGitHub {
           owner = "erlang";
           repo = "otp";
-          rev = "a230f26086b3db9097f06d4bb91fb3b2e9379c77";
-          sha256 = "1g26vf7ab18r9knxa2ykn3j6vrhhiyqbg6jf3gfjxw2c94z51a9m";
+          rev = "69292a11cd4b31fd3ff73b44f28d527f2d16f555";
+          sha256 = "1v5hna4gf2i9lmiyykbs4w2r1yym2p6jb21nxfa5vlhwq85mldfb";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d9cd526f43981e0826af59cdc4bb702f644781d9/recipes/erlang";
@@ -10081,6 +10228,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    eshell-bookmark = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "eshell-bookmark";
+        version = "2.0.0";
+        src = fetchFromGitHub {
+          owner = "Fuco1";
+          repo = "eshell-bookmark";
+          rev = "deda4b848b2fb979dbe73ead2cb866610e3596ed";
+          sha256 = "14dmsnixf9vqdhsixw693sml0fn80zcf0b37z049fb40cmppqxdw";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/e7bf4702a907727990fcc676980f2b219e22ab0c/recipes/eshell-bookmark";
+          sha256 = "1bybxlq1h5chrjxqjb23kq8dmgw2xrjwkrnvpbphblqzpdy5ck0s";
+          name = "eshell-bookmark";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/eshell-bookmark";
+          license = lib.licenses.free;
+        };
+      }) {};
     eshell-did-you-mean = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "eshell-did-you-mean";
@@ -10120,6 +10288,27 @@
         packageRequires = [ cl-lib dash emacs ];
         meta = {
           homepage = "https://melpa.org/#/eshell-git-prompt";
+          license = lib.licenses.free;
+        };
+      }) {};
+    eshell-prompt-extras = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "eshell-prompt-extras";
+        version = "0.96";
+        src = fetchFromGitHub {
+          owner = "hiddenlotus";
+          repo = "eshell-prompt-extras";
+          rev = "7581c109673c40aceff278cd524273f50ffe170d";
+          sha256 = "1m1jisjz974cfz89i6l2zq666yzhsqipc6dmqlrm8mw81fxsfm1h";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/7fabdb05de9b8ec18a3a566f99688b50443b6b44/recipes/eshell-prompt-extras";
+          sha256 = "0kh4lvjkayjdz5lqvdqmdcblxizxk9kwmigjwa68kx8z6ngmfwa5";
+          name = "eshell-prompt-extras";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://melpa.org/#/eshell-prompt-extras";
           license = lib.licenses.free;
         };
       }) {};
@@ -10417,22 +10606,22 @@
           license = lib.licenses.free;
         };
       }) {};
-    evil = callPackage ({ fetchFromGitHub, fetchurl, goto-chg, lib, melpaBuild, undo-tree }:
+    evil = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, goto-chg, lib, melpaBuild, undo-tree }:
     melpaBuild {
         pname = "evil";
-        version = "1.2.12";
+        version = "1.2.13";
         src = fetchFromGitHub {
           owner = "emacs-evil";
           repo = "evil";
-          rev = "0ad4c2dae1249558f7b59a78a685e4f8092009c9";
-          sha256 = "1z7ysn0h62i674pw47k905713m4ch7hrisk4834rf53zq3c9sabn";
+          rev = "427cf5faa57e8794ac93f594dc3d1972e687a25a";
+          sha256 = "02xc9zgrabnlwk3wlsxbzbhdzi3fm5fk8kimvgdcp8vsnpdcrhql";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/440482c0edac8ee8bd4fe22f6bc5c1607f34c7ad/recipes/evil";
           sha256 = "1d36r6mi5nvrwnk4a9338wmhr72fcbrwj0r8gmvivpjdngjy4k39";
           name = "evil";
         };
-        packageRequires = [ goto-chg undo-tree ];
+        packageRequires = [ cl-lib emacs goto-chg undo-tree ];
         meta = {
           homepage = "https://melpa.org/#/evil";
           license = lib.licenses.free;
@@ -10963,6 +11152,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    evil-test-helpers = callPackage ({ evil, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "evil-test-helpers";
+        version = "1.2.13";
+        src = fetchFromGitHub {
+          owner = "emacs-evil";
+          repo = "evil";
+          rev = "427cf5faa57e8794ac93f594dc3d1972e687a25a";
+          sha256 = "02xc9zgrabnlwk3wlsxbzbhdzi3fm5fk8kimvgdcp8vsnpdcrhql";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/87da8c50f9167ad9c3844b23becb6904f809611d/recipes/evil-test-helpers";
+          sha256 = "0l4skyznzgr76z518q22lf90ymlsfcs02w8vqkg8az1nfl3ch7fs";
+          name = "evil-test-helpers";
+        };
+        packageRequires = [ evil ];
+        meta = {
+          homepage = "https://melpa.org/#/evil-test-helpers";
+          license = lib.licenses.free;
+        };
+      }) {};
     evil-text-object-python = callPackage ({ emacs, evil, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "evil-text-object-python";
@@ -11301,12 +11511,12 @@
     eziam-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "eziam-theme";
-        version = "0.4.4";
+        version = "0.4.5";
         src = fetchFromGitHub {
           owner = "thblt";
           repo = "eziam-theme-emacs";
-          rev = "63395a2367d1d48983a9363d2d0bf518177297bd";
-          sha256 = "15vgv0z4vzdnc3vb98j2hy4bv5x83f4c1dzgx49r61vka7p5is0q";
+          rev = "4a79230739cfaa607f39fbfe53339692b83c3933";
+          sha256 = "0cdaayp2ca6wcqh11snmc50p4gl6sika58jxvn5dklsipzxv75v8";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/4e0411583bd4fdbe425eb07de98851136fa1eeb0/recipes/eziam-theme";
@@ -11871,6 +12081,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    flex-compile = callPackage ({ buffer-manage, dash, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "flex-compile";
+        version = "0.1";
+        src = fetchFromGitHub {
+          owner = "plandes";
+          repo = "flex-compile";
+          rev = "4ca317883404a14c1b4920d7b3e6f0bffb04a8f2";
+          sha256 = "08ax91bdf4dwky8zp0cwmk53wqyqs893j7q1jah5cimnhgi82ksz";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/259caeebc317e81ab9d532a371ea85656c2b1619/recipes/flex-compile";
+          sha256 = "1hlh4k7qgln87xajnjjhf1yyg6bgdwd0iczhlfw8gdwfj5xpjd38";
+          name = "flex-compile";
+        };
+        packageRequires = [ buffer-manage dash emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/flex-compile";
+          license = lib.licenses.free;
+        };
+      }) {};
     floobits = callPackage ({ fetchFromGitHub, fetchurl, highlight, json ? null, lib, melpaBuild }:
     melpaBuild {
         pname = "floobits";
@@ -11958,12 +12189,12 @@
     flycheck = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, let-alist, lib, melpaBuild, pkg-info, seq }:
     melpaBuild {
         pname = "flycheck";
-        version = "30";
+        version = "31";
         src = fetchFromGitHub {
           owner = "flycheck";
           repo = "flycheck";
-          rev = "9c063965e893f0cc7c97fabb810ac41ec22f82fb";
-          sha256 = "1vyncqicafmy9av2nsawywn56ay50zdyjba9r55vv11baklabg8w";
+          rev = "401b115d10e202a1b31f57340438420081af21ce";
+          sha256 = "141i6wzqlb0dslmca6930cal7q4y5wbwzmxrpjk3hgm6nxz483p8";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/649f9c3576e81409ae396606798035173cc6669f/recipes/flycheck";
@@ -12210,12 +12441,12 @@
     flycheck-joker = callPackage ({ fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild }:
     melpaBuild {
         pname = "flycheck-joker";
-        version = "1.0.0";
+        version = "1.1.0";
         src = fetchFromGitHub {
           owner = "candid82";
           repo = "flycheck-joker";
-          rev = "e7964140cbb0ee7badfc3d67c6412f5c3a461f76";
-          sha256 = "0mqnhcpkf86dxqj0y7g5mnn91m81jdvrsbwikyqvx46z1jpi0y37";
+          rev = "c34c3922a2e8bc918f250602e0ddf655cdcad456";
+          sha256 = "0fp7h0pmxk02x1kisqvnb9wkjjn9bl91capmnllrb7qmb24w6pd5";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/599bf33a5d4a4a590b355001e532cab4e1ee9ef6/recipes/flycheck-joker";
@@ -12441,12 +12672,12 @@
     flycheck-pycheckers = callPackage ({ fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild }:
     melpaBuild {
         pname = "flycheck-pycheckers";
-        version = "0.2";
+        version = "0.4";
         src = fetchFromGitHub {
           owner = "msherry";
           repo = "flycheck-pycheckers";
-          rev = "220c551df591792d08fc9d149ab3329171743cb9";
-          sha256 = "0q1sz28nlnamcm4l587q94b7cyak9d4wpgpr33a05m9lw4a6z74i";
+          rev = "a3d39139dbe5cdaa64dda90907bb8653f196c71e";
+          sha256 = "1i1kliy0n9b7b0rby419030n35f59xb8952widaszz4z8qb7xw9k";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/af36dca316b318d25d65c9e842f15f736e19ea63/recipes/flycheck-pycheckers";
@@ -12546,12 +12777,12 @@
     flycheck-swift3 = callPackage ({ emacs, fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild }:
     melpaBuild {
         pname = "flycheck-swift3";
-        version = "1.1.0";
+        version = "2.0.0";
         src = fetchFromGitHub {
           owner = "GyazSquare";
           repo = "flycheck-swift3";
-          rev = "6b0b7c6fffc86809d0535afebd6b0972059992d5";
-          sha256 = "0d411idv9ib1jhmdbjb8ycc8clmm1ygpwapaka3d50gkgrmfin4q";
+          rev = "756833425f51baa9eb0a2fa7493df6e68612c88d";
+          sha256 = "1hvrg717q0nlz4r8wby82gs3vdx8fdhf38rg4j77j3fqfmxdd3fi";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/f1fb8c731c118327dc0bbb726e046fec46bcfb82/recipes/flycheck-swift3";
@@ -13299,27 +13530,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    forecast = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "forecast";
-        version = "0.6.2";
-        src = fetchFromGitHub {
-          owner = "cadadr";
-          repo = "forecast.el";
-          rev = "1eb60db1760572e3b1b87f6d672e3aa0812d6d94";
-          sha256 = "1imrn4wc744fdcm1pkfjk8gmilzcrjzawbcg6mhdkzsz5cnb7klb";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/e6ff6a4ee29b96bccb2e4bc0644f2bd2e51971ee/recipes/forecast";
-          sha256 = "0whag2n1120384w304g0w4bqr7svdxxncdhnz4rznfpxlgiw2rsc";
-          name = "forecast";
-        };
-        packageRequires = [ emacs ];
-        meta = {
-          homepage = "https://melpa.org/#/forecast";
-          license = lib.licenses.free;
-        };
-      }) {};
     foreman-mode = callPackage ({ dash, dash-functional, emacs, f, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "foreman-mode";
@@ -13491,12 +13701,12 @@
     fsharp-mode = callPackage ({ company, company-quickhelp, dash, fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild, popup, pos-tip, s }:
     melpaBuild {
         pname = "fsharp-mode";
-        version = "1.9.8";
+        version = "1.9.10";
         src = fetchFromGitHub {
           owner = "rneatherway";
           repo = "emacs-fsharp-mode-bin";
-          rev = "9766952bd7830cb0d319736961af8e42e67d42fe";
-          sha256 = "1krncbzdhp6kpypaqdn6fhvxhhc1pvy2ayn4w4ljmsd7wx6zazyi";
+          rev = "71435fdd100712d6894d8d72a5667b250a0d8eb7";
+          sha256 = "1c718gfms4zhzj06zmzdw71q6vhbf7mh3cgvq9vf8bnlv910p832";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/dc45611e2b629d8bc5f74555368f964420b79541/recipes/fsharp-mode";
@@ -13598,6 +13808,27 @@
         packageRequires = [ ivy ];
         meta = {
           homepage = "https://melpa.org/#/function-args";
+          license = lib.licenses.free;
+        };
+      }) {};
+    futhark-mode = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "futhark-mode";
+        version = "0.1.0";
+        src = fetchFromGitHub {
+          owner = "HIPERFIT";
+          repo = "futhark";
+          rev = "2a7d824f7265a35bb928bf4de8e46d02e0a56a12";
+          sha256 = "0dkx9xl39k0bcspyx37410rb5ngphw9svinwjw1kgq0pqhc2qxdf";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/0607f01aad7e77d53595ad8db95d32acfd29b148/recipes/futhark-mode";
+          sha256 = "1k22xkg6vd60hk58zkxhmsw2gs6ikzmidvxcdglnr46m6x7r7pnq";
+          name = "futhark-mode";
+        };
+        packageRequires = [ cl-lib ];
+        meta = {
+          homepage = "https://melpa.org/#/futhark-mode";
           license = lib.licenses.free;
         };
       }) {};
@@ -15218,6 +15449,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    goto-chg = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "goto-chg";
+        version = "1.7";
+        src = fetchFromGitHub {
+          owner = "emacs-evil";
+          repo = "goto-chg";
+          rev = "171b1331022caf12d8c3593e9b5075f87ee958d4";
+          sha256 = "1jcnrin4j1x8p63fd9r37dq1vr5a7a1nvzk6kp0bdsgn9vbjmapc";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/cf1fc176430fe3ab55ce537a0efc59780bb812be/recipes/goto-chg";
+          sha256 = "1yd4jq4zql4av9nr1sdk4nsnnk54c3brgjhpczndy1ipiaxlnydy";
+          name = "goto-chg";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://melpa.org/#/goto-chg";
+          license = lib.licenses.free;
+        };
+      }) {};
     goto-gem = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "goto-gem";
@@ -15547,12 +15799,12 @@
     green-is-the-new-black-theme = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "green-is-the-new-black-theme";
-        version = "0.0.1";
+        version = "0.0.3";
         src = fetchFromGitHub {
           owner = "fredcamps";
           repo = "green-is-the-new-black-emacs";
-          rev = "2b1011836fc04940d542e9a783b99670a08b308b";
-          sha256 = "16v7l4ynj4p1hq243rqckfgppmj8cvm0lyybjjqaqblqjd1ki90d";
+          rev = "b9cdecd04691311c30c94ad4ec81124e63b9b122";
+          sha256 = "124q733rirc8a2d9xfparphcjrrbxhp4wxf070l8hqp3p2764bka";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3e42528d5677fd90515cad47266c07ea3d4363fb/recipes/green-is-the-new-black-theme";
@@ -15734,12 +15986,12 @@
     gscholar-bibtex = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "gscholar-bibtex";
-        version = "0.3.2";
+        version = "0.3.3";
         src = fetchFromGitHub {
           owner = "cute-jumper";
           repo = "gscholar-bibtex";
-          rev = "655bccf0b12c9d95ec992ee4bfb5c7c9a4d0c99b";
-          sha256 = "1ivdq3mgym14v5hpv938248vifw1xk9z16d2f38d9xj01icik522";
+          rev = "ba4ce159e385d695d8560e8b06b3cbe48424861c";
+          sha256 = "0idnfhk17avp0r4706grjqqkz0xl98gs0bx7wrkvwym3y2gadlz2";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/9fa546d3dce59b07a623ee83e3befe139dc10481/recipes/gscholar-bibtex";
@@ -15881,12 +16133,12 @@
     hackernews = callPackage ({ fetchFromGitHub, fetchurl, json ? null, lib, melpaBuild }:
     melpaBuild {
         pname = "hackernews";
-        version = "0.3.1";
+        version = "0.4.0";
         src = fetchFromGitHub {
           owner = "clarete";
           repo = "hackernews.el";
-          rev = "452e939211ebc0af7256a2f0e8cdad5c426694e6";
-          sha256 = "1c49lfm5saafxks591qyy2nilymxz3aqlxpsmnad5d0kfhvjr47z";
+          rev = "22a15dc57dd6aab7793c0f9c2b72e161e0bee00c";
+          sha256 = "0bpbiadv4bf3lllsm0w1jcw8nc7c9zl97m972hbxb1dgv90gvs5b";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c43a342e47e5ede468bcf51a60d4dea3926f51bd/recipes/hackernews";
@@ -16174,12 +16426,12 @@
     hasky-stack = callPackage ({ emacs, f, fetchFromGitHub, fetchurl, lib, magit-popup, melpaBuild }:
     melpaBuild {
         pname = "hasky-stack";
-        version = "0.5.0";
+        version = "0.6.0";
         src = fetchFromGitHub {
           owner = "hasky-mode";
           repo = "hasky-stack";
-          rev = "38a33e2ed02d57afb6b38bf36741f5bf7e38e45b";
-          sha256 = "03zg58hrka2q7sqm3f14xgcs2mjxhlyybkf9w6pp8icr4wdsih4z";
+          rev = "a3f890fb8570369898ee9718b128d4e7123a6585";
+          sha256 = "0bc5i4s7aclwrsh8yrhfwwlfbcs5hdbzm31glikd487asv30jq9c";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c3faf544872478c3bccf2fe7dc51d406031e4d80/recipes/hasky-stack";
@@ -16237,12 +16489,12 @@
     helm = callPackage ({ async, emacs, fetchFromGitHub, fetchurl, helm-core, lib, melpaBuild, popup }:
     melpaBuild {
         pname = "helm";
-        version = "2.8.4";
+        version = "2.8.5";
         src = fetchFromGitHub {
           owner = "emacs-helm";
           repo = "helm";
-          rev = "0fc89c212b8a90ea8de0401f8d1b446ef9a24d93";
-          sha256 = "0yava3cn0g382mgnczgqmc1fhd2nbdr16n48vjlvk8bsb3n4va1m";
+          rev = "2385b81edc706f7efc74f2aff4854399254cde17";
+          sha256 = "02qhjyaqxh18g23lbcfpygz1ng7skifbqb6xkgh5wii1qykqxy6m";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/7e8bccffdf69479892d76b9336a4bec3f35e919d/recipes/helm";
@@ -16573,12 +16825,12 @@
     helm-core = callPackage ({ async, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "helm-core";
-        version = "2.8.4";
+        version = "2.8.5";
         src = fetchFromGitHub {
           owner = "emacs-helm";
           repo = "helm";
-          rev = "0fc89c212b8a90ea8de0401f8d1b446ef9a24d93";
-          sha256 = "0yava3cn0g382mgnczgqmc1fhd2nbdr16n48vjlvk8bsb3n4va1m";
+          rev = "2385b81edc706f7efc74f2aff4854399254cde17";
+          sha256 = "02qhjyaqxh18g23lbcfpygz1ng7skifbqb6xkgh5wii1qykqxy6m";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ef7a700c5665e6d72cb4cecf7fb5a2dd43ef9bf7/recipes/helm-core";
@@ -17623,12 +17875,12 @@
     helm-smex = callPackage ({ emacs, fetchFromGitHub, fetchurl, helm, lib, melpaBuild, smex }:
     melpaBuild {
         pname = "helm-smex";
-        version = "0.2";
+        version = "0.3";
         src = fetchFromGitHub {
           owner = "ptrv";
           repo = "helm-smex";
-          rev = "7af4e4b44671f739b39584fc50c20084700701ac";
-          sha256 = "1dhzglpd48mb47iyii8igb1dldvnr4alg18m7g8xb529dx8z9wni";
+          rev = "2269375dfa452b88b5170d1a5d5849ebb2c1e413";
+          sha256 = "0n2ki7g0hygsq4bi5zkhp3v772ld7niiajfznxmv11dgn949a52s";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/85568bd732da952053148e07b95e53f7caf5f62c/recipes/helm-smex";
@@ -17812,12 +18064,12 @@
     helpful = callPackage ({ dash, elisp-refs, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "helpful";
-        version = "0.1";
+        version = "0.2";
         src = fetchFromGitHub {
           owner = "Wilfred";
           repo = "helpful";
-          rev = "a5d8bc41e43177953d8ba3972a83755ddd4e1073";
-          sha256 = "0sr31df42cbrhzqxjvx1fcbafwq30jslqf715scrzyiziddf83zq";
+          rev = "b9a06978b6ffcd7f0ea213a6f534fa39318f0050";
+          sha256 = "1czqvmlca3w7n28c04dl3ljn8gbvfc565lysxlrhvgmv08iagnxm";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/889d34b654de13bd413d46071a5ff191cbf3d157/recipes/helpful";
@@ -20452,6 +20704,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    jsonnet-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "jsonnet-mode";
+        version = "0.0.1";
+        src = fetchFromGitHub {
+          owner = "mgyucht";
+          repo = "jsonnet-mode";
+          rev = "efe768fdcff25d746674fbbf229b9e1a7efea4f1";
+          sha256 = "1a52266y83z9i3sg7hhc8sw7rhjy5i9wdy2bv7s2fv00lnngaj29";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/ba17372732723f73e8eeb6e7c47abc0edeb20da4/recipes/jsonnet-mode";
+          sha256 = "1aadys887szlc924qr645lby9f8vzvxkwhq6byhppk1b01h911ia";
+          name = "jsonnet-mode";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/jsonnet-mode";
+          license = lib.licenses.free;
+        };
+      }) {};
     jsx-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "jsx-mode";
@@ -20623,16 +20896,16 @@
     kaolin-theme = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "kaolin-theme";
-        version = "0.6";
+        version = "0.9";
         src = fetchFromGitHub {
-          owner = "0rdy";
+          owner = "ogdenwebb";
           repo = "kaolin-theme";
-          rev = "041cc6637a58a3a24086d1c2b8c3eb113434127e";
-          sha256 = "1qx6568s8wj6ha8wfy8hih1qwwcdiybdb83w3fr9lqwh0lyhjp0f";
+          rev = "d43ba0e8e6b13b08e4d74de20c6e594ebb225501";
+          sha256 = "0gg19rh5q1gl6ylwrmjq0dqh6p5fkms1av6bbgry6fqv8220xf8n";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/d2abf9d914cdc210bbd47ea92d0dac76683e21f0/recipes/kaolin-theme";
-          sha256 = "1316sn1xpli9aqbhn8sldyvsc2fwk1ql9aw4l0rgkfbivvcklp7c";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/a67c2a3ad82efcb32ba4943c7ac10fe2768d9d51/recipes/kaolin-theme";
+          sha256 = "009064hhn39f9w9qxa3m0kwqhj5a12j7hg4916j9hslpwy5ghc0c";
           name = "kaolin-theme";
         };
         packageRequires = [ emacs ];
@@ -21617,12 +21890,12 @@
     live-py-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "live-py-mode";
-        version = "2.16.0";
+        version = "2.17.0";
         src = fetchFromGitHub {
           owner = "donkirkby";
           repo = "live-py-plugin";
-          rev = "96f22fe5892775b8a9a081898e1a4f00fbb8a674";
-          sha256 = "005g84acwjns587lawgms63b9840xswpqj0ccgdaqj6g9p0ynmqa";
+          rev = "0da66c7c01e8fea952faa3e21a34664b37918400";
+          sha256 = "0xzqg5nrrsapxsnyk919w5nb6pad7w06f0c266x9cs4m9wih82wk";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c7615237e80b46b5c50cb51a3ed5b07d92566fb7/recipes/live-py-mode";
@@ -21784,12 +22057,12 @@
     logview = callPackage ({ datetime, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "logview";
-        version = "0.8.1";
+        version = "0.8.2";
         src = fetchFromGitHub {
           owner = "doublep";
           repo = "logview";
-          rev = "134b41557ab539219d9e3a1b3c8939df93676726";
-          sha256 = "1jfdm64r6rj7pl6270v084fvaga5csa4snvbfjdlhs5bshn1d0v2";
+          rev = "72b6c5349206172a146b2c730b8ac040a92ebc3f";
+          sha256 = "1f93iyxf8v0jazzh6jljrm7r28z00nn14wr90qrh9y9chyq72n63";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1df3c11ed7738f32e6ae457647e62847701c8b19/recipes/logview";
@@ -22001,12 +22274,12 @@
     magit-annex = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, magit, melpaBuild }:
     melpaBuild {
         pname = "magit-annex";
-        version = "1.3.1";
+        version = "1.4.0";
         src = fetchFromGitHub {
           owner = "magit";
           repo = "magit-annex";
-          rev = "ae6250aead8f283eac8d6951a249cfc7d85e0b40";
-          sha256 = "0n6dhc92z5w67rcfngjzprzbdn42ja263gdqa7fncqq9p66slccq";
+          rev = "895c229c2b0d822a4debb302d8638105ecb4ee20";
+          sha256 = "0316csgc95dalqmkxj6qlb7inzcg4csfs9n3im1ygswcswpdaajh";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/cec5af50ae7634cc566adfbfdf0f95c3e2951c0c/recipes/magit-annex";
@@ -22106,12 +22379,12 @@
     magit-gitflow = callPackage ({ fetchFromGitHub, fetchurl, lib, magit, magit-popup, melpaBuild }:
     melpaBuild {
         pname = "magit-gitflow";
-        version = "2.2.2";
+        version = "2.2.3";
         src = fetchFromGitHub {
           owner = "jtatarik";
           repo = "magit-gitflow";
-          rev = "5bdcfe0a7bf4f5bb9a927baa4880233bf11a4a6b";
-          sha256 = "12pi6aw44lnzzcw0zgz5rxvcf4p700fkz4q2skbapwmds8gw3fg9";
+          rev = "cc41b561ec6eea947fe9a176349fb4f771ed865b";
+          sha256 = "0jz69wrrzvqadaphmjrr146nzvmphsbl7rmc3ccnpw1gw6gnz81f";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/dfaeb33dec2c75d21733b6e51d063664c6544e4d/recipes/magit-gitflow";
@@ -22890,12 +23163,12 @@
     merlin = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "merlin";
-        version = "3.0.2";
+        version = "3.0.3";
         src = fetchFromGitHub {
           owner = "the-lambda-church";
           repo = "merlin";
-          rev = "b53e4beeeb8da6d7cb035990a7e805fea5da0de6";
-          sha256 = "1lw0s78zwr8rd4q4pg34m9q8yd5swh1fff3c5p992a2qlzfb0hax";
+          rev = "a5dbf8e321ff162476555e62264468dd6f55c279";
+          sha256 = "0mq4ddr3g64dd4bhq812hb5xvlkswfmib1nw34f3m8sghmaxcd5z";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b1b9bfd3164e62758dc0a3362d85c6627ed7cbf8/recipes/merlin";
@@ -23831,6 +24104,27 @@
           license = lib.licenses.free;
         };
       }) {};
+    mustache = callPackage ({ dash, fetchFromGitHub, fetchurl, ht, lib, melpaBuild, s }:
+    melpaBuild {
+        pname = "mustache";
+        version = "0.23";
+        src = fetchFromGitHub {
+          owner = "Wilfred";
+          repo = "mustache.el";
+          rev = "b0ea352813592424164520a49e86c04600242752";
+          sha256 = "1n2ymd92qpvsby6ms0l3kjhdzzc47rri2aiscc6bs07hm4mjpr9q";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/d1bcf9599ca6d2c29333071a80f96808d4ab52e2/recipes/mustache";
+          sha256 = "1pjr00xx77mlfw1myxaz6i3y2gbivhbiq5hyjxxbjlfrkm1vxc8g";
+          name = "mustache";
+        };
+        packageRequires = [ dash ht s ];
+        meta = {
+          homepage = "https://melpa.org/#/mustache";
+          license = lib.licenses.free;
+        };
+      }) {};
     mustache-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "mustache-mode";
@@ -24338,12 +24632,12 @@
     no-littering = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "no-littering";
-        version = "0.5.10";
+        version = "0.5.11";
         src = fetchFromGitHub {
           owner = "emacscollective";
           repo = "no-littering";
-          rev = "227c2d175e95dbed6a5c6e37b12bb9a3fcf2de94";
-          sha256 = "1wgfcghzhsa0siz1vf3rq69h1ilyblj5rsmijnyymp9fhxgyyll6";
+          rev = "a4b42b185b65e78bc3bb6523e23aefb1213eb3b2";
+          sha256 = "1yzcawvz3vbq6pgr0b3sk0qg24jx1fpkinwcmsdl283ib8msbc7g";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/57a2fb9524df3fdfdc54c403112e12bd70888b23/recipes/no-littering";
@@ -24481,12 +24775,12 @@
     nov = callPackage ({ dash, emacs, esxml, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "nov";
-        version = "0.1.7";
+        version = "0.2.1";
         src = fetchFromGitHub {
           owner = "wasamasa";
           repo = "nov.el";
-          rev = "91c4329f64ddc9a598fa6c58e1d9264aee073e72";
-          sha256 = "0x3ijjhjg2q8gdqf4hgr2d8wy32qhxy48kbz0slibkn9yik3pvlz";
+          rev = "19ab463864f137b43704b4f34173349c88e84d8e";
+          sha256 = "00f5hhw157nwdwy26yn6l3z2hgk6xxvx5xl0hasskj1l9rg0zgh2";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/cf543955ba2d5d0074fa2a5ba176f9415f6e006d/recipes/nov";
@@ -24712,12 +25006,12 @@
     ob-http = callPackage ({ cl-lib ? null, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "ob-http";
-        version = "0.1.0";
+        version = "0.2.0";
         src = fetchFromGitHub {
           owner = "zweifisch";
           repo = "ob-http";
-          rev = "9155a413e41d918042e9839399e3940aa0f8499c";
-          sha256 = "1b39g0nifw0000s0x8ir0cfr716jypq6b5n2l1i4mrby6aw3bw1k";
+          rev = "20393dd8130d21a3f06d8514da14c5ffdd88ae44";
+          sha256 = "0xa7rgsb0d1d96h5bb0n0sy1hgmd2fg6r6g2aqp1c29ld4hpi7r7";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/950b02f76a04f453992b8720032e8c4cec9a039a/recipes/ob-http";
@@ -24985,12 +25279,12 @@
     omni-kill = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "omni-kill";
-        version = "0.2.3";
+        version = "0.5.1";
         src = fetchFromGitHub {
           owner = "AdrieanKhisbe";
           repo = "omni-kill.el";
-          rev = "8a1145b58b4736c9163bcd5b28c8fea80b2ea97b";
-          sha256 = "07grj81alrr6qgs3jmqkjzphkvi26w6jm5hf1f5wyx7h6q293ady";
+          rev = "192d51d843c6581d593a4eb01f1b49ad59d206cf";
+          sha256 = "0n24rhzl1zhlkdkjigsczyc0z3yrihz9qnn1icrk6nkms107qbnn";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c24df34d2fa5d908223379e909148423ba327ae2/recipes/omni-kill";
@@ -25006,12 +25300,12 @@
     omni-log = callPackage ({ dash, emacs, fetchFromGitHub, fetchurl, ht, lib, melpaBuild, s }:
     melpaBuild {
         pname = "omni-log";
-        version = "0.3.3";
+        version = "0.3.6";
         src = fetchFromGitHub {
           owner = "AdrieanKhisbe";
           repo = "omni-log.el";
-          rev = "e86c80065030306645e28badcb0c25c549560106";
-          sha256 = "10nsl45z3a1mvagffcsqj501x8wk3avmsncyn9laq3k4z1hjgdz5";
+          rev = "20021eb788cbeec0371145468430b259686f519d";
+          sha256 = "1sf2zbhjaz5b9xmz6632338cga7d326ibgw8b8c6c6b4vk16yhqc";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/47bb19bb7b4713c3fd82c1035a2fe66588c069e3/recipes/omni-log";
@@ -25048,12 +25342,12 @@
     omni-scratch = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "omni-scratch";
-        version = "0.4.1";
+        version = "0.5.0";
         src = fetchFromGitHub {
           owner = "AdrieanKhisbe";
           repo = "omni-scratch.el";
-          rev = "0da549c1386f93ed4de201bf8779ba64ddc91347";
-          sha256 = "0qfi54z2jqrkrdzriandwc9myzc27sxsx7nf20jf5qvcdgn13cl1";
+          rev = "e73d4c3f9e0d4774261496d018cf944a254e06f5";
+          sha256 = "0rmpnqb16v0hxfhw4lq2d27vhfhqv1mh8whq2l718l8c280yfn6k";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/6ba3e128a7fe4476d82266506b18ba9984c37944/recipes/omni-scratch";
@@ -25094,8 +25388,8 @@
         src = fetchFromGitHub {
           owner = "OmniSharp";
           repo = "omnisharp-emacs";
-          rev = "b425270bed93b427ff519d6f51ad1d97531a0a92";
-          sha256 = "0l9dk9idfsr21q0icx9fpgqyi4qlhnqal6sypak5zh8dgchrqif9";
+          rev = "40b6251a96057c80a958362a0886c06eea5bfd62";
+          sha256 = "176qfjd0qfgypj7pyi2p7v6zn7sic86gcgxz056k4y2akm6aa2p6";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/e327c483be04de32638b420c5b4e043d12a2cd01/recipes/omnisharp";
@@ -25290,12 +25584,12 @@
     org-autolist = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "org-autolist";
-        version = "0.13";
+        version = "0.14";
         src = fetchFromGitHub {
           owner = "calvinwyoung";
           repo = "org-autolist";
-          rev = "da332fadcd9be4c5eb21c5e98c392b89743750b2";
-          sha256 = "0j6fqgzvbmvvdh0dgwsxq004wxys2zwnq9wa3idm087ynp2a2ani";
+          rev = "c82d1e83e982b5f0c106b8800e5b0cfd5f73fdc1";
+          sha256 = "0ykiafbdjb2iy0s1gr6l51gddjbk08iwj4v13hgm8b675bl0cw56";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ca8e2cdb282674b20881bf6b4fc49af42a5d09a7/recipes/org-autolist";
@@ -25647,12 +25941,12 @@
     org-journal = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "org-journal";
-        version = "1.12.1";
+        version = "1.12.2";
         src = fetchFromGitHub {
           owner = "bastibe";
           repo = "org-journal";
-          rev = "d9b5512994c54ebcbc0dcccbf1c779fbb8a89d3d";
-          sha256 = "0s1b6lgr841iifznbwqn8r0chbfd0vph5v8n6cc0grak8n6nqgxr";
+          rev = "cda1980b013afabd299e7a2294517897f6442d98";
+          sha256 = "1y6idbp74vrr3g0r10n09znky8ih94kzf5fyil47sjkqyzzmpk3s";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/7fabdb05de9b8ec18a3a566f99688b50443b6b44/recipes/org-journal";
@@ -25707,35 +26001,15 @@
           license = lib.licenses.free;
         };
       }) {};
-    org-mac-iCal = callPackage ({ fetchgit, fetchurl, lib, melpaBuild }:
-    melpaBuild {
-        pname = "org-mac-iCal";
-        version = "7.9.3.5";
-        src = fetchgit {
-          url = "git://orgmode.org/org-mode.git";
-          rev = "592dc2ee7e4c80b9b61efb77117c8dc22d6cefd1";
-          sha256 = "0rvsn085r1sgvv0gwvjlfgn7371bjd254hdzamc97m122pqr7cxr";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/ee69e5e7b1617a29919d5fcece92414212fdf963/recipes/org-mac-iCal";
-          sha256 = "1ilzvmw1x5incagp1vf8d9v9mz0krlv7bpv428gg3gpqzpm6kksw";
-          name = "org-mac-iCal";
-        };
-        packageRequires = [];
-        meta = {
-          homepage = "https://melpa.org/#/org-mac-iCal";
-          license = lib.licenses.free;
-        };
-      }) {};
     org-mime = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "org-mime";
-        version = "0.0.7";
+        version = "0.0.9";
         src = fetchFromGitHub {
           owner = "org-mime";
           repo = "org-mime";
-          rev = "dd1b9881af705b9e78f79791c9f933cabe59c125";
-          sha256 = "0ndyqz2hpvnx6kykjz4d8nmngdjfavlwchl2dasi6m98b585liqa";
+          rev = "62791db188fa6a9a6b4e53c5c29fb4fa46582b98";
+          sha256 = "1l1fyyyyyi8nj4vpkyhpvz1yyqa2vn7042kp9443kqcswdfc9660";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/521678fa13884dae69c2b4b7a2af718b2eea4b28/recipes/org-mime";
@@ -26139,12 +26413,12 @@
     org-tfl = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, org }:
     melpaBuild {
         pname = "org-tfl";
-        version = "0.3.4";
+        version = "0.4.0";
         src = fetchFromGitHub {
           owner = "storax";
           repo = "org-tfl";
-          rev = "f0405e3ad62b90ea43489bdd6312adbd77edb9f3";
-          sha256 = "0cznw60ivaz42ass35sf9i62x7mf9in6z8kr8wc5i1mb7hafy2hk";
+          rev = "f0d7d39106a1de5457f5160cddd98ab892b61066";
+          sha256 = "1rwdibiq0w4nzccmvdkpwnmfga70y35lfg2xlkqxd02x7bfl7j3m";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/d9e97f2fee577c7e3fb42e4ca9d4f422c8907faf/recipes/org-tfl";
@@ -26307,12 +26581,12 @@
     org-vcard = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "org-vcard";
-        version = "0.1.0";
+        version = "0.2.0";
         src = fetchFromGitHub {
           owner = "flexibeast";
           repo = "org-vcard";
-          rev = "5c4e17c166fb0406d5dfdc8876b0e182ba7af8fd";
-          sha256 = "1qf4pqsg12y1qx7di0y5dp0f4slyp69h2q6y21hldzknhwxx4yy4";
+          rev = "a6ab82ab28fa78f7c985d3ea9c9fafdd17f7ea8b";
+          sha256 = "14l3xqahqmnfl3sskqcr33xpcsic8dm9cr9wmbv5la3xv14n10k7";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/df860814a09c376c9a6a2c5e7f528bbae29810b2/recipes/org-vcard";
@@ -26364,6 +26638,36 @@
         packageRequires = [ dash-functional deferred s ];
         meta = {
           homepage = "https://melpa.org/#/org2jekyll";
+          license = lib.licenses.free;
+        };
+      }) {};
+    org2web = callPackage ({ cl-lib ? null, dash, el2org, fetchFromGitHub, fetchurl, ht, htmlize, lib, melpaBuild, mustache, org, simple-httpd }:
+    melpaBuild {
+        pname = "org2web";
+        version = "0.9.1";
+        src = fetchFromGitHub {
+          owner = "tumashu";
+          repo = "org2web";
+          rev = "5243b399927a4c474bb3b8d1c8a00799df1f27d7";
+          sha256 = "0wsvfn409a2ivbich8b8zqza78sprirg4bl7igx536ydqclmi0n7";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/2864959163442165b9b1cd5471dc2649508decde/recipes/org2web";
+          sha256 = "0lcqf0pgkd7jilasw1485fy45k269jxvyl7hl7qrcs94s6fy2vaf";
+          name = "org2web";
+        };
+        packageRequires = [
+          cl-lib
+          dash
+          el2org
+          ht
+          htmlize
+          mustache
+          org
+          simple-httpd
+        ];
+        meta = {
+          homepage = "https://melpa.org/#/org2web";
           license = lib.licenses.free;
         };
       }) {};
@@ -26706,12 +27010,12 @@
     ox-epub = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, org }:
     melpaBuild {
         pname = "ox-epub";
-        version = "0.2.1";
+        version = "0.2.3";
         src = fetchFromGitHub {
           owner = "ofosos";
           repo = "ox-epub";
-          rev = "113300ed2c66cca10624e6d7bf5ff0a72e05653a";
-          sha256 = "1xj643jybrd6idn6bazp0canj8pm9v3gs199fa17hlag7151ancw";
+          rev = "022406066891d7a0f1fe8e2f1ddd7741dcf0accb";
+          sha256 = "1yybx9psjydbrrbdp7fpp4pih8jxflvl3wz9k489hvp6p0nffapp";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/c3ac31dfef00e83fa6b716ea006f35afb5dc6cd5/recipes/ox-epub";
@@ -26724,15 +27028,36 @@
           license = lib.licenses.free;
         };
       }) {};
+    ox-gfm = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "ox-gfm";
+        version = "1.0";
+        src = fetchFromGitHub {
+          owner = "larstvei";
+          repo = "ox-gfm";
+          rev = "99f93011b069e02b37c9660b8fcb45dab086a07f";
+          sha256 = "0drdypmgxk3238hmkqw9s3cw9wv94cyfqar5ar0bv0k69s92pxj8";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/10e90430f29ce213fe57c507f06371ea0b29b66b/recipes/ox-gfm";
+          sha256 = "065ngmzfd3g2h8n903hc4d363hz4z5rrdgizh2xpz03kf3plca6q";
+          name = "ox-gfm";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://melpa.org/#/ox-gfm";
+          license = lib.licenses.free;
+        };
+      }) {};
     ox-hugo = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, org }:
     melpaBuild {
         pname = "ox-hugo";
-        version = "0.1.2";
+        version = "0.2.1";
         src = fetchFromGitHub {
           owner = "kaushalmodi";
           repo = "ox-hugo";
-          rev = "a486141e4e2c3f9f67e799e20af150611d77f850";
-          sha256 = "1srrkc0bajmhp614avk4yr51zsp0gnmn47r1wi7qxkr6ybxwx8k1";
+          rev = "a0a1bb95d12fd45e3e111d29fd49b8171db1109b";
+          sha256 = "00pn5adk6qw4lpfsw1lxhp0466q3sndgqgrh4y821lbxssx89lh7";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/1e1240bb7b5bb8773f804b987901566a20e3e8a9/recipes/ox-hugo";
@@ -27060,27 +27385,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    paper-theme = callPackage ({ emacs, fetchFromGitHub, fetchurl, hexrgb, lib, melpaBuild }:
-    melpaBuild {
-        pname = "paper-theme";
-        version = "1.0.0";
-        src = fetchFromGitHub {
-          owner = "cadadr";
-          repo = "paper-theme";
-          rev = "15af5e31492f79dc0d47787150ef39d6318a2608";
-          sha256 = "1xh614czldjvfl66vhkyaai5k4qsg1l3mz6wd5b1w6kd45qrc54i";
-        };
-        recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/a35a0888a7a27174b5de58d99b01554769041f46/recipes/paper-theme";
-          sha256 = "04diqm2c9fm29zyms3hplkzb4kb7b2kyrxdsy0jxyjj5kabypd50";
-          name = "paper-theme";
-        };
-        packageRequires = [ emacs hexrgb ];
-        meta = {
-          homepage = "https://melpa.org/#/paper-theme";
-          license = lib.licenses.free;
-        };
-      }) {};
     paradox = callPackage ({ emacs, fetchFromGitHub, fetchurl, hydra, let-alist, lib, melpaBuild, seq, spinner }:
     melpaBuild {
         pname = "paradox";
@@ -27310,18 +27614,19 @@
           license = lib.licenses.free;
         };
       }) {};
-    password-store = callPackage ({ f, fetchgit, fetchurl, lib, melpaBuild, s }:
+    password-store = callPackage ({ f, fetchFromGitHub, fetchurl, lib, melpaBuild, s }:
     melpaBuild {
         pname = "password-store";
         version = "1.7.1";
-        src = fetchgit {
-          url = "https://git.zx2c4.com/password-store";
+        src = fetchFromGitHub {
+          owner = "zx2c4";
+          repo = "password-store";
           rev = "38ec1c72e29c872ec0cdde82f75490640d4019bf";
           sha256 = "04rqph353qfhnrwji6fmvrbk4yag8brqpbpaysq5z0c9l4p9ci87";
         };
         recipeFile = fetchurl {
-          url = "https://raw.githubusercontent.com/milkypostman/melpa/ceff76206bd44d92c00adc931236c4ae15db5583/recipes/password-store";
-          sha256 = "06l4xlvrjswy5kndn6h6swliqcp007nh4fyvma3jaac4f3x2qi65";
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/207f8ec84572176749d328cb2bbc4e87c36f202c/recipes/password-store";
+          sha256 = "03r8j14l12yc42b51fzvn1jh8j85nyl1rg6c80r0a7ihwkj27jv6";
           name = "password-store";
         };
         packageRequires = [ f s ];
@@ -27333,12 +27638,12 @@
     password-store-otp = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, password-store, s }:
     melpaBuild {
         pname = "password-store-otp";
-        version = "0.1.3";
+        version = "0.1.5";
         src = fetchFromGitHub {
           owner = "volrath";
           repo = "password-store-otp.el";
-          rev = "2965da7d8edd32bd4ef62f487ea6bcd08c599c89";
-          sha256 = "1svm6rlh4f0rjcl0fjy3x4bfakdn9npi8w7ak217ad2k08j44bzd";
+          rev = "a39a64a91de36e87b852339635bd3c5fb0e32441";
+          sha256 = "0gb48blvnn6ci2wl45z81p41ny7vbgl610hqy6b2hyr2171qjd60";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/fc89d02554a6ff150ad42634879073892f3e88be/recipes/password-store-otp";
@@ -27772,12 +28077,12 @@
     pfuture = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "pfuture";
-        version = "1.1";
+        version = "1.2";
         src = fetchFromGitHub {
           owner = "Alexander-Miller";
           repo = "pfuture";
-          rev = "a6c32c69abdb9b91baf8036b88cc4f477f611bd5";
-          sha256 = "0ly38dzg754n4s2xs09kaisxs14ikm42d9sjhw9p9xirzqm7zd5j";
+          rev = "8b5cd8dfb8769d2b24484a313d3d21938afd3dfb";
+          sha256 = "1d63sfwy7qmldhq2xda9dglg91cy2kpjdr2rlmqb48w95wf0am3m";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5fb70c9f56a58b5c7a2e8b69b191aa2fc7c9bcc8/recipes/pfuture";
@@ -28945,12 +29250,12 @@
     protobuf-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "protobuf-mode";
-        version = "3.4.0";
+        version = "3.4.1";
         src = fetchFromGitHub {
           owner = "google";
           repo = "protobuf";
-          rev = "80a37e0782d2d702d52234b62dd4b9ec74fd2c95";
-          sha256 = "0385j54kgr71h0cxh5vqr81qs57ack2g2k9mcdbq188v4ckjacyx";
+          rev = "b04e5cba356212e4e8c66c61bbe0c3a20537c5b9";
+          sha256 = "1lzxmbqlnmi34kymnf399azv86gmdbrf71xiad6wc24bzpkzqybb";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b4e7f5f641251e17add561991d3bcf1fde23467b/recipes/protobuf-mode";
@@ -29323,12 +29628,12 @@
     pyim = callPackage ({ async, cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, popup, pos-tip, pyim-basedict }:
     melpaBuild {
         pname = "pyim";
-        version = "1.6.1";
+        version = "1.6.4";
         src = fetchFromGitHub {
           owner = "tumashu";
           repo = "pyim";
-          rev = "f4dacfbac11d6d58f1fcbf766691e03b6983a9f6";
-          sha256 = "0dy0y159fqcip805l86gmjbsgbcvj3hm5rfsc6slinmxsrl4nl9l";
+          rev = "d44db4cb74c1c0cf6f814ff14d0be8e733f8404a";
+          sha256 = "02b2aknx127xvl8amf74krvd7z33kyr049iw5h0665zkzsli4g8w";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/151a0af91a58e27f724854d85d5dd9668229fe8d/recipes/pyim";
@@ -29344,7 +29649,7 @@
     pyim-basedict = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "pyim-basedict";
-        version = "0.2";
+        version = "0.3.1";
         src = fetchFromGitHub {
           owner = "tumashu";
           repo = "pyim-basedict";
@@ -29911,12 +30216,12 @@
     rdf-prefix = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "rdf-prefix";
-        version = "1.8";
+        version = "1.9";
         src = fetchFromGitHub {
           owner = "simenheg";
           repo = "rdf-prefix";
-          rev = "35129521d5b6035e5dd75d5b3481ce4971f46034";
-          sha256 = "1iy9385n8a2b7ph4wdf8p92n81slirsxxckrc3khbk5zrpp62z5k";
+          rev = "25cc3c8902f16191496b549705b00ffc7dff51f1";
+          sha256 = "00ycsqzgn5rq8r4r86z1j43i2a7wj4r3c2vcggdaizyf4parmgmy";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a5f083bd629697038ea6391c7a4eeedc909a5231/recipes/rdf-prefix";
@@ -30625,12 +30930,12 @@
     rjsx-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, js2-mode, lib, melpaBuild }:
     melpaBuild {
         pname = "rjsx-mode";
-        version = "0.2.0";
+        version = "0.3.0";
         src = fetchFromGitHub {
           owner = "felipeochoa";
           repo = "rjsx-mode";
-          rev = "4a24c86a1873289538134fe431e544fa3e12e788";
-          sha256 = "0yv622nnbcjnnaki49f7cz8cvrg13d0h9higadp83bl1lczhgw8j";
+          rev = "79bedb1d188e209be5cfef3bea8906df9c509ab8";
+          sha256 = "1dh76r9hy1d1f9xhdywslgv0w3c9nhsbwvpd8icgp300x5c6a3zh";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b83be7efdef2457e1320fe3dec46484fbd20263c/recipes/rjsx-mode";
@@ -31066,12 +31371,12 @@
     s = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "s";
-        version = "1.11.0";
+        version = "1.12.0";
         src = fetchFromGitHub {
           owner = "magnars";
           repo = "s.el";
-          rev = "a56f0d0fedf9754e1728067ac868100f2499357d";
-          sha256 = "08vf62fcrnbmf2ppb759kzznjdz8x72fqdwbc4n8nbswrwgm2ikl";
+          rev = "12f116d58ac03706496bd682c6449b452681874e";
+          sha256 = "1g8mqd13llj007al4nlxxx4z2lcsg3wk970mgjn0avwrhjjgdmmv";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/855ea20024b606314f8590129259747cac0bcc97/recipes/s";
@@ -31231,22 +31536,22 @@
           license = lib.licenses.free;
         };
       }) {};
-    sbt-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    sbt-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "sbt-mode";
-        version = "0.2";
+        version = "0.3";
         src = fetchFromGitHub {
           owner = "ensime";
           repo = "emacs-sbt-mode";
-          rev = "217d56bc2ec93a77a9e644233f4fb1815e437c61";
-          sha256 = "1lvf7y1n63p8jvnp6ppwmxq2s6h9sk45319576f3s28ixsfa6cp2";
+          rev = "bdf31a1ffe637d1445b149804d5f5cc29333a1bd";
+          sha256 = "0ygp0c2hy4zp5x0ghplxf2fhrf16cn37sk2zf6i43zqz6gydzq8a";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/364abdc3829fc12e19f00b534565227dbc30baad/recipes/sbt-mode";
           sha256 = "0v0n70czgkdijnw5jd4na41vlrmqcshvr8gdpv0bv55ilqhiihc8";
           name = "sbt-mode";
         };
-        packageRequires = [];
+        packageRequires = [ emacs ];
         meta = {
           homepage = "https://melpa.org/#/sbt-mode";
           license = lib.licenses.free;
@@ -31255,7 +31560,7 @@
     scala-mode = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "scala-mode";
-        version = "0.23";
+        version = "1.0.0";
         src = fetchFromGitHub {
           owner = "ensime";
           repo = "emacs-scala-mode";
@@ -31946,12 +32251,12 @@
     shx = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "shx";
-        version = "0.0.9";
+        version = "0.0.10";
         src = fetchFromGitHub {
           owner = "riscy";
           repo = "shx-for-emacs";
-          rev = "8166b02ebbab43d8a33d47b8221a94b69fc63487";
-          sha256 = "0n97iys2xyg1lzkn8bqsx0sgqpzci1pxg69v42cpzmyrz3h54bwp";
+          rev = "e53d798ba4a4c07a3ee1c194840c937b18c02087";
+          sha256 = "0sig9gpa2wn23skwny9jpvwxax0gbwp143anvgkc5gm87iw2jgrd";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/7a2ff78ae3c4289ebf9e06cdfd8f8082c395a16f/recipes/shx";
@@ -32699,22 +33004,22 @@
           license = lib.licenses.free;
         };
       }) {};
-    snoopy = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    snoopy = callPackage ({ cl-lib ? null, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "snoopy";
-        version = "0.1.1";
+        version = "0.2.0";
         src = fetchFromGitHub {
           owner = "anmonteiro";
           repo = "snoopy-mode";
-          rev = "8d2b7b1354414f261b237f2fed0d472803ba3909";
-          sha256 = "05q407dg6jppmqdxpp1ba8xs6yjilsa74hga46dbhcc9nzj9850a";
+          rev = "ec4123bdebfe0bb7bf4feaac2dc02b59caffe386";
+          sha256 = "01l44lshw0zvykay9886s1vqryanagkd4ciw3ramchn0baqz11vl";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/4a882cd92964ac195a09469006c9a44dc202f000/recipes/snoopy";
           sha256 = "1wa8jykqyj6rxqfhwbiyli6yh8s7n0pqv7fc9sfaymarda93zbgi";
           name = "snoopy";
         };
-        packageRequires = [ emacs ];
+        packageRequires = [ cl-lib emacs ];
         meta = {
           homepage = "https://melpa.org/#/snoopy";
           license = lib.licenses.free;
@@ -32807,12 +33112,12 @@
     sotclojure = callPackage ({ cider, clojure-mode, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, sotlisp }:
     melpaBuild {
         pname = "sotclojure";
-        version = "1.2";
+        version = "1.3.1";
         src = fetchFromGitHub {
           owner = "Malabarba";
           repo = "speed-of-thought-clojure";
-          rev = "8d879ef41c004726cca3c27a81b7543cc273c19b";
-          sha256 = "13yn2yadkpmykaly3l3xsq1bhm4sxyk8k1px555y11qi0mfdcjhh";
+          rev = "ceac82aa691e8d98946471be6aaff9c9a4603c32";
+          sha256 = "1a6riq7ksk5m76dsgc75d8b992nyr50l48l8cpms9064m6b0r9jv";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/3a2ccef8af91eada4449d9cd4bda6bd28272722e/recipes/sotclojure";
@@ -33562,12 +33867,12 @@
     suggest = callPackage ({ dash, emacs, f, fetchFromGitHub, fetchurl, lib, loop, melpaBuild, s }:
     melpaBuild {
         pname = "suggest";
-        version = "0.4";
+        version = "0.5";
         src = fetchFromGitHub {
           owner = "Wilfred";
           repo = "suggest.el";
-          rev = "5cb70e500df430cb9ffc8ae0ab67976c1d7d226f";
-          sha256 = "1001z5zaj4ln05js08cz13lgc11dqxc6sgp1s35g19sfhip4xyim";
+          rev = "05beef9ecf94107d72d0070fa092a8392505b012";
+          sha256 = "008d9kk8vb90n8j5dvw1rslfny66q012022na03dzbnmq3f73k7a";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b9fd27e812549587dc2ec26bb58974177ff263ff/recipes/suggest";
@@ -33706,22 +34011,22 @@
           license = lib.licenses.free;
         };
       }) {};
-    swift-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    swift-mode = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild, seq }:
     melpaBuild {
         pname = "swift-mode";
-        version = "2.4.0";
+        version = "3.0";
         src = fetchFromGitHub {
           owner = "chrisbarrett";
           repo = "swift-mode";
-          rev = "50394e4ffa80cb395ddd3c3128f995644820e2bc";
-          sha256 = "1dwrfbdfgndvv2rv4vl4vr82lzbkvk46z5fxbngd66yrx21rav24";
+          rev = "e8d9a5d7af59e8be25997b8b048d7c3e257cd0b0";
+          sha256 = "035478shf1crb1qnhk5rmz08xgn0z2p6fsw0yii1a4q5f3h85xrc";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/19cb133191cd6f9623e99e958d360113595e756a/recipes/swift-mode";
           sha256 = "1imr53f8agfza9zxs1h1mwyhg7yaywqqffd1lsvm1m84nvxvri2d";
           name = "swift-mode";
         };
-        packageRequires = [ emacs ];
+        packageRequires = [ emacs seq ];
         meta = {
           homepage = "https://melpa.org/#/swift-mode";
           license = lib.licenses.free;
@@ -34002,12 +34307,12 @@
     systemd = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "systemd";
-        version = "1.5";
+        version = "1.6";
         src = fetchFromGitHub {
           owner = "holomorph";
           repo = "systemd-mode";
-          rev = "4c1b2befd0c853dcc7bca52d9b084933c3a08254";
-          sha256 = "1sdrga3mmajai2jcf4zpcii0l2b9wch8rhdsbjlzx76ia5snp23l";
+          rev = "1e7567a9973bf80cab0d7e0355656a84bee7ca96";
+          sha256 = "0ylgnvpfindg4cxccbqy02ic7p0i9rygf1w16dm1filwhbqvjplq";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/ca810e512c357d1d0130aeeb9b46b38c595e3351/recipes/systemd";
@@ -34653,12 +34958,12 @@
     tide = callPackage ({ cl-lib ? null, dash, fetchFromGitHub, fetchurl, flycheck, lib, melpaBuild, s, typescript-mode }:
     melpaBuild {
         pname = "tide";
-        version = "2.5.2";
+        version = "2.5.3";
         src = fetchFromGitHub {
           owner = "ananthakumaran";
           repo = "tide";
-          rev = "f1daf10e931858ac8d6ff676cf02ca73d3c62558";
-          sha256 = "1hj5mfpkfczy09ghmivkkzwmn6nawwv0ydm4ckz4mggps42hn0j1";
+          rev = "e5d1d3852aaf63cbfb0abaec1792a62bed024a72";
+          sha256 = "1kwssyzbjwl2vyll0p49l57z41yv6k1jnzbsdnh0d1h81nixg5wk";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a21e063011ebbb03ac70bdcf0a379f9e383bdfab/recipes/tide";
@@ -34799,12 +35104,12 @@
     tracking = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "tracking";
-        version = "2.5";
+        version = "2.6";
         src = fetchFromGitHub {
           owner = "jorgenschaefer";
           repo = "circe";
-          rev = "13c605e639194c3da0c2e685056fac685f8c76a0";
-          sha256 = "0n7v0g332ml1ang2fjc8rjbi8h1f4bqazcqi8dlfn99vvv8kcd21";
+          rev = "59f1096238e6c30303a6fe9fc1c635f49e5946c6";
+          sha256 = "19h3983zy3f15cgs86irvbdzz55qyjm48qd7gjlzcxplr7vnnh0j";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a2b295656d53fddc76cacc86b239e5648e49e3a4/recipes/tracking";
@@ -34820,12 +35125,12 @@
     transmission = callPackage ({ emacs, fetchFromGitHub, fetchurl, let-alist, lib, melpaBuild }:
     melpaBuild {
         pname = "transmission";
-        version = "0.11.1";
+        version = "0.12";
         src = fetchFromGitHub {
           owner = "holomorph";
           repo = "transmission";
-          rev = "d465378a59e2eb91372564a56e60a9ab00e48f9c";
-          sha256 = "0al0xz59lrqj97fxmyxiphblg1bvbzahc6srd8klg7s0378ybblw";
+          rev = "0de5a5fa2438890ae9c2ca61999042ab175df3e9";
+          sha256 = "1wqlbbm71s1hvglsdp1qs7nvj6gnkjkai4rr8hhp1lliiyd5vmia";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/9ed7e414687c0bd82b140a1bd8044084d094d18f/recipes/transmission";
@@ -34859,22 +35164,22 @@
           license = lib.licenses.free;
         };
       }) {};
-    treemacs = callPackage ({ ace-window, cl-lib ? null, dash, emacs, f, fetchFromGitHub, fetchurl, lib, melpaBuild, pfuture, s }:
+    treemacs = callPackage ({ ace-window, cl-lib ? null, dash, emacs, f, fetchFromGitHub, fetchurl, hydra, lib, melpaBuild, pfuture, s }:
     melpaBuild {
         pname = "treemacs";
-        version = "1.10";
+        version = "1.11.5";
         src = fetchFromGitHub {
           owner = "Alexander-Miller";
           repo = "treemacs";
-          rev = "19723297eefdc9d3afef546f1839c88acfbeef9c";
-          sha256 = "117644jkyfi0p050hqpy6x4rk85jxnnnldmslzvvr7yprpc04hbw";
+          rev = "aa1dabcf28f2b145376141c5a39376eaaf70ad6a";
+          sha256 = "1r8fk1y68wscisxi8miia7wbz7agrn3n8gkk5kn8d1b8sk6hxpcs";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/486f21e99856a77f470d246f3c71cd32d2e61ad6/recipes/treemacs";
           sha256 = "07npjnhn9a0b537h1wmvy57bmicd2cji7bslp4wbnrfmmg2jdc3a";
           name = "treemacs";
         };
-        packageRequires = [ ace-window cl-lib dash emacs f pfuture s ];
+        packageRequires = [ ace-window cl-lib dash emacs f hydra pfuture s ];
         meta = {
           homepage = "https://melpa.org/#/treemacs";
           license = lib.licenses.free;
@@ -34883,12 +35188,12 @@
     treemacs-evil = callPackage ({ evil, fetchFromGitHub, fetchurl, lib, melpaBuild, treemacs }:
     melpaBuild {
         pname = "treemacs-evil";
-        version = "1.10";
+        version = "1.11.5";
         src = fetchFromGitHub {
           owner = "Alexander-Miller";
           repo = "treemacs";
-          rev = "19723297eefdc9d3afef546f1839c88acfbeef9c";
-          sha256 = "117644jkyfi0p050hqpy6x4rk85jxnnnldmslzvvr7yprpc04hbw";
+          rev = "aa1dabcf28f2b145376141c5a39376eaaf70ad6a";
+          sha256 = "1r8fk1y68wscisxi8miia7wbz7agrn3n8gkk5kn8d1b8sk6hxpcs";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/a52c2770097fe8968bff7c31ac411b3d9b60972e/recipes/treemacs-evil";
@@ -34904,12 +35209,12 @@
     treemacs-projectile = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild, projectile, treemacs }:
     melpaBuild {
         pname = "treemacs-projectile";
-        version = "1.10";
+        version = "1.11.5";
         src = fetchFromGitHub {
           owner = "Alexander-Miller";
           repo = "treemacs";
-          rev = "19723297eefdc9d3afef546f1839c88acfbeef9c";
-          sha256 = "117644jkyfi0p050hqpy6x4rk85jxnnnldmslzvvr7yprpc04hbw";
+          rev = "aa1dabcf28f2b145376141c5a39376eaaf70ad6a";
+          sha256 = "1r8fk1y68wscisxi8miia7wbz7agrn3n8gkk5kn8d1b8sk6hxpcs";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/b694918c94e6311745776d451aa2519924beef2d/recipes/treemacs-projectile";
@@ -35771,12 +36076,12 @@
     vhdl-tools = callPackage ({ emacs, fetchFromGitHub, fetchurl, ggtags, helm, lib, melpaBuild, outshine }:
     melpaBuild {
         pname = "vhdl-tools";
-        version = "5.6";
+        version = "5.7";
         src = fetchFromGitHub {
           owner = "csantosb";
           repo = "vhdl-tools";
-          rev = "c08343904835cbae12f48e0758b0a6a014d76a74";
-          sha256 = "1skh9p5s9nbl6jvljj9bfn19fdzjx8lvx1q6rzldld07xwaif4qb";
+          rev = "40d5e1020b1a2b6e8ff04cbd8c84bf7959e4e7af";
+          sha256 = "1ndrvwjgfjnmaw71y4452ck9aqlwnpxa7379ldsn7gfl0r67qhsi";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/69fe2f8fb98ac1af1d3185f62ae1c89e646cfebf/recipes/vhdl-tools";
@@ -35996,6 +36301,27 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/volatile-highlights";
+          license = lib.licenses.free;
+        };
+      }) {};
+    vue-mode = callPackage ({ edit-indirect, fetchFromGitHub, fetchurl, lib, melpaBuild, mmm-mode, ssass-mode, vue-html-mode }:
+    melpaBuild {
+        pname = "vue-mode";
+        version = "0.3.1";
+        src = fetchFromGitHub {
+          owner = "CodeFalling";
+          repo = "vue-mode";
+          rev = "fe501dba780025066dcdcd2055e772d06c2abdbc";
+          sha256 = "0k67kzrh2fjhjiqcy1yq5cmcwjpx85yd2xxvkqvv4791q58f7c4z";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/2e5e0a9fff332aeec09f6d3d758e2b67dfdf8397/recipes/vue-mode";
+          sha256 = "0gy7a5sliaijq0666l55vbkg15anrw7k1828szdn1ppkraw14bn0";
+          name = "vue-mode";
+        };
+        packageRequires = [ edit-indirect mmm-mode ssass-mode vue-html-mode ];
+        meta = {
+          homepage = "https://melpa.org/#/vue-mode";
           license = lib.licenses.free;
         };
       }) {};
@@ -36737,11 +37063,11 @@
     wisp-mode = callPackage ({ fetchhg, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "wisp-mode";
-        version = "0.9.2";
+        version = "0.9.6";
         src = fetchhg {
           url = "https://bitbucket.com/ArneBab/wisp";
-          rev = "7ce954278aef";
-          sha256 = "116cspnc4lhf6gk73yr9sy7013jp88vq5zayghzgnkbdlaw6zmz3";
+          rev = "4d41c0814bbc";
+          sha256 = "1xy9a27qdl7hm7x2gbhxql63paxi16441rczl2i8ps032l4ffdnj";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/5b7972602399f9df9139cff177e38653bb0f43ed/recipes/wisp-mode";
@@ -36778,12 +37104,12 @@
     with-editor = callPackage ({ async, emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "with-editor";
-        version = "2.6.0";
+        version = "2.7.0";
         src = fetchFromGitHub {
           owner = "magit";
           repo = "with-editor";
-          rev = "241726118dee067a8d9880d53c6a781d580ba8a1";
-          sha256 = "0q06qfir64nib604f23gdmbzl23mcsnysfd0x36cx9nwik95wl0x";
+          rev = "99d3278b1c79718de16dd4f57dcc8c4aa31a4051";
+          sha256 = "1mcfinr1wv87hqn2787dcyn7lkgfni4xfgsji50pwj3zfgg0yqyr";
         };
         recipeFile = fetchurl {
           url = "https://raw.githubusercontent.com/milkypostman/melpa/8c52c840dc35f3fd17ec660e113ddbb53aa99076/recipes/with-editor";
@@ -37087,6 +37413,27 @@
         packageRequires = [];
         meta = {
           homepage = "https://melpa.org/#/xbm-life";
+          license = lib.licenses.free;
+        };
+      }) {};
+    xcode-project = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "xcode-project";
+        version = "1.0.0";
+        src = fetchFromGitHub {
+          owner = "nhojb";
+          repo = "xcode-project";
+          rev = "f5548a26a1afc0b0d873556c25f6d8b6b9c2aa8c";
+          sha256 = "0xb1cvjaw7zjnw6c5aq315vvlc3cncris62jis44jb8s5r8gxcrv";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/49b866ebf7e707bc74525f83dd5038e6e860fcef/recipes/xcode-project";
+          sha256 = "0igp30f6ypmp4l8zmdfpa5bza4avm7mq2gj8v7b3ii655v91n6vi";
+          name = "xcode-project";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/xcode-project";
           license = lib.licenses.free;
         };
       }) {};
@@ -37468,6 +37815,25 @@
           license = lib.licenses.free;
         };
       }) {};
+    yatex = callPackage ({ fetchhg, fetchurl, lib, melpaBuild }: melpaBuild {
+        pname = "yatex";
+        version = "1.80";
+        src = fetchhg {
+          url = "https://www.yatex.org/hgrepos/yatex/";
+          rev = "ca7cf34e959c";
+          sha256 = "19pczpzl0wvkdassskcssq5qrpica0bffqxxi8sqp1j35px6v4ma";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/e28710244a1bef8f56156fe1c271520896a9c694/recipes/yatex";
+          sha256 = "17np4am7yan1bh4706azf8in60c41158h3z591478j5b1w13y5a6";
+          name = "yatex";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://melpa.org/#/yatex";
+          license = lib.licenses.free;
+        };
+      }) {};
     yaxception = callPackage ({ fetchFromGitHub, fetchurl, lib, melpaBuild }:
     melpaBuild {
         pname = "yaxception";
@@ -37706,6 +38072,27 @@
         packageRequires = [ esxml ];
         meta = {
           homepage = "https://melpa.org/#/zone-nyan";
+          license = lib.licenses.free;
+        };
+      }) {};
+    zoom = callPackage ({ emacs, fetchFromGitHub, fetchurl, lib, melpaBuild }:
+    melpaBuild {
+        pname = "zoom";
+        version = "0.1.0";
+        src = fetchFromGitHub {
+          owner = "cyrus-and";
+          repo = "zoom";
+          rev = "ed8aca43820678ff6e7b8ed697cba8dbb3a6136e";
+          sha256 = "1na1syvbayqwbsvd1d0ajyzjvhg8q3s3mqrx82ffcbxr0ijyzzj8";
+        };
+        recipeFile = fetchurl {
+          url = "https://raw.githubusercontent.com/milkypostman/melpa/3fe094c99756ad29eda9bc51f31bb70c4ddc4131/recipes/zoom";
+          sha256 = "09bk0nnfj72an2b3rravd6qp21gdgcm1m55qnf2r8rzbgqymq5ls";
+          name = "zoom";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://melpa.org/#/zoom";
           license = lib.licenses.free;
         };
       }) {};

--- a/pkgs/applications/editors/emacs-modes/org-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/org-generated.nix
@@ -1,10 +1,10 @@
 { callPackage }: {
     org = callPackage ({ elpaBuild, fetchurl, lib }: elpaBuild {
         pname = "org";
-        version = "20170911";
+        version = "20171009";
         src = fetchurl {
-          url = "http://orgmode.org/elpa/org-20170911.tar";
-          sha256 = "16d69g1qnfcj7d2q9ni5dz5wh9pid9mzhwyfg4z93s9xizzlnw64";
+          url = "http://orgmode.org/elpa/org-20171009.tar";
+          sha256 = "1v8y4gmfrnzsdy9mspqzn157da7lb7z2wvp95r1iywf64325gv5s";
         };
         packageRequires = [];
         meta = {
@@ -14,10 +14,10 @@
       }) {};
     org-plus-contrib = callPackage ({ elpaBuild, fetchurl, lib }: elpaBuild {
         pname = "org-plus-contrib";
-        version = "20170911";
+        version = "20171009";
         src = fetchurl {
-          url = "http://orgmode.org/elpa/org-plus-contrib-20170911.tar";
-          sha256 = "0bgrsccar4v9viq99w2h4rjavql14zgdwkwaa1bprga3af78jr82";
+          url = "http://orgmode.org/elpa/org-plus-contrib-20171009.tar";
+          sha256 = "0iv1f7hbqh46mymk097x69q00pqpbkcyzjfd9a9slf5xkw1g1lk1";
         };
         packageRequires = [];
         meta = {


### PR DESCRIPTION
The big news for this change is that melpa has stopped supporting packages located anywhere other than `git` and `hg`---so there's a lot of stuff removed from the melpa-packages list.