### PR TITLE
haskell: ghcjs packages: fix build of fail

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -68,6 +68,9 @@ self: super:
 
 ## OTHER PACKAGES
 
+  # haddock throws the error: No input file(s).
+  fail = dontHaddock super.fail;
+
   cereal = addBuildDepend super.cereal [ self.fail ];
 
   entropy = overrideCabal super.entropy (old: {


### PR DESCRIPTION
@peti in https://github.com/NixOS/nixpkgs/pull/30726 I discovered that `fail` fails to build with GHCJS on `release-17.09`. Apparently it also fails on `master`. 