### PR TITLE
python.pkgs.cufflinks: init at 0.12.0

### DIFF
--- a/pkgs/development/python-modules/colorlover/default.nix
+++ b/pkgs/development/python-modules/colorlover/default.nix
@@ -1,0 +1,23 @@
+{ buildPythonPackage, fetchPypi, python, stdenv, nose
+}:
+
+buildPythonPackage rec {
+  pname = "colorlover";
+  version = "0.2.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1clwvssrj007r07prfvkqnpjy3f77dlp584lj879x8mwl8f0japi";
+  };
+
+  # no tests included in distributed archive
+  doCheck = false;
+
+  meta = {
+    homepage = https://github.com/jackparmer/colorlover;
+    description = "Color scales in Python for humans";
+    license = stdenv.lib.licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ globin ];
+  };
+}

--- a/pkgs/development/python-modules/cufflinks/default.nix
+++ b/pkgs/development/python-modules/cufflinks/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage, stdenv, fetchPypi, pandas, plotly, colorlover
+}:
+
+buildPythonPackage rec {
+  pname = "cufflinks";
+  version = "0.12.0";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04ninvwm6277n3hqc17ririss90cd832wza3q3vf115rrrds3xyy";
+  };
+
+  propagatedBuildInputs = [ pandas plotly colorlover ];
+
+  # tests not included in archive
+  doCheck = false;
+
+  meta = {
+    homepage = https://github.com/santosjorge/cufflinks;
+    description = "Productivity Tools for Plotly + Pandas";
+    license = stdenv.lib.licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ globin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1669,6 +1669,8 @@ in {
 
   csvkit =  callPackage ../development/python-modules/csvkit { };
 
+  cufflinks = callPackage ../development/python-modules/cufflinks { };
+
   cx_Freeze = callPackage ../development/python-modules/cx_freeze {};
 
   cvxopt = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2932,6 +2932,8 @@ in {
 
   colorama = callPackage ../development/python-modules/colorama { };
 
+  colorlover = callPackage ../development/python-modules/colorlover { };
+
   CommonMark = buildPythonPackage rec {
     name = "CommonMark-${version}";
     version = "0.6.3";


### PR DESCRIPTION
###### Motivation for this change
Currently not packaged

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

