### PR TITLE
shmig: init at 2017-07-24

### DIFF
--- a/pkgs/development/tools/database/shmig/default.nix
+++ b/pkgs/development/tools/database/shmig/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub
+, withMySQL ? false, withPSQL ? false, withSQLite ? false
+, mariadb, postgresql, sqlite, gawk, which
+, lib
+}:
+
+stdenv.mkDerivation {
+  name = "shmig-2017-07-24";
+
+  src = fetchFromGitHub {
+    owner = "mbucc";
+    repo = "shmig";
+    rev = "aff54e03d13f8f95b422cf898505490a56152a4a";
+    sha256 = "08q94dka5yqkzkis3w7j1q8kc7d3kk7mb2drx8ms59jcqvp847j3";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postPatch = ''
+    patchShebangs .
+
+    substituteInPlace shmig \
+      --replace "\`which mysql\`" "${lib.optionalString withMySQL "${mariadb}/bin/mysql"}" \
+      --replace "\`which psql\`" "${lib.optionalString withPSQL "${postgresql}/bin/psql"}" \
+      --replace "\`which sqlite3\`" "${lib.optionalString withSQLite "${sqlite}/bin/sqlite3"}" \
+      --replace "awk" "${gawk}/bin/awk" \
+      --replace "which" "${which}/bin/which"
+  '';
+
+  preBuild = ''
+    mkdir -p $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Minimalistic database migration tool with MySQL, PostgreSQL and SQLite support";
+    homepage = "https://github.com/mbucc/shmig";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6263,6 +6263,8 @@ with pkgs;
 
   serpent = callPackage ../development/compilers/serpent { };
 
+  shmig = callPackage ../development/tools/database/shmig { };
+
   smlnjBootstrap = callPackage ../development/compilers/smlnj/bootstrap.nix { };
   smlnj = if stdenv.isDarwin
             then callPackage ../development/compilers/smlnj { }


### PR DESCRIPTION
###### Motivation for this change

`shmig` is a simple, shell-based database migration tool which is quite helpful.

To avoid building several (possibly useless) derivations, I made the usage of MySQL, PgSQL and SQLite optional. These values are empty which causes the following error if you try to use them: `shmig: unknown database type: sqlite`.

Using an override expression it is possible to enable support for one of these databases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

