### PR TITLE
kubectl: init at v1.8.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -272,6 +272,7 @@
   ivan-tkatchev = "Ivan Tkatchev <tkatchev@gmail.com>";
   j-keck = "Jürgen Keck <jhyphenkeck@gmail.com>";
   jagajaga = "Arseniy Seroka <ars.seroka@gmail.com>";
+  jamesthompson = "James Thompson <jamesthompsonoxford@gmail.com>";
   jammerful = "jammerful <jammerful@gmail.com>";
   jansol = "Jan Solanti <jan.solanti@paivola.fi>";
   javaguirre = "Javier Aguirre <contacto@javaguirre.net>";

--- a/pkgs/tools/admin/kubectl/default.nix
+++ b/pkgs/tools/admin/kubectl/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+
+  name = "kubectl";
+
+  version = "v1.8.1";
+
+  src =
+    if stdenv.system == "x86_64-darwin" then
+      fetchurl {
+        url = "https://storage.googleapis.com/kubernetes-release/release/${version}/bin/darwin/amd64/kubectl";
+        sha256 = "034g4j0vnqcw1ln6cnj2hy5sbnk0d7f11ayxv8j2al72czgbi3z7";
+      }
+    else
+      fetchurl {
+        url = "https://storage.googleapis.com/kubernetes-release/release/${version}/bin/linux/amd64/kubectl";
+        sha256 = "1bdgsqbmcacrj56x2p6qkqghsrr3hpb64hr54vyi13smisvpv9g5";
+      };
+
+  phases = [ "installPhase" "postInstall" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src $out/bin/kubectl
+  '';
+
+  postInstall = ''
+    chmod +x $out/bin/kubectl
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Kubernetes command line tool";
+    longDescription = "The kubernetes command line tool. This package has the program: kubectl";
+    license = licenses.asl20;
+    homepage = "https://kubernetes.io/docs/user-guide/kubectl";
+    maintainers = with maintainers; [ jthompson ];
+    platforms = with platforms; linux ++ darwin;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7330,6 +7330,8 @@ with pkgs;
 
   kcov = callPackage ../development/tools/analysis/kcov { };
 
+  kubectl = callPackage ../tools/admin/kubectl { };
+
   kube-aws = callPackage ../development/tools/kube-aws { };
 
   lcov = callPackage ../development/tools/analysis/lcov { };


### PR DESCRIPTION
###### Motivation for this change

kubectl is needed to administrate kubernetes clusters from the command line.

For google cloud users, it isn't installable through the google-cloud-sdk
derivation - this pulls the precompiled binary and installs it.

As far as I can tell there is no hosted tarball archive for this binary, hence
this binary install approach.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

