### PR TITLE
nixpkgs manual: remove reference to now defunct nixpkgs monitor

### DIFF
--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -48,6 +48,4 @@ The binaries are made available via a [binary cache](https://cache.nixos.org).
 
 The current Nix expressions of the channels are available in the
 [`nixpkgs-channels`](https://github.com/NixOS/nixpkgs-channels) repository,
-which has branches corresponding to the available channels. There is also the
-[Nixpkgs Monitor](http://monitor.nixos.org) which keeps track of updates
-and security vulnerabilities.
+which has branches corresponding to the available channels.


### PR DESCRIPTION
###### Motivation for this change

I can't speak to its official status, or if there are plans to revive it, but AFAICT the monitor has been dead for a long time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

