### PR TITLE
babl: 1.2.8 -> 1.3.4

### DIFF
--- a/pkgs/development/libraries/babl/default.nix
+++ b/pkgs/development/libraries/babl/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "babl-0.1.28";
+  name = "babl-0.1.34";
 
   src = fetchurl {
     url = "http://ftp.gtk.org/pub/babl/0.1/${name}.tar.bz2";
-    sha256 = "00w6xfcv960c98qvxv81gcbj8l1jiab9sggmdl77m19awwiyvwv3";
+    sha256 = "0nwakj313l2dh5npx18avkg4z17i2prkxbl6vj547a08n6ry1gsy";
   };
 
   meta = with stdenv.lib; { 


### PR DESCRIPTION
###### Motivation for this change

Motivation for change: GIMP 2.9.6 requires at least BABL v1.3.0 so upgrading to latest release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) - _this is a library_
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

