### PR TITLE
freeimage: fix CVE-2015-0852 & CVE-2016-5684

### DIFF
--- a/pkgs/development/libraries/freeimage/default.nix
+++ b/pkgs/development/libraries/freeimage/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, darwin }:
+{ stdenv, fetchpatch, fetchurl, unzip, darwin }:
 
 stdenv.mkDerivation {
   name = "freeimage-3.17.0";
@@ -7,6 +7,17 @@ stdenv.mkDerivation {
     url = mirror://sourceforge/freeimage/FreeImage3170.zip;
     sha256 = "12bz57asdcfsz3zr9i9nska0fb6h3z2aizy412qjqkixkginbz7v";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://anonscm.debian.org/cgit/debian-science/packages/freeimage.git/plain/debian/patches/Fix-CVE-2015-0852.patch";
+      sha256 = "0qkb96mvvhji75gz7dma3vj2b71smp96z3kl2ydj6skvnw6slnmc";
+    })
+    (fetchpatch {
+      url = "https://anonscm.debian.org/cgit/debian-science/packages/freeimage.git/plain/debian/patches/Fix-CVE-2016-5684.patch";
+      sha256 = "18g5ckrvqfjcldis7zf7hmfl8b3mgnc6akd6x3cdq8c5j7l1y98f";
+    })
+  ];
 
   buildInputs = [ unzip ] ++ stdenv.lib.optional stdenv.isDarwin darwin.cctools;
 


### PR DESCRIPTION
###### Motivation for this change

- [CVE-2015-0852](https://nvd.nist.gov/vuln/detail/CVE-2015-0852)
- [CVE-2016-5684](https://nvd.nist.gov/vuln/detail/CVE-2016-5684)

`emulationstation` fails to build in `nox-review` but that's [already been the case](https://hydra.nixos.org/build/62794164/nixlog/1).

/cc @viric 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

