### PR TITLE
astroid: 0.9.1 -> 0.10.2

### DIFF
--- a/pkgs/applications/networking/mailreaders/astroid/default.nix
+++ b/pkgs/applications/networking/mailreaders/astroid/default.nix
@@ -1,31 +1,30 @@
-{ stdenv, fetchFromGitHub, scons, pkgconfig, gnome3, gmime, webkitgtk24x-gtk3
+{ stdenv, fetchFromGitHub, scons, pkgconfig, gnome3, gmime3, webkitgtk24x-gtk3
 , libsass, notmuch, boost, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "astroid-${version}";
-  version = "0.9.1";
+  version = "0.10.2";
 
   src = fetchFromGitHub {
     owner = "astroidmail";
     repo = "astroid";
     rev = "v${version}";
-    sha256 = "0ha2jd3fvc54amh0x8f58s9ac4r8xgyhvkwd4jvs0h4mfh6cg496";
+    sha256 = "0y1i40xbjjvnylqpdkvj0m9fl6f5k9zk1z4pqg3vhj8x1ys8am1c";
   };
 
   nativeBuildInputs = [ scons pkgconfig wrapGAppsHook ];
 
-  buildInputs = [ gnome3.gtkmm gmime webkitgtk24x-gtk3 libsass gnome3.libpeas
-                  notmuch boost gnome3.gsettings_desktop_schemas
-                  gnome3.adwaita-icon-theme ];
+  buildInputs = [ gnome3.gtkmm gmime3 webkitgtk24x-gtk3 libsass gnome3.libpeas
+                  notmuch boost gnome3.gsettings_desktop_schemas ];
 
   buildPhase = "scons --propagate-environment --prefix=$out build";
   installPhase = "scons --propagate-environment --prefix=$out install";
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://astroidmail.github.io/;
     description = "GTK+ frontend to the notmuch mail system";
-    maintainers = [ stdenv.lib.maintainers.bdimcheff ];
-    license = stdenv.lib.licenses.gpl3Plus;
-    platforms = stdenv.lib.platforms.linux;
+    maintainers = with maintainers; [ bdimcheff SuprDewd ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Also:
- Use gmime3 instead of gmime2: https://github.com/astroidmail/astroid/issues/405
- Remove adwaita-icon-theme, as it is not needed
- Add SuprDewd as a maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

