### PR TITLE
nixos/compton: default to xrender backend

### DIFF
--- a/nixos/modules/services/x11/compton.nix
+++ b/nixos/modules/services/x11/compton.nix
@@ -7,12 +7,15 @@ let
 
   cfg = config.services.compton;
 
-  configFile = let
-    opacityRules = optionalString (length cfg.opacityRules != 0)
-      (concatStringsSep "\n"
-        (map (a: "opacity-rule = [ \"${a}\" ];") cfg.opacityRules)
-      );
-  in pkgs.writeText "compton.conf"
+  floatBetween = a: b: with lib; with types;
+    addCheck str (x: versionAtLeast x a && versionOlder x b);
+
+  pairOf = x: with types; addCheck (listOf x) (y: lib.length y == 2);
+
+  opacityRules = optionalString (length cfg.opacityRules != 0)
+    (concatMapStringsSep ",\n" (rule: ''"${rule}"'') cfg.opacityRules);
+
+  configFile = pkgs.writeText "compton.conf"
     (optionalString cfg.fade ''
       # fading
       fading = true;
@@ -36,7 +39,9 @@ let
       inactive-opacity = ${cfg.inactiveOpacity};
       menu-opacity     = ${cfg.menuOpacity};
 
-      ${opacityRules}
+      opacity-rule = [
+        ${opacityRules}
+      ];
 
       # other options
       backend = ${toJSON cfg.backend};
@@ -64,7 +69,7 @@ in {
     };
 
     fadeDelta = mkOption {
-      type = types.int;
+      type = types.addCheck types.int (x: x > 0);
       default = 10;
       example = 5;
       description = ''
@@ -73,11 +78,12 @@ in {
     };
 
     fadeSteps = mkOption {
-      type = types.listOf types.str;
+      type = pairOf (floatBetween "0.01" "1.01");
       default = [ "0.028" "0.03" ];
       example = [ "0.04" "0.04" ];
       description = ''
         Opacity change between fade steps (in and out).
+        (numbers in range 0.01 - 1.0)
       '';
     };
 
@@ -104,7 +110,7 @@ in {
     };
 
     shadowOffsets = mkOption {
-      type = types.listOf types.int;
+      type = pairOf types.int;
       default = [ (-15) (-15) ];
       example = [ (-10) (-15) ];
       description = ''
@@ -113,11 +119,11 @@ in {
     };
 
     shadowOpacity = mkOption {
-      type = types.str;
+      type = floatBetween "0.0" "1.01";
       default = "0.75";
       example = "0.8";
       description = ''
-        Window shadows opacity (number in range 0 - 1).
+        Window shadows opacity (number in range 0.0 - 1.0).
       '';
     };
 
@@ -136,42 +142,46 @@ in {
     };
 
     activeOpacity = mkOption {
-      type = types.str;
+      type = floatBetween "0.0" "1.01";
       default = "1.0";
       example = "0.8";
       description = ''
-        Opacity of active windows.
+        Opacity of active windows (number in range 0.0 - 1.0).
       '';
     };
 
     inactiveOpacity = mkOption {
-      type = types.str;
+      type = floatBetween "0.1" "1.01";
       default = "1.0";
       example = "0.8";
       description = ''
-        Opacity of inactive windows.
+        Opacity of inactive windows (number in range 0.1 - 1.0).
       '';
     };
 
     menuOpacity = mkOption {
-      type = types.str;
+      type = floatBetween "0.0" "1.01";
       default = "1.0";
       example = "0.8";
       description = ''
-        Opacity of dropdown and popup menu.
+        Opacity of dropdown and popup menu (number in range 0.0 - 1.0).
       '';
     };
 
     opacityRules = mkOption {
       type = types.listOf types.str;
       default = [];
+      example = [
+        "95:class_g = 'URxvt' && !_NET_WM_STATE@:32a"
+        "0:_NET_WM_STATE@:32a *= '_NET_WM_STATE_HIDDEN'"
+      ];
       description = ''
-        Opacity rules to be handled by compton.
+        Rules that control the opacity of windows, in format PERCENT:PATTERN.
       '';
     };
 
     backend = mkOption {
-      type = types.str;
+      type = types.enum [ "glx" "xrender" ];
       default = "glx";
       description = ''
         Backend to use: <literal>glx</literal> or <literal>xrender</literal>.
@@ -179,17 +189,20 @@ in {
     };
 
     vSync = mkOption {
-     type = types.str;
-     default = "none";
-     example = "opengl-swc";
-     description = ''
-       Enable vertical synchronization using the specified method.
-       See <literal>compton(1)</literal> man page available methods.
-     '';
+      type = types.enum [
+        "none" "drm" "opengl"
+        "opengl-oml" "opengl-swc" "opengl-mswc"
+      ];
+      default = "none";
+      example = "opengl-swc";
+      description = ''
+        Enable vertical synchronization using the specified method.
+        See <literal>compton(1)</literal> man page an explanation.
+      '';
     };
 
     refreshRate = mkOption {
-      type = types.int;
+      type = types.addCheck types.int (x: x >= 0);
       default = 0;
       example = 60;
       description = ''

--- a/nixos/modules/services/x11/compton.nix
+++ b/nixos/modules/services/x11/compton.nix
@@ -182,7 +182,7 @@ in {
 
     backend = mkOption {
       type = types.enum [ "glx" "xrender" ];
-      default = "glx";
+      default = "xrender";
       description = ''
         Backend to use: <literal>glx</literal> or <literal>xrender</literal>.
       '';


### PR DESCRIPTION
###### Motivation for this change
Currently the compton backend defaults to `glx`. A user reported me that this can cause weird glitches on some graphic cards. Moreover both the man page and the Compton documentation says `xrender` is the default backend and this can be confusing.

I set the backend back to `xrender` and also improved the checks on numeric values.

###### Things done

- [x] Tested using a NixOS virtual machine
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

