### PR TITLE
Fix "batch" command on NixOS

### DIFF
--- a/nixos/modules/services/scheduling/atd.nix
+++ b/nixos/modules/services/scheduling/atd.nix
@@ -42,6 +42,8 @@ in
 
   config = mkIf cfg.enable {
 
+    # Not wrapping "batch" because it's a shell script (kernel drops perms
+    # anyway) and it's patched to invoke the "at" setuid wrapper.
     security.wrappers = builtins.listToAttrs (
       map (program: { name = "${program}"; value = {
       source = "${at}/bin/${program}";
@@ -49,7 +51,7 @@ in
       group = "atd";
       setuid = true;
       setgid = true;
-    };}) [ "at" "atq" "atrm" "batch" ]);
+    };}) [ "at" "atq" "atrm" ]);
 
     environment.systemPackages = [ at ];
 

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -214,6 +214,7 @@ in rec {
   # Run the tests for each platform.  You can run a test by doing
   # e.g. ‘nix-build -A tests.login.x86_64-linux’, or equivalently,
   # ‘nix-build tests/login.nix -A result’.
+  tests.atd = callTest tests/atd.nix {};
   tests.acme = callTest tests/acme.nix {};
   tests.avahi = callTest tests/avahi.nix {};
   tests.bittorrent = callTest tests/bittorrent.nix {};

--- a/nixos/tests/atd.nix
+++ b/nixos/tests/atd.nix
@@ -1,0 +1,36 @@
+import ./make-test.nix ({ pkgs, lib, ... }:
+
+{
+  name = "atd";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ bjornfor ];
+  };
+
+  machine =
+    { config, pkgs, ... }:
+    { services.atd.enable = true;
+      users.extraUsers.alice = { isNormalUser = true; };
+    };
+
+  # "at" has a resolution of 1 minute
+  testScript = ''
+    startAll;
+
+    $machine->fail("test -f ~root/at-1");
+    $machine->fail("test -f ~root/batch-1");
+    $machine->fail("test -f ~alice/at-1");
+    $machine->fail("test -f ~alice/batch-1");
+
+    $machine->succeed("echo 'touch ~root/at-1' | at now+1min");
+    $machine->succeed("echo 'touch ~root/batch-1' | batch");
+    $machine->succeed("su - alice -c \"echo 'touch at-1' | at now+1min\"");
+    $machine->succeed("su - alice -c \"echo 'touch batch-1' | batch\"");
+
+    $machine->succeed("sleep 1.5m");
+
+    $machine->succeed("test -f ~root/at-1");
+    $machine->succeed("test -f ~root/batch-1");
+    $machine->succeed("test -f ~alice/at-1");
+    $machine->succeed("test -f ~alice/batch-1");
+  '';
+})

--- a/pkgs/tools/system/at/default.nix
+++ b/pkgs/tools/system/at/default.nix
@@ -1,4 +1,7 @@
-{ fetchurl, stdenv, bison, flex, pam, sendmailPath ? "/run/wrappers/bin/sendmail" }:
+{ fetchurl, stdenv, bison, flex, pam
+, sendmailPath ? "/run/wrappers/bin/sendmail"
+, atWrapperPath ? "/run/wrappers/bin/at"
+}:
 
 stdenv.mkDerivation rec {
   name = "at-${version}";
@@ -29,6 +32,13 @@ stdenv.mkDerivation rec {
        --with-jobdir=/var/spool/atjobs --with-atspool=/var/spool/atspool
        --with-daemon_username=atd --with-daemon_groupname=atd
     '';
+
+  # Ensure that "batch" can invoke the setuid "at" wrapper, if it exists, or
+  # else we get permission errors (on NixOS). "batch" is a shell script, so
+  # when the kernel executes it it drops setuid perms.
+  postInstall = ''
+    sed -i "6i test -x ${atWrapperPath} && exec ${atWrapperPath} -qb now  # exec doesn't return" "$out/bin/batch"
+  '';
 
   meta = {
     description = ''The classical Unix `at' job scheduling command'';


### PR DESCRIPTION
###### Motivation for this change
Fix https://github.com/NixOS/nixpkgs/issues/12392

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

