### PR TITLE
profanity: enable python and gpg support, parallel builds and enforcement of enabled features

### DIFF
--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -38,6 +38,13 @@ stdenv.mkDerivation rec {
     ++ optionals pgpSupport          [ gpgme ]
     ++ optionals pythonPluginSupport [ python ];
 
+  # Enable feature flags, so that build fail if libs are missing
+  configureFlags = [ "--enable-c-plugins" "--enable-otr" ]
+    ++ optionals notifySupport       [ "--enable-notifications" ]
+    ++ optionals traySupport         [ "--enable-icons" ]
+    ++ optionals pgpSupport          [ "--enable-pgp" ]
+    ++ optionals pythonPluginSupport [ "--enable-python-plugins" ];
+
   meta = {
     description = "A console based XMPP client";
     longDescription = ''

--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -4,11 +4,13 @@
 , autoAwaySupport ? false, libXScrnSaver ? null, libX11 ? null
 , notifySupport ? false,   libnotify ? null, gdk_pixbuf ? null
 , traySupport ? false,     gnome2 ? null
+, pgpSupport ? true,       gpgme ? null
 }:
 
 assert autoAwaySupport -> libXScrnSaver != null && libX11 != null;
 assert notifySupport   -> libnotify != null && gdk_pixbuf != null;
 assert traySupport     -> gnome2 != null;
+assert pgpSupport      -> gpgme != null;
 
 with stdenv.lib;
 
@@ -30,7 +32,8 @@ stdenv.mkDerivation rec {
     glib openssl expat ncurses libotr curl
   ] ++ optionals autoAwaySupport [ libXScrnSaver libX11 ]
     ++ optionals notifySupport   [ libnotify gdk_pixbuf ]
-    ++ optionals traySupport     [ gnome2.gtk ];
+    ++ optionals traySupport     [ gnome2.gtk ]
+    ++ optionals pgpSupport      [ gpgme ];
 
   meta = {
     description = "A console based XMPP client";

--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -21,7 +21,10 @@ stdenv.mkDerivation rec {
     sha256 = "1f7ylw3mhhnii52mmk40hyc4kqhpvjdr3hmsplzkdhsfww9kflg3";
   };
 
+  enableParallelBuilding = true;
+
   nativeBuildInputs = [ pkgconfig ];
+
   buildInputs = [
     readline libuuid libmesode
     glib openssl expat ncurses libotr curl

--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -1,16 +1,18 @@
 { stdenv, fetchurl, pkgconfig, glib, openssl, expat, libmesode
 , ncurses, libotr, curl, readline, libuuid
 
-, autoAwaySupport ? false, libXScrnSaver ? null, libX11 ? null
-, notifySupport ? false,   libnotify ? null, gdk_pixbuf ? null
-, traySupport ? false,     gnome2 ? null
-, pgpSupport ? true,       gpgme ? null
+, autoAwaySupport ? false,       libXScrnSaver ? null, libX11 ? null
+, notifySupport ? false,         libnotify ? null, gdk_pixbuf ? null
+, traySupport ? false,           gnome2 ? null
+, pgpSupport ? true,            gpgme ? null
+, pythonPluginSupport ? true,   python ? null
 }:
 
-assert autoAwaySupport -> libXScrnSaver != null && libX11 != null;
-assert notifySupport   -> libnotify != null && gdk_pixbuf != null;
-assert traySupport     -> gnome2 != null;
-assert pgpSupport      -> gpgme != null;
+assert autoAwaySupport     -> libXScrnSaver != null && libX11 != null;
+assert notifySupport       -> libnotify != null && gdk_pixbuf != null;
+assert traySupport         -> gnome2 != null;
+assert pgpSupport          -> gpgme != null;
+assert pythonPluginSupport -> python != null;
 
 with stdenv.lib;
 
@@ -30,10 +32,11 @@ stdenv.mkDerivation rec {
   buildInputs = [
     readline libuuid libmesode
     glib openssl expat ncurses libotr curl
-  ] ++ optionals autoAwaySupport [ libXScrnSaver libX11 ]
-    ++ optionals notifySupport   [ libnotify gdk_pixbuf ]
-    ++ optionals traySupport     [ gnome2.gtk ]
-    ++ optionals pgpSupport      [ gpgme ];
+  ] ++ optionals autoAwaySupport     [ libXScrnSaver libX11 ]
+    ++ optionals notifySupport       [ libnotify gdk_pixbuf ]
+    ++ optionals traySupport         [ gnome2.gtk ]
+    ++ optionals pgpSupport          [ gpgme ]
+    ++ optionals pythonPluginSupport [ python ];
 
   meta = {
     description = "A console based XMPP client";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16084,6 +16084,7 @@ with pkgs;
     notifySupport   = config.profanity.notifySupport   or true;
     traySupport     = config.profanity.traySupport     or true;
     autoAwaySupport = config.profanity.autoAwaySupport or true;
+    python = python3;
   };
 
   psi = kde4.callPackage ../applications/networking/instant-messengers/psi { };


### PR DESCRIPTION
###### Motivation for this change

Enabling python and gpg support, parallel builds and enforcement of enabled features.

If wanted, I can split up the PR or squash commits as needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

