### PR TITLE
Always enable OpenSSL plugin for StrongSwan.

### DIFF
--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
   configureFlags =
     [ "--enable-swanctl" "--enable-cmd" "--enable-systemd"
       "--enable-farp" "--enable-dhcp"
+      "--enable-openssl"
       "--enable-eap-sim" "--enable-eap-sim-file" "--enable-eap-simaka-pseudonym"
       "--enable-eap-simaka-reauth" "--enable-eap-identity" "--enable-eap-md5"
       "--enable-eap-gtc" "--enable-eap-aka" "--enable-eap-aka-3gpp2"
@@ -55,7 +56,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional (stdenv.system == "i686-linux") "--enable-padlock"
     ++ stdenv.lib.optionals enableTNC [
          "--disable-gmp" "--disable-aes" "--disable-md5" "--disable-sha1" "--disable-sha2" "--disable-fips-prf"
-         "--enable-curl" "--enable-openssl"
+         "--enable-curl"
          "--enable-eap-tnc" "--enable-eap-ttls" "--enable-eap-dynamic" "--enable-tnccs-20"
          "--enable-tnc-imc" "--enable-imc-os" "--enable-imc-attestation"
          "--enable-tnc-imv" "--enable-imv-attestation"


### PR DESCRIPTION
The NIST elliptic curve groups (ecp192 etc.) are only available if the OpenSSL plugin is enabled, and these groups are currently the only EC groups supported on iOS and macOS devices, so it's likely that many StrongSwan users will want these curves to be enabled by default.

See https://wiki.strongswan.org/projects/strongswan/wiki/IKEv2CipherSuites

Currently the OpenSSL plugin is only enabled if `enableTNC` is `true`, but that option pulls in a bunch of other stuff, as well.
