### PR TITLE
buildNodePackage: Fix impure packages patching

### DIFF
--- a/pkgs/development/web/nodejs/build-node-package.nix
+++ b/pkgs/development/web/nodejs/build-node-package.nix
@@ -145,7 +145,7 @@ let
         function replaceImpureVersionSpec(versionSpec) {
             var parsedUrl = url.parse(versionSpec);
 
-            if(versionSpec == "latest" || versionSpec == "unstable" ||
+            if(versionSpec == "" || versionSpec == "latest" || versionSpec == "unstable" ||
                 versionSpec.substr(0, 2) == ".." || dependency.substr(0, 2) == "./" || dependency.substr(0, 2) == "~/" || dependency.substr(0, 1) == '/' || /^[^/]+\/[^/]+$/.test(versionSpec))
                 return '*';
             else if(parsedUrl.protocol == "git:" || parsedUrl.protocol == "git+ssh:" || parsedUrl.protocol == "git+http:" || parsedUrl.protocol == "git+https:" ||


### PR DESCRIPTION
###### Motivation for this change

`buildNodePackage` replaces impure version specs in `package.json` before `npm install`.

It currently changes package like these:
```
{
  "dependencies": {
    "package1":"latest"
  }
}
```

To:

```
{
  "dependencies": {
    "package1":"*"
  }
}
```

such that packages fetched by nix is used, pureness is maintained.

However it does not handle the case of empty version string (""), which is same as "latest".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
