### PR TITLE
[RDY] pygccxml + castxml + pybindgen

### DIFF
--- a/pkgs/development/python-modules/pybindgen/default.nix
+++ b/pkgs/development/python-modules/pybindgen/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchPypi, buildPythonPackage, setuptools_scm, pygccxml }:
+buildPythonPackage rec {
+  pname = "PyBindGen";
+  version = "0.18.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1sl4jn8rildv6f62cab66w791cixhaaxl7gwg9labs099rl74yl6";
+  };
+
+  buildInputs = [ setuptools_scm ];
+
+  checkInputs = [ pygccxml ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/gjcarneiro/pybindgen;
+    description = "Python Bindings Generator";
+    license = licenses.lgpl2;
+    maintainers = with maintainers; [ teto ];
+  };
+}
+
+

--- a/pkgs/development/python-modules/pygccxml/default.nix
+++ b/pkgs/development/python-modules/pygccxml/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, castxml, fetchFromGitHub, buildPythonPackage,
+llvmPackages, clang }:
+buildPythonPackage rec {
+  pname = "pygccxml";
+  version = "1.9.1";
+
+  src = fetchFromGitHub {
+    owner  = "gccxml";
+    repo   = "pygccxml";
+    rev    = "v${version}";
+    sha256 = "02ip03s0vmp7czzflbvf7qnybibfrd0rzqbc5zfmq3zmpnck3hvm";
+  };
+
+  buildInputs = [ castxml llvmPackages.libcxxStdenv];
+
+  # running the suite is hard, needs to generate xml_generator.cfg
+  # but the format doesn't accept -isystem directives
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/gccxml/pygccxml;
+    description = "Python package for easy C++ declarations navigation";
+    license = licenses.boost;
+    maintainers = with maintainers; [ teto ];
+  };
+}

--- a/pkgs/development/tools/castxml/default.nix
+++ b/pkgs/development/tools/castxml/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub
+, pythonPackages
+, pkgconfig
+, cmake
+, llvmPackages
+, withMan ? true
+}:
+stdenv.mkDerivation rec {
+
+  name    = "${pname}-${version}";
+  pname   = "CastXML";
+  version = "20180403";
+
+  src = fetchFromGitHub {
+    owner  = "CastXML";
+    repo   = "CastXML";
+    rev    = "c2a44d06d9379718292b696f4e13a2725ff9d95e";
+    sha256 = "1hjh8ihjyp1m2jb5yypp5c45bpbz8k004f4p1cjw4gc7pxhjacdj";
+  };
+
+  buildInputs = [
+    cmake
+    llvmPackages.clang-unwrapped
+    llvmPackages.llvm
+  ] ++ stdenv.lib.optionals withMan [ pythonPackages.sphinx ];
+
+  propagatedbuildInputs = [ llvmPackages.libclang ];
+
+  preConfigure = ''
+    cmakeFlagsArray+=(
+     ${if withMan then "-DSPHINX_MAN=ON" else ""}
+  )'';
+
+  # 97% tests passed, 96 tests failed out of 2866
+  # mostly because it checks command line and nix append -isystem and all
+  doCheck=false;
+  checkPhase = ''
+    # -E exclude 4 tests based on names
+    # see https://github.com/CastXML/CastXML/issues/90
+    ctest -E 'cmd.cc-(gnu|msvc)-((c-src-c)|(src-cxx))-cmd'
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.kitware.com;
+    license = licenses.asl20;
+    description = "Abstract syntax tree XML output tool";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -111,6 +111,8 @@ with pkgs;
 
   buildMaven = callPackage ../build-support/build-maven.nix {};
 
+  castxml = callPackage ../development/tools/castxml { };
+
   cmark = callPackage ../development/libraries/cmark { };
 
   dhallToNix = callPackage ../build-support/dhall-to-nix.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8811,7 +8811,7 @@ in {
   keyutils = callPackage ../development/python-modules/keyutils { };
 
   klein = callPackage ../development/python-modules/klein { };
- 
+
   koji = callPackage ../development/python-modules/koji { };
 
   kombu = buildPythonPackage rec {
@@ -18709,6 +18709,10 @@ EOF
 
     propagatedBuildInputs = with self; [];
   };
+
+  pybindgen = callPackage ../development/python-modules/pybindgen {};
+
+  pygccxml = callPackage ../development/python-modules/pygccxml {};
 
   pymacaroons-pynacl = callPackage ../development/python-modules/pymacaroons-pynacl { };
 


### PR DESCRIPTION
###### Motivation for this change
I use the simulator www.nsnam.org in my work. I need these libraries in order to generate the python bindings castxml + pygccxml. 

Castxml linking stage fails because it can't find -ltinfo. Comments in the repository say it's not available. Not sure what to do. 

###### Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

