### PR TITLE
libhttpseverywhere: 0.4.5 -> 0.6.5

### DIFF
--- a/pkgs/development/libraries/libhttpseverywhere/default.nix
+++ b/pkgs/development/libraries/libhttpseverywhere/default.nix
@@ -1,7 +1,8 @@
-{stdenv, fetchurl, gnome3, glib, json_glib, libxml2, libarchive, libsoup, gobjectIntrospection, meson, ninja, pkgconfig,  valadoc}:
+{ stdenv, fetchurl, pkgconfig, meson, ninja, valadoc
+, gnome3, glib, json_glib, libarchive, libsoup, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
-  major = "0.4";
+  major = "0.6";
   minor = "5";
   version = "${major}.${minor}";
 
@@ -9,15 +10,19 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libhttpseverywhere/${major}/libhttpseverywhere-${version}.tar.xz";
-    sha256 = "07sgcw285rl9wqr5k7srs3fj7fhgrrw6w780jx8wy8jw2bfwlvj2";
+    sha256 = "0ksf6vqjyjii29dvy5147dmgqlqsq4d70xxai0p2prkx4jrwgj3z";
   };
 
-  nativeBuildInputs = [ gnome3.vala valadoc  gobjectIntrospection meson ninja pkgconfig ];
-  buildInputs = [ glib gnome3.libgee libxml2 json_glib libsoup libarchive ];
+  nativeBuildInputs = [ gnome3.vala gobjectIntrospection meson ninja pkgconfig valadoc ];
+  buildInputs = [ glib gnome3.libgee json_glib libsoup libarchive ];
+
+  mesonFlags = "-Denable_valadoc=true";
 
   doCheck = true;
 
   checkPhase = "./httpseverywhere_test";
+
+  outputs = [ "out" "devdoc" ];
 
   meta = {
     description = "library to use HTTPSEverywhere in desktop applications";


### PR DESCRIPTION
###### Motivation for this change

Update libhttpseverywhere to the latest version including support for the updated ruleset format.
Prior version's ruleset update funtionality ceased to work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

