### PR TITLE
Revert "desktop-managers: do not leak feh to PATH"

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -109,5 +109,9 @@ in
 
   };
 
-  xcfg.displayManager.session = cfg.session.list;
+  config = {
+    services.xserver.displayManager.session = cfg.session.list;
+    environment.systemPackages =
+      mkIf cfg.session.needBGPackages [ pkgs.feh ]; # xsetroot via xserver.enable
+  };
 }


### PR DESCRIPTION
Reverts NixOS/nixpkgs#30286

`xcfg.desktopManager.session` in `desktop-managers/default.nix` leads to evaluation error.