### PR TITLE
Netdata version bump and module permission fix

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -291,6 +291,7 @@ in rec {
   tests.nat.firewall = callTest tests/nat.nix { withFirewall = true; };
   tests.nat.firewall-conntrack = callTest tests/nat.nix { withFirewall = true; withConntrackHelpers = true; };
   tests.nat.standalone = callTest tests/nat.nix { withFirewall = false; };
+  tests.netdata = callTest tests/netdata.nix { };
   tests.networking.networkd = callSubTests tests/networking.nix { networkd = true; };
   tests.networking.scripted = callSubTests tests/networking.nix { networkd = false; };
   # TODO: put in networking.nix after the test becomes more complete

--- a/nixos/tests/netdata.nix
+++ b/nixos/tests/netdata.nix
@@ -1,0 +1,25 @@
+# This test runs netdata and checks for data via apps.plugin
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "netdata";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ cransom ];
+  };
+
+  nodes = {
+    netdata =
+      { config, pkgs, ... }:
+        {
+          environment.systemPackages = with pkgs; [ curl jq ];
+          services.netdata.enable = true;
+        };
+    };
+
+  testScript = ''
+    startAll;
+
+    $netdata->waitForUnit("netdata.service");
+    #check if netdata can read disk ops for root owned processes. if > 0, successful. verifies both netdata working and apps.plugin has elevated capabilities.
+    $netdata->waitUntilSucceeds("curl -s http://localhost:19999/api/v1/data\?chart=users.pwrites | jq -e '[.data[range(10)][.labels | indices(\"root\")[0]]] | add | . > 0'") ;
+  '';
+})

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, zlib, pkgconfig, libuuid }:
+{ stdenv, fetchFromGitHub, autoreconfHook, zlib, pkgconfig, libuuid, libcap }:
 
 stdenv.mkDerivation rec{
-  version = "1.7.0";
+  version = "1.8.0";
   name = "netdata-${version}";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "firehol";
     repo = "netdata";
-    sha256 = "1fv01jnbgwbafsxavlji90zdqizn8m4nfg9ivc4sbi05j036bg6n";
+    sha256 = "1kc6fzzfkfzz3yxy663s7ydq5kn6i6nvaycav8s0sa9k1wkpj3fv";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ zlib libuuid ];
+  buildInputs = [ zlib libuuid libcap ];
 
   # Allow UI to load when running as non-root
   patches = [ ./web_access.patch ];


### PR DESCRIPTION
###### Motivation for this change
The version bump is minor, but the module changes allows one of the default plugins to properly read data from `/proc` to report more process stats. I also added a test to verify the setuid capability.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm all ears if there's a better way to pull in a setuid binary. I tried libredirect but it didn't catch `execve` and there's no option in netdata itself yet to specify multiple directories for plugins so I could just use /run/wrappers/bin/apps.plugin directly.
