### PR TITLE
cryfs: init at 0.9.7 and minor updates to dependencies (scrypt and spdlog)

### DIFF
--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "spdlog-${version}";
-  version = "0.13.0";
+  version = "0.14.0";
 
   src = fetchFromGitHub {
-    owner = "gabime";
-    repo = "spdlog";
-    rev = "v${version}";
-    sha256 = "0pfagrkq6afpkl269vbi1fd6ckakzpr5b5cbapb8rr7hgsrilxza";
+    owner  = "gabime";
+    repo   = "spdlog";
+    rev    = "v${version}";
+    sha256 = "13730429gwlabi432ilpnja3sfvy0nn2719vnhhmii34xcdyc57q";
   };
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
   # cmakeFlags = [ "-DSPDLOG_BUILD_EXAMPLES=ON" ];
 

--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -28,8 +28,5 @@ stdenv.mkDerivation rec {
     license        = licenses.mit;
     maintainers    = with maintainers; [ obadz ];
     platforms      = platforms.all;
-
-    # This is a header-only library, no point in hydra building it:
-    hydraPlatforms = [];
   };
 }

--- a/pkgs/tools/filesystems/cryfs/default.nix
+++ b/pkgs/tools/filesystems/cryfs/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchFromGitHub
+, cmake, pkgconfig, coreutils
+, boost, cryptopp, curl, fuse, openssl, python, spdlog
+}:
+
+stdenv.mkDerivation rec {
+  name = "cryfs-${version}";
+  version = "0.9.7";
+
+  src = fetchFromGitHub {
+    owner  = "cryfs";
+    repo   = "cryfs";
+    rev    = "${version}";
+    sha256 = "1wsv4cyjkyg3cyr6vipw1mj41bln2m69123l3miav8r4mvmkfq8w";
+  };
+
+  prePatch = ''
+    patchShebangs src
+
+    substituteInPlace vendor/scrypt/CMakeLists.txt \
+      --replace /usr/bin/ ""
+
+    # scrypt in nixpkgs only produces a binary so we lift the patching from that so allow
+    # building the vendored version. This is very much NOT DRY.
+    # The proper solution is to have scrypt generate a dev output with the required files and just symlink
+    # into vendor/scrypt
+    for f in Makefile.in autocrap/Makefile.am libcperciva/cpusupport/Build/cpusupport.sh ; do
+      substituteInPlace vendor/scrypt/scrypt-*/scrypt/$f --replace "command -p " ""
+    done
+
+    # cryfs is vendoring an old version of spdlog
+    rm -rf vendor/spdlog/spdlog
+    ln -s ${spdlog} vendor/spdlog/spdlog
+  '';
+
+  buildInputs = [ boost cryptopp curl fuse openssl python spdlog ];
+
+  # coreutils is needed for the vendored scrypt
+  nativeBuildInputs = [ cmake coreutils pkgconfig ];
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    "-DCRYFS_UPDATE_CHECKS=OFF"
+    "-DBoost_USE_STATIC_LIBS=OFF" # this option is case sensitive
+    "-DBUILD_TESTING=ON"
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Cryptographic filesystem for the cloud";
+    homepage    = https://www.cryfs.org;
+    license     = licenses.lgpl3;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms   = with platforms; linux;
+  };
+}

--- a/pkgs/tools/security/scrypt/default.nix
+++ b/pkgs/tools/security/scrypt/default.nix
@@ -2,27 +2,26 @@
 
 stdenv.mkDerivation rec {
   name = "scrypt-${version}";
-  version = "1.2.0";
+  version = "1.2.1";
 
   src = fetchurl {
     url = "https://www.tarsnap.com/scrypt/${name}.tgz";
-    sha256 = "1m39hpfby0fdjam842773i5w7pa0qaj7f0r22jnchxsj824vqm0p";
+    sha256 = "0xy5yhrwwv13skv9im9vm76rybh9f29j2dh4hlh2x01gvbkza8a6";
   };
 
   buildInputs = [ openssl ];
 
   patchPhase = ''
-    substituteInPlace Makefile.in \
-      --replace "command -p mv" "mv"
-    substituteInPlace autocrap/Makefile.am \
-      --replace "command -p mv" "mv"
+    for f in Makefile.in autotools/Makefile.am libcperciva/cpusupport/Build/cpusupport.sh ; do
+      substituteInPlace $f --replace "command -p " ""
+    done
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Encryption utility";
     homepage    = https://www.tarsnap.com/scrypt.html;
-    license     = stdenv.lib.licenses.bsd2;
-    platforms   = stdenv.lib.platforms.all;
-    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+    license     = licenses.bsd2;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ thoughtpolice ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1881,6 +1881,8 @@ with pkgs;
 
   enblend-enfuse = callPackage ../tools/graphics/enblend-enfuse { };
 
+  cryfs = callPackage ../tools/filesystems/cryfs { };
+
   encfs = callPackage ../tools/filesystems/encfs {
     tinyxml2 = tinyxml-2;
   };


### PR DESCRIPTION
###### Motivation for this change

Apart from cryfs being really neat on its own, it is also needed for the Plasma Vault introduced in Plasma 5.11 and #30305.

Cc: @thoughtpolice and @obadz due to dependencies

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

