### PR TITLE
cli-visualizer: fix

### DIFF
--- a/pkgs/applications/misc/cli-visualizer/default.nix
+++ b/pkgs/applications/misc/cli-visualizer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fftw, ncurses, libpulseaudio }:
+{ stdenv, fetchFromGitHub, fftw, ncurses5, libpulseaudio, makeWrapper }:
 
 stdenv.mkDerivation rec {
   version = "1.5";
@@ -15,13 +15,15 @@ stdenv.mkDerivation rec {
     sed '1i#include <cmath>' -i src/Transformer/SpectrumCircleTransformer.cpp
   '';
 
-  buildInputs = [ fftw ncurses libpulseaudio ];
+  buildInputs = [ fftw ncurses5 libpulseaudio makeWrapper ];
 
   buildFlags = [ "ENABLE_PULSE=1" ];
 
   installPhase = ''
     mkdir -p $out/bin
     cp build/vis $out/bin/vis
+    # See https://github.com/dpayne/cli-visualizer/issues/62#issuecomment-330738075
+    wrapProgram $out/bin/vis --set TERM rxvt-256color
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
cli-visualizer hasn't been working (at least for me with pulseaudio backend) since #28334. Downgrading to ncurses5 at least made it work somehow. There are still some weird artifacts though, with konsole, alacritty and maybe others, but not termite and probably xterm. The issue is the same as https://github.com/dpayne/cli-visualizer/issues/62. Wrapping the binary with TERM set to either `xterm-termite` or `rxvt-256color` solves the issue for now (the latter of which I used here). See [this comment](https://github.com/dpayne/cli-visualizer/issues/62#issuecomment-330738075).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

