### PR TITLE
Build Tensorflow from source

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/0.4.nix
+++ b/pkgs/development/tools/build-managers/bazel/0.4.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, jdk, zip, unzip, bash, makeWrapper, which
+{ stdenv, lib, fetchurl, jdk, zip, unzip, bash, makeWrapper, which, coreutils
 # Always assume all markers valid (don't redownload dependencies).
 # Also, don't clean up environment variables.
 , enableNixHacks ? false
@@ -23,27 +23,24 @@ stdenv.mkDerivation rec {
     sha256 = "0asmq3kxnl4326zhgh13mvcrc8jvmiswjj4ymrq0943q4vj7nwrb";
   };
 
+  preUnpack = ''
+    mkdir bazel
+    cd bazel
+  '';
   sourceRoot = ".";
 
   patches = lib.optional enableNixHacks ./nix-hacks.patch;
 
   postPatch = ''
-    for f in $(grep -l -r '#!/bin/bash'); do
-      substituteInPlace "$f" --replace '#!/bin/bash' '#!${bash}/bin/bash'
+    for f in $(grep -l -r '/bin/bash'); do
+      substituteInPlace "$f" --replace '/bin/bash' '${bash}/bin/bash'
     done
-    for f in \
-      src/main/java/com/google/devtools/build/lib/analysis/CommandHelper.java \
-      src/main/java/com/google/devtools/build/lib/bazel/rules/BazelConfiguration.java \
-      src/main/java/com/google/devtools/build/lib/bazel/rules/sh/BazelShRuleClasses.java \
-      src/main/java/com/google/devtools/build/lib/rules/cpp/LinkCommandLine.java \
-      ; do
-      substituteInPlace "$f" --replace /bin/bash ${bash}/bin/bash
+    for f in $(grep -l -r '/usr/bin/env'); do
+      substituteInPlace "$f" --replace '/usr/bin/env' '${coreutils}/bin/env'
     done
   '';
 
   buildInputs = [
-    stdenv.cc
-    stdenv.cc.cc.lib
     jdk
     zip
     unzip
@@ -58,12 +55,7 @@ stdenv.mkDerivation rec {
     bash
   ];
 
-  # If TMPDIR is in the unpack dir we run afoul of blaze's infinite symlink
-  # detector (see com.google.devtools.build.lib.skyframe.FileFunction).
-  # Change this to $(mktemp -d) as soon as we figure out why.
-
   buildPhase = ''
-    export TMPDIR=/tmp
     ./compile.sh
     ./output/bazel --output_user_root=/tmp/.bazel build //scripts:bash_completion \
       --spawn_strategy=standalone \

--- a/pkgs/development/tools/build-managers/bazel/0.4.nix
+++ b/pkgs/development/tools/build-managers/bazel/0.4.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchurl, jdk, zip, unzip, bash, makeWrapper, which }:
+{ stdenv, lib, fetchurl, jdk, zip, unzip, bash, makeWrapper, which
+# Always assume all markers valid (don't redownload dependencies).
+# Also, don't clean up environment variables.
+, enableNixHacks ? false
+}:
 
 stdenv.mkDerivation rec {
 
@@ -20,6 +24,8 @@ stdenv.mkDerivation rec {
   };
 
   sourceRoot = ".";
+
+  patches = lib.optional enableNixHacks ./nix-hacks.patch;
 
   postPatch = ''
     for f in $(grep -l -r '#!/bin/bash'); do

--- a/pkgs/development/tools/build-managers/bazel/nix-hacks.patch
+++ b/pkgs/development/tools/build-managers/bazel/nix-hacks.patch
@@ -1,0 +1,51 @@
+diff --git a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+index eafa09fb5..d2d5e40e8 100644
+--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
++++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+@@ -287,21 +287,8 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
+           markerData.put(key, value);
+         }
+       }
+-      boolean result = false;
+-      if (markerRuleKey.equals(ruleKey)) {
+-        result = handler.verifyMarkerData(rule, markerData, env);
+-        if (env.valuesMissing()) {
+-          return null;
+-        }
+-      }
+ 
+-      if (result) {
+-        return new Fingerprint().addString(content).digestAndReset();
+-      } else {
+-        // So that we are in a consistent state if something happens while fetching the repository
+-        markerPath.delete();
+-        return null;
+-      }
++      return new Fingerprint().addString(content).digestAndReset();
+ 
+     } catch (IOException e) {
+       throw new RepositoryFunctionException(e, Transience.TRANSIENT);
+diff --git a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
+index a7ebc8f7a..40f2049fa 100644
+--- a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
++++ b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
+@@ -129,7 +129,6 @@ public class JavaSubprocessFactory implements SubprocessFactory {
+     ProcessBuilder builder = new ProcessBuilder();
+     builder.command(params.getArgv());
+     if (params.getEnv() != null) {
+-      builder.environment().clear();
+       builder.environment().putAll(params.getEnv());
+     }
+ 
+diff --git a/src/main/java/com/google/devtools/build/lib/worker/Worker.java b/src/main/java/com/google/devtools/build/lib/worker/Worker.java
+index 0268d1b2b..637364657 100644
+--- a/src/main/java/com/google/devtools/build/lib/worker/Worker.java
++++ b/src/main/java/com/google/devtools/build/lib/worker/Worker.java
+@@ -77,7 +77,6 @@ class Worker {
+         new ProcessBuilder(command)
+             .directory(workDir.getPathFile())
+             .redirectError(Redirect.appendTo(logFile.getPathFile()));
+-    processBuilder.environment().clear();
+     processBuilder.environment().putAll(workerKey.getEnv());
+ 
+     this.process = processBuilder.start();

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25974,8 +25974,12 @@ EOF
 
   tensorflow-tensorboard = callPackage ../development/python-modules/tensorflow-tensorboard { };
 
-  tensorflow = callPackage ../development/python-modules/tensorflow {
+  tensorflow = callPackage ../development/python-modules/tensorflow rec {
+    bazel = pkgs.bazel_0_4;
     cudaSupport = pkgs.config.cudaSupport or false;
+    inherit (pkgs.linuxPackages) nvidia_x11;
+    cudatoolkit = pkgs.cudatoolkit8;
+    cudnn = pkgs.cudnn6_cudatoolkit8;
   };
 
   tensorflowWithoutCuda = self.tensorflow.override {


### PR DESCRIPTION
###### Motivation for this change

(Do not merge before #30433!)

What it says.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is based atop https://github.com/NixOS/nixpkgs/pull/30433 , so there are extra commits (you are only interested in the last two).

Possible problem with this are long compile times with CUDA (half an hour+) where previously we uesd prebuilt binaries.

Bazel is a wonderful tool for building projects -- it's certainly a genius idea to create and use a 500k LoC Java build manager tool which eats 1.5G of memory for building C++. Unfortunately, Nix is not enterprise enough so our ways to isolate builds were not supported by Basel, making building a project with it effectively impossible in Nix (which is why TensorFlow used binary distribution before). Specifically, Bazel tries to download all external project dependencies by itself, which fails because of Nix isolation. In vanilla Bazel there is no way to circumvent this (please correct me if there's a better way!).

My solution is to add a special patched version of Bazel which skips checking of fetched dependencies checksums (which depend, among other things, on build directory paths). Then we can do two-staged build as described in https://github.com/NixOS/nixpkgs/commit/9b3559f274638a911d5337cabb671a63f47e82ea.

This, along with TensorFlow's own pecularities (special scripts for everything, awful compile times because _all_ dependent libraries like CURL or ffmpeg are built statically, incomprehensible build system scripts even considering Bazel etc.) made this PR a work of three or four straight days. I'd say this gets a solid second place in my list of my most awful packages after [Telegram](https://github.com/NixOS/nixpkgs/pull/14266).

Sorry for the rant \~_\~