### PR TITLE
szip: 2.1 -> 2.1.1

### DIFF
--- a/pkgs/development/libraries/szip/default.nix
+++ b/pkgs/development/libraries/szip/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchurl }:
     
-stdenv.mkDerivation {
-  name = "szip-2.1";
+stdenv.mkDerivation rec {
+  name = "szip-${version}";
+  version = "2.1.1";
   src = fetchurl {
-    url = ftp://ftp.hdfgroup.org/lib-external/szip/2.1/src/szip-2.1.tar.gz;
-    sha256 = "1vym7r4by02m0yqj10023xyps5b21ryymnxb4nb2gs32arfxj5m8";
+    url = "ftp://ftp.hdfgroup.org/lib-external/szip/${version}/src/szip-${version}.tar.gz";
+    sha256 = "1a8415a7xifagb22aq9dmy7b2s5l0y6diany3b4qigylw6adlzc9";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Version 2.1 is not available anymore upstream. Replaced by version 2.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

