### PR TITLE
openrct2: init at 0.1.1

### DIFF
--- a/pkgs/games/openrct2/default.nix
+++ b/pkgs/games/openrct2/default.nix
@@ -1,0 +1,70 @@
+{ stdenv, fetchurl, fetchFromGitHub,
+  SDL2, cmake, curl, fontconfig, freetype, jansson, libiconv, libpng,
+  libpthreadstubs, libzip, mesa_glu, openssl, pkgconfig, speexdsp, zlib
+}:
+
+let
+  name = "openrct2-${version}";
+  version = "0.1.1";
+
+  openrct2-src = fetchFromGitHub {
+    owner = "OpenRCT2";
+    repo = "OpenRCT2";
+    rev = "v${version}";
+    sha256 = "1xxwqx2gzvsdrsy76rz3sys9m4pyn9q25nbnkba3cw1z4l2b73lg";
+  };
+
+  title-sequences-src = fetchFromGitHub {
+    owner = "OpenRCT2";
+    repo = "title-sequences";
+    rev = "v0.1.0";
+    sha256 = "17c926lhby90ilvyyl6jsiy0df8dw5jws97xigp3x8hddhvv7c16";
+  };
+in
+stdenv.mkDerivation rec {
+  inherit name;
+
+  srcs = [ openrct2-src title-sequences-src ];
+  sourceRoot = ".";
+
+  buildInputs = [
+    SDL2
+    cmake
+    curl
+    fontconfig
+    freetype
+    jansson
+    libiconv
+    libpng
+    libpthreadstubs
+    libzip
+    mesa_glu
+    openssl
+    pkgconfig
+    speexdsp
+    zlib
+  ];
+
+  postUnpack = ''
+    cp -r ${openrct2-src}/* ${sourceRoot}
+    cp -r ${title-sequences-src} ${sourceRoot}/title
+
+    # creating temporary files in fixCmakeFiles fails otherwise
+    chmod -R u+w ${sourceRoot}
+  '';
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=RELWITHDEBINFO" "-DDOWNLOAD_TITLE_SEQUENCES=OFF"];
+
+  makeFlags = ["all" "g2"];
+
+  preFixup = "ln -s $out/share/openrct2 $out/bin/data";
+
+  meta = with stdenv.lib; {
+    description = "An open source re-implementation of RollerCoaster Tycoon 2 (original game required)";
+    homepage = https://openrct2.website/;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ geistesk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10090,6 +10090,8 @@ with pkgs;
 
   ortp = callPackage ../development/libraries/ortp { };
 
+  openrct2 = callPackage ../games/openrct2/default.nix { };
+
   osm-gps-map = callPackage ../development/libraries/osm-gps-map { };
 
   p11_kit = callPackage ../development/libraries/p11-kit { };


### PR DESCRIPTION
###### Motivation for this change
This PR adds the open source re-implementation of RollerCoaster Tycoon 2, [OpenRCT2](https://github.com/OpenRCT2/OpenRCT2), to the nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

