### PR TITLE
shotwell: 0.26.2 -> 0.27.0

### DIFF
--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   version = "${major}.${minor}";
-  major = "0.26";
-  minor = "2";
+  major = "0.27";
+  minor = "0";
   name = "shotwell-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/shotwell/${major}/${name}.tar.xz";
-    sha256 = "0frjqa6nmh025clwnb74z2rzbdq65wjcp2lf9csgcbkpahyjhrag";
+    sha256 = "03vwp314kckr67p7shrysqpr95hc3326lk3bv40g11i9clsik1a2";
   };
 
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/glib-2.0 -I${glib.out}/lib/glib-2.0/include";


### PR DESCRIPTION
###### Motivation for this change

Update shotwell to the last version

> 
>   * Remove F-Spot import support
>   * Create a commandline utility to test image transformations
>   * Speed up color transformations a bit
>   * Bump GTK+ requirement to 3.18 and remove deprecated functions
>   * Clean-up histogram drawing code
>   * Run thumbnailer with nice 19
>   * Update VAAPI blacklisting for video thumbnailer and new plugin structure
>   * Add configurable image background
>   * Split several dialogs from shotwell.ui file
>   * Move Tumblr to default plugin set
>   * Remove some unnecessary memcpys on import
>   * Add Meson build support
>   * Some more ngettext for plurals
>   * Add --fullscreen/-f option for viewer
>   * Add option to install Ubuntu apport hook
>   * Fix issue when importing to NTFS-backed vboxfs
>   * Fix GSettings schema search path for running out-of-tree
>   * Work around "Camera locked: -53" error on GNOME
> * Fix issue with missing highlight on dnd actions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

