### PR TITLE
fetchgitrev: fix parsing and add certs for https://github.com fetching

### DIFF
--- a/pkgs/build-support/fetchgitrevision/default.nix
+++ b/pkgs/build-support/fetchgitrevision/default.nix
@@ -1,10 +1,12 @@
-runCommand: git: repository: branch:
+runCommand: git: cacert: repository: branch:
   import (runCommand "head-revision"
-    { buildInputs = [ git ];
+    { buildInputs = [ git cacert ];
       dummy = builtins.currentTime;
     }
     ''
-      rev=$(git ls-remote ${repository} | grep "refs/${branch}$" | awk '{ print $1 }')
+      rev=$(git -c http.sslCAinfo=${cacert}/etc/ssl/certs/ca-bundle.crt \
+                ls-remote ${repository} | \
+            grep "refs/${branch}$" | awk '{ print $1 }')
       echo "[ \"$rev\" ]" > $out
       echo Latest revision in ${branch} is $rev
     '')

--- a/pkgs/build-support/fetchgitrevision/default.nix
+++ b/pkgs/build-support/fetchgitrevision/default.nix
@@ -6,7 +6,7 @@ runCommand: git: cacert: repository: branch:
     ''
       rev=$(git -c http.sslCAinfo=${cacert}/etc/ssl/certs/ca-bundle.crt \
                 ls-remote ${repository} | \
-            grep "refs/${branch}$" | awk '{ print $1 }')
+            egrep "refs(/.*|)/${branch}$" | awk '{ print $1 }')
       echo "[ \"$rev\" ]" > $out
       echo Latest revision in ${branch} is $rev
     '')

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -151,7 +151,7 @@ with pkgs;
 
   fetchgitPrivate = callPackage ../build-support/fetchgit/private.nix { };
 
-  fetchgitrevision = import ../build-support/fetchgitrevision runCommand git;
+  fetchgitrevision = import ../build-support/fetchgitrevision runCommand git cacert;
 
   fetchgitLocal = callPackage ../build-support/fetchgitlocal { };
 


### PR DESCRIPTION
###### Motivation for this change

Fix fetchgitrevision to work properly.  There appear to be no current uses of this in the nixpkgs repo, but attempts to use it locally failed until the patches in this PR were applied.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
     *Note* this was tested without using sandbox: when sandboxing is enabled, uses of fetchgitrevision fail with a DNS lookup error for github.com.  I believe this is a side-effect of sandboxing and unrelated to the changes here.
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

