### PR TITLE
Cherry-pick ghcjsHEAD upgrade on release-17.09

### DIFF
--- a/pkgs/development/compilers/ghcjs/ghcjs-head.patch
+++ b/pkgs/development/compilers/ghcjs/ghcjs-head.patch
@@ -46,24 +46,6 @@ index db8b12e..7b815c5 100644
        mapM_ patchPackage =<< allPackages
        preparePrimops
        buildGenPrim
-@@ -1141,7 +1132,7 @@ cabalStage1 pkgs = sub $ do
-   globalFlags <- cabalGlobalFlags
-   flags <- cabalInstallFlags (length pkgs == 1)
-   let args = globalFlags ++ ("install" : pkgs) ++
--             [ "--solver=topdown" -- the modular solver refuses to install stage1 packages
-+             [ "--allow-boot-library-installs"
-              ] ++ map ("--configure-option="<>) configureOpts ++ flags
-   checkInstallPlan pkgs args
-   cabal_ args
-@@ -1162,7 +1153,7 @@ cabalInstall pkgs = do
- -- uses somewhat fragile parsing of --dry-run output, find a better way
- checkInstallPlan :: [Package] -> [Text] -> B ()
- checkInstallPlan pkgs opts = do
--  plan <- cabal (opts ++ ["-v2", "--dry-run"])
-+  plan <- cabal (opts ++ ["-vverbose+nowrap", "--dry-run"])
-   when (hasReinstalls plan || hasUnexpectedInstalls plan || hasNewVersion plan) (err plan)
-   where
-     hasReinstalls = T.isInfixOf "(reinstall)"   -- reject reinstalls
 @@ -1201,14 +1192,14 @@ cabalInstallFlags parmakeGhcjs = do
             , "--avoid-reinstalls"
             , "--builddir",      "dist"

--- a/pkgs/development/compilers/ghcjs/ghcjs.patch
+++ b/pkgs/development/compilers/ghcjs/ghcjs.patch
@@ -46,24 +46,6 @@ index db8b12e..7b815c5 100644
        mapM_ patchPackage =<< allPackages
        preparePrimops
        buildGenPrim
-@@ -1141,7 +1132,7 @@ cabalStage1 pkgs = sub $ do
-   globalFlags <- cabalGlobalFlags
-   flags <- cabalInstallFlags (length pkgs == 1)
-   let args = globalFlags ++ ("install" : pkgs) ++
--             [ "--solver=topdown" -- the modular solver refuses to install stage1 packages
-+             [ "--allow-boot-library-installs"
-              ] ++ map ("--configure-option="<>) configureOpts ++ flags
-   checkInstallPlan pkgs args
-   cabal_ args
-@@ -1162,7 +1153,7 @@ cabalInstall pkgs = do
- -- uses somewhat fragile parsing of --dry-run output, find a better way
- checkInstallPlan :: [Package] -> [Text] -> B ()
- checkInstallPlan pkgs opts = do
--  plan <- cabal (opts ++ ["-v2", "--dry-run"])
-+  plan <- cabal (opts ++ ["-vverbose+nowrap", "--dry-run"])
-   when (hasReinstalls plan || hasUnexpectedInstalls plan || hasNewVersion plan) (err plan)
-   where
-     hasReinstalls = T.isInfixOf "(reinstall)"   -- reject reinstalls
 @@ -1201,14 +1192,14 @@ cabalInstallFlags parmakeGhcjs = do
             , "--avoid-reinstalls"
             , "--builddir",      "dist"

--- a/pkgs/development/compilers/ghcjs/head.nix
+++ b/pkgs/development/compilers/ghcjs/head.nix
@@ -6,19 +6,15 @@ bootPkgs.callPackage ./base.nix {
   inherit bootPkgs;
 
   ghcjsSrc = fetchFromGitHub {
-    # TODO: switch back to the regular ghcjs repo
-    # when https://github.com/ghcjs/ghcjs/pull/573 is merged.
-    owner = "k0001";
+    owner = "ghcjs";
     repo = "ghcjs";
-    rev = "600015e085a28da601b65a41c513d4a458fcd184";
-    sha256 = "01kirrg0fnfwhllvwgfqjiwzwj4yv4lyig87x61n9jp6y5shzjdx";
+    rev = "2b3759942fb5b2fc1a58d314d9b098d4622fa6b6";
+    sha256 = "15asapg0va8dvcdycsx8dgk4xcpdnhml4h31wka6vvxf5anzz8aw";
   };
   ghcjsBootSrc = fetchgit {
-    # TODO: switch back to git://github.com/ghcjs/ghcjs-boot.git
-    # when https://github.com/ghcjs/ghcjs-boot/pull/41 is merged.
-    url = git://github.com/basvandijk/ghcjs-boot.git;
-    rev = "19a3b157ecb807c2224daffda5baecc92b76af35";
-    sha256 = "16sgr8vfr1nx5ljnk8gckgjk70zpa67ix4dbr9aizkwyz41ilfrb";
+    url = git://github.com/ghcjs/ghcjs-boot.git;
+    rev = "106e144cca6529a1b9612c11aea5d6ef65b96745";
+    sha256 = "0gxg8iiwvm93x1dwhxypczn9qiz4m1xvj8i7cf4snfdy2jdyhi5l";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/compilers/ghcjs/head.nix
+++ b/pkgs/development/compilers/ghcjs/head.nix
@@ -45,4 +45,6 @@ bootPkgs.callPackage ./base.nix {
     "unix"
   ];
   stage2 = import ./head_stage2.nix;
+
+  patches = [ ./ghcjs-head.patch ];
 }

--- a/pkgs/development/compilers/ghcjs/head_stage2.nix
+++ b/pkgs/development/compilers/ghcjs/head_stage2.nix
@@ -2,117 +2,145 @@
 
 {
   async = callPackage
-    ({ mkDerivation, base, HUnit, stm, test-framework
-     , test-framework-hunit, stdenv
-     }:
-     mkDerivation {
-       pname = "async";
-       version = "2.1.1";
-       src = "${ghcjsBoot}/boot/async";
-       doCheck = false;
-       libraryHaskellDepends = [ base stm ];
-       testHaskellDepends = [
-         base HUnit test-framework test-framework-hunit
-       ];
-       jailbreak = true;
-       homepage = https://github.com/simonmar/async;
-       description = "Run IO operations asynchronously and wait for their results";
-       license = stdenv.lib.licenses.bsd3;
-     }) {};
+    ({ mkDerivation, base, HUnit, stdenv, stm, test-framework
+      , test-framework-hunit
+      }:
+      mkDerivation {
+        pname = "async";
+        version = "2.1.1";
+        src = "${ghcjsBoot}/boot/async";
+        doCheck = false;
+        libraryHaskellDepends = [ base stm ];
+        testHaskellDepends = [
+          base HUnit test-framework test-framework-hunit
+        ];
+        jailbreak = true;
+        homepage = "https://github.com/simonmar/async";
+        description = "Run IO operations asynchronously and wait for their results";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
   aeson = callPackage
     ({ mkDerivation, attoparsec, base, base-compat, base-orphans
-     , base16-bytestring, bytestring, containers, deepseq, directory
-     , dlist, fetchgit, filepath, generic-deriving, ghc-prim, hashable
-     , hashable-time, HUnit, integer-logarithms, QuickCheck
-     , quickcheck-instances, scientific, stdenv, tagged
-     , template-haskell, test-framework, test-framework-hunit
-     , test-framework-quickcheck2, text, time, time-locale-compat
-     , unordered-containers, uuid-types, vector
-     }:
-     mkDerivation {
-       pname = "aeson";
-       version = "1.1.1.0";
-       src = "${ghcjsBoot}/boot/aeson";
-       libraryHaskellDepends = [
-         attoparsec base base-compat bytestring containers deepseq dlist
-         ghc-prim hashable scientific tagged template-haskell text time
-         time-locale-compat unordered-containers uuid-types vector
-       ];
-       testHaskellDepends = [
-         attoparsec base base-compat base-orphans base16-bytestring
-         bytestring containers directory dlist filepath generic-deriving
-         ghc-prim hashable hashable-time HUnit integer-logarithms QuickCheck
-         quickcheck-instances scientific tagged template-haskell
-         test-framework test-framework-hunit test-framework-quickcheck2 text
-         time time-locale-compat unordered-containers uuid-types vector
-       ];
-       jailbreak = true;
-       homepage = https://github.com/bos/aeson;
-       description = "Fast JSON parsing and encoding";
-       license = stdenv.lib.licenses.bsd3;
-     }) {};
+      , base16-bytestring, bytestring, containers, deepseq, directory
+      , dlist, filepath, generic-deriving, ghc-prim, hashable
+      , hashable-time, HUnit, integer-logarithms, QuickCheck
+      , quickcheck-instances, scientific, stdenv, tagged
+      , template-haskell, test-framework, test-framework-hunit
+      , test-framework-quickcheck2, text, th-abstraction, time
+      , time-locale-compat, unordered-containers, uuid-types, vector
+      }:
+      mkDerivation {
+        pname = "aeson";
+        version = "1.2.2.0";
+        src = "${ghcjsBoot}/boot/aeson";
+        doCheck = false;
+        libraryHaskellDepends = [
+          attoparsec base base-compat bytestring containers deepseq dlist
+          ghc-prim hashable scientific tagged template-haskell text
+          th-abstraction time time-locale-compat unordered-containers
+          uuid-types vector
+        ];
+        testHaskellDepends = [
+          attoparsec base base-compat base-orphans base16-bytestring
+          bytestring containers directory dlist filepath generic-deriving
+          ghc-prim hashable hashable-time HUnit integer-logarithms QuickCheck
+          quickcheck-instances scientific tagged template-haskell
+          test-framework test-framework-hunit test-framework-quickcheck2 text
+          time time-locale-compat unordered-containers uuid-types vector
+        ];
+        jailbreak = true;
+        homepage = "https://github.com/bos/aeson";
+        description = "Fast JSON parsing and encoding";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
   attoparsec = callPackage
     ({ mkDerivation, array, base, bytestring, case-insensitive
-     , containers, criterion, deepseq, directory, filepath, ghc-prim
-     , http-types, parsec, QuickCheck, quickcheck-unicode, scientific
-     , tasty, tasty-quickcheck, text, transformers, unordered-containers
-     , vector, stdenv
-     }:
-     mkDerivation {
-       pname = "attoparsec";
-       version = "0.13.1.0";
-       src = "${ghcjsBoot}/boot/attoparsec";
-       libraryHaskellDepends = [
-         array base bytestring containers deepseq scientific text
-         transformers
-       ];
-       testHaskellDepends = [
-         array base bytestring deepseq QuickCheck quickcheck-unicode
-         scientific tasty tasty-quickcheck text transformers vector
-       ];
-       benchmarkHaskellDepends = [
-         array base bytestring case-insensitive containers criterion deepseq
-         directory filepath ghc-prim http-types parsec scientific text
-         transformers unordered-containers vector
-       ];
-       jailbreak = true;
-       homepage = https://github.com/bos/attoparsec;
-       description = "Fast combinator parsing for bytestrings and text";
-       license = stdenv.lib.licenses.bsd3;
-     }) {};
+      , containers, criterion, deepseq, directory, filepath, ghc-prim
+      , http-types, parsec, QuickCheck, quickcheck-unicode, scientific
+      , stdenv, tasty, tasty-quickcheck, text, transformers
+      , unordered-containers, vector
+      }:
+      mkDerivation {
+        pname = "attoparsec";
+        version = "0.13.1.0";
+        src = "${ghcjsBoot}/boot/attoparsec";
+        doCheck = false;
+        libraryHaskellDepends = [
+          array base bytestring containers deepseq scientific text
+          transformers
+        ];
+        testHaskellDepends = [
+          array base bytestring deepseq QuickCheck quickcheck-unicode
+          scientific tasty tasty-quickcheck text transformers vector
+        ];
+        benchmarkHaskellDepends = [
+          array base bytestring case-insensitive containers criterion deepseq
+          directory filepath ghc-prim http-types parsec scientific text
+          transformers unordered-containers vector
+        ];
+        jailbreak = true;
+        homepage = "https://github.com/bos/attoparsec";
+        description = "Fast combinator parsing for bytestrings and text";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
+  base-compat = callPackage
+    ({ mkDerivation, base, hspec, QuickCheck, stdenv, unix }:
+      mkDerivation {
+        pname = "base-compat";
+        version = "0.9.3";
+        src = "${ghcjsBoot}/boot/base-compat";
+        doCheck = false;
+        libraryHaskellDepends = [ base unix ];
+        testHaskellDepends = [ base hspec QuickCheck ];
+        jailbreak = true;
+        description = "A compatibility layer for base";
+        license = stdenv.lib.licenses.mit;
+      }) {};
+  bytestring-builder = callPackage
+    ({ mkDerivation, base, bytestring, deepseq, stdenv }:
+      mkDerivation {
+        pname = "bytestring-builder";
+        version = "0.10.8.1.0";
+        src = "${ghcjsBoot}/boot/bytestring-builder";
+        doCheck = false;
+        libraryHaskellDepends = [ base bytestring deepseq ];
+        jailbreak = true;
+        description = "The new bytestring builder, packaged outside of GHC";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
   case-insensitive = callPackage
     ({ mkDerivation, base, bytestring, criterion, deepseq, hashable
-     , HUnit, test-framework, test-framework-hunit, text, stdenv
-     }:
-     mkDerivation {
-       pname = "case-insensitive";
-       version = "1.2.0.8";
-       src = "${ghcjsBoot}/boot/case-insensitive";
-       doCheck = false;
-       libraryHaskellDepends = [ base bytestring deepseq hashable text ];
-       testHaskellDepends = [
-         base bytestring HUnit test-framework test-framework-hunit text
-       ];
-       benchmarkHaskellDepends = [ base bytestring criterion deepseq ];
-       jailbreak = true;
-       homepage = https://github.com/basvandijk/case-insensitive;
-       description = "Case insensitive string comparison";
-       license = stdenv.lib.licenses.bsd3;
-     }) {};
+      , HUnit, stdenv, test-framework, test-framework-hunit, text
+      }:
+      mkDerivation {
+        pname = "case-insensitive";
+        version = "1.2.0.8";
+        src = "${ghcjsBoot}/boot/case-insensitive";
+        doCheck = false;
+        libraryHaskellDepends = [ base bytestring deepseq hashable text ];
+        testHaskellDepends = [
+          base bytestring HUnit test-framework test-framework-hunit text
+        ];
+        benchmarkHaskellDepends = [ base bytestring criterion deepseq ];
+        jailbreak = true;
+        homepage = "https://github.com/basvandijk/case-insensitive";
+        description = "Case insensitive string comparison";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
   dlist = callPackage
     ({ mkDerivation, base, Cabal, deepseq, QuickCheck, stdenv }:
-     mkDerivation {
-       pname = "dlist";
-       version = "0.8.0.2";
-       src = "${ghcjsBoot}/boot/dlist";
-       doCheck = false;
-       libraryHaskellDepends = [ base deepseq ];
-       testHaskellDepends = [ base Cabal QuickCheck ];
-       jailbreak = true;
-       homepage = https://github.com/spl/dlist;
-       description = "Difference lists";
-       license = stdenv.lib.licenses.bsd3;
-     }) {};
+      mkDerivation {
+        pname = "dlist";
+        version = "0.8.0.2";
+        src = "${ghcjsBoot}/boot/dlist";
+        doCheck = false;
+        libraryHaskellDepends = [ base deepseq ];
+        testHaskellDepends = [ base Cabal QuickCheck ];
+        jailbreak = true;
+        homepage = "https://github.com/spl/dlist";
+        description = "Difference lists";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
   extensible-exceptions = callPackage
     ({ mkDerivation, base, stdenv }:
       mkDerivation {
@@ -125,10 +153,21 @@
         description = "Extensible exceptions";
         license = stdenv.lib.licenses.bsd3;
       }) {};
+  fail = callPackage
+    ({ mkDerivation, stdenv }:
+      mkDerivation {
+        pname = "fail";
+        version = "4.9.0.0";
+        src = "${ghcjsBoot}/boot/fail";
+        jailbreak = true;
+        homepage = "https://prime.haskell.org/wiki/Libraries/Proposals/MonadFail";
+        description = "Forward-compatible MonadFail class";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
   hashable = callPackage
-    ({ mkDerivation, base, bytestring, ghc-prim, HUnit, integer-gmp
-      , QuickCheck, random, stdenv, test-framework, test-framework-hunit
-      , test-framework-quickcheck2, text, unix
+    ({ mkDerivation, base, bytestring, criterion, ghc-prim, HUnit
+      , integer-gmp, QuickCheck, random, siphash, stdenv, test-framework
+      , test-framework-hunit, test-framework-quickcheck2, text, unix
       }:
       mkDerivation {
         pname = "hashable";
@@ -142,22 +181,56 @@
           base bytestring ghc-prim HUnit QuickCheck random test-framework
           test-framework-hunit test-framework-quickcheck2 text unix
         ];
+        benchmarkHaskellDepends = [
+          base bytestring criterion ghc-prim integer-gmp siphash text
+        ];
         jailbreak = true;
-        homepage = http://github.com/tibbe/hashable;
+        homepage = "http://github.com/tibbe/hashable";
         description = "A class for types that can be converted to a hash value";
         license = stdenv.lib.licenses.bsd3;
+      }) {};
+  integer-logarithms = callPackage
+    ({ mkDerivation, array, base, ghc-prim, integer-gmp, QuickCheck
+      , smallcheck, stdenv, tasty, tasty-hunit, tasty-quickcheck
+      , tasty-smallcheck
+      }:
+      mkDerivation {
+        pname = "integer-logarithms";
+        version = "1.0.2";
+        src = "${ghcjsBoot}/boot/integer-logarithms";
+        doCheck = false;
+        libraryHaskellDepends = [ array base ghc-prim integer-gmp ];
+        testHaskellDepends = [
+          base QuickCheck smallcheck tasty tasty-hunit tasty-quickcheck
+          tasty-smallcheck
+        ];
+        jailbreak = true;
+        homepage = "https://github.com/phadej/integer-logarithms";
+        description = "Integer logarithms";
+        license = stdenv.lib.licenses.mit;
       }) {};
   mtl = callPackage
     ({ mkDerivation, base, stdenv, transformers }:
       mkDerivation {
         pname = "mtl";
-        version = "2.2.2";
+        version = "2.2.1";
         src = "${ghcjsBoot}/boot/mtl";
         doCheck = false;
         libraryHaskellDepends = [ base transformers ];
         jailbreak = true;
-        homepage = http://github.com/ekmett/mtl;
+        homepage = "http://github.com/ekmett/mtl";
         description = "Monad classes, using functional dependencies";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
+  nats = callPackage
+    ({ mkDerivation, stdenv }:
+      mkDerivation {
+        pname = "nats";
+        version = "1.1.1";
+        src = "${ghcjsBoot}/boot/nats";
+        jailbreak = true;
+        homepage = "http://github.com/ekmett/nats/";
+        description = "Natural numbers";
         license = stdenv.lib.licenses.bsd3;
       }) {};
   old-time = callPackage
@@ -184,30 +257,57 @@
         description = "Parallel programming library";
         license = stdenv.lib.licenses.bsd3;
       }) {};
+  random = callPackage
+    ({ mkDerivation, base, stdenv, time }:
+      mkDerivation {
+        pname = "random";
+        version = "1.1";
+        src = "${ghcjsBoot}/boot/random";
+        doCheck = false;
+        libraryHaskellDepends = [ base time ];
+        testHaskellDepends = [ base ];
+        jailbreak = true;
+        description = "random number library";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
   scientific = callPackage
     ({ mkDerivation, base, binary, bytestring, containers, criterion
-     , deepseq, ghc-prim, hashable, integer-gmp, integer-logarithms
-     , QuickCheck, smallcheck, tasty, tasty-ant-xml, tasty-hunit
-     , tasty-quickcheck, tasty-smallcheck, text, vector, stdenv
-     }:
-     mkDerivation {
-       pname = "scientific";
-       version = "0.3.4.10";
-       src = "${ghcjsBoot}/boot/scientific";
-       libraryHaskellDepends = [
-         base binary bytestring containers deepseq ghc-prim hashable
-         integer-gmp integer-logarithms text vector
-       ];
-       testHaskellDepends = [
-         base binary bytestring QuickCheck smallcheck tasty tasty-ant-xml
-         tasty-hunit tasty-quickcheck tasty-smallcheck text
-       ];
-       benchmarkHaskellDepends = [ base criterion ];
-       jailbreak = true;
-       homepage = https://github.com/basvandijk/scientific;
-       description = "Numbers represented using scientific notation";
-       license = stdenv.lib.licenses.bsd3;
-     }) {};
+      , deepseq, ghc-prim, hashable, integer-gmp, integer-logarithms
+      , QuickCheck, smallcheck, stdenv, tasty, tasty-ant-xml, tasty-hunit
+      , tasty-quickcheck, tasty-smallcheck, text, vector
+      }:
+      mkDerivation {
+        pname = "scientific";
+        version = "0.3.4.10";
+        src = "${ghcjsBoot}/boot/scientific";
+        doCheck = false;
+        libraryHaskellDepends = [
+          base binary bytestring containers deepseq ghc-prim hashable
+          integer-gmp integer-logarithms text vector
+        ];
+        testHaskellDepends = [
+          base binary bytestring QuickCheck smallcheck tasty tasty-ant-xml
+          tasty-hunit tasty-quickcheck tasty-smallcheck text
+        ];
+        benchmarkHaskellDepends = [ base criterion ];
+        jailbreak = true;
+        homepage = "https://github.com/basvandijk/scientific";
+        description = "Numbers represented using scientific notation";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
+  semigroups = callPackage
+    ({ mkDerivation, base, stdenv }:
+      mkDerivation {
+        pname = "semigroups";
+        version = "0.18.3";
+        src = "${ghcjsBoot}/boot/semigroups";
+        doCheck = false;
+        libraryHaskellDepends = [ base ];
+        jailbreak = true;
+        homepage = "http://github.com/ekmett/semigroups/";
+        description = "Anything that associates";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
   stm = callPackage
     ({ mkDerivation, array, base, stdenv }:
       mkDerivation {
@@ -230,27 +330,27 @@
         libraryHaskellDepends = [ base ];
         testHaskellDepends = [ base containers HUnit mtl ];
         jailbreak = true;
-        homepage = http://www.cs.uu.nl/wiki/GenericProgramming/SYB;
+        homepage = "http://www.cs.uu.nl/wiki/GenericProgramming/SYB";
         description = "Scrap Your Boilerplate";
         license = stdenv.lib.licenses.bsd3;
       }) {};
   tagged = callPackage
-    ({ mkDerivation, base, deepseq, template-haskell, transformers
-     , transformers-compat, stdenv
-     }:
-     mkDerivation {
-       pname = "tagged";
-       version = "0.8.5";
-       src = "${ghcjsBoot}/boot/tagged";
-       doCheck = false;
-       libraryHaskellDepends = [
-         base deepseq template-haskell transformers transformers-compat
-       ];
-       jailbreak = true;
-       homepage = http://github.com/ekmett/tagged;
-       description = "Haskell 98 phantom types to avoid unsafely passing dummy arguments";
-       license = stdenv.lib.licenses.bsd3;
-     }) {};
+    ({ mkDerivation, base, deepseq, stdenv, template-haskell
+      , transformers, transformers-compat
+      }:
+      mkDerivation {
+        pname = "tagged";
+        version = "0.8.5";
+        src = "${ghcjsBoot}/boot/tagged";
+        doCheck = false;
+        libraryHaskellDepends = [
+          base deepseq template-haskell transformers transformers-compat
+        ];
+        jailbreak = true;
+        homepage = "http://github.com/ekmett/tagged";
+        description = "Haskell 98 phantom types to avoid unsafely passing dummy arguments";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
   text = callPackage
     ({ mkDerivation, array, base, binary, bytestring, deepseq, directory
       , ghc-prim, HUnit, integer-gmp, QuickCheck, quickcheck-unicode
@@ -271,57 +371,104 @@
           test-framework-hunit test-framework-quickcheck2
         ];
         jailbreak = true;
-        homepage = https://github.com/bos/text;
+        homepage = "https://github.com/bos/text";
         description = "An efficient packed Unicode text type";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
+  th-abstraction = callPackage
+    ({ mkDerivation, base, containers, ghc-prim, stdenv
+      , template-haskell
+      }:
+      mkDerivation {
+        pname = "th-abstraction";
+        version = "0.2.6.0";
+        src = "${ghcjsBoot}/boot/th-abstraction";
+        doCheck = false;
+        libraryHaskellDepends = [
+          base containers ghc-prim template-haskell
+        ];
+        testHaskellDepends = [ base containers template-haskell ];
+        jailbreak = true;
+        homepage = "https://github.com/glguy/th-abstraction";
+        description = "Nicer interface for reified information about data types";
+        license = stdenv.lib.licenses.isc;
+      }) {};
+  time-locale-compat = callPackage
+    ({ mkDerivation, base, old-locale, stdenv, time }:
+      mkDerivation {
+        pname = "time-locale-compat";
+        version = "0.1.1.3";
+        src = "${ghcjsBoot}/boot/time-locale-compat";
+        doCheck = false;
+        libraryHaskellDepends = [ base old-locale time ];
+        jailbreak = true;
+        homepage = "https://github.com/khibino/haskell-time-locale-compat";
+        description = "Compatibility of TimeLocale between old-locale and time-1.5";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
+  transformers-compat = callPackage
+    ({ mkDerivation, base, ghc-prim, stdenv, transformers }:
+      mkDerivation {
+        pname = "transformers-compat";
+        version = "0.5.1.4";
+        src = "${ghcjsBoot}/boot/transformers-compat";
+        doCheck = false;
+        libraryHaskellDepends = [ base ghc-prim transformers ];
+        jailbreak = true;
+        homepage = "http://github.com/ekmett/transformers-compat/";
+        description = "A small compatibility shim exposing the new types from transformers 0.3 and 0.4 to older Haskell platforms.";
         license = stdenv.lib.licenses.bsd3;
       }) {};
   unordered-containers = callPackage
     ({ mkDerivation, base, bytestring, ChasingBottoms, containers
-     , criterion, deepseq, deepseq-generics, hashable, hashmap, HUnit
-     , mtl, QuickCheck, random, test-framework, test-framework-hunit
-     , test-framework-quickcheck2, stdenv
-     }:
-     mkDerivation {
-       pname = "unordered-containers";
-       version = "0.2.7.2";
-       src = "${ghcjsBoot}/boot/unordered-containers";
-       libraryHaskellDepends = [ base deepseq hashable ];
-       testHaskellDepends = [
-         base ChasingBottoms containers hashable HUnit QuickCheck
-         test-framework test-framework-hunit test-framework-quickcheck2
-       ];
-       benchmarkHaskellDepends = [
-         base bytestring containers criterion deepseq deepseq-generics
-         hashable hashmap mtl random
-       ];
-       jailbreak = true;
-       homepage = https://github.com/tibbe/unordered-containers;
-       description = "Efficient hashing-based container types";
-       license = stdenv.lib.licenses.bsd3;
-     }) {};
+      , criterion, deepseq, deepseq-generics, hashable, hashmap, HUnit
+      , mtl, QuickCheck, random, stdenv, test-framework
+      , test-framework-hunit, test-framework-quickcheck2
+      }:
+      mkDerivation {
+        pname = "unordered-containers";
+        version = "0.2.7.2";
+        src = "${ghcjsBoot}/boot/unordered-containers";
+        doCheck = false;
+        libraryHaskellDepends = [ base deepseq hashable ];
+        testHaskellDepends = [
+          base ChasingBottoms containers hashable HUnit QuickCheck
+          test-framework test-framework-hunit test-framework-quickcheck2
+        ];
+        benchmarkHaskellDepends = [
+          base bytestring containers criterion deepseq deepseq-generics
+          hashable hashmap mtl random
+        ];
+        jailbreak = true;
+        homepage = "https://github.com/tibbe/unordered-containers";
+        description = "Efficient hashing-based container types";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
   uuid-types = callPackage
     ({ mkDerivation, base, binary, bytestring, containers, criterion
-     , deepseq, hashable, HUnit, QuickCheck, random, stdenv, tasty
-     , tasty-hunit, tasty-quickcheck, text
-     }:
-     mkDerivation {
-       pname = "uuid-types";
-       version = "1.0.3";
-       src = "${ghcjsBoot}/boot/uuid/uuid-types";
-       libraryHaskellDepends = [
-         base binary bytestring deepseq hashable random text
-       ];
-       testHaskellDepends = [
-         base bytestring HUnit QuickCheck tasty tasty-hunit tasty-quickcheck
-       ];
-       benchmarkHaskellDepends = [
-         base bytestring containers criterion deepseq random
-       ];
-       jailbreak = true;
-       homepage = https://github.com/aslatter/uuid;
-       description = "Type definitions for Universally Unique Identifiers";
-       license = stdenv.lib.licenses.bsd3;
-     }) {};
+      , deepseq, hashable, HUnit, QuickCheck, random, stdenv, tasty
+      , tasty-hunit, tasty-quickcheck, text, unordered-containers
+      }:
+      mkDerivation {
+        pname = "uuid-types";
+        version = "1.0.3";
+        src = "${ghcjsBoot}/boot/uuid/uuid-types";
+        doCheck = false;
+        libraryHaskellDepends = [
+          base binary bytestring deepseq hashable random text
+        ];
+        testHaskellDepends = [
+          base bytestring HUnit QuickCheck tasty tasty-hunit tasty-quickcheck
+        ];
+        benchmarkHaskellDepends = [
+          base bytestring containers criterion deepseq random
+          unordered-containers
+        ];
+        jailbreak = true;
+        homepage = "https://github.com/hvr/uuid";
+        description = "Type definitions for Universally Unique Identifiers";
+        license = stdenv.lib.licenses.bsd3;
+      }) {};
   vector = callPackage
     ({ mkDerivation, base, deepseq, ghc-prim, primitive, QuickCheck
       , random, stdenv, template-haskell, test-framework
@@ -338,7 +485,7 @@
           test-framework-quickcheck2 transformers
         ];
         jailbreak = true;
-        homepage = https://github.com/haskell/vector;
+        homepage = "https://github.com/haskell/vector";
         description = "Efficient Arrays";
         license = stdenv.lib.licenses.bsd3;
       }) {};
@@ -366,16 +513,15 @@
           test-framework-hunit test-framework-quickcheck2 text
         ];
         jailbreak = true;
-        homepage = http://github.com/ghcjs/ghcjs-base;
-        description = "Base library for GHCJS";
+        homepage = "http://github.com/ghcjs/ghcjs-base";
+        description = "base library for GHCJS";
         license = stdenv.lib.licenses.mit;
       }) {};
   Cabal = callPackage
     ({ mkDerivation, array, base, binary, bytestring, containers
-      , deepseq, directory, extensible-exceptions, filepath, HUnit
-      , old-time, pretty, process, QuickCheck, regex-posix, stdenv
-      , test-framework, test-framework-hunit, test-framework-quickcheck2
-      , time, unix
+      , deepseq, directory, exceptions, filepath, old-time, pretty
+      , process, QuickCheck, regex-posix, stdenv, tagged, tasty
+      , tasty-hunit, tasty-quickcheck, time, transformers, unix
       }:
       mkDerivation {
         pname = "Cabal";
@@ -387,12 +533,12 @@
           pretty process time unix
         ];
         testHaskellDepends = [
-          base bytestring containers directory extensible-exceptions filepath
-          HUnit old-time process QuickCheck regex-posix test-framework
-          test-framework-hunit test-framework-quickcheck2 unix
+          base bytestring containers directory exceptions filepath old-time
+          pretty process QuickCheck regex-posix tagged tasty tasty-hunit
+          tasty-quickcheck transformers unix
         ];
         jailbreak = true;
-        homepage = http://www.haskell.org/cabal/;
+        homepage = "http://www.haskell.org/cabal/";
         description = "A framework for packaging Haskell software";
         license = stdenv.lib.licenses.bsd3;
       }) {};


### PR DESCRIPTION
This is a cherry-pick of 582c7d24fc978fb342f7d4e9ea8b818fc8006724 and 78aa7f2338a4c1b9700b561cb123c6dc9ef053b6 which upgrade and fix ghcjsHEAD on `release-17.09`.

@cocreature @peti it would be great if this can be merged.