### PR TITLE
avian: add meta.maintainers

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -176,6 +176,7 @@
   dupgit = "Olivier Delhomme <olivier.delhomme@free.fr>";
   dywedir = "Vladyslav M. <dywedir@protonmail.ch>";
   e-user = "Alexander Kahl <nixos@sodosopa.io>";
+  earldouglas = "James Earl Douglas <james@earldouglas.com>";
   ebzzry = "Rommel Martinez <ebzzry@ebzzry.io>";
   edanaher = "Evan Danaher <nixos@edanaher.net>";
   edef = "edef <edef@edef.eu>";

--- a/pkgs/development/compilers/avian/default.nix
+++ b/pkgs/development/compilers/avian/default.nix
@@ -32,5 +32,6 @@ stdenv.mkDerivation rec {
     homepage = https://readytalk.github.io/avian/;
     license = stdenv.lib.licenses.isc;
     platforms = stdenv.lib.platforms.all;
+    maintainers = [ stdenv.lib.maintainers.earldouglas ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Improve maintainability by assigning a maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

