### PR TITLE
foomatic-filters: fix CVE-2015-8327 & CVE-2015-8560

### DIFF
--- a/pkgs/misc/drivers/foomatic-filters/default.nix
+++ b/pkgs/misc/drivers/foomatic-filters/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, perl, cups, dbus, enscript }:
+{ stdenv, fetchpatch, fetchurl, pkgconfig, perl, cups, dbus, enscript }:
 
 stdenv.mkDerivation rec {
   name = "foomatic-filters-4.0.17";
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ perl cups dbus enscript ];
+
+  patches = [
+    # for CVE-2015-8327 & CVE-2015-8560
+    (fetchpatch {
+      url = "https://anonscm.debian.org/cgit/collab-maint/foomatic-filters.git/plain/debian/patches/0500-r7406_also_consider_the_back_tick_as_an_illegal_shell_escape_character.patch";
+      sha256 = "055nwi3sjf578nk40bqsch3wx8m2h65hdih0wmxflb6l0hwkq4p4";
+    })
+  ];
 
   preConfigure =
     ''


### PR DESCRIPTION
###### Motivation for this change

- [CVE-2015-8327](https://nvd.nist.gov/vuln/detail/CVE-2015-8327)
- [CVE-2015-8560](https://nvd.nist.gov/vuln/detail/CVE-2015-8560)

/cc @7c6f434c 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

