### PR TITLE
bfd, opcodes: Init separate derivations for binutils libraries

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -205,6 +205,7 @@
   eqyiel = "Ruben Maher <r@rkm.id.au>";
   ericbmerritt = "Eric Merritt <eric@afiniate.com>";
   ericsagnes = "Eric Sagnes <eric.sagnes@gmail.com>";
+  ericson2314 = "John Ericson <John.Ericson@Obsidian.Systems>";
   erictapen = "Justin Humm <justin.humm@posteo.de>";
   erikryb = "Erik Rybakken <erik.rybakken@math.ntnu.no>";
   ertes = "Ertugrul Söylemez <esz@posteo.de>";

--- a/pkgs/development/compilers/llvm/3.4/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.4/llvm.nix
@@ -6,7 +6,7 @@
 , cmake
 , python2
 , libffi
-, binutils
+, libbfd
 , libxml2
 , valgrind
 , ncurses
@@ -67,7 +67,7 @@ in stdenv.mkDerivation rec {
     "-DLLVM_BUILD_TESTS=ON"
     "-DLLVM_ENABLE_FFI=ON"
     "-DLLVM_REQUIRES_RTTI=1"
-    "-DLLVM_BINUTILS_INCDIR=${stdenv.lib.getDev binutils}/include"
+    "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
     "-DCMAKE_CXX_FLAGS=-std=c++11"
   ] ++ stdenv.lib.optional (!stdenv.isDarwin) "-DBUILD_SHARED_LIBS=ON";
 

--- a/pkgs/development/compilers/llvm/3.5/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.5/llvm.nix
@@ -6,7 +6,7 @@
 , cmake
 , python
 , libffi
-, binutils
+, libbfd
 , libxml2
 , valgrind
 , ncurses
@@ -70,7 +70,7 @@ in stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional enableSharedLibraries
     "-DBUILD_SHARED_LIBS=ON"
     ++ stdenv.lib.optional (!isDarwin)
