### PR TITLE
`NIX_PATH`-free `nixpkgs`

### DIFF
--- a/doc/bootstrap.xml
+++ b/doc/bootstrap.xml
@@ -79,7 +79,7 @@ with rec {
     tarball = stage1-tarball;
   };
 
-  stage1 = import stage1-path { inherit system; };
+  stage1 = import stage1-path { inherit system; config = {}; };
 };
 
 let

--- a/doc/bootstrap.xml
+++ b/doc/bootstrap.xml
@@ -80,47 +80,44 @@ with rec {
   };
 
   stage1 = import stage1-path { inherit system; config = {}; };
+
+  paths = 
+    builtins.filter (f: "default.nix" != f)
+      (builtins.attrNames
+        (builtins.readDir ./.));
+
+  toKeyVal = file: {
+    name = builtins.replaceStrings [ ".json" ] [ "" ] file;
+
+    value = 
+      let
+        json = builtins.fromJSON (builtins.readFile (./. + "/${file}"));
+      in
+        stage1.fetchFromGitHub {
+          owner = "NixOS";
+          repo  = "nixpkgs";
+          inherit (json) rev sha256;
+        };
+  };
+
+  pinnedNixpkgs = builtins.listToAttrs(map toKeyVal paths);
 };
 
-let
-  pinnedNixpkgs =
-    let
-      paths = 
-        builtins.filter (f: "default.nix" != f)
-          (builtins.attrNames
-            (builtins.readDir ./.));
-
-      toKeyVal = file: {
-        name = builtins.replaceStrings [ ".json" ] [ "" ] file;
-
-        value = 
-          let
-            json = builtins.fromJSON (builtins.readFile (./. + "/${file}"));
-          in
-            stage1.fetchFromGitHub {
-              owner = "NixOS";
-              repo  = "nixpkgs";
-              inherit (json) rev sha256;
-            };
-      };
-    in
-      builtins.listToAttrs(map toKeyVal paths);
-in
-  # The resulting attribute set given by `pinnedNixpkgs` provides the
-  # `fetchFromGitHub` derivation for each `*.json` file within this
-  # directory keyed by its filename without the `.json` extension.
-  #
-  # e.g: If this directory were to contain these `.json` files:
-  #
-  # .
-  # ├── 16_09.json
-  # ├── 17_03.json
-  # └── 17_09.json
-  #
-  # ... then this file would produce this attribute set:
-  #
-  # $ nix-instantiate --eval --expr 'import ./default.nix'
-  # { 16_09 = <CODE>; 17_03 = <CODE>; 17_09 = <CODE>; }
-  pinnedNixpkgs
+# The resulting attribute set given by `pinnedNixpkgs` provides the
+# `fetchFromGitHub` derivation for each `*.json` file within this
+# directory keyed by its filename without the `.json` extension.
+#
+# e.g: If this directory were to contain these `.json` files:
+#
+# .
+# ├── 16_09.json
+# ├── 17_03.json
+# └── 17_09.json
+#
+# ... then this file would produce this attribute set:
+#
+# $ nix-instantiate --eval --expr 'import ./default.nix'
+# { 16_09 = <CODE>; 17_03 = <CODE>; 17_09 = <CODE>; }
+pinnedNixpkgs
 ]]></programlisting>
 </chapter>

--- a/doc/bootstrap.xml
+++ b/doc/bootstrap.xml
@@ -67,11 +67,9 @@ with rec {
     builder = builtin-paths.shell;
     args = [
       (builtins.toFile "nixpkgs-unpacker" ''
-        "$coreutils/mkdir" -p "$out"
+        "$coreutils/mkdir" --parents "$out"
         cd "$out"
-        "$gzip" -c -d "$tarball" > temporary.tar
-        "$tar" -xf temporary.tar --strip-components=1
-        "$coreutils/rm" temporary.tar
+        "$gzip" --decompress < "$tarball" | "$tar" --extract --strip-components=1
       '')
     ];
 

--- a/doc/bootstrap.xml
+++ b/doc/bootstrap.xml
@@ -109,15 +109,22 @@ with rec {
 #
 # e.g: If this directory were to contain these `.json` files:
 #
+# ```
 # .
 # ├── 16_09.json
 # ├── 17_03.json
 # └── 17_09.json
+# ```
 #
 # ... then this file would produce this attribute set:
 #
-# $ nix-instantiate --eval --expr 'import ./default.nix'
+# ```
+# $ nix-instantiate --eval ./default.nix
 # { 16_09 = <CODE>; 17_03 = <CODE>; 17_09 = <CODE>; }
+# ```
+#
+# ... where each field is a derivation that fetches the corresponding `nixpkgs`
+# source tree
 pinnedNixpkgs
 ]]></programlisting>
 </chapter>

