### PR TITLE
cc-wrapper: disable POSIX compatibility

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -1,5 +1,5 @@
 #! @shell@
-set -eu -o pipefail
+set -eu -o pipefail +o posix
 shopt -s nullglob
 
 if (( "${NIX_DEBUG:-0}" >= 7 )); then

--- a/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
@@ -1,5 +1,5 @@
 #! @shell@
-set -eu -o pipefail
+set -eu -o pipefail +o posix
 shopt -s nullglob
 
 if (( "${NIX_DEBUG:-0}" >= 7 )); then

--- a/pkgs/build-support/cc-wrapper/gnatlink-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnatlink-wrapper.sh
@@ -1,5 +1,5 @@
 #! @shell@
-set -eu -o pipefail
+set -eu -o pipefail +o posix
 shopt -s nullglob
 
 if (( "${NIX_DEBUG:-0}" >= 7 )); then

--- a/pkgs/build-support/cc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-wrapper.sh
@@ -1,5 +1,5 @@
 #! @shell@
-set -eu -o pipefail
+set -eu -o pipefail +o posix
 shopt -s nullglob
 
 if (( "${NIX_DEBUG:-0}" >= 7 )); then


### PR DESCRIPTION
###### Motivation for this change


When `POSIXLY_CORRECT` environment variable is set the script runs in sh compatibility mode, which fails because we use process piping in [utils.sh](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/cc-wrapper/utils.sh#L36). This patch explicitly disables POSIX compatibility mode.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Checked by unsafe editing of script in Nix store and running the compiler on `configure` script which mysteriously failed before.