### PR TITLE
multicompiler: add multicompiler package

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -11,6 +11,7 @@
 , isGNU ? false, isClang ? cc.isClang or false, gnugrep ? null
 , buildPackages ? {}
 , useMacosReexportHack ? false
+, overridePrefix ? ""
 }:
 
 with stdenvNoCC.lib;
@@ -32,8 +33,10 @@ let
   #
   # TODO(@Ericson2314) Make unconditional, or optional but always true by
   # default.
-  prefix = stdenv.lib.optionalString (targetPlatform != hostPlatform)
-                                     (targetPlatform.config + "-");
+  prefix = if overridePrefix != ""
+           then overridePrefix
+           else stdenv.lib.optionalString (targetPlatform != hostPlatform)
+                                          (targetPlatform.config + "-");
 
   ccVersion = (builtins.parseDrvName cc.name).version;
   ccName = (builtins.parseDrvName cc.name).name;

--- a/pkgs/development/compilers/multicompiler/default.nix
+++ b/pkgs/development/compilers/multicompiler/default.nix
@@ -1,0 +1,140 @@
+{ pkgs ? import <nixpkgs> {}
+, stdenv
+, fetchFromGitHub
+, debugVersion ? false
+, enableSharedLibraries ? !pkgs.stdenv.isDarwin
+}:
+
+let
+
+  fetch = { ver, name, sha256}: fetchFromGitHub {
+    owner = "securesystemslab";
+    repo = name;
+    rev = ver;
+    inherit sha256;
+    };
+
+  mc_llvm_data = {
+    ver = "879d92f";
+    name = "multicompiler";
+    sha256 = "1lzdpz1x8c9hr86znc5z7dfg53yxwzdxnl2375dcz6ihdq55yv6h";
+  };
+
+  mc_clang_data = {
+    ver = "ebe9315";
+    name = "multicompiler-clang";
+    sha256 =  "1cmqapdm1p6kxwlr09ksxjk6ss1l7fx55rm8p7d91cmpxrzm49f3";
+  };
+
+  gcc = if pkgs.stdenv.cc.isGNU then pkgs.stdenv.cc.cc else pkgs.stdenv.cc.cc.gcc;
+
+  mvcc = pkgs.stdenv.mkDerivation rec {
+    version = "3.5.2";
+    name = "multicompiler";
+
+    unpackPhase = ''
+      unpackFile ${fetch mc_llvm_data}
+      mv ${mc_llvm_data.name}-${mc_llvm_data.ver}-src multicompiler
+      chmod -R ug+rw multicompiler
+      cd multicompiler/tools
+      unpackFile ${fetch mc_clang_data}
+      mv ${mc_clang_data.name}-${mc_clang_data.ver}-src clang
+      chmod -R ug+rw clang
+      cd ..
+      '';
+
+    buildInputs = with pkgs; [ cmake libedit libxml2 llvm python perl groff libffi ];
+
+    propagatedBuildInputs = with pkgs; [ ncurses zlib ];
+
+    # hacky fix: created binaries need to be run before installation
+    preBuild = ''
+      mkdir -p $out/
+      ln -sv $PWD/lib $out
+    '';
+
+    postBuild = ''
+      rm -fR $out
+      paxmark m bin/{lli,llvm-rtdyld}
+
+      paxmark m unittests/ExecutionEngine/JIT/JITTests
+      paxmark m unittests/ExecutionEngine/MCJIT/MCJITTests
+      paxmark m unittests/Support/SupportTests
+    '';
+
+    cmakeFlags = with pkgs.stdenv; [
+      "-DCMAKE_CXX_FLAGS=-std=c++11"
+      "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"
+      "-DLLVM_BUILD_TESTS=ON"
+      "-DLLVM_ENABLE_FFI=ON"
+      "-DLLVM_REQUIRES_RTTI=1"
+      "-DLLVM_TARGETS_TO_BUILD=X86"
+    ] ++ lib.optional enableSharedLibraries
+      "-DBUILD_SHARED_LIBS=ON"
+      ++ lib.optional (!isDarwin)
+      "-DLLVM_BINUTILS_INCDIR=${pkgs.binutils.dev}/include"
+      ++ lib.optionals ( isDarwin) [
+      "-DCMAKE_CXX_FLAGS=-stdlib=libc++"
+      "-DCAN_TARGET_i386=false"
+    ] ++
+    # Maybe with compiler-rt this won't be needed?
+    (lib.optional pkgs.stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}") ++
+    (lib.optional (pkgs.stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${cc.libc}/include");
+
+    patches =
+      pkgs.stdenv.lib.optionals (!pkgs.stdenv.isDarwin) [./fix-llvm-config.patch ];
+
+    postPatch = ''
+      #sed -i -e 's/Args.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/Tools.cpp
+      #sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/ToolChains.cpp
+    '';
+
+    installPhase = ''
+      set -x
+      mkdir -p $out/bin
+      install -m755 bin/* $out/bin/
+      mkdir -p $out/lib
+      # install -m644 lib $out/lib
+      cp -r lib/* $out/lib/
+      # Includes get installed in this odd location because this is
+      # where the ccWrap will hard-code the search for them (see
+      # pkgs/build-support/cc-wrapper/default.nix setting of libc-cflags).
+      incdir=$out/lib/gcc/clang/3.5.2/include-fixed
+      # mkdir -p $incdir
+      # install -m644 lib/clang/3.5.2/include/*.h $incdir/
+      mkdir -p $(dirname $incdir)
+      ln -s $out/lib/clang/3.5.2/include $incdir
+      set +x
+      '';
+
+    # Clang expects to find LLVMgold in its own prefix
+    # Clang expects to find sanitizer libraries in its own prefix
+    postInstall = ''
+      #ln -sv ${pkgs.llvm}/lib/LLVMgold.so $out/lib
+      ln -sv $out/lib/clang/${version}/lib $out/lib/clang/${version}/
+      ln -sv $out/bin/clang $out/bin/cpp
+    '';
+
+    # Provide attributes used by wrapCC (pkgs/build-support/cc-wrapper/default.nix)
+    passthru = {
+      isClang = true;
+    } // pkgs.stdenv.lib.optionalAttrs pkgs.stdenv.isLinux {
+      inherit gcc;
+    };
+
+    meta = with pkgs.stdenv.lib; {
+      description = "LLVM-based compiler to create artificial software diversity to protect software from code-reuse attacks";
+      platforms = platforms.all;
+      homepage = http://github.com/securesystemslab/multicompiler/;
+      license = licenses.ncsa;
+      maintainers = [ maintainers.kquick ];
+    };
+  };
+
+in
+pkgs.wrapCCWith {
+  name = "cc-wrapper"; # with overridePrefix as well
+  cc = mvcc;
+  libc = stdenv.cc.libc;
+  overridePrefix = "mv";
+}

--- a/pkgs/development/compilers/multicompiler/fix-llvm-config.patch
+++ b/pkgs/development/compilers/multicompiler/fix-llvm-config.patch
@@ -1,0 +1,13 @@
+diff --git a/utils/llvm-build/llvmbuild/main.py b/utils/llvm-build/llvmbuild/main.py
+index eacefdf60bf..40d25f5cef8 100644
+--- a/utils/llvm-build/llvmbuild/main.py
++++ b/utils/llvm-build/llvmbuild/main.py
+@@ -412,7 +412,7 @@ subdirectories = %s
+             if library_name is None:
+                 library_name_as_cstr = '0'
+             else:
+-                library_name_as_cstr = '"lib%s.a"' % library_name
++                library_name_as_cstr = '"lib%s.so"' % library_name
+             f.write('  { "%s", %s, %d, { %s } },\n' % (
+                 name, library_name_as_cstr, is_installed,
+                 ', '.join('"%s"' % dep

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6314,17 +6314,18 @@ with pkgs;
 
   wla-dx = callPackage ../development/compilers/wla-dx { };
 
-  wrapCCWith = { name ? "", cc, libc, extraBuildCommands ? "" }: ccWrapperFun rec {
-    nativeTools = targetPlatform == hostPlatform && stdenv.cc.nativeTools or false;
-    nativeLibc = targetPlatform == hostPlatform && stdenv.cc.nativeLibc or false;
-    nativePrefix = stdenv.cc.nativePrefix or "";
-    noLibc = !nativeLibc && (libc == null);
+  wrapCCWith = { name ? "", cc, libc, extraBuildCommands ? "", overridePrefix ? "" }:
+    ccWrapperFun rec {
+      nativeTools = targetPlatform == hostPlatform && stdenv.cc.nativeTools or false;
+      nativeLibc = targetPlatform == hostPlatform && stdenv.cc.nativeLibc or false;
+      nativePrefix = stdenv.cc.nativePrefix or "";
+      noLibc = !nativeLibc && (libc == null);
 
-    isGNU = cc.isGNU or false;
-    isClang = cc.isClang or false;
+      isGNU = cc.isGNU or false;
+      isClang = cc.isClang or false;
 
-    inherit name cc libc extraBuildCommands;
-  };
+      inherit name cc libc extraBuildCommands overridePrefix;
+    };
 
   ccWrapperFun = callPackage ../build-support/cc-wrapper;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6119,6 +6119,8 @@ with pkgs;
   mozart-binary = callPackage ../development/compilers/mozart/binary.nix { };
   mozart = mozart-binary;
 
+  multicompiler = callPackage ../development/compilers/multicompiler { };
+
   nim = callPackage ../development/compilers/nim { };
   nrpl = callPackage ../development/tools/nrpl { };
 


### PR DESCRIPTION
###### Motivation for this change

Adds the multicompiler, which is a fork of the llvm-based clang which provides artificial software diversity to protect software from code-reuse attacks.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