-    "-DLLVM_BINUTILS_INCDIR=${stdenv.lib.getDev binutils}/include"
+    "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
     ++ stdenv.lib.optionals ( isDarwin) [
     "-DCMAKE_CXX_FLAGS=-stdlib=libc++"
     "-DCAN_TARGET_i386=false"

--- a/pkgs/development/compilers/llvm/3.7/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.7/llvm.nix
@@ -6,7 +6,7 @@
 , cmake
 , python2
 , libffi
-, binutils
+, libbfd
 , libxml2
 , valgrind
 , ncurses
@@ -80,7 +80,7 @@ in stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional enableSharedLibraries
     "-DBUILD_SHARED_LIBS=ON"
     ++ stdenv.lib.optional (!isDarwin)
-    "-DLLVM_BINUTILS_INCDIR=${stdenv.lib.getDev binutils}/include"
+    "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
     ++ stdenv.lib.optionals ( isDarwin) [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DCAN_TARGET_i386=false"

--- a/pkgs/development/compilers/llvm/3.8/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.8/llvm.nix
@@ -6,7 +6,7 @@
 , cmake
 , python
 , libffi
-, binutils
+, libbfd
 , libxml2
 , valgrind
 , ncurses
@@ -79,7 +79,7 @@ in stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional enableSharedLibraries [
     "-DLLVM_LINK_LLVM_DYLIB=ON"
   ] ++ stdenv.lib.optional (!isDarwin)
-    "-DLLVM_BINUTILS_INCDIR=${stdenv.lib.getDev binutils}/include"
+    "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
     ++ stdenv.lib.optionals ( isDarwin) [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DCAN_TARGET_i386=false"

--- a/pkgs/development/compilers/llvm/3.9/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.9/llvm.nix
@@ -6,7 +6,7 @@
 , cmake
 , python
 , libffi
-, binutils
+, libbfd
 , libxml2
 , valgrind
 , ncurses
@@ -123,7 +123,7 @@ in stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional enableSharedLibraries [
     "-DLLVM_LINK_LLVM_DYLIB=ON"
   ] ++ stdenv.lib.optional (!isDarwin)
-    "-DLLVM_BINUTILS_INCDIR=${stdenv.lib.getDev binutils}/include"
+    "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
     ++ stdenv.lib.optionals (isDarwin) [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DCAN_TARGET_i386=false"

--- a/pkgs/development/compilers/llvm/4/llvm.nix
+++ b/pkgs/development/compilers/llvm/4/llvm.nix
@@ -6,7 +6,7 @@
 , cmake
 , python
 , libffi
-, binutils
+, libbfd
 , libxml2
 , valgrind
 , ncurses
@@ -107,7 +107,7 @@ in stdenv.mkDerivation rec {
     "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
   ]
   ++ stdenv.lib.optional (!isDarwin)
-    "-DLLVM_BINUTILS_INCDIR=${stdenv.lib.getDev binutils}/include"
+    "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
   ++ stdenv.lib.optionals (isDarwin) [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DCAN_TARGET_i386=false"

--- a/pkgs/development/compilers/llvm/5/llvm.nix
+++ b/pkgs/development/compilers/llvm/5/llvm.nix
@@ -6,7 +6,7 @@
 , cmake
 , python
 , libffi
-, binutils
+, libbfd
 , libxml2
 , valgrind
 , ncurses
@@ -101,7 +101,7 @@ in stdenv.mkDerivation rec {
     "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
   ]
   ++ stdenv.lib.optional (!isDarwin)
-    "-DLLVM_BINUTILS_INCDIR=${stdenv.lib.getDev binutils}/include"
+    "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
   ++ stdenv.lib.optionals (isDarwin) [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DCAN_TARGET_i386=false"

--- a/pkgs/development/compilers/mono/llvm.nix
+++ b/pkgs/development/compilers/mono/llvm.nix
@@ -5,7 +5,7 @@
 , cmake
 , python
 , libffi
-, binutils
+, libbfd
 , libxml2
 , valgrind
 , ncurses
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = with stdenv; [
     "-DLLVM_ENABLE_FFI=ON"
-    "-DLLVM_BINUTILS_INCDIR=${stdenv.lib.getDev binutils}/include"
+    "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
     "-DCMAKE_CXX_FLAGS=-std=c++11"
   ] ++ stdenv.lib.optional (!isDarwin) "-DBUILD_SHARED_LIBS=ON";
 

--- a/pkgs/development/interpreters/lush/default.nix
+++ b/pkgs/development/interpreters/lush/default.nix
@@ -1,5 +1,5 @@
 {stdenv, fetchurl, libX11, xproto, indent, readline, gsl, freeglut, mesa, SDL
-, blas, binutils, intltool, gettext, zlib, libSM}:
+, blas, libbfd, intltool, gettext, zlib, libSM}:
 
 stdenv.mkDerivation rec {
   baseName = "lush";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    libX11 libSM xproto indent readline gsl freeglut mesa SDL blas binutils
+    libX11 libSM xproto indent readline gsl freeglut mesa SDL blas libbfd
     intltool gettext zlib
   ];
 

--- a/pkgs/development/libraries/libbfd/default.nix
+++ b/pkgs/development/libraries/libbfd/default.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, fetchurl, autoreconfHook264, bison, binutils
+, libiberty, zlib
+}:
+
+stdenv.mkDerivation rec {
+  name = "libbfd-${version}";
+  inherit (binutils) version src;
+
+  outputs = [ "out" "dev" ];
+
+  patches = binutils.patches ++ [
+    ../../tools/misc/binutils/build-components-separately.patch
+  ];
+
+  # We just want to build libbfd
+  postPatch = ''
+    cd bfd
+  '';
+
+  nativeBuildInputs = [ autoreconfHook264 bison ];
+  buildInputs = [ libiberty zlib ];
+
+  configurePlatforms = [ "build" "host" ];
+  configureFlags = [
+    "--enable-targets=all" "--enable-64-bit-bfd"
+    "--enable-install-libbfd"
+    "--enable-shared"
+    "--with-system-zlib"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A library for manipulating containers of machine code";
+    longDescription = ''
+      BFD is a library which provides a single interface to read and write
+      object files, executables, archive files, and core files in any format.
+      It is associated with GNU Binutils, and elsewhere often distributed with
+      it.
+    '';
+    homepage = http://www.gnu.org/software/binutils/;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ ericson2314 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/libiberty/default.nix
+++ b/pkgs/development/libraries/libiberty/default.nix
@@ -1,15 +1,18 @@
-{ stdenv, lib, fetchurl, gcc, staticBuild ? false }:
+{ stdenv, fetchurl, gcc, staticBuild ? false }:
 
 stdenv.mkDerivation rec {
   name = "libiberty-${gcc.cc.version}";
 
   inherit (gcc.cc) src;
 
+  outputs = [ "out" "dev" ];
+
   postUnpack = "sourceRoot=\${sourceRoot}/libiberty";
 
-  configureFlags = [ "--enable-install-libiberty" ] ++ lib.optional (!staticBuild) "--enable-shared";
+  configureFlags = [ "--enable-install-libiberty" ]
+    ++ stdenv.lib.optional (!staticBuild) "--enable-shared";
 
-  postInstall = lib.optionalString (!staticBuild) ''
+  postInstall = stdenv.lib.optionalString (!staticBuild) ''
     cp pic/libiberty.a $out/lib*/libiberty.a
   '';
 
@@ -17,7 +20,7 @@ stdenv.mkDerivation rec {
     homepage = http://gcc.gnu.org/;
     license = licenses.lgpl2;
     description = "Collection of subroutines used by various GNU programs";
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = with maintainers; [ abbradar ericson2314 ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libopcodes/default.nix
+++ b/pkgs/development/libraries/libopcodes/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, buildPackages
+, fetchurl, autoreconfHook264, bison, binutils
+, libiberty, libbfd
+}:
+
+stdenv.mkDerivation rec {
+  name = "libopcodes-${version}";
+  inherit (binutils) version src;
+
+  outputs = [ "out" "dev" ];
+
+  patches = binutils.patches ++ [
+    ../../tools/misc/binutils/build-components-separately.patch
+  ];
+
+  # We just want to build libopcodes
+  postPatch = ''
+    cd opcodes
+    find . ../include/opcode -type f -exec sed {} -i -e 's/"bfd.h"/<bfd.h>/' \;
+  '';
+
+  nativeBuildInputs = [ autoreconfHook264 bison buildPackages.stdenv.cc ];
+  buildInputs = [ libiberty ];
+  # dis-asm.h includes bfd.h
+  propagatedBuildInputs = [ libbfd ];
+
+  configurePlatforms = [ "build" "host" ];
+  configureFlags = [
+    "--enable-targets=all" "--enable-64-bit-bfd"
+    "--enable-install-libbfd"
+    "--enable-shared"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A library from binutils for manipulating machine code";
+    homepage = http://www.gnu.org/software/binutils/;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ ericson2314 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/lightning/default.nix
+++ b/pkgs/development/libraries/lightning/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, binutils }:
+{ stdenv, fetchurl, libopcodes }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -11,8 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "19j9nwl88k660045s40cbz5zrl1wpd2mcxnnc8qqnnaj311a58qz";
   };
 
-  # Needs libopcodes.so from binutils for 'make check'
-  buildInputs = [ binutils ];
+  buildInputs = stdenv.lib.optional doCheck libopcodes;
 
   doCheck = true;
 

--- a/pkgs/development/tools/analysis/kcov/default.nix
+++ b/pkgs/development/tools/analysis/kcov/default.nix
@@ -1,4 +1,7 @@
-{stdenv, fetchurl, cmake, pkgconfig, zlib, curl, elfutils, python, libiberty, binutils}:
+{ stdenv
+, fetchurl, cmake, pkgconfig
+, zlib, curl, elfutils, python, libiberty, libopcodes
+}:
 
 stdenv.mkDerivation rec {
   name = "kcov-${version}";
@@ -10,8 +13,9 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = "patchShebangs src/bin-to-c-source.py";
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake zlib curl elfutils python libiberty binutils ];
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [ zlib curl elfutils python libiberty libopcodes ];
 
   meta = with stdenv.lib; {
     description = "Code coverage tester for compiled programs, Python scripts and shell scripts";

--- a/pkgs/development/tools/misc/binutils/build-components-separately.patch
+++ b/pkgs/development/tools/misc/binutils/build-components-separately.patch
@@ -1,0 +1,178 @@
+From bc09a9236f67e710d545ac11bcdac7b55dbcc1a0 Mon Sep 17 00:00:00 2001
+From: John Ericson <John.Ericson@Obsidian.Systems>
+Date: Thu, 12 Oct 2017 11:16:57 -0400
+Subject: [PATCH] Build components separately
+
+---
+ bfd/configure.ac     | 18 +++---------------
+ opcodes/Makefile.am  | 17 +++++++++++++----
+ opcodes/configure.ac | 45 ++++++---------------------------------------
+ 3 files changed, 22 insertions(+), 58 deletions(-)
+
+diff --git a/bfd/configure.ac b/bfd/configure.ac
+index 9a183c1628..8728837384 100644
+--- a/bfd/configure.ac
++++ b/bfd/configure.ac
+@@ -241,31 +241,19 @@ AC_CACHE_CHECK(linker --as-needed support, bfd_cv_ld_as_needed,
+ 
+ LT_LIB_M
+ 
+-# When building a shared libbfd, link against the pic version of libiberty
+-# so that apps that use libbfd won't need libiberty just to satisfy any
+-# libbfd references.
+-# We can't do that if a pic libiberty is unavailable since including non-pic
+-# code would insert text relocations into libbfd.
+ SHARED_LIBADD=
+-SHARED_LDFLAGS=
++SHARED_LDFLAGS=-liberty
+ if test "$enable_shared" = "yes"; then
+-changequote(,)dnl
+-  x=`sed -n -e 's/^[ 	]*PICFLAG[ 	]*=[ 	]*//p' < ../libiberty/Makefile | sed -n '$p'`
+-changequote([,])dnl
+-  if test -n "$x"; then
+-    SHARED_LIBADD="-L`pwd`/../libiberty/pic -liberty"
+-  fi
+-
+ # More hacks to build DLLs on Windows.
+   case "${host}" in
+   *-*-cygwin*)
+     SHARED_LDFLAGS="-no-undefined"
+-    SHARED_LIBADD="-L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lcygwin -lkernel32"
++    SHARED_LIBADD="-liberty -lintl -lcygwin -lkernel32"
+   ;;
+ 
+   # Hack to build or1k-src on OSX
+   or1k*-*-darwin*)
+-    SHARED_LIBADD="-L`pwd`/../libiberty/pic -L`pwd`/../intl -liberty -lintl"
++    SHARED_LIBADD="-liberty -lintl"
+   ;;
+   esac
+ 
+diff --git a/opcodes/Makefile.am b/opcodes/Makefile.am
+index 925e7ff651..47b395c195 100644
+--- a/opcodes/Makefile.am
++++ b/opcodes/Makefile.am
+@@ -52,7 +52,7 @@ libopcodes_la_LDFLAGS += -rpath $(rpath_bfdlibdir)
+ endif
+ 
+ # This is where bfd.h lives.
+-BFD_H = ../bfd/bfd.h
++BFD_H = $(BFDDIR)/bfd.h
+ 
+ BUILD_LIBS = @BUILD_LIBS@
+ BUILD_LIB_DEPS = @BUILD_LIB_DEPS@
+@@ -303,7 +303,7 @@ OFILES = @BFD_MACHINES@
+ # development.sh is used to determine -Werror default.
+ CONFIG_STATUS_DEPENDENCIES = $(BFDDIR)/development.sh
+ 
+-AM_CPPFLAGS = -I. -I$(srcdir) -I../bfd -I$(INCDIR) -I$(BFDDIR) @HDEFINES@ @INCINTL@
++AM_CPPFLAGS = -I. -I$(srcdir) -I$(INCDIR) -I$(BFDDIR) @HDEFINES@ @INCINTL@
+ 
+ disassemble.lo: disassemble.c
+ if am__fastdepCC
+@@ -324,12 +324,21 @@ libopcodes_la_SOURCES =  dis-buf.c disassemble.c dis-init.c
+ # old version of libbfd, or to pick up libbfd for the wrong architecture
+ # if host != build. So for building with shared libraries we use a
+ # hardcoded path to libbfd.so instead of relying on the entries in libbfd.la.
+-libopcodes_la_DEPENDENCIES = $(OFILES) @SHARED_DEPENDENCIES@
++libopcodes_la_DEPENDENCIES = $(OFILES) @SHARED_DEPENDENCIES@ libtool-soversion
+ libopcodes_la_LIBADD = $(OFILES) @SHARED_LIBADD@
+-libopcodes_la_LDFLAGS += -release `cat ../bfd/libtool-soversion` @SHARED_LDFLAGS@
++libopcodes_la_LDFLAGS += -release `cat libtool-soversion` @SHARED_LDFLAGS@
+ # Allow dependency tracking to work on all the source files.
+ EXTRA_libopcodes_la_SOURCES = $(LIBOPCODES_CFILES)
+ 
++libtool-soversion:
++	@echo "creating $@"
++	bfd_soversion="$(VERSION)" ;\
++	. $(BFDDIR)/development.sh ;\
++	if test "$$development" = true ; then \
++	  bfd_soversion="$(VERSION).$${bfd_version_date}" ;\
++	fi ;\
++	echo "$${bfd_soversion}" > $@
++
+ # libtool will build .libs/libopcodes.a.  We create libopcodes.a in
+ # the build directory so that we don't have to convert all the
+ # programs that use libopcodes.a simultaneously.  This is a hack which
+diff --git a/opcodes/configure.ac b/opcodes/configure.ac
+index b9f5eb8a4f..ef2c2152b7 100644
+--- a/opcodes/configure.ac
++++ b/opcodes/configure.ac
+@@ -89,6 +89,7 @@ AC_PROG_INSTALL
+ 
+ AC_CHECK_HEADERS(string.h strings.h stdlib.h limits.h)
+ ACX_HEADER_STRING
++GCC_HEADER_STDINT(bfd_stdint.h)
+ 
+ AC_CHECK_DECLS([basename, stpcpy])
+ 
+@@ -134,61 +135,27 @@ AC_CACHE_CHECK(linker --as-needed support, bfd_cv_ld_as_needed,
+ 
+ LT_LIB_M
+ 
+-#Libs for generator progs
+-if test "x$cross_compiling" = "xno"; then
+-  BUILD_LIBS=../libiberty/libiberty.a
+-  BUILD_LIB_DEPS=$BUILD_LIBS
+-else
+-  # if cross-compiling, assume that the system provides -liberty
+-  # and that the version is compatible with new headers.
+-  BUILD_LIBS=-liberty
+-  BUILD_LIB_DEPS=
+-fi
+-BUILD_LIBS="$BUILD_LIBS $LIBINTL"
+-BUILD_LIB_DEPS="$BUILD_LIB_DEPS $LIBINTL_DEP"
++BUILD_LIBS="-liberty $LIBINTL"
++BUILD_LIB_DEPS="$LIBINTL_DEP"
+ 
+ AC_SUBST(BUILD_LIBS)
+ AC_SUBST(BUILD_LIB_DEPS)
+ 
+ # Horrible hacks to build DLLs on Windows and a shared library elsewhere.
+ SHARED_LDFLAGS=
+-SHARED_LIBADD=
++SHARED_LIBADD=-liberty
+ SHARED_DEPENDENCIES=
+ if test "$enable_shared" = "yes"; then
+-# When building a shared libopcodes, link against the pic version of libiberty
+-# so that apps that use libopcodes won't need libiberty just to satisfy any
+-# libopcodes references.
+-# We can't do that if a pic libiberty is unavailable since including non-pic
+-# code would insert text relocations into libopcodes.
+ # Note that linking against libbfd as we do here, which is itself linked
+ # against libiberty, may not satisfy all the libopcodes libiberty references
+ # since libbfd may not pull in the entirety of libiberty.
+-changequote(,)dnl
+-  x=`sed -n -e 's/^[ 	]*PICFLAG[ 	]*=[ 	]*//p' < ../libiberty/Makefile | sed -n '$p'`
+-changequote([,])dnl
+-  if test -n "$x"; then
+-    SHARED_LIBADD="-L`pwd`/../libiberty/pic -liberty"
+-  fi
+-
+   case "${host}" in
+     *-*-cygwin*)
+       SHARED_LDFLAGS="-no-undefined"
+-      SHARED_LIBADD="-L`pwd`/../bfd -lbfd -L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lcygwin"
++      SHARED_LIBADD="-lbfd -liberty -lintl -lcygwin"
+       ;;
+-   *-*-darwin*)
+-     SHARED_LIBADD="-Wl,`pwd`/../bfd/.libs/libbfd.dylib ${SHARED_LIBADD}"
+-     SHARED_DEPENDENCIES="../bfd/libbfd.la"
+-     ;;
+     *)
+-      case "$host_vendor" in
+-        hp)
+-          SHARED_LIBADD="-Wl,`pwd`/../bfd/.libs/libbfd.sl ${SHARED_LIBADD}"
+-	  ;;
+-	*)
+-          SHARED_LIBADD="-Wl,`pwd`/../bfd/.libs/libbfd.so ${SHARED_LIBADD}"
+-	  ;;
+-      esac
+-      SHARED_DEPENDENCIES="../bfd/libbfd.la"
++      SHARED_LIBADD="-lbfd ${SHARED_LIBADD}"
+       ;;
+   esac
+ 
+-- 
+2.14.2
+

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -50,13 +50,9 @@ stdenv.mkDerivation rec {
     ./no-plugins.patch
   ];
 
-  outputs = [ "out" ]
-    ++ optional (targetPlatform == hostPlatform && !hostPlatform.isDarwin) "lib" # problems in Darwin stdenv
-    ++ [ "info" ]
-    ++ optional (targetPlatform == hostPlatform) "dev";
+  outputs = [ "out" "info" ];
 
-  nativeBuildInputs = [ bison ]
-    ++ optional (hostPlatform != buildPlatform) buildPackages.stdenv.cc;
+  nativeBuildInputs = [ bison buildPackages.stdenv.cc ];
   buildInputs = [ zlib ];
 
   inherit noSysDirs;
@@ -87,11 +83,16 @@ stdenv.mkDerivation rec {
     then []
     else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
-  configureFlags =
-    [ "--enable-shared" "--enable-deterministic-archives" "--disable-werror" ]
-    ++ optional (stdenv.system == "mips64el-linux") "--enable-fix-loongson2f-nop"
-    ++ optionals gold [ "--enable-gold" "--enable-plugins" ]
-    ++ optional (stdenv.system == "i686-linux") "--enable-targets=x86_64-linux-gnu";
+  configureFlags = [
+    "--enable-targets=all" "--enable-64-bit-bfd"
+    "--disable-install-libbfd"
+    "--disable-shared" "--enable-static"
+    "--with-system-zlib"
+
+    "--enable-deterministic-archives"
+    "--disable-werror"
+    "--enable-fix-loongson2f-nop"
+  ] ++ optionals gold [ "--enable-gold" "--enable-plugins" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -110,6 +110,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://www.gnu.org/software/binutils/;
     license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ ericson2314 ];
     platforms = platforms.unix;
 
     /* Give binutils a lower priority than gcc-wrapper to prevent a

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   passthru = {
-    inherit prefix;
+    inherit prefix version;
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -1,18 +1,19 @@
-{ fetchurl, stdenv, ncurses, readline, gmp, mpfr, expat, texinfo, zlib
-, dejagnu, perl, pkgconfig
+{ stdenv
+
+# Build time
+, fetchurl, pkgconfig, perl, texinfo, setupDebugInfoDirs
+
+# Run time
+, ncurses, readline, gmp, mpfr, expat, zlib, dejagnu
 
 , buildPlatform, hostPlatform, targetPlatform
 
 , pythonSupport ? hostPlatform == buildPlatform && !hostPlatform.isCygwin, python ? null
 , guile ? null
 
-# Support all known targets in one gdb binary.
-, multitarget ? false
-
 # Additional dependencies for GNU/Hurd.
 , mig ? null, hurd ? null
 
-, setupDebugInfoDirs
 }:
 
 let
@@ -58,10 +59,16 @@ stdenv.mkDerivation rec {
   configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
   configureFlags = with stdenv.lib; [
-    "--with-gmp=${gmp.dev}" "--with-mpfr=${mpfr.dev}" "--with-system-readline"
-    "--with-system-zlib" "--with-expat" "--with-libexpat-prefix=${expat.dev}"
-  ] ++ stdenv.lib.optional (!pythonSupport) "--without-python"
-    ++ stdenv.lib.optional multitarget "--enable-targets=all";
+    "--enable-targets=all" "--enable-64-bit-bfd"
+    "--disable-install-libbfd"
+    "--disable-shared" "--enable-static"
+    "--with-system-zlib"
+    "--with-system-readline"
+
+    "--with-gmp=${gmp.dev}"
+    "--with-mpfr=${mpfr.dev}"
+    "--with-expat" "--with-libexpat-prefix=${expat.dev}"
+  ] ++ stdenv.lib.optional (!pythonSupport) "--without-python";
 
   postInstall =
     '' # Remove Info files already provided by Binutils and other packages.

--- a/pkgs/development/tools/profiling/EZTrace/default.nix
+++ b/pkgs/development/tools/profiling/EZTrace/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchurl, autoconf, libelf, libiberty, gfortran, zlib, binutils }:
+{ stdenv
+, fetchurl, autoconf, gfortran
+, libelf, libiberty, zlib, libbfd, libopcodes
+, buildPackages
+}:
 
 stdenv.mkDerivation rec {
   version = "1.0.6";
@@ -9,12 +13,15 @@ stdenv.mkDerivation rec {
     sha256 = "06q5y9qmdn1h0wjmy28z6gwswskmph49j7simfqcqwv05gvd9svr";
   };
 
-  # Goes past the rpl_malloc linking failure
+  # Goes past the rpl_malloc linking failure; fixes silent file breakage
   preConfigure = ''
     export ac_cv_func_malloc_0_nonnull=yes
+    substituteInPlace ./configure \
+      --replace "/usr/bin/file" "${buildPackages.file}/bin/file"
   '';
 
-  buildInputs = [ autoconf libelf libiberty gfortran zlib binutils ];
+  nativeBuildInputs = [ autoconf gfortran ];
+  buildInputs = [ libelf libiberty zlib libbfd libopcodes ];
 
   meta = {
     description = "Tool that aims at generating automatically execution trace from HPC programs";

--- a/pkgs/development/tools/profiling/oprofile/default.nix
+++ b/pkgs/development/tools/profiling/oprofile/default.nix
@@ -1,5 +1,8 @@
-{ stdenv, fetchurl, binutils, popt, zlib, pkgconfig, linuxHeaders, coreutils
-, libiberty_static, withGUI ? false , qt4 ? null}:
+{ stdenv, buildPackages
+, fetchurl, pkgconfig
+, libbfd, popt, zlib, linuxHeaders, libiberty_static
+, withGUI ? false, qt4 ? null
+}:
 
 # libX11 is needed because the Qt build stuff automatically adds `-lX11'.
 assert withGUI -> qt4 != null;
@@ -14,12 +17,12 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace opjitconv/opjitconv.c \
-      --replace "/bin/rm" "${coreutils}/bin/rm" \
-      --replace "/bin/cp" "${coreutils}/bin/cp"
+      --replace "/bin/rm" "${buildPackages.coreutils}/bin/rm" \
+      --replace "/bin/cp" "${buildPackages.coreutils}/bin/cp"
   '';
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ binutils zlib popt linuxHeaders libiberty_static ]
+  buildInputs = [ libbfd zlib popt linuxHeaders libiberty_static ]
     ++ stdenv.lib.optionals withGUI [ qt4 ];
 
   configureFlags = [

--- a/pkgs/development/tools/profiling/sysprof/default.nix
+++ b/pkgs/development/tools/profiling/sysprof/default.nix
@@ -1,5 +1,7 @@
-{ fetchurl, stdenv, binutils
-, pkgconfig, gtk2, glib, pango, libglade }:
+{ stdenv
+, fetchurl, pkgconfig
+, gtk2, glib, pango, libglade
+}:
 
 stdenv.mkDerivation rec {
   name = "sysprof-1.2.0";
@@ -10,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ binutils gtk2 glib pango libglade ];
+  buildInputs = [ gtk2 glib pango libglade ];
 
   meta = {
     homepage = http://sysprof.com/;

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -353,7 +353,7 @@ in rec {
       bzip2.bin llvmPackages.llvm llvmPackages.llvm.lib zlib.out zlib.dev libffi.out coreutils ed diffutils gnutar
       gzip ncurses.out ncurses.dev ncurses.man gnused bash gawk
       gnugrep llvmPackages.clang-unwrapped patch pcre.out binutils-raw.out
-      binutils-raw.dev binutils gettext
+      binutils gettext
       cc.expand-response-params
     ]) ++ (with pkgs.darwin; [
       dyld Libsystem CF cctools ICU libiconv locale

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -179,7 +179,6 @@ rec {
         for i in as ld ar ranlib nm strip readelf objdump; do
           cp ${binutils.out}/bin/$i $out/bin
         done
-        cp -d ${binutils.lib}/lib/lib*.so* $out/lib
 
         chmod -R u+w $out
 

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -128,7 +128,6 @@ rec {
         for i in as ld ar ranlib nm strip readelf objdump; do
           cp ${binutils.out}/bin/$i $out/bin
         done
-        cp -d ${binutils.lib}/lib/lib*.so* $out/lib
 
         chmod -R u+w $out
 

--- a/pkgs/tools/filesystems/grive/default.nix
+++ b/pkgs/tools/filesystems/grive/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, cmake, libgcrypt, json_c, curl, expat, boost, binutils }:
+{ stdenv, fetchgit, cmake, libgcrypt, json_c, curl, expat, boost, libiberty }:
 
 stdenv.mkDerivation rec {
   version = "0.3.0";
@@ -10,10 +10,10 @@ stdenv.mkDerivation rec {
     sha256 = "11cqfcjl128nfg1rjvpvr9x1x2ch3kyliw4vi14n51zqp82f9ysb";
   };
 
-  buildInputs = [cmake libgcrypt json_c curl expat stdenv binutils boost];
+  buildInputs = [cmake libgcrypt json_c curl expat stdenv libiberty boost];
 
-  # work around new binutils headers, see
-  # http://stackoverflow.com/questions/11748035/binutils-bfd-h-wants-config-h-now
+  # work around new libiberty headers, see
+  # http://stackoverflow.com/questions/11748035/libiberty-bfd-h-wants-config-h-now
   prePatch = ''
     sed -i '1i#define PACKAGE "grive"\n#define PACKAGE_VERSION "${version}"' \
       libgrive/src/bfd/SymbolInfo.cc

--- a/pkgs/tools/filesystems/grive2/default.nix
+++ b/pkgs/tools/filesystems/grive2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, fetchurl, yajl, cmake, libgcrypt, curl, expat, boost, binutils }:
+{ stdenv, fetchFromGitHub, pkgconfig, fetchurl, yajl, cmake, libgcrypt, curl, expat, boost, libiberty }:
 
 stdenv.mkDerivation rec {
   version = "0.5.0";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkgconfig ];
 
-  buildInputs = [ libgcrypt yajl curl expat stdenv boost binutils ];
+  buildInputs = [ libgcrypt yajl curl expat stdenv boost libiberty ];
 
   meta = with stdenv.lib; {
     description = "A console Google Drive client";

--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchgit, python3Packages, docutils
-, acl, apktool, binutils, bzip2, cbfstool, cdrkit, colord, colordiff, coreutils, cpio, diffutils, dtc
+, acl, apktool, libbfd, bzip2, cbfstool, cdrkit, colord, colordiff, coreutils, cpio, diffutils, dtc
 , e2fsprogs, file, findutils, fontforge-fonttools, fpc, gettext, ghc, ghostscriptX, giflib, gnupg1, gnutar
 , gzip, imagemagick, jdk, libarchive, libcaca, llvm, mono, openssh, pdftk, pgpdump, poppler_utils, sng, sqlite
 , squashfsTools, tcpdump, unoconv, unzip, xxd, xz
@@ -28,7 +28,7 @@ python3Packages.buildPythonApplication rec {
   # Still missing these tools: docx2txt enjarify js-beautify oggDump Rscript
   # Also these libraries: python3-guestfs
   pythonPath = with python3Packages; [ debian libarchive-c python_magic tlsh rpm ] ++ [
-      acl binutils bzip2 cdrkit colordiff coreutils cpio diffutils dtc e2fsprogs file findutils
+      acl libbfd bzip2 cdrkit colordiff coreutils cpio diffutils dtc e2fsprogs file findutils
       fontforge-fonttools gettext gnutar gzip libarchive libcaca pgpdump sng sqlite
       squashfsTools unzip xxd xz
     ] ++ lib.optionals enableBloat [

--- a/pkgs/tools/package-management/rpm/default.nix
+++ b/pkgs/tools/package-management/rpm/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, cpio, zlib, bzip2, file, elfutils, libarchive, nspr, nss, popt, db, xz, python, lua, pkgconfig, binutils, autoreconfHook }:
+{ stdenv
+, pkgconfig, autoreconfHook
+, fetchurl, cpio, zlib, bzip2, file, elfutils, libbfd, libarchive, nspr, nss, popt, db, xz, python, lua
+}:
 
 stdenv.mkDerivation rec {
   name = "rpm-${version}";
@@ -15,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ cpio zlib bzip2 file libarchive nspr nss db xz python lua ];
 
   # rpm/rpmlib.h includes popt.h, and then the pkg-config file mentions these as linkage requirements
-  propagatedBuildInputs = [ popt elfutils nss db bzip2 libarchive binutils ];
+  propagatedBuildInputs = [ popt elfutils nss db bzip2 libarchive libbfd ];
 
   NIX_CFLAGS_COMPILE = "-I${nspr.dev}/include/nspr -I${nss.dev}/include/nss";
 

--- a/pkgs/tools/security/sbsigntool/default.nix
+++ b/pkgs/tools/security/sbsigntool/default.nix
@@ -1,5 +1,7 @@
-{ stdenv, fetchgit, autoconf, automake, utillinux, openssl, libuuid, gnu-efi
-, binutils, pkgconfig, help2man }:
+{ stdenv
+, fetchgit, autoconf, automake, pkgconfig, help2man
+, utillinux, openssl, libuuid, gnu-efi, libbfd
+}:
 
 stdenv.mkDerivation rec {
   name = "sbsigntool-${version}";
@@ -15,8 +17,8 @@ stdenv.mkDerivation rec {
 
   prePatch = "patchShebangs .";
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ autoconf automake utillinux openssl libuuid gnu-efi binutils help2man ];
+  nativeBuildInputs = [ autoconf automake pkgconfig help2man ];
+  buildInputs = [ utillinux openssl libuuid gnu-efi libbfd ];
 
   configurePhase = ''
     substituteInPlace configure.ac --replace "@@NIX_GNUEFI@@" "${gnu-efi}"

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -57,6 +57,7 @@ mapAliases (rec {
   foomatic_filters = foomatic-filters;  # 2016-08
   fuse_exfat = exfat;                   # 2015-09-11
   gettextWithExpat = gettext; # 2016-02-19
+  gdb-multitarget = gdb; # added 2017-11-13
   git-hub = gitAndTools.git-hub; # added 2016-04-29
   googleAuthenticator = google-authenticator; # added 2016-10-16
   grantlee5 = libsForQt5.grantlee;  # added 2015-12-19

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7680,8 +7680,6 @@ with pkgs;
     inherit (gnu) mig;
   };
 
-  gdb-multitarget = lowPrio (gdb.override { multitarget = true; });
-
   valgrind = callPackage ../development/tools/analysis/valgrind {
     inherit (darwin) xnu bootstrap_cmds cctools;
     llvm = llvm_39;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -77,6 +77,10 @@ with pkgs;
     { deps = [ autoconf automake gettext libtool ]; }
     ../build-support/setup-hooks/autoreconf.sh;
 
+  autoreconfHook264 = makeSetupHook
+    { deps = [ autoconf264 automake111x gettext libtool ]; }
+    ../build-support/setup-hooks/autoreconf.sh;
+
   ensureNewerSourcesHook = { year }: makeSetupHook {}
     (writeScript "ensure-newer-sources-hook.sh" ''
       postUnpackHooks+=(_ensureNewerSources)
@@ -7832,6 +7836,10 @@ with pkgs;
   };
 
   belle-sip = callPackage ../development/libraries/belle-sip { };
+
+  libbfd = callPackage ../development/libraries/libbfd { };
+
+  libopcodes = callPackage ../development/libraries/libopcodes { };
 
   bobcat = callPackage ../development/libraries/bobcat { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15226,7 +15226,7 @@ in {
     preConfigure = ''
       substituteInPlace setup.py \
         --replace '"/usr/include"' '"${pkgs.gdb}/include"' \
-        --replace '"/usr/lib"' '"${pkgs.binutils.lib}/lib"'
+        --replace '"/usr/lib"' '"${pkgs.libbfd}/lib"'
     '';
 
     meta = {


### PR DESCRIPTION
###### Motivation for this change

This is intended to be reviewed commit by commit.

On most distros, these are just built and distributed as part of binutils. We don't use binutils across the board, however, but rather switch between binutils and a cctools-binutils mashup, and change the
outputs on binutils too. This creates a combinatorial conditional soup which is hard to maintain.

My hope is to lower the the state space. While my patch isn't the most maintainable, they make downstream packages become more maintainable to compensate. The additional derivations themselves are completely platform-agnostic, always they always supports all possible target
platforms, and always yield "out" and "dev" outputs. That, in turn, allows downstream packages to not worry about a dependency shape-shifting under them.

In fact, the actual binutils package can avoid needing multiple outputs now that these serve the requisite libraries, so that also can become simpler on all platforms, too, removing the original wart this PR circumnavigates for now. Actually changing the binutils package to leverage is a mass rebuild, however, so I'll leave that for a separate PR.

I do hope to upstream something like my patch too, but until then I'll make myself maintainer of these derivations.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built stdenv on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @bgamari @orivej
