### PR TITLE
steam-chrootenv: change curl to gnutls, add libtbb

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -161,6 +161,7 @@
   dgonyeo = "Derek Gonyeo <derek@gonyeo.com>";
   dipinhora = "Dipin Hora <dipinhora+github@gmail.com>";
   disassembler = "Samuel Leathers <disasm@gmail.com>";
+  dizfer = "David Izquierdo <david@izquierdofernandez.com>";
   dmalikov = "Dmitry Malikov <malikov.d.y@gmail.com>";
   DmitryTsygankov = "Dmitry Tsygankov <dmitry.tsygankov@gmail.com>";
   dmjio = "David Johnson <djohnson.m@gmail.com>";

--- a/pkgs/development/libraries/libtbb/default.nix
+++ b/pkgs/development/libraries/libtbb/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, tree }: 
+
+stdenv.mkDerivation rec {
+  name = "libtbb-${version}";
+  version = "2018_U1";
+
+  src = fetchFromGitHub {
+    owner = "01org";
+    repo = "tbb";
+    rev = "${version}";
+    sha256 = "1lygz07va6hsv2vlx9zwz5d2n81rxsdhmh0pqxgj8n1bvb1rp0qw";
+  };
+
+  buildInputs = [ tree ];
+
+  installPhase = ''
+    mkdir -p "$out"/usr/include "$out"/lib
+    install -m755 build/linux_*/*.so* "$out"/lib/
+    cp -a include/tbb "$out"/usr/include/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.threadingbuildingblocks.org/";
+    description = "High level abstract threading library";
+    platforms = platforms.unix;
+    license = licenses.apache2;
+    maintainers = with maintainers; [ dizfer ];
+  };
+}
+

--- a/pkgs/development/libraries/libtbb/default.nix
+++ b/pkgs/development/libraries/libtbb/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.threadingbuildingblocks.org/";
     description = "High level abstract threading library";
     platforms = platforms.unix;
-    license = licenses.apache2;
+    license = licenses.asl20;
     maintainers = with maintainers; [ dizfer ];
   };
 }

--- a/pkgs/games/steam/runtime-wrapped.nix
+++ b/pkgs/games/steam/runtime-wrapped.nix
@@ -57,6 +57,7 @@ let
     glew110
     openssl
     libidn
+    libtbb
 
     # Other things from runtime
     xlibs.libXinerama

--- a/pkgs/games/steam/runtime-wrapped.nix
+++ b/pkgs/games/steam/runtime-wrapped.nix
@@ -26,7 +26,7 @@ let
     xlibs.libICE
     gnome2.GConf
     freetype
-    curl
+    (curl.override { gnutlsSupport = true; sslSupport = false; })
     nspr
     nss
     fontconfig

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3119,6 +3119,8 @@ with pkgs;
 
   libsrs2 = callPackage ../development/libraries/libsrs2 { };
 
+  libtbb = callPackage ../development/libraries/libtbb { };
+
   libtermkey = callPackage ../development/libraries/libtermkey { };
 
   libtelnet = callPackage ../development/libraries/libtelnet { };


### PR DESCRIPTION
###### Motivation for this change
Civilization: Beyond Earth complains about two missing libraries when attempting to launch it.
One complaint is solved by compiling libcurl with gnutls support instead of openssl, which probably makes sense because it's the Ubuntu default AFAIK. The other is because our runtime doesn't include libtbb. This PR adds libtbb to nixpkgs, and modifies Steam's chroot curl to be compiled with gnutls support. Together, the three commits allow Civ: BE to launch when using the native runtime instead of Steam's.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
