### PR TITLE
usbmuxd service: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -237,6 +237,7 @@
   ./services/hardware/udev.nix
   ./services/hardware/udisks2.nix
   ./services/hardware/upower.nix
+  ./services/hardware/usbmuxd.nix
   ./services/hardware/thermald.nix
   ./services/logging/SystemdJournal2Gelf.nix
   ./services/logging/awstats.nix

--- a/nixos/modules/services/hardware/usbmuxd.nix
+++ b/nixos/modules/services/hardware/usbmuxd.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  options.services.usbmuxd.enable = mkOption {
+    type = types.bool;
+    default = false;
+    description = ''
+      Enable the usbmuxd ("USB multiplexing daemon") service. This daemon is in
+      charge of multiplexing connections over USB to an iOS device. This is
+      needed for transferring data from and to iOS devices (see ifuse). Also
+      this may enable plug-n-play tethering for iPhones.
+    '';
+  };
+
+  config = mkIf config.services.usbmuxd.enable {
+    systemd.services.usbmuxd = {
+      description = "usbmuxd";
+      wantedBy = [ "multi-user.target" ];
+      unitConfig.Documentation = "man:usbmuxd(8)";
+      serviceConfig.ExecStart = "${pkgs.usbmuxd}/bin/usbmuxd -f";
+    };
+  };
+}

--- a/nixos/modules/services/hardware/usbmuxd.nix
+++ b/nixos/modules/services/hardware/usbmuxd.nix
@@ -2,24 +2,73 @@
 
 with lib;
 
+let
+
+  defaultUserGroup = "usbmux";
+  apple = "05ac";
+
+  cfg = config.services.usbmuxd;
+
+in
+
 {
-  options.services.usbmuxd.enable = mkOption {
-    type = types.bool;
-    default = false;
-    description = ''
-      Enable the usbmuxd ("USB multiplexing daemon") service. This daemon is in
-      charge of multiplexing connections over USB to an iOS device. This is
-      needed for transferring data from and to iOS devices (see ifuse). Also
-      this may enable plug-n-play tethering for iPhones.
-    '';
+  options.services.usbmuxd = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable the usbmuxd ("USB multiplexing daemon") service. This daemon is
+        in charge of multiplexing connections over USB to an iOS device. This is
+        needed for transferring data from and to iOS devices (see ifuse). Also
+        this may enable plug-n-play tethering for iPhones.
+      '';
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = defaultUserGroup;
+      description = ''
+        The user usbmuxd should use to run after startup.
+      '';
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = defaultUserGroup;
+      description = ''
+        The group usbmuxd should use to run after startup.
+      '';
+    };
   };
 
-  config = mkIf config.services.usbmuxd.enable {
+  config = mkIf cfg.enable {
+
+    users.extraUsers = optional (cfg.user == defaultUserGroup) {
+      name = cfg.user;
+      description = "usbmuxd user";
+      group = cfg.group;
+    };
+
+    users.extraGroups = optional (cfg.group == defaultUserGroup) {
+      name = cfg.group;
+    };
+
+    # Give usbmuxd permission for Apple devices
+    services.udev.extraRules = ''
+      SUBSYSTEM=="usb", ATTR{idVendor}=="${apple}", GROUP="${cfg.group}"
+    '';
+
     systemd.services.usbmuxd = {
       description = "usbmuxd";
       wantedBy = [ "multi-user.target" ];
       unitConfig.Documentation = "man:usbmuxd(8)";
-      serviceConfig.ExecStart = "${pkgs.usbmuxd}/bin/usbmuxd -f";
+      serviceConfig = {
+        # Trigger the udev rule manually. This doesn't require replugging the
+        # device when first enabling the option to get it to work
+        ExecStartPre = "${pkgs.libudev}/bin/udevadm trigger -s usb -a idVendor=${apple}";
+        ExecStart = "${pkgs.usbmuxd}/bin/usbmuxd -U ${cfg.user} -f";
+      };
     };
+
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The usbmuxd daemon is required for accessing files on connected iOS devices (along with ifuse). Also apparently enabling it allows Plug-and-Play tethering for iPhones, which is awesome.

This was tested by me and @grahamc, but it would be nice to have others try it out. Just run `sudo usbmuxd -f` in a terminal and connect your cellular iOS device, should work just like that.

Since this easily provides internet access, it would be very handy to enable this in the installer media by default, I'm probably gonna do a PR for that after this is merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

