### PR TITLE
electrum: add support for LedgerHQ hardware wallet

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -29,7 +29,7 @@ python2Packages.buildPythonApplication rec {
 
     # TODO plugins
     # amodem
-    # btchip
+    btchip
     # matplotlib
   ];
 

--- a/pkgs/development/python-modules/btchip/default.nix
+++ b/pkgs/development/python-modules/btchip/default.nix
@@ -15,6 +15,6 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     description = "Python communication library for Ledger Hardware Wallet products";
     homepage = "https://github.com/LedgerHQ/btchip-python";
-    license = licenses.apache2;
+    license = licenses.asl20;
   };
 }

--- a/pkgs/development/python-modules/btchip/default.nix
+++ b/pkgs/development/python-modules/btchip/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, hidapi, pyscard, ecdsa }:
+
+buildPythonPackage rec {
+  pname = "btchip-python";
+  version = "0.1.21";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "16g9l3rpxpvvkdx08mgy0ligvsfcpzdrh4hplj104cpprrbsqd6v";
+  };
+
+  buildInputs = [ hidapi pyscard ecdsa ];
+
+  meta = with stdenv.lib; {
+    description = "Python communication library for Ledger Hardware Wallet products";
+    homepage = "https://github.com/LedgerHQ/btchip-python";
+    license = licenses.apache2;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -153,6 +153,8 @@ in {
 
   bugseverywhere = callPackage ../applications/version-management/bugseverywhere {};
 
+  btchip = callPackage ../development/python-modules/btchip { };
+
   dbf = callPackage ../development/python-modules/dbf { };
 
   dbfread = callPackage ../development/python-modules/dbfread { };


### PR DESCRIPTION
###### Motivation for this change

Adding support for LedgerHQ hardware wallet in electrum by adding a dependency on `btchip`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

