### PR TITLE
meliae: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/meliae/default.nix
+++ b/pkgs/development/python-modules/meliae/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, cython
+, isPy3k
+, simplejson
+}:
+
+buildPythonPackage rec {
+  pname = "meliae";
+  version = "0.4.0";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "16gcgjzcjlbfarwlj18fn089bz34kzfw8varbzxsi9ma0amijrcp";
+  };
+
+  disabled = isPy3k;
+
+  doCheck = true;
+
+  checkPhase = ''
+    python setup.py build_ext -i
+    python run_tests.py
+  '';
+
+  checkInputs = [ simplejson ];
+
+  propagatedBuildInputs = [ cython ];
+
+  meta = with stdenv.lib; {
+    description = "Python Memory Usage Analyzer";
+    homepage = http://launchpad.net/meliae;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ xvapx ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11650,6 +11650,8 @@ in {
     };
   };
 
+  meliae = callPackage ../development/python-modules/meliae {};
+
   memcached = buildPythonPackage rec {
     name = "memcached-1.51";
 


### PR DESCRIPTION
###### Motivation for this change
To update Tribler from 7.0.0-rc2 to 7.0.0-rc3 we need this new dependency

###### Things done
Added meliae 0.4.0 to pyhonPackages.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

