### PR TITLE
easyloggingpp: 9.95.0 -> 9.96.0

### DIFF
--- a/pkgs/development/libraries/easyloggingpp/default.nix
+++ b/pkgs/development/libraries/easyloggingpp/default.nix
@@ -1,3 +1,6 @@
+# To use this package with a CMake and pkg-config build:
+# pkg_check_modules(EASYLOGGINGPP REQUIRED easyloggingpp)
+# add_executable(main src/main.cpp ${EASYLOGGINGPP_PREFIX}/include/easylogging++.cc)
 { stdenv, fetchFromGitHub, cmake, gtest }:
 stdenv.mkDerivation rec {
   name = "easyloggingpp-${version}";
@@ -10,9 +13,22 @@ stdenv.mkDerivation rec {
   };
   nativeBuildInputs = [cmake];
   buildInputs = [gtest];
-  cmakeFlags = [ "-Dtest=ON" "-Dbuild_static_lib=ON"];
+  cmakeFlags = [ "-Dtest=ON" ];
   NIX_CFLAGS_COMPILE = "-std=c++11" +
     stdenv.lib.optionalString stdenv.isLinux " -pthread";
+  postInstall = ''
+    mkdir -p $out/include
+    cp ../src/easylogging++.cc $out/include
+    mkdir -p $out/lib/pkgconfig
+    cat << EOF > $out/lib/pkgconfig/easyloggingpp.pc
+    Name: easyloggingpp
+    Description: A C++ Logging Library
+    Version: ${version}
+    prefix=$out
+    includedir=\''${prefix}/include
+    Cflags: -I\''${includedir}
+    EOF
+  '';
   meta = {
     description = "C++ logging library";
     homepage = https://muflihun.github.io/easyloggingpp/;

--- a/pkgs/development/libraries/easyloggingpp/default.nix
+++ b/pkgs/development/libraries/easyloggingpp/default.nix
@@ -4,13 +4,14 @@
 { stdenv, fetchFromGitHub, cmake, gtest }:
 stdenv.mkDerivation rec {
   name = "easyloggingpp-${version}";
-  version = "9.95.0";
+  version = "9.96.0";
   src = fetchFromGitHub {
     owner = "muflihun";
     repo = "easyloggingpp";
     rev = "v${version}";
-    sha256 = "0gzmznw6ffag9x55lixxffy6x7mvb7691x0md4q9rbh88zkws7kq";
+    sha256 = "134arh13rksfsxa80h6xw104458ihzp1mpblz5sprx5gxkq7yqfv";
   };
+
   nativeBuildInputs = [cmake];
   buildInputs = [gtest];
   cmakeFlags = [ "-Dtest=ON" ];
@@ -19,15 +20,6 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/include
     cp ../src/easylogging++.cc $out/include
-    mkdir -p $out/lib/pkgconfig
-    cat << EOF > $out/lib/pkgconfig/easyloggingpp.pc
-    Name: easyloggingpp
-    Description: A C++ Logging Library
-    Version: ${version}
-    prefix=$out
-    includedir=\''${prefix}/include
-    Cflags: -I\''${includedir}
-    EOF
   '';
   meta = {
     description = "C++ logging library";


### PR DESCRIPTION
Added a pkg-config file and copied the relevant source file into the
nix store. The idea is that the user may now relatively easily include
the library’s source file in their project using common CMake features.

###### Motivation for this change

The easyloggingpp package used to be header-only, but long compile times motivated a change to move as much code as possible into a C++ source file that could be compiled separately. Suggested use of the library involves either:

- Link to a static library compiled from the C++ source file
- Include the C++ source file in your own project

The former is not preferred in nixpkgs (or several other distros), as @Mic92 rightfully pointed out in https://github.com/NixOS/nixpkgs/pull/30256

The latter has an additional advantage in that several pre-processor definitions may be used to control the logging library's behavior *if* one recompiles the source file.

To support including the source file in what I hope is a nixpkgs-friendly way, I create a `pkg-config` file for the project during installation so that including the source file in a project built by `cmake` involves something like the following,

```
pkg_check_modules(EASYLOGGINGPP REQUIRED easyloggingpp)
add_executable(main src/main.cpp ${EASYLOGGINGPP_PREFIX}/src/easylogging++.cc)
```

That example is included in a comment in the nix package definition.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
