### PR TITLE
bowtie2: init at 2.3.3.1

### DIFF
--- a/pkgs/applications/science/biology/bowtie2/default.nix
+++ b/pkgs/applications/science/biology/bowtie2/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, zlib, tbb }:
+
+stdenv.mkDerivation rec {
+  pname = "bowtie2";
+  version = "2.3.3.1";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "BenLangmead";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1pcyks76bnnkq6h0gqjw4fkdddjjnw7k5ibim7ajkbvfw58a99y0";
+  };
+
+  buildInputs = [ zlib tbb ];
+
+  installFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "An ultrafast and memory-efficient tool for aligning sequencing reads to long reference sequences";
+    license = licenses.gpl3;
+    homepage = http://bowtie-bio.sf.net/bowtie2;
+    maintainers = with maintainers; [ rybern ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -762,6 +762,8 @@ with pkgs;
 
   bootchart = callPackage ../tools/system/bootchart { };
 
+  bowtie2 = callPackage ../applications/science/biology/bowtie2 { };
+
   boxfs = callPackage ../tools/filesystems/boxfs { };
 
   brasero-original = lowPrio (callPackage ../tools/cd-dvd/brasero { });


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

