### PR TITLE
nixos/postfix: support alternate smtp ports when relaying

### DIFF
--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -63,7 +63,7 @@ let
     relayhost            = if cfg.relayHost == "" then "" else
                              if cfg.lookupMX
                              then "${cfg.relayHost}:${toString cfg.relayPort}"
-                             else "[${cfg.relayHost}]:${toString cfg.relayPort}"
+                             else "[${cfg.relayHost}]:${toString cfg.relayPort}";
 
     mail_spool_directory = "/var/spool/mail/";
     setgid_group         = setgidGroup;

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -60,11 +60,11 @@ let
     manpage_directory    = "${pkgs.postfix}/share/man";
     html_directory       = "${pkgs.postfix}/share/postfix/doc/html";
     shlib_directory      = false;
-    relayhost            = if cfg.lookupMX || cfg.relayHost == ""
-                             then cfg.relayHost
-                             else
-			       "[${cfg.relayHost}]"
-			       + optionalString (cfg.relayPort != null) ":${toString cfg.relayPort}";
+    relayhost            = if cfg.relayHost == "" then "" else
+                             if cfg.lookupMX
+                             then "${cfg.relayHost}:${toString cfg.relayPort}"
+                             else "[${cfg.relayHost}]:${toString cfg.relayPort}"
+
     mail_spool_directory = "/var/spool/mail/";
     setgid_group         = setgidGroup;
   }
@@ -461,13 +461,10 @@ in
       };
 
       relayPort = mkOption {
-        type = types.nullOr types.int;
-        default = null;
-        example = 587;
+        type = types.int;
+        default = 25;
         description = "
-          Specify an optional port for outbound mail relay. (Note:
-          only used if an explicit <option>relayHost</option> is
-          defined.)
+          SMTP port for relay mail relay.
         ";
       };
 


### PR DESCRIPTION
###### Motivation for this change
Adds an option `services.postfix.relayPort` to support using an alternative smtp port when using a regular relay.

###### Things done
Tested ability to send via relay with and without `relayPort` set.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

