### PR TITLE
Package some security/pentesting tools

### DIFF
--- a/pkgs/tools/security/dnsenum/default.nix
+++ b/pkgs/tools/security/dnsenum/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, makeWrapper, perl, perlPackages }:
+
+stdenv.mkDerivation rec {
+  name = "dnsenum-${version}";
+  version = "1.2.4.2";
+
+  src = fetchFromGitHub {
+    owner = "fwaeytens";
+    repo = "dnsenum";
+    rev = version;
+    sha256 = "1bg1ljv6klic13wq4r53bg6inhc74kqwm3w210865b1v1n8wj60v";
+  };
+
+  propagatedBuildInputs = with perlPackages; [
+    perl NetDNS NetIP NetNetmask StringRandom XMLWriter NetWhoisIP WWWMechanize
+  ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -vD dnsenum.pl $out/bin/dnsenum
+    install -vD dns.txt -t $out/share
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/fwaeytens/dnsenum;
+    description = "A tool to enumerate DNS information";
+    maintainers = [ maintainers.globin ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/security/dnsrecon/default.nix
+++ b/pkgs/tools/security/dnsrecon/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, python2 }:
+
+python2.pkgs.buildPythonApplication rec {
+  name = "dnsrecon-${version}";
+  version = "0.8.9+git20170501";
+
+  src = fetchFromGitHub {
+    owner = "darkoperator";
+    repo = "dnsrecon";
+    rev = "c96739859cc25177df0a9a3a3b7bdcfe62d87394";
+    sha256 = "0xs38yqlghqv9qhzzky15ljis7753lzm9bjqyqfn9vwb20czbc48";
+  };
+
+  format = "other";
+
+  pythonPath = with python2.pkgs; [
+    dns netaddr
+  ];
+
+  postPatch = ''
+    substituteInPlace dnsrecon.py \
+      --replace namelist.txt "../share/namelist.txt"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -vD dnsrecon.py $out/bin/dnsrecon
+    install -vD namelist.txt -t $out/share
+    install -vd $out/${python2.sitePackages}/
+    cp -R lib $out/${python2.sitePackages}
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "DNS Enumeration Script";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = [ maintainers.globin ];
+  };
+}

--- a/pkgs/tools/security/fierce/default.nix
+++ b/pkgs/tools/security/fierce/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, makeWrapper, perl, perlPackages }:
+
+stdenv.mkDerivation rec {
+  name = "fierce-${version}";
+  version = "0.9.9-1kali4";
+
+  src = fetchurl {
+    url = "http://git.kali.org/gitweb/?p=packages/fierce.git;a=snapshot;h=3bb8050c1e1ebdb1090e103a494c8b1fc0928509;sf=tgz";
+    name = "${name}.tar.gz";
+    sha256 = "0ikiqlajivxybvbgmhsl767m5j1hqaggxic3yfzp8vk1d3mpbhy7";
+  };
+
+  buildInputs = [ perl ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  postPatch = ''
+    substituteInPlace fierce.pl --replace hosts.txt "$out/share/hosts.txt"
+  '';
+
+  installPhase = ''
+    install -vD fierce.pl $out/bin/fierce
+    install -vD hosts.txt -t $out/share
+    wrapProgram "$out/bin/fierce" --set PERL5LIB \
+      "${with perlPackages; stdenv.lib.makePerlPath [ NetDNS ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mschwager/fierce;
+    description = "DNS reconnaissance tool for locating non-contiguous IP space";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.globin ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/security/theharvester/default.nix
+++ b/pkgs/tools/security/theharvester/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, python2 }:
+
+python2.pkgs.buildPythonApplication rec {
+  name = "theharvester-${version}";
+  version = "2.7";
+
+  src = fetchFromGitHub {
+    owner = "laramies";
+    repo = "theHarvester";
+    rev = version;
+    sha256 = "0a8k6mdlprz4ahx8kmcadgd0fma1cbpc1ssb9la03y1rgkflq91s";
+  };
+
+  format = "other";
+
+  propagatedBuildInputs = with python2.pkgs; [ requests ];
+
+  postPatch = ''
+    mv lib theharvester_lib
+    for f in theHarvester.py theharvester_lib/*; do
+      substituteInPlace $f \
+        --replace 'from lib' 'from theharvester_lib'
+    done
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -vD theHarvester.py $out/bin/theharvester
+    install -vd $out/${python2.sitePackages}/
+    cp -R theharvester_lib discovery myparser.py $out/${python2.sitePackages}
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "E-mails, subdomains and names Harvester";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = [ maintainers.globin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4631,6 +4631,8 @@ with pkgs;
 
   thefuck = callPackage ../tools/misc/thefuck { };
 
+  theharvester = callPackage ../tools/security/theharvester { };
+
   thin-provisioning-tools = callPackage ../tools/misc/thin-provisioning-tools {  };
 
   tiled = libsForQt5.callPackage ../applications/editors/tiled { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1748,6 +1748,8 @@ with pkgs;
 
   dmg2img = callPackage ../tools/misc/dmg2img { };
 
+  dnsenum = callPackage ../tools/security/dnsenum { };
+
   dnsrecon = callPackage ../tools/security/dnsrecon { };
 
   docbook2odf = callPackage ../tools/typesetting/docbook2odf {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2013,6 +2013,8 @@ with pkgs;
 
   flashbench = callPackage ../os-specific/linux/flashbench { };
 
+  fierce = callPackage ../tools/security/fierce { };
+
   figlet = callPackage ../tools/misc/figlet { };
 
   file = callPackage ../tools/misc/file { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1748,6 +1748,8 @@ with pkgs;
 
   dmg2img = callPackage ../tools/misc/dmg2img { };
 
+  dnsrecon = callPackage ../tools/security/dnsrecon { };
+
   docbook2odf = callPackage ../tools/typesetting/docbook2odf {
     inherit (perlPackages) PerlMagick;
   };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -10291,6 +10291,14 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  NetNetmask = buildPerlPackage rec {
+    name = "Net-Netmask-1.9022";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MU/MUIR/modules/${name}.tar.gz";
+      sha256 = "0cqmlcxifh5phb3m6bi5pddv0f235vhjvcr0aipjwxfyyhgrq287";
+    };
+  };
+
   NetOAuth = buildPerlPackage {
     name = "Net-OAuth-0.28";
     src = fetchurl {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -10470,6 +10470,22 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  NetWhoisIP = buildPerlPackage rec {
+    name = "Net-Whois-IP-1.19";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/B/BS/BSCHMITZ/${name}.tar.gz";
+      sha256 = "08kj2h9qiyfvv3jfz619xl796j93cslg7d96919mnrnjy6hdz6zh";
+    };
+
+    propagatedBuildInputs = [ RegexpIPv6 LWPProtocolhttps ];
+    doCheck = false;
+
+    # https://rt.cpan.org/Public/Bug/Display.html?id=99377
+    postPatch = ''
+      substituteInPlace IP.pm --replace " AutoLoader" ""
+    '';
+  };
+
   NumberCompare = buildPerlPackage rec {
     name = "Number-Compare-0.03";
     src = fetchurl {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12475,6 +12475,14 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  StringRandom = buildPerlModule rec {
+    name = "String-Random-0.29";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      sha256 = "0p2sa5ah10hjf9jyqgfp9p4nkkwpnmaq60faxlzv47dbcrgad90x";
+    };
+  };
+
   StringRewritePrefix = buildPerlPackage {
     name = "String-RewritePrefix-0.007";
     src = fetchurl {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -10206,10 +10206,10 @@ let self = _self // overrides; _self = with self; {
   };
 
   NetDNS = buildPerlPackage rec {
-    name = "Net-DNS-1.05";
+    name = "Net-DNS-1.12";
     src = fetchurl {
       url = "mirror://cpan/authors/id/N/NL/NLNETLABS/${name}.tar.gz";
-      sha256 = "900198014110af96ebac34af019612dd2ddd6af30178600028c3c940d089d5c8";
+      sha256 = "1zy16idzc96n20fm9976qapz89n3f44xpylhs5cvfgyyg7z03zr5";
     };
     propagatedBuildInputs = [ DigestHMAC ];
     makeMakerFlags = "--noonline-tests";


### PR DESCRIPTION
###### Motivation for this change
All of these hadn't been packaged, yet.

For the cases where the git version is packaged, the currently released version was quite outdated and didn't contain a number of bug fixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

