### PR TITLE
bgpdump: init at 2017-09-29

### DIFF
--- a/pkgs/tools/networking/bgpdump/default.nix
+++ b/pkgs/tools/networking/bgpdump/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, autoconf, zlib, bzip2 }:
+{ stdenv, fetchzip, autoreconfHook, zlib, bzip2 }:
 
 stdenv.mkDerivation rec {
   name = "bgpdump-2017-09-29";
@@ -8,12 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "09g9vz2zc4nyzl669w1j7fxw21ifja6dxbp0xbqh6n7w3gpx2g88";
   };
 
-  buildInputs = [ autoconf zlib bzip2 ];
-  configurePhase = ''
-    autoheader
-    autoconf
-    ./configure --prefix=$out
-  '';
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ zlib bzip2 ];
 
   meta = {
     homepage = https://bitbucket.org/ripencc/bgpdump/wiki/Home;

--- a/pkgs/tools/networking/bgpdump/default.nix
+++ b/pkgs/tools/networking/bgpdump/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchzip, autoconf, zlib, bzip2 }:
+
+stdenv.mkDerivation rec {
+  name = "bgpdump-2017-09-29";
+
+  src = fetchzip {
+    url = "https://bitbucket.org/ripencc/bgpdump/get/94a0e724b335.zip";
+    sha256 = "09g9vz2zc4nyzl669w1j7fxw21ifja6dxbp0xbqh6n7w3gpx2g88";
+  };
+
+  buildInputs = [ autoconf zlib bzip2 ];
+  configurePhase = ''
+    autoheader
+    autoconf
+    ./configure --prefix=$out
+  '';
+
+  meta = {
+    homepage = https://bitbucket.org/ripencc/bgpdump/wiki/Home;
+    description = ''Analyze dump files produced by Zebra/Quagga or MRT'';
+    license = stdenv.lib.licenses.hpnd;
+    maintainers = with stdenv.lib.maintainers; [ lewo ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13809,6 +13809,8 @@ with pkgs;
     inherit (gnome2) zenity;
   };
 
+  bgpdump = callPackage ../tools/networking/bgpdump { };
+
   blackbox = callPackage ../applications/version-management/blackbox { };
 
   bleachbit = callPackage ../applications/misc/bleachbit { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

