### PR TITLE
dotnet-sdk : init at 2.0.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -329,6 +329,7 @@
   kragniz = "Louis Taylor <louis@kragniz.eu>";
   kristoff3r = "Kristoffer Søholm <k.soeholm@gmail.com>";
   ktosiek = "Tomasz Kontusz <tomasz.kontusz@gmail.com>";
+  kuznero = "Roman Kuznetsov <roman@kuznero.com>";
   lassulus = "Lassulus <lassulus@gmail.com>";
   layus = "Guillaume Maudoux <layus.on@gmail.com>";
   ldesgoui = "Lucas Desgouilles <ldesgoui@gmail.com>";

--- a/pkgs/development/compilers/dotnet/sdk/default.nix
+++ b/pkgs/development/compilers/dotnet/sdk/default.nix
@@ -1,0 +1,53 @@
+{ stdenv
+, fetchurl
+, libunwind
+, openssl
+, icu
+, libuuid
+, zlib
+, curl
+, patchelf
+}:
+
+let
+  rpath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc libunwind libuuid icu openssl zlib curl ];
+in
+  stdenv.mkDerivation rec {
+    version = "2.0.3";
+    name = "dotnet-sdk-${version}";
+
+    src = fetchurl {
+      url = "https://dotnetcli.azureedge.net/dotnet/Sdk/2.0.3-servicing-007037/dotnet-sdk-2.0.3-servicing-007037-linux-x64.tar.gz";
+      sha256 = "0kqk1f0vfdfyb9mp7d4y83airkxyixmxb7lrx0h0hym2a9661ch8";
+    };
+
+    unpackPhase = "tar xvzf $src";
+
+    buildPhase = ''
+      runHook preBuild
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./dotnet
+      patchelf --set-rpath "${rpath}" ./dotnet
+      find -type f -name "*.so" -exec patchelf --set-rpath "${rpath}" {} \;
+      echo -n "dotnet-sdk version: "
+      ./dotnet --version
+      runHook postBuild
+    '';
+
+    dontPatchELF = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/bin
+      cp -r ./ $out
+      ln -s $out/dotnet $out/bin/dotnet
+      runHook postInstall
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = https://dotnet.github.io/;
+      description = ".NET Core SDK 2.0.2 with .NET Core 2.0.0";
+      platforms = [ "x86_64-linux" ];
+      maintainers = with maintainers; [ kuznero ];
+      license = licenses.mit;
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -118,6 +118,8 @@ with pkgs;
 
   dotnetbuildhelpers = callPackage ../build-support/dotnetbuildhelpers { };
 
+  dotnet-sdk = callPackage ../development/compilers/dotnet/sdk/default.nix { };
+
   dispad = callPackage ../tools/X11/dispad { };
 
   vsenv = callPackage ../build-support/vsenv {


### PR DESCRIPTION
###### Motivation for this change

Introduce dotnet-sdk package (dotnet client utility).

###### Things done

Wrapped pre-built linux binaries.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

