### PR TITLE
sent: 0.2 -> 1

### DIFF
--- a/pkgs/applications/misc/sent/default.nix
+++ b/pkgs/applications/misc/sent/default.nix
@@ -1,15 +1,18 @@
-{ stdenv, fetchurl, libpng, libX11, libXft
+{ stdenv, fetchurl, farbfeld, libX11, libXft
 , patches ? [] }:
 
 stdenv.mkDerivation rec {
-  name = "sent-0.2";
+  name = "sent-1";
 
   src = fetchurl {
-    url = "http://dl.suckless.org/tools/${name}.tar.gz";
-    sha256 = "0xhh752hwaa26k4q6wvrb9jnpbnylss2aw6z11j7l9rav7wn3fak";
+    url = "https://dl.suckless.org/tools/${name}.tar.gz";
+    sha256 = "0cxysz5lp25mgww73jl0mgip68x7iyvialyzdbriyaff269xxwvv";
   };
 
-  buildInputs = [ libpng libX11 libXft ];
+  buildInputs = [ farbfeld libX11 libXft ];
+
+  # unpacking doesn't create a directory
+  sourceRoot = ".";
 
   inherit patches;
 
@@ -17,8 +20,8 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A simple plaintext presentation tool";
-    homepage = http://tools.suckless.org/sent/;
-    license = licenses.mit;
+    homepage = https://tools.suckless.org/sent/;
+    license = licenses.isc;
     platforms = platforms.linux;
     maintainers = with maintainers; [ pSub ];
   };


### PR DESCRIPTION
###### Motivation for this change
Update sent to current version, adding farbfeld-dependency, updating license and URL

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

