### PR TITLE
proot: static by default, bump to 2017-10-15

### DIFF
--- a/pkgs/tools/system/proot/default.nix
+++ b/pkgs/tools/system/proot/default.nix
@@ -2,13 +2,12 @@
 , talloc, docutils
 , enableStatic ? true }:
 
-stdenv.mkDerivation rec {
+({ version, rev, sha256, patches }: stdenv.mkDerivation {
   name = "proot-${version}";
-  version = "5.1.0";
+  inherit version;
 
   src = fetchFromGitHub {
-    sha256 = "0azsqis99gxldmbcg43girch85ysg4hwzf0h1b44bmapnsm89fbz";
-    rev = "v${version}";
+    inherit rev sha256;
     repo = "proot";
     owner = "cedric-vincent";
   };
@@ -18,12 +17,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  patches = [
-    (fetchpatch { # debian patch for aarch64 build
-      sha256 = "18milpzjkbfy5ab789ia3m4pyjyr9mfzbw6kbjhkj4vx9jc39svv";
-      url = "https://sources.debian.net/data/main/p/proot/5.1.0-1.2/debian/patches/arm64.patch";
-    })
-  ];
+  inherit patches;
 
   preBuild = stdenv.lib.optionalString enableStatic ''
     export LDFLAGS="-static"
@@ -48,4 +42,20 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [ ianwookim nckx makefu ];
   };
-}
+})
+(if stdenv.isAarch64 then rec {
+  version = "5.1.0";
+  sha256 = "0azsqis99gxldmbcg43girch85ysg4hwzf0h1b44bmapnsm89fbz";
+  rev = "v${version}";
+  patches = [
+    (fetchpatch { # debian patch for aarch64 build
+      sha256 = "18milpzjkbfy5ab789ia3m4pyjyr9mfzbw6kbjhkj4vx9jc39svv";
+      url = "https://sources.debian.net/data/main/p/proot/5.1.0-1.2/debian/patches/arm64.patch";
+    })
+  ];
+} else {
+  version = "5.1.0.20171015";
+  sha256 = "0jam87msh5jx8vpb19n6xwxw1xlig5amdcqif7gn2rc8nhswpxif";
+  rev = "0bf2ee17daafeeadfed079cec97fe1ac781e696a";
+  patches = [];
+})

--- a/pkgs/tools/system/proot/default.nix
+++ b/pkgs/tools/system/proot/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, fetchpatch
 , talloc, docutils
-, enableStatic ? false }:
+, enableStatic ? true }:
 
 stdenv.mkDerivation rec {
   name = "proot-${version}";


### PR DESCRIPTION
###### Motivation for this change

There is no reason not to have it statically linked by default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

