### PR TITLE
twilio: init at 6.8.0

### DIFF
--- a/pkgs/development/python-modules/twilio/default.nix
+++ b/pkgs/development/python-modules/twilio/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub
+, pyjwt, pysocks, pytz, requests, six, nose, mock }:
+
+buildPythonPackage rec {
+  pname = "twilio";
+  version = "6.8.0";
+  name = "${pname}-${version}";
+
+  # tests not included in PyPi, so fetch from github instead
+  src = fetchFromGitHub {
+    owner = "twilio";
+    repo = "twilio-python";
+    rev = version;
+    sha256 = "1vi3m6kvbmv643jbz95q59rcn871y0sss48kw2nqziyr5iswfx8c";
+  };
+
+  buildInputs = [ nose mock ];
+
+  propagatedBuildInputs = [ pyjwt pysocks pytz six requests ];
+
+  meta = with stdenv.lib; {
+    description = "Twilio API client and TwiML generator";
+    homepage = https://github.com/twilio/twilio-python/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ flokli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26486,6 +26486,8 @@ EOF
 
   stripe = callPackage ../development/python-modules/stripe { };
 
+  twilio = callPackage ../development/python-modules/twilio { };
+
   uranium = callPackage ../development/python-modules/uranium { };
 
   vine = callPackage ../development/python-modules/vine { };


### PR DESCRIPTION
###### Motivation for this change

This adds the `twilio` python library.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

