### PR TITLE
googleearth: 7.1 -> 7.3 and move to Qt5

### DIFF
--- a/pkgs/applications/misc/googleearth/default.nix
+++ b/pkgs/applications/misc/googleearth/default.nix
@@ -1,17 +1,20 @@
-{ stdenv, fetchurl, glibc, mesa, freetype, glib, libSM, libICE, libXi, libXv
-, libXrender, libXrandr, libXfixes, libXcursor, libXinerama, libXext, libX11, qt4
-, zlib, fontconfig, dpkg }:
+{ stdenv, fetchurl, glibc, mesa, alsaLib, freetype, glib, libSM, libICE, libXi, libXv
+, libXrender, libXrandr, libXfixes, libXcursor, libXinerama, libXext, libX11
+, qtbase, qtdeclarative, qtlocation, qtmultimedia, qtscript, qtsensors, qtsvg, qtwebchannel, qtwebkit, qtx11extras
+, zlib, fontconfig, dpkg, makeWrapper }:
 
 let
-  arch =
-    if stdenv.system == "x86_64-linux" then "amd64"
-    else if stdenv.system == "i686-linux" then "i386"
-    else abort "Unsupported architecture";
-  sha256 =
-    if arch == "amd64"
-    then "0dwnppn5snl5bwkdrgj4cyylnhngi0g66fn2k41j3dvis83x24k6"
-    else "0gndbxrj3kgc2dhjqwjifr3cl85hgpm695z0wi01wvwzhrjqs0l2";
-  fullPath = stdenv.lib.makeLibraryPath [
+  arch = {
+    "x86_64-linux" = "amd64";
+    "i686-linux"   = "i386";
+  }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
+
+  sha256 = {
+    "x86_64-linux" = "05j4j93w64s3gzrp30v4h4sfcwbbndww7g9rkvg09c7rgkl374iw";
+    "i686-linux"   = "16y3sv6cbg71r55kqdqj30szhgnsgk17jpf6j2w7qixl3n233z1b";
+  }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
+
+  libPath = stdenv.lib.makeLibraryPath [
     glibc
     glib
     stdenv.cc.cc
@@ -20,60 +23,81 @@ let
     libXi
     libXv
     mesa
-    libXrender
-    libXrandr
-    libXfixes
-    libXcursor
-    libXinerama
-    freetype
-    libXext
     libX11
-    qt4
+    libXcursor
+    libXext
+    libXfixes
+    libXinerama
+    libXrandr
+    libXrender
+    qtbase qtdeclarative qtlocation qtmultimedia qtscript qtsensors qtsvg qtwebchannel qtwebkit qtx11extras
     zlib
-    fontconfig
+    alsaLib
+    fontconfig freetype
   ];
-in
-stdenv.mkDerivation rec {
-  version = "7.1.4.1529";
+
+in stdenv.mkDerivation rec {
   name = "googleearth-${version}";
+  version = "7.3.0.3832";
 
   src = fetchurl {
-    url = "https://dl.google.com/earth/client/current/google-earth-stable_current_${arch}.deb";
+    url = "https://dl.google.com/earth/client/current/google-earth-pro-stable_current_${arch}.deb";
     inherit sha256;
   };
 
-  phases = "unpackPhase installPhase";
+  dontBuild = true;
+  dontPatchELF = true;
+  dontStrip = false;
 
-  buildInputs = [ dpkg ];
+  nativeBuildInputs = [ dpkg makeWrapper ];
 
   unpackPhase = ''
-    dpkg-deb -x ${src} ./
+    mkdir -p $out
+    dpkg-deb -x ${src} $out
   '';
 
   installPhase =''
-    mkdir $out
-    mv usr/* $out/
-    rmdir usr
-    mv * $out/
-    rm $out/bin/google-earth $out/opt/google/earth/free/google-earth
-    ln -s $out/opt/google/earth/free/googleearth $out/bin/google-earth
+    runHook preInstall
 
-    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "${fullPath}:\$ORIGIN" \
-      $out/opt/google/earth/free/googleearth-bin
+    dir=$out/opt/google/earth/pro
 
-    for a in $out/opt/google/earth/free/*.so* ; do
-      patchelf --set-rpath "${fullPath}:\$ORIGIN" $a
+    mv $out/usr/* $out/
+    mv $dir/*.desktop $out/share/applications
+
+    rmdir $out/{etc,usr}
+
+    rm $out/bin/* $dir/google-earth-pro $dir/libQt*
+
+    for f in $dir/googleearth-bin $dir/repair_tool ; do
+      patchelf \
+        --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "${libPath}:\$ORIGIN" \
+        $f
     done
+
+    for f in $dir/*.so* $dir/plugins/*.so $dir/plugins/**/*.so ; do
+      chmod 755 $f # patchelf will bail without write permissions
+      patchelf --set-rpath "${libPath}:\$ORIGIN" $f
+    done
+
+    for f in $out/share/applications/*.desktop ; do
+      sed -i $f -e 's,Exec=.*,Exec=$out/bin/google-earth,g'
+    done
+
+    substituteInPlace $dir/qt.conf \
+      --replace Plugins=plugins Plugins=$dir/plugins
+
+    makeWrapper $dir/googleearth $out/bin/google-earth \
+     --set LIBGL_DEBUG verbose
+
+    runHook postInstall
   '';
 
-  dontPatchELF = true;
-
-  meta = {
+  meta = with stdenv.lib; {
     description = "A world sphere viewer";
-    homepage = http://earth.google.com;
-    license = stdenv.lib.licenses.unfree;
-    maintainers = [ stdenv.lib.maintainers.viric ];
-    platforms = stdenv.lib.platforms.linux;
+    homepage    = https://earth.google.com;
+    license     = licenses.unfree;
+    maintainers = with maintainers; [ viric ];
+    platforms   = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14901,7 +14901,7 @@ with pkgs;
 
   google-chrome-dev = google-chrome.override { chromium = chromiumDev; channel = "dev"; };
 
-  googleearth = callPackage_i686 ../applications/misc/googleearth { };
+  googleearth = libsForQt5.callPackage ../applications/misc/googleearth { };
 
   google-play-music-desktop-player = callPackage ../applications/audio/google-play-music-desktop-player {
     inherit (gnome2) GConf;


### PR DESCRIPTION
This is still WIP as it launches with a black screen on a Yoga 2 Pro with intel
graphics and a no-brand desktop using nVidia 650GTX and the nouveau driver but I'd be very interested to see if it runs for other people - especially @chris-martin ref #30491.

Cc: @viric 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

