### PR TITLE
selendroid: fix selendroid-selenium and 0.11.0 -> 0.17.0

### DIFF
--- a/pkgs/development/tools/selenium/selendroid/default.nix
+++ b/pkgs/development/tools/selenium/selendroid/default.nix
@@ -1,15 +1,25 @@
 { stdenv, fetchurl, makeWrapper, jdk, selenium-server-standalone }:
 
 with stdenv.lib;
-
+let
+    name = "selendroid-standalone-${version}";
+    pluginName = "selendroid-grid-plugin-${version}";
+    version = "0.11.0";
+    srcs = {
+      jar = fetchurl {
+        url = "https://github.com/selendroid/selendroid/releases/download/${version}/${name}-with-dependencies.jar";
+        sha256 = "1p6k974pr2634q1g65wx243cxdqhac63x8w2gsmh6vnni0818clk";
+      };
+      gridPlugin = fetchurl {
+        url = "https://search.maven.org/remotecontent?filepath=io/selendroid/selendroid-grid-plugin/${version}/${pluginName}.jar";
+        sha256 = "1iazmdv2z0k03fa1xlfipwdf3s9j6404kkpfs5xdyy0513ah02a0";
+      };
+    };
+in
 stdenv.mkDerivation rec {
-  name = "selendroid-standalone-${version}";
-  version = "0.11.0";
 
-  src = fetchurl {
-    url = "https://github.com/selendroid/selendroid/releases/download/${version}/selendroid-standalone-${version}-with-dependencies.jar";
-    sha256 = "1p6k974pr2634q1g65wx243cxdqhac63x8w2gsmh6vnni0818clk";
-  };
+  inherit name;
+  inherit version;
 
   unpackPhase = "true";
 
@@ -17,17 +27,21 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/share/lib/selendroid
-    cp $src $out/share/lib/selendroid/${name}.jar
+    cp ${srcs.jar} $out/share/lib/selendroid/${name}.jar
+    cp ${srcs.gridPlugin} $out/share/lib/selendroid/${pluginName}.jar
+
     makeWrapper ${jdk}/bin/java $out/bin/selendroid \
       --add-flags "-jar $out/share/lib/selendroid/${name}.jar"
     makeWrapper ${jdk}/bin/java $out/bin/selendroid-selenium \
       --add-flags "-Dfile.encoding=UTF-8" \
-      --add-flags "-cp \"$out/share/lib/selendroid/${name}.jar:${selenium-server-standalone}/share/lib/${selenium-server-standalone.name}/${selenium-server-standalone.name}.jar\"" \
-      --add-flags "org.openqa.grid.selenium.GridLauncherV3"
+      --add-flags "-cp ${selenium-server-standalone}/share/lib/${selenium-server-standalone.name}/${selenium-server-standalone.name}.jar:$out/share/lib/selendroid/${pluginName}.jar" \
+      --add-flags "org.openqa.grid.selenium.GridLauncherV3" \
+      --add-flags "-role hub" \
+      --add-flags "-capabilityMatcher io.selendroid.grid.SelendroidCapabilityMatcher"
   '';
 
   meta = {
-    homepage = https://code.google.com/p/selenium;
+    homepage = http://selendroid.io/;
     description = "Test automation for native or hybrid Android apps and the mobile web";
     maintainers = with maintainers; [ offline ];
     platforms = platforms.all;

--- a/pkgs/development/tools/selenium/selendroid/default.nix
+++ b/pkgs/development/tools/selenium/selendroid/default.nix
@@ -4,15 +4,15 @@ with stdenv.lib;
 let
     name = "selendroid-standalone-${version}";
     pluginName = "selendroid-grid-plugin-${version}";
-    version = "0.11.0";
+    version = "0.17.0";
     srcs = {
       jar = fetchurl {
         url = "https://github.com/selendroid/selendroid/releases/download/${version}/${name}-with-dependencies.jar";
-        sha256 = "1p6k974pr2634q1g65wx243cxdqhac63x8w2gsmh6vnni0818clk";
+        sha256 = "10lxdsgp711pv8r6dk2aagnbvnn1b25zfqjvz7plc73zqhx1dxvw";
       };
       gridPlugin = fetchurl {
         url = "https://search.maven.org/remotecontent?filepath=io/selendroid/selendroid-grid-plugin/${version}/${pluginName}.jar";
-        sha256 = "1iazmdv2z0k03fa1xlfipwdf3s9j6404kkpfs5xdyy0513ah02a0";
+        sha256 = "1x6cjmp2hpghbgbf8vss0qaj2n4sfl29wp3bc4k1s3hnnpccvz70";
       };
     };
 in


### PR DESCRIPTION
###### Motivation for this change

I unfortunately tested the wrong executable in https://github.com/NixOS/nixpkgs/pull/30186. The `selendroid-selenium` executable was broken indeed. Because I couldn't find any docs, I tested the version before the selenium update. This one was broken as well, so it seems that this was broken some time ago. My best guess at what it was supposed to do is [this](http://selendroid.io/scale.html) docs session about scaling selendroid, so I made it start a selendroid hub.

I also updated the version along the way.

###### Things done

- Changed `selendroid-selenium` to start a selendroid hub
- Tested both standalone as well as grid configuration by running a simple test

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

