### PR TITLE
vrb: init at 0.5.1

### DIFF
--- a/pkgs/development/libraries/vrb/default.nix
+++ b/pkgs/development/libraries/vrb/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "vrb-${version}";
+  version = "0.5.1";
+
+  src = fetchurl {
+    url = "http://vrb.sourceforge.net/download/${name}.tar.bz2";
+    sha256 = "d579ed1998ef2d78e2ef8481a748d26e1fa12cdda806d2e31d8ec66ffb0e289f";
+  };
+
+  patches = [
+    ./removed_options.patch
+    ./unused-but-set-variable.patch
+  ];
+
+  postPatch = ''
+    patchShebangs configure
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/man/man3
+    cp -p vrb/man/man3/*.3 $out/share/man/man3/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A virtual ring buffer library written in C";
+    license     = licenses.lgpl21;
+    homepage    = http://vrb.sourceforge.net/;
+    maintainers = [ maintainers.bobvanderlinden ];
+    platforms   = platforms.linux;
+  };
+}
+

--- a/pkgs/development/libraries/vrb/removed_options.patch
+++ b/pkgs/development/libraries/vrb/removed_options.patch
@@ -1,0 +1,13 @@
+--- a/configure	2010-10-05 16:32:59.000000000 +0200
++++ b/configure	2010-10-05 16:33:08.000000000 +0200
+@@ -341,8 +341,8 @@
+     pgm_warn=( "${pgm_warn[@]}" -Winline )
+ fi
+ 
+-lib_feat=( -fomit-frame-pointer -funsigned-char -funsigned-bitfields -fgnu-linker -frerun-loop-opt -finline -finline-functions -fmove-all-movables )
+-pgm_feat=( -fomit-frame-pointer -funsigned-char -funsigned-bitfields -fgnu-linker -frerun-loop-opt -finline -finline-functions -fmove-all-movables )
++lib_feat=( -fomit-frame-pointer -funsigned-char -funsigned-bitfields -frerun-loop-opt -finline -finline-functions )
++pgm_feat=( -fomit-frame-pointer -funsigned-char -funsigned-bitfields -frerun-loop-opt -finline -finline-functions )
+ 
+ lib_cp_opt=( -pipe )
+ pgm_cp_opt=( -pipe )

--- a/pkgs/development/libraries/vrb/unused-but-set-variable.patch
+++ b/pkgs/development/libraries/vrb/unused-but-set-variable.patch
@@ -1,0 +1,19 @@
+--- a/vrb/src/bin/vbuf.c1	2011-06-13 22:14:24.000000000 +0200
++++ b/vrb/src/bin/vbuf.c	2011-06-13 22:14:43.000000000 +0200
+@@ -426,7 +426,6 @@
+     int			opt_progress		;
+     int			output_fd		;
+     int			poll_time		;
+-    int			poll_num		;
+     int			poll_write		;
+     int			poll_read		;
+ 
+@@ -861,7 +860,7 @@
+ 	    poll_time = display_time - get_time_ms();
+ 	    if ( poll_time < 0 ) poll_time = 0;
+ 	}
+-	poll_num = poll( poll_list, 2, poll_time );
++	poll( poll_list, 2, poll_time );
+ 
+ 	//-----------------------
+ 	// Check for poll events.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10898,6 +10898,8 @@ with pkgs;
 
   vmime = callPackage ../development/libraries/vmime { };
 
+  vrb = callPackage ../development/libraries/vrb { };
+
   vrpn = callPackage ../development/libraries/vrpn { };
 
   vsqlite = callPackage ../development/libraries/vsqlite { };


### PR DESCRIPTION
###### Motivation for this change

This adds vrb 0.5.1: a virtual ring buffer library for C.

This is based on a PKGBUILD for ArchLinux.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