--- a/doc/bootstrap.xml
+++ b/doc/bootstrap.xml
@@ -1,0 +1,128 @@
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xml:id="chap-bootstrap">
+
+<title>Bootstrapping Nixpkgs</title>
+
+<para>This chapter describes how to bootstrap a pinned Nixpkgs revision without
+the use of the <varname>NIX_PATH</varname>.  This improves the reproducibility
+of your builds by removing the <varname>NIX_PATH</varname> as a source of
+variability.</para>
+
+<para>To do so, follow the instructions in the following file, which is
+self-documenting:</para>
+
+<programlisting><![CDATA[
+# This file provides a way to bootstrap and pin `nixpkgs` without the use of
+# `<nixpkgs>`.  Instead, this depends only on `<nix>` (a builtin path to the
+# current Nix installation).  This comes in handy if you do not want to depend
+# on the `NIX_PATH` at all
+#
+# Save this file as `default.nix` within a directory named `./nixpkgs/`
+#
+# Then for each revision of `nixpkgs` that you want to pin, run:
+#
+# ```bash
+# $ nix-prefetch-git https://github.com/NixOS/nixpkgs.git "${REVISION}" > "./nixpkgs/{REVISION_NAME}.json"
+# ```
+#
+# For example, you might do:
+#
+# ```bash
+# $ nix-prefetch-git https://github.com/NixOS/nixpkgs.git c6356ce381cd04c676eb0f6028e1f8395bdba323 > nixpkgs/17_09.json
+# ```
+#
+# Then you can use the pinned `nixpkgs` by importing the `./nixpkgs/` directory
+# and accessing the store path as an attribute named after the
+# `${REVISION_NAME}`, like this:
+#
+# ```nix
+# let
+#   nixpkgs = (import ./nixpkgs)."17_09";
+# 
+#   pkgs = import nixpkgs { };
+#
+# in
+#   ...
+# ```
+
+
+with rec {
+  system = builtins.currentSystem;
+
+  builtin-paths = import <nix/config.nix>;
+
+  hashes = {
+    commit = "76d649b59484607901f0c1b8f737d8376a904019";
+    sha256 = "01c2f4mj4ahir0sxk9kxbymg2pki1pc9a3y6r9x6ridry75fzb8h";
+  };
+
+  stage1-tarball = import <nix/fetchurl.nix> {
+    url = "https://github.com/NixOS/nixpkgs/archive/${hashes.commit}.tar.gz";
+    inherit (hashes) sha256;
+  };
+
+  stage1-path = builtins.derivation {
+    name = "nixpkgs-bootstrap-stage1";
+    builder = builtin-paths.shell;
+    args = [
+      (builtins.toFile "nixpkgs-unpacker" ''
+        "$coreutils/mkdir" -p "$out"
+        cd "$out"
+        "$gzip" -c -d "$tarball" > temporary.tar
+        "$tar" -xf temporary.tar --strip-components=1
+        "$coreutils/rm" temporary.tar
+      '')
+    ];
+
+    inherit system;
+
+    inherit (builtin-paths) tar gzip coreutils;
+    tarball = stage1-tarball;
+  };
+
+  stage1 = import stage1-path { inherit system; };
+};
+
+let
+  pinnedNixpkgs =
+    let
+      paths = 
+        builtins.filter (f: "default.nix" != f)
+          (builtins.attrNames
+            (builtins.readDir ./.));
+
+      toKeyVal = file: {
+        name = builtins.replaceStrings [ ".json" ] [ "" ] file;
+
+        value = 
+          let
+            json = builtins.fromJSON (builtins.readFile (./. + "/${file}"));
+          in
+            stage1.fetchFromGitHub {
+              owner = "NixOS";
+              repo  = "nixpkgs";
+              inherit (json) rev sha256;
+            };
+      };
+    in
+      builtins.listToAttrs(map toKeyVal paths);
+in
+  # The resulting attribute set given by `pinnedNixpkgs` provides the
+  # `fetchFromGitHub` derivation for each `*.json` file within this
+  # directory keyed by its filename without the `.json` extension.
+  #
+  # e.g: If this directory were to contain these `.json` files:
+  #
+  # .
+  # ├── 16_09.json
+  # ├── 17_03.json
+  # └── 17_09.json
+  #
+  # ... then this file would produce this attribute set:
+  #
+  # $ nix-instantiate --eval --expr 'import ./default.nix'
+  # { 16_09 = <CODE>; 17_03 = <CODE>; 17_09 = <CODE>; }
+  pinnedNixpkgs
+]]></programlisting>
+</chapter>

--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -20,6 +20,7 @@
   <xi:include href="languages-frameworks/index.xml" />
   <xi:include href="package-notes.xml" />
   <xi:include href="overlays.xml" />
+  <xi:include href="bootstrap.xml" />
   <xi:include href="coding-conventions.xml" />
   <xi:include href="submitting-changes.xml" />
   <xi:include href="reviewing-contributions.xml" />


### PR DESCRIPTION
This adds a new section to the Nixpkgs manual documenting how to bootstrap and
pin `nixpkgs` without the use of the `NIX_PATH`

The main reasons for including this code in the documentation (as opposed to
a file in the `nixpkgs` repository were):

* To improve discoverability of this trick
* You wouldn't be able to programmatically retrieve the code anyway ☺
* There's no obvious place to include this file in the repository

Credit to @taktoa who authored this code and Awake Security (that sponsored this work and
approved open sourcing it).  I'm only upstreaming the work that was already done

###### Motivation for this change

The `NIX_PATH` is a common source of non-reproducibility in commercial Nix deployments.
This fixes that by not only pinning `nixpkgs` but doing so in such a way that the pinning
process does not itself depend on the `NIX_PATH`

###### Things done

I built this on `macOS`:

```shell
$ nix-build docs/
```

... and opened up the generated documentation to verify that the section
rendered correctly

cc: @peti and @basvandijk, who I mentioned this trick to earlier today