### PR TITLE
vault: 0.8.1 -> 0.8.3

### DIFF
--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -9,13 +9,13 @@ let
   };
 in stdenv.mkDerivation rec {
   name = "vault-${version}";
-  version = "0.8.1";
+  version = "0.8.3";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = "vault";
     rev = "v${version}";
-    sha256 = "19y688nvi0vr7cdnaa5sy2m65xicjwi5qgkgzyjvb7r3zb0dnli1";
+    sha256 = "1dcmqbcdkj42614am2invb6wf8v29z4sp4d354a4d83rwhyb0qly";
   };
 
   nativeBuildInputs = [ go gox removeReferencesTo ];
@@ -26,6 +26,8 @@ in stdenv.mkDerivation rec {
 
     mkdir -p src/github.com/hashicorp
     ln -s $(pwd) src/github.com/hashicorp/vault
+
+    mkdir -p .git/hooks
 
     GOPATH=$(pwd) make
   '';


### PR DESCRIPTION
###### Motivation for this change

v0.8.1 doesn't support the `kv` backend described in the [mount a backend](https://www.vaultproject.io/intro/getting-started/secret-backends.html#mount-a-backend) documentation. After upgrading to 0.8.3 the new feature works as expected.

The `mkdir -p` addition is necessary because of [this upstream change](https://github.com/hashicorp/vault/pull/3288).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip --against b591b5cf5b4c1684404bfacb04b8449eb651c378"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @rushmorem @offline @pradeepchhetri