### PR TITLE
git-crypt: add runtime dependencies to PATH

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, openssl, gnupg1compat, makeWrapper }:
+{ fetchFromGitHub, git, gnupg1compat, makeWrapper, openssl, stdenv }:
 
 stdenv.mkDerivation rec {
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     make install PREFIX=$out
-    wrapProgram $out/bin/* --prefix PATH : ${gnupg1compat}/bin
+    wrapProgram $out/bin/* --prefix PATH : $out/bin:${git}/bin:${gnupg1compat}/bin
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

git-crypt won't work if git and git-crypt are not in PATH. This surfaced after dbb8958fefd486a3eb53c8db1af7e2452047a608. Test like this:

```
PATH= $(nix-build --no-out-link '<nixpkgs>' --attr git-crypt)/bin/git-crypt unlock
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

