### PR TITLE
et: 2017-03-04 -> 0.1

### DIFF
--- a/pkgs/applications/misc/et/default.nix
+++ b/pkgs/applications/misc/et/default.nix
@@ -2,22 +2,17 @@
 
 stdenv.mkDerivation rec {
   name = "et-${version}";
-  version = "2017-03-04";
+  version = "0.1";
 
   src = fetchFromGitHub {
     owner = "geistesk";
     repo = "et";
-    rev = "151e9b6bc0d2d4f45bda8ced740ee99d0f2012f6";
-    sha256 = "1a1jdnzmal05k506bbvzlwsj2f3kql6l5xc1gdabm79y6vaf4r7s";
+    rev = "${version}";
+    sha256 = "1d2hq6p1y2ynk0a3l35lwbm1fcl9kg7rpjcin8bx4xcdpbw42y94";
   };
 
   buildInputs = [ libnotify gdk_pixbuf ];
   nativeBuildInputs = [ pkgconfig ];
-
-  prePatch = ''
-    substituteInPlace Makefile \
-        --replace ' = gcc' ' ?= gcc'
-  '';
 
   installPhase = ''
     mkdir -p $out/bin
@@ -26,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Minimal libnotify-based (egg) timer for GNU/Linux";
+    description = "Minimal libnotify-based (egg) timer";
     homepage = https://github.com/geistesk/et;
     license = licenses.gpl3;
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change
This PR updates `et` to a newer version which also includes this fix NixOS/nixpkgs@c0e7983 by LnL7.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

