### PR TITLE
intecture-agent: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/tools/admin/intecture/agent.nix
+++ b/pkgs/tools/admin/intecture/agent.nix
@@ -5,16 +5,16 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "intecture-agent-${version}";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "intecture";
     repo = "agent";
     rev = version;
-    sha256 = "0b59ij9c7hv2p4jx96f3acbygw27wiv8cfzzg6sg73l6k244k6l6";
+    sha256 = "0j27qdgyxybaixggh7k57mpm6rifimn4z2vydk463msc8b3kgywj";
   };
 
-  depsSha256 = "1f94j54pg94f2x2lmmyj8dlki8plq6vnppmf3hzk3kd0rp7fzban";
+  depsSha256 = "1n57i9wkak76ram748mwq0dn32d041ajd31laqc13c76pp29agrp";
 
   buildInputs = [ openssl zeromq czmq zlib ];
 


### PR DESCRIPTION
###### Motivation for this change

Version update

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

