### PR TITLE
nix-bundle: 0.1.2 → 0.2.0

### DIFF
--- a/pkgs/tools/package-management/nix-bundle/default.nix
+++ b/pkgs/tools/package-management/nix-bundle/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   pname = "nix-bundle";
   name = "${pname}-${version}";
-  version = "0.1.3";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "matthewbauer";
     repo = pname;
     rev = "v${version}";
-    sha256 = "15r77pchf4s4cdv4lvw2zw1yic78k8p0n2r954qq370vscw30yac";
+    sha256 = "0klabmygbhzlwxja8p2w8fp8ip3xaa5ym9c15rp9qxzh03hfmdjx";
   };
 
   # coreutils, gnutar is actually needed by nix for bootstrap
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     makeWrapper $out/share/nix-bundle/nix-bundle.sh $out/bin/nix-bundle \
       --prefix PATH : ${binPath}
+    cp $out/share/nix-bundle/nix-run.sh $out/bin/nix-run
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Standard update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

