### PR TITLE
criu: 2.0 -> 2.12.1

### DIFF
--- a/pkgs/os-specific/linux/criu/default.nix
+++ b/pkgs/os-specific/linux/criu/default.nix
@@ -1,26 +1,27 @@
 { stdenv, fetchurl, protobuf, protobufc, asciidoc
-, xmlto, utillinux, docbook_xsl, libpaper, libnl, libcap, pkgconfig
+, xmlto, utillinux, docbook_xsl, libpaper, libnl, libcap, libnet, pkgconfig
 , python }:
 
 stdenv.mkDerivation rec {
   name    = "criu-${version}";
-  version = "2.0";
+  version = "2.12.1";
 
   src = fetchurl {
     url    = "http://download.openvz.org/criu/${name}.tar.bz2";
-    sha256 = "1zqqshslcf503lqip89azp1zz0i8kb7v19b3dyp52izpak62c1z8";
+    sha256 = "18m0sjgcfvzc86w49fd3kxw145nmrsvc5w7zf42nxdiklmszbr1k";
   };
 
   enableParallelBuilding = true;
   nativeBuildInputs = [ pkgconfig docbook_xsl ];
-  buildInputs = [ protobuf protobufc asciidoc xmlto libpaper libnl libcap python ];
+  buildInputs = [ protobuf protobufc asciidoc xmlto libpaper libnl libcap libnet python ];
 
   patchPhase = ''
     chmod +w ./scripts/gen-offsets.sh
     substituteInPlace ./scripts/gen-offsets.sh --replace hexdump ${utillinux}/bin/hexdump
     substituteInPlace ./Documentation/Makefile --replace "2>/dev/null" ""
+    substituteInPlace ./Documentation/Makefile --replace "-m custom.xsl" "-m custom.xsl --skip-validation -x ${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl"
     substituteInPlace ./criu/Makefile --replace "-I/usr/include/libnl3" "-I${libnl.dev}/include/libnl3"
-    substituteInPlace ./Makefile --replace "tar-name := $(shell git tag -l v$(CRIU_VERSION))" "tar-name = 2.0" # --replace "-Werror" ""
+    substituteInPlace ./Makefile --replace "head-name := \$(shell git tag -l v\$(CRIU_VERSION))" "head-name = ${version}.0"
     ln -sf ${protobuf}/include/google/protobuf/descriptor.proto ./images/google/protobuf/descriptor.proto
 
     # Avoid a glibc >= 2.25 deprecation warning that gets fatal via -Werror.
@@ -31,7 +32,9 @@ stdenv.mkDerivation rec {
 
   makeFlags = "PREFIX=$(out)";
 
-  hardeningDisable = [ "stackprotector" ];
+  hardeningDisable = [ "stackprotector" "fortify" ];
+  # dropping fortify here as well as package uses it by default:
+  # command-line>:0:0: error: "_FORTIFY_SOURCE" redefined [-Werror]
 
   installPhase = ''
     mkdir -p $out/etc/logrotate.d


### PR DESCRIPTION
###### Motivation for this change

criu: 2.0 -> 2.12.1

No luck with upgrading to 3.x

cc @thoughtpolice 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

