### PR TITLE
Update firefox.syncserver and its dependencies

### DIFF
--- a/pkgs/development/python-modules/serversyncstorage/default.nix
+++ b/pkgs/development/python-modules/serversyncstorage/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, buildPythonPackage
+, fetchgit
+, isPy27
+, testfixtures
+, unittest2
+, webtest
+, pyramid
+, sqlalchemy
+, simplejson
+, mozsvc
+, cornice
+, pyramid_hawkauth
+, pymysql
+, pymysqlsa
+, umemcache
+, WSGIProxy
+, requests
+, pybrowserid
+}:
+
+buildPythonPackage rec {
+  name = "serversyncstorage-${version}";
+  version = "1.6.11";
+  disabled = !isPy27;
+
+  src = fetchgit {
+    url = https://github.com/mozilla-services/server-syncstorage.git;
+    rev = "refs/tags/${version}";
+    sha256 = "197gj2jfs2c6nzs20j37kqxwi91wabavxnfm4rqmrjwhgqjwhnm0";
+  };
+
+  buildInputs = [ testfixtures unittest2 webtest ];
+  propagatedBuildInputs = [
+    pyramid sqlalchemy simplejson mozsvc cornice pyramid_hawkauth pymysql
+    pymysqlsa umemcache WSGIProxy requests pybrowserid
+  ];
+}

