### PR TITLE
weechat-xmpp: init at 2017-08-30

### DIFF
--- a/pkgs/applications/networking/instant-messengers/weechat-xmpp/default.nix
+++ b/pkgs/applications/networking/instant-messengers/weechat-xmpp/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, xmpppy }:
+
+stdenv.mkDerivation {
+  name = "weechat-jabber-2017-08-30";
+
+  src = fetchFromGitHub {
+    repo = "weechat-xmpp";
+    owner = "sleduc";
+    sha256 = "0s02xs0ynld9cxxzj07al364sfglyc5ir1i82133mq0s8cpphnxv";
+    rev = "8f6c21f5a160c9318c7a2d8fd5dcac7ab2e0d843";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share
+    cp jabber.py $out/share/jabber.py
+  '';
+
+  buildInputs = [ xmpppy ];
+
+  postPatch = ''
+    substituteInPlace jabber.py \
+      --replace "__NIX_OUTPUT__" "${xmpppy}/lib/python2.7/site-packages"
+  '';
+
+  patches = [
+    ./libpath.patch
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A fork of the jabber plugin for weechat";
+    homepage = "https://github.com/sleduc/weechat-xmpp";
+    maintainers = with maintainers; [ ma27 ];
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/weechat-xmpp/libpath.patch
+++ b/pkgs/applications/networking/instant-messengers/weechat-xmpp/libpath.patch
@@ -1,0 +1,16 @@
+diff --git a/jabber.py b/jabber.py
+index 27006a3..e53c2c0 100644
+--- a/jabber.py
++++ b/jabber.py
+@@ -95,6 +95,11 @@ SCRIPT_COMMAND = SCRIPT_NAME
+ import re
+ import warnings
+ 
++import sys
++
++sys.path.append('__NIX_OUTPUT__')
++
++
+ import_ok = True
+ 
+ try:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17017,6 +17017,8 @@ with pkgs;
     inherit (luaPackages) cjson;
   };
 
+  weechat-xmpp = callPackage ../applications/networking/instant-messengers/weechat-xmpp {};
+
   westonLite = callPackage ../applications/window-managers/weston {
     pango = null;
     freerdp = null;


### PR DESCRIPTION
###### Motivation for this change

`weechat-jabber` requires `xmpppy` and as I don't like to install such libraries globally I decided that it's worth creating a simple derivation for this.

<del>__Note:__ I'm afraid this might generate legal issues as the source isn't distributed with a license on GitHub. Can anyone give me some advice how to proceed here?</del>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

