### PR TITLE
pythonPackages.yowsup: init at v2.5.2

### DIFF
--- a/pkgs/development/python-modules/yowsup/argparse-dependency.patch
+++ b/pkgs/development/python-modules/yowsup/argparse-dependency.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 053ed07..60f0d9a 100755
+--- a/setup.py
++++ b/setup.py
+@@ -5,7 +5,7 @@ import yowsup
+ import platform
+ import sys
+ 
+-deps = ['python-dateutil', 'argparse', 'python-axolotl>=0.1.39', 'six']
++deps = ['python-dateutil', 'python-axolotl>=0.1.39', 'six']
+ 
+ if sys.version_info < (2,7):
+     deps += ['importlib']

--- a/pkgs/development/python-modules/yowsup/default.nix
+++ b/pkgs/development/python-modules/yowsup/default.nix
@@ -1,16 +1,21 @@
-{ buildPythonPackage, stdenv, fetchFromGitHub, six, python-axolotl }:
+{ buildPythonPackage, stdenv, fetchFromGitHub, six, python-axolotl, pytest }:
 
 buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "yowsup";
-  version = "v2.5.2";
+  version = "2.5.2";
 
   src = fetchFromGitHub {
     owner = "tgalal";
     repo = "yowsup";
-    rev = version;
+    rev = "v${version}";
     sha256 = "16l8jmr32wwvl11m0a4r4id3dkfqj2n7dn6gky1077xwmj2da4fl";
   };
+
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    HOME=$(mktemp -d) py.test yowsup
+  '';
 
   patches = [ ./argparse-dependency.patch ];
 

--- a/pkgs/development/python-modules/yowsup/default.nix
+++ b/pkgs/development/python-modules/yowsup/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage, stdenv, fetchFromGitHub, six, python-axolotl }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "yowsup";
+  version = "v2.5.2";
+
+  src = fetchFromGitHub {
+    owner = "tgalal";
+    repo = "yowsup";
+    rev = version;
+    sha256 = "16l8jmr32wwvl11m0a4r4id3dkfqj2n7dn6gky1077xwmj2da4fl";
+  };
+
+  patches = [ ./argparse-dependency.patch ];
+
+  propagatedBuildInputs = [ six python-axolotl ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/tgalal/yowsup";
+    description = "The python WhatsApp library";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26537,6 +26537,8 @@ EOF
     };
   };
 
+  yowsup = callPackage ../development/python-modules/yowsup { };
+
   wptserve = callPackage ../development/python-modules/wptserve { };
 
   yenc = callPackage ../development/python-modules/yenc { };


### PR DESCRIPTION
###### Motivation for this change

The `yowsup` library is needed for the WhatsApp script provided by weechat: https://github.com/weechat/scripts/blob/master/python/whatsapp.py

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

