### PR TITLE
ipget: init at 0.2.5

### DIFF
--- a/pkgs/applications/networking/ipget/default.nix
+++ b/pkgs/applications/networking/ipget/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildGoPackage, fetchFromGitHub, fetchgx }:
+
+buildGoPackage rec {
+  name = "ipget-${version}";
+  version = "0.2.5";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/ipfs/ipget";
+  
+  extraSrcPaths = [
+    (fetchgx {
+      inherit name src;
+      sha256 = "1d4w8zl5mcppn3d4bl7qdkiqlf8gi3z2a62nygx17bqpa3da8cf3";
+    })
+  ];
+ 
+  goDeps = ../../../tools/package-management/gx/deps.nix;
+
+  src = fetchFromGitHub {
+    owner = "ipfs";
+    repo = "ipget";
+    inherit rev;
+    sha256 = "0a8yxqhl469ipiznrgkp3yi1xz3xzcbpx60wabqppq8hccrdiybk";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Retrieve files over IPFS and save them locally";
+    homepage = https://ipfs.io/;
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2717,6 +2717,8 @@ with pkgs;
   ipfs = callPackage ../applications/networking/ipfs { };
   ipfs-migrator = callPackage ../applications/networking/ipfs-migrator { };
 
+  ipget = callPackage ../applications/networking/ipget { };
+
   ipmitool = callPackage ../tools/system/ipmitool {
     static = false;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I have to reuse deps file from gx. If I don't I get an error about missing dependencies that completely matches what is broken in upstream CI:
https://travis-ci.org/ipfs/ipget/jobs/231391696

I don't know much about go and could not succeed with generating deps file with ```go2nix```, so **cc** @fpletz @kamilchm 