### PR TITLE
convox: init at 20171002150509

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -556,6 +556,7 @@
   sheganinans = "Aistis Raulinaitis <sheganinans@gmail.com>";
   shell = "Shell Turner <cam.turn@gmail.com>";
   shlevy = "Shea Levy <shea@shealevy.com>";
+  shosti = "Emanuel Evans <mail@emanuel.industries>";
   siddharthist = "Langston Barrett <langston.barrett@gmail.com>";
   sifmelcara = "Ming Chuan <ming@culpring.com>";
   sigma = "Yann Hodique <yann.hodique@gmail.com>";

--- a/pkgs/development/tools/convox/default.nix
+++ b/pkgs/development/tools/convox/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, buildGoPackage }:
+
+buildGoPackage rec {
+  name = "convox-${version}";
+  version = "20171007002353";
+
+  meta = with stdenv.lib; {
+    description = "Open-source PaaS";
+    homepage = https://convox.com;
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ shosti ];
+  };
+
+  goPackagePath = "github.com/convox/rack";
+  subPackages = [ "cmd/convox" ];
+
+  src = fetchFromGitHub {
+    owner = "convox";
+    repo = "rack";
+    rev = version;
+    sha256 = "1pggvcrq68jp9z0041jwc14i89bs69zgglbfbyk5lz8xgm4476l6";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -920,6 +920,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Foundation AddressBook;
   };
 
+  convox = callPackage ../development/tools/convox { };
+
   coturn = callPackage ../servers/coturn { };
 
   coursier = callPackage ../development/tools/coursier {};


### PR DESCRIPTION
###### Motivation for this change

This adds the CLI tool for [convox](https://convox.com/), which is a PaaS built on top of AWS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

