### PR TITLE
opensubdiv: fix glew paths

### DIFF
--- a/pkgs/development/libraries/opensubdiv/default.nix
+++ b/pkgs/development/libraries/opensubdiv/default.nix
@@ -28,8 +28,8 @@
     [ "-DNO_TUTORIALS=1"
       "-DNO_REGRESSION=1"
       "-DNO_EXAMPLES=1"
-      "-DGLEW_INCLUDE_DIR=${glew}/include"
-      "-DGLEW_LIBRARY=${glew}/lib"
+      "-DGLEW_INCLUDE_DIR=${glew.dev}/include"
+      "-DGLEW_LIBRARY=${glew.dev}/lib"
     ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Include and lib are not in ${glew} but in ${glew.dev}.

This changes what is found by the cmake of opensubdiv and some features
are now enabled, such as OpenGL 4.2 support.

###### Motivation for this change

Get opensubdiv right.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

