### PR TITLE
tribler: 7.0.0-rc2 -> 7.0.0-rc3

### DIFF
--- a/pkgs/applications/networking/p2p/tribler/default.nix
+++ b/pkgs/applications/networking/p2p/tribler/default.nix
@@ -4,12 +4,11 @@
 stdenv.mkDerivation rec {
   pname = "tribler";
   name = "${pname}-${version}";
-  version = "7.0.0-rc2";
-  revision = "1d3ddb8";
+  version = "7.0.0-rc3";
 
   src = fetchurl {
     url = "https://github.com/Tribler/tribler/releases/download/v${version}/Tribler-v${version}.tar.xz";
-    sha256 = "0wlv32cw52c5khnrm218dccgn2l177933p4dhp7m50hipqfb0ly2";
+    sha256 = "0f1f8mzbk1ygkh8lv9y1s9mvslv12d94mxvmp3b4s2vm8w4syza7";
   };
 
   buildInputs = [
@@ -40,6 +39,8 @@ stdenv.mkDerivation rec {
     pythonPackages.decorator
     pythonPackages.feedparser
     pythonPackages.service-identity
+    pythonPackages.psutil
+    pythonPackages.meliae
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
To update tribler from 7.0.0-rc2 to 7.0.0-rc3

###### Things done
Updated tribler version, added new dependencies, removed unused revision variable.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This PR depends on #30508, if/when that PR is accepted, i will rebase.
Until then, this is not to be merged.
