### PR TITLE
cntk: init at 2.2

### DIFF
--- a/pkgs/applications/science/math/cntk/default.nix
+++ b/pkgs/applications/science/math/cntk/default.nix
@@ -1,0 +1,98 @@
+{ lib, stdenv, fetchgit, fetchFromGitHub, fetchpatch, cmake
+, openblas, opencv3, libzip, boost, protobuf, openmpi
+, onebitSGDSupport ? false
+, cudaSupport ? false, cudatoolkit, nvidia_x11
+, cudnnSupport ? false, cudnn
+}:
+
+assert cudnnSupport -> cudaSupport;
+
+let
+  # Old specific version required for CNTK.
+  cub = fetchFromGitHub {
+    owner = "NVlabs";
+    repo = "cub";
+    rev = "1.4.1";
+    sha256 = "1lcdwblz03c0yq1lxndg566kg14b5qm14x5qixjbmz6wq85kgmqc";
+  };
+
+in stdenv.mkDerivation rec {
+  name = "CNTK-${version}";
+  version = "2.2";
+
+  # Submodules
+  src = fetchgit {
+    url = "https://github.com/Microsoft/CNTK";
+    rev = "v${version}";
+    sha256 = "0q4knrwiyphb2fbqf9jzqvkz2jzj6jmbmang3lavdvsh7z0n8zz9";
+  };
+
+  patches = [
+    # Fix "'exp' was not declared"
+    (fetchpatch {
+      url = "https://github.com/imriss/CNTK/commit/ef1cca6df95cc507deb8471df2c0dd8cbfeef23b.patch";
+      sha256 = "0z7xyrxwric0c4h7rfs05f544mcq6d10wgs0vvfcyd2pcf410hy7";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ openblas opencv3 libzip boost protobuf openmpi ]
+             ++ lib.optional cudaSupport cudatoolkit
+             ++ lib.optional cudnnSupport cudnn;
+
+  configureFlags = [
+    "--with-opencv=${opencv3}"
+    "--with-libzip=${libzip.dev}"
+    "--with-openblas=${openblas}"
+    "--with-boost=${boost.dev}"
+    "--with-protobuf=${protobuf}"
+    "--with-mpi=${openmpi}"
+  ] ++ lib.optionals cudaSupport [
+    "--cuda=yes"
+    "--with-cuda=${cudatoolkit}"
+    "--with-gdk-include=${cudatoolkit}/include"
+    "--with-gdk-nvml-lib=${nvidia_x11}/lib"
+    "--with-cub=${cub}"
+  ] ++ lib.optional onebitSGDSupport "--1bitsgd=yes";
+
+  configurePhase = ''
+    sed -i \
+      -e 's,^GIT_STATUS=.*,GIT_STATUS=,' \
+      -e 's,^GIT_COMMIT=.*,GIT_COMMIT=v${version},' \
+      -e 's,^GIT_BRANCH=.*,GIT_BRANCH=v${version},' \
+      -e 's,^BUILDER=.*,BUILDER=nixbld,' \
+      -e 's,^BUILDMACHINE=.*,BUILDMACHINE=machine,' \
+      -e 's,^BUILDPATH=.*,BUILDPATH=/homeless-shelter,' \
+      -e '/git does not exist/d' \
+      Tools/generate_build_info
+
+    patchShebangs .
+    mkdir build
+    cd build
+    ${lib.optionalString cudnnSupport ''
+      mkdir cuda
+      ln -s ${cudnn}/include cuda
+      export configureFlags="$configureFlags --with-cudnn=$PWD"
+    ''}
+    ../configure $configureFlags
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    # Moving to make patchelf remove references later.
+    mv lib $out
+    cp bin/cntk $out/bin
+  '';
+
+  hardeningDisable = [ "format" ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/Microsoft/CNTK";
+    description = "An open source deep-learning toolkit";
+    license = if onebitSGDSupport then licenses.unfreeRedistributable else licenses.mit;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18744,6 +18744,14 @@ with pkgs;
     cudnnSupport = cudaSupport;
   };
 
+  cntk = callPackage ../applications/science/math/cntk rec {
+    cudaSupport = pkgs.config.cudaSupport or false;
+    cudnnSupport = cudaSupport;
+    inherit (linuxPackages) nvidia_x11;
+    cudatoolkit = cudatoolkit8;
+    cudnn = cudnn6_cudatoolkit8;
+  };
+
   ecm = callPackage ../applications/science/math/ecm { };
 
   eukleides = callPackage ../applications/science/math/eukleides {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2578,6 +2578,27 @@ in {
     };
   };
 
+  cntk = buildPythonPackage rec {
+    inherit (pkgs.cntk) name version src meta;
+
+    buildInputs = [ pkgs.cntk pkgs.swig pkgs.openmpi ];
+    propagatedBuildInputs = with self; [ numpy scipy enum34 protobuf pip ];
+
+    CNTK_LIB_PATH = "${pkgs.cntk}/lib";
+    CNTK_COMPONENT_VERSION = pkgs.cntk.version;
+
+    postPatch = ''
+      cd bindings/python
+    '';
+
+    postInstall = ''
+      rm -rf $out/${python.sitePackages}/cntk/libs
+      ln -s ${pkgs.cntk}/lib $out/${python.sitePackages}/cntk/libs
+      # It's not installed for some reason.
+      cp cntk/cntk_py.py $out/${python.sitePackages}/cntk
+    '';
+  };
+
   celery = buildPythonPackage rec {
     name = "celery-${version}";
     version = "4.0.2";


### PR DESCRIPTION
###### Motivation for this change

(Do not merge before https://github.com/NixOS/nixpkgs/pull/30433! Needs CUDA patches from there to work correctly)

A deep learning toolkit, with support in Keras.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested by running an experiment in Keras with CUDA.