### PR TITLE
add sphinx_guzzle_theme

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -205,6 +205,7 @@
   falsifian = "James Cook <james.cook@utoronto.ca>";
   fare = "Francois-Rene Rideau <fahree@gmail.com>";
   fgaz = "Francesco Gazzetta <francygazz@gmail.com>";
+  flokli = "Florian Klink <flokli@flokli.de>";
   florianjacob = "Florian Jacob <projects+nixos@florianjacob.de>";
   flosse = "Markus Kohlhase <mail@markus-kohlhase.de>";
   fluffynukeit = "Daniel Austin <dan@fluffynukeit.com>";

--- a/pkgs/development/python-modules/guzzle_sphinx_theme/default.nix
+++ b/pkgs/development/python-modules/guzzle_sphinx_theme/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, sphinx, fetchPypi }:
+
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "guzzle_sphinx_theme";
+  version = "0.7.11";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1rnkzrrsbnifn3vsb4pfaia3nlvgvw6ndpxp7lzjrh23qcwid34v";
+  };
+
+  doCheck = false; # no tests
+
+  propagatedBuildInputs = [ sphinx ];
+
+  meta = with stdenv.lib; {
+    description = "Sphinx theme used by Guzzle: http://guzzlephp.org";
+    homepage = https://github.com/guzzle/guzzle_sphinx_theme/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ flokli ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20554,25 +20554,7 @@ in {
     };
   });
 
-  sphinx_guzzle_theme = buildPythonPackage (rec {
-    version = "0.7.11";
-    name = "sphinx_guzzle_theme-${version}";
-
-    src = pkgs.fetchurl {
-      url = "https://github.com/guzzle/guzzle_sphinx_theme/archive/${version}.tar.gz";
-      sha256 = "f5f0e3d541c09ace912e0fa75dafd46f5a54314a929913c7de9709e677d5aa09";
-    };
-
-    buildInputs = with self; [ sphinx ];
-
-    meta = with stdenv.lib; {
-      description = "Sphinx theme used by Guzzle: http://guzzlephp.org";
-      homepage = https://github.com/guzzle/guzzle_sphinx_theme/;
-      license = licenses.mit;
-      maintainers = with maintainers; [ flokli ];
-      platforms = platforms.unix;
-    };
-  });
+  guzzle_sphinx_theme = callPackage ../development/python-modules/guzzle_sphinx_theme { };
 
   sphinx-testing = callPackage ../development/python-modules/sphinx-testing { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20554,6 +20554,26 @@ in {
     };
   });
 
+  sphinx_guzzle_theme = buildPythonPackage (rec {
+    version = "0.7.11";
+    name = "sphinx_guzzle_theme-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/guzzle/guzzle_sphinx_theme/archive/${version}.tar.gz";
+      sha256 = "f5f0e3d541c09ace912e0fa75dafd46f5a54314a929913c7de9709e677d5aa09";
+    };
+
+    buildInputs = with self; [ sphinx ];
+
+    meta = with stdenv.lib; {
+      description = "Sphinx theme used by Guzzle: http://guzzlephp.org";
+      homepage = https://github.com/guzzle/guzzle_sphinx_theme/;
+      license = licenses.mit;
+      maintainers = with maintainers; [ flokli ];
+      platforms = platforms.unix;
+    };
+  });
+
   sphinx-testing = callPackage ../development/python-modules/sphinx-testing { };
 
   sphinxcontrib-blockdiag = buildPythonPackage (rec {


### PR DESCRIPTION
###### Motivation for this change

This adds `sphinx_guzzle_theme`, which is used for sphinx documentation in various projects, including [BorgBackup](https://borgbackup.readthedocs.io). This could also be used for #30287.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

