### PR TITLE
pptp: correct reference to ${iproute}/bin/ip

### DIFF
--- a/pkgs/tools/networking/pptp/default.nix
+++ b/pkgs/tools/networking/pptp/default.nix
@@ -12,12 +12,12 @@ stdenv.mkDerivation rec {
   patchPhase =
     ''
       sed -e 's/install -o root/install/' -i Makefile
-      sed -e 's,/bin/ip,${iproute}/sbin/ip,' -i routing.c
     '';
   preConfigure =
     ''
-      makeFlagsArray=( PPPD=${ppp}/sbin/pppd BINDIR=$out/sbin \
-          MANDIR=$out/share/man/man8 PPPDIR=$out/etc/ppp )
+      makeFlagsArray=( IP=${iproute}/bin/ip PPPD=${ppp}/sbin/pppd \
+                       BINDIR=$out/sbin MANDIR=$out/share/man/man8 \
+                       PPPDIR=$out/etc/ppp )
     '';
 
   nativeBuildInputs = [ perl which ];


### PR DESCRIPTION
###### Motivation for this change

A reference to /bin/ip was left hanging, causing failure when establishing a connection caused
pptp to try and manipulate routes.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-
nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested establishing a pptp connection.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

