### PR TITLE
MacOS support for gn and v8_6_x

### DIFF
--- a/pkgs/development/libraries/v8/6_x.nix
+++ b/pkgs/development/libraries/v8/6_x.nix
@@ -96,7 +96,7 @@ in
 
 stdenv.mkDerivation rec {
   name = "v8-${version}";
-  version = "6.2.414.27";
+  version = "6.2.414.30";
 
   inherit doCheck;
 
@@ -104,7 +104,7 @@ stdenv.mkDerivation rec {
     owner = "v8";
     repo = "v8";
     rev = version;
-    sha256 = "15zrb9bcpnhljhrilqnjaak3a4xnhj8li6ra12g3gkrw3fzir9a2";
+    sha256 = "0n9bpk8njm65sm8cvlmd8qha5q22d6vp10ykq1mzim4y64wipz84";
   };
 
   postUnpack = ''

--- a/pkgs/development/libraries/v8/6_x.nix
+++ b/pkgs/development/libraries/v8/6_x.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchgit, fetchFromGitHub, gn, ninja, python, glib, pkgconfig
+{ stdenv, lib, fetchgit, fetchFromGitHub, gn, libtool, ninja, python, glib, pkgconfig
 , doCheck ? false
 , snapshot ? true
 }:
@@ -11,6 +11,9 @@ let
          else if stdenv.is64bit
               then"x64"
               else "ia32";
+
+  librarySuffix = stdenv.hostPlatform.extensions.sharedLibrary;
+
   git_url = "https://chromium.googlesource.com";
 
   deps = {
@@ -116,6 +119,14 @@ stdenv.mkDerivation rec {
   '';
 
   prePatch = ''
+    chmod u+w -R .
+  '';
+
+  patches = stdenv.lib.optionals stdenv.isDarwin [
+    ./no-xcode-gn.patch
+  ];
+
+  postPatch = ''
     # use our gn, not the bundled one
     sed -i -e 's#gn_path = .*#gn_path = "${gn}/bin/gn"#' tools/mb/mb.py
 
@@ -123,7 +134,6 @@ stdenv.mkDerivation rec {
     if [ "$doCheck" = "" ]; then sed -i -e '/"test:gn_all",/d' BUILD.gn; fi
 
     # disable sysroot usage
-    chmod u+w build/config build/config/sysroot.gni
     sed -i build/config/sysroot.gni \
         -e '/use_sysroot =/ { s#\(use_sysroot =\).*#\1 false#; :a  n; /current_cpu/ { s/^/#/; ba };  }'
 
@@ -141,7 +151,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ gn ninja pkgconfig ];
-  buildInputs = [ python glib ];
+  buildInputs = [ python glib ] ++ stdenv.lib.optionals stdenv.isDarwin [ libtool ];
 
   buildPhase = ''
     ninja -C out.gn/${arch}.release/
@@ -153,7 +163,8 @@ stdenv.mkDerivation rec {
     install -vD out.gn/${arch}.release/d8 "$out/bin/d8"
     install -vD out.gn/${arch}.release/mksnapshot "$out/bin/mksnapshot"
     mkdir -p "$out/lib"
-    for f in libicui18n.so libicuuc.so libv8_libbase.so libv8_libplatform.so libv8.so; do
+    for f in libicui18n${librarySuffix} libicuuc${librarySuffix} libv8_libbase${librarySuffix} \
+             libv8_libplatform${librarySuffix} libv8${librarySuffix}; do
         install -vD out.gn/${arch}.release/$f "$out/lib/$f"
     done
     install -vD out.gn/${arch}.release/icudtl.dat "$out/lib/icudtl.dat"
@@ -165,7 +176,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Google's open source JavaScript engine";
     maintainers = with maintainers; [ cstrahan proglodyte ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     license = licenses.bsd3;
   };
 }

--- a/pkgs/development/libraries/v8/no-xcode-gn.patch
+++ b/pkgs/development/libraries/v8/no-xcode-gn.patch
@@ -1,0 +1,119 @@
+diff -ur nix-build-v8-6.2.414.27.drv-0/build/config/compiler/BUILD.gn nix-build-v8-6.2.414.27.drv-1/v8-6.2.414.27-src/build/config/compiler/BUILD.gn
+--- nix-build-v8-6.2.414.27.drv-0/build/config/compiler/BUILD.gn	2017-10-13 22:30:19.000000000 +0200
++++ nix-build-v8-6.2.414.27.drv-1/build/config/compiler/BUILD.gn	2017-10-14 13:21:38.000000000 +0200
+@@ -1233,6 +1233,8 @@
+       ]
+     }
+   }
++
++  cflags += [ "-Wno-unknown-warning-option" ]
+ }
+ 
+ # chromium_code ---------------------------------------------------------------
+diff -ur nix-build-v8-6.2.414.27.drv-0/build/config/mac/BUILD.gn nix-build-v8-6.2.414.27.drv-1/v8-6.2.414.27-src/build/config/mac/BUILD.gn
+--- nix-build-v8-6.2.414.27.drv-0/build/config/mac/BUILD.gn	2017-10-13 22:30:19.000000000 +0200
++++ nix-build-v8-6.2.414.27.drv-1/build/config/mac/BUILD.gn	2017-10-14 12:31:04.000000000 +0200
+@@ -3,7 +3,6 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/sysroot.gni")
+-import("//build/config/mac/mac_sdk.gni")
+ import("//build/config/mac/symbols.gni")
+ 
+ # This is included by reference in the //build/config/compiler config that
+@@ -25,11 +24,6 @@
+     ]
+   }
+ 
+-  # This is here so that all files get recompiled after an Xcode update.
+-  # (defines are passed via the command line, and build system rebuild things
+-  # when their commandline changes). Nothing should ever read this define.
+-  defines = [ "CR_XCODE_VERSION=$xcode_version" ]
+-
+   asmflags = common_mac_flags
+   cflags = common_mac_flags
+ 
+@@ -52,16 +46,6 @@
+ # that is Mac-only. Please see that target for advice on what should go in
+ # :runtime_library vs. :compiler.
+ config("runtime_library") {
+-  common_flags = [
+-    "-isysroot",
+-    rebase_path(sysroot, root_build_dir),
+-    "-mmacosx-version-min=$mac_deployment_target",
+-  ]
+-
+-  asmflags = common_flags
+-  cflags = common_flags
+-  ldflags = common_flags
+-
+   # Prevent Mac OS X AssertMacros.h (included by system header) from defining
+   # macros that collide with common names, like 'check', 'require', and
+   # 'verify'.
+diff -ur nix-build-v8-6.2.414.27.drv-0/build/config/sysroot.gni nix-build-v8-6.2.414.27.drv-1/v8-6.2.414.27-src/build/config/sysroot.gni
+--- nix-build-v8-6.2.414.27.drv-0/build/config/sysroot.gni	2017-10-13 22:30:24.000000000 +0200
++++ nix-build-v8-6.2.414.27.drv-1/build/config/sysroot.gni	2017-10-14 12:30:00.000000000 +0200
+@@ -71,8 +71,7 @@
+         "Missing sysroot ($sysroot). To fix, run: build/linux/sysroot_scripts/install-sysroot.py --arch=$_script_arch")
+   }
+ } else if (is_mac) {
+-  import("//build/config/mac/mac_sdk.gni")
+-  sysroot = mac_sdk_path
++  sysroot = ""
+ } else if (is_ios) {
+   import("//build/config/ios/ios_sdk.gni")
+   sysroot = ios_sdk_path
+diff -ur nix-build-v8-6.2.414.27.drv-0/build/toolchain/mac/BUILD.gn nix-build-v8-6.2.414.27.drv-1/v8-6.2.414.27-src/build/toolchain/mac/BUILD.gn
+--- nix-build-v8-6.2.414.27.drv-0/build/toolchain/mac/BUILD.gn	2017-10-13 22:30:19.000000000 +0200
++++ nix-build-v8-6.2.414.27.drv-1/build/toolchain/mac/BUILD.gn	2017-10-14 12:29:51.000000000 +0200
+@@ -11,7 +11,6 @@
+ if (is_ios) {
+   import("//build/config/ios/ios_sdk.gni")
+ }
+-import("//build/config/mac/mac_sdk.gni")
+ import("//build/config/mac/symbols.gni")
+ 
+ assert(host_os == "mac")
+@@ -84,13 +83,7 @@
+       host_toolchain = host_toolchain
+     }
+ 
+-    # Supports building with the version of clang shipped with Xcode when
+-    # targeting iOS by not respecting clang_base_path.
+-    if (toolchain_args.current_os == "ios" && use_xcode_clang) {
+-      prefix = ""
+-    } else {
+-      prefix = rebase_path("$clang_base_path/bin/", root_build_dir)
+-    }
++    prefix = ""
+ 
+     _cc = "${prefix}clang"
+     _cxx = "${prefix}clang++"
+@@ -425,27 +418,6 @@
+       description = "COPY_BUNDLE_DATA {{source}} {{output}}"
+       pool = ":bundle_pool($default_toolchain)"
+     }
+-    tool("compile_xcassets") {
+-      _tool = rebase_path("//build/toolchain/mac/compile_xcassets.py",
+-                          root_build_dir)
+-      if (is_ios) {
+-        _sdk_name = ios_sdk_name
+-        _min_deployment_target = ios_deployment_target
+-        _compress_pngs = ""
+-      } else {
+-        _sdk_name = mac_sdk_name
+-        _min_deployment_target = mac_deployment_target
+-        _compress_pngs = " -c "
+-      }
+-      command = "$env_wrapper rm -f {{output}} && " +
+-                "TOOL_VERSION=${tool_versions.compile_xcassets} " +
+-                "python $_tool -p $_sdk_name -t $_min_deployment_target " +
+-                "$_compress_pngs -T {{bundle_product_type}} -o {{output}} " +
+-                "{{inputs}}"
+-
+-      description = "COMPILE_XCASSETS {{output}}"
+-      pool = ":bundle_pool($default_toolchain)"
+-    }
+   }
+ }
+ 

