### PR TITLE
[RDY] init gpg python bindings +  Alot: 0.5.1 -> 0.7.0

### DIFF
--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -1,7 +1,6 @@
 { stdenv, fetchurl, fetchpatch, libgpgerror, gnupg, pkgconfig, glib, pth, libassuan
 , file, which
 , autoreconfHook
-# git can apparently be removed when setting some envvar
 , git
 , texinfo5
 , qtbase ? null
@@ -59,4 +58,3 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fuuzetsu primeos ];
   };
 }
-

--- a/pkgs/development/python-modules/alot/default.nix
+++ b/pkgs/development/python-modules/alot/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, buildPythonPackage, fetchFromGitHub, isPy3k
-, notmuch, urwid, urwidtrees, twisted, python_magic, configobj, pygpgme, mock, file, gpgme
-, service-identity, gpg
+, notmuch, urwid, urwidtrees, twisted, python_magic, configobj, mock, file, gpgme
+, service-identity
 , gnupg ? null, sphinx, awk ? null, procps ? null, future ? null
 , withManpage ? false }:
 
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     configobj
     service-identity
     file
-    gpg
+    gpgme
   ];
 
   # some twisted tests need the network (test_env_set... )

--- a/pkgs/development/python-modules/alot/default.nix
+++ b/pkgs/development/python-modules/alot/default.nix
@@ -1,17 +1,22 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, isPy3k
-, notmuch, urwid, urwidtrees, twisted, python_magic, configobj, pygpgme, mock, file, gpgme}:
+{ stdenv, lib, buildPythonPackage, fetchFromGitHub, isPy3k
+, notmuch, urwid, urwidtrees, twisted, python_magic, configobj, pygpgme, mock, file, gpgme
+, service-identity, gpg
+, gnupg ? null, sphinx, awk ? null, procps ? null, future ? null
+, withManpage ? false }:
+
 
 buildPythonPackage rec {
-  version = "0.5.1";
   pname = "alot";
+  version = "0.7";
+  outputs = [ "out" ] ++ lib.optional withManpage "man";
 
   disabled = isPy3k;
 
   src = fetchFromGitHub {
     owner = "pazz";
-    repo = pname;
-    rev = "version";
-    sha256 = "0ipkhc5wllfq78lg47aiq4qih0yjq8ad9xkrbgc88xk8pk9166i8";
+    repo = "alot";
+    rev = "${version}";
+    sha256 = "1y932smng7qx7ybmqw4qh75b0lv9imfs5ak9fd0qhysij8kpmdhi";
   };
 
   postPatch = ''
@@ -20,6 +25,8 @@ buildPythonPackage rec {
                 "themes_dir = string(default='$out/share/themes')"
   '';
 
+  nativeBuildInputs = lib.optional withManpage sphinx;
+
   propagatedBuildInputs = [
     notmuch
     urwid
@@ -27,21 +34,32 @@ buildPythonPackage rec {
     twisted
     python_magic
     configobj
-    pygpgme
-    mock
+    service-identity
     file
+    gpg
   ];
 
-  postInstall = ''
-    mkdir -p $out/share
+  # some twisted tests need the network (test_env_set... )
+  doCheck = false;
+  postBuild = lib.optionalString withManpage "make -C docs man";
+
+  checkInputs =  [ awk future mock gnupg procps ];
+
+  postInstall = lib.optionalString withManpage ''
+    mkdir -p $out/man
+    cp -r docs/build/man $out/man
+  ''
+  + ''
+    mkdir -p $out/share/applications
     cp -r extra/themes $out/share
-    wrapProgram $out/bin/alot \
-      --prefix LD_LIBRARY_PATH : '${stdenv.lib.makeLibraryPath [ notmuch file gpgme ]}'
+
+    sed "s,/usr/bin,$out/bin,g" extra/alot.desktop > $out/share/applications/alot.desktop
   '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/pazz/alot;
     description = "Terminal MUA using notmuch mail";
+    license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ garbas ];
   };

--- a/pkgs/development/python-modules/service_identity/default.nix
+++ b/pkgs/development/python-modules/service_identity/default.nix
@@ -13,8 +13,6 @@
 buildPythonPackage rec {
   pname = "service_identity";
   version = "17.0.0";
-  name = "${pname}-${version}";
-
 
   src = fetchFromGitHub {
     owner = "pyca";
@@ -33,6 +31,6 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Service identity verification for pyOpenSSL";
     license = licenses.mit;
-    homepage = "https://service-identity.readthedocs.io";
+    homepage = https://service-identity.readthedocs.io;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8173,6 +8173,8 @@ in {
 
   google_gax = callPackage ../development/python-modules/google_gax { };
 
+  gpg = toPythonModule (pkgs.gpgme.override { withPython=true; });
+
   grammalecte = callPackage ../development/python-modules/grammalecte { };
 
   greenlet = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8173,7 +8173,7 @@ in {
 
   google_gax = callPackage ../development/python-modules/google_gax { };
 
-  gpg = toPythonModule (pkgs.gpgme.override { withPython=true; });
+  gpgme = toPythonModule (pkgs.gpgme.override { withPython=true; });
 
   grammalecte = callPackage ../development/python-modules/grammalecte { };
 


### PR DESCRIPTION
###### Motivation for this change
Updating the CLI notmuch-based mailreader alot

###### Things done
- copied the extra/alot.desktop file to $out/share/applications
- now generates the man
- alot now needs the gpg binary for its tests, added it in checkOutputs.

Nevertheless some things are wrong:
- `man alot`doesn't work after installation via nix-env. I believe it's a known nixos problem. I've tried using multiple outputs but not sure how to make it better.
- 3 of the tests don't pass see https://github.com/NixOS/nixpkgs/issues/30392

I've not tested yet the gpg support but other than that it seems to work 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

