### PR TITLE
darwin: fix assorted xcbuild builds

### DIFF
--- a/pkgs/development/tools/xcbuild/platform.nix
+++ b/pkgs/development/tools/xcbuild/platform.nix
@@ -188,6 +188,22 @@ let
       Type = "ProductType";
       Name = "Dynamic Library";
       PackageTypes = [ "com.apple.package-type.mach-o-dylib" ];
+      DefaultBuildProperties = {
+        FULL_PRODUCT_NAME = "$(EXECUTABLE_NAME)";
+        MACH_O_TYPE = "mh_dylib";
+        REZ_EXECUTABLE = "YES";
+        EXECUTABLE_SUFFIX = ".$(EXECUTABLE_EXTENSION)";
+        EXECUTABLE_EXTENSION = "dylib";
+        DYLIB_COMPATIBILITY_VERSION = "1";
+        DYLIB_CURRENT_VERSION = "1";
+        FRAMEWORK_FLAG_PREFIX = "-framework";
+        LIBRARY_FLAG_PREFIX = "-l";
+        LIBRARY_FLAG_NOSPACE = "YES";
+        STRIP_STYLE = "debugging";
+        GCC_INLINES_ARE_PRIVATE_EXTERN = "YES";
+        CODE_SIGNING_ALLOWED = "YES";
+        CODE_SIGNING_REQUIRED = "NO";
+      };
     }
     {
       Identifier = "com.apple.product-type.library.static";
@@ -247,7 +263,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "nixpkgs.platform";
+  name = "MacOSX.platform";
   buildInputs = [ xcbuild ];
   buildCommand = ''
     mkdir -p $out/
@@ -264,6 +280,6 @@ stdenv.mkDerivation {
 
     mkdir -p $out/Developer/SDKs/
     cd $out/Developer/SDKs/
-    cp -r ${sdk} nix.nixpkgs.sdk
+    cp -r ${sdk} ${sdk.name}
   '';
 }

--- a/pkgs/development/tools/xcbuild/sdk.nix
+++ b/pkgs/development/tools/xcbuild/sdk.nix
@@ -19,7 +19,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "nix.nixpkgs.sdk";
+  name = "MacOSX.sdk";
   buildInputs = [ xcbuild ];
   buildCommand = ''
     mkdir -p $out/

--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -221,6 +221,7 @@ let
     libresolv       = applePackage "libresolv"         "osx-10.11.6"     "09flfdi3dlzq0yap32sxidacpc4nn4va7z12a6viip21ix2xb2gf" {};
     Libsystem       = applePackage "Libsystem"         "osx-10.11.6"     "1nfkmbqml587v2s1d1y2s2v8nmr577jvk51y6vqrfvsrhdhc2w94" {};
     libutil         = applePackage "libutil"           "osx-10.11.6"     "1gmgmcyqdyc684ih7dimdmxdljnq7mzjy5iqbf589wc0pa8h5abm" {};
+    libutil-new     = applePackage "libutil/new.nix"   "osx-10.11.6"     "1gmgmcyqdyc684ih7dimdmxdljnq7mzjy5iqbf589wc0pa8h5abm" {};
     libunwind       = applePackage "libunwind"         "osx-10.11.6"     "0miffaa41cv0lzf8az5k1j1ng8jvqvxcr4qrlkf3xyj479arbk1b" {};
     mDNSResponder   = applePackage "mDNSResponder"     "osx-10.11.6"     "069incq28a78yh1bnr17h9cd5if5mwqpq8ahnkyxxx25fkaxgzcf" {};
     objc4           = applePackage "objc4"             "osx-10.11.6"     "00b7vbgxni8frrqyi69b4njjihlwydzjd9zj9x4z5dbx8jabkvrj" {};

--- a/pkgs/os-specific/darwin/apple-source-releases/file_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/file_cmds/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, appleDerivation, xcbuild, zlib, bzip2, lzma }:
+{ stdenv, appleDerivation, xcbuild, zlib, bzip2, lzma, ncurses, libutil-new }:
 
 appleDerivation rec {
-  buildInputs = [ xcbuild zlib bzip2 lzma ];
+  buildInputs = [ xcbuild zlib bzip2 lzma ncurses libutil-new ];
 
   # some commands not working:
   # mtree: _simple.h not found
@@ -11,14 +11,15 @@ appleDerivation rec {
     substituteInPlace file_cmds.xcodeproj/project.pbxproj \
       --replace "FC8A8CAA14B655FD001B97AD /* PBXTargetDependency */," "" \
       --replace "FC8A8C9C14B655FD001B97AD /* PBXTargetDependency */," "" \
-      --replace "productName = file_cmds;" ""
+      --replace "productName = file_cmds;" "" \
+      --replace '/usr/lib/libcurses.dylib' 'libncurses.dylib'
     sed -i -re "s/name = ([a-zA-Z]+);/name = \1; productName = \1;/" file_cmds.xcodeproj/project.pbxproj
   '';
 
   # temporary install phase until xcodebuild has "install" support
   installPhase = ''
     mkdir -p $out/bin/
-    install file_cmds-*/Build/Products/Release/* $out/bin/
+    install file_cmds-*/Build/Products/Release/* $out/bin
 
     for n in 1; do
       mkdir -p $out/share/man/man$n

--- a/pkgs/os-specific/darwin/apple-source-releases/libutil/new.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libutil/new.nix
@@ -1,0 +1,33 @@
+{ stdenv, appleDerivation, xcbuild }:
+
+# TODO: make this the official libutil expression once we've integrated xcbuild in the bootstrap
+appleDerivation {
+  buildInputs = [ xcbuild ];
+
+  dontUseXcbuild = true;
+
+  prePatch = ''
+    substituteInPlace tzlink.c \
+      --replace '#include <xpc/xpc.h>' ""
+  '';
+
+  buildPhase = ''
+    xcodebuild -target util
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib $out/include
+
+    cp libutil-*/Build/Products/Release/*.dylib $out/lib
+    cp libutil-*/Build/Products/Release/*.h $out/include
+
+    # TODO: figure out how to get this to be right the first time around
+    install_name_tool -id $out/lib/libutil.dylib $out/lib/libutil.dylib
+  '';
+
+  meta = with stdenv.lib; {
+    maintainers = with maintainers; [ copumpkin ];
+    platforms   = platforms.darwin;
+    license     = licenses.apsl20;
+  };
+}


### PR DESCRIPTION
This includes adding a new xcbuild-based libutil build to test the waters a bit there. We'll need to get xcbuild into the stdenv bootstrap before we can make the main build, but it's nice to see that it can work.

cc @matthewbauer @LnL7 