### PR TITLE
pulsemixer: init at 1.3.0-license

### DIFF
--- a/pkgs/tools/audio/pulsemixer/default.nix
+++ b/pkgs/tools/audio/pulsemixer/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, python3, libpulseaudio }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "pulsemixer";
+  version = "1.3.0-license";
+
+  src = fetchFromGitHub {
+    owner = "GeorgeFilipkin";
+    repo = pname;
+    rev = version;
+    sha256 = "186xbzyn35w2j58l68mccj0cnf0wxj93zb7s0r26zj4cppwszn90";
+  };
+
+  inherit libpulseaudio;
+
+  buildInputs = [ python3 ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install pulsemixer $out/bin/
+  '';
+
+  postFixup = ''
+    substituteInPlace "$out/bin/pulsemixer" \
+      --replace "libpulse.so.0" "$libpulseaudio/lib/libpulse.so.0"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cli and curses mixer for pulseaudio";
+    homepage = https://github.com/GeorgeFilipkin/pulsemixer;
+    license = licenses.mit;
+    maintainers = [ maintainers.woffs ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3557,6 +3557,8 @@ with pkgs;
 
   pnmixer = callPackage ../tools/audio/pnmixer { };
 
+  pulsemixer = callPackage ../tools/audio/pulsemixer { };
+
   pwsafe = callPackage ../applications/misc/pwsafe {
     wxGTK = wxGTK30;
   };


### PR DESCRIPTION
###### Motivation for this change

A nice cmdline pulseaudio mixer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

