### PR TITLE
msmtp: compiles with keyring support by default

### DIFF
--- a/pkgs/applications/networking/msmtp/default.nix
+++ b/pkgs/applications/networking/msmtp/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchurl, autoreconfHook, pkgconfig
 , openssl, netcat-gnu, gnutls, gsasl, libidn, Security
+, libsecret, withKeyring ? true
 , systemd ? null }:
 
 let
@@ -20,11 +21,13 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ openssl gnutls gsasl libidn ]
-    ++ stdenv.lib.optional stdenv.isDarwin Security;
+    ++ stdenv.lib.optional stdenv.isDarwin Security
+    ++ stdenv.lib.optional withKeyring libsecret;
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   configureFlags =
-    stdenv.lib.optional stdenv.isDarwin [ "--with-macosx-keyring" ];
+    stdenv.lib.optional stdenv.isDarwin [ "--with-macosx-keyring" ]
+    ++ stdenv.lib.optional withKeyring [ "--with-libsecret" ];
 
   postInstall = ''
     substitute scripts/msmtpq/msmtpq $out/bin/msmtpq \

--- a/pkgs/applications/networking/msmtp/default.nix
+++ b/pkgs/applications/networking/msmtp/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, autoreconfHook, pkgconfig
 , openssl, netcat-gnu, gnutls, gsasl, libidn, Security
-, libsecret ? null
+, withKeyring ? true, libsecret ? null
 , systemd ? null }:
 
 let
@@ -20,13 +20,14 @@ in stdenv.mkDerivation rec {
     ./paths.patch
   ];
 
-  buildInputs = [ openssl gnutls gsasl libidn libsecret ]
-    ++ stdenv.lib.optional stdenv.isDarwin Security;
+  buildInputs = [ openssl gnutls gsasl libidn ]
+    ++ stdenv.lib.optional stdenv.isDarwin Security
+    ++ stdenv.lib.optional withKeyring libsecret;
+
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   configureFlags =
     stdenv.lib.optional stdenv.isDarwin [ "--with-macosx-keyring" ];
-    # ++ stdenv.lib.optional withKeyring [ "--with-libsecret" ];
 
   postInstall = ''
     substitute scripts/msmtpq/msmtpq $out/bin/msmtpq \

--- a/pkgs/applications/networking/msmtp/default.nix
+++ b/pkgs/applications/networking/msmtp/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, autoreconfHook, pkgconfig
 , openssl, netcat-gnu, gnutls, gsasl, libidn, Security
-, libsecret, withKeyring ? true
+, libsecret ? null
 , systemd ? null }:
 
 let
@@ -20,14 +20,13 @@ in stdenv.mkDerivation rec {
     ./paths.patch
   ];
 
-  buildInputs = [ openssl gnutls gsasl libidn ]
-    ++ stdenv.lib.optional stdenv.isDarwin Security
-    ++ stdenv.lib.optional withKeyring libsecret;
+  buildInputs = [ openssl gnutls gsasl libidn libsecret ]
+    ++ stdenv.lib.optional stdenv.isDarwin Security;
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   configureFlags =
-    stdenv.lib.optional stdenv.isDarwin [ "--with-macosx-keyring" ]
-    ++ stdenv.lib.optional withKeyring [ "--with-libsecret" ];
+    stdenv.lib.optional stdenv.isDarwin [ "--with-macosx-keyring" ];
+    # ++ stdenv.lib.optional withKeyring [ "--with-libsecret" ];
 
   postInstall = ''
     substitute scripts/msmtpq/msmtpq $out/bin/msmtpq \


### PR DESCRIPTION
As it is recommended by msmtp http://msmtp.sourceforge.net/doc/msmtp.html#Authentication.

###### Motivation for this change
That's the "cleaner" way to retrieve password and recommended way as well.
Not sure it will pass on mac.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