--- a/pkgs/development/python-modules/syncserver/default.nix
+++ b/pkgs/development/python-modules/syncserver/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, buildPythonPackage
+, fetchgit
+, isPy27
+, unittest2
+, cornice
+, gunicorn
+, pyramid
+, requests
+, simplejson
+, sqlalchemy
+, mozsvc
+, tokenserver
+, serversyncstorage
+, configparser
+}:
+
+buildPythonPackage rec {
+  name = "syncserver-${version}";
+  version = "1.6.0";
+  disabled = ! isPy27;
+
+  src = fetchgit {
+    url = https://github.com/mozilla-services/syncserver.git;
+    rev = "refs/tags/${version}";
+    sha256 = "1fsiwihgq3z5b5kmssxxil5g2abfvsf6wfikzyvi4sy8hnym77mb";
+  };
+
+  buildInputs = [ unittest2 ];
+  propagatedBuildInputs = [
+    cornice gunicorn pyramid requests simplejson sqlalchemy mozsvc tokenserver
+    serversyncstorage configparser
+  ];
+
+  meta = {
+    maintainers = [ ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/tokenserver/default.nix
+++ b/pkgs/development/python-modules/tokenserver/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, buildPythonPackage
+, fetchgit
+, testfixtures
+, cornice
+, mozsvc
+, pybrowserid
+, tokenlib
+, pymysql
+, umemcache
+, hawkauthlib
+, alembic
+, pymysqlsa
+, paste
+, boto
+}:
+
+buildPythonPackage rec {
+  name = "tokenserver-${version}";
+  version = "1.2.27";
+
+  src = fetchgit {
+    url = https://github.com/mozilla-services/tokenserver.git;
+    rev = "refs/tags/${version}";
+    sha256 = "0il3bgjld495g9gxvvrm56kpan5swaizzg216qz3zxmb6w9ly3fm";
+  };
+
+  doCheck = false;
+  buildInputs = [ testfixtures ];
+  propagatedBuildInputs = [ cornice mozsvc pybrowserid tokenlib
+    pymysql umemcache hawkauthlib alembic pymysqlsa paste boto ];
+
+  meta = {
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -344,6 +344,8 @@ in {
 
   rhpl = disabledIf isPy3k (callPackage ../development/python-modules/rhpl {});
 
+  serversyncstorage = callPackage ../development/python-modules/serversyncstorage {};
+
   simpleeval = callPackage ../development/python-modules/simpleeval { };
 
   sip = callPackage ../development/python-modules/sip { };
@@ -22190,26 +22192,6 @@ EOF
       license = licenses.gpl2Plus;
       maintainers =  with maintainers; [ gal_bolle ];
     };
-  };
-
-  serversyncstorage = buildPythonPackage rec {
-    name = "serversyncstorage-${version}";
-    version = "1.6.11";
-    disabled = !isPy27;
-
-    src = pkgs.fetchgit {
-      url = https://github.com/mozilla-services/server-syncstorage.git;
-      rev = "refs/tags/${version}";
-      sha256 = "197gj2jfs2c6nzs20j37kqxwi91wabavxnfm4rqmrjwhgqjwhnm0";
-    };
-
-    propagatedBuildInputs = with self; [
-      pyramid sqlalchemy simplejson mozsvc cornice pyramid_hawkauth pymysql
-      pymysqlsa umemcache WSGIProxy requests pybrowserid
-    ];
-    buildInputs = with self; [ testfixtures unittest2 webtest ];
-
-    #doCheck = false; # lazy packager
   };
 
   WSGIProxy = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22210,13 +22210,13 @@ EOF
 
   syncserver = buildPythonPackage rec {
     name = "syncserver-${version}";
-    version = "1.5.2";
+    version = "1.6.0";
     disabled = ! isPy27;
 
     src = pkgs.fetchgit {
       url = https://github.com/mozilla-services/syncserver.git;
       rev = "refs/tags/${version}";
-      sha256 = "1pk4rvwvsd1vxbpzg39hxqi8pi9v6b4s6m0mqbpg88s6s7i6ks3m";
+      sha256 = "1fsiwihgq3z5b5kmssxxil5g2abfvsf6wfikzyvi4sy8hnym77mb";
     };
 
     buildInputs = with self; [ unittest2 ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22233,13 +22233,13 @@ EOF
 
   serversyncstorage = buildPythonPackage rec {
     name = "serversyncstorage-${version}";
-    version = "1.5.13";
+    version = "1.6.11";
     disabled = !isPy27;
 
     src = pkgs.fetchgit {
       url = https://github.com/mozilla-services/server-syncstorage.git;
       rev = "refs/tags/${version}";
-      sha256 = "0m14v7n105y06w3mdp35pyxyzjj5vqwbznzdbixhkms3df6md2lq";
+      sha256 = "197gj2jfs2c6nzs20j37kqxwi91wabavxnfm4rqmrjwhgqjwhnm0";
     };
 
     propagatedBuildInputs = with self; [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -354,6 +354,8 @@ in {
     hdf5 = pkgs.hdf5.override { zlib = pkgs.zlib; };
   };
 
+  tokenserver = callPackage ../development/python-modules/tokenserver {};
+
   unifi = callPackage ../development/python-modules/unifi { };
 
   pyunbound = callPackage ../tools/networking/unbound/python.nix { };
@@ -21236,26 +21238,6 @@ EOF
     checkPhase = ''
       py.test $out/${python.sitePackages}/zmq/ -k "not test_large_send and not test_recv_json_cancelled"
     '';
-  };
-
-  tokenserver = buildPythonPackage rec {
-    name = "tokenserver-${version}";
-    version = "1.2.27";
-
-    src = pkgs.fetchgit {
-      url = https://github.com/mozilla-services/tokenserver.git;
-      rev = "refs/tags/${version}";
-      sha256 = "0il3bgjld495g9gxvvrm56kpan5swaizzg216qz3zxmb6w9ly3fm";
-    };
-
-    doCheck = false;
-    buildInputs = [ self.testfixtures ];
-    propagatedBuildInputs = with self; [ cornice mozsvc pybrowserid tokenlib
-      pymysql umemcache hawkauthlib alembic pymysqlsa paste boto ];
-
-    meta = {
-      platforms = platforms.all;
-    };
   };
 
   testfixtures = callPackage ../development/python-modules/testfixtures {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -350,6 +350,8 @@ in {
 
   supervise_api = callPackage ../development/python-modules/supervise_api { };
 
+  syncserver = callPackage ../development/python-modules/syncserver {};
+
   tables = callPackage ../development/python-modules/tables {
     hdf5 = pkgs.hdf5.override { zlib = pkgs.zlib; };
   };
@@ -22187,29 +22189,6 @@ EOF
       description = "An SVG to TikZ converter";
       license = licenses.gpl2Plus;
       maintainers =  with maintainers; [ gal_bolle ];
-    };
-  };
-
-  syncserver = buildPythonPackage rec {
-    name = "syncserver-${version}";
-    version = "1.6.0";
-    disabled = ! isPy27;
-
-    src = pkgs.fetchgit {
-      url = https://github.com/mozilla-services/syncserver.git;
-      rev = "refs/tags/${version}";
-      sha256 = "1fsiwihgq3z5b5kmssxxil5g2abfvsf6wfikzyvi4sy8hnym77mb";
-    };
-
-    buildInputs = with self; [ unittest2 ];
-    propagatedBuildInputs = with self; [
-      cornice gunicorn pyramid requests simplejson sqlalchemy mozsvc tokenserver
-      serversyncstorage configparser
-    ];
-
-    meta = {
-      maintainers = [ ];
-      platforms = platforms.all;
     };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21240,17 +21240,18 @@ EOF
 
   tokenserver = buildPythonPackage rec {
     name = "tokenserver-${version}";
-    version = "1.2.11";
+    version = "1.2.27";
 
     src = pkgs.fetchgit {
       url = https://github.com/mozilla-services/tokenserver.git;
       rev = "refs/tags/${version}";
-      sha256 = "1cvkvxcday1qc3zyarasj3l7322w8afhrcxcsvb5wac1ryh1w6y2";
+      sha256 = "0il3bgjld495g9gxvvrm56kpan5swaizzg216qz3zxmb6w9ly3fm";
     };
 
     doCheck = false;
     buildInputs = [ self.testfixtures ];
-    propagatedBuildInputs = with self; [ cornice mozsvc pybrowserid tokenlib ];
+    propagatedBuildInputs = with self; [ cornice mozsvc pybrowserid tokenlib
+      pymysql umemcache hawkauthlib alembic pymysqlsa paste boto ];
 
     meta = {
       platforms = platforms.all;


### PR DESCRIPTION
###### Motivation for this change
Update; also fixes compatibility with recent versions of Firefox Android.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).