### PR TITLE
oraclejdk: 8u144 -> 8u151, 8u152; 9 -> 9.0.1 [Critical security fixes]

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "144";
+  patchVersion = "151";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "1i5pginc65xl5vxzwid21ykakmfkqn59v3g01vpr94v28w30jk32";
-  sha256_x86_64 = "1r5axvr8dg2qmr4zjanj73sk9x50m7p0w3vddz8c6ckgav7438z8";
+  sha256_i686 = "0w1snn9hxwvdnk77frhdzbsm6v30v99dy5zmpy8ij7yxd57z6ql0";
+  sha256_x86_64 = "0zq2dxbxmshz080yskhc8y2wbqi0y0kl9girxjbb4rwk837010n7";
   sha256_armv7l = "10r3nyssx8piyjaspravwgj2bnq4537041pn0lz4fk5b3473kgfb";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "144";
+  patchVersion = "152";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "1i5pginc65xl5vxzwid21ykakmfkqn59v3g01vpr94v28w30jk32";
-  sha256_x86_64 = "1r5axvr8dg2qmr4zjanj73sk9x50m7p0w3vddz8c6ckgav7438z8";
+  sha256_i686 = "0gjc7kcfx40f43z1w1qsn1fqxdz8d46wml2g11qgm55ishhv2q7w";
+  sha256_x86_64 = "1gv1348hrgna9l3sssv3g9jzs37y1lkx05xq83chav9z1hs3p2r1";
   sha256_armv7l = "10r3nyssx8piyjaspravwgj2bnq4537041pn0lz4fk5b3473kgfb";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;

--- a/pkgs/development/compilers/oraclejdk/jdk9-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk9-linux.nix
@@ -30,7 +30,7 @@ assert stdenv.system == "x86_64-linux";
 assert swingSupport -> xorg != null;
 
 let
-  version = "9";
+  version = "9.0.1";
 
   downloadUrlBase = http://www.oracle.com/technetwork/java/javase/downloads;
 
@@ -63,19 +63,19 @@ let result = stdenv.mkDerivation rec {
       requireFile {
         name = "jdk-${version}_linux-x64_bin.tar.gz";
         url =  "${downloadUrlBase}/jdk9-downloads-3848520.html";
-        sha256 = "0vbgy7h9h089l3xh6sl57v57g28x1djyiigqs4z6gh7wahx7hv8w";
+        sha256 = "0560dc3icrwb0ifykshvzkr04b1jr153m26x1r8rp0nhjbzz1nic";
       }
     else if packageType == "JRE" then
       requireFile {
         name = "jre-${version}_linux-x64_bin.tar.gz";
         url = "${downloadUrlBase}/jre9-downloads-3848532.html";
-        sha256 = "18i4jjb6sby67xg5ql6dkk3ja1nackbb23g1bnp522450nclpxdb";
+        sha256 = "11pfcck8am48yv7riaj10g6h79xdiy8lm5a9wjqbm3g9cls9ar1w";
       }
     else if packageType == "ServerJRE" then
       requireFile {
         name = "serverjre-${version}_linux-x64_bin.tar.gz";
         url = "${downloadUrlBase}/server-jre9-downloads-3848530.html";
-        sha256 = "01bxi7lx13lhlpbifw93b6r7a9bayiykw8kzwlyyqi8pz3pw8c5h";
+        sha256 = "1biyks6jy0a2kksaj9qbsjifv34ym5mdw8akibmkwr1xh0wavygc";
       }
     else abort "unknown package Type ${packageType}";
 


### PR DESCRIPTION
###### Motivation for this change

- Critical security fixes
- Other changes

http://www.oracle.com/technetwork/java/javase/9-0-1-relnotes-3883752.html
http://www.oracle.com/technetwork/java/javase/8u151-relnotes-3850493.html
http://www.oracle.com/technetwork/java/javase/8u152-relnotes-3850503.html
http://www.oracle.com/technetwork/security-advisory/cpuoct2017-3236626.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

