### PR TITLE
ghcjs: Do not mark as broken

### DIFF
--- a/pkgs/development/compilers/ghcjs/default.nix
+++ b/pkgs/development/compilers/ghcjs/default.nix
@@ -2,5 +2,4 @@
 
 bootPkgs.callPackage ./base.nix {
   inherit bootPkgs;
-  broken = true;  # https://hydra.nixos.org/build/62184741
 }


### PR DESCRIPTION
###### Motivation for this change

The problem that caused the build failure has been fixed in #30214.

###### Things done

Remove `broken = true` from `ghcjs`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

