### PR TITLE
[WIP] gutenberg: init at v0.2.1

### DIFF
--- a/pkgs/applications/misc/gutenberg/default.nix
+++ b/pkgs/applications/misc/gutenberg/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, rustPlatform, cmake }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "gutenberg-${version}";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "Keats";
+    repo = "gutenberg";
+    rev = "v${version}";
+    sha256 = "0mc9wxwv8lk4l2yghqfvgv25bb2mly7dllfm31gm94kpmm4kkh8k";
+  };
+
+  cargoSha256 = "0mjxyfx923ynxjanc3qp24w7rg44gk2z4fnfwzkqza40r02nfwnf";
+
+  buildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "An opinionated static site generator with everything built-in";
+    homepage = https://www.getgutenberg.io/;
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14966,6 +14966,8 @@ with pkgs;
 
   gv = callPackage ../applications/misc/gv { };
 
+  gutenberg = callPackage ../applications/misc/gutenberg { };
+
   guvcview = callPackage ../os-specific/linux/guvcview {
     pulseaudioSupport = config.pulseaudio or true;
     ffmpeg = ffmpeg_2;


### PR DESCRIPTION
###### Motivation for this change

gutenberg!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Doesn't build yet, won't be able to work on this in the near future so thought I'd share in case someone wants to pick it up from here.

Build fails with:
```
...
   Compiling aster v0.41.0
   Compiling quasi_codegen v0.32.0
   Compiling bindgen v0.26.3
   Compiling sass-sys v0.4.0
error: failed to run custom build command for `sass-sys v0.4.0`
process didn't exit successfully: `/tmp/nix-build-gutenberg-0.2.1.drv-0/gutenberg-v0.2.1-src/target/release/build/sass-sys-5d59912088df96d5/build-script-build` (exit code: 101)
--- stderr
fatal: Not a git repository (or any of the parent directories): .git
thread 'main' panicked at 'Build error:
STDERR:mkdir: cannot create directory 'lib': Permission denied
make: *** [Makefile:231: lib] Error 1

STDOUT:mkdir lib
', /nix/store/2kvac2qn3hf7i9s0q2hpgsv7gnddj48a-gutenberg-0.2.1-vendor/sass-sys/build.rs:42:8
note: Run with `RUST_BACKTRACE=1` for a backtrace.

builder for ‘/nix/store/1gq97nk123g1wy0k2kl4avpmkrc5azdh-gutenberg-0.2.1.drv’ failed with exit code 101
error: build of ‘/nix/store/1gq97nk123g1wy0k2kl4avpmkrc5azdh-gutenberg-0.2.1.drv’ failed
```

Things I've tried that didn't seem to help:

* Using fetchgit + leaveDotGit=true + fetchSubmodules=true (submodules contain syntax highlighting bits apparently, haven't looked into that or checked if they're part of the github release)
* including libsass and pkgconfig (see https://github.com/compass-rs/sass-sys/blob/master/build.rs#L41 for what I think is cause of build failure)

It's possible(but I'm not sure, just guessing based on the 'permission denied' mkdir error above) that the build would succeed if the source was read-write instead of read-only, haven't tried this because I'm not sure how to appropriately tell rust where to find the source.

Hope this helps!