### PR TITLE
pam module: enable pam_keyinit.so by default

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -330,6 +330,7 @@ let
           ${optionalString cfg.setEnvironment ''
             session required pam_env.so envfile=${config.system.build.pamEnvironment}
           ''}
+          session required pam_keyinit.so force revoke
           session required pam_unix.so
           ${optionalString cfg.setLoginUid
               "session ${


### PR DESCRIPTION
Closes #27574

###### Motivation for this change

Fixes ecryptfs regression (from 17.03 to 17.09) as explained in https://github.com/NixOS/nixpkgs/issues/27574#issuecomment-335964189

I'm unfortunately not entirely sure what other side-effects this might have, though this [thread](https://bugzilla.novell.com/show_bug.cgi?id=1045886) seems to say that enabling `pam_keyinit` is "recommended" anyway.

Hopefully someone more competent can opine.

From `pam_keyinit`'s man page:

> The pam_keyinit PAM module ensures that the invoking process has a session keyring other than the user default session keyring.
> 
> The session component of the module checks to see if the process's session keyring is the user default, and, if it is, creates a new anonymous session keyring with which to replace it.
> 
> If a new session keyring is created, it will install a link to the user common keyring in the session keyring so that keys common to the user will be automatically accessible through it.
> 
> The session keyring of the invoking process will thenceforth be inherited by all its children unless they override it.
> 
> This module is intended primarily for use by login processes. Be aware that after the session keyring has been replaced, the old session keyring and the keys it contains will no longer be accessible.
> 
> This module should not, generally, be invoked by programs like su, since it is usually desirable for the key set to percolate through to the alternate context. The keys have their own permissions system to manage this.

AFAIK we don't have a separate `pam.nix` for `su` and `sudo` so can't carve them out.

> This module should be included as early as possible in a PAM configuration, so that other PAM modules can attach tokens to the keyring.

> force
> - Causes the session keyring of the invoking process to be replaced unconditionally.

(Without `force`, regression wouldn't go away)

> revoke
> - Causes the session keyring of the invoking process to be revoked when the invoking process exits if the session keyring was created for this process in the first place.

(Wasn't sure about this one but it sounded conservative so I put it in)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

