### PR TITLE
notify-desktop: init at 0.2.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -673,6 +673,7 @@
   xwvvvvwx = "David Terry <davidterry@posteo.de>";
   yarr = "Dmitry V. <savraz@gmail.com>";
   yegortimoshenko = "Yegor Timoshenko <yegortimoshenko@gmail.com>";
+  ylwghst = "Burim Augustin Berisa <ylwghst@onionmail.info>";
   yochai = "Yochai <yochai@titat.info>";
   yorickvp = "Yorick van Pelt <yorickvanpelt@gmail.com>";
   yuriaisaka = "Yuri Aisaka <yuri.aisaka+nix@gmail.com>";

--- a/pkgs/tools/misc/notify-desktop/default.nix
+++ b/pkgs/tools/misc/notify-desktop/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, dbus, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "notify-desktop";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "nowrep";
+    repo = "notify-desktop";
+    rev = "9863919fb4ce7820810ac14a09a46ee73c3d56cc";
+    sha256 = "1brcvl2fx0yzxj9mc8hzfl32zdka1f1bxpzsclcsjplyakyinr1a";
+  };
+
+  buildInputs = [ dbus pkgconfig ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m 755 bin/notify-desktop $out/bin/notify-desktop
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Little application that lets you send desktop notifications with one command";
+    longDescription = ''
+      It's basically clone of notify-send from libnotify,
+      but it supports reusing notifications on screen by passing its ID.
+      It also does not use any external dependencies (except from libdbus of course).
+    '';
+    homepage = "https://github.com/nowrep/notify-desktop";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ylwghst ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3570,6 +3570,8 @@ with pkgs;
 
   nixbot = callPackage ../tools/misc/nixbot {};
 
+  notify-desktop = callPackage ../tools/misc/notify-desktop {};
+
   nkf = callPackage ../tools/text/nkf {};
 
   nlopt = callPackage ../development/libraries/nlopt { octave = null; };


### PR DESCRIPTION
###### Motivation for this change

I'm customizing a WM and I needed to test out some UI functionality this kind of utility, but there wasn't
any available in the nixpkgs repository.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [+] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [+] Tested execution of all binary files (usually in `./result/bin/`)
- [+] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
---