### PR TITLE
services.compton: add `opacityRules` option

### DIFF
--- a/nixos/modules/services/x11/compton.nix
+++ b/nixos/modules/services/x11/compton.nix
@@ -7,7 +7,12 @@ let
 
   cfg = config.services.compton;
 
-  configFile = pkgs.writeText "compton.conf"
+  configFile = let
+    opacityRules = optionalString (length cfg.opacityRules != 0)
+      (concatStringsSep "\n"
+        (map (a: "opacity-rule = [ \"${a}\" ];") cfg.opacityRules)
+      );
+  in pkgs.writeText "compton.conf"
     (optionalString cfg.fade ''
       # fading
       fading = true;
@@ -30,7 +35,9 @@ let
       active-opacity   = ${cfg.activeOpacity};
       inactive-opacity = ${cfg.inactiveOpacity};
       menu-opacity     = ${cfg.menuOpacity};
-      
+
+      ${opacityRules}
+
       # other options
       backend = ${toJSON cfg.backend};
       vsync = ${toJSON cfg.vSync};
@@ -152,6 +159,14 @@ in {
       example = "0.8";
       description = ''
         Opacity of dropdown and popup menu.
+      '';
+    };
+
+    opacityRules = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = ''
+        Opacity rules to be handled by compton.
       '';
     };
 


### PR DESCRIPTION
###### Motivation for this change

A true hacker requires a transparent terminal ;)

Furthermore I'd love to have this configurable using the `services.compton` module.

To test the change I built the following test VM:

``` nix
{
  compton = { pkgs, ... }: {
    users.extraUsers.vm = {
      isNormalUser = true;
      password = "vm";
    };
    environment.systemPackages = [ pkgs.google-chrome ];
    services.xserver = {
      enable = true;
      windowManager.i3.enable = true;
      windowManager.default = "i3";
    };
    services.compton = {
      enable = true;
      opacityRules = [ "70:class_g = 'Google-chrome'" ];
    };
    nixpkgs.config.allowUnfree = true;
  };
}
```

This makes `google-chrome` transparent in the VM.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

