### PR TITLE
qutebrowser: 0.11 -> 1.0

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -29,12 +29,12 @@ let
 
 in buildPythonApplication rec {
   name = "qutebrowser-${version}";
-  version = "1.0.0";
+  version = "1.0.1";
   namePrefix = "";
 
   src = fetchurl {
     url = "https://github.com/The-Compiler/qutebrowser/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "18j8y1djbgh29yig8wy55yxg3r7g60rky72163qpwkbdancfvzzp";
+    sha256 = "1gphn8a0xfy5iqiznvgd6fbbzp7r5sp697ayfwnvllvmbr5az9vs";
   };
 
   # Needs tox

--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -2,9 +2,12 @@
 , qtbase, pyqt5, jinja2, pygments, pyyaml, pypeg2, pyopengl, cssutils, glib_networking
 , asciidoc, docbook_xml_dtd_45, docbook_xsl, libxml2, libxslt
 , gst-plugins-base, gst-plugins-good, gst-plugins-bad, gst-plugins-ugly, gst-libav
-, qtwebkit-plugins
-, withWebEngineDefault ? false
+, qtwebkit-plugins ? null
+, attrs
+, withWebEngineDefault ? true
 }:
+
+assert (! withWebEngineDefault) -> qtwebkit-plugins != null;
 
 let
   pdfjs = stdenv.mkDerivation rec {
@@ -26,29 +29,30 @@ let
 
 in buildPythonApplication rec {
   name = "qutebrowser-${version}";
-  version = "0.11.0";
+  version = "1.0.0";
   namePrefix = "";
 
   src = fetchurl {
     url = "https://github.com/The-Compiler/qutebrowser/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "13ihx66jm1dd6vx8px7pm0kbzf2sf9x43hhivc1rp17kahnxxdyv";
+    sha256 = "18j8y1djbgh29yig8wy55yxg3r7g60rky72163qpwkbdancfvzzp";
   };
 
   # Needs tox
   doCheck = false;
 
   buildInputs = [
-    qtbase qtwebkit-plugins
+    qtbase
     gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav
     glib_networking
-  ];
+  ]
+    ++ lib.optional (! withWebEngineDefault) qtwebkit-plugins;
 
   nativeBuildInputs = [
     makeWrapper wrapGAppsHook asciidoc docbook_xml_dtd_45 docbook_xsl libxml2 libxslt
   ];
 
   propagatedBuildInputs = [
-    pyyaml pyqt5 jinja2 pygments pypeg2 cssutils pyopengl
+    pyyaml pyqt5 jinja2 pygments pypeg2 cssutils pyopengl attrs
   ];
 
   postPatch = ''
@@ -62,7 +66,7 @@ in buildPythonApplication rec {
 
   postInstall = ''
     install -Dm644 doc/qutebrowser.1 "$out/share/man/man1/qutebrowser.1"
-    install -Dm644 qutebrowser.desktop \
+    install -Dm644 misc/qutebrowser.desktop \
         "$out/share/applications/qutebrowser.desktop"
     for i in 16 24 32 48 64 128 256 512; do
         install -Dm644 "icons/qutebrowser-''${i}x''${i}.png" \
@@ -73,8 +77,8 @@ in buildPythonApplication rec {
     install -Dm755 -t "$out/share/qutebrowser/userscripts/" misc/userscripts/*
   '';
 
-  postFixup = lib.optionalString withWebEngineDefault ''
-    wrapProgram $out/bin/qutebrowser --add-flags "--backend webengine"
+  postFixup = lib.optionalString (! withWebEngineDefault) ''
+    wrapProgram $out/bin/qutebrowser --add-flags "--backend webkit"
   '';
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16188,7 +16188,7 @@ with pkgs;
   falkon = libsForQt5.callPackage ../applications/networking/browsers/falkon { };
 
   qutebrowser = libsForQt5.callPackage ../applications/networking/browsers/qutebrowser {
-    inherit (python3Packages) buildPythonApplication pyqt5 jinja2 pygments pyyaml pypeg2 cssutils pyopengl;
+    inherit (python3Packages) buildPythonApplication pyqt5 jinja2 pygments pyyaml pypeg2 cssutils pyopengl attrs;
     inherit (gst_all_1) gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav;
   };
 


### PR DESCRIPTION
This updates has a few breaking changes, most importantly WebEngine
is now enabled by default and the configuration system was completely
changed (requiring uers to manually migrate their configuration).

More info: https://blog.qutebrowser.org/qutebrowser-v100-released.html

`withWebEngineDefault` is a bit unfortunately named now. The alternative would be to replace it by `withWebKitDefault`, but I'm not sure if breaking the config of people that set that variable would be worth it.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

