### PR TITLE
kexectools: 2.0.14 -> 2.0.15

### DIFF
--- a/pkgs/os-specific/linux/kexectools/default.nix
+++ b/pkgs/os-specific/linux/kexectools/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "kexec-tools-${version}";
-  version = "2.0.14";
+  version = "2.0.15";
 
   src = fetchurl {
     urls = [
       "mirror://kernel/linux/utils/kernel/kexec/${name}.tar.xz"
       "http://horms.net/projects/kexec/kexec-tools/${name}.tar.xz"
     ];
-    sha256 = "1ihd3kzw8xnc5skq4pb633rr80007knjm4n1dd67a24xkplygcpz";
+    sha256 = "1rwl04y1mpb28yq5ynnk8j124dmhj5p8c4hcdn453sri2j37p6w9";
   };
 
   hardeningDisable = [ "format" "pic" "relro" ];


### PR DESCRIPTION
###### Motivation for this change

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=876042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via `nixos/tests/kexec.nix`: the test fails at the same location as before
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

