### PR TITLE
go: use absolute dir in getGoDirs()

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -140,7 +140,7 @@ go.stdenv.mkDerivation (
       if [ -n "$subPackages" ]; then
         echo "$subPackages" | sed "s,\(^\| \),\1$goPackagePath/,g"
       else
-        pushd go/src >/dev/null
+        pushd "$NIX_BUILD_TOP/go/src" >/dev/null
         find "$goPackagePath" -type f -name \*$type.go -exec dirname {} \; | grep -v "/vendor/" | sort | uniq
         popd >/dev/null
       fi


### PR DESCRIPTION
###### Motivation for this change

I have a `postBuild` in a nix expression which does a `cd`. That broke running the tests.

This fix uses an absolute path to prevent the error from happening. The other use of `pushd` in that file already uses the same idea:

https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/go-modules/generic/default.nix#L175


@cstrahan is listed as maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

