### PR TITLE
alembic: use threadsafe hdf5

### DIFF
--- a/pkgs/development/libraries/alembic/default.nix
+++ b/pkgs/development/libraries/alembic/default.nix
@@ -14,7 +14,8 @@ stdenv.mkDerivation rec
 
   outputs = [ "bin" "dev" "out" "lib" ];
 
-  buildInputs = [ unzip cmake openexr hdf5 ];
+  nativeBuildInputs = [ unzip cmake ];
+  buildInputs = [ openexr hdf5 ];
 
   sourceRoot = "${name}-src";
 

--- a/pkgs/development/libraries/alembic/default.nix
+++ b/pkgs/development/libraries/alembic/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, unzip, cmake, openexr, hdf5 }:
+{ stdenv, fetchFromGitHub, unzip, cmake, openexr, hdf5-threadsafe }:
 
 stdenv.mkDerivation rec
 {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec
   outputs = [ "bin" "dev" "out" "lib" ];
 
   nativeBuildInputs = [ unzip cmake ];
-  buildInputs = [ openexr hdf5 ];
+  buildInputs = [ openexr hdf5-threadsafe ];
 
   sourceRoot = "${name}-src";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2565,6 +2565,13 @@ with pkgs;
     inherit gfortran;
   });
 
+  hdf5-threadsafe = appendToName "threadsafe" (hdf5.overrideAttrs (oldAttrs: {
+      # Threadsafe hdf5
+      # However, hdf5 hl (High Level) library is not considered stable
+      # with thread safety and should be disabled.
+      configureFlags = oldAttrs.configureFlags ++ ["--enable-threadsafe" "--disable-hl" ];
+  }));
+
   hdfview = callPackage ../tools/misc/hdfview {
     javac = jdk;
   };


### PR DESCRIPTION
###### Motivation for this change

Allowing `alembic` (and perhaps other libraries) to load `hdf5` encoded files in a concurrent manner. To achieve this, this change:

- Enables thread-safe support in `hdf5` in a separate package `hdf5-threadsafe`.
- Use the later for the `alembic` package

###### Discussion

By default, `hdf5` is not thread-safe hence `--enable-threadsafe` is mandatory to load `alembic` file (using `hdf5`) in a concurrent context.

However this change is not benign for all `hdf5` users: the High Level (`hl`) library included in `hdf5` does not officially support thread safety. The recommended way is to `--disable-hl`. However this may not be acceptable for some users of hdf5 (actually 21 derivation in nixpkgs). So I do not propose this for the default hdf5 derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

