### PR TITLE
[WIP] docbook: put DTDs in $out/share/xml instead of $out/xml

### DIFF
--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/builder.sh
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/builder.sh
@@ -1,7 +1,10 @@
 source $stdenv/setup
 
-mkdir -p $out/xml/dtd/docbook
-cd $out/xml/dtd/docbook
+mkdir -p $out/share/xml/dtd/docbook
+cd $out/share/xml/dtd/docbook
+# The symlink is for compatibility and should be removed when derivations refer to
+# share/xml instead of xml
+ln -s $out/share/xml $out/xml
 unpackFile $src
 find . -type f -exec chmod -x {} \;
 eval "$postInstall"

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/builder.sh
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/builder.sh
@@ -1,10 +1,8 @@
 source $stdenv/setup
 
-mkdir -p $out/share/xml/dtd/docbook
-cd $out/share/xml/dtd/docbook
-# The symlink is for compatibility and should be removed when derivations refer to
-# share/xml instead of xml
-ln -s $out/share/xml $out/xml
+dir=$out/share/${stdenv.lib.replaceStrings [ "-xml" ] [ "" ] name}/dtd
+mkdir -p $dir
+cd $dir
 unpackFile $src
 find . -type f -exec chmod -x {} \;
 eval "$postInstall"


### PR DESCRIPTION
###### Motivation for this change

Currently, the docbook derivation puts things into $out/xml which really should be $out/share/xml.

This causes a truly massive rebuild so I'm not sure if it's really worth it and I have NOT run ```nox-review wip``` on this. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

