### PR TITLE
pell: 0.0.1 -> 0.0.2

### DIFF
--- a/pkgs/applications/misc/pell/default.nix
+++ b/pkgs/applications/misc/pell/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "pell";
-  version = "0.0.1";
+  version = "0.0.2";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "ebzzry";
     repo = pname;
-    rev = "3f95341eb9439c7a6be1f3c6366c0552ab8208f0";
-    sha256 = "183aj3ys080g2kahl8x8rkhzlsb6h5ls9xm1v2kasfbn1pi5i6nn";
+    rev = "ec14de0a9b666433954184167bf3b82cf21193f8";
+    sha256 = "0r2gbb4l9rr5x99m62zicknsp1gf9fr124xpyd8ak9izr5hvskn9";
   };
 
   installPhase = ''
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = https://github.com/ebzzry/pell;
-    description = "A simple periodic host monitor using ping";
+    description = "A simple host availability monitor";
     license = licenses.mit;
     maintainers = [ maintainers.ebzzry ];
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

