### PR TITLE
meritous: init at 1.4

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -31,6 +31,7 @@
   ak = "Alexander Kjeldaas <ak@formalprivacy.com>";
   akaWolf = "Artjom Vejsel <akawolf0@gmail.com>";
   akc = "Anders Claesson <akc@akc.is>";
+  alexvorobiev = "Alex Vorobiev <alexander.vorobiev@gmail.com";
   algorith = "Dries Van Daele <dries_van_daele@telenet.be>";
   alibabzo = "Alistair Bill <alistair.bill@gmail.com>";
   all = "Nix Committers <nix-commits@lists.science.uu.nl>";

--- a/pkgs/games/meritous/default.nix
+++ b/pkgs/games/meritous/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitLab, SDL, SDL_image, SDL_mixer, zlib, binutils }:
+
+stdenv.mkDerivation rec {
+  name = "meritous-${version}";
+  version = "1.4";
+
+  src = fetchFromGitLab {
+    owner = "meritous";
+    repo = "meritous";
+    rev = "314af46d84d2746eec4c30a0f63cbc2e651d5303";
+    sha256 = "1hrwm65isg5nwzydyd8gvgl3p36sbj09rsn228sppr8g5p9sm10x";
+  };
+
+  prePatch = ''
+    substituteInPlace Makefile \
+      --replace "CPPFLAGS +=" "CPPFLAGS += -DSAVES_IN_HOME -DDATADIR=\\\"$out/share/meritous\\\"" \
+      --replace sld-config ${SDL.dev}/bin/sdl-config
+    substituteInPlace src/audio.c \
+      --replace "filename[64]" "filename[256]"
+  '';
+
+  buildInputs = [ SDL SDL_image SDL_mixer zlib ];
+
+  installPhase = ''
+    install -m 555 -D meritous $out/bin/meritous
+    mkdir -p $out/share/meritous
+    cp -r dat/* $out/share/meritous/
+  '';
+
+  hardeningDisable = [ "stackprotector" "fortify" ];
+
+  meta = with stdenv.lib; {
+    description = "Action-adventure dungeon crawl game";
+    homepage = http://www.asceai.net/meritous/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.alexvorobiev ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1141,6 +1141,8 @@ with pkgs;
 
   masscan = callPackage ../tools/security/masscan { };
 
+  meritous = callPackage ../games/meritous { };
+
   meson = callPackage ../development/tools/build-managers/meson { };
 
   mp3fs = callPackage ../tools/filesystems/mp3fs { };


### PR DESCRIPTION
###### Motivation for this change
Action-adventure dungeon crawl game

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

