### PR TITLE
firefox-bin 56.0 -> 56.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,955 +1,955 @@
 {
-  version = "56.0";
+  version = "56.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ach/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ach/firefox-56.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "5e91b737751e62f34d2d138956c115120993cd6e8f4f86b7e59dbbcd38f6dc30f7550cac45d3a8ed866cf24c566d042c4ca43bf1e14c8f8452db428a78d167a0";
+      sha512 = "8c6f9261a614b353e20b2b4a07f21eae8aa86cde092544ca924c5501bed8b4c26d8a1dcc2abd91c57704ba3c99b43014483c8f58a0aba2e0d515d8de2df93682";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/af/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/af/firefox-56.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "7e523a24713b84e182ac060562827778d99d9c6125410ba9dffc151e53fa87774943a4dd3ce2c4afc9d17340ab08fd951832af35d5715d143303dbc94bf95d87";
+      sha512 = "826b056547856e7a18b7e352123462491850d10699cd33b9dac696cbe3112aea3fc445db77f1f10392ac56f400967f9b4de6433d9d24f3e756b1edffa72259cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/an/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/an/firefox-56.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "410b11e1bf797a5bbde80fdca6ec0b223e5fb4404441636b633379d42c1bf337faf00f70ac71da2b44c71ef9a1e7fe9aaea0e71184640d5e5f20335d46b9ae03";
+      sha512 = "7bc420dbea0fd02c1ba03b6e4f8b17a9bf053dbebc2a9a91a07a725299f0b976eaeff55f3918a7dfd30828d47d02e266e3eebdbd4a431a5fbff9e066d6065604";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ar/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ar/firefox-56.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "82b390cb188629f0942c8c23db1c84a377ee6e6046add935faa036c93d7d0e9da50ffdb6f7bd0cee540781fd05fd28e9f5799c6970607e412659a625f850d262";
+      sha512 = "2dd2226eb5318e42d54a03eb51c0929b18431661e567ad8524a1229445ac399e2dabd63e4abde3af5eeeca6ffbccae37c38b31f5a35c6828de297538216310b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/as/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/as/firefox-56.0.1.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "d321a7b25d3b06ae356ce875b10d42082ada5673ed73edea419a1b021853fc7079c356d8e7a352b248d470bff90adc0ccfdbcfbd886945c219106bfb00b47931";
+      sha512 = "5616393b8a26383b24113f6b14c95dc96a9d1ec5778995325e48284e1299a4eceb4715e2488570c1ccbac3f38c286efb65afeb128d3489320dfebb86d32fd6a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ast/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ast/firefox-56.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "9ea303a429ce7e3c33e306c5c3cf9e8ba30e9c1441b8beddf3480a488fc99fc95f996f3b38763c04539f9438bdecafb77fa019d4b3a81edbcafd024d4afbe32c";
+      sha512 = "84105f28470ca3b173ef7d569942243f206e8d438e76166ed0ddd9b4d08e3d725447d44a846132a9fdefcfb35a869f0d765732e9662b4513f3da0aee8fdc93ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/az/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/az/firefox-56.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "6fd4196be196b6770635499c1f4eac4b3b1f67073c8a4c2d78fa89bb50ddf64248e8722bcf2367987bd8eddac93663f7f75790985afd39e1399b71121e73f26f";
+      sha512 = "05c402cd86b8b133487e012f1abb4ccab4a90756415fa9f7421e8a50482bf2fa853034d4f779120b6d8fb9c124df2f16b9a4ef65d3eb38698db90d612da58f12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/be/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/be/firefox-56.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "3be882b52db840e9d16976a8596877b1266e83bf1523e32467ba914a1295dccd5b578368bd19eb6a2c864a34e0deb06d75ac798b65e8d4216923c9e60826f0ee";
+      sha512 = "fa1135d28c23475a0184336067bbcfcdf7b707b5424896b9a0766fefc92a8f5fafd4e50ed0064f8e4acf698738672b089c284fb427ab6db2ffce63baadbce3d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/bg/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/bg/firefox-56.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "f5e04004f3ae5944e3b2cfd8922a670bf41c962135a6e65fcee7feef70b4e8de9c159bdb823f9819065b4225de621347066a9dc863aab6bec2bebd05b8fc74eb";
+      sha512 = "d470db1e995fa104b7504cd9f4b3f86851b130f5743235848a12725b294e4bf5a66327b93a0e6ebaeb8273711033a8b69f9493ed48b3c09c3dfa4899e8f09148";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/bn-BD/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/bn-BD/firefox-56.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "6383795dbc65a2d63485bb9014b6119259bf07cdd9e0240fbbf3101b9c955d2008739dc8a7cea4e98ae17212ffb867cfc88ec781935a27d2a8e009e3f2bdb66b";
+      sha512 = "4c2c612bafd1cc5db227d98e215e261546368391b2d3a5f13992f0704790a3bc0768b664fcb913418a31c97ff3f04019057634becbe62e357a8ceea48d31c28e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/bn-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/bn-IN/firefox-56.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "0233366e72f24498be112a584180181401b3bd5dd9dbfdd5b5a320ae2fb7e96c283e0b142c8e3a46e8f3a1ad9958833f7ce3f4a85add5f5b70a3b0e7ca29d996";
+      sha512 = "776dc919081b9ba8de3613614654371b34ae1e31134bce63afe8fb05eea9133cc27e8214ff41046708bc5d812e9046605ffbbbfe8740ab795d908dd714c93cc7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/br/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/br/firefox-56.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "667ade9dae138550defba527024f0900ae78a84d98f427ab5d767140d3bb0636677390ca0365dde4b526e2b0b318ab87aaf6c39f85818fc9f2dc671fb7a4a39b";
+      sha512 = "17d0fd5524a52ce8a81acc3799235e2e6cda905df6b40f70dbc837353fba96a4304a46078f887825f381adc6f5b0c519c71d2ac2fc848a7a5e96bf55d37e2cbd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/bs/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/bs/firefox-56.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "0addc663903145e6a95350ee23c734e7fc42156c07d27e60efc0228da0e4b20f230f76e7802edc795b95c8ba7c1db3133896f4bc3e56221a782eeb78ca57409f";
+      sha512 = "667a7384d89e1ef3b1dede6a6c362104957937352e49406852e6be76e615b1d093e6a8db700e9658cad7e56297d56e46baa0cf0fdb2188ef9d744e44683ee30b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ca/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ca/firefox-56.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "3a9b9622324528b7c7196269cd76ef6e15063ffd1944277ff4ec7cec8f972001718368154a5edbe7af8247262218aed697db46296a13e5861432848d3a29475a";
+      sha512 = "32f87cd6f5bfc8b9dbf10ab1339bc525b80ba50e24881797cb244b7b7079fe25a28ba6934cd7534802baa3e672b9b78ba36b973b264c1d00988669491b23b5e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/cak/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/cak/firefox-56.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "b691c0828637e13cb73ff281a939030effd78c7760cdd5826f723ea7b13f4c7b63bfddcfb27b61aab414f1621291756f5b98ca966efeac368e21e780147affeb";
+      sha512 = "ec9cc56a2cd7b4a9f9849124df9179184facccab1abe062b0e5f05410704562bef4dde4bfef5ed10187b5f1edf86033b5f94b077d8d48169e037c3b17514f038";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/cs/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/cs/firefox-56.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "d99ac651fb417674cbc0750e5e1250d2e622275eead4d9709107f05359d1f62b248295e9120cc0ef1d5de61d22c0f3a889470b1b7fd4c04440d0f1a4730071d9";
+      sha512 = "cdf3b7123c4b69d22f2aee8dcc816833ed876fbca1e0c0995180a170d7859fc10344384ca4c8150e6d0334978e5123371df2da3ef2d726eb39792307d76150ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/cy/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/cy/firefox-56.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "68bab0e265332111a09f04d651bbfca5b462cfd0c4ecc81f7f09f5722f52bd9a089ac28303879681d9ddc7c0da7456f71cc1a67094d2165d3f722c25ccd8115f";
+      sha512 = "2d9e04aa36cfb0c05359a9d51706cd759dde52901d80f68601d3f7beaa06419432a3026c1c4b4a098d31253ec871df227d69ba9c79ddbd282a229376d2789774";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/da/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/da/firefox-56.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "694e988e88b8b111f4c47e75dd439b03edf5e6d3476a0aaf6ff6a64f3732f2b47bb5639a017e026b49d5cad28ff2d9beaa1fdf39571400cf64753a2830a162a5";
+      sha512 = "1e8dc3f4deb5d87d8c2b89c32311062c5c5fd2e374af249e84c247d438f0a3fae53f97e0134ab9a778a84a7f49ee3f44cbbb5057212cce95bc4e977fbf205095";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/de/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/de/firefox-56.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "9647ad2fb13dbbd3bf83c43acfd835fcabcfc27480f31798939065ddd6fa4559fd22d11b656a735f88f30895842059c34f6860b61945e96608756306c3447957";
+      sha512 = "0acba4c4c7905eba03d6752e4de2b901716e0050d896359cf7821ebb4dd197f80d5b261b1c7c6838ac6da663063b134990a7cd785fc13ac1928f78e9de926d29";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/dsb/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/dsb/firefox-56.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "0faa30e572a216576ea8ef60d0d23847fe731634cbe87873a4e7fbd74dbfef85f7ea1c46175d5519ee0265a36603a97c0641c564f72a89de623320137dffbdd5";
+      sha512 = "de51364f0b3fa5f9075ffb50613cd274685a6a9ffd9f665a658da352caab4268e6e1e1458b8c6158c6f511184f6546c0c7fb8f78eac36de6b514104e6bb543c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/el/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/el/firefox-56.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "754f1dd8cc5e229af2f66205054c60d6c5c78f92e8434a2c079a2e4f0ef28a4b29e1b5ffa0e1828c613b749fa0105874dea03bceb6b2e3a01fb910f1a91005f9";
+      sha512 = "0c5292a67bf838f975eddfddf27da2cf54905479a2a88ea8e558161a491cd681f137d2f147f875e449e06ee99685b96aaf73214813cd7c9dacfe425340a8a850";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/en-GB/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/en-GB/firefox-56.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "c16a44f0b057075193bcdad11220ab8e2a4f342980b5b04912bf00a4dd7c6f92d8367319422e27f96413f2aefbbd60b012d62909658a42cf62b5d12abc09ea19";
+      sha512 = "83fbd797a7a798985b8413228f99cf18ee7904295070fd46e00dc960e72a7a59106cbc1e1f92d613070a7ebc91912f41dcdcf1c36a537b26612d11110ee05db3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/en-US/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/en-US/firefox-56.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "8b92bd537c2f962855e7ee4b259c99f3ecdb9939c56da118f38063588de222fddd66ea72fe95ceca5895229804fcb946ece9fd5beb476be771be430804d06be1";
+      sha512 = "45f14c5c4d707b10b3e1803950389486a59543ab408d449f19f04718f50e17c29c00d51a48edf7cdaf05dc5b7037dd221e3902c3c4c64fa2ffaa97346ecfd87c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/en-ZA/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/en-ZA/firefox-56.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "bbe364ece5f1da652530684fa36d2e13051fc85f90c147046110acaf4266ae187067a7b1c59dd48cdbfc5e10ca8df478579e20d19ed1e00b839f4fa1e99c2608";
+      sha512 = "c863347c33335f480cceef6d3461cb44940f87816c7c0d9ddfcc2f1f0722333100acf766105eb97210796e0389df4374b8b0f99c0e4da021e8ecc605ea64b914";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/eo/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/eo/firefox-56.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "2098fcc0e8405a3ac148ab4aa6ea3fd686b4ca839a3102886de515234b06a246bf4c588e6e0b3ecb0ce5c053b4f42e1d01cce79249ca22e041ec35e151b58ffb";
+      sha512 = "e0f322497f5b5dbb274926ba65106437a054e524b7819b5adb134a4af7b67eec58ea5c5d0e098569c96cf842fd91e06901e31240459a309c62cb87f9d1f7ecb2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/es-AR/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/es-AR/firefox-56.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "868e89a57c7ec69ff936dfc3dc3042ababa7c703bbabf5c12044668de922f22f0fe395f792891c839739e859a570676605d17c3c86c362b78155089e9ebc2437";
+      sha512 = "a11866faa165e7c14f0a932681b1cbb4139b733225eb7e3fee7eb952a7c7fc8eb20ea2ce06e1201ce4a6e26835587bad025fec89366ec013de7a5e5c417df498";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/es-CL/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/es-CL/firefox-56.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "cab2543a4d0d2201f4d956a5a35593c0f52df8ebf03ab4872450c409b11ea9c13b794897d8f4bfab6d362d50e72823c57405f8d78d3204d5f621592e188e69dd";
+      sha512 = "07cef4339fcba4a24f9fe8023f78809f7d7d2fc5bad3ded7ee7d54776ec9aee0b4409664ac342cb75a309f3426111e9c0278e61feeacdaf9779647bac2fe7bf9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/es-ES/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/es-ES/firefox-56.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "4f48a78207b5bfafccd8c76f5d5e06a38e79fda36739ef3f2f6359cd392c02a79367eaf8c136ed56c8ead59dd176388de3bbab6146898939fa93db01cfbf53a8";
+      sha512 = "e3416bc824c1d342f50bb275f94c5a70b91877fda49d8efab2691e739e6cc8dc69d6c8b7da42227b28942e8fe235fb9cf56de52e1f2b3d34a3bf6e6cd37e74ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/es-MX/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/es-MX/firefox-56.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "deaf33a4da6e9caf88668d6ca1f634f581c258f8d2ae47d1631735e5311a2818ff951c5a95c6c555dcdc3a182872bd64efceaeea3350ec6229c5207366f8a928";
+      sha512 = "647dcdd35334f37ba558ba5b31ac984f0a48181387704932445a216ad4bb9e1941f93424d36be4dba6ceb4d42a2dcbff15b011f07eb342c413003fb91be00a8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/et/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/et/firefox-56.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "9ccdebf0492d629be1e6514cbb9422bbb224bd7894e05d6343fcec32dad2e6817727c9becc1df487b402a5e61880d073f3315f4fbe221905c60d5c8324bbd57d";
+      sha512 = "09bfbbdc62edc88417211067f4a73772605eb650d689be07df028dac9366dd268891f4ee8cf8f122fd109339739caa6be1a6eca1d35b1240bb89a763427316ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/eu/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/eu/firefox-56.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "2acea950147b6ccc824a42a0256730a6fa1e7226a4bb3ad093a555af5d8323c1a4cbf8affa20ffdedbb3a0c1e2629082dcd01a8c4a18490c1cec579f6546e371";
+      sha512 = "41c99bc9d6047b5a05ad564aac31e217cee3db42e66f6f5bc442034e3210b0732c8bb3d64600eacd16719360242c1991957d81cd0d24218535dfefee0b1397d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/fa/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/fa/firefox-56.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "e4694064bfc8e00b3afb3c83c5286e93010c2d9a90daf781bf141787190aa6314bcfec9ba542fa136efa653b7527ba7c264ff4cd8cf1e529f1402ec2abe90f3e";
+      sha512 = "16c8a8cfb2d87d6ad84180074d78790fe1edd59cf443638606b17178a453a810e78a3f8a393ce730ab65d31688ad0e0ded0b25012f0b74baade3bf6d2fe34788";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ff/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ff/firefox-56.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "93d864d355ebea2d8add77031f490edb13f1e1faaa65e4207a4013c5bab1b473f6fd8d7f5867cd5a3bc30aa23263911f4dab2552adf570675427bbd3e3e93268";
+      sha512 = "b56c8672b0004958277471e1fd7b97fe0fbf180ca4f272a90cabf7b5aeeb534845bf6d0086cb7ccf0ee61170a310f0db9a782cbf4e660034cc978179f7d0d343";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/fi/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/fi/firefox-56.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "2bbdbe8798e2050432bc53f655d533fde999c8081a8a7d494e48d482afb572a08b3c63840124dd50374cca813aae7e87629cfcd68ef9596eb749b5bcef0270d7";
+      sha512 = "206429b73399333fbb9e787132157a51096989e3cfc9cfcf2573ab5dc12de2d0d8b73fcbeeec6c08535ef4fa179899677a7beadaf698f661e3960a1e05edd617";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/fr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/fr/firefox-56.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "c3903b640f674f5da1a7097543e917ea7c56c2c8749a30776fdaeb518d7b0ac874533cca0aae643d24175fa6307ec5cf00ab457ce3dbcad52a02e4269c12550f";
+      sha512 = "837bbb752d18c6697c8fb357d228b9cb24eacd2b4f9d7ee58959639d165d06de585602ef30391a5110a4711a0c2ab8e104395cbe20a5671da67d3cf90947f73a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/fy-NL/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/fy-NL/firefox-56.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "246cc7102dd43351a6751f71b30e347a67db6997744fd6b94d2179706304a370a36bf31b00aec32a41cda37ec0b734cb93b759bc30369ebfecd20ab3680b0c74";
+      sha512 = "1d4fc9621b08e34c6dbc19c016a4ebfc503aba17d9f69d6d281a2937eeaef8dce4b6cc0ca7d5d39392f487c9d19556bc175bbfed798e946bc81325f111f45dec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ga-IE/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ga-IE/firefox-56.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "cf825c5e47045afdad04cce7622ff91e82c2ab10c14d6c7f0338f37221fffd1df86b79a6dd606a333c83e029a21421220616af6bf417c1a12dab8504ede297ac";
+      sha512 = "41f88d1026df2521498c5f78c5bb12cd4e91620c87966429bf26b23cbaf872c2aa3e0ba5fedff05458b8e885901e5978c260537a865964672f0bc558e615b769";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/gd/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/gd/firefox-56.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "82f09b004babae82f2e84ebc3d7aff0f556eddfc3be0ecc1abe90a18ac67e846304ce478fdb6c3a757ffefbef50fe733666796c4820c701f249c09cc246eb396";
+      sha512 = "67ec86420e978b7f30e3ceeab403e3901c50c5ed3baa4958e2e36cbd4db95645198c2df81ac9f68160342a09b882b21c397210a82eeb6c1243264e404e9b9fb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/gl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/gl/firefox-56.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "f5b6513b4dac92b02a4961febf7c734b5b9e1f9e235bda4749fb139c9c050116d1f1f222daa50c0bd6209b7958f8610800d4504d9a9d7ea255bc70ae7149f211";
+      sha512 = "81d2149fa9f1ba4f1b69c8f2973ba1f127f64f4bfeeea0dcb5451dc88f3b681f7ccee5fcae9bc8b7c1d36f85f000cd4210b54c360694d909f0cb66728553a0fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/gn/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/gn/firefox-56.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "de42e872ce6ce31c020a539c3c85c0ad568c720a2667964fcfc6adbc5725fb84c4d559902cd36f7daa42864c8c276d18bce57c994bb0a996727291ab29f43362";
+      sha512 = "93b576f861273b96bba97eea33598d421f0251a847e853f1506fca08d094922ff445ebc36468fa457181359afcf4a7e1f185057c2cad6826376e03a6b996c8d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/gu-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/gu-IN/firefox-56.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "a894ee96d15bbfcd81a596d0e1c3fe72b01c02250c54e85e7f66321db735c157a8cc971c0aa04fbfaba367817b360ee5b9acdd000d46f85ff035c5ab3762aed5";
+      sha512 = "c377fc5936257a8cbce11206b0668bae64c32693161472a2e568da00c662739873b2b409cdedf041efc7bc47956219c746c05c0e95654c2e4b553b384e40ca24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/he/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/he/firefox-56.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "fa3eeb6926593e77505583f5321d7fa21928642c900c9ea3147cd8967b36478e30a15069ebcf23212f82a32030713144fac0cb836808e7e3ddad4184f03629a6";
+      sha512 = "9d82c000a8a09f69c9daf8f04cacec5a9c333da22f42600259d75aee7e8ebb57f76854921b34f5de078caf03edccacb59831ccf9f8b3a885842fdd1e42761b83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/hi-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/hi-IN/firefox-56.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "1749903bceca3b06fede93fe4a3cc531cdfc65d9bd1ceec7cfba0fb0c1c6cf74118de4e5f8b59125f429ab0797fd308b511bb50087237a2b470ed164281fa143";
+      sha512 = "1bf8c4f4252ccae9bdeb6201e631ee178c9c33c17661f680a5688138ce875f05b17618935247dd614a99c8b4c59355300160efe3dce3ed4dc672ec1ebe301a21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/hr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/hr/firefox-56.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "244a2895a30d6f6cadb7de82c5b1fa193a41d7c255d27ad525f30e057a2571531999992f3b8735b5cc549ec4e0340d0027b59c4518992cedc4fc2ed89be4c73e";
+      sha512 = "67db04beb477b841f50125957f1354c597a4e02adfe3a95e0e177bbe436fb103ff99a68a384e8431894669cca72eb27f3250f7547696771eb9dbacfc6ea9d39d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/hsb/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/hsb/firefox-56.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "274ebe64c5e0395d26443ababf3c998f583024d979d498bdb6de65defe330bb862abb8b29202bf17c8c6f5d938623936dc9336d13e99c214027d9cfc261f2b74";
+      sha512 = "1e3420c4003335e238df8b2d1f1e8116f4aa6f134140f0c4201bc1641c854a716d5845b1cde494e9d7fa8842bbf8a6075e5cf0e06fa7c6e5730429e4543df2c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/hu/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/hu/firefox-56.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "4aeb33a804b88312fb68e1429627328accb82db368b017214c9dc9a8023dd2a702e787c03020a5047bccad9fbfa82b5f44a9079ba9235dc03393e1b766b88f7b";
+      sha512 = "81935ef98b9b92db81f2ee3cb32bc081890c6e72c5fad4fbf601e9fbdddf85983f4c2d39d4b3a75f01137e3864bce1deb029bc6d7e1c2fb3927f40c7e06e6232";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/hy-AM/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/hy-AM/firefox-56.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "92202f50142c2e0dd0384d5d65ed1d059f55ecdf583e37777017ca3fa428225e1ced4206140f268fa5eaca301414b217f5e46f435ada4ce1a70be87d5dc30cb6";
+      sha512 = "2505aa2f68de27a09a24bf1323a6bfb30eb35a60d4abb97451f5fe749d4a47a199a5f8ff8071beff19c9074627d68f5a3ad014694b6799c2a318b9547996b6a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/id/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/id/firefox-56.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "b2b109fda6ac076c933765698026d278da662bf026a4e38b351676d2c73fee10969f39650217ad225bab1ad387fce1f42b7c5152385f1779d98264e0403ed04d";
+      sha512 = "ae6d762a66edca161f9e4a547b3ca99b34f727961fc5ab7a57885d3b9ab78a0c0d1ef6b80fbf15451ad06b9f59d7bde4dbaffebadfa51bd8f89c7107da7296f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/is/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/is/firefox-56.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "b5d753de5f044b693345c0dbb112555baa0f84a385338780c99bf465fdc09410b920083ad160f4eb56db5e2b73e3571aed8f8ae3b3d57142b9e5e452c39836a9";
+      sha512 = "91cdf41d9433d20cb737833a006f7b0e3408de9dc80d689f14d4c8c2cb1ee1cfbdb37196ec8cfc68e6ebf56d53b437917ecd9d18f935aaae5f4cddb7ab277d94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/it/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/it/firefox-56.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "3c6017bcbaa10da0d8fae0c37713cd06c010b9940791f6f9f9aac3f8393d18406759c6ea0c12fec02c50d52e436d401d67839859d96322d7ef3c664063d380cc";
+      sha512 = "5d051cc24c2cd5811b0a6738902a232718d3a6458b372fe9ed7923a15b18329607e93f062b4ec08fff4eb270adefaf9e39498e22522c102ea23b1d0a50bf3f7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ja/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ja/firefox-56.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "ba0f3bc654e0a6cf96ac555733cba556c3725474df71be52af06741a6690c8213c604f1f04b2df048b756addb86b85593e8b91b0bac714925e53469c7701c067";
+      sha512 = "796535836414b3f676c0e037f03cda49feabcee5bda2bda64130d569881fc5da7eb6040ea5a534a7f8685720801fc0cc9196f7d7d4225315929198598995e239";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ka/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ka/firefox-56.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "2bce012298b2b80e4567923b99c96dc49a6d2282cdd24b464c98dd36c2a66915f8486aca673abf34df63cfdba2bd2bf6999397610ef64a55804fd589cb581517";
+      sha512 = "d597a777779ecda47c588208ff350512282af7b933a599014f65b8c7777f68baec93eebbce982e3d77fb42d77b26d533d63c67d2a96a5d4024b1f595a28c2204";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/kab/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/kab/firefox-56.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "b2e2c667d4551724cf9fddbcd8ed4029c4d91a6f7363804b9f1382d6f4463ba65887174cb44cd4f7a5be525db8699ef4f517dcc3f87018d65e9fa136219278ee";
+      sha512 = "2c60fbaaef100c38d4d95f986289d9cfdf4abb739aa3320a882d218b949d7e293d2b8cb52380cc4991a7115d12eddc9439d6894d862a631c6e3b274680cdc1bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/kk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/kk/firefox-56.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "3e3dda19c1f03c144cdabbb4f968eec57df764053655d0a5cb69476d6bbb312cac0f06555422c1d95985871f37525f1675bdd4575008fbed99cdba2f0e80a3e3";
+      sha512 = "aa8e9255072a1154dfb4230effc9ad6649b02931c24ef4ce8e979fe4bfd9c350aa9dba39a7d0b866e11e96be29e0fd7a15f8f7ff9708ce26e430491453b49c23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/km/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/km/firefox-56.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "ed50a3fe8f72d0391a3facaf08bfa34bf8227689fd74e2372bb78a2cd76a99f150669a0a30c01879096a6fb4e6b1bdbd15b41756cf41000a1f10f3e5b7038cac";
+      sha512 = "e5c38d3ce0adc014510f5557577a2bdeca238f9675f2cad90e42b4ee15bbc2315cd869ec4d3a6fa380203491699d1402f5aa59c1c8cd8cdb15caeedfbb7b7590";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/kn/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/kn/firefox-56.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "fc3d3adb8a3e92e2da7e3970ab3f45a1c8750acdc11d5f7c062249a6f025070ee631dec1f8ccc9237f00442b4c9c782f51d8f2ba420ef5a8c3c4e3601e292d27";
+      sha512 = "ec5bd88e09660e6b3e02fa34bd3f8f5b81be7a6dbadf55e56256535ddfeb5734aab85ac47d16a14c41ca8b0b66b697c50250178ed341347a6763ee2009173610";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ko/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ko/firefox-56.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "05e6a136e711d1b13adf78037dcbcc21a6af7aa8eebcfca0c839810d8df4e87fd951a12c705504a585e729af72b6f6bed8189d3c5f8919f68f2aea72cca2f1b5";
+      sha512 = "33f6b9850a1f2d5f6d363b5830305c498c50eb705b552301d34988e9a446d2b438e83ab29cac45fd1be3c7be016a0eaa631aeeedf4742de4f27957c02a804491";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/lij/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/lij/firefox-56.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "d0ad5add37962d986b6faf324a4e9faab8c0366c6c04b34bbc5829159ed7364d108c5b324cd6ee42de279bc58c414d347054218dad268132a2543913841b2846";
+      sha512 = "77d2cfa449fc522f314749aa3a0850591efe4862bbb9a8e9dc1abb9d99c2b16439f7845aff9686d201bd23c88725212d28b1837fe1f2b20aea3c78525a8e1ef2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/lt/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/lt/firefox-56.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "efb74c5479867061c9a8ae525893114d85d253322a4411a7d67f5d1bfd17843b371ff58167d8c9f199cdfe7f3b13592072ccfb5eb88ad62a511272ff6419b620";
+      sha512 = "6a7c041f241fb6302e7c67b0a920ff613170b716e02258def0c87fe9332a69318f962797ffed9ead3a60b8a951f517f07f201053ff4ff4dace188d737bcdbd0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/lv/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/lv/firefox-56.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "030e445cbb156c12d77c1858262b6261e73fecf3091478cc9de47c4867c53b7ef807ed8a15caf2d217ca00e2d90a05f8a86e4a1f836abc99731c9384d74a1c98";
+      sha512 = "ef9166f0826ebcbac5352e48a1ecd23a0d88b6dd1ce2d5ec24b0b71326e03a7b4b175eee299aa620862aca9000a00e98472e1a605d214616933512e73a439808";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/mai/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/mai/firefox-56.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "abe8c9eb6fc36fa2eeaac29f7d53c9ced228383d24cff0c43520aba9975c6b400aa6ba44584c05395c9a4fe156ad1ec2e348cb8ab813933f514729bc4eb3569b";
+      sha512 = "291aafdbc820b39b7473192a3781b96ec2fa3ddfd378c27674e18a24eda51b6aa112df86a68b6cde6c922c9567449d75942d470b09399424517cc818418b7219";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/mk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/mk/firefox-56.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "a8c268b53e392f147aa371a7c5e623352fe80689e5d65b325540a478e9b2015ed91bbb7cae309117b16677dff1cab99e64de171dba3936a01101579b49efcd3c";
+      sha512 = "9224e087bbd6b49630023dc92ae752e62cf0a9e4169dac65b07acc8dfe143b333f8840875da4b5f3ce119ee31987721c0cb8088c202cf42d6d24c773c1406415";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ml/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ml/firefox-56.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "655369ea9047c3715e7e46065fadc255516e170f1892f0e0a02aa6c77ab94927b43f0d125be3b886dc7295a43cec304baf3268d701bb9aa6cf263eeed2f95974";
+      sha512 = "e8fe9fda9253b20f898314839e8f70e3011fd3bc6d1a08c762c38363066452f854c530ada25bd5417a3f6eb0ea4ffac525bc5b0bd67b6e6eddca35c8eac9a6d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/mr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/mr/firefox-56.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "f944bc416068446084e9fddcbcfc44ff096e29c2feeb2b1a40530317f7fbabc1c3f31419d749fc859789be9188c875e7d769d3aa09e286eaef305623f5a49d70";
+      sha512 = "07ee71ab15cea520c5c1403be55a7f09eede71787f9a404bdd18882935112a7cf423850df7b5c5afd3e595b2bd3af053858a9bbc6f152583ecd03adb0cb56dd5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ms/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ms/firefox-56.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "25d47aa89a88da6932cced36e2d5ea5de7fa9e1d7dbfece462842daa65ff018d7af81c26659267f5a40bf621e79ca0df30f1ecc5abc5d5b159673c73d10b0e69";
+      sha512 = "ef839f697bb37a81f988d28d6195b33f7aa92b1f0c67cb40b04ef3820a2f86f024a34e964f4f2ce8bfd81cb2695e6875d8d72aa426db447c6e65c1a277eb1379";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/my/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/my/firefox-56.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "3611e75b8d4c838ce81320e4f72d8b3425959e1962bf1b147da081f23a6536ff4e28204d01154f7e2f4eef3dd48796180d42ad7a4467d66cfbb56089784b3fe7";
+      sha512 = "06e24ae1c4d86ed2677d776037378e5f50b3481f7e96cb0e32369574fb2a04c5d572c7478ba2054f3929a0714aa960c8d9ebc8d7b9559d7f294c31c775e9b70d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/nb-NO/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/nb-NO/firefox-56.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "1a1ebe6b9b118c89a3642504c5d1175e64aa37d652741255ab93e7ed8770a21e2208434d19f95bc01deaffab7e33a011352bac5783401add797ee4c9535055e1";
+      sha512 = "c2384749c1121cf7b184e49fb7ce535a2387ea32285ad52f63afa6a02746c556459f61d7f19a60552e63958aa9541c81bffe13c6a96f71c598bc4501bfa4024d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/nl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/nl/firefox-56.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "e5348a13c66e3b6f5dcd1765bdaee0adffd0dad195be0c52dadd99fe1dbe5e381e5aea7b9e48d4c77059d1fbb0b214c25d3b51f83de79c5dc33089e2629f7298";
+      sha512 = "b207a5f091f556dae81fe4d35a14e39ddb1eba9fe9ac4440d7335eaef561466f14d843d91fb8a312379a0c7ff039a763fd041088031cb48761aec6f58f681fbd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/nn-NO/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/nn-NO/firefox-56.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "fc7ebfebccd5c3be0a06a02b98da1d18eb6402e2b97a44a8a483845df0365a073260930eb7651ee481c5f788bd0b158e5b97017818427b9143772601ed7b1af0";
+      sha512 = "e5a6e1ecef59fae002c4605e7c838e00ccf6fa232427c42a29cf27f1bb4db7c84d4c4aa70eae84b5ad40eed109de11270d02574101eaf690a212b219448cf273";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/or/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/or/firefox-56.0.1.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "2e450311632a130b4fdeb1aca3be2073e22acc1016315663037b0ce5daece961a2ea276b96da06219f6a6259ced97d819e2feed745c38148e766d2a08896835a";
+      sha512 = "f259f88c0e4669c4d174fd011493883811042ecb4b4752c7c69dce61d7c6c28267428327f891c2eede911667807b6554373e8f2dcb8ba9e2f3d90472aa2ec960";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/pa-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/pa-IN/firefox-56.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "ab2ce9dca08d20bd9f389f04ef1b2049ef60cf98c0423a59202b623419714fc1a1a40210e11a73a804adbfec1d6bf142747b7a80e7c83e35d905b9c48d7bcf12";
+      sha512 = "cdc2cdd6902c86eab3098514b2b676db6d8a323d3b78b2da6104fe1be17cc15b3d38d5fdd1692a87521d6afce8c8bb8e0f78bb7d291145ebc05b5a76d47e34b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/pl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/pl/firefox-56.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "d9b75c4777f029eb9645a076de83b634f8ce003dc3bc2276c94f7e6434fb5d4b06eac0a2998b2e4abedeabfadbcd9410c9c6bbe58cdf5bb257601f3dc0dbf0db";
+      sha512 = "edc50ffc298fc92100faf0b529716e14dfed8e41965e3b4a8d040bb90a526309bbf52c60d8d8cb816e0db99bf09401b27602cbf0e7e947e3ecbdf61f5c53be59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/pt-BR/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/pt-BR/firefox-56.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "bfbbbf7c2f94fdb5a15b3170f7ee6489a4cedaca07385643f659e553923c0ac06b7e7d38f80ffff082a56c1f2f08fa883067d1a3fce1531f1e4160d9c8f7dd70";
+      sha512 = "9da419264035792c3e9f601bd9198e77e0fae17a7ff2e34b6322667cd95bb79ba064a59b6336ef33571f6cb5f721a7f4f35e1f9ccc94e68196c310a683410846";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/pt-PT/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/pt-PT/firefox-56.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "5033151554eff19cbd1b9c66cf5338a20a8855e677761f89cbee022b8a2cef962161a91a7e67b85c34ab3b44ec4f4a1a638e5f7955e998bc29dc55ba072b905f";
+      sha512 = "b151504acc244ad3b80c2dd7ec87fc04682e06bb53338bc39aae164ba1a279c316eb84e33d1b41f4261135c39f0a0830a7f74f5ad7d0d3b9ea0bb458d628a9a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/rm/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/rm/firefox-56.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "12426599187b70240624401aed139c9c61ca58d3bc721bcad01d253942b30ef3beee77cd8d76c17c9204ed8a6b919cfa9709e775c520654c7570f26a1e5234f0";
+      sha512 = "480b46a34d36fc03107af64caa5c6f0cff95021cdd094e7c0641f28938f5f21aab8e50b8985e0b42c3cec2650dd4c9538df93570afbffa399241ca8b757c2ad0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ro/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ro/firefox-56.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "3eb917db04503d692883d621d783d6df623ece55da12769fed51634457ab9dcc4c879b79c232054e504d266cfd167a208e728c0b9bdfb2b9a80e0edc60ed0524";
+      sha512 = "3d257170a028575739fea107cdd55a39bce7c534244b4701716e0ae8930e79f04a9fad14c5123c1799fc7ff0d1e98b563e338621408c7e9fed1fd1b84c72a930";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ru/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ru/firefox-56.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "a839398c7afcbcc7e4902106a980675ef46123c7c8466da61586db623bf559e4238448003c722594d8b0a39b1da1efceb93d923d5160ae20e5d3bb6230005d4b";
+      sha512 = "954853d2f0adf078eb840b02be69500b0abe8d76947d1e71dc48492473492e3c3162b1dacfb1089397e2a4985af4ec71b57a01d86fa7cc3f22515aa5f772dd04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/si/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/si/firefox-56.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "c37aabe213ba6eb7bf12d56cdb65ce8b95fe95c40fdb0edb58e9abac064e4ef232fc75787d2b44647cd1887f117d6144d00d495dc196fade8bcc96ef06c6af82";
+      sha512 = "3cadc96524cb58a02aea721a7ae54fd81e660faddebeaa7f2a1b498fc5fc4341ea04093743270121af5757bbe9f6e80c9dead96c03a3e576b530ed3ad4edf7df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/sk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/sk/firefox-56.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "b79303551562b52e1fcec89819ea2ab04e1c5dcf41b9dde067da2d2e0a51307ceb45e0417c94c1f446bb80ee2c7f0e1f61479d33088c843423d5b195a6df4ebd";
+      sha512 = "b800b287c876bc0512295ea2f797e0c330604a9bb9ea5d8ba37b23f79d78701721bf98a329bd58c157d7e8866352fbf9a9508e0959ebbec2f05eef6534eb9c72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/sl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/sl/firefox-56.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "c51c1a2a81e6644c144840ae3a671e74165add9244975f2671a17ba6beba9096219e630b4475b9a576cf0d0c2fe8001692903a984bfa1adf92b7c34bed46cd9c";
+      sha512 = "3a672e005fea767d6af13691c2799d95ec7ea6004e889119624d01d02643bd73a2ae7c6a2b7c96b80572366ea54b77a4d83aa02370a884f18e86e6633f774a9f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/son/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/son/firefox-56.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "f40f28d3774c528e0b8043e30e9b4f88b46b1e3a296934d155c9b340e099937804f7d5b80c845df251f70401099dd089a09169c55b9f39f7b22a02261381ab73";
+      sha512 = "01a506d12757586c61a100755d2610686f2623c9ec7c60bcd1908fa02b16ac129ad0be7d38a43de1cb7fb402860a55595f87ff6b16e80360f26832dbf2c897bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/sq/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/sq/firefox-56.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "728941b8eafc179e5100add0d2489a418b28973e2427586cb662c34e7ff080bf528ae7037835b7c8965b68c6cab3fa5883cd6bc8f1b849937a5d37cf069765c0";
+      sha512 = "e5ea656718a965bb86d826a1989bae6c20f3722f3d7a2b2937fdca06422133b94fc0845c7dcf7577527399b8ef6e78c13e4f37c3109061dfe62ae12f4338c27e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/sr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/sr/firefox-56.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "3108a89eedd792e44334b232a127c7c8896d1a9fe389acb206118f341a747f65924798e99c36bc1be19c215988785fbd1cecd20f2707afe63a9b0664e23051a8";
+      sha512 = "c436c4df233230f0cc848bb29e36c2715d7d6bef09bcf3fee60e35277b2dfbaf5d0556507c5853daffd823c7ac3af47e9733746302e98cd55c5a45eb68477fa2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/sv-SE/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/sv-SE/firefox-56.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "a59983dae6d6814e45564dfd7b199412b7d7ea76afa0b0fcdad9019ea047b3c45d49317af4624d99a2375a525dcf72b92af0f34a51d955543fcaff8f407c6f23";
+      sha512 = "62f2e7154161ab18902e107d83d437fbab65de3195e49ed009eafbfe2a4f82bc1960f4343c52121edd8c36a57200fd5a6468706bbdbeac9b60416988964e548b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ta/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ta/firefox-56.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "458033fe202c3191cf6c8930ea8697aca2c534bb4c86c7f0a85925ca830086120d4bc3a8148530b8f04c621c5da6d2674321ad6b4f9af7fff0b7c02770550ed2";
+      sha512 = "3c125c9c03646ab80a65a5f84b14c5a2cdd0419cfa0356fc1f28a77b3df463653d369e9aafafeb90a4281333f9ce270097a6aef6b25ad4408312360fc751f5ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/te/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/te/firefox-56.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "ce7dd880adf34db123f85dd1e8d28dd3219e9db59177ae8f4e978efddec67b82025d4a2a2d90b7e8acd4f093b3d019e4b4e8203c70e1e8a41756bbd1c8eb95ab";
+      sha512 = "4642cd96dc68b059b6790ad1313f499126d0b68fad49fdc369f7c70b3ecdaceec3fb4572dcac0f75a415566b6de04ac6086dba1c57e8d5db4f5c360ff5b8bdb5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/th/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/th/firefox-56.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "7c23001e41e8e09f7468c74c79dcfbdaf655894f1c9a20bd87357e39f970faefdc1601b4d0ac2e442d4ee490362f17a4817269509280e180a2cfc31f8ebb1e64";
+      sha512 = "593768af7dc80b1a5850c493f80f2c538fa76e1b5d3b288d74c6be2bb3736cab29a6a1f68902074b0a3c3813eb29f0b461dcf0130ad7fa4f620917a8c1e2b738";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/tr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/tr/firefox-56.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "27bfd7c5d3cc45be0d29d4ffd4d449a0c564bf5eb7d7f86b808429bfc4cd54cffa9b7dab213122930b2b666ccdc99d09f8641670f79a1d1250988a1db4079a2d";
+      sha512 = "8314f255717a1dd56949075a8ac915e816d7647c39027ac636f79bbc2f6d7b9d1bb593a1ce03a9feb1ba41d4cf2a9613a9e64a42db448813b874fd0906267b2b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/uk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/uk/firefox-56.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "4073153ae727ba314dcb77ef8d8fadebb5e397a4c379d028ab381194a0c9a325ee2573ee22ce407c7d774758d74644f033f5e17f1ec402026bbb1b1c4b806520";
+      sha512 = "bf6ab16560f18a8e2eecc010f6838839561c0255beb6fcdd9a13767a34edffbce58fa2911ef13f5d6767cf19c96e0df520d6682d3441bf860d0654357bdc8f83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/ur/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/ur/firefox-56.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "e0ab4125e4d46529eb27a5d1e2039f36463b88b87370151955fe33d602bd1c72ee4fbe79cf669beea81444f340df3da1a3ac4acc73ef47162acc7240fe230841";
+      sha512 = "0a6f44415b465597fc58bda25f371da6cf7f31718a310c96ce1f1096c75f627391e62d10086d6816d64e4199ab0d971f1fb8759f6509967f0a7f79d8b6b08f16";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/uz/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/uz/firefox-56.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "628af5328deb486ebac3c3e631a3314c39e3a3cd4d76610c640ae60b5a827b62a4364898c895aa2f7bb300146451b3d21a1eadd484ec77665828591b111b40f5";
+      sha512 = "57b40355881e13373f3d122585c6e7fbe48ebcf86bbaaa78756e75c669d359b1948a5a42715d32ad4cb9569008be271e15ea2f8a998dfd15f7db36ef92453386";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/vi/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/vi/firefox-56.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "2e4117e805227dbbd96f2b5af658971018000e7dd89859f5f68369e45885125b60810a19f5d62affb98290b0846fe18ac7e96552fc8500369ae10ad1a2ee245c";
+      sha512 = "3f16a785a361dad4e395882cd2a72bb8dacd5c58c47b75d18d9406602a0b23ef227788652656398de09278f9fbb52dc61b7a9c649d5382a1fac663510f228a71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/xh/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/xh/firefox-56.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "b915c86aa00d09bb02424f93b6135e3f407daf73d8cead602682e13e78d6eefbdafa5116f8ed8683f3d42a2eaeaf3bc63660acbf9c4104fe99a8d80ca1ebe695";
+      sha512 = "e2792d9bc89033739104f8c14111dd07c28dc49be4ffa820ccdf88023d93ab7598f1b954183ee3abbb47b78ba05e596dbc7f458cc7c77cda91bae64ce561e5cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/zh-CN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/zh-CN/firefox-56.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "27491f5c075c2a9ab48cadbea211be12d4cd1a4b110d7e0f211a7255cc5109f9b1bdeadca1606afb0fccbf70351aef6ad7fcb251a49280e46fca546e28df9e04";
+      sha512 = "6ed90f1a4b157484c4f1fd0a171d948afbf2af06ec8141ce34285c521861f2bd3c3ca231feb4b8b69146c84bfcc83a675b4b69f1889476844d3cfb4626dcea6a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-x86_64/zh-TW/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-x86_64/zh-TW/firefox-56.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "46c370fb51c1691b06ff026b9ae5a9682713c3c564b077bee4e3fed9ea80c796787a37dfb79babb095c05ae49db364ab552913a43e48ce43a628b3747a15f68a";
+      sha512 = "e953cbc61b8b30de35dcb73407f817651fad295633ae52d299d6205668c49ed4e432ca2e5c8bdf411317c3dda1c4d71a3472cbccba94489573f96c42c09e6345";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ach/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ach/firefox-56.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "d8524970684dde392a393ecdff1897af03835ac07a529a643050e49a53e12dee472f33697bd66cccfb1f2ed78a261dd479d4aa25f3a56ac953579f6c6d5621d2";
+      sha512 = "386e84934aad44376173c7ce27e732e81612d231a4e527f4765cc7cfc1843badffc8caa1526cecfc546507f2e370fe55a85c6cf55b9b750d98a70514301c4da8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/af/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/af/firefox-56.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "3624bad2947f43d9aa89a4a5867d7a406fb34dba9aa06bfbfbb44405fef3b3f78e4ba64789cb02cae561c8112b65d81ec291460522602798ede3408b7127e1d7";
+      sha512 = "708c0012276f2473853efda705cb982d809edcdd300a08c105eb848be95efda784720bd2042f7d352c3b6ad96f5a63f53a70b98c9db29dbd93f14ce40f44390c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/an/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/an/firefox-56.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "ad7ee2ba36ac9a84ee44a16ffaf39cffaa10325c54fb573565780ebf3d176b7f7652349bcd02f0d7d1d4f51b8fd6e010f081f770bd0393e10225ac8ef4262f5a";
+      sha512 = "630d51145d27671fc739bf8ed45286bcd3884a0afc15f39c837fa213f0fe9bfd0213e6d8269fdd1887844bf07302ccf2bd8cce38e7f7d4f2f706486487736561";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ar/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ar/firefox-56.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "4796be96acf7b5a52844e52cf86f0bd90c8b6f3b4c8cc116578529371a77a44fe4a1176a1b4832aa4046a3e9a6291b13bd57c63b0df31cc6b2ba7f4fc58905e5";
+      sha512 = "07a668a25ab4faac23a4a2adfef2b6482261b22cbaccd4121a510af96958443e4ae35d6e83bac15ee0e64aafdf5a5d4e4c21cded777ec65f0c333f9474cab397";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/as/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/as/firefox-56.0.1.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "26c69f994389ebc7a0ed737c5f925f812e0ce0a1d2222406a17801891cc6ba8150c99aed0636f6585415d8ec6e7b4e51d39b39dbdfce1e0326af89faa8ab6179";
+      sha512 = "46263df53558751c587f1e6f6c4a9f3fe5c4833d3c984fb507f7bece693da7d85298a85a21eff38527a81cb1f24f6cd1c8292ebd280238f70e076a4da7748e95";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ast/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ast/firefox-56.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "511f7e3cb28b888c45fbe31e398d3b66192f8e6498021e34c10298096bdd16c839a0aac8db6a103efab12978f099ee3c414028ac4966bd7626556c8eb6f2ac99";
+      sha512 = "92daf3ec9160505501af044b1122a544f6a6e744ed262b5e7e9fa7d1d303e68dcfe7333970b97df9add69d8dcd4b29f8bbe1dfa47301ee16da677486c73d8e77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/az/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/az/firefox-56.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "2694b535a2bce0c5049a143b2a8c9d62bf1dd29e4ce18d7e686df43e87aa745b284c6272a6b1fc5bab58b023427120bd694f7e8e681320aaf0f9bb41bde0e7ec";
+      sha512 = "d8bfe731b8d80ccdd85f3f389fadd76fae2691ef2b02527cb96f2bead142e35fc74f7a904d62e25672eeabc51ba746e18fae70876c8c86efb22b05fe9137593f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/be/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/be/firefox-56.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "77d586ba3244e6fbedf354ad3b71edfdc20b7ec35ae520769aec4037bc45dd9d1a4ae858121c869a9e0f888f0d94d43ed0e0b4a25703d8cd0f0d8537b9631bd7";
+      sha512 = "8a27be65f3e5c586411534990cb948e995e69dc0d6f7cb52afc13c47b42e42507771e3665da57ad86ee5ae532130fd176b10cd17770cab7b2ea50b0121b35ab4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/bg/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/bg/firefox-56.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "eddb4223b62e2bc1e54f27ffd1df85696b9bd169f65b75dbc8f96cccbfd59d110b262f0a149a88b584d4a02c9cda81ced7ea4884be8edd4888d50fb26a850eb5";
+      sha512 = "2c2136346ca821f96300c59705ff077d9b3fccc097bb0da9732554b07278064d92a9238ee0a99cbbed354dcd13422b65334b03ec4a0bd0656b61e5bc8a1ed51d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/bn-BD/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/bn-BD/firefox-56.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "d5ac79231ef0f559059b62cc2b7b438fad544ebc4f44f8a88a1e2503c36547de70a485c4aa0ec575835be54657ff102d2f8d5ea5b009a5f4ee3ab9bc1c8553cf";
+      sha512 = "8c53e006d3d7cec66d5fba1eeb1ff8c0beda661f1033b2e648ff84f6a41e9496d08d90763c0356e5cf9139c699851b878bc1ee3f1f40aabd3d26a42d17554395";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/bn-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/bn-IN/firefox-56.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "ff104d3271479d8df7c5d63ecaa03ce67bcfce839e155bb8b7f12b0f4ce7eb950f0b36f542e6c87402b070ba23d7154124bfe51a10c560bb7d756cef9ba0db85";
+      sha512 = "696a769b55ed6beac2d7f61248deecdad88b85b048c6fea3bd8da1a7cadc792eaeef816ab83b184b0c65b3bae315bc7acc96e8415c69b4d92e50f40f96621471";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/br/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/br/firefox-56.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "5c25ffd7d5a7cc974c924e04103fa81f3d4bae58b2d00a9fe57b6c849de91e29be73533e2dfa49b07ccd45f1bfa7f80861fb6736beb5deeaa55460192ca3c231";
+      sha512 = "3eff8fe64026f8d337ac279193aed4f79320c35d4f5269900517c21bde2075595ad1b4afc68e05f64c8993517e832d1c34e39fc60d5eb6d1b1b6184fa912c416";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/bs/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/bs/firefox-56.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "63ad8bf0161537029da342ed24784c08daa7934c40231402ba867d9812ec0d01d93db251f5c253592de53b69300f669754fbe530ae4cc5f4a7043031a7dcaa32";
+      sha512 = "b964f5d6540f4d70f50cf0ac3858539f58ac50b691758568a5dceb3045b7acef99af65f9d1873f01a7e633b101ee37cdfd8382ea35c8719d35e5a89006883570";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ca/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ca/firefox-56.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "09ba0756946a02bbaf697f452275d3ae908e7fdb5af166e7586b84d1ae0983db0ca9008c48be93f409a56485a189da957f5ea9c18f9fb68c2c09621e16a1faff";
+      sha512 = "309ad23f3b042434c3c0779d59838c920063e64734d42075581ed3aab88de947e5fe2d74dab5ee17feb1462fa7125dee6b114087cae68fdd6c402207f248d1ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/cak/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/cak/firefox-56.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "eeab51af57e52689003339d3f02e60da8bbc13ead89343330328eeab34cbd55c4cdab4706075aced5b440378b83e84be7d9a62182fc76f47d7945a1b1f0fa337";
+      sha512 = "9454a093f4fbb2466fa63a565461f209783f24919c970e95ccb25d8c9b56260fcabbdd9bcb6ca5fa4a1e1098fef4fe50882e923954363c83cc3536f98f95e078";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/cs/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/cs/firefox-56.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "938cef9e5f0e7bbb6b3fc87bc71ddf5b71e97c89a53aa959b940f48345876ca0c8d368f4b630776fef51a1cd64496c96c1f75f32cb7d6ad0d92bb0a3c01cffe7";
+      sha512 = "b487d98f8f060d34164d78ca77d7e3f28cad212c2c9a8788a6f8f13939a8fba5bd6501765e0bcfeb3c57ce82076187cd158cead63f06b27657018e9b1c63ec6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/cy/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/cy/firefox-56.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "f70dc0dd9c92b9789d8de307a7151836729fb98c55666d13beb66958f3824493adec8a409109be6ee076a26a723e5b9da1c4e6363a881f1546a739978e78e7be";
+      sha512 = "3a3fe1ceb21e39bc5ae1f7a33afbdaef00a3fa2e713a8bb094c7ccdb4d724ea3a09907d427f55cefad987482f91db48e8e988b6847132ef2083c65851a95eb88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/da/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/da/firefox-56.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "4b9d83ec54935a6249111ef8605c184e3226223038b65cd709b7207d46d5342665fac40bd2672c40f8207a0436fe38be96bc762573d0a6453cd6dec15683df3f";
+      sha512 = "c9a9073ba8fe937853feddb194c1168e188aa22fc8cecfce619c0eebc6168feea1b18201bb5cc5bd0ae758b2468dc99444a6c2bd3f248814218af5777e848853";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/de/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/de/firefox-56.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "ba2d976917ab0559f4c70140231c2df3c372d7363f897ba92bfecb67f7c58ac6ae4dfbd43724b3404dc8aaf8c72828ea89108c8fd11792a30e34ce9969a3b3af";
+      sha512 = "12f5dd9ba04c6986e2764663648e34dbb21f8008919d6834acada2d6c6d409de4d12df026612ad6945be11836ef7db325e6e39e75fef38bd4eba95655e4f3c0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/dsb/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/dsb/firefox-56.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "706d77a27896c711fb5660203fee10f22fc902ee5b0dc8d26c95e61c49b8fcd39049fde234143af86b0be562ae162894a9a97613b326ae7011cae9f583a8b08f";
+      sha512 = "7e77a0af3a68facd2147d315f8fb0af7ba3defb712b15b1e21591ae2574d7881ceb8fce934b7ad4fe7ed341e5db6697cfcf5b901069771c8475359b4551a24b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/el/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/el/firefox-56.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "da683e296a10a6e548a6838c62d3ffeb26e1ae3e89c5aaad76b10cecdf5712421f2a2cda90105ea1da815c883d5c52da805eb31dc241bd93aa9199201efc9b8e";
+      sha512 = "7e577a58a549b67c2c9d1d85750d2f371b1b280555efcf48d16a4ec931f51474a14a424887abbb2de09bc182553d394777496b7abcf34226e63cf43cc4c874cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/en-GB/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/en-GB/firefox-56.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "61f6f0646daa9c530d098b3dd5679fda75161cb26e3b39b69616629ff1674b0cceaa4aa2d6b56826e54f6f4dfe2038b9186637980facfc63abf247765cdf1bd4";
+      sha512 = "b7c892f50bdc51e9fde38cef564edc44190adce6b8b36a1d5a301b5677b8ca46b68a31b5caef490e691320e76e8f712ecd7e9d963effca203464a2396345f380";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/en-US/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/en-US/firefox-56.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "c6c0573e967681e19667060f239aba9910648213f77d9c7b38b0d9318944ce89062235cbda54e55e0901a23f2a9aa7fdf1a7f02ae94217f6ad554f3ee9010f23";
+      sha512 = "52eb7a5344c457535c263c68a6e3b4714a513bf0c3fd5f8796e8bcd0ef9d86346a7757afaf8193a8de41635b88dcb8d5b666dba86e92f75ce267f14c8adcd356";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/en-ZA/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/en-ZA/firefox-56.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "7e288b18a6c85549c4239972a2d162ea1288fc5939494f612a9fe2a4ee7f39954506618e354dd3965cbbe221467cf1f74227a42c43f8cef96045defe958fd6d2";
+      sha512 = "4a086746611b98886a83759f546738c814577698f92b4d443bc4f0da0f1a8f5956461839bb7c3cf662d9c7386ce8d0828572abe96d17d490ced06257b311bc14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/eo/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/eo/firefox-56.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "9f3074cbcc973fd5bed0ce0b6f6090da9a7ebd05c543a065466a3b0968e58afff473d1637242fadee31840d5cc0504f6001e7cd2849dace0eff4edfd4411349e";
+      sha512 = "b65e271afc2cc1da1c9f3b9a6cfc00f6b1dd5e63043ab9c1f17eab024603869269d55efc4bcd713cd8a860f0b79fd77dc21e165e7d8690a720e7faf1c804cded";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/es-AR/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/es-AR/firefox-56.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "ef56e3dbd4f13b49b05db59e5f89ba3e3188dc7df4d2f340401510cd59620363a3294ef2b95c01e7c3cbb511f2ece013130a09445c314390679401d369067d6f";
+      sha512 = "bce196c4e86e0d2dbdcf42f4ef7d876c5afa1b407513a294c98e052ba9c320a4155ef1d41d67fc6ae089e3a57e5402c1fa7092b1efe47f95765d44ee519163d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/es-CL/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/es-CL/firefox-56.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "85b0284aa6ce08609ae6e7c874c02a8332ab723debff8bb6d1b500b8da791090b44742908683ca64405dcd85dbfc474b4157f873daedfdb9e678e0bc908e2a63";
+      sha512 = "9de7fb8363a8f4c632694de52b86ddf467427e64f4e92fb00c7001b8fa6df8b23ff43d77b74a4277cc1ebede986fbe4d387cf694ba82e35db0f4578382cfe77c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/es-ES/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/es-ES/firefox-56.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "36519bebb0e79a405610bac938c8a0183ba857fd733b71bb50f82f9fb16883a52818596f9bd776a56798829cf9d4761658d498069bae228ccb123da266459642";
+      sha512 = "9516ec93d60e4b5c6067148d9b9da6b40defba7cd1fe72d4a1b44bd59bc4f0d503dd6a29151aa14404b32d3cd3a95daf05660853ebb3d484845452c852362140";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/es-MX/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/es-MX/firefox-56.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "93d40e3df17392b4268e4efa1cd9c23d3da1f702b0e0a2305a05a31f80af0ed26738dc4eb6a4db60a7f43e7de13662ddbcae8ceaad972aaeae40a21856d9fb42";
+      sha512 = "8d4e0b0f9ad6b3875317e3e7fc0f249b239e1816a4dc335d444433b521460ad16a0374851caee132e58eba3b46005c5a294fb84774ca56084df108d861dbc335";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/et/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/et/firefox-56.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "bbbc7dac5d3a122a9a77790d570a8943bacf4bdf1595e1297d26a23cc99efc88de088aae9533b86d573bd10f81fa741ab765177bbf86f2920232ea3a832509a1";
+      sha512 = "ef60fa3a4c2933dff4fba6d8bf3f8f79faca16768802fccb4e1ce161bad315acd78abc09f998fc516683fd72fe9187b6a523961210d8629a2efa4f1102469322";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/eu/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/eu/firefox-56.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "a36172e47a17109d2790961f3317dc0a23404856224411393d4bc0a238ff3ea8ef9af46098f215beef85c35a20bc7d515e764ed3a5c4a1cf0da31c019788933f";
+      sha512 = "3bf28fe5886583c920da5ba845899674ed06586ac0b36ca353bd40cac4de2ff76d833da55b5d96c45d87e9ae66c33017a20817d4f2761a152750767b6957ae11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/fa/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/fa/firefox-56.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "c735cf60f7726485fd10d7da09bbd75f0ecb47c84f03fd4b2ed75efa32e906867cd5c99945cb4354792bd7a978c48f61fccb7634e931c370db8c28479023354d";
+      sha512 = "c56e142399445b45322a68cef53cecb063a37d24a697509da1333de4817ce1870a18e76745c113b6c3689fae28ec66f60806f478d2e88d2e213e31115558403b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ff/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ff/firefox-56.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "bf54987c9cc48218793e68580fba1f906d9168afa4adaf340c50c21d36859ed01cfc0b0485ba7aa835b1de78afaadee8c137e767589186090308316a4c0aefd8";
+      sha512 = "7f868d56a29ef7d03be1fbce98ae4bf7af96db7f7bc4f1729e7d5f0758bdb2e0d0471c3f46046fd21937dd410bf0ae822dc035ebdd27b1f8df3b92032ac5ffff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/fi/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/fi/firefox-56.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "597cd931f7a639e4e1c0cee220968269a03cb54bf72da2c658803c5ff2707523c6d1cfd9cd301b2b5df7db63f1d6d78b873b709003b67add35108d02a7011596";
+      sha512 = "449a103aedbb4596afc4a8b2ddfba5d9885756c7fa6983c25fb609ff3e280a83af4e28b04279b8f5243b46f366b8808b3e6d43286eeb60415d662ebe487e1c03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/fr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/fr/firefox-56.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "54dd3162f6783703b7ebbff0a15d4d733cee206feb59e131cc974cd431f9a83e8fd703c2ea03149dfd2d06289ca0db18e91a95c53a757b6b04abca506240c1f6";
+      sha512 = "c171d03ca2b067236087978b86c4e69f6253f1b73b34b198607c4f501893d0fe9baddbcdb28ce033fa796982a8a08885cad361dea673dc572594edfa49c906ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/fy-NL/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/fy-NL/firefox-56.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "cb9dd1f14d61068f74d7cb1d5368bdffadedc7f53059a66ea845cc7a0118ad01041b4d1b23f038b388fce9df91f962e2db8dc7ae13d35c472d9a2f19ef7f39b9";
+      sha512 = "8592c501f694fcbc478670f892bc239e0a7ec152ff386d418d8852cd7489b94665f7bbaccce6bb43ecc376525f23417c6ff7899ab1c30d4276d9b4495612f930";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ga-IE/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ga-IE/firefox-56.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "d54a01a07aa3d4c5b66f8fa2653ad06715ebe473756d56e685ccf23596854c1190b871cab8827507b2da0f42b0843d2d696633cdd173a155596ffacf2b8e9a08";
+      sha512 = "5e9b9fc017bda23d0a0336054fd5f8e04abc7fcd4c2bd165d27e01e76053ef19e074b83cb547949212c49c3efbfc2c620b0df3841fe46efcd4e269da4bdeff09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/gd/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/gd/firefox-56.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "bf8e248055b68eb8b04a37aca7711aaeb30401c126e911fd36658ae4fb140bf006f818291fad4dd1d82951ffed74f94d1174420254ef6ea19925276dbe660062";
+      sha512 = "500d0360a5b6310f6616343fbfa4ffc5d6dab8e16f99ce1963d7818d9b4fa99c5d93e6d062b9a27ce6b495c0cb6152bf9bd10c677a4a15c912a563ac20066283";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/gl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/gl/firefox-56.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "527d0febe7c58b7205cfbb21cf2e054bc8f390c28fb6a8e2f317c6bc8d58092b92f9f285dad6da1e01722da5cb198d9cb2f60ec36aef9f03cb87b48674f67b27";
+      sha512 = "8cf6391df871e5d8eba58ffdccb4bcc40f97310b880603fb6633053d5b6332b347bc0819b281fed6c0370c15cab63aa78cad92a0791fc7b694ea327c5d265ca5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/gn/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/gn/firefox-56.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "1599e5a6a242884d9fc13568d4ee48ba925c0d3f9ea6ca4ca1254ed39cd8187813efa86d1f65b8d7aa570f4d35420edf9a6412fe66bac34b748bde4ca9973022";
+      sha512 = "23d7ea2d103190f5b6052d06e92fbd56b410301bd2546d55b56d797e02f2d3591d6d9009b8d9b6527219e0ea118811b01b9b97dc85ce9ee6cfd4952e0d442197";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/gu-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/gu-IN/firefox-56.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "f6f1cc145a65c1ecce6e5e5b3293af37e731a24d1d15fb1c8e8c87d37745f823f8156f934931db0542106365a960cc81000cce8df37c863f6db47a48ce2dc382";
+      sha512 = "14234d0cab5c8e90385616d7d97b9e9107e4681469cf85fb21b8e4dea052d66fdd99b71b2da3e948cff4a5419f2c609c7b92b03883cb8eb86524f84a137d4c10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/he/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/he/firefox-56.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "fa56346e138b1981a125a5815b880ebdc192e9eba2af5348dbbab3cd601c35e61bb22bfaede27647705c7bfbf11fcec5e0773838dfe50e14cefa716d7f843304";
+      sha512 = "d2bd55a5ce635e0355a9639d9f4299b078f30a7a3111df5904c45f7c2751075adf9ae6096fed8e5344d96468f1e3f7eb0a40077609a26636d8071dd2d75cc910";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/hi-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/hi-IN/firefox-56.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "9176dfa4d5207108217fc9df663797bfb97ddccdb43762db85247f42f3d2c6f2ef309f68cd157f9f4972c80546d131d81c5780dd6ed92d267d8567a7d9420aee";
+      sha512 = "634fb324bb4df03e5ecdff8c01ac0cc108b42269652ec76606ba47a5b90d3f9a6ff7cc28c1d1fe0995ab5e36c6124ab10351059f369a0b4e91627aaedb49080c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/hr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/hr/firefox-56.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "0c1b1845e6aff8cd81dac114b2654ecfdf3176b7b9995c839fabb07fa52cf1ab5ed0cd93cafa969e98ce7fdc7883b7d40fa19e688c7b2e0850db69f71e13e146";
+      sha512 = "dfb13315937377347bb8d8804bbbbd1402525739be2b21f01536c04c210d9e4cf6bfb6e1e9a64b4b04bc8001066d0bdbf74873e55cafb2e5008c0e6302c7d967";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/hsb/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/hsb/firefox-56.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "88a6e49f8346f566db7a6807a5999a01ae3b843a2cb16051a7d82b250e8bb7169818ca4fd34893cc8c111ab00d62d7fedba651ba813b3bcdf639e1dc196cac3d";
+      sha512 = "4a5df6642eb981bdc27dc3473dd6e267d605e3ac9df350aa13d82350d2e58be6f0bae314371532922fcc9c8d4086678cb744c2502b38305d99c0c6cb010e8146";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/hu/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/hu/firefox-56.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "0fc08455d35212d8beb1097f7ce7c1ddc5519cc6faa62c9fc6294abe4cc3a020d13d514fb2b4e1b27eebbd351aabda70a1de68bcc3865f85c782bae7a19b0fb8";
+      sha512 = "39d9c881d9ff91cb5458a307d04a21e74ab57d653b08b81303f5a0cf72002b128894e6be4f4d1101df4004f2481fad4c6f63d3fe771d5e7dff31a9428f840522";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/hy-AM/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/hy-AM/firefox-56.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "89c3f56d2f6b4efbdc44e3fcadebbff7ac77b845eaa2f6220e1855f547c6aa14a727a493736f7e913602c6c354f259085bdc66eaa0ba3bdae9ce53a37de991ae";
+      sha512 = "0d4e2486577213e7a390d2f4b2d48b54e693748c19fb01c021e356ccf186db25e976324bb589da5040f394a4c5463f4c6f71c691ffcc900644e9996d01ff7cc3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/id/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/id/firefox-56.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "6ac431518cdaf8e2bbad23f44793b46c87e205513a3df8c092bdc4b25729ed7355779edd2bf154f9d49fae48747518aa12acb6ef55a3206e0f52ffa53dd2aa5e";
+      sha512 = "4c60276f146358a9de2b6c98cd54e0a10c9ae19ca20c2f4e5a6f86b0ca7f9b180604b58e085fda97be9e9457b3f7a1d36ce05ae2010e8a9b5a782679152cc4ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/is/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/is/firefox-56.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "b4fde08b7dfb09bedb2fd9fb7e3a1876dbe07ad2eaf7a706bbcda18728d997dac192f736ebcec4c0f3cf0ca2b49804f49030222ce25612987b73539acd98bbf1";
+      sha512 = "0c0ad6ed37d5ba059cda0fdf8c8cfbbdb3cb671a81c434d76feda7572d5f71ed4e05884d583d6ffc9a168f8176fabcf1de030d19f018a28e24a341bfe6ac5dd6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/it/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/it/firefox-56.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "ab91f86b0f8458e00fad441799056c396600d714316c0a1bf332253ad476c8a00a8b3c5634396fd70d60ff0ba32d6adb1a8ae3b2a01f42d1458b7796b0f09d84";
+      sha512 = "80f9a72be17b90f7e81650246c6338bba58ddfeaf911e1f9b3b81137751b32ff90e2945cf700850a72951c582f2a6b1c2e20b024fc5589d0316f583e1c3040d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ja/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ja/firefox-56.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "0b7e8d83b677ff51e8ab1c335d9befe05f3cee0444b0dce063b99516381697a985e5ce3d3b80b45ef563766166c65e7ff7d503c04240c44798a8a847ff66e05a";
+      sha512 = "f4af35418ef0e77dd7deff58041775097ffdbffd98c0b6b8da5da672535db33caf30648aad020e3be360232105020fbdaa254bbb141166fbc4065446c828a915";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ka/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ka/firefox-56.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "c09b1b11629f242918d231a27a3dba59fc8198c0c0a4c5ac2e648be6caf08c0644e89c9452c47b5ab4690f967a67054c4637cc83db6bf64eb6d9d796d5927cd8";
+      sha512 = "11f32a5b7a6b0e96728154769a71cc47741f7791610c327acf6e3e9929b09dc0d37feffa00d95d220e0fbed6c7daf4cc040bca86e3368523583f3b15affba9f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/kab/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/kab/firefox-56.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "b78db07da52542eb646c484c567f36c3d56b8613c6ee183ab02735a45397e28dc8cf1da3d42bd5ed0326554c93a4e53f85993f27193df05ea383873ca9767252";
+      sha512 = "80ed0a4fa480e89c8925c810bb80f1e43b8f26ed5fef4a8f641081ca59437b6069cca82f27d4437016c1767df00c307d48325a76dccf77d1cb434eecbdb41184";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/kk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/kk/firefox-56.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "dcb8a95db799748531fec235d1c348a5feb04b5a6ae86b93e3adb23b7f1142c4ce12f19c0007b34a9c0a7ecbf8760c476cf99398fb001810fb852c67883cec75";
+      sha512 = "639eac112c2a1471d4178304371996314c4eef6567fb205b586bb3e1eb94f87e30e7b10e81027a620a4def25c5e71412f6ba6fa00414d38843873df80745811b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/km/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/km/firefox-56.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "23565ee1f7f0ba89821efdffae8bf2a615e11d8ff74b56425097ee4cdc6abe2795d81513cb7066165c445cbb44f4f8b0bbc1add77f23b797a372cd9068f8794a";
+      sha512 = "f6c535a31dda743fa54985b5eeb97e3091243434923ebb75ed75ffb62350133f068251a17e1b2172ddc92dd3520e7d29af7276bfdc711760df855e850d6bcb5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/kn/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/kn/firefox-56.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "4646c1431dbcd96f943268a1a80e87ecb94db9c9d71eca80383c26f02ff8e117b22aba03f4d829b0a381ec04e249b2533fb104a2609437bca7f6b78e143a5d41";
+      sha512 = "07b371373494feca79ccba78df2706a9442a6d7ed743e8bdd94619ae1f0c814f66776d4d7f37fdc98a1d157d71a2d22450b5c3d6a39a84a15b63fd9911639f15";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ko/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ko/firefox-56.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "efd5b303fec5ab0be91dc457f383fd9cd14ba7f877d2be5b0133d9a8e7fc03b67cc0ebe9414c4ffa3859fa022656185cb78be955483bd749ffce258197b2ba64";
+      sha512 = "a39ef1b093a707f1e6e1bd7bfd9affe4684b19bfba33a88e81f51040bb7bde29e9c4ed12a7d49c30959f9a0201a5504fbb3e8300cf738767739d93d92553651c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/lij/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/lij/firefox-56.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "611d457dee0be03eace5e51160466748770e82b4d71617f7cd4aa0e48935c73fbe4334a786d1055be869b32c61cc1c189138650062408e66a382dab12bf9afa9";
+      sha512 = "9b4636d1520d94b5955e3f3feeb2aa91463f4e7bfae4cd63e102ff29a6ddbca091e7c27a45b31e14db00b3c2e3b49fff32abd7edbe5cbe6447a4544aadef9f20";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/lt/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/lt/firefox-56.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "c8760630354790f3c4d9964b594f4813d690ff30d62234c748c7c38758e4428873d55f7b54e5ba7f3c6008b0d5d14ff0b3e4de51d564d9c52b056eaf31753bc3";
+      sha512 = "8196df53989aae3ad1ad326ae85b9e24d717e2668b28958e7478a40408aa12dfdebc0df77bee73b7d7bb60ff593d45e650b772b71c17446d38875c2157b61918";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/lv/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/lv/firefox-56.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "6b074f3f4ef5e1c349db0ddb5e9bdb275af226d10768eb40322c14ec8b4c8d0c6f300d89b20911350ed1bbf84d9e7c28d3d4ed74f7f5944a2a60e13460c1eb3c";
+      sha512 = "288f37186f690c21e858cd89c0cffd0dacf1ae8a93b0c3edc9ef9a6438733dbd03f0418c14d9a779723acbbbe4c37a8f587d6ee64375de8d5b1a966df7962b0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/mai/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/mai/firefox-56.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "4e9e84e48187535075a0a424c99c5a7d2b5ef1a30e5b86662e295b8116d64a5448588bb9e262edeaa03138ecad46ccaf388ef9d3b053315b3dc77efd08ab2c9f";
+      sha512 = "5eee203c914db080e4809df94156f2d431f68c9bab5664c854cb66306e566ca6a45c4b6d683e7e543ceddc91d60964959b661d0a2da9b26f9b461a2e099a37f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/mk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/mk/firefox-56.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "adf41bac2ede4a91ffb3f107ecbfd40e945ad1fe23b44cfd0907400c12e526b8181ade5155ffb669a5f9a3c2ce08d06a5feb49d7faddb51494b6c404372ed083";
+      sha512 = "a5ad175c42bf938100b75012732053724edc1940e8ee759e2c248f8c394f5a23f3ec7964ffa282702a6d2eb5831c618457f823490b01c21723e4101b53a29024";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ml/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ml/firefox-56.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "b7d2c89c066cb142ad45098c7580268c4ef6e53588a1cdda100d195047efb33b62ad0ae0c6092810b69799647201526bca3654f3256f82692a678ad357dbd950";
+      sha512 = "dd45c351fc34dfc331c4ef9b475ed119dad87ea97be0d33dcafd013a3dfcc6b3975b4305fb4e3734a54b5378ebb8b354b7e91a4d89673f12c5b13ea4adab3287";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/mr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/mr/firefox-56.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "932431c5cccbccf0bea43ba18e4463721c78a2d0b87bb53f89b2e3ce7d1d98ff0c22af78e1643010f7ad3a1c74c1ecfc302841b522d24000960711aa469835e5";
+      sha512 = "19e6fb31009faed74fde46a969af17090629e5d32963cfc3e041ca0e77fcda09987b96fc109e8a399127794aec531d13a3406309bf84c29c27d8f8f3423de194";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ms/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ms/firefox-56.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "594ea2dcf622aff32d66a8d7336ccfc96abf50429214ae0503c05377c9fc79ba35bad70e05f713b44127e6aba2ef09ae29c7187ec17470645d413b1d1a30924f";
+      sha512 = "f34afc4cdfe9fe3d9c2836bbf0588fb39fa11c5b07a4acaddcd3ae44fb9c427f97b49b5579fe84b71b5f64ac3449fa8da9aff89de7395cf65c55b860d1148109";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/my/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/my/firefox-56.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "f7135ab56d292beeec62f075eb8e2a958adc95af848408b6d051992ca4def002ed6bbebd6f3733577ee9853bee99d346e6e749ef455aac4646bac3de9812c33d";
+      sha512 = "f10f83c008ae871a53598232c6e1a524a21efd9eb669639d16229e340713a6959c0fedd01179c40cb91dccf33af2dc0e21c58ae901aea63d9c334e0a96d9f7a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/nb-NO/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/nb-NO/firefox-56.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "82d1317e251b5c93b8c913a7a0a54b8582ad8a80fa242cf0d4e997f5d09615779a5b1a544a55a68feec2a49144f3a8e13be37a3f32caacfd7ffaae150ab8a4a6";
+      sha512 = "0d09dbc8d16648108560f4a45d93b5ebf0ab008e920d060e5cf031cb3c734ac4e0bc0510daca96f016dd729f759a66b6c0ba856256110a47c015511bb203f732";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/nl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/nl/firefox-56.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "d3ee1e58a46266688aab03a55846bd5cbc9ef96188cbc0c6a723088a71637390d14feb62dc5b1af48659b4bf41466ead9504d8c086eaf1a775d50f30d23982f4";
+      sha512 = "4413018700d0040be812f9082e9502fdb56db522a06df336b9a070189c7ef0938a5d830a9072db3bb5e721d25a9a63d3b5105222ff6a808d3dc6fccb1ef193f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/nn-NO/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/nn-NO/firefox-56.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "0a07cec43e602baa4fba8ba23c76d820c3fb0a7698968d6324d49b3a2cd88541f9c54998a090be173bcb5b31f0de85c0e5700e83cfc91ca9e448a4886503a346";
+      sha512 = "07a6fa48cee70d0cc97b6f6928e70b37be4e9de05e800a95aa1bcb733239129791568a11d75e1e2a647c6e08cb3ecec02979bf75b487ffc54fd11b46fc4d8a3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/or/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/or/firefox-56.0.1.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "5fbc52e53d63561249da9c3c33b28504fe7278bf91b218bb683d9d35fbd20ec94ffbb359e9d8ee2c3afa00f1f9bda0f13b07bcf266ccf1f19f647747b5b40b1b";
+      sha512 = "4dd3449deedca5a13a26e05a6d13a3d4e2e414f9997f4873668daa03d09873e674ea98f79c98c48fbab86c9a3f32820f8e17eb1fc6111e5bc1ce73da5584eaed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/pa-IN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/pa-IN/firefox-56.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "a91a0569b9dd8f5cbbfa66b67f7d737a4cc5cd2178eaee9d5b243230672813caaa17483f10d831c0aba89a2dc97945588a7b06d016aed7c4f6ca5e4ba80cd0c1";
+      sha512 = "b09bcd351a39c9c9cae213f18cd3ec49af8dd7d203a37f0ece99b54d7ad81aa711fc54b1b772502bcc071fa18a0a7f6af8d99b62bdc00437a0ef667d459426b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/pl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/pl/firefox-56.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "fd2dd21020116fc81e91c2ad92827e58803d06ecb63069953f7a6d49321152dbbee83d84aee280f9a2306220986a4e56dca36f0df771e61e950389b0981b6058";
+      sha512 = "910f5f8b9b34b20b4ed86f444c905171d23f459cc4a37f6fc700d5386a22758b51ffd8a9b3f747fe339f4be3a4967318c0bfb6f618c0602e8daf2369b6f95f07";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/pt-BR/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/pt-BR/firefox-56.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "e1eacb5b8da228b881503b0e1e43de40b7dd6808690011fbef6c5b367ec7d9edf1ae7df8d2e65ce6239a00a5b20296739dccc8086fbbd3634ae7153f2704a847";
+      sha512 = "ea5b6fcde8864aad6a3e005e5cd46e9e4c26b6de1b1bca8490e10ed2f7c7bbf44d93105c64c280327485b3537ca1354e8ea2749328a536a06fd0e34b70990ee9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/pt-PT/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/pt-PT/firefox-56.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "240094ce50b49a3537cb5b6e80dd2381309ea7684eacd5b7fa207f097b75728d48041ed0ce7eced5ae6da20ab769d4d8730eef0dacf534d5b1dc701730937503";
+      sha512 = "4bf071edcbd35a2b556d3593a70df66024f871a49abf32812c2e25cf3a9fb466ae87e6a958a5299c54972c68807b8154995eb7bc268bdb8cfffe32cd80f96b88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/rm/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/rm/firefox-56.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "78191dbb18f1cd6ab2425ad6ba38402fe98e20888fea662b3b6c347751de512439bb3cf349ffb2daaba93011cd33a2cecd6e383a45800224ccf9443ca4c2075b";
+      sha512 = "7dfe47e52cc71504cd1f4682bfed645a1fa1b622cf75f07cb650f8c42863cc9b5cb0d4b10c74e1e075c95155df8a52a08ddd4b13da45fc99e4c453a0c46845f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ro/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ro/firefox-56.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "b62b8c628864e176eddf410a402dcb5e39bec295ce97891b054b13727591cdf4ccd2973825e513929808c67a7519cd3aa550040eb359dea18b97bb4f01ea3dd8";
+      sha512 = "25fc42b92545f9219bd4d1502bd05b3ab848b590118fbc9d44dde00cd64e033016aba7eb2918de1d5a80e307b9743cd508567f076bc3de1eec2af966b126f574";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ru/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ru/firefox-56.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "51e61b637de95df9a400416546003fa5105390acd48aa1f8a3511b39fab76c83a6ba3d41cd5b15148837ea2df295dff06ef7baabaf44994130f0be73af4e13d7";
+      sha512 = "fdb9d2c7fd6708231b2b5b617a7d89698d77167a53e21cea7bd0da47b32bdfb5858e8c74c616e7265cac7095652829eb26e73d91c0949c3a11f238637bba56d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/si/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/si/firefox-56.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "3ff9503a991fc935cc7f0afbf69f76b1cb0ad68c21348bb9034c6af6e262fc87f49ffc0025702846b0c85d72b371cd573ad3147fa9dadf04ba846b22033aac62";
+      sha512 = "60663c3a8e66d416015dcb80b01eb991b28f7e0715a24d1fa3f1725bacd7d02360eaec1b7e75257a06cfc8bb9a7a960d654e52a9a128490df5c1821514388d94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/sk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/sk/firefox-56.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "4d574e1381c689f847b1d2be8f8f8e5d31d9e3e7765da00ae44d801716bfad56c1cdf18824bc203b6ca8124e9ab598b938c9082b57482146cbb7dfd6607bdb3c";
+      sha512 = "c0774271d098dc55be6154d2f687b4dc0018b359a4fab9a073818f0333c9a513a4f5934aa33948d40f59f10f79812741206eca43804ef3e1c9bba5a386355db0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/sl/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/sl/firefox-56.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "a960a47cd5349e6c7073052672273c8a889e3d8650453f99ff118313ad692e9a0ae5ff8777ac52fc69a40e24665064d03e4cff4942796d554b75a1e4168f5790";
+      sha512 = "8a87e18213b70b0e25ba89fded209d2d0782f844f492fdf8f0d3beaa35d3c67ed3a537418c14c2e68ee3b20fd829475bfa763ccadad0b4ff06046dd0127927ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/son/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/son/firefox-56.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "c2a18b625ca95c4e4070409bf7a4bf42d0338c6b4c8065938297b4c0834c7018271e8d6001b8fde382719ca313d5ebae9dd811499e84e1ee917c8b3a512f8534";
+      sha512 = "bd84d6da25363521111b7dbe1153cfdc1b17a5eced2ade76a841c60cbe11a00d274b9a556f5320698a1ee846faaad5ceb42bd79e0164e14efadcf31796244bf3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/sq/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/sq/firefox-56.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "588076f33cab37b746ef25362a55c1cd8455a1c4ebf55dcf079b16b19cd7dd77a9c1cd57496117b5c3fb3907b1b047649f4e6f6eb0ed2e0e034ffa291e6f9b91";
+      sha512 = "955f7b8b8bc497325dfdfea24264c6784907f86340cdec78ffa01a79a10bd58154341960f0e6fcdc1504d9b5cd7d44b7b3ef9be348695b47089701a7e1c832b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/sr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/sr/firefox-56.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "995b5a57fdb617f1b8ceecbdd22ee408e4d83b73ed5b2cc49abda0a4de5d6ca0d5bd54346efcbb2d181b5a77d978e4611e7235bf66b3c501dc25785a4afb737b";
+      sha512 = "85562676547412364aa8043b9e4cada72b46e078628686fddab5444c7a8d5fd8d363d0429efa67478d290cc1671b52948095a75566e98993f49c04cda3f20881";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/sv-SE/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/sv-SE/firefox-56.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "050c87742013c5de08d072171a10ff365ac50f2900c65039f3ed699b206a684323bd08c7941027eb6f6f7862ba8bd7011054e83f92fb0a9e9a3f208bd1e4617a";
+      sha512 = "4a7aae7ae216e3db74f2f77bb747e06f69abbda483e2cb59bf7906e23b18b612461e08b5360abadec61ccb5ad39d536453376db35dd130df5d5173807a9ecc06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ta/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ta/firefox-56.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "8ba9e5eceb691c34c067a620167de35a130c3cbf67f0dd5417c27915b507891939d9080c9b7b3616ce939a17c153c8204639b7e3b431d564d43f79783a61b857";
+      sha512 = "510eec52d5d41e3ac7e7759d78e572ce2b7d7235d39e3cd01925dbc43c71f46d6b90493db27a45f6a36a50089173f70a301591b00ade07372ee08a2fcdeba2f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/te/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/te/firefox-56.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "c57380183538fd0a54a98f6fc9a9ad2a37c8a26f7beea65967b18ace44b88d2231a3509e643204322bd2c8111b8e9edd176a0712a32b34e4078c686a3b138bb9";
+      sha512 = "8c0936ccc1a92126573495e5747f6739c0995fb7280e686b31fa62e6c2c7a6527aba36c9ec1043cb5a3244fac368c899b9ac5afa30b0d121fbe97d1a9a41d7ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/th/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/th/firefox-56.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "bb9c8c108ba03016bffbcdc66dd5972df779c55349db431acc289ce2e8d299b930e9f17c8e3eac04b17a50e3e226eb73df91b8de0ee690915de8b3dccd7ddb2d";
+      sha512 = "ca7f55274ff6171f297904d9be0451294cfdf9fef93bccf51f8880e3b69237daa9058de6f8e272b754d85fedbd69144cb1337b653f47029a212fbc938bcca9b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/tr/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/tr/firefox-56.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "2bb15f16c35021a319ea79b653185fc87e81fb55764eda65f78d049dfc876c3b95828fab69bbf7521738cb2107e8cf16c2bae40332d2ce891aefc086ec582b30";
+      sha512 = "b82558a077b562b485984d3864966135d5be8fd27a1b266d59beb4e2f1cc556b40d29133c63f3666eaf22f7eeb174fdf4f16e0e0804ae73a68e57f16f5d900aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/uk/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/uk/firefox-56.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "bcb377c223a8f969b78832ce581dd4f21c4ef08409445faf3409651ec28f66361d8fda763104a6e39590e2e02ced75d7d0554d643e96a33784d471e9f1aba06a";
+      sha512 = "7f291c45f4b5569b3cac12f91538073a1c4e52be473c2e6b9c7974dfddaf85696c78f3b08849d960f1fbbac7d6f750d1e1cfd22993daeca1ebb2cbe3c98b0002";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/ur/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/ur/firefox-56.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "dfe75ccf52fa8a9d96309162e6499074446c609664a2d0971b9a7a0d64ccd4923494975af8d9b1710d7d5093b259d4ec56f43faeca331fbaf2c435f3cd5ed406";
+      sha512 = "733a8362e3abe0b7cd6fa94bec4dec3f317ccb08cece1c495ef712f0764f732878880a3cb5b90c54fa67bbf9531b1e4ceb8cf888e3b505f955252ee7f9e46390";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/uz/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/uz/firefox-56.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "81618bda3809d1c489fdd03be8aeb440a7963464efc381664d6ebeae5d106cc36008977592a16ad629711a00a731f25cd651f789f84260add8f272cb7f6d39e0";
+      sha512 = "d5e35145dc54462297e48fe8f4ef1e743ee9b164c9cf45604f293cd2d1433908ef26b3460d961669472c061a2572c655beee9d9c44ecadb153e1ad5bcc161e97";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/vi/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/vi/firefox-56.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "08d962b2ba18586e8bfc32d55ff800ce86125d59a7bdf6e6cb554b76d069aca86835cbe3985ff23c0462ab9f65758a12a0bcece39ce192d37d2eb2b66db8eaa6";
+      sha512 = "428950b7fb6152de6fe8beb1b1e8f42a5d0d112b20be1a502fed6534441c4fb3fdf2e30b45e71f2d463aa622657ef3784730204af8e853de0847a68332450144";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/xh/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/xh/firefox-56.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "fdf12790a573445cd48c5313579cb3d4016cde9ff8283c5adb63c7e51b6e2b42aa855f331842ecaf62c99c30641ed7b8531e9b2fefa3de1ee03530bafb12ee30";
+      sha512 = "6127dac54537eb2fcc689acb20ce1ecfa8c8ace6f9c62b6f096b2bb4d9c7d47a70fedb9891afc1f5e0ec286ae8d04e677ab833e6fa534a8f8d4a728977624694";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/zh-CN/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/zh-CN/firefox-56.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "e828b745ee8526a2acea5a701982240172050342e0df0efc15dd87dfaea0271d42f7bc06435d4bc4af657f725462de49df8232d985debe15514d19d50b184663";
+      sha512 = "648ba81769c529476ef7a5875a518ce5aeb49466af86b5d07e411adf7abbab4f90134ae994e3009dd62767aee0376973b08247c8222bfc6359e4cff6b8a19918";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0/linux-i686/zh-TW/firefox-56.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/56.0.1/linux-i686/zh-TW/firefox-56.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "c1b058d91c7b8d242238bd8411bfb339e2712b6c550329bd06fac837faf453320310cf0d11597e9ca6d5d9abf084ad761a6701deeb6673547fcd60a094c6452f";
+      sha512 = "230ea83c02b46c856f35ff15c6e9ece08e55b4407dc9e65411e92e1f6a8db15fadc3da44ae8a610b9ab96bf29a052c1d42a8b75d7346d242e8a9135b62e5ab09";
     }
     ];
 }


### PR DESCRIPTION
(cherry picked from commit 916f6583a9f7952230737b7ef29b3e4b05f148f1)

###### Motivation for this change

update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

