### PR TITLE
haskellPackages.amqp-utils: fix dependencies

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -969,4 +969,8 @@ self: super: {
   # Depends on broken fluid.
   fluid-idl-http-client = markBroken super.fluid-idl-http-client;
 
+  # depends on amqp >= 0.17
+  amqp-utils = super.amqp-utils.override {
+    amqp = dontCheck super.amqp_0_18_1;
+  };
 }

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2850,7 +2850,6 @@ dont-distribute-packages:
   AMI:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   ampersand:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   amqp-conduit:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  amqp-utils:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   analyze-client:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   anansi-pandoc:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   anatomy:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]


### PR DESCRIPTION
###### Motivation for this change

just a suggestion to make amqp-utils buildable

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

