### PR TITLE
stapler: init at 2016-04-24

### DIFF
--- a/pkgs/tools/typesetting/stapler/default.nix
+++ b/pkgs/tools/typesetting/stapler/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonApplication, fetchFromGitHub, pypdf2, more-itertools }:
+
+buildPythonApplication rec {
+  pname = "stapler";
+  version = "2016-04-24";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "hellerbarde";
+    repo = pname;
+    rev = "7c153e6a8f52573ff886ebf0786b64e17699443a";
+    sha256 = "1wyrsfp2zrc23k853if4lp2lp0rzscsg1g4wijks0gha1zap94wy";
+  };
+
+  propagatedBuildInputs = [ pypdf2 more-itertools ];
+
+  checkPhase = ''
+    staplelib/tests.py
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/hellerbarde/stapler;
+    description = "Manipulate PDF documents from the command line";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4434,6 +4434,10 @@ with pkgs;
 
   sqliteman = callPackage ../applications/misc/sqliteman { };
 
+  stapler = callPackage ../tools/typesetting/stapler {
+    inherit (python2Packages) buildPythonApplication pypdf2 more-itertools;
+  };
+
   stdman = callPackage ../data/documentation/stdman { };
 
   storebrowse = callPackage ../tools/system/storebrowse { };


### PR DESCRIPTION
###### Motivation for this change
I use `fetchFromGitHub` instead of `fetchPypi` because the files needed to run the tests were not uploaded to PyPI.
Also, it doens't make sense to use the commit for a specific version, since I don't think a new version will ever be published.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

