### PR TITLE
hyper: 1.4.3 -> 1.4.8

### DIFF
--- a/pkgs/applications/misc/hyper/default.nix
+++ b/pkgs/applications/misc/hyper/default.nix
@@ -12,11 +12,11 @@ let
   ];
 in
 stdenv.mkDerivation rec {
-  version = "1.4.3";
+  version = "1.4.8";
   name = "hyper-${version}";
   src = fetchurl {
     url = "https://github.com/zeit/hyper/releases/download/${version}/hyper_${version}_amd64.deb";
-    sha256 = "0f0qxhvwwcpsjnv1rgmdzdl5jwfprnd7fjnd6sb8liq250pij3ld";
+    sha256 = "0v31z3p5h3qr8likifbq9kk08fpfyf8g1hrz6f6v90z4b2yhkf51";
   };
   buildInputs = [ dpkg ];
   unpackPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Upstream release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

