### PR TITLE
yabar-unstable: 2017-09-09 -> 2017-10-12

### DIFF
--- a/pkgs/applications/window-managers/yabar/build.nix
+++ b/pkgs/applications/window-managers/yabar/build.nix
@@ -2,6 +2,7 @@
 , xcbutilwm, alsaLib, wirelesstools, asciidoc, libxslt, makeWrapper, docbook_xsl
 , configFile ? null, lib
 , rev, sha256, version
+, playerctl
 }:
 
 stdenv.mkDerivation {
@@ -20,6 +21,7 @@ stdenv.mkDerivation {
   buildInputs = [
     cairo gdk_pixbuf libconfig pango xcbutilwm docbook_xsl
     alsaLib wirelesstools asciidoc libxslt makeWrapper
+    playerctl
   ];
 
   postPatch = ''
@@ -28,7 +30,7 @@ stdenv.mkDerivation {
       --replace "a2x" "${asciidoc}/bin/a2x --no-xmllint"
   '';
 
-  makeFlags = [ "DESTDIR=$(out)" "PREFIX=/" ];
+  makeFlags = [ "DESTDIR=$(out)" "PREFIX=/" "PLAYERCTL=1" ];
 
   postInstall = ''
     mkdir -p $out/share/yabar/examples

--- a/pkgs/applications/window-managers/yabar/unstable.nix
+++ b/pkgs/applications/window-managers/yabar/unstable.nix
@@ -2,9 +2,9 @@
 
 let
   overrides = {
-    version = "unstable-2017-09-09";
+    version = "unstable-2017-10-12";
 
-    rev    = "d3934344ba27f5bdf122bf74daacee6d49284dab";
-    sha256 = "14zrlzva8i83ffg426mrf6yli8afwq6chvc7yi78ngixyik5gzhx";
+    rev    = "cbecc7766e37f29d50705da0a82dc76ce7c3b86e";
+    sha256 = "1wprjas3k14rxfl06mgr0xq2ra735w1c7dq4xrdvii887wnl37xb";
   } // attrs;
 in callPackage ./build.nix overrides


### PR DESCRIPTION
###### Motivation for this change

`yabar-unstable` contains some new features...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

