### PR TITLE
modemmanager: rename ModemManager.service to modem-manager.service

### DIFF
--- a/pkgs/tools/networking/modem-manager/default.nix
+++ b/pkgs/tools/networking/modem-manager/default.nix
@@ -2,11 +2,12 @@
 , libmbim, libqmi, systemd }:
 
 stdenv.mkDerivation rec {
-  name = "ModemManager-${version}";
+  name = "modem-manager-${version}";
+  pname = "ModemManager";
   version = "1.6.8";
 
   src = fetchurl {
-    url = "http://www.freedesktop.org/software/ModemManager/${name}.tar.xz";
+    url = "http://www.freedesktop.org/software/${pname}/${pname}-${version}.tar.xz";
     sha256 = "0xj3ng7qcqxkib5qkprwghcivaz0mn449fw08l67h1zbpz23bh7z";
   };
 
@@ -30,7 +31,8 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    mv $out/$out/etc/systemd/system/ModemManager.service $out/etc/systemd/system
+    # rename to modem-manager to be in style
+    mv $out/$out/etc/systemd/system/ModemManager.service $out/etc/systemd/system/modem-manager.service
     rm -rf $out/$out/etc
     mv $out/$out/* $out
     DIR=$out/$out
@@ -40,7 +42,7 @@ stdenv.mkDerivation rec {
 
     # systemd in NixOS doesn't use `systemctl enable`, so we need to establish
     # aliases ourselves.
-    ln -s $out/etc/systemd/system/ModemManager.service \
+    ln -s $out/etc/systemd/system/modem-manager.service \
       $out/etc/systemd/system/dbus-org.freedesktop.ModemManager1.service
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3354,7 +3354,7 @@ with pkgs;
 
   mmake = callPackage ../tools/misc/mmake { };
 
-  modemmanager = callPackage ../tools/networking/modemmanager {};
+  modemmanager = callPackage ../tools/networking/modem-manager {};
 
   modsecurity_standalone = callPackage ../tools/security/modsecurity { };
 


### PR DESCRIPTION
…

This is in line with NetworkManager.service being renamed to
network-manager.service

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

