### PR TITLE
lbdb: 0.38 -> 0.44

### DIFF
--- a/pkgs/tools/misc/lbdb/add-methods-to-rc.patch
+++ b/pkgs/tools/misc/lbdb/add-methods-to-rc.patch
@@ -1,0 +1,11 @@
+--- a/lbdb.rc.in
++++ b/lbdb.rc.in
+@@ -40,7 +40,7 @@
+ # - m_vcf        search a vcard (according to RFC2426) file.
+ # - m_khard      search a CardDAV address book via khard
+ 
+-METHODS="m_inmail m_passwd m_finger"
++METHODS="@MODULES@"
+ 
+ 
+ #

--- a/pkgs/tools/misc/lbdb/default.nix
+++ b/pkgs/tools/misc/lbdb/default.nix
@@ -1,17 +1,39 @@
-{ stdenv, fetchurl, perl, finger_bsd }:
+{ stdenv, fetchurl, perl, perlPackages, finger_bsd, makeWrapper
+, abook ? null
+, gnupg ? null
+, goobook ? null
+, khard ? null
+}:
 
 let
-  version = "0.38";
+  version = "0.44";
 in
-
+with stdenv.lib;
+with perlPackages;
 stdenv.mkDerivation {
   name = "lbdb-${version}";
   src = fetchurl {
     url = "http://www.spinnaker.de/debian/lbdb_${version}.tar.gz";
-    sha256 = "1279ssfrh4cqrjzq5q47xbdlw5qx3aazxjshi86ljm4cw6xxvgar";
+    sha256 = "0kjz3n2ilrg6yrz8z40714ppdprgwhbgvzcsjzs822l6da4qxna3";
   };
 
-  buildInputs = [ perl ] ++ stdenv.lib.optional (!stdenv.isDarwin) finger_bsd;
+  buildInputs = [ goobook makeWrapper perl ConvertASN1 NetLDAP AuthenSASL ]
+    ++ optional (!stdenv.isDarwin) finger_bsd
+    ++ optional   (abook != null) abook
+    ++ optional   (gnupg != null) gnupg
+    ++ optional (goobook != null) goobook
+    ++ optional   (khard != null) khard;
+  configureFlags = [ ]
+    ++ optional   (abook != null) "--with-abook"
+    ++ optional   (gnupg != null) "--with-gpg"
+    ++ optional (goobook != null) "--with-goobook"
+    ++ optional   (khard != null) "--with-khard";
+
+  patches = [ ./add-methods-to-rc.patch ];
+  postFixup = "wrapProgram $out/lib/mutt_ldap_query --prefix PERL5LIB : "
+    + "${AuthenSASL}/${perl.libPrefix}"
+    + ":${ConvertASN1}/${perl.libPrefix}"
+    + ":${NetLDAP}/${perl.libPrefix}";
 
   meta = {
     homepage = http://www.spinnaker.de/lbdb/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15280,7 +15280,7 @@ with pkgs;
 
   lastfmsubmitd = callPackage ../applications/audio/lastfmsubmitd { };
 
-  lbdb = callPackage ../tools/misc/lbdb { };
+  lbdb = callPackage ../tools/misc/lbdb { abook = null; gnupg = null; goobook = null; khard = null; };
 
   lbzip2 = callPackage ../tools/compression/lbzip2 { };
 


### PR DESCRIPTION
###### Motivation for this change

Update to latest upstream version. Enable goobook support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

