### PR TITLE
robotfindskitten: install req'd data and put bin in $out/bin

### DIFF
--- a/pkgs/games/robotfindskitten/default.nix
+++ b/pkgs/games/robotfindskitten/default.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ncurses ];
 
+  makeFlags = [ "execgamesdir=$(out)/bin" ];
+
+  postInstall = ''
+    install -Dm644 {nki,$out/share/games/robotfindskitten}/vanilla.nki
+  '';
+
   meta = {
     description = "Yet another zen simulation; A simple find-the-kitten game";
     homepage = http://robotfindskitten.org/;


### PR DESCRIPTION
###### Motivation for this change

As-is the game doesn't appear on $PATH when installed,
and when invoked directly fails to run due to missing required data file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

