### PR TITLE
iniparser: 3.1 -> 4.0

### DIFF
--- a/pkgs/development/libraries/iniparser/default.nix
+++ b/pkgs/development/libraries/iniparser/default.nix
@@ -1,17 +1,23 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub }:
 
 let
   inherit (stdenv.lib) optional;
-in
-stdenv.mkDerivation rec{
-  name = "iniparser-3.1";
 
-  src = fetchurl {
-    url = "${meta.homepage}/iniparser-3.1.tar.gz";
-    sha256 = "1igmxzcy0s25zcy9vmcw0kd13lh60r0b4qg8lnp1jic33f427pxf";
+in stdenv.mkDerivation rec {
+  name = "iniparser-${version}";
+  version = "4.0";
+
+  src = fetchFromGitHub {
+    owner = "ndevilla";
+    repo = "iniparser";
+    rev = "v${version}";
+    sha256 = "0339qa0qxa5z02xjcs5my8v91v0r9jm4piswrl1sa29kwyxgv5nb";
   };
 
   patches = ./no-usr.patch;
+
+  doCheck = true;
+  preCheck = "patchShebangs test/make-tests.sh";
 
   # TODO: Build dylib on Darwin
   buildFlags = (if stdenv.isDarwin then [ "libiniparser.a" ] else [ "libiniparser.so" ]) ++ [ "CC=cc" ];
@@ -23,7 +29,7 @@ stdenv.mkDerivation rec{
     cp src/*.h $out/include
 
     mkdir -p $out/share/doc/${name}
-    for i in AUTHORS INSTALL LICENSE README; do
+    for i in AUTHORS INSTALL LICENSE README.md; do
       bzip2 -c -9 $i > $out/share/doc/${name}/$i.bz2;
     done;
     cp -r html $out/share/doc/${name}
@@ -36,7 +42,7 @@ stdenv.mkDerivation rec{
   '');
 
   meta = {
-    homepage = http://ndevilla.free.fr/iniparser;
+    inherit (src.meta) homepage;
     description = "Free standalone ini file parsing library";
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/iniparser/no-usr.patch
+++ b/pkgs/development/libraries/iniparser/no-usr.patch
@@ -1,14 +1,13 @@
-diff -urN iniparser3.0b.orig/Makefile iniparser3.0b/Makefile
---- iniparser3.0b.orig/Makefile	2008-01-16 19:56:08.000000000 +0100
-+++ iniparser3.0b/Makefile	2008-01-16 19:56:49.000000000 +0100
-@@ -11,8 +11,8 @@
+--- a/Makefile	2017-10-20 20:30:41.494608284 +0200
++++ b/Makefile	2017-10-20 20:33:22.279212026 +0200
+@@ -20,8 +20,8 @@
  ARFLAGS = rcv
  
  SHLD = ${CC} ${CFLAGS}
--LDSHFLAGS = -shared -Wl,-Bsymbolic  -Wl,-rpath -Wl,/usr/lib -Wl,-rpath,/usr/lib
--LDFLAGS = -Wl,-rpath -Wl,/usr/lib -Wl,-rpath,/usr/lib
+-LDSHFLAGS = -shared -Wl,-Bsymbolic
+-LDFLAGS += -Wl,-rpath -Wl,/usr/lib -Wl,-rpath,/usr/lib
 +LDSHFLAGS = -shared
 +LDFLAGS =
  
- # Set RANLIB to ranlib on systems that require it (Sun OS < 4, Mac OSX)
- # RANLIB  = ranlib
+ # .so.0 is for version 3.x, .so.1 is 4.x
+ SO_TARGET ?= libiniparser.so.1


### PR DESCRIPTION
###### Motivation for this change

FYI: @wkennington in case you want to run some manual tests. The `samba` test is still succeeding.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

---

