### PR TITLE
djbdns: fix root server list at build time

### DIFF
--- a/nixos/modules/services/networking/dnscache.nix
+++ b/nixos/modules/services/networking/dnscache.nix
@@ -18,10 +18,13 @@ let
       '') ips}
     '') cfg.domainServers)}
 
-    # djbdns contains an outdated list of root servers;
-    # if one was not provided in config, provide a current list
-    if [ ! -e servers/@ ]; then
-      awk '/^.?.ROOT-SERVERS.NET/ { print $4 }' ${pkgs.dns-root-data}/root.hints > $out/servers/@
+    # if a list of root servers was not provided in config, copy it
+    # over. (this is also done by dnscache-conf, but we 'rm -rf
+    # /var/lib/dnscache/root' below & replace it wholesale with this,
+    # so we have to ensure servers/@ exists ourselves.)
+    if [ ! -e $out/servers/@ ]; then
+      #note: symlink does not work, not sure why
+      cp ${pkgs.djbdns}/etc/dnsroots.global $out/servers/@;
     fi
   '';
 

--- a/pkgs/tools/networking/djbdns/default.nix
+++ b/pkgs/tools/networking/djbdns/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glibc } :
+{ stdenv, fetchurl, glibc, dns-root-data } :
 
 let
   version = "1.05";
@@ -23,6 +23,8 @@ stdenv.mkDerivation {
   postPatch = ''
     echo gcc -O2 -include ${glibc.dev}/include/errno.h > conf-cc
     echo $out > conf-home
+    # djbdns ships with an outdated list of root servers
+    awk '/^.?.ROOT-SERVERS.NET/ { print $4 }' ${dns-root-data}/root.hints > dnsroots.global
     sed -i "s|/etc/dnsroots.global|$out/etc/dnsroots.global|" dnscache-conf.c
   '';
 


### PR DESCRIPTION
as suggested by @peterhoeg in
https://github.com/NixOS/nixpkgs/commit/1b7e5eaa79241080eac2a0b79883a17c9e5f4731#commitcomment-24560631

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).