### PR TITLE
modex: add modex analysis tool package

### DIFF
--- a/pkgs/development/tools/analysis/modex/default.nix
+++ b/pkgs/development/tools/analysis/modex/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, bison, flex }:
+
+stdenv.mkDerivation rec {
+  version = "2.10";
+  name = "modex-${version}";
+
+  src = fetchurl {
+    url = "http://spinroot.com/modex/modex${version}.tar.gz";
+    sha256 = "1iz41w926jgx7b42cmfv7v3i4qwdldababqv60f54bisvrq7psws";
+  };
+
+  preConfigure = ''
+    substituteInPlace makefile --replace /usr/local/modex $out/share/modex
+    substituteInPlace makefile --replace /usr/local $out
+    substituteInPlace xtract.c --replace /usr/local $out/share
+    '';
+
+  sourceRoot = "Src2.10";
+
+  preInstall = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/modex/Examples
+    mkdir -p $out/share/modex/Manual
+    '';
+
+  postInstall = ''
+    install -m755 ../Scripts/verify $out/bin/
+    install -m644 ../Examples/* $out/share/modex/Examples/
+    install -m644 ../Manual/* $out/share/modex/Manual/
+    '';
+  
+  propagatedBuildInputs = [ ];
+
+  buildInputs = [ bison flex ];
+
+  meta = {
+    description = "Mechanical extraction of verification models from implementation level C code for spin.";
+    platforms = stdenv.lib.platforms.all;
+    license = stdenv.lib.licenses.free;
+    homepage = "http://spinroot.com/modex";
+    maintainers = [ stdenv.lib.maintainers.kquick ];
+  };
+}

--- a/pkgs/development/tools/analysis/modex/default.nix
+++ b/pkgs/development/tools/analysis/modex/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Mechanical extraction of verification models from implementation level C code for spin";
-    platforms = stdenv.lib.platforms.all;
+    platforms = stdenv.lib.platforms.linux;
     license = {
       fullName = "Educational, notice must be maintained, non-monetizable";
       location = "tarball extracted $sourceRoot/modex.c";

--- a/pkgs/development/tools/analysis/modex/default.nix
+++ b/pkgs/development/tools/analysis/modex/default.nix
@@ -34,7 +34,11 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Mechanical extraction of verification models from implementation level C code for spin";
     platforms = stdenv.lib.platforms.all;
-    license = stdenv.lib.licenses.free;
+    license = {
+      fullName = "Educational, notice must be maintained, non-monetizable";
+      location = "tarball extracted $sourceRoot/modex.c";
+      free = true;
+    };
     homepage = "http://spinroot.com/modex";
     maintainers = [ stdenv.lib.maintainers.kquick ];
   };

--- a/pkgs/development/tools/analysis/modex/default.nix
+++ b/pkgs/development/tools/analysis/modex/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ bison flex ];
 
   meta = {
-    description = "Mechanical extraction of verification models from implementation level C code for spin.";
+    description = "Mechanical extraction of verification models from implementation level C code for spin";
     platforms = stdenv.lib.platforms.all;
     license = stdenv.lib.licenses.free;
     homepage = "http://spinroot.com/modex";

--- a/pkgs/development/tools/analysis/modex/default.nix
+++ b/pkgs/development/tools/analysis/modex/default.nix
@@ -29,8 +29,6 @@ stdenv.mkDerivation rec {
     install -m644 ../Manual/* $out/share/modex/Manual/
     '';
   
-  propagatedBuildInputs = [ ];
-
   buildInputs = [ bison flex ];
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7378,6 +7378,8 @@ with pkgs;
 
   moby = callPackage ../development/tools/misc/moby { };
 
+  modex = callPackage ../development/tools/analysis/modex { };
+
   msgpack-tools = callPackage ../development/tools/msgpack-tools { };
 
   msitools = callPackage ../development/tools/misc/msitools { };


### PR DESCRIPTION
###### Motivation for this change

Add new tool not currently in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

