### PR TITLE
alacritty: unstable 2017-09-02 -> 2017-10-17

### DIFF
--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -29,16 +29,16 @@ let
 in
 
 buildRustPackage rec {
-  name = "alacritty-unstable-2017-09-02";
+  name = "alacritty-unstable-2017-10-17";
 
   src = fetchFromGitHub {
     owner = "jwilm";
     repo = "alacritty";
-    rev = "22fa4260fc9210fbb5288090df79c92e7b3788e4";
-    sha256 = "0jjvvm0fm25p1h1rgfqlnhq4bwrjdxpb2pgnmpik9pl7qwy3q7s1";
+    rev = "5ac42bb13bc68c5cbc44869dc9fc9ac19402a6e6";
+    sha256 = "0h37x12r33xwz9vf1n8y24c0ph5w17lhkpfi5q6lbpgidvbs6fyx";
   };
 
-  depsSha256 = "19lrj4i6vzmf22r6xg99zcwvzjpiar8pqin1m2nvv78xzxx5yvgb";
+  depsSha256 = "05gkl2zg546i2pm0gx11s56f7dk72qpm39kml1d2myj81s0vyb5z";
 
   buildInputs = [
     cmake


### PR DESCRIPTION
Update to alacritty. Now includes live font resizing:

https://github.com/jwilm/alacritty/commit/8a0b1d9c3f5a9ddb98469a340bbcd06374d4a24e

The commit that I updated to was a few later, which also includes some bug fixes:

https://github.com/jwilm/alacritty/commit/5ac42bb13bc68c5cbc44869dc9fc9ac19402a6e6

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions

Tests pass and terminal works.