### PR TITLE
gummi: init at 0.6.6

### DIFF
--- a/pkgs/applications/misc/gummi/default.nix
+++ b/pkgs/applications/misc/gummi/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, pkgs, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  version = "0.6.6";
+  name = "gummi-${version}";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "alexandervdm";
+    repo = "gummi";
+    rev = "${version}";
+    sha256 = "1vw8rhv8qj82l6l22kpysgm9mxilnki2kjmvxsnajbqcagr6s7cn";
+  };
+
+  nativeBuildInputs = with pkgs; [ pkgconfig intltool autoreconfHook makeWrapper ];
+  buildInputs = with pkgs; [ glib gnome2.gtksourceview gnome2.pango gtk2-x11 gtkspell2 poppler ];
+
+  preFixup = ''
+    wrapProgram "$out/bin/gummi" \
+      --prefix XDG_DATA_DIRS : "${pkgs.gnome2.gtksourceview}/share"
+  '';
+
+  postInstall = ''
+    install -Dpm644 COPYING $out/share/licenses/$name/COPYING
+    '';
+
+  meta = {
+    homepage = http://gummi.midnightcoding.org/;
+    description = "Simple LaTex editor for GTK users";
+    license = stdenv.lib.licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ flokli ];
+    platforms = with stdenv.lib.platforms; linux;
+    inherit version;
+  };
+}

--- a/pkgs/applications/misc/gummi/default.nix
+++ b/pkgs/applications/misc/gummi/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchFromGitHub, pkgs, makeWrapper }:
+{ stdenv, fetchFromGitHub, pkgs, makeWrapper
+, glib, gnome2, gnome3, gtk2-x11, gtkspell2, poppler
+, pkgconfig, intltool, autoreconfHook, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   version = "0.6.6";
@@ -11,17 +14,21 @@ stdenv.mkDerivation rec {
     sha256 = "1vw8rhv8qj82l6l22kpysgm9mxilnki2kjmvxsnajbqcagr6s7cn";
   };
 
-  nativeBuildInputs = with pkgs; [ pkgconfig intltool autoreconfHook makeWrapper ];
-  buildInputs = with pkgs; [ glib gnome2.gtksourceview gnome2.pango gtk2-x11 gtkspell2 poppler ];
+  nativeBuildInputs = [
+    pkgconfig intltool autoreconfHook makeWrapper wrapGAppsHook
+  ];
+  buildInputs = [
+    glib gnome2.gtksourceview gnome2.pango gtk2-x11 gtkspell2 poppler
+    gnome3.defaultIconTheme
+  ];
 
-  preFixup = ''
-    wrapProgram "$out/bin/gummi" \
-      --prefix XDG_DATA_DIRS : "${pkgs.gnome2.gtksourceview}/share"
+  preConfigure = ''
+    gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${pkgs.gnome2.gtksourceview}/share")
   '';
 
   postInstall = ''
     install -Dpm644 COPYING $out/share/licenses/$name/COPYING
-    '';
+  '';
 
   meta = {
     homepage = http://gummi.midnightcoding.org/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19033,6 +19033,8 @@ with pkgs;
 
   guetzli = callPackage ../applications/graphics/guetzli { };
 
+  gummi = callPackage ../applications/misc/gummi { };
+
   gxemul = callPackage ../misc/emulators/gxemul { };
 
   hatari = callPackage ../misc/emulators/hatari { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

