### PR TITLE
electrum: Enable plotting support

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -13,6 +13,7 @@ python2Packages.buildPythonApplication rec {
     dns
     ecdsa
     jsonrpclib
+    matplotlib
     pbkdf2
     protobuf
     pyaes
@@ -30,7 +31,6 @@ python2Packages.buildPythonApplication rec {
     # TODO plugins
     # amodem
     # btchip
-    # matplotlib
   ];
 
   preBuild = ''


### PR DESCRIPTION
###### Motivation for this change

Plotting seems to be a core feature now, with a menu entry available by
default. Without the matplotlib dependency this opens a warning popup
though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

