### PR TITLE
firehol: 3.1.4 -> 3.1.5, iprange: 1.0.3 -> 1.0.4

### DIFF
--- a/pkgs/applications/networking/firehol/default.nix
+++ b/pkgs/applications/networking/firehol/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   name = "firehol-${version}";
-  version = "3.1.4";
+  version = "3.1.5";
 
   src = fetchFromGitHub {
     owner = "firehol";
     repo = "firehol";
     rev = "v${version}";
-    sha256 = "121kjq5149r11k58lr9mkqns2k8jbdbjg2k93v8v7axhng6js7s9";
+    sha256 = "15cy1zxfpprma2zkmhj61zzhmw1pfnyhln7pca5lzvr1ifn2d0y0";
   };
 
   patches = [

--- a/pkgs/applications/networking/firehol/iprange.nix
+++ b/pkgs/applications/networking/firehol/iprange.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "iprange-${version}";
-  version = "1.0.3";
+  version = "1.0.4";
 
   src = fetchurl {
     url = "https://github.com/firehol/iprange/releases/download/v${version}/iprange-${version}.tar.xz";
-    sha256 = "0lwgl5ybrhsv43llq3kgdjpvgyfl43f3nxm0g8a8cd7zmn754bg2";
+    sha256 = "0rymw4ydn09dng34q4g5111706fyppzs2gd5br76frgvfj4x2f71";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
This PR updates firehol to 3.1.5 and its dependency iprange to 1.0.4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

