### PR TITLE
scalafmt: fix platforms

### DIFF
--- a/pkgs/development/tools/scalafmt/default.nix
+++ b/pkgs/development/tools/scalafmt/default.nix
@@ -30,7 +30,6 @@ stdenv.mkDerivation rec {
     description = "Opinionated code formatter for Scala";
     homepage = http://scalafmt.org;
     license = licenses.asl20;
-    platforms = platforms.linux;
     maintainers = [ maintainers.markus1189 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
scalafmt refuses to evaluate on darwin, while it's JRE-based and is as cross-platform as JRE itself, so it makes sense to remove the "platforms" constraint.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

