### PR TITLE
palemoon: 27.4.2 -> 27.5.0

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -10,14 +10,14 @@
 
 stdenv.mkDerivation rec {
   name = "palemoon-${version}";
-  version = "27.4.2";
+  version = "27.5.0";
 
   src = fetchFromGitHub {
     name   = "palemoon-src";
     owner  = "MoonchildProductions";
     repo   = "Pale-Moon";
     rev    = version + "_Release";
-    sha256 = "155c1a76kkx9p8cnz9d33xx30asjr32x10cccx0gyq1lm1b9ffbl";
+    sha256 = "0m4fgwxn6hs8r240i6acaajx76cvqy1b7cqmdsxd33qpjrrj1h9d";
   };
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
27.5.1 is "out", but there is no GitHub Release

(Although, this shouldn't be an issue since it was
mostly Win10-only changes anyway)

###### Motivation for this change
I use this browser every day

###### Things done
Version bump with hash update; built successfully and am posting from the very built browser

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
