### PR TITLE
geoclue2: 2.4.3 -> 2.4.7 and add wrapGAppsHook

### DIFF
--- a/pkgs/development/libraries/geoclue/2.0.nix
+++ b/pkgs/development/libraries/geoclue/2.0.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, intltool, libintlOrEmpty, pkgconfig, glib, json_glib, libsoup, geoip
-, dbus, dbus_glib, modemmanager, avahi
+, dbus, dbus_glib, modemmanager, avahi, glib_networking, wrapGAppsHook
 }:
 
 with stdenv.lib;
@@ -13,11 +13,11 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pkgconfig
+    pkgconfig intltool wrapGAppsHook
   ];
 
   buildInputs = libintlOrEmpty ++
-   [ intltool glib json_glib libsoup geoip
+   [ glib json_glib libsoup geoip
      dbus dbus_glib avahi
    ] ++ optionals (!stdenv.isDarwin) [ modemmanager ];
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = optionalString stdenv.isDarwin " -lintl";
 
-  propagatedBuildInputs = [ dbus dbus_glib glib ];
+  propagatedBuildInputs = [ dbus dbus_glib glib glib_networking ];
 
   meta = with stdenv.lib; {
     description = "Geolocation framework and some data providers";

--- a/pkgs/development/libraries/geoclue/2.0.nix
+++ b/pkgs/development/libraries/geoclue/2.0.nix
@@ -5,11 +5,11 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "geoclue-2.4.3";
+  name = "geoclue-2.4.7";
 
   src = fetchurl {
     url = "http://www.freedesktop.org/software/geoclue/releases/2.4/${name}.tar.xz";
-    sha256 = "0pk07k65dlw37nz8z5spksivsv5nh96xmbi336rf2yfxf2ldpadd";
+    sha256 = "19hfmr8fa1js8ynazdyjxlyrqpjn6m1719ay70ilga4rayxrcyyi";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
geoclue2 on my machine failed to contact Mozilla because it was unable to find glib_networking. On GNOME systems this will be set by environment variable, but without GNOME it isn't. Adding `glib_networking` via the `wrapGAppsHook` solved this issue.

Additionally, when geoclue2 found an NMEA source on the local network via Avahi, it would crash on `No GSettings schemas are installed on the system` without that hook.

This PR solves both problems, as well as upgrading the package to the latest upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

