### PR TITLE
Update CODEOWNERS to use darwin-maintainers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,9 +35,8 @@ pkgs/applications/science/math/R @peti
 pkgs/development/r-modules       @peti
 
 # Darwin-related
-pkgs/stdenv/darwin/*    @copumpkin @LnL7
-pkgs/os-specific/darwin/*       @LnL7
-pkgs/os-specific/darwin/apple-source-releases/* @copumpkin
+/pkgs/stdenv/darwin/             @org/darwin-maintainers
+/pkgs/os-specific/darwin/        @org/darwin-maintainers
 
 # Beam-related (Erlang, Elixir, LFE, etc)
 pkgs/development/beam-modules/*	@gleber


### PR DESCRIPTION
This sets up the Darwin-maintainers team as CODEOWNERS for Darwin paths. So anyone in that team will get notified (instead of just listing individuals).

/cc @org/darwin-maintainers

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

