### PR TITLE
Libabc: add new libabc package

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -323,6 +323,7 @@
   konimex = "Muhammad Herdiansyah <herdiansyah@netc.eu>";
   koral = "Koral <koral@mailoo.org>";
   kovirobi = "Kovacsics Robert <kovirobi@gmail.com>";
+  kquick = "Kevin Quick <quick@sparq.org>";
   kragniz = "Louis Taylor <louis@kragniz.eu>";
   kristoff3r = "Kristoffer Søholm <k.soeholm@gmail.com>";
   ktosiek = "Tomasz Kontusz <tomasz.kontusz@gmail.com>";

--- a/pkgs/applications/science/logic/abc/libabc.nix
+++ b/pkgs/applications/science/logic/abc/libabc.nix
@@ -1,0 +1,41 @@
+{ fetchhg, stdenv, pkgs }:
+
+stdenv.mkDerivation rec {
+
+  # Note that this derivation provides only the library, but under the
+  # "abc" name, to associate with libabc, which conforms to the
+  # standard library dependency referencing nomenclature.  The binary
+  # is available as a separate package with the "abc-verifier" naming.
+
+  name = "abc-${version}";
+  version = "20160818";
+
+  src = fetchhg {
+    url    = "https://bitbucket.org/alanmi/abc";
+    rev    = "a2e5bc66a68a72ccd267949e5c9973dd18f8932a";
+    sha256 = "09yvhj53af91nc54gmy7cbp7yljfcyj68a87494r5xvdfnsj11gy";
+  };
+
+  buildInputs = [ ];
+  preBuild = ''
+    export buildFlags="CC=$CC CXX=$CXX LD=$CXX ABC_USE_NO_READLINE=1 libabc.a"
+  '';
+
+  # n.b. the following are documented, but libabc.so is not a valid make target:
+  # ABC_USE_PIC=1 libabc.so
+
+  enableParallelBuilding = true;
+  installPhase = ''
+    mkdir -p $out/lib
+    mv libabc.a $out/lib
+    # mv libabc.so $out/lib
+  '';
+
+  meta = {
+    description = "A library for sequential logic synthesis and formal verification";
+    homepage    = "https://people.eecs.berkeley.edu/~alanmi/abc/abc.htm";
+    license     = stdenv.lib.licenses.mit;
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.kquick ];
+  };
+}

--- a/pkgs/applications/science/logic/abc/libabc.nix
+++ b/pkgs/applications/science/logic/abc/libabc.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
     sha256 = "09yvhj53af91nc54gmy7cbp7yljfcyj68a87494r5xvdfnsj11gy";
   };
 
-  buildInputs = [ ];
   preBuild = ''
     export buildFlags="CC=$CC CXX=$CXX LD=$CXX ABC_USE_NO_READLINE=1 libabc.a"
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18481,6 +18481,7 @@ with pkgs;
 
   ### SCIENCE/LOGIC
 
+  abc = callPackage ../applications/science/logic/abc/libabc.nix {};
   abc-verifier = callPackage ../applications/science/logic/abc {};
 
   abella = callPackage ../applications/science/logic/abella {};


### PR DESCRIPTION
###### Motivation for this change

Adds new package to provide the libabc library for other applications to link against.

Replaces pull request https://github.com/NixOS/nixpkgs/pull/27198
Depends on pull request https://github.com/NixOS/nixpkgs/pull/30565

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
     *N/A*
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
     *N/A*
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
     *N/A*
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

