### PR TITLE
theft: init at 0.4.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -323,6 +323,7 @@
   konimex = "Muhammad Herdiansyah <herdiansyah@netc.eu>";
   koral = "Koral <koral@mailoo.org>";
   kovirobi = "Kovacsics Robert <kovirobi@gmail.com>";
+  kquick = "Kevin Quick <quick@sparq.org>";
   kragniz = "Louis Taylor <louis@kragniz.eu>";
   kristoff3r = "Kristoffer Søholm <k.soeholm@gmail.com>";
   ktosiek = "Tomasz Kontusz <tomasz.kontusz@gmail.com>";

--- a/pkgs/development/libraries/theft/default.nix
+++ b/pkgs/development/libraries/theft/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  version = "0.4.3";
+  name = "theft-${version}";
+
+  src = fetchFromGitHub {
+    owner = "silentbicycle";
+    repo = "theft";
+    rev = "v${version}";
+    sha256 = "1ibh8np12lafnrsrvjbbzlyq45zq654939x0y22vdnc6s8dpbhw4";
+  };
+
+  preConfigure = "patchShebangs ./scripts/mk_bits_lut";
+  # doCheck = true;
+  
+  propagatedBuildInputs = [ ];
+
+  buildInputs = [ ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+  postInstall = ''
+      install -m644 vendor/greatest.h $out/include/
+    '';
+  
+  meta = {
+    description = "A C library for property-based testing.";
+    platforms = stdenv.lib.platforms.linux;
+    homepage = "http://github.com/silentbicycle/theft/";
+    license = stdenv.lib.licenses.isc;
+    maintainers = [ stdenv.lib.maintainers.kquick ];
+  };
+}

--- a/pkgs/development/libraries/theft/default.nix
+++ b/pkgs/development/libraries/theft/default.nix
@@ -12,12 +12,10 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = "patchShebangs ./scripts/mk_bits_lut";
-  # doCheck = true;
+
+  doCheck = true;
+  checkTarget = "test";
   
-  propagatedBuildInputs = [ ];
-
-  buildInputs = [ ];
-
   installFlags = [ "PREFIX=$(out)" ];
   postInstall = ''
       install -m644 vendor/greatest.h $out/include/

--- a/pkgs/development/libraries/theft/default.nix
+++ b/pkgs/development/libraries/theft/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     '';
   
   meta = {
-    description = "A C library for property-based testing.";
+    description = "A C library for property-based testing";
     platforms = stdenv.lib.platforms.linux;
     homepage = "http://github.com/silentbicycle/theft/";
     license = stdenv.lib.licenses.isc;

--- a/pkgs/development/libraries/theft/default.nix
+++ b/pkgs/development/libraries/theft/default.nix
@@ -17,9 +17,7 @@ stdenv.mkDerivation rec {
   checkTarget = "test";
   
   installFlags = [ "PREFIX=$(out)" ];
-  postInstall = ''
-      install -m644 vendor/greatest.h $out/include/
-    '';
+  postInstall = "install -m644 vendor/greatest.h $out/include/";
   
   meta = {
     description = "A C library for property-based testing";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10766,6 +10766,8 @@ with pkgs;
 
   tet = callPackage ../development/tools/misc/tet { };
 
+  theft = callPackage ../development/libraries/theft { };
+
   thrift = callPackage ../development/libraries/thrift {
     inherit (pythonPackages) twisted;
   };


### PR DESCRIPTION
###### Motivation for this change

Package is not currently in nixpkgs.

Depends on pull request #30565

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
     *N/A*
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
     *N/A*
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
     *N/A*
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

