### PR TITLE
services.xserver: assert that either desktop- or window manager is not "none"

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -81,6 +81,14 @@ following incompatible changes:</para>
       That means that old configuration is not overwritten by default when update to the znc options are made.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      The option <option>services.xserver.desktopManager.default</option> is now <literal>none</literal> by default.
+      An assertion failure is thrown if WM's and DM's default are <literal>none</literal>.
+      To explicitly run a plain X session without and DM or WM, the newly introduced option <option>services.xserver.plainX</option>
+      must be set to true.
+    </para>
+  </listitem>
 </itemizedlist>
 
 </section>

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -87,8 +87,8 @@ in
 
       default = mkOption {
         type = types.str;
-        default = "";
-        example = "none";
+        default = "none";
+        example = "plasma5";
         description = "Default desktop manager loaded if none have been chosen.";
         apply = defaultDM:
           if defaultDM == "" && cfg.session.list != [] then

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -161,6 +161,15 @@ in
         '';
       };
 
+      plainX = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether the X11 session can be plain (without DM/WM) and
+          the Xsession script will be used as fallback or not.
+        '';
+      };
+
       autorun = mkOption {
         type = types.bool;
         default = true;
@@ -552,6 +561,9 @@ in
                 + "${toString (length primaryHeads)} heads set to primary: "
                 + concatMapStringsSep ", " (x: x.output) primaryHeads;
       })
+      { assertion = cfg.desktopManager.default == "none" && cfg.windowManager.default == "none" -> cfg.plainX;
+        message = "Either the desktop manager or the window manager shouldn't be `none`! To explicitly allow this, you can also set `services.xserver.plainX` to `true`.";
+      }
     ];
 
     environment.etc =


### PR DESCRIPTION
###### Motivation for this change

setting a DM or WM is something I tend to forget when I want to built test machines with an X11 inside, so this assertion might catch unexpected behavior when building machines with X.

resolves #11064 (/cc @nbp )

I tested this against the following expressions:

``` nix
{
  # VMs without X11 still evaluate
  empty = { pkgs, ... }: {
  };

  # needs to be commented out to avoid evaluation errors
  # no DM/WM set, should break
  onlyX11 = { pkgs, ... }: {
    services.xserver.enable = true;
  };

  # DM set, evaluates
  x11WithDM = { pkgs, ... }: {
    services.xserver = {
      enable = true;
      desktopManager.plasma5.enable = true;
      desktopManager.default = "plasma5";
    };
  };

  # WM set, evaluates
  x11WithWM = { pkgs, ... }: {
    services.xserver = {
      enable = true;
      windowManager.i3.enable = true;
      windowManager.default = "i3";
    };
  };

  # plain X sessions must be enabled explicitly
  x11Plain = { pkgs, ... }:{
    services.xserver.enable = true;
    services.xserver.plainX = true;
  };
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

