### PR TITLE
notepadqq: 0.53.0 -> 1.2.0

### DIFF
--- a/pkgs/applications/editors/notepadqq/default.nix
+++ b/pkgs/applications/editors/notepadqq/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, fetchgit, pkgconfig, which, qtbase, qtsvg, qttools, qtwebkit }:
+{ stdenv, fetchgit, pkgconfig, which, qtbase, qtsvg, qttools, qtwebkit}:
 
 let
-  version = "0.53.0";
+  version = "1.2.0";
 in stdenv.mkDerivation {
   name = "notepadqq-${version}";
   src = fetchgit {
     url = "https://github.com/notepadqq/notepadqq.git";
-    rev = "3b0751277fb268ec72b466b37d0f0977c536bc1b";
-    sha256 = "0hw94mn2xg2r58afvz1xg990jinv9aa33942zgwq54qwj61r93hi";
+    rev = "ab074d30e02d49e0fe6957c1523e7fed239aff7d";
+    sha256 = "0j8vqsdw314qpk5lrgccm9n7gbyr14ac3s65sl1qn87pxhrz1hpg";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Per #30719 I am bumping to version 1.2.0.

###### Motivation for this change
The Notepadqq package was out-of-date (0.53.0).

###### Things done
Bumped Notepadqq to 1.2.0. Tested, successfully, on my local machine using `nix-build -A notepadqq`. The app itself seems to be running fine.  