### PR TITLE
vuze: init at 5750

### DIFF
--- a/pkgs/applications/networking/p2p/vuze/default.nix
+++ b/pkgs/applications/networking/p2p/vuze/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchsvn, jdk, jre, ant, swt, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "vuze-${version}";
+  version = "5750";
+
+  src = fetchsvn {
+    url = "http://svn.vuze.com/public/client/tags/RELEASE_${version}";
+    sha256 = "07w6ipyiy8hi88d6yxbbf3vkv26mj7dcz9yr8141hb2ig03v0h0p";
+  };
+
+  buildInputs = [ makeWrapper jdk ant ];
+
+  buildPhase = "ant";
+
+  installPhase = ''
+    install -D dist/Vuze_0000-00.jar $out/share/java/Vuze_${version}-00.jar
+    makeWrapper ${jre}/bin/java $out/bin/vuze \
+      --add-flags "-Xmx256m -Djava.library.path=${swt}/lib -cp $out/share/java/Vuze_${version}-00.jar:${swt}/jars/swt.jar org.gudy.azureus2.ui.swt.Main"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Torrent client";
+    homepage = http://www.vuze.com;
+    license = licenses.free;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ volth ];
+  };
+}

--- a/pkgs/applications/networking/p2p/vuze/default.nix
+++ b/pkgs/applications/networking/p2p/vuze/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Torrent client";
     homepage = http://www.vuze.com;
-    license = licenses.free;
+    license = licenses.unfree;
     platforms = platforms.all;
     maintainers = with maintainers; [ volth ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16995,6 +16995,8 @@ with pkgs;
 
   vue = callPackage ../applications/misc/vue { };
 
+  vuze = callPackage ../applications/networking/p2p/vuze { };
+
   vwm = callPackage ../applications/window-managers/vwm { };
 
   vym = callPackage ../applications/misc/vym { };


### PR DESCRIPTION
###### Motivation for this change

A torrent client (build from Java sources)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

