### PR TITLE
xmr-stak-cpu: init at 1.3.0

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -56,6 +56,8 @@ rec {
 
   stellar-core = callPackage ./stellar-core.nix { };
 
+  xmr-stak-cpu = callPackage ./xmr-stak-cpu.nix { donationLevel = "2.0"; };
+
   zcash = callPackage ./zcash {
     withGui = false;
     openssl = openssl_1_1_0;

--- a/pkgs/applications/altcoins/xmr-stak-cpu.nix
+++ b/pkgs/applications/altcoins/xmr-stak-cpu.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, cmake,
+libmicrohttpd,
+openssl,
+hwloc,
+donationLevel
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "xmr-stak-cpu-${version}";
+  version = "1.3.0";
+
+  buildInputs = [ cmake libmicrohttpd openssl hwloc ];
+
+  preConfigure = ''sed -i "s|fDevDonationLevel = 2.0|fDevDonationLevel = ${donationLevel}|" donate-level.h'';
+
+  postInstall = ''
+      mkdir $out/etc
+      mv $out/bin/config.txt $out/etc/xmr-stak-cpu.config.txt
+  '';
+
+  src = fetchFromGitHub {
+    owner = "fireice-uk";
+    repo = "xmr-stak-cpu";
+    rev = "v${version}-1.5.0";
+    sha256 = "1i12zdzkvmnmx2r40hp71vr019ws7s1gkabwj4my27z6hinw6f8b";
+  };
+
+  meta = {
+    description = "Universal Stratum pool miner (CPU version)";
+    homepage = https://github.com/fireice-uk/xmr-stak-cpu;
+    maintainers = [stdenv.lib.maintainers.nico202];
+    license = stdenv.lib.licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13712,6 +13712,7 @@ with pkgs;
   ethabi = self.altcoins.ethabi;
   ethrun = self.altcoins.ethrun;
   seth = self.altcoins.seth;
+  xmr-stak-cpu = self.altcoins.xmr-stak-cpu;
   dapp = self.altcoins.dapp;
   hevm = self.altcoins.hevm;
 


### PR DESCRIPTION
###### Motivation for this change
Package missing. It's an alt-coin (monero) pool miner, so I don't know if it suits here or in misc.
Also, I don't know how to ensure that the donationLevel parameter is a double. I'm passing it as a string for now

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

