### PR TITLE
cmake: setup CMAKE_FRAMEWORK_PATH

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -84,6 +84,9 @@ makeCmakeFindLibs(){
         -L*)
           export CMAKE_LIBRARY_PATH="$CMAKE_LIBRARY_PATH${CMAKE_LIBRARY_PATH:+:}${flag:2}"
           ;;
+        -F*)
+          export CMAKE_FRAMEWORK_PATH="$CMAKE_FRAMEWORK_PATH${CMAKE_FRAMEWORK_PATH:+:}${flag:2}"
+          ;;
         -isystem)
           isystem_seen=1
           ;;


### PR DESCRIPTION
###### Motivation for this change

This tells cmake how to find macOS frameworks. Same usage as for libraries or includes.

Fixes #26197
