### PR TITLE
sddm-kcm: init at 5.10.5

### DIFF
--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -137,6 +137,7 @@ let
       plasma-workspace-wallpapers = callPackage ./plasma-workspace-wallpapers.nix {};
       polkit-kde-agent = callPackage ./polkit-kde-agent.nix {};
       powerdevil = callPackage ./powerdevil.nix {};
+      sddm-kcm = callPackage ./sddm-kcm.nix {};
       startkde = callPackage ./startkde {};
       systemsettings = callPackage ./systemsettings.nix {};
     };

--- a/pkgs/desktops/plasma-5/sddm-kcm.nix
+++ b/pkgs/desktops/plasma-5/sddm-kcm.nix
@@ -1,0 +1,16 @@
+{
+  mkDerivation, extra-cmake-modules, shared_mime_info,
+  libpthreadstubs, libXcursor, libXdmcp,
+  qtquickcontrols2, qtx11extras,
+  karchive, ki18n, kio, knewstuff
+}:
+
+mkDerivation {
+  name = "sddm-kcm";
+  nativeBuildInputs = [ extra-cmake-modules shared_mime_info ];
+  buildInputs = [
+    libpthreadstubs libXcursor libXdmcp
+    qtquickcontrols2 qtx11extras
+    karchive ki18n kio knewstuff
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18217,7 +18217,7 @@ with pkgs;
     kinfocenter kmenuedit kscreen kscreenlocker ksshaskpass ksysguard
     kwallet-pam kwayland-integration kwin kwrited milou oxygen plasma-desktop
     plasma-integration plasma-nm plasma-pa plasma-workspace
-    plasma-workspace-wallpapers polkit-kde-agent powerdevil startkde
+    plasma-workspace-wallpapers polkit-kde-agent powerdevil sddm-kcm startkde
     systemsettings;
 
   ### SCIENCE


### PR DESCRIPTION
###### Motivation for this change

I wanted to see if a custom theme was being detected properly, so I packaged this. It is however for all other purposes completely pointless as it tries to change ```/etc/sddm.conf``` which is obviously read-only.

@ttuegel - what do you think? Merge or throw away?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

