### PR TITLE
fzy: 0.7 -> 0.9

### DIFF
--- a/pkgs/tools/misc/fzy/default.nix
+++ b/pkgs/tools/misc/fzy/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "fzy-${version}";
-  version = "0.7";
+  version = "0.9";
 
   src = fetchFromGitHub {
     owner = "jhawthorn";
     repo = "fzy";
     rev = version;
-    sha256 = "11sc92j9fx23byxv5y4rq0jxp55vc9mrn5hx9lb162vdrl8a4222";
+    sha256 = "1f1sh88ivdgnqaqha5ircfd9vb0xmss976qns022n0ddb91k5ka6";
   };
 
   makeFlags = "PREFIX=$(out)";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/jhawthorn/fzy/releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

