### PR TITLE
nixos/unified-remote: init at 3.6.0.745

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -606,6 +606,7 @@
   ./services/web-apps/tt-rss.nix
   ./services/web-apps/selfoss.nix
   ./services/web-apps/quassel-webserver.nix
+  ./services/web-apps/unified-remote.nix
   ./services/web-servers/apache-httpd/default.nix
   ./services/web-servers/caddy.nix
   ./services/web-servers/fcgiwrap.nix

--- a/nixos/modules/services/web-apps/unified-remote.nix
+++ b/nixos/modules/services/web-apps/unified-remote.nix
@@ -1,0 +1,123 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.unified-remote;
+  remotesPath = "${cfg.stateDir}/remotes";
+
+in
+
+{
+  options = {
+    services.unified-remote = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Whether to enable Unified Remote server.
+          Set this along with <code>openFirewall</code>.
+        '';
+      };
+
+      stateDir = mkOption {
+        type = types.path;
+        default = "/var/lib/unified-remote";
+        description = "Path to the state directory.";
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Open the firewall. This should be set else Unified Remote cannot be used.";
+      };
+
+      remotesPort = mkOption {
+        type = types.int;
+        default = 9512;
+        description = "TCP port to access the remotes. Only configures the firewall.";
+      };
+
+      discoveryPort = mkOption {
+        type = types.int;
+        default = 9511;
+        description = "UDP port for autodiscovery. Only configures the firewall.";
+      };
+
+      webPort = mkOption {
+        type = types.int;
+        default = 9510;
+        description = "TCP port for the web server. Only configures the firewall.";
+      };
+
+      pkg = mkOption {
+        type = types.package;
+        default = pkgs.unified-remote;
+        description = "The Unified Remote derivation to use.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "unified-remote";
+        description = "The user to run Unified Remote as.";
+      };
+
+      uinputGroup = mkOption {
+        type = types.str;
+        default = "uinput";
+        description = "The group to enable access to /dev/uinput";
+      };
+
+    };
+  };
+
+  config = mkMerge [
+
+    (mkIf cfg.enable {
+      boot.kernelModules = [ "uinput" ];
+
+      services.udev.extraRules = ''
+        KERNEL=="uinput", GROUP="${cfg.uinputGroup}", MODE="0660", TAG+="unified-remote"
+      '';
+
+      users.users."${cfg.user}" = {
+        extraGroups = [ cfg.uinputGroup ];
+        isSystemUser = true;
+        home = cfg.stateDir;
+        createHome = true;
+      };
+
+      users.groups = builtins.listToAttrs [
+        { name = cfg.uinputGroup; value = {}; }
+      ];
+
+      systemd.services.unified-remote = {
+        enable = true;
+        description = "Unified Remote server";
+        wantedBy = [ "multi-user.target" ];
+        path = [ pkgs.unified-remote pkgs.rsync ];
+        serviceConfig.User = cfg.user;
+        serviceConfig.Type = "forking";
+        serviceConfig.PIDFile = "${cfg.stateDir}/pid";
+        script = ''
+          rsync --chmod=D0700,F0600 -r --delete "${pkgs.unified-remote}/bin/remotes/" "${remotesPath}"
+          urserver \
+            --daemon \
+            --pidfile "${cfg.stateDir}"/pid \
+            --remotes "${remotesPath}"
+        '';
+      };
+
+    })
+
+    (mkIf cfg.openFirewall {
+      networking.firewall.allowedTCPPorts = [ cfg.remotesPort cfg.webPort ];
+      networking.firewall.allowedUDPPorts = [ cfg.remotesPort cfg.discoveryPort ];
+    })
+
+    ];
+
+}

