### PR TITLE
Update cockroachdb to v1.1.1 and enable build on darwin

### DIFF
--- a/pkgs/servers/sql/cockroachdb/default.nix
+++ b/pkgs/servers/sql/cockroachdb/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, buildGoPackage, fetchurl, cmake, xz, which }:
+{ stdenv, buildGoPackage, fetchurl, cmake, xz, which, autoconf }:
 
 buildGoPackage rec {
   name = "cockroach-${version}";
-  version = "v1.0.5";
+  version = "v1.1.1";
 
   goPackagePath = "github.com/cockroachdb/cockroach";
 
   src = fetchurl {
     url = "https://binaries.cockroachdb.com/cockroach-${version}.src.tgz";
-    sha256 = "0jjl6zb8pyxws3i020h98vdr217railca8h6n3xijkvcqy9dj8wa";
+    sha256 = "0d2nlm291k4x7hqi0kh76j6pj8b1dwbdww5f95brf0a9bl1n7qxr";
   };
 
-  buildInputs = [ cmake xz which ];
+  nativeBuildInputs = [ cmake xz which autoconf ];
 
   buildPhase =
     ''

--- a/pkgs/servers/sql/cockroachdb/default.nix
+++ b/pkgs/servers/sql/cockroachdb/default.nix
@@ -2,37 +2,36 @@
 
 buildGoPackage rec {
   name = "cockroach-${version}";
-  version = "v1.1.1";
+  version = "1.1.1";
 
   goPackagePath = "github.com/cockroachdb/cockroach";
 
   src = fetchurl {
-    url = "https://binaries.cockroachdb.com/cockroach-${version}.src.tgz";
+    url = "https://binaries.cockroachdb.com/cockroach-v${version}.src.tgz";
     sha256 = "0d2nlm291k4x7hqi0kh76j6pj8b1dwbdww5f95brf0a9bl1n7qxr";
   };
 
   nativeBuildInputs = [ cmake xz which autoconf ];
 
-  buildPhase =
-    ''
-      cd $NIX_BUILD_TOP/go/src/${goPackagePath}
-      patchShebangs ./
-      make buildoss
-      cd src/${goPackagePath}
-      for asset in man autocomplete; do
-        ./cockroach gen $asset
-      done
-    '';
+  buildPhase = ''
+    runHook preBuild
+    cd $NIX_BUILD_TOP/go/src/${goPackagePath}
+    patchShebangs .
+    make buildoss
+    cd src/${goPackagePath}
+    for asset in man autocomplete; do
+      ./cockroach gen $asset
+    done
+    runHook postBuild
+  '';
 
-  installPhase =
-    ''
-      mkdir -p $bin/{bin,share}
-      mv cockroach $bin/bin/
-      mv man $bin/share/
-
-      mkdir -p $out/share/bash-completion/completions
-      mv cockroach.bash $out/share/bash-completion/completions
-    '';
+  installPhase = ''
+    runHook preInstall
+    install -D cockroach $bin/bin/cockroach
+    install -D cockroach.bash $bin/share/bash-completion/completions/cockroach.bash
+    cp -r man $bin/share/man
+    runHook postInstall
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://www.cockroachlabs.com;

--- a/pkgs/servers/sql/cockroachdb/default.nix
+++ b/pkgs/servers/sql/cockroachdb/default.nix
@@ -38,7 +38,7 @@ buildGoPackage rec {
     homepage = https://www.cockroachlabs.com;
     description = "A scalable, survivable, strongly-consistent SQL database";
     license = licenses.asl20;
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = [ maintainers.rushmorem ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

