### PR TITLE
kernel: Build Tegra PCI support.

### DIFF
--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -545,6 +545,9 @@ rec {
       # Cavium ThunderX stuff.
       PCI_HOST_THUNDER_ECAM y
 
+      # Nvidia Tegra stuff.
+      PCI_TEGRA y
+
       # The default (=y) forces us to have the XHCI firmware available in initrd,
       # which our initrd builder can't currently do easily.
       USB_XHCI_TEGRA m


### PR DESCRIPTION
This enables Nvidia Tegra dev kits (e.g., Jetson TX1) to boot from PCIe devices, such as NVMe boards.

/cc @dezgeg 