--- a/nixos/tests/unified-remote.nix
+++ b/nixos/tests/unified-remote.nix
@@ -1,0 +1,32 @@
+import ./make-test.nix {
+  name = "unified-remote";
+
+  nodes = {
+    server = { pkgs, ... }:
+    {
+      networking.firewall.enable = true;
+      nixpkgs.config.allowUnfree = true;
+      services.unified-remote.enable = true;
+      services.unified-remote.openFirewall = true;
+    };
+    client = { pkgs, ... }:
+    {
+    };
+  };
+
+  testScript = { nodes, ... }:
+    let cfg = nodes.server.config.services.unified-remote;
+        inherit (builtins) toString;
+    in
+    ''
+      $server->waitForUnit('network-online.target');
+      $server->waitForUnit('unified-remote.service');
+      $client->waitForUnit('multi-user.target');
+      $server->waitForUnit('network-online.target');
+      $client->succeed('nc -w 1 -z server ${toString cfg.remotesPort}');
+      $client->succeed('nc -w 1 -z -u server ${toString cfg.remotesPort}');
+      $client->succeed('nc -w 1 -z server ${toString cfg.webPort}');
+      $client->succeed('nc -w 1 -z -u server ${toString cfg.discoveryPort}');
+      $client->succeed('curl --connect-timeout 1 http://server:${toString cfg.webPort}/web');
+    '';
+}

--- a/pkgs/servers/unified-remote/default.nix
+++ b/pkgs/servers/unified-remote/default.nix
@@ -1,0 +1,74 @@
+{ pkgs
+, stdenv
+, dpkg
+, patchelf
+, makeWrapper
+, fetchurl
+, bluez
+, libX11
+, libXtst
+
+# Unified Remote's download page only provides the latest.
+#
+#  Pass in the version and sha256 to allow easy overriding on updates
+#  without waiting for nixpkgs to propagate the changes.
+, pkgVersion ? "3.6.0.745"
+, pkgSha256 ? "92c1c8828bc9337fa84036cda8a880ed913b81e12a10a8835d034367af2f75a6"
+
+, ... }:
+
+
+assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux";
+
+let
+  arch = if stdenv.system == "i686-linux"
+    then "x86"
+    else "x64";
+in
+
+stdenv.mkDerivation {
+  name = "unified-remote-${pkgVersion}";
+  src = fetchurl {
+    url = "https://www.unifiedremote.com/download/linux-${arch}-deb";
+    sha256 = pkgSha256;
+  };
+
+  nativeBuildInputs = [ dpkg patchelf makeWrapper ];
+  buildInputs = [ bluez libX11 ];
+
+  buildCommand = ''
+    mkdir -p $out
+    dpkg -x $src $out
+    mv $out/opt/urserver $out/bin
+    rmdir $out/opt
+    mv $out/bin/urserver-autostart.desktop $out/usr/share/applications
+
+    for name in urserver urserver-autostart; do
+      path=$out/usr/share/applications/$name.desktop
+      substituteInPlace "$path" --replace /opt/urserver $out/bin
+    done
+
+    patchelf \
+      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $out/bin/urserver
+
+    mkdir $out/lib
+
+    ln -s "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ]}/libstdc++.so.6" $out/lib/
+    ln -s "${stdenv.lib.makeLibraryPath [ bluez ]}/libbluetooth.so.3" $out/lib/
+    ln -s "${stdenv.lib.makeLibraryPath [ libX11 ]}/libX11.so.6" $out/lib
+    ln -s "${stdenv.lib.makeLibraryPath [ libXtst ]}/libXtst.so.6" $out/lib
+
+    wrapProgram $out/bin/urserver --prefix LD_LIBRARY_PATH : $out/lib
+
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.unifiedremote.com;
+    description = "Turn your smartphone into a universal remote control";
+    license = licenses.unfree;
+    maintainers = [ maintainers.badi ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12011,6 +12011,8 @@ with pkgs;
 
   unifi = callPackage ../servers/unifi { };
 
+  unified-remote = callPackage ../servers/unified-remote {};
+
   virtuoso6 = callPackage ../servers/sql/virtuoso/6.x.nix { };
 
   virtuoso7 = callPackage ../servers/sql/virtuoso/7.x.nix { };


### PR DESCRIPTION
###### Motivation for this change

Hi

I've used [Unified Remote](https://www.unifiedremote.com/) to control my media center PC from an old phone for years now.
After switching the OS to NixOS, I needed to run something similar.
A superficial search didn't turn up a comparable service already in NixOS and everyone in the house is already comfortable with Unified Remote, hence this PR.

###### Example usage:

1. Enable the service
   ```
   services.unified-remote.enable = true;
   services.unified-remote.openFirewall = true;
   ```
1. Install app on phone

###### Things done

1. Adds the `unified-remote` package
1. Adds a `unified-remote` service
1. Adds nixos test

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
   I think. This is both package and nixos/service.

---

