### PR TITLE
xosview2: init at 2.2.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -566,6 +566,7 @@
   schristo = "Scott Christopher <schristopher@konputa.com>";
   scolobb = "Sergiu Ivanov <sivanov@colimite.fr>";
   sdll = "Sasha Illarionov <sasha.delly@gmail.com>";
+  SeanZicari = "Sean Zicari <sean.zicari@gmail.com>";
   sepi = "Raffael Mancini <raffael@mancini.lu>";
   seppeljordan = "Sebastian Jordan <sebastian.jordan.mail@googlemail.com>";
   shanemikel = "Shane Pearlman <shanemikel1@gmail.com>";

--- a/pkgs/tools/X11/xosview2/default.nix
+++ b/pkgs/tools/X11/xosview2/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, libX11 }:
+
+stdenv.mkDerivation rec {
+  name = "xosview2-${version}";
+  version = "2.2.2";
+
+  src = fetchurl {
+    url = "mirror://sourceforge.net/xosview/${name}.tar.gz";
+    sha256 = "3502e119a5305ff2396f559340132910807351c7d4e375f13b5c338404990406";
+  };
+
+  # The software failed to buid with this enabled; it seemed tests were not implemented
+  doCheck = false;
+
+  buildInputs = [ libX11 ];
+
+  meta = with stdenv.lib; {
+    description = "Lightweight program that gathers information from your operating system and displays it in graphical form";
+    longDescription = ''
+      xosview is a lightweight program that gathers information from your
+      operating system and displays it in graphical form. It attempts to show
+      you in a quick glance an overview of how your system resources are being
+      utilized.
+
+      It can be configured to be nothing more than a small strip showing a
+      couple of parameters on a desktop task bar. Or it can display dozens of
+      meters and rolling graphical charts over your entire screen.
+
+      Since xosview renders all graphics with core X11 drawing methods, you can
+      run it on one machine and display it on another. This works even if your
+      other host is an operating system not running an X server inside a
+      virtual machine running on a physically different host. If you can
+      connect to it on a network, then you can popup an xosview instance and
+      monitor what is going on.
+    '';
+    homepage = "http://xosview.sourceforge.net/index.html";
+    license = licenses.gpl1;
+    maintainers = [ maintainers.SeanZicari ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19692,6 +19692,8 @@ with pkgs;
 
   xosd = callPackage ../misc/xosd { };
 
+  xosview2 = callPackage ../tools/X11/xosview2 { };
+
   xpad = callPackage ../applications/misc/xpad {
     inherit (gnome3) gtksourceview;
   };


### PR DESCRIPTION
###### Motivation for this change


xosview is a handy utility that I wanted to have a nix package for.

http://xosview.sourceforge.net/

This program does not yet support all of the possible libraries it can be compiled to use. From the README:

> The configure script will attempt to look for the xpm library to load
    background images with.  It will also look for the Xft library for freetype2
    font support.  If it finds the SM/ICE libraries it will configure support
    for working as a session client.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

