### PR TITLE
r-modules: Fix a number of popular R packages

### DIFF
--- a/pkgs/development/libraries/v8/3.14.nix
+++ b/pkgs/development/libraries/v8/3.14.nix
@@ -1,0 +1,86 @@
+# This old version of V8 is still needed for the R V8 module
+{ stdenv, callPackage, fetchFromGitHub, gyp, readline, python, which, icu, ... }:
+
+assert readline != null;
+
+with stdenv.lib;
+let
+  version = "3.14.5.10";
+  sha256 = "08vhl84166x13b3cbx8y0g99yqx772zd33gawsa1nxqkyrykql6k";
+
+  arch = if stdenv.is64bit then "x64" else "ia32";
+
+in
+stdenv.mkDerivation rec {
+  name = "v8-${version}";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "v8";
+    repo = "v8";
+    rev = "${version}";
+    inherit sha256;
+  };
+  patchPhase = ''
+    sed -i 's,#!/usr/bin/env python,#!${python}/bin/python,' build/gyp_v8
+    sed -i 's,#!/usr/bin/python,#!${python}/bin/python,' build/gyp_v8
+  '';
+
+  configurePhase = ''
+    PYTHONPATH="tools/generate_shim_headers:$PYTHONPATH" \
+    PYTHONPATH="$(toPythonPath ${gyp}):$PYTHONPATH" \
+      build/gyp_v8 \
+        -f make \
+        --generator-output="out" \
+        -Dflock_index=0 \
+        -Dv8_enable_i18n_support=1 \
+        -Duse_system_icu=1 \
+        -Dconsole=readline \
+        -Dcomponent=shared_library \
+        -Dv8_target_arch=${arch}
+  '';
+
+  nativeBuildInputs = [ which ];
+  buildInputs = [ readline python icu ];
+
+  # http://code.google.com/p/v8/issues/detail?id=2149
+  NIX_CFLAGS_COMPILE = concatStringsSep " " [
+    "-Wno-error=strict-overflow"
+    "-Wno-unused-local-typedefs"
+    "-Wno-aggressive-loop-optimizations"
+  ];
+
+  buildFlags = [
+    "LINK=g++"
+    "-C out"
+    "builddir=$(CURDIR)/Release"
+    "BUILDTYPE=Release"
+  ];
+
+  postPatch = stdenv.lib.optionalString (!stdenv.cc.isClang) ''
+    sed -i build/standalone.gyp -e 's,-Wno-format-pedantic,,g'
+  '';
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    install -vD out/Release/d8 "$out/bin/d8"
+    ${if stdenv.system == "x86_64-darwin" then ''
+    install -vD out/Release/lib.target/libv8.dylib "$out/lib/libv8.dylib"
+    '' else ''
+    install -vD out/Release/lib.target/libv8.so "$out/lib/libv8.so"
+    ''}
+    cp -vr include "$out/"
+  '';
+
+  postFixup = if stdenv.isDarwin then ''
+    install_name_tool -change /usr/local/lib/libv8.dylib $out/lib/libv8.dylib -change /usr/lib/libgcc_s.1.dylib ${stdenv.cc.cc.lib}/lib/libgcc_s.1.dylib $out/bin/d8
+    install_name_tool -id $out/lib/libv8.dylib -change /usr/lib/libgcc_s.1.dylib ${stdenv.cc.cc.lib}/lib/libgcc_s.1.dylib $out/lib/libv8.dylib
+  '' else null;
+
+  meta = with stdenv.lib; {
+    description = "Google's open source JavaScript engine";
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -253,6 +253,7 @@ let
     fftwtools = [ pkgs.fftw.dev ];
     Formula = [ pkgs.gmp ];
     geoCount = [ pkgs.gsl_1 ];
+    gdtools = [ pkgs.cairo.dev pkgs.fontconfig.lib pkgs.freetype.dev ];
     git2r = [ pkgs.zlib.dev pkgs.openssl.dev ];
     GLAD = [ pkgs.gsl_1 ];
     glpkAPI = [ pkgs.gmp pkgs.glpk ];
@@ -260,32 +261,37 @@ let
     graphscan = [ pkgs.gsl_1 ];
     gsl = [ pkgs.gsl_1 ];
     h5 = [ pkgs.hdf5-cpp pkgs.which ];
+    haven = [ pkgs.libiconv ];
     h5vc = [ pkgs.zlib.dev ];
     HiCseg = [ pkgs.gsl_1 ];
     imager = [ pkgs.x11 ];
     iBMQ = [ pkgs.gsl_1 ];
-    igraph = [ pkgs.gmp ];
+    igraph = [ pkgs.gmp pkgs.libxml2.dev ];
     JavaGD = [ pkgs.jdk ];
     jpeg = [ pkgs.libjpeg.dev ];
     KFKSDS = [ pkgs.gsl_1 ];
     kza = [ pkgs.fftw.dev ];
     libamtrack = [ pkgs.gsl_1 ];
+    magick = [ pkgs.imagemagick.dev ];
     mixcat = [ pkgs.gsl_1 ];
     mvabund = [ pkgs.gsl_1 ];
     mwaved = [ pkgs.fftw.dev ];
     ncdf4 = [ pkgs.netcdf ];
     nloptr = [ pkgs.nlopt ];
-    openssl = [ pkgs.openssl.dev ];
+    odbc = [ pkgs.unixODBC ];
+    openssl = [ pkgs.openssl pkgs.openssl.dev ];
     outbreaker = [ pkgs.gsl_1 ];
     pander = [ pkgs.pandoc pkgs.which ];
     pbdMPI = [ pkgs.openmpi ];
     pbdNCDF4 = [ pkgs.netcdf ];
     pbdPROF = [ pkgs.openmpi ];
     pbdZMQ = [ pkgs.which ];
+    pdftools = [ pkgs.poppler.dev ];
     PKI = [ pkgs.openssl.dev ];
     png = [ pkgs.libpng.dev ];
     PopGenome = [ pkgs.zlib.dev ];
     proj4 = [ pkgs.proj ];
+    protolite = [ pkgs.protobuf ];
     qtbase = [ pkgs.qt4 ];
     qtpaint = [ pkgs.qt4 ];
     R2GUESS = [ pkgs.gsl_1 ];
@@ -293,6 +299,7 @@ let
     RAppArmor = [ pkgs.libapparmor ];
     rapportools = [ pkgs.which ];
     rapport = [ pkgs.which ];
+    readxl = [ pkgs.libiconv ];
     rbamtools = [ pkgs.zlib.dev ];
     rcdd = [ pkgs.gmp.dev ];
     RcppCNPy = [ pkgs.zlib.dev ];
@@ -315,14 +322,15 @@ let
     rmatio = [ pkgs.zlib.dev ];
     Rmpfr = [ pkgs.gmp pkgs.mpfr.dev ];
     Rmpi = [ pkgs.openmpi ];
-    RMySQL = [ pkgs.zlib pkgs.mysql.lib ];
+    RMySQL = [ pkgs.zlib pkgs.mysql.lib pkgs.mariadb pkgs.openssl.dev ];
     RNetCDF = [ pkgs.netcdf pkgs.udunits ];
     RODBCext = [ pkgs.libiodbc ];
     RODBC = [ pkgs.libiodbc ];
+    rpanel = [ pkgs.bwidget ];
     rpg = [ pkgs.postgresql ];
     rphast = [ pkgs.pcre.dev pkgs.zlib pkgs.bzip2 pkgs.gzip pkgs.readline ];
     Rpoppler = [ pkgs.poppler ];
-    RPostgreSQL = [ pkgs.postgresql ];
+    RPostgreSQL = [ pkgs.postgresql pkgs.postgresql ];
     RProtoBuf = [ pkgs.protobuf ];
     rPython = [ pkgs.python ];
     RSclient = [ pkgs.openssl.dev ];
@@ -331,6 +339,7 @@ let
     rtfbs = [ pkgs.zlib pkgs.pcre.dev pkgs.bzip2 pkgs.gzip pkgs.readline ];
     rtiff = [ pkgs.libtiff.dev ];
     runjags = [ pkgs.jags ];
+    RSymphony = [ pkgs.symphony ];
     RVowpalWabbit = [ pkgs.zlib.dev pkgs.boost ];
     rzmq = [ pkgs.zeromq3 ];
     SAVE = [ pkgs.zlib pkgs.bzip2 pkgs.icu pkgs.lzma pkgs.pcre ];
@@ -338,6 +347,7 @@ let
     seewave = [ pkgs.fftw.dev pkgs.libsndfile.dev ];
     seqinr = [ pkgs.zlib.dev ];
     seqminer = [ pkgs.zlib.dev pkgs.bzip2 ];
+    sf = [ pkgs.gdal pkgs.proj pkgs.geos ];
     showtext = [ pkgs.zlib pkgs.libpng pkgs.icu pkgs.freetype.dev ];
     simplexreg = [ pkgs.gsl_1 ];
     SOD = [ pkgs.opencl-headers ];
@@ -349,12 +359,13 @@ let
     survSNP = [ pkgs.gsl_1 ];
     sysfonts = [ pkgs.zlib pkgs.libpng pkgs.freetype.dev ];
     TAQMNGR = [ pkgs.zlib.dev ];
+    tesseract = [ pkgs.tesseract pkgs.leptonica ];
     tiff = [ pkgs.libtiff.dev ];
     TKF = [ pkgs.gsl_1 ];
     tkrplot = [ pkgs.xorg.libX11 pkgs.tk.dev ];
     topicmodels = [ pkgs.gsl_1 ];
     udunits2 = [ pkgs.udunits pkgs.expat ];
-    V8 = [ pkgs.v8 ];
+    V8 = [ pkgs.v8_3_14 ];
     VBLPCM = [ pkgs.gsl_1 ];
     VBmix = [ pkgs.gsl_1 pkgs.fftw pkgs.qt4 ];
     WhopGenome = [ pkgs.zlib.dev ];
@@ -401,12 +412,20 @@ let
     chebpol = [ pkgs.pkgconfig ];
     fftw = [ pkgs.pkgconfig ];
     geoCount = [ pkgs.pkgconfig ];
+    gdtools = [ pkgs.pkgconfig ];
     kza = [ pkgs.pkgconfig ];
+    magick = [ pkgs.pkgconfig ];
     mwaved = [ pkgs.pkgconfig ];
+    odbc = [ pkgs.pkgconfig ];
+    openssl = [ pkgs.pkgconfig ];
+    pdftools = [ pkgs.pkgconfig ];
+    sf = [ pkgs.pkgconfig ];
     showtext = [ pkgs.pkgconfig ];
     spate = [ pkgs.pkgconfig ];
     stringi = [ pkgs.pkgconfig ];
+    sys = [ pkgs.libapparmor ];
     sysfonts = [ pkgs.pkgconfig ];
+    tesseract = [ pkgs.pkgconfig ];
     Cairo = [ pkgs.pkgconfig ];
     Rsymphony = [ pkgs.pkgconfig pkgs.doxygen pkgs.graphviz pkgs.subversion ];
     qtutils = [ pkgs.qt4 ];
@@ -782,8 +801,10 @@ let
     });
 
     RMySQL = old.RMySQL.overrideDerivation (attrs: {
-      patches = [ ./patches/RMySQL.patch ];
       MYSQL_DIR="${pkgs.mysql.lib}";
+      preConfigure = ''
+        patchShebangs configure
+        '';
     });
 
     devEMF = old.devEMF.overrideDerivation (attrs: {
@@ -818,6 +839,9 @@ let
 
     openssl = old.openssl.overrideDerivation (attrs: {
       OPENSSL_INCLUDES = "${pkgs.openssl.dev}/include";
+      preConfigure = ''
+        sed -i.bak 's|^\( *PKG_LIBS_VERSIONED=\).*$|\1$PKG_LIBS|' configure
+        '';
     });
 
     Rserve = old.Rserve.overrideDerivation (attrs: {
@@ -835,7 +859,71 @@ let
     });
 
     V8 = old.V8.overrideDerivation (attrs: {
-      preConfigure = "export V8_INCLUDES=${pkgs.v8}/include";
+      preConfigure = ''
+        export INCLUDE_DIR=${pkgs.v8_3_14}/include
+        export LIB_DIR=${pkgs.v8_3_14}/lib
+        patchShebangs configure
+        '';
+    });
+
+    acs = old.acs.overrideDerivation (attrs: {
+      preConfigure = ''
+        patchShebangs configure
+        '';
+    });
+
+    gdtools = old.gdtools.overrideDerivation (attrs: {
+      preConfigure = ''
+        patchShebangs configure
+        '';
+      NIX_LDFLAGS = "-lfontconfig -lfreetype";
+    });
+
+    magick = old.magick.overrideDerivation (attrs: {
+      preConfigure = ''
+        patchShebangs configure
+        '';
+    });
+
+    protolite = old.protolite.overrideDerivation (attrs: {
+      preConfigure = ''
+        patchShebangs configure
+        '';
+    });
+
+    rpanel = old.rpanel.overrideDerivation (attrs: {
+      preConfigure = ''
+        export TCLLIBPATH="${pkgs.bwidget}/lib/bwidget${pkgs.bwidget.version}"
+      '';
+      TCLLIBPATH = "${pkgs.bwidget}/lib/bwidget${pkgs.bwidget.version}";
+    });
+
+    OpenMx = old.OpenMx.overrideDerivation (attrs: {
+      preConfigure = ''
+        patchShebangs configure
+        '';
+    });
+
+    odbc = old.odbc.overrideDerivation (attrs: {
+      preConfigure = ''
+        patchShebangs configure
+        '';
+    });
+
+    x13binary = old.x13binary.overrideDerivation (attrs: {
+      preConfigure = ''
+        patchShebangs configure
+        '';
+    });
+
+    geojsonio = old.geojsonio.overrideDerivation (attrs: {
+      preConfigure = ''
+        export SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
+        '';
+    });
+
+    rstan = old.rstan.overrideDerivation (attrs: {
+      NIX_CFLAGS_COMPILE = "${attrs.NIX_CFLAGS_COMPILE} -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION";
     });
 
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10845,6 +10845,13 @@ with pkgs;
     gnutls = gnutls;
   });
 
+  # 3.14 is needed for R V8 module in ../development/r-modules/default.nix
+  v8_3_14 = callPackage ../development/libraries/v8/3.14.nix {
+    inherit (python2Packages) python gyp;
+    cctools = darwin.cctools;
+    stdenv = overrideCC stdenv gcc5;
+  };
+
   v8_3_16_14 = callPackage ../development/libraries/v8/3.16.14.nix {
     inherit (python2Packages) python gyp;
     cctools = darwin.cctools;


### PR DESCRIPTION
###### Motivation for this change

We tried to build around 1000 of the top CRAN packages (by download).  Some of them had build errors and and this pull request fixes many of those.

The R V8 package still depends on V8 3.14 so this is also included.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

