### PR TITLE
go-ethereum-classic: 3.5.86 -> 4.0.0

### DIFF
--- a/pkgs/applications/altcoins/go-ethereum-classic/default.nix
+++ b/pkgs/applications/altcoins/go-ethereum-classic/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "go-ethereum-classic-${version}";
-  version = "3.5.86";
+  version = "4.0.0";
 
   goPackagePath = "github.com/ethereumproject/go-ethereum";
   subPackages = [ "cmd/evm" "cmd/geth" ];
@@ -10,7 +10,7 @@ buildGoPackage rec {
   src = fetchgit {
     rev = "v${version}";
     url = "https://github.com/ethereumproject/go-ethereum";
-    sha256 = "1k59hl3qvx4422zqlp259566fnxq5bs67jhm0v6a1zfr1k8iqzwh";
+    sha256 = "06f1w7s45q4zva1xjrx92xinsdrixl0m6zhx5hvdjmg3xqcbwr79";
   };
 
   goDeps = ./deps.nix;


### PR DESCRIPTION
###### Motivation for this change

Update go-ethereum-classic version to 4.0.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

