### PR TITLE
coqPackages.dpdgraph: remove support for coq 8.7

### DIFF
--- a/pkgs/development/coq-modules/dpdgraph/default.nix
+++ b/pkgs/development/coq-modules/dpdgraph/default.nix
@@ -1,11 +1,6 @@
 { stdenv, fetchFromGitHub, autoreconfHook, coq, ocamlPackages }:
 
 let param = {
-  "8.7" = {
-    version = "0.6.1";
-    rev = "c3b87af6bfa338e18b83f014ebd0e56e1f611663";
-    sha256 = "1jaafkwsb5450378nprjsds1illgdaq60gryi8kspw0i25ykz2c9";
-  };
   "8.6" = {
     version = "0.6.1";
     rev = "c3b87af6bfa338e18b83f014ebd0e56e1f611663";


### PR DESCRIPTION
coqPackages_8_7.dpdgraph won't build since Coq 8.7.0 is not yet supported
upstream.

###### Motivation for this change

coq-dpdgraph was not released for Coq 8.7.0, so I don't understand why this was pushed. @jwiegley can you confirm that this never built? Or did I miss something in my setup?

By the way, a new release of coq-dpdgraph should happen soon.