### PR TITLE
coqPackages.QuickChick: remove support for coq 8.7

### DIFF
--- a/pkgs/development/coq-modules/QuickChick/default.nix
+++ b/pkgs/development/coq-modules/QuickChick/default.nix
@@ -20,11 +20,6 @@ let param =
       sha256 = "06kwnrfndnr6w8bmaa2s0i0rkqyv081zj55z3vcyn0wr6x6mlsz9";
     };
 
-    "8.7" = {
-      version = "20170616";
-      rev = "366ee3f8e599b5cab438a63a09713f44ac544c5a";
-      sha256 = "06kwnrfndnr6w8bmaa2s0i0rkqyv081zj55z3vcyn0wr6x6mlsz9";
-    };
   }."${coq.coq-version}"
 ; in
 


### PR DESCRIPTION
coqPackages_8_7.QuickChick won't build since Coq 8.7.0 is not yet supported
upstream.

###### Motivation for this change

I'm working upstream on the port of QuickChick to Coq 8.7.0, and I don't see how a Coq 8.7.0 derivation for QuickChick could be ready before that is done. In fact, even some dependencies don't build (it would require #30690).

I'm a proud Nix newbie, so I don't know what the usual practice is, but I find it strange to push untested (and broken) packages that don't even rely on a released version. Sorry to moan, but as an upstream author, I'm not happy to see my software packaged in such state.