### PR TITLE
dump1090: init at bff92c4

### DIFF
--- a/pkgs/applications/misc/dump1090/default.nix
+++ b/pkgs/applications/misc/dump1090/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, pkgconfig, libusb, rtl-sdr }:
+
+stdenv.mkDerivation rec {
+  name = "dump1090-${version}";
+  version = "2014-10-31";
+
+  src = fetchFromGitHub {
+    owner = "MalcolmRobb";
+    repo = "dump1090";
+    rev = "bff92c4ad772a0a8d433f788d39dae97e00e4dbe";
+    sha256 = "06aaj9gpz5v4qzvnp8xf18wdfclp0jvn3hflls79ly46gz2dh9hy";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ libusb rtl-sdr ];
+
+  makeFlags = [ "PREFIX=$out" ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share
+    cp -v dump1090 $out/bin/dump1090
+    cp -vr public_html $out/share/dump1090
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A simple Mode S decoder for RTLSDR devices";
+    homepage = https://github.com/MalcolmRobb/dump1090;
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ earldouglas ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -122,6 +122,8 @@ with pkgs;
 
   dispad = callPackage ../tools/X11/dispad { };
 
+  dump1090 = callPackage ../applications/misc/dump1090 { };
+
   vsenv = callPackage ../build-support/vsenv {
     vs = vs90wrapper;
   };


### PR DESCRIPTION
###### Motivation for this change

Allow nix users to easily install dump1090.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

