### PR TITLE
vagrant: Adds bash-completion to the proper folder.

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -127,8 +127,7 @@ in stdenv.mkDerivation rec {
     wrapProgram "$out/bin/vagrant" --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ libxml2 libxslt ]}" \
                                    --prefix LD_LIBRARY_PATH : "$out/opt/vagrant/embedded/lib"
 
-    mkdir -p "$out/share/bash-completion/completions/"
-    cp "opt/vagrant/embedded/gems/gems/vagrant-$version/contrib/bash/completion.sh" \
+    install -D "opt/vagrant/embedded/gems/gems/vagrant-$version/contrib/bash/completion.sh" \
       "$out/share/bash-completion/completions/vagrant"
   '';
 

--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -126,6 +126,10 @@ in stdenv.mkDerivation rec {
     cp -r usr/bin "$out"
     wrapProgram "$out/bin/vagrant" --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ libxml2 libxslt ]}" \
                                    --prefix LD_LIBRARY_PATH : "$out/opt/vagrant/embedded/lib"
+
+    mkdir -p "$out/share/bash-completion/completions/"
+    cp "opt/vagrant/embedded/gems/gems/vagrant-$version/contrib/bash/completion.sh" \
+      "$out/share/bash-completion/completions/vagrant"
   '';
 
   preFixup = ''


### PR DESCRIPTION
###### Motivation for this change

Tab completion is a time-saver!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
