### PR TITLE
ion: 1.0.3 -> 1.0.5

### DIFF
--- a/pkgs/shells/ion/default.nix
+++ b/pkgs/shells/ion/default.nix
@@ -4,16 +4,16 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "ion-${version}";
-  version = "1.0.3";
+  version = "1.0.5";
 
   src = fetchFromGitHub {
     owner = "redox-os";
     repo = "ion";
     rev = version;
-    sha256 = "0c2haw9qiwysyp1xj6qla8d6zpsdlygagzh86sk04c2b4ssyaca3";
+    sha256 = "0i0acl5nw254mw8dbfmb4792rr71is98a5wg32yylfnlrk7zlf8z";
   };
 
-  cargoSha256 = "0ydi44710as0bb442zryzx30nk4mscdw3gsahwprnsvvaril33rn";
+  cargoSha256 = "0ffp6r5jqyf9j8jd77vbvc6l3xm09ipbraj6av6iciw1sxskib33";
 
   meta = with stdenv.lib; {
     description = "Modern system shell with simple (and powerful) syntax";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/redox-os/ion/releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

