### PR TITLE
postfix: add relayPort option.

### DIFF
--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -62,7 +62,9 @@ let
     shlib_directory      = false;
     relayhost            = if cfg.lookupMX || cfg.relayHost == ""
                              then cfg.relayHost
-                             else "[${cfg.relayHost}]";
+                             else
+			       "[${cfg.relayHost}]"
+			       + optionalString (cfg.relayPort != null) ":${toString cfg.relayPort}";
     mail_spool_directory = "/var/spool/mail/";
     setgid_group         = setgidGroup;
   }
@@ -455,6 +457,17 @@ in
         default = "";
         description = "
           Mail relay for outbound mail.
+        ";
+      };
+
+      relayPort = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        example = 587;
+        description = "
+          Specify an optional port for outbound mail relay. (Note:
+          only used if an explicit <option>relayHost</option> is
+          defined.)
         ";
       };
 


### PR DESCRIPTION
Note that because Nixpkgs uses the `[relayhost]` Postconf syntax for specifying relay hosts (with brackets `[]`), it is not legal syntax to include the port as part of the `relayHost` option string.

For example, `mail.example.org:587` is legal syntax, but `[mail.example.org:587]` is not; it must be written as `[mail.example.org]:587`, hence the need for this additional option.


