### PR TITLE
haskell-packages: fix all-cabal-hashes component lookup

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -122,7 +122,7 @@ let
     ''
       set +o pipefail
       for component in ${all-cabal-hashes}/*; do
-        if ls $component | grep -q ${name}; then
+        if ls $component | grep -q "^${name}$"; then
           echo "builtins.storePath $component" > $out
           exit 0
         fi


### PR DESCRIPTION
###### Motivation for this change

Previously, if a package name in a later component was a substring of a package name in an earlier component, the earlier component would be selected due to a partial-name match.  This commit prevents partial matches.
