### PR TITLE
pcl: qt4 -> qt5; 1.8.0 -> 1.8.1

### DIFF
--- a/pkgs/development/libraries/pcl/default.nix
+++ b/pkgs/development/libraries/pcl/default.nix
@@ -1,33 +1,28 @@
-{ stdenv, fetchFromGitHub, cmake, qhull, flann, boost, vtk, eigen, pkgconfig, qt4
+{ stdenv, fetchFromGitHub, cmake, qhull, flann, boost, vtk, eigen, pkgconfig, qtbase
 , libusb1, libpcap, libXt, libpng, Cocoa, AGL, cf-private, OpenGL
 }:
 
 stdenv.mkDerivation rec {
-  name = "pcl-1.8.0";
+  name = "pcl-1.8.1";
 
   src = fetchFromGitHub {
     owner = "PointCloudLibrary";
     repo = "pcl";
     rev = name;
-    sha256 = "1pki4y7mc2dryxc8wa7rs4hg74qab80rpy90jnw3j8fzf09kxcll";
+    sha256 = "05wvqqi2fyk5innw4mg356r71c1hmc9alc7xkf4g81ds3b3867xq";
   };
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake qhull flann boost eigen libusb1 libpcap
-                  libpng vtk qt4 libXt ]
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ qhull flann boost eigen libusb1 libpcap
+                  libpng vtk qtbase libXt ]
+
     ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa AGL cf-private ];
   cmakeFlags = stdenv.lib.optionals stdenv.isDarwin [
     "-DCMAKE_OSX_SYSROOT=" "-DCMAKE_OSX_DEPLOYMENT_TARGET="
     "-DOPENGL_INCLUDE_DIR=${OpenGL}/Library/Frameworks"
   ];
-
-  preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
-    NIX_CFLAGS_COMPILE=$(echo "$NIX_CFLAGS_COMPILE" | sed "s,[[:space:]]*-F$NIX_STORE/[[:alnum:]]*-CF-osx-[[:digit:].]*/Library/Frameworks,,g")
-    sed -i 's,^\(      target_link_libraries("''${LIB_NAME}" "-framework Cocoa")\),\1\n      target_link_libraries("''${LIB_NAME}" "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation"),' visualization/CMakeLists.txt
-    sed -i 's,^\(set(SUBSYS_DEPS common io kdtree geometry search)\),\1\nset(CMAKE_OSX_SYSROOT "")\nset(CMAKE_OSX_DEPLOYMENT_TARGET ""),' visualization/CMakeLists.txt
-  '';
 
   meta = {
     homepage = http://pointclouds.org/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10100,8 +10100,7 @@ with pkgs;
 
   pcg_c = callPackage ../development/libraries/pcg-c { };
 
-  pcl = callPackage ../development/libraries/pcl {
-    vtk = vtkWithQt4;
+  pcl = libsForQt5.callPackage ../development/libraries/pcl {
     inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) Cocoa AGL OpenGL;
   };


### PR DESCRIPTION
###### Motivation for this change
Get pcl building on darwin.

Drop the qt4 dependency as it is rotting.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