--- a/pkgs/development/tools/build-managers/gn/NSPressureConfiguration.patch
+++ b/pkgs/development/tools/build-managers/gn/NSPressureConfiguration.patch
@@ -1,0 +1,33 @@
+--- a/base/mac/sdk_forward_declarations.h.orig	2017-10-13 22:49:16.000000000 +0200
++++ a/base/mac/sdk_forward_declarations.h	2017-10-13 22:48:16.000000000 +0200
+@@ -41,10 +41,6 @@
+ };
+ typedef NSInteger NSPressureBehavior;
+ 
+-@interface NSPressureConfiguration : NSObject
+-- (instancetype)initWithPressureBehavior:(NSPressureBehavior)pressureBehavior;
+-@end
+-
+ enum {
+   NSSpringLoadingHighlightNone = 0,
+   NSSpringLoadingHighlightStandard,
+@@ -187,19 +187,6 @@
+ - (NSLayoutConstraint*)constraintGreaterThanOrEqualToConstant:(CGFloat)c;
+ @end
+ 
+-@interface NSView (ElCapitanSDK)
+-- (void)setPressureConfiguration:(NSPressureConfiguration*)aConfiguration
+-    API_AVAILABLE(macos(10.11));
+-@property(readonly, strong)
+-    NSLayoutXAxisAnchor* leftAnchor API_AVAILABLE(macos(10.11));
+-@property(readonly, strong)
+-    NSLayoutXAxisAnchor* rightAnchor API_AVAILABLE(macos(10.11));
+-@property(readonly, strong)
+-    NSLayoutYAxisAnchor* bottomAnchor API_AVAILABLE(macos(10.11));
+-@property(readonly, strong)
+-    NSLayoutDimension* widthAnchor API_AVAILABLE(macos(10.11));
+-@end
+-
+ @interface NSWindow (ElCapitanSDK)
+ - (void)performWindowDragWithEvent:(NSEvent*)event;
+ @end

--- a/pkgs/development/tools/build-managers/gn/RemoveGetModelIdentifier.patch
+++ b/pkgs/development/tools/build-managers/gn/RemoveGetModelIdentifier.patch
@@ -1,0 +1,76 @@
+diff --git a/base/mac/mac_util.h b/base/mac/mac_util.h
+index 67d188084..8c0a78e8f 100644
+--- a/base/mac/mac_util.h
++++ b/base/mac/mac_util.h
+@@ -158,18 +158,6 @@ inline bool IsOSLaterThan10_12_DontCallThis() {
+   return !IsAtMostOS10_12();
+ }
+ 
+-// Retrieve the system's model identifier string from the IOKit registry:
+-// for example, "MacPro4,1", "MacBookPro6,1". Returns empty string upon
+-// failure.
+-BASE_EXPORT std::string GetModelIdentifier();
+-
+-// Parse a model identifier string; for example, into ("MacBookPro", 6, 1).
+-// If any error occurs, none of the input pointers are touched.
+-BASE_EXPORT bool ParseModelIdentifier(const std::string& ident,
+-                                      std::string* type,
+-                                      int32_t* major,
+-                                      int32_t* minor);
+-
+ }  // namespace mac
+ }  // namespace base
+ 
+diff --git a/base/mac/mac_util.mm b/base/mac/mac_util.mm
+index 9615f9d2e..7f825e5b4 100644
+--- a/base/mac/mac_util.mm
++++ b/base/mac/mac_util.mm
+@@ -434,48 +434,5 @@ int MacOSXMinorVersion() {
+ }
+ }  // namespace internal
+ 
+-std::string GetModelIdentifier() {
+-  std::string return_string;
+-  ScopedIOObject<io_service_t> platform_expert(
+-      IOServiceGetMatchingService(kIOMasterPortDefault,
+-                                  IOServiceMatching("IOPlatformExpertDevice")));
+-  if (platform_expert) {
+-    ScopedCFTypeRef<CFDataRef> model_data(
+-        static_cast<CFDataRef>(IORegistryEntryCreateCFProperty(
+-            platform_expert,
+-            CFSTR("model"),
+-            kCFAllocatorDefault,
+-            0)));
+-    if (model_data) {
+-      return_string =
+-          reinterpret_cast<const char*>(CFDataGetBytePtr(model_data));
+-    }
+-  }
+-  return return_string;
+-}
+-
+-bool ParseModelIdentifier(const std::string& ident,
+-                          std::string* type,
+-                          int32_t* major,
+-                          int32_t* minor) {
+-  size_t number_loc = ident.find_first_of("0123456789");
+-  if (number_loc == std::string::npos)
+-    return false;
+-  size_t comma_loc = ident.find(',', number_loc);
+-  if (comma_loc == std::string::npos)
+-    return false;
+-  int32_t major_tmp, minor_tmp;
+-  std::string::const_iterator begin = ident.begin();
+-  if (!StringToInt(
+-          StringPiece(begin + number_loc, begin + comma_loc), &major_tmp) ||
+-      !StringToInt(
+-          StringPiece(begin + comma_loc + 1, ident.end()), &minor_tmp))
+-    return false;
+-  *type = ident.substr(0, number_loc);
+-  *major = major_tmp;
+-  *minor = minor_tmp;
+-  return true;
+-}
+-
+ }  // namespace mac
+ }  // namespace base

--- a/pkgs/development/tools/build-managers/gn/bootstrap.patch
+++ b/pkgs/development/tools/build-managers/gn/bootstrap.patch
@@ -1,0 +1,20 @@
+diff --git a/bootstrap/bootstrap.py b/bootstrap/bootstrap.py
+index f154ed2..690f614 100755
+--- a/tools/gn/bootstrap/bootstrap.py
++++ b/tools/gn/bootstrap/bootstrap.py
+@@ -691,11 +691,15 @@ def write_gn_ninja(path, root_gen_dir, options):
+         'base/mac/bundle_locations.mm',
+         'base/mac/call_with_eh_frame.cc',
+         'base/mac/call_with_eh_frame_asm.S',
++        'base/mac/dispatch_source_mach.cc',
+         'base/mac/foundation_util.mm',
++        'base/mac/mac_logging.mm',
+         'base/mac/mach_logging.cc',
++        'base/mac/mac_util.mm',
+         'base/mac/scoped_mach_port.cc',
+         'base/mac/scoped_mach_vm.cc',
+         'base/mac/scoped_nsautorelease_pool.mm',
++        'base/mac/scoped_nsobject.mm',
+         'base/memory/shared_memory_handle_mac.cc',
+         'base/memory/shared_memory_mac.cc',
+         'base/message_loop/message_pump_mac.mm',

