### PR TITLE
musl: 1.1.16 -> 1.1.17, build with stack protector

### DIFF
--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -2,17 +2,17 @@
 
 stdenv.mkDerivation rec {
   name    = "musl-${version}";
-  version = "1.1.16";
+  version = "1.1.17";
 
   src = fetchurl {
     url    = "http://www.musl-libc.org/releases/${name}.tar.gz";
-    sha256 = "048h0w4yjyza4h05bkc6dpwg3hq6l03na46g0q1ha8fpwnjqawck";
+    sha256 = "0r0lyp2w6v2bvm8h1si7w3p2qx037szl14qnxm5p00568z3m3an8";
   };
 
   enableParallelBuilding = true;
 
-  # required to avoid busybox segfaulting on startup when invoking
-  # nix-build "<nixpkgs/pkgs/stdenv/linux/make-bootstrap-tools.nix>"
+  # Disable auto-adding stack protector flags,
+  # so musl can selectively disable as needed
   hardeningDisable = [ "stackprotector" ];
 
   preConfigure = ''
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-shared"
     "--enable-static"
+    "CFLAGS=-fstack-protector-strong"
   ];
 
   patches = [];


### PR DESCRIPTION
###### Motivation for this change

Release notes:
http://www.openwall.com/lists/musl/2017/10/19/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

