### PR TITLE
desktop-managers: Fix unsupported attribute 'xcfg'

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -109,5 +109,5 @@ in
 
   };
 
-  xcfg.displayManager.session = cfg.session.list;
+  config.services.xserver.displayManager.session = cfg.session.list;
 }


### PR DESCRIPTION
###### Motivation for this change
After https://github.com/NixOS/nixpkgs/pull/30286 a nixos-rebuild results in:
```
error: Module `/etc/nixos/nixpkgs/nixos/modules/services/x11/desktop-managers/default.nix' has an unsupported attribute `xcfg'. This is caused by assignments to the top-level attributes `config' or `options'.
(use ‘--show-trace’ to show detailed location information)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

