### PR TITLE
xpointerbarrier: init at 17.10

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -671,6 +671,7 @@
   xnwdd = "Guillermo NWDD <nwdd+nixos@no.team>";
   xvapx = "Marti Serra <marti.serra.coscollano@gmail.com>";
   xwvvvvwx = "David Terry <davidterry@posteo.de>";
+  xzfc = "Albert Safin <xzfcpw@gmail.com>";
   yarr = "Dmitry V. <savraz@gmail.com>";
   yegortimoshenko = "Yegor Timoshenko <yegortimoshenko@gmail.com>";
   yochai = "Yochai <yochai@titat.info>";

--- a/pkgs/tools/X11/xpointerbarrier/default.nix
+++ b/pkgs/tools/X11/xpointerbarrier/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, xorg, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  name = "xpointerbarrier-${version}";
+  version = "17.10";
+
+  src = fetchFromGitHub {
+    owner = "vain";
+    repo = "xpointerbarrier";
+    rev = "v${version}";
+    sha256 = "0p4qc7ggndf74d2xdf38659prx3r3lfi5jc8nmqx52c9fqdshcrk";
+  };
+
+  buildInputs = [ xorg.libX11 xorg.libXfixes xorg.libXrandr ];
+
+  makeFlags = "prefix=$(out)";
+
+  meta = {
+    homepage = https://github.com/vain/xpointerbarrier;
+    description = "Create X11 pointer barriers around your working area";
+    license = stdenv.lib.licenses.mit;
+    maintainers = stdenv.lib.maintainers.xzfc;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17331,6 +17331,8 @@ with pkgs;
 
   xpdf = libsForQt5.callPackage ../applications/misc/xpdf { };
 
+  xpointerbarrier = callPackage ../tools/X11/xpointerbarrier {};
+
   xkb_switch = callPackage ../tools/X11/xkb-switch { };
 
   xkblayout-state = callPackage ../applications/misc/xkblayout-state { };


### PR DESCRIPTION
###### Motivation for this change

This utility may be useful for multi-monitor setups.
Also, add myself to `maintainers.nix`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

