### PR TITLE
gogland: fix debugger

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -78,7 +78,7 @@ let
     });
 
   buildGogland = { name, version, src, license, description, wmClass, update-channel }:
-    (mkJetBrainsProduct {
+    lib.overrideDerivation (mkJetBrainsProduct {
       inherit name version src wmClass jdk;
       product = "Gogland";
       meta = with stdenv.lib; {
@@ -93,6 +93,13 @@ let
         maintainers = [ maintainers.miltador ];
         platforms = platforms.linux;
       };
+    }) (attrs: {
+      postFixup = (attrs.postFixup or "") + ''
+        interp="$(cat $NIX_CC/nix-support/dynamic-linker)"
+        patchelf --set-interpreter $interp $out/gogland*/plugins/intellij-go-plugin/lib/dlv/linux/dlv
+
+        chmod +x $out/gogland*/plugins/intellij-go-plugin/lib/dlv/linux/dlv
+      '';
     });
 
   buildIdea = { name, version, src, license, description, wmClass, update-channel }:


### PR DESCRIPTION
###### Motivation for this change

gogland debugger was not working

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

