### PR TITLE
Many packages used in computer animation industry

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -248,6 +248,7 @@
   grburst = "Julius Elias <grburst@openmailbox.org>";
   gridaphobe = "Eric Seidel <eric@seidel.io>";
   guibert = "David Guibert <david.guibert@gmail.com>";
+  guibou = "Guillaume Bouchard <guillaum.bouchard@gmail.com>";
   guillaumekoenig = "Guillaume Koenig <guillaume.edward.koenig@gmail.com>";
   guyonvarch = "Joris Guyonvarch <joris@guyonvarch.me>";
   hakuch = "Jesse Haber-Kucharsky <hakuch@gmail.com>";

--- a/pkgs/development/libraries/alembic/default.nix
+++ b/pkgs/development/libraries/alembic/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, unzip, cmake, openexr, hdf5 }:
+
+stdenv.mkDerivation rec
+{
+  name = "alembic-${version}";
+  version = "1.7.4";
+
+  src = fetchFromGitHub {
+    owner = "alembic";
+    repo = "alembic";
+    rev = "${version}";
+    sha256 = "00r6d8xk2sq5hdl5lp14nhyh1b2d68fxpzbm69fk6iq2f2gv0iqv";
+  };
+
+  outputs = [ "bin" "dev" "out" "lib" ];
+
+  buildInputs = [ unzip cmake openexr hdf5 ];
+
+  sourceRoot = "${name}-src";
+
+  enableParallelBuilding = true;
+
+  buildPhase = ''
+    cmake -DUSE_HDF5=ON -DCMAKE_INSTALL_PREFIX=$out/ -DUSE_TESTS=OFF .
+
+    mkdir $out
+    mkdir -p $bin/bin
+    mkdir -p $dev/include
+    mkdir -p $lib/lib
+  '';
+
+  installPhase = ''
+    make install
+
+    mv $out/bin $bin/
+    mv $out/lib $lib/
+    mv $out/include $dev/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An open framework for storing and sharing scene data";
+    homepage = "http://alembic.io/";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = [ maintainers.guibou ];
+  };
+}

