### PR TITLE
kitty: init at 0.4.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -605,6 +605,7 @@
   teh = "Tom Hunger <tehunger@gmail.com>";
   telotortium = "Robert Irelan <rirelan@gmail.com>";
   teto = "Matthieu Coudron <mcoudron@hotmail.com>";
+  tex = "Milan Svoboda <milan.svoboda@centrum.cz>";
   thall = "Niclas Thall <niclas.thall@gmail.com>";
   thammers = "Tobias Hammerschmidt <jawr@gmx.de>";
   the-kenny = "Moritz Ulrich <moritz@tarn-vedra.de>";

--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -13,22 +13,20 @@ buildPythonApplication rec {
     sha256 = "1gvr9l3bgbf87b2ih36zfi5qcga925vjjr8snbak7sgxqzifimij";
   };
 
-  buildInputs = [ pkgconfig glew fontconfig glfw ncurses libunistring ];
+  buildInputs = [ glew fontconfig glfw ncurses libunistring ];
+
+  nativeBuildInputs = [ pkgconfig ];
 
   buildPhase = ''
     python3 setup.py linux-package
   '';
 
   installPhase = ''
-    cd linux-package
-    mkdir -p $out/bin/
-    mkdir -p $out/lib/
-    mkdir -p $out/share
-    cp -r bin/* $out/bin
-    cp -r share/* $out/share/
-    cp -r lib/* $out/lib/
-
-    wrapProgram "$out/bin/kitty" --set PATH "$out/bin:/run/wrappers/bin:/run/current-system/sw/bin:${stdenv.lib.makeBinPath [ imagemagick ]}"
+    runHook preInstall
+    mkdir -p $out
+    cp -r linux-package/{bin,share,lib} $out
+    wrapProgram "$out/bin/kitty" --prefix PATH : "$out/bin:${stdenv.lib.makeBinPath [ imagemagick ]}"
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, pkgs, python3Packages, glfw, libunistring, glew, fontconfig, zlib, pkgconfig, ncurses, imagemagick, makeWrapper }:
+
+with python3Packages;
+buildPythonApplication rec {
+  version = "0.4.0";
+  name = "kitty-${version}";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "kovidgoyal";
+    repo = "kitty";
+    rev = "v${version}";
+    sha256 = "1gvr9l3bgbf87b2ih36zfi5qcga925vjjr8snbak7sgxqzifimij";
+  };
+
+  buildInputs = [ pkgconfig glew fontconfig glfw ncurses libunistring ];
+
+  buildPhase = ''
+    python3 setup.py linux-package
+  '';
+
+  installPhase = ''
+    cd linux-package
+    mkdir -p $out/bin/
+    mkdir -p $out/lib/
+    mkdir -p $out/share
+    cp -r bin/* $out/bin
+    cp -r share/* $out/share/
+    cp -r lib/* $out/lib/
+
+    wrapProgram "$out/bin/kitty" --set PATH "$out/bin:/run/wrappers/bin:/run/current-system/sw/bin:${stdenv.lib.makeBinPath [ imagemagick ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/kovidgoyal/kitty;
+    description = "A modern, hackable, featureful, OpenGL based terminal emulator";
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -2,7 +2,7 @@
 
 with python3Packages;
 buildPythonApplication rec {
-  version = "0.4.0";
+  version = "0.4.2";
   name = "kitty-${version}";
   format = "other";
 
@@ -10,7 +10,7 @@ buildPythonApplication rec {
     owner = "kovidgoyal";
     repo = "kitty";
     rev = "v${version}";
-    sha256 = "1gvr9l3bgbf87b2ih36zfi5qcga925vjjr8snbak7sgxqzifimij";
+    sha256 = "058676r2b83mjggbfc701v3vlviaslf7qciz8sm8lcda82k01wfp";
   };
 
   buildInputs = [ glew fontconfig glfw ncurses libunistring ];
@@ -33,5 +33,6 @@ buildPythonApplication rec {
     homepage = https://github.com/kovidgoyal/kitty;
     description = "A modern, hackable, featureful, OpenGL based terminal emulator";
     license = licenses.gpl3;
+    maintainers = with maintainers; [ tex ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15277,6 +15277,8 @@ with pkgs;
 
   kipi-plugins = libsForQt5.callPackage ../applications/graphics/kipi-plugins { };
 
+  kitty = callPackage ../applications/misc/kitty { };
+
   kiwix = callPackage ../applications/misc/kiwix { };
 
   kmplayer = libsForQt5.callPackage ../applications/video/kmplayer { };


### PR DESCRIPTION
https://github.com/kovidgoyal/kitty.git

###### Motivation for this change
Adding new application: terminal kitty (opengl, c, python)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

