### PR TITLE
ltk: fix haskell-gi-overloading dependency

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -973,4 +973,7 @@ self: super: {
   amqp-utils = super.amqp-utils.override {
     amqp = dontCheck super.amqp_0_18_1;
   };
+
+  # depends on haskell-gi-overloading-0.0
+  ltk = doJailbreak super.ltk;
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -979,4 +979,7 @@ self: super: {
 
   # tests fail
   leksah-server = dontCheck super.leksah-server;
+
+  # depends on haskell-gi-overloading-0.0
+  leksah = doJailbreak super.leksah;
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -976,4 +976,7 @@ self: super: {
 
   # depends on haskell-gi-overloading-0.0
   ltk = doJailbreak super.ltk;
+
+  # tests fail
+  leksah-server = dontCheck super.leksah-server;
 }


### PR DESCRIPTION
Before, building ltk failed like this:

```
building path(s) ‘/nix/store/dczjcg5li0wfbs17blbb302y68kwygm8-ltk-0.16.1.0’, ‘/nix/store/hjv7bc3ibj65iq16bczk36jslbk92q7g-ltk-0.16.1.0-doc’
setupCompilerEnvironmentPhase
Build with /nix/store/m74s3ylqgnpycnhaj1hxqax3xpx9l9z9-ghc-8.0.2.
unpacking sources
unpacking source archive /nix/store/yr06vdmj97j4f44qnggyini6z9ypkvqc-ltk-0.16.1.0.tar.gz
source root is ltk-0.16.1.0
setting SOURCE_DATE_EPOCH to timestamp 1502714953 of file ltk-0.16.1.0/src/Text/PrinterParser.hs
patching sources
compileBuildDriverPhase
setupCompileFlags: -package-db=/tmp/nix-build-ltk-0.16.1.0.drv-0/package.conf.d -j1 -threaded
[1 of 1] Compiling Main             ( Setup.lhs, /tmp/nix-build-ltk-0.16.1.0.drv-0/Main.o )
Linking Setup ...
configuring
configureFlags: --verbose --prefix=/nix/store/dczjcg5li0wfbs17blbb302y68kwygm8-ltk-0.16.1.0 --libdir=$prefix/lib/$compiler --libsubdir=$pkgid --docdir=/nix/store/hjv7bc3ibj65iq16bczk36jslbk92q7g-ltk-0.16.1.0-doc/share/doc --with-gcc=gcc --package-db=/tmp/nix-build-ltk-0.16.1.0.drv-0/package.conf.d --ghc-option=-optl=-Wl,-rpath=/nix/store/dczjcg5li0wfbs17blbb302y68kwygm8-ltk-0.16.1.0/lib/ghc-8.0.2/ltk-0.16.1.0 --ghc-option=-j1 --disable-split-objs --disable-library-profiling --disable-profiling --enable-shared --disable-coverage --enable-library-vanilla --enable-executable-dynamic --enable-tests --ghc-option=-split-sections --extra-include-dirs=/nix/store/hvgsm5rdxj9mx5d8bf9wji0j2xw563yw-gtk+3-3.22.21-dev/include --extra-lib-dirs=/nix/store/hvgsm5rdxj9mx5d8bf9wji0j2xw563yw-gtk+3-3.22.21-dev/lib --extra-include-dirs=/nix/store/1gyr9vfwv9v8sbjy0ymgdkjnfw80j987-expat-2.2.4-dev/include --extra-lib-dirs=/nix/store/1gyr9vfwv9v8sbjy0ymgdkjnfw80j987-expat-2.2.4-dev/lib --extra-lib-dirs=/nix/store/mpxglx71nqxp62vxacp0i12dq7h622na-expat-2.2.4/lib --extra-include-dirs=/nix/store/3jxq33qrlfpjdx17c8d62lmcxfbf2yxm-glib-2.54.0-dev/include --extra-lib-dirs=/nix/store/3jxq33qrlfpjdx17c8d62lmcxfbf2yxm-glib-2.54.0-dev/lib --extra-include-dirs=/nix/store/q8k7r5zbf03ydrpm7imfzds5b2nmdf0a-zlib-1.2.11-dev/include --extra-lib-dirs=/nix/store/q8k7r5zbf03ydrpm7imfzds5b2nmdf0a-zlib-1.2.11-dev/lib --extra-lib-dirs=/nix/store/i8wz3m067dzbs5x2glhxvcg7lvds1942-zlib-1.2.11/lib --extra-include-dirs=/nix/store/0phm8p3mf0rapxsxcy6v7q298y6a7ax8-libffi-3.2.1-dev/include --extra-lib-dirs=/nix/store/0phm8p3mf0rapxsxcy6v7q298y6a7ax8-libffi-3.2.1-dev/lib --extra-lib-dirs=/nix/store/hhcby2ncg7s75bm8f87j4i7wjzx20nvw-libffi-3.2.1/lib --extra-include-dirs=/nix/store/d15b3lh1c4452m6w66sjgrw21aps2z8b-glibc-iconv-2.25-49/include --extra-lib-dirs=/nix/store/dq0sfiqgdyxy4z4m1cnplv3ay18kljav-glib-2.54.0/lib --extra-include-dirs=/nix/store/5j0yfykrgjplgs70wacmvrzbm0a3r3qj-cairo-1.14.10-dev/include --extra-lib-dirs=/nix/store/5j0yfykrgjplgs70wacmvrzbm0a3r3qj-cairo-1.14.10-dev/lib --extra-include-dirs=/nix/store/jbvsw0c6mzvn4ksikvb355c51hanivdz-libXext-1.3.3-dev/include --extra-lib-dirs=/nix/store/jbvsw0c6mzvn4ksikvb355c51hanivdz-libXext-1.3.3-dev/lib --extra-include-dirs=/nix/store/azczg71cnfxjc63dhpm8f6w62695zrx1-xextproto-7.3.0/include --extra-lib-dirs=/nix/store/azczg71cnfxjc63dhpm8f6w62695zrx1-xextproto-7.3.0/lib --extra-include-dirs=/nix/store/hcajgay8nx6f94rgl4ynk8xp8dvv69wp-xproto-7.0.31/include --extra-lib-dirs=/nix/store/hcajgay8nx6f94rgl4ynk8xp8dvv69wp-xproto-7.0.31/lib --extra-include-dirs=/nix/store/lm3q222avj0if827hqnscm8132w6bfqi-libXau-1.0.8-dev/include --extra-lib-dirs=/nix/store/lm3q222avj0if827hqnscm8132w6bfqi-libXau-1.0.8-dev/lib --extra-lib-dirs=/nix/store/vw96cn3hv144mmfmpbcgf041509nrb9v-libXau-1.0.8/lib --extra-lib-dirs=/nix/store/1izhmghnramlx67427iswvvzy80bc13v-libXext-1.3.3/lib --extra-include-dirs=/nix/store/vrdcbrr7g8hknsi7vdfn4hh0kh7p34x8-fontconfig-2.12.1-dev/include --extra-lib-dirs=/nix/store/vrdcbrr7g8hknsi7vdfn4hh0kh7p34x8-fontconfig-2.12.1-dev/lib --extra-include-dirs=/nix/store/lbc47zddfrygkghmx9xlf99ll3q2q3sx-freetype-2.7.1-dev/include --extra-lib-dirs=/nix/store/lbc47zddfrygkghmx9xlf99ll3q2q3sx-freetype-2.7.1-dev/lib --extra-include-dirs=/nix/store/aa8i4gpsb44n2zyv5byr7fm97q48h425-bzip2-1.0.6.0.1-dev/include --extra-lib-dirs=/nix/store/aa8i4gpsb44n2zyv5byr7fm97q48h425-bzip2-1.0.6.0.1-dev/lib --extra-lib-dirs=/nix/store/5dnva19r2z20jahsx3jxm565qwjxsynl-bzip2-1.0.6.0.1/lib --extra-include-dirs=/nix/store/d39gr8bvrhgj3licf2k2sxaf2pwr43hg-libpng-apng-1.6.31-dev/include --extra-lib-dirs=/nix/store/d39gr8bvrhgj3licf2k2sxaf2pwr43hg-libpng-apng-1.6.31-dev/lib --extra-lib-dirs=/nix/store/xajc39y4sy34a086w86138jfv31f65nx-libpng-apng-1.6.31/lib --extra-lib-dirs=/nix/store/7rda899md2d4q26lxb43yg3cmrgcdr1r-freetype-2.7.1/lib --extra-lib-dirs=/nix/store/28xmsklwik9jpddq6wwybmg0ghh92gwx-fontconfig-2.12.1-lib/lib --extra-include-dirs=/nix/store/gcz451vvp5v3kx8i5sbxd4qs0inq21v3-pixman-0.34.0/include --extra-lib-dirs=/nix/store/gcz451vvp5v3kx8i5sbxd4qs0inq21v3-pixman-0.34.0/lib --extra-include-dirs=/nix/store/jypwzca909k9jmhlbhdjp9i08kby7mz5-libXrender-0.9.10-dev/include --extra-lib-dirs=/nix/store/jypwzca909k9jmhlbhdjp9i08kby7mz5-libXrender-0.9.10-dev/lib --extra-include-dirs=/nix/store/kxi3k7l47975flk2874xrxcsagz9f8vr-renderproto-0.11.1/include --extra-lib-dirs=/nix/store/kxi3k7l47975flk2874xrxcsagz9f8vr-renderproto-0.11.1/lib --extra-include-dirs=/nix/store/n8qx80rpdmxyrjk90c7bv93jizd3if9g-libX11-1.6.5-dev/include --extra-lib-dirs=/nix/store/n8qx80rpdmxyrjk90c7bv93jizd3if9g-libX11-1.6.5-dev/lib --extra-include-dirs=/nix/store/sd0vh8fgkj8gnazja6rrs3bjfbjlkn6f-libxcb-1.12-dev/include --extra-lib-dirs=/nix/store/sd0vh8fgkj8gnazja6rrs3bjfbjlkn6f-libxcb-1.12-dev/lib --extra-lib-dirs=/nix/store/hj7cj844wbnsqiqja81vc2lbgn1s47x1-libxcb-1.12/lib --extra-include-dirs=/nix/store/ivkkg1ika5iflrnzhjskl1w76nx380gz-kbproto-1.0.7/include --extra-lib-dirs=/nix/store/ivkkg1ika5iflrnzhjskl1w76nx380gz-kbproto-1.0.7/lib --extra-lib-dirs=/nix/store/m04h4v9863198a36k5xhv25hz6qf2cql-libX11-1.6.5/lib --extra-lib-dirs=/nix/store/vfp7hb5a5in4wbxxqy1vymyy3w9bv467-libXrender-0.9.10/lib --extra-include-dirs=/nix/store/q0ahw8bwzqdznnih9khs5v0ms8ri7g1b-xcb-util-0.4.0-dev/include --extra-lib-dirs=/nix/store/q0ahw8bwzqdznnih9khs5v0ms8ri7g1b-xcb-util-0.4.0-dev/lib --extra-lib-dirs=/nix/store/127qsvkr13v3vks48n967fnk6sz2aqxp-xcb-util-0.4.0/lib --extra-include-dirs=/nix/store/lbah9wclx0x7ahy7kfzwly00zxn3sz37-mesa-noglu-17.1.10-dev/include --extra-lib-dirs=/nix/store/lbah9wclx0x7ahy7kfzwly00zxn3sz37-mesa-noglu-17.1.10-dev/lib --extra-include-dirs=/nix/store/d3h9zicsnxlddx5ld519wlk2lhcd5xzd-libXdamage-1.1.4-dev/include --extra-lib-dirs=/nix/store/d3h9zicsnxlddx5ld519wlk2lhcd5xzd-libXdamage-1.1.4-dev/lib --extra-include-dirs=/nix/store/xfmx6m0m5pi9xghihgjh0ikp1r1f0ff2-damageproto-1.2.1/include --extra-lib-dirs=/nix/store/xfmx6m0m5pi9xghihgjh0ikp1r1f0ff2-damageproto-1.2.1/lib --extra-include-dirs=/nix/store/1ca2dj8llpsgb4riq2p0c514jq5d25xa-libXfixes-5.0.2-dev/include --extra-lib-dirs=/nix/store/1ca2dj8llpsgb4riq2p0c514jq5d25xa-libXfixes-5.0.2-dev/lib --extra-include-dirs=/nix/store/jsfrwyfai70gnbvh7g6dygqkcd9h45px-fixesproto-5.0/include --extra-lib-dirs=/nix/store/jsfrwyfai70gnbvh7g6dygqkcd9h45px-fixesproto-5.0/lib --extra-lib-dirs=/nix/store/8qsy14m386h3l1wgnq92lf9rdmv205dc-libXfixes-5.0.2/lib --extra-lib-dirs=/nix/store/58wv742ljn4cw2iijax6gpifwhzy4vsk-libXdamage-1.1.4/lib --extra-include-dirs=/nix/store/p7yjm9xby0gdapjcjgj9bpcv3a5qxkkv-libXxf86vm-1.1.4-dev/include --extra-lib-dirs=/nix/store/p7yjm9xby0gdapjcjgj9bpcv3a5qxkkv-libXxf86vm-1.1.4-dev/lib --extra-include-dirs=/nix/store/yi8sywpqfzl5ap0liamivj5jvc1b7z7h-xf86vidmodeproto-2.3.1/include --extra-lib-dirs=/nix/store/yi8sywpqfzl5ap0liamivj5jvc1b7z7h-xf86vidmodeproto-2.3.1/lib --extra-lib-dirs=/nix/store/10bir5xrxjj9anx2k2r52rf60cr4im13-libXxf86vm-1.1.4/lib --extra-include-dirs=/nix/store/0bgqk7076xrq4i1iav27c0adrc0c342w-libdrm-2.4.83-dev/include --extra-lib-dirs=/nix/store/0bgqk7076xrq4i1iav27c0adrc0c342w-libdrm-2.4.83-dev/lib --extra-lib-dirs=/nix/store/5g1zf879403gpl5fnnqn6331g74xicwn-libdrm-2.4.83/lib --extra-lib-dirs=/nix/store/sw4kprs436aj65435v2y2vgwjcpwc79d-mesa-noglu-17.1.10/lib --extra-lib-dirs=/nix/store/fa7wrzvv93y68sr4v7bfv0sq33ijjcfn-cairo-1.14.10/lib --extra-include-dirs=/nix/store/y7kqs9b9a7c70i958zga033pbi2m5mb1-pango-1.40.12-dev/include --extra-lib-dirs=/nix/store/y7kqs9b9a7c70i958zga033pbi2m5mb1-pango-1.40.12-dev/lib --extra-include-dirs=/nix/store/bj3rb68r8w964gfrmay03z7gnzg91p8w-harfbuzz-1.5.1-dev/include --extra-lib-dirs=/nix/store/bj3rb68r8w964gfrmay03z7gnzg91p8w-harfbuzz-1.5.1-dev/lib --extra-include-dirs=/nix/store/2wblsrrhf41zfyr7v0ackkn8vjkh1zyk-graphite2-1.3.6/include --extra-lib-dirs=/nix/store/2wblsrrhf41zfyr7v0ackkn8vjkh1zyk-graphite2-1.3.6/lib --extra-lib-dirs=/nix/store/riicxh9dp1bx90fjcf2yr7gw3wj0x7fm-harfbuzz-1.5.1/lib --extra-include-dirs=/nix/store/cw5hy5mz22jdka0415qf6ir5qcfx06wi-libXft-2.3.2-dev/include --extra-lib-dirs=/nix/store/cw5hy5mz22jdka0415qf6ir5qcfx06wi-libXft-2.3.2-dev/lib --extra-lib-dirs=/nix/store/czkv6rffbd32dyrqbq8ar4vg58hv6dsn-libXft-2.3.2/lib --extra-lib-dirs=/nix/store/5xd1zb7b23q0p9mlvjcj5z115ymh5fb5-pango-1.40.12/lib --extra-include-dirs=/nix/store/p7rcvxxc70si6s3w8ylyc6w501l6mhzm-gdk-pixbuf-2.36.7-dev/include --extra-lib-dirs=/nix/store/p7rcvxxc70si6s3w8ylyc6w501l6mhzm-gdk-pixbuf-2.36.7-dev/lib --extra-include-dirs=/nix/store/jdya63cghjqx15x18sz2xqw270y4zwaf-libtiff-4.0.8-dev/include --extra-lib-dirs=/nix/store/jdya63cghjqx15x18sz2xqw270y4zwaf-libtiff-4.0.8-dev/lib --extra-include-dirs=/nix/store/4j0xwakgh5n441jynrp7i942j0qc8lrm-libjpeg-turbo-1.5.2-dev/include --extra-lib-dirs=/nix/store/4j0xwakgh5n441jynrp7i942j0qc8lrm-libjpeg-turbo-1.5.2-dev/lib --extra-lib-dirs=/nix/store/bsqid2phn9ad8fyw2d63anzrrxp7a9x4-libjpeg-turbo-1.5.2/lib --extra-include-dirs=/nix/store/v6s9mvcg8wqpgbbmf86fq1h5sy0jv15b-xz-5.2.3-dev/include --extra-lib-dirs=/nix/store/v6s9mvcg8wqpgbbmf86fq1h5sy0jv15b-xz-5.2.3-dev/lib --extra-lib-dirs=/nix/store/j41pm590lflva7kkx643kycix8njjrld-xz-5.2.3/lib --extra-lib-dirs=/nix/store/caqnkc27nvhgbara1grqblyl117sq8gd-libtiff-4.0.8/lib --extra-include-dirs=/nix/store/1jg55h9jikyasnpfgnnynb1jzza6kp12-jasper-2.0.13-dev/include --extra-lib-dirs=/nix/store/1jg55h9jikyasnpfgnnynb1jzza6kp12-jasper-2.0.13-dev/lib --extra-lib-dirs=/nix/store/4flns1cwwvy2x3l1b0dbhnz4wrip07bw-jasper-2.0.13/lib --extra-lib-dirs=/nix/store/ykmhgbm3qb0sckrzgb0ivhk9b4saiwi1-gdk-pixbuf-2.36.7/lib --extra-include-dirs=/nix/store/xnmykq14a635qhb2anjdiv6q9m6qgnyk-atk-2.26.0-dev/include --extra-lib-dirs=/nix/store/xnmykq14a635qhb2anjdiv6q9m6qgnyk-atk-2.26.0-dev/lib --extra-include-dirs=/nix/store/vx1qc0mfipfsc02p0s466m8j5jmwmkwj-gobject-introspection-1.52.1-dev/include --extra-lib-dirs=/nix/store/vx1qc0mfipfsc02p0s466m8j5jmwmkwj-gobject-introspection-1.52.1-dev/lib --extra-lib-dirs=/nix/store/al907j2gpc7nwlnv2h5w372gx88ipmgb-gobject-introspection-1.52.1/lib --extra-lib-dirs=/nix/store/33sv1dzaasnyw3y2z1jrwfhz6d4c5a5b-atk-2.26.0/lib --extra-include-dirs=/nix/store/7pdps4ffvd2553glmiygwjr5xj4w2xdw-at-spi2-atk-2.26.0/include --extra-lib-dirs=/nix/store/7pdps4ffvd2553glmiygwjr5xj4w2xdw-at-spi2-atk-2.26.0/lib --extra-include-dirs=/nix/store/zqamgxrca2806sa6qccaihkq7wiwzrqw-libXrandr-1.5.1-dev/include --extra-lib-dirs=/nix/store/zqamgxrca2806sa6qccaihkq7wiwzrqw-libXrandr-1.5.1-dev/lib --extra-include-dirs=/nix/store/0qi36vmhk3hwm7i9p6gfz29y6gzl7g8m-randrproto-1.5.0/include --extra-lib-dirs=/nix/store/0qi36vmhk3hwm7i9p6gfz29y6gzl7g8m-randrproto-1.5.0/lib --extra-lib-dirs=/nix/store/iqmcckzwnqg1lg018kzis9limbn02rqw-libXrandr-1.5.1/lib --extra-include-dirs=/nix/store/zj818qh9811m51hsfxsrjk1namhs9764-libXcomposite-0.4.4-dev/include --extra-lib-dirs=/nix/store/zj818qh9811m51hsfxsrjk1namhs9764-libXcomposite-0.4.4-dev/lib --extra-include-dirs=/nix/store/vkj8b92ik46w6m0pfnp9klbp7dx0fyil-compositeproto-0.4.2/include --extra-lib-dirs=/nix/store/vkj8b92ik46w6m0pfnp9klbp7dx0fyil-compositeproto-0.4.2/lib --extra-lib-dirs=/nix/store/yzbwi32dnbb3d2fymh5ahg3laqch4i8y-libXcomposite-0.4.4/lib --extra-include-dirs=/nix/store/8qqcwmcsbs1c19h1l9g28m7dcs3gi809-libXi-1.7.9-dev/include --extra-lib-dirs=/nix/store/8qqcwmcsbs1c19h1l9g28m7dcs3gi809-libXi-1.7.9-dev/lib --extra-include-dirs=/nix/store/zh620nqawrvrg0rc4hbw2dp4ind0l8b3-inputproto-2.3.2/include --extra-lib-dirs=/nix/store/zh620nqawrvrg0rc4hbw2dp4ind0l8b3-inputproto-2.3.2/lib --extra-lib-dirs=/nix/store/79a8ha4pkk8x1z8ri78gif3kf4i1z2ik-libXi-1.7.9/lib --extra-include-dirs=/nix/store/jms8lknxwjmvrbdzrkqphb4qhql4pgqd-libXcursor-1.1.14-dev/include --extra-lib-dirs=/nix/store/jms8lknxwjmvrbdzrkqphb4qhql4pgqd-libXcursor-1.1.14-dev/lib --extra-lib-dirs=/nix/store/pj43xhylb8inskbml2p99i17d0cz8l3f-libXcursor-1.1.14/lib --extra-include-dirs=/nix/store/rnr25dmvrf78qbga77j45krclwag5vvk-libSM-1.2.2-dev/include --extra-lib-dirs=/nix/store/rnr25dmvrf78qbga77j45krclwag5vvk-libSM-1.2.2-dev/lib --extra-include-dirs=/nix/store/pfqi9p5rp77d40kxv8i2566vrh8hfwqw-libICE-1.0.9-dev/include --extra-lib-dirs=/nix/store/pfqi9p5rp77d40kxv8i2566vrh8hfwqw-libICE-1.0.9-dev/lib --extra-lib-dirs=/nix/store/fvjaiqhdhg0cagdlqyc3aizkn6scd9fv-libICE-1.0.9/lib --extra-lib-dirs=/nix/store/jjyakizjnriy8vd54ils6fmi0fgz8dlj-libSM-1.2.2/lib --extra-include-dirs=/nix/store/jwmmalm2dsh59xs0w8l6rdmrv22yvpj1-wayland-1.12.0/include --extra-lib-dirs=/nix/store/jwmmalm2dsh59xs0w8l6rdmrv22yvpj1-wayland-1.12.0/lib --extra-include-dirs=/nix/store/lp091q6chzg6ic6ag2gbrcxh90xzs7sx-libXinerama-1.1.3-dev/include --extra-lib-dirs=/nix/store/lp091q6chzg6ic6ag2gbrcxh90xzs7sx-libXinerama-1.1.3-dev/lib --extra-include-dirs=/nix/store/8rlgps101mczb1mnk6g0hyqim3gmmnw6-xineramaproto-1.2.1/include --extra-lib-dirs=/nix/store/8rlgps101mczb1mnk6g0hyqim3gmmnw6-xineramaproto-1.2.1/lib --extra-lib-dirs=/nix/store/0wzq6xb64qnx59qm4grla2k40389gqla-libXinerama-1.1.3/lib --extra-include-dirs=/nix/store/3fp6xsapddsg9l69b0444q2mi3idfigx-cups-2.2.2-dev/include --extra-include-dirs=/nix/store/2d2in2wqdgxr0p210lv17dvxibpnfw49-gmp-6.1.2-dev/include --extra-lib-dirs=/nix/store/z5z8ldravlksmw7fqalyzr4i75x8ayjv-gmp-6.1.2/lib --extra-lib-dirs=/nix/store/db6dvvaa07ak9ry1rhr45456dsidhwcg-cups-2.2.2-lib/lib --extra-lib-dirs=/nix/store/7767vq6laj5qrcgr6hpxc4j2nnrk73kv-cups-2.2.2/lib --extra-lib-dirs=/nix/store/j353wyysz6qviv7c3dkaj92fgyk60pgr-gtk+3-3.22.21/lib
Configuring ltk-0.16.1.0...
Setup: Encountered missing dependencies:
haskell-gi-overloading ==0.0.*
builder for ‘/nix/store/34bj2fp7k0d3539c4hzqbvkfrz5j7bzg-ltk-0.16.1.0.drv’ failed with exit code 1
```

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

