### PR TITLE
kisslicer: init at 1.6.2

### DIFF
--- a/pkgs/tools/misc/kisslicer/default.nix
+++ b/pkgs/tools/misc/kisslicer/default.nix
@@ -1,0 +1,56 @@
+{ fetchzip
+, libX11
+, mesa
+, makeWrapper
+, stdenv
+}:
+
+let
+
+  libPath = stdenv.lib.makeLibraryPath [
+    mesa
+    stdenv.cc.cc
+    libX11
+  ];
+  inidir = "\\\${XDG_CONFIG_HOME:-\\$HOME/.config}/kisslicer";
+
+in stdenv.mkDerivation rec {
+
+  name = "kisslicer-1.6.2";
+
+  src = fetchzip {
+    url = "http://www.kisslicer.com/uploads/1/5/3/8/15381852/kisslicer_linux64_1.6.2_release.zip";
+    sha256 = "0fb7hzic78skq3ykc37srnjsw0yri7m0pb3arlz076ws7jrcbr0f";
+    stripRoot = false;
+  };
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  buildInputs = [
+    makeWrapper
+    mesa
+    libX11
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -p * $out/bin
+  '';
+
+  fixupPhase = ''
+    chmod 755 $out/bin/KISSlicer
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath ${libPath}   $out/bin/KISSlicer
+    wrapProgram $out/bin/KISSlicer \
+      --add-flags "-inidir ${inidir}" \
+      --run "mkdir -p ${inidir}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Convert STL files into Gcode";
+    homepage = http://www.kisslicer.com;
+    license = licenses.unfree;
+    maintainers = [ maintainers.cransom ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1128,6 +1128,8 @@ with pkgs;
 
   kapacitor = callPackage ../servers/monitoring/kapacitor { };
 
+  kisslicer = callPackage ../tools/misc/kisslicer { };
+
   lcdproc = callPackage ../servers/monitoring/lcdproc { };
 
   languagetool = callPackage ../tools/text/languagetool {  };


### PR DESCRIPTION
###### Motivation for this change
I'd like to use my favorite 3d printing slicer under NixOS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