--- a/pkgs/development/libraries/openexrid-unstable/default.nix
+++ b/pkgs/development/libraries/openexrid-unstable/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub, unzip, re2, openfx, zlib, ilmbase, mesa, openexr }:
+
+stdenv.mkDerivation rec
+{
+  name = "openexrid-unstable-${version}";
+  version = "2017-09-17";
+
+  src = fetchFromGitHub {
+    owner = "MercenariesEngineering";
+    repo = "openexrid";
+    rev = "bec0081548a096f9bcdd1504970c96264b0fc050";
+    sha256 = "0h4b74lv59p4hhrvrqdmlnchn2i0v5id4kl8xc7j26l9884q0383";
+  };
+
+  outputs = [ "dev" "out" "lib" ];
+
+  patches = [ ./openexrid.patch ];
+
+  NIX_CFLAGS_COMPILE=''-I${ilmbase.dev}/include/OpenEXR
+                       -I${openexr.dev}/include/OpenEXR
+                       -I${openfx.dev}/include/OpenFX
+                      '';
+
+  buildInputs = [ unzip re2 openfx zlib ilmbase mesa openexr ];
+
+  enableParallelBuilding = true;
+
+  buildPhase = ''
+      mkdir openexrid/release
+
+      PREFIX=$out make -C openexrid install
+
+      mkdir $dev;
+      mkdir $lib;
+  '';
+
+  installPhase = ''
+      find $out
+      mv $out/include $dev/
+      mv $out/lib $lib/
+      '';
+
+  meta = with stdenv.lib; {
+    description = "OpenEXR files able to isolate any object of a CG image with a perfect antialiazing";
+    homepage = "https://github.com/MercenariesEngineering/openexrid";
+    maintainers = [ maintainers.guibou ];
+    platforms = platforms.all;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/libraries/openexrid-unstable/openexrid.patch
+++ b/pkgs/development/libraries/openexrid-unstable/openexrid.patch
@@ -1,0 +1,35 @@
+diff --git a/makefile b/makefile
+index 7a92771..31ef664 100644
+--- a/makefile
++++ b/makefile
+@@ -8,8 +8,8 @@ _openexrid:
+ _openfx:
+ 	make -C openfx
+ 
+-_test: _openexrid
+-	make -C test
++#_test: _openexrid
++#	make -C test
+ 
+ clean:
+ 	make -C openfx clean
+diff --git a/makefile.config b/makefile.config
+index 0c6cdfa..0166c4c 100644
+--- a/makefile.config
++++ b/makefile.config
+@@ -4,7 +4,7 @@
+ 
+ PREFIX ?= ~/openexrid
+ 
+-OFX_INCLUDE ?= /usr/include/openfx
++OFX_INCLUDE ?= /usr/include/OpenFX
+ EXR_INCLUDE ?= /usr/include/OpenEXR
+ EXR_LIB ?= /usr/lib
+ RE2_INCLUDE ?= /usr/include
+@@ -13,5 +13,5 @@ RE2_LIB ?= /usr/lib
+ VERSION ?= release
+ CPPFLAGS += -O3 -Wall -DNDEBUG -fPIC -I $(EXR_INCLUDE) -I $(OFX_INCLUDE) -I $(RE2_INCLUDE) -Dlinux
+ LDFLAGS += -L$(EXR_LIB) -L$(RE2_LIB) -L../openexrid/$(VERSION) -lpthread
+-LDFLAGS += -Wl,-Bstatic -lopenexrid -lIlmImf -lIlmThread -lIex -lImath -lHalf -lz -lre2 -Wl,-Bdynamic
++LDFLAGS += -lopenexrid -lIlmImf -lIlmThread -lIex -lImath -lHalf -lz -lre2 -Wl,-Bdynamic
+ 

--- a/pkgs/development/libraries/openfx/default.nix
+++ b/pkgs/development/libraries/openfx/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, unzip }:
+
+stdenv.mkDerivation rec
+{
+  name = "openfx-${version}";
+  version = "1.4";
+
+  src = fetchFromGitHub {
+    owner = "ofxa";
+    repo = "openfx";
+    rev = "OFX_Release_1_4_TAG";
+    sha256 = "0k9ggzr6bisn77mipjfvawg3mv4bz50b63v8f7w1jhldi1sfy548";
+  };
+
+  buildInputs = [ unzip ];
+
+  outputs = [ "dev" "out" ];
+
+  enableParallelBuilding = true;
+
+  buildPhase = ''
+      mkdir $dev
+      mkdir $out
+      '';
+
+  installPhase = ''
+     mkdir -p $dev/include/OpenFX/
+     cp -r include/* $dev/include/OpenFX/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Image processing plug-in standard";
+    homepage = "http://openeffects.org/";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = [ maintainers.guibou ];
+  };
+}

--- a/pkgs/development/libraries/openvdb/default.nix
+++ b/pkgs/development/libraries/openvdb/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, unzip, openexr, boost, jemalloc, c-blosc, ilmbase, tbb }:
+
+stdenv.mkDerivation rec
+{
+  name = "openvdb-${version}";
+  version = "4.0.2";
+
+  src = fetchFromGitHub {
+    owner = "dreamworksanimation";
+    repo = "openvdb";
+    rev = "v${version}";
+    sha256 = "0kqlsfa9rdpxpw7v61vfknvs11axh196ilqk6bnyyfkslmmcak45";
+  };
+
+  outputs = [ "out" ];
+
+  buildInputs = [ unzip openexr boost tbb jemalloc c-blosc ilmbase ];
+
+  sourceRoot = "openvdb-v${version}-src/openvdb";
+
+  installTargets = "install_lib";
+
+  enableParallelBuilding = true;
+
+  buildFlags = ''lib
+    DESTDIR=$(out)
+    HALF_LIB=-lHalf
+    TBB_LIB=-ltbb
+    BLOSC_LIB=-lblosc
+    LOG4CPLUS_LIB=
+    BLOSC_INCLUDE_DIR=${c-blosc}/include/
+    BLOSC_LIB_DIR=${c-blosc}/lib/
+    '';
+
+  installFlags = ''DESTDIR=$(out)'';
+
+  NIX_CFLAGS_COMPILE="-I${openexr.dev}/include/OpenEXR -I${ilmbase.dev}/include/OpenEXR/";
+  NIX_LDFLAGS="-lboost_iostreams";
+
+  meta = with stdenv.lib; {
+    description = "An open framework for voxel";
+    homepage = "http://www.openvdb.org";
+    maintainers = [ maintainers.guibou ];
+    platforms = platforms.all;
+    license = licenses.mpl20;
+  };
+}

--- a/pkgs/development/libraries/partio/default.nix
+++ b/pkgs/development/libraries/partio/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchFromGitHub, unzip, cmake, freeglut, mesa, zlib, swig, python, doxygen, xorg }:
+
+stdenv.mkDerivation rec
+{
+  name = "partio-${version}";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "wdas";
+    repo = "partio";
+    rev = "v${version}";
+    sha256 = "0z7n5ay21ca7g7xb80v6jmr96x9k7vm7zawawvmx71yj32rg1n34";
+  };
+
+  outputs = [ "dev" "out" "lib" ];
+
+  buildInputs = [ unzip cmake freeglut mesa zlib swig python doxygen xorg.libXi xorg.libXmu ];
+
+  sourceRoot = "partio-v${version}-src";
+
+  enableParallelBuilding = true;
+
+  buildPhase = ''
+    sed 's/ADD_LIBRARY (partio /ADD_LIBRARY (partio SHARED /' -i ../src/lib/CMakeLists.txt
+    CXXFLAGS="-std=c++11" cmake .
+    make partio
+
+    mkdir $dev
+    mkdir -p $lib/lib
+    mkdir $out
+      '';
+
+  # TODO:
+  # Sexpr support
+
+  installPhase = ''
+    mkdir $dev/lib
+    mkdir -p $dev/include/partio
+
+    mv lib/libpartio.so $lib/lib
+
+    mv ../src/lib/* $dev/include/partio
+  '';
+
+  meta = with stdenv.lib; {
+    description = "C++ (with python bindings) library for easily reading/writing/manipulating common animation particle formats such as PDB, BGEO, PTC";
+    homepage = "https://www.disneyanimation.com/technology/partio.html";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = [ maintainers.guibou ];
+  };
+}

--- a/pkgs/development/libraries/ptex/default.nix
+++ b/pkgs/development/libraries/ptex/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, zlib, python, cmake }:
+
+stdenv.mkDerivation rec
+{
+  name = "ptex-${version}";
+  version = "2.1.28";
+
+  src = fetchFromGitHub {
+    owner = "wdas";
+    repo = "ptex";
+    rev = "v${version}";
+    sha256 = "1h6gb3mpis4m6ph7h9q764w50f9jrar3jz2ja76rn5czy6wn318x";
+  };
+
+  outputs = [ "bin" "dev" "out" "lib" ];
+
+  buildInputs = [ zlib python cmake ];
+
+  sourceRoot = "ptex-v${version}-src";
+
+  enableParallelBuilding = true;
+
+  buildPhase = ''
+      mkdir -p $out
+
+      make prefix=$out
+
+      mkdir -p $bin/bin
+      mkdir -p $dev/include
+      mkdir -p $lib/lib
+      '';
+
+  installPhase = ''
+    make install
+    mv $out/bin $bin/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Per-Face Texture Mapping for Production Rendering";
+    homepage = "http://ptex.us/";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = [ maintainers.guibou ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15724,6 +15724,8 @@ with pkgs;
     ruby = ruby_2_1;
   };
 
+  partio = callPackage ../development/libraries/partio {};
+
   pcmanfm = callPackage ../applications/misc/pcmanfm { };
 
   pcmanfm-qt = lxqt.pcmanfm-qt;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15890,6 +15890,8 @@ with pkgs;
 
   opencpn = callPackage ../applications/misc/opencpn { };
 
+  openfx = callPackage ../development/libraries/openfx {};
+
   openimageio = callPackage ../applications/graphics/openimageio { };
 
   openjump = callPackage ../applications/misc/openjump { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13621,6 +13621,8 @@ with pkgs;
 
   airwave = callPackage ../applications/audio/airwave/default.nix { };
 
+  alembic = callPackage ../development/libraries/alembic {};
+
   alchemy = callPackage ../applications/graphics/alchemy { };
 
   alock = callPackage ../misc/screensavers/alock { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15740,6 +15740,8 @@ with pkgs;
 
   polybar = callPackage ../applications/misc/polybar { };
 
+  ptex = callPackage ../development/libraries/ptex {};
+
   rssguard = libsForQt5.callPackage ../applications/networking/feedreaders/rssguard { };
 
   scudcloud = callPackage ../applications/networking/instant-messengers/scudcloud { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10058,6 +10058,8 @@ with pkgs;
 
   openslp = callPackage ../development/libraries/openslp {};
 
+  openvdb = callPackage ../development/libraries/openvdb {};
+
   inherit (callPackages ../development/libraries/libressl { })
     libressl_2_5
     libressl_2_6;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10032,6 +10032,8 @@ with pkgs;
 
   openexr = callPackage ../development/libraries/openexr { };
 
+  openexrid-unstable = callPackage ../development/libraries/openexrid-unstable { };
+
   openldap = callPackage ../development/libraries/openldap { };
 
   opencolorio = callPackage ../development/libraries/opencolorio { };


### PR DESCRIPTION
###### Motivation for this change

All of these packages are standard in rendering / animation / cinema industry:

- ptex : texture loading
- alembic : asset description
- partio : particules description
- openfx : post processing filters
- openexrid : post processing
- openvdb : voxel modelisation

We are using nix to build our product: http://guerillarender.com/ which depends on theses libs. I wanted to upstream this work.

These packages are created with our setup in mind, for example, I did not included the openvdb binaries or documentation. I'm motivated to take maintainership of these packages and improve them as needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

