### PR TITLE
putty: 0.67 -> 0.70

### DIFF
--- a/pkgs/applications/networking/remote/putty/default.nix
+++ b/pkgs/applications/networking/remote/putty/default.nix
@@ -1,12 +1,16 @@
-{ stdenv, fetchurl, ncurses, gtk2, pkgconfig, autoconf, automake, perl, halibut, libtool }:
+{ stdenv, fetchurl, autoconf, automake, pkgconfig, libtool
+, gtk2, halibut, ncurses, perl }:
 
 stdenv.mkDerivation rec {
-  version = "0.67";
+  version = "0.70";
   name = "putty-${version}";
 
   src = fetchurl {
-    url = "http://the.earth.li/~sgtatham/putty/latest/${name}.tar.gz";
-    sha256 = "0isak6dy5vmfzf9ckcq6jvhgrn3xfmfcmziaa7g2jqm4x1c286c0";
+    urls = [
+      "https://the.earth.li/~sgtatham/putty/${version}/${name}.tar.gz"
+      "ftp://ftp.wayne.edu/putty/putty-website-mirror/${version}/${name}.tar.gz"
+    ];
+    sha256 = "1gmhwwj1y7b5hgkrkxpf4jddjpk9l5832zq5ibhsiicndsfs92mv";
   };
 
   preConfigure = ''
@@ -19,8 +23,9 @@ stdenv.mkDerivation rec {
     cd unix
   '';
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gtk2 ncurses autoconf automake perl halibut libtool ];
+  nativeBuildInputs = [ autoconf automake halibut libtool perl pkgconfig ];
+  buildInputs = [ gtk2 ncurses ];
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "A Free Telnet/SSH Client";


### PR DESCRIPTION
###### Motivation for this change
Update putty to v0.70
and use a stable src URL + add a mirror

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

