### PR TITLE
snapcast: init at 0.11.1

### DIFF
--- a/pkgs/applications/audio/snapcast/client.nix
+++ b/pkgs/applications/audio/snapcast/client.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, alsaLib, libvorbis, tremor, flac, alsaUtils, avahi }:
+
+stdenv.mkDerivation rec {
+  name = "snapcast-client-${version}";
+  version = "v0.11.1";
+
+  src = fetchFromGitHub {
+    owner = "badaix";
+    repo = "snapcast";
+    rev = version;
+    sha256 = "15bzc4didslk6lprb74cv0d2m9hdvxh4vaah3jrkazvnignqmwfh";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ alsaLib alsaUtils libvorbis tremor flac avahi ];
+
+  buildPhase = ''
+    cd client
+    make DESTDIR=$out
+  '';
+
+  installPhase = ''
+    install -vD snapclient $out/bin/snapclient
+    install -vD snapclient.1 $out/share/man/man1/snapclient.1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Synchronous multi-room audio player -- client";
+    homepage = https://github.com/badaix/snapcast;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ TealG ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/audio/snapcast/client.nix
+++ b/pkgs/applications/audio/snapcast/client.nix
@@ -14,14 +14,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ alsaLib alsaUtils libvorbis tremor flac avahi ];
 
-  buildPhase = ''
-    cd client
-    make DESTDIR=$out
-  '';
+  sourceRoot = "client";
+  makeFlags = [ "DESTDIR=$(out)" ];
 
   installPhase = ''
+    runHook preInstall
     install -vD snapclient $out/bin/snapclient
     install -vD snapclient.1 $out/share/man/man1/snapclient.1
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/audio/snapcast/server.nix
+++ b/pkgs/applications/audio/snapcast/server.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, alsaLib, alsaUtils, libvorbis, flac, avahi }:
+
+stdenv.mkDerivation rec {
+  name = "snapcast-server-${version}";
+  version = "v0.11.1";
+
+  src = fetchFromGitHub {
+    owner = "badaix";
+    repo = "snapcast";
+    rev = version;
+    sha256 = "15bzc4didslk6lprb74cv0d2m9hdvxh4vaah3jrkazvnignqmwfh";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ alsaLib alsaUtils libvorbis flac avahi ];
+
+  buildPhase = ''
+    cd server
+    make DESTDIR=$out
+  '';
+
+  installPhase = ''
+    install -vD snapserver $out/bin/snapserver
+    install -vD snapserver.1 $out/share/man/man1/snapserver.1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Synchronous multi-room audio player -- server";
+    homepage = https://github.com/badaix/snapcast;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ TealG ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/audio/snapcast/server.nix
+++ b/pkgs/applications/audio/snapcast/server.nix
@@ -14,14 +14,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ alsaLib alsaUtils libvorbis flac avahi ];
 
-  buildPhase = ''
-    cd server
-    make DESTDIR=$out
-  '';
+  sourceRoot = "server";
+  makeFlags = [ "DESTDIR=$(out)" ];
 
   installPhase = ''
+    runHook preInstall
     install -vD snapserver $out/bin/snapserver
     install -vD snapserver.1 $out/share/man/man1/snapserver.1
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4415,6 +4415,9 @@ with pkgs;
 
   snabb = callPackage ../tools/networking/snabb { } ;
 
+  snapcast-client = callPackage ../applications/audio/snapcast/client.nix { };
+  snapcast-server = callPackage ../applications/audio/snapcast/server.nix { };
+
   sng = callPackage ../tools/graphics/sng {
     libpng = libpng12;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