--- a/pkgs/development/tools/build-managers/gn/default.nix
+++ b/pkgs/development/tools/build-managers/gn/default.nix
@@ -4,13 +4,13 @@ let
   depsGit = {
     "tools/gn" = fetchgit {
       url = "https://chromium.googlesource.com/chromium/src/tools/gn";
-      rev = "d0c518db129975ce88ff1de26c857873b0619c4b";
-      sha256 = "0l15vzmjyx6bwlz1qhn3fy7yx3qzzxr3drnkj3l0p0fmyxza52vx";
+      rev = "858366e6b3803ff067862a9b994776fc11124ba2";
+      sha256 = "0nylfi9jnp8f8i1vr7jxdskvjr7hi1g9hg7qxxqcy4bdrfr2npra";
     };
     "base" = fetchgit {
       url = "https://chromium.googlesource.com/chromium/src/base";
-      rev = "bc6e3ce8ca01b894751e1f7b22b561e3ae2e7f17";
-      sha256 = "1yl49v6nxbrfms52xf7fiwh7d4301m2aj744pa3hzzh989c5j6g5";
+      rev = "d56f52a20c2ca2ab28579677d2ea5483401bd47e";
+      sha256 = "0b29bmi3qfnvxwcljzbzi6im49nd7j6pf9zb5c53zb9pilwpsrqq";
     };
     "build" = fetchgit {
       url = "https://chromium.googlesource.com/chromium/src/build";
@@ -32,7 +32,7 @@ let
 in
   stdenv.mkDerivation rec {
     name = "gn";
-    version = "0.0.0.20170629";
+    version = "0.0.0.20171013";
     sourceRoot = ".";
 
     unpackPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10849,6 +10849,7 @@ with pkgs;
   };
 
   v8_6_x = callPackage ../development/libraries/v8/6_x.nix {
+    libtool = darwin.cctools;
     inherit (python2Packages) python;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7395,7 +7395,10 @@ with pkgs;
 
   ninja = callPackage ../development/tools/build-managers/ninja { };
 
-  gn = callPackage ../development/tools/build-managers/gn { };
+  gn = callPackage ../development/tools/build-managers/gn {
+    inherit (darwin.apple_sdk.frameworks) AppKit ApplicationServices Cocoa CoreBluetooth Foundation ImageCaptureCore;
+    libtool = darwin.cctools;
+  };
 
   nixbang = callPackage ../development/tools/misc/nixbang {
       pythonPackages = python3Packages;


### PR DESCRIPTION
###### Motivation for this change

With #29726 I introduced a new package v8_6_x which repackaged V8 on GN build system, yet for Linux only. This PR adds support for MacOS/darwin

Also updates gn to current Git master and V8 6.2.414.30

The added patch file `pkgs/development/tools/build-managers/gn/apple_apsl.patch` actually adds "sources" needed for the MacOS build. I preferred adding a patch since it only needs a very small number of files, which are otherwise part of "third party" Git repository with 2,5GB download size. Downloading that for just a few kB didn't feel right to me.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

