### PR TITLE
expect: update website URL

### DIFF
--- a/pkgs/tools/misc/expect/default.nix
+++ b/pkgs/tools/misc/expect/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A tool for automating interactive applications";
-    homepage = http://expect.nist.gov/;
+    homepage = http://expect.sourceforge.net/;
     license = "Expect";
     platforms = platforms.unix;
     maintainers = with maintainers; [ wkennington ];


### PR DESCRIPTION
###### Motivation for this change
expect.nist.gov no longer resolves.  It seems the website has been moved to http://expect.sourceforge.net/ , though there is also a page on nist.gov at https://www.nist.gov/services-resources/software/expect .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

