### PR TITLE
rust build support: Find Cargo.lock file upwards in tree

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-deps
+++ b/pkgs/build-support/rust/fetch-cargo-deps
@@ -50,7 +50,18 @@ EOF
     export CARGO_HOME=$out
     cd $src
 
-    if [[ ! -f Cargo.lock ]]; then
+    find_upwards() {
+        [[ "$(realpath "$1")" == "/" ]] && return 1
+        if [ -f "$1/$2" ]; then
+            echo "$1/$2"
+        else
+            find_upwards "../$1" "$2"
+        fi
+    }
+
+    cargo_lock=$(find_upwards . "Cargo.lock")
+
+    if [[ -z "$cargo_lock" ]]; then
         echo
         echo "ERROR: The Cargo.lock file doesn't exist"
         echo


### PR DESCRIPTION
Cargo, the build tool for the rust ecosystem, provides a feature named
"workspaces". In workspaces, multiple library- and binary-crates can be
bundled together in one repository/project.

The workspace functionality also provides functionality where
dependencies are built once for several crates in the workspace. Thus
the "Cargo.lock" file (as well as the ./target folder where the final
binary lives) are placed in the top-level directory of the repository,
while the `cargo build` command may be called somewhere in the working
tree.

Because of this we need to make sure that we find the `Cargo.lock` file
by not only searching the current directory but also the directories
above the `${sourceRoot}`.

This change introduces a little helper to walk up the file tree and
check for a file, starting with the current directory.

---

This is not tested at all and only a proposal. @Mic92 and I discussed what needs to be done for this to work in https://github.com/NixOS/nixpkgs/issues/29981 and this is my first proposal.
The helper function does not yet stop at `/nix/store/<dir>`, though.

