### PR TITLE
Fix munin_stats plugin when running munin-node only

### DIFF
--- a/nixos/modules/services/monitoring/munin.nix
+++ b/nixos/modules/services/monitoring/munin.nix
@@ -193,6 +193,9 @@ in
       };
     };
 
+    # munin_stats plugin breaks as of 2.0.33 when this doesn't exist
+    systemd.tmpfiles.rules = [ "d /var/run/munin 0755 munin munin -" ];
+
   }) (mkIf cronCfg.enable {
 
     systemd.timers.munin-cron = {

--- a/nixos/modules/services/monitoring/munin.nix
+++ b/nixos/modules/services/monitoring/munin.nix
@@ -215,9 +215,11 @@ in
       };
     };
 
-    system.activationScripts.munin-cron = stringAfter [ "users" "groups" ] ''
-      mkdir -p /var/{run,log,www,lib}/munin
-      chown -R munin:munin /var/{run,log,www,lib}/munin
-    '';
+    systemd.tmpfiles.rules = [
+      "d /var/run/munin 0755 munin munin -"
+      "d /var/log/munin 0755 munin munin -"
+      "d /var/www/munin 0755 munin munin -"
+      "d /var/lib/munin 0755 munin munin -"
+    ];
   })];
 }


### PR DESCRIPTION
###### Motivation for this change

If you run munin-node without having munin-cron on the same machine, the automatically enabled munin_stats plugin which prints general statistics fails on every munin call (i.e. every 5 minutes):

```
munin-node: Error output from munin_stats:
munin-node: Error in tempfile() using template /var/run/munin/XXXXXXXXXX: Parent directory (/var/run/munin/) does not exist at /nix/store/dr4inq7f91d62mbr7qphhmxf8320i44r-munin-2.0.33/lib/perl5/site_perl/Munin/Plugin.pm line 280.
munin-node: Service 'munin_stats' exited with status 2/0.
```
Happens on 17.09 and master. This is because munin-node does not create the `MUNIN_PLUGSTATE` directory `/var/run/munin`. This is fixed with 95bb82d by using systemd.tmpfiles, would be nice to get this cherry-picked to 17.09. 086c0e6 converts munin-cron to systemd.tmpfiles as well, but that commit is not necessary to fix this issue (and not strictly necessary at all, of course. Is there a policy regarding mkdir+chown activationScripts vs. systemd.tmpfiles?)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

