### PR TITLE
tixati: init at 2.55

### DIFF
--- a/pkgs/applications/networking/p2p/tixati/default.nix
+++ b/pkgs/applications/networking/p2p/tixati/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Torrent client";
     homepage = http://www.tixati.com;
-    license = licenses.free;
+    license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ volth ];
   };

--- a/pkgs/applications/networking/p2p/tixati/default.nix
+++ b/pkgs/applications/networking/p2p/tixati/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, glib, zlib, dbus, dbus_glib, gtk2, gdk_pixbuf, cairo, pango }:
+
+stdenv.mkDerivation rec {
+  name = "tixati-${version}";
+  version = "2.55";
+
+  src = fetchurl {
+    url = "https://download2.tixati.com/download/tixati-${version}-1.x86_64.manualinstall.tar.gz";
+    sha256 = "02mha6lfcb0mg0y977bxa6xg8krpbsbzpm4b5xw6y6wign4d8a8w";
+  };
+
+  installPhase = ''
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+             --set-rpath ${stdenv.lib.makeLibraryPath [ glib zlib dbus dbus_glib gtk2 gdk_pixbuf cairo pango ]} \
+             tixati
+    install -D tixati         $out/bin/tixati
+    install -D tixati.desktop $out/share/applications/tixati.desktop
+    install -D tixati.png     $out/share/icons/tixati.png
+  '';
+
+  dontStrip = true;
+
+  meta = with stdenv.lib; {
+    description = "Torrent client";
+    homepage = http://www.tixati.com;
+    license = licenses.free;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ volth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16723,6 +16723,8 @@ with pkgs;
 
   tint2 = callPackage ../applications/misc/tint2 { };
 
+  tixati = callPackage ../applications/networking/p2p/tixati { };
+
   tkcvs = callPackage ../applications/version-management/tkcvs { };
 
   tla = callPackage ../applications/version-management/arch { };


### PR DESCRIPTION
###### Motivation for this change

A torrent client (closed source single binary)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

