### PR TITLE
bb: init at 1.3rc1

### DIFF
--- a/pkgs/applications/misc/bb/default.nix
+++ b/pkgs/applications/misc/bb/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, aalib, ncurses, xorg, libmikmod }:
+
+stdenv.mkDerivation rec {
+  name    = "bb-${version}";
+  version = "1.3rc1";
+
+  src = fetchurl {
+    url    = "mirror://sourceforge/aa-project/bb/${version}/${name}.tar.gz";
+    sha256 = "1i411glxh7g4pfg4gw826lpwngi89yrbmxac8jmnsfvrfb48hgbr";
+  };
+
+  buildInputs = [
+    aalib ncurses libmikmod
+    xorg.libXau xorg.libXdmcp xorg.libX11
+  ];
+
+  meta = with stdenv.lib; {
+    homepage    = http://aa-project.sourceforge.net/bb;
+    description = "AA-lib demo";
+    license     = licenses.gpl2;
+    maintainers = maintainers.rnhmjoj;
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13611,6 +13611,8 @@ with pkgs;
 
   bazaarTools = callPackage ../applications/version-management/bazaar/tools.nix { };
 
+  bb =  callPackage ../applications/misc/bb { };
+
   beast = callPackage ../applications/audio/beast {
     inherit (gnome2) libgnomecanvas libart_lgpl;
     guile = guile_1_8;


### PR DESCRIPTION
###### Motivation for this change
No system installation is complete without running bb.

###### Things done
- [x] Tested using sandboxing 
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s)
- [x] Tested compilation of all pkgs that depend on this change (none)
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Issues
- When music is on the output freezes but the music keep playing
  (probably mikmod's faul. Reports: [1](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=123150) [2](https://bugs.launchpad.net/ubuntu/+source/bb/+bug/212401))
- Near the end of the demo bb segfaults
