### PR TITLE
libmsgpack/libtoxcore/qtox: several related package upgrades

### DIFF
--- a/pkgs/applications/networking/instant-messengers/qtox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/qtox/default.nix
@@ -2,25 +2,25 @@
   libtoxcore,
   libpthreadstubs, libXdmcp, libXScrnSaver,
   qtbase, qtsvg, qttools, qttranslations,
-  ffmpeg, filter-audio, libsodium, libopus,
+  ffmpeg, filter-audio, libexif, libsodium, libopus,
   libvpx, openal, opencv, pcre, qrencode, sqlcipher }:
 
 mkDerivation rec {
   name = "qtox-${version}";
-  version = "1.11.0";
+  version = "1.12.1";
 
   src = fetchFromGitHub {
-    owner  = "tux3";
+    owner  = "qTox";
     repo   = "qTox";
     rev    = "v${version}";
-    sha256 = "0h8v359h1xn2xm6xa9q56mjiw58ap1bpiwx1dxxmphjildxadwck";
+    sha256 = "1832ay0167qjc2vvpps507mnb0531y3d3pxmlm5nakvcwjs7vl8d";
   };
 
   buildInputs = [
     libtoxcore
     libpthreadstubs libXdmcp libXScrnSaver
     qtbase qtsvg qttools qttranslations
-    ffmpeg filter-audio libopus libsodium
+    ffmpeg filter-audio libexif libopus libsodium
     libvpx openal opencv pcre qrencode sqlcipher
   ];
 
@@ -37,6 +37,7 @@ mkDerivation rec {
 
   meta = with lib; {
     description = "Qt Tox client";
+    homepage    = https://tox.chat;
     license     = licenses.gpl3;
     maintainers = with maintainers; [ viric jgeerds akaWolf peterhoeg ];
     platforms   = platforms.all;

--- a/pkgs/applications/networking/instant-messengers/utox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/utox/default.nix
@@ -25,9 +25,9 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DENABLE_UPDATER=OFF"
-  ];
+  ] ++ stdenv.lib.optional (!doCheck) "-DENABLE_TESTS=OFF";
 
-  doCheck = false;
+  doCheck = true;
 
   checkTarget = "test";
 

--- a/pkgs/development/libraries/libmsgpack/2.0.nix
+++ b/pkgs/development/libraries/libmsgpack/2.0.nix
@@ -1,12 +1,12 @@
 { callPackage, fetchFromGitHub, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "2.1.5";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner  = "msgpack";
     repo   = "msgpack-c";
     rev    = "cpp-${version}";
-    sha256 = "0n4kvma3dldfsvv7b0zw23qln6av5im2aqqd6m890i75zwwkw0zv";
+    sha256 = "189m44pwpcpf7g4yhzfla4djqyp2kl54wxmwfaj94gwgj5s370i7";
   };
 })

--- a/pkgs/development/libraries/libmsgpack/generic.nix
+++ b/pkgs/development/libraries/libmsgpack/generic.nix
@@ -11,16 +11,21 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  enableParallelBuilding = true;
+
   crossAttrs = {
   } // stdenv.lib.optionalAttrs (hostPlatform.libc == "msvcrt") {
-    cmakeFlags = "-DMSGPACK_BUILD_EXAMPLES=OFF -DCMAKE_SYSTEM_NAME=Windows";
+    cmakeFlags = [
+      "-DMSGPACK_BUILD_EXAMPLES=OFF"
+      "-DCMAKE_SYSTEM_NAME=Windows"
+    ];
   };
 
   meta = with stdenv.lib; {
     description = "MessagePack implementation for C and C++";
-    homepage = http://msgpack.org;
+    homepage    = http://msgpack.org;
+    license     = licenses.asl20;
     maintainers = with maintainers; [ redbaron wkennington ];
-    license = licenses.asl20;
-    platforms = platforms.all;
+    platforms   = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libtoxcore/default.nix
+++ b/pkgs/development/libraries/libtoxcore/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "libtoxcore-${version}";
-  version = "0.1.8";
+  version = "0.1.10";
 
   src = fetchFromGitHub {
     owner  = "TokTok";
     repo   = "c-toxcore";
     rev    = "v${version}";
-    sha256 = "08vdq3j60wn62lj2z9f3f47hibns93rvaqx5xc5bm3nglk70q7kk";
+    sha256 = "1d3f7lnlxra2lhih838bvlahxqv50j35g9kfyzspq971sb5z30mv";
   };
 
   cmakeFlags = [
@@ -24,7 +24,11 @@ stdenv.mkDerivation rec {
     libopus
     libvpx
   ];
+
   nativeBuildInputs = [ cmake pkgconfig ];
+
+  enableParallelBuilding = true;
+
   checkInputs = [ check ];
 
   checkPhase = "ctest";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9227,6 +9227,7 @@ with pkgs;
   libmtp = callPackage ../development/libraries/libmtp { };
 
   libmsgpack = callPackage ../development/libraries/libmsgpack { };
+  libmsgpack_2_0 = callPackage ../development/libraries/libmsgpack/2.0.nix { };
   libmsgpack_1_4 = callPackage ../development/libraries/libmsgpack/1.4.nix { };
 
   libmysqlconnectorcpp = callPackage ../development/libraries/libmysqlconnectorcpp {


### PR DESCRIPTION
###### Motivation for this change

This change carries a number of other changes that arose as a consequence of the ```libmsgpack``` change.

```nox-review``` fails but that is because ```pjsip``` fails and thus ```ring-daemon``` which was the case anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

