### PR TITLE
plymouth: fix breeze-plymouth (and other themes)

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -193,6 +193,11 @@ in
         theme = "breeze";
       };
 
+      boot.plymouth = {
+        theme = mkDefault "breeze";
+        themePackages = mkDefault [ pkgs.breeze-plymouth ];
+      };
+
       security.pam.services.kde = { allowNullPassword = true; };
 
       # Doing these one by one seems silly, but we currently lack a better


### PR DESCRIPTION
###### Motivation for this change
Plymouth puts commands into the initrd, which has strict restrictions on output references. So we need to be careful to get rid of those. One common case (which appears in `breeze-plymouth`) is to set `ImageDir` or `ScriptFile` to be the store path of the package (it needs to be absolute). This leads to a reference on that store path, which is banned.

The most robust solution to this that I could come up with was to just look through all the files in the included themes and replace anything that looked like a reference to plymouth or the theme's `share/plymouth/themes` directory to the one in `$out`. This works pretty well for the things I've tried.

With this patch the `breeze` theme works. `breeze-text` still doesn't work - it uses `breeze-text.so`, which has some rpath references that would need to be patched. As it is, they get nuked by `nukeReferences` and so just fail to work. I'm not really sure of a good way to do this patching robustly. In general it seems tough to get plymouth things with arbitrary dependencies working nicely in the initrd with reference restrictions.

Given that the theme now works, I set it as the default if you're using `plasma5`, similarly to how it sets a theme for sddm.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

