### PR TITLE
curl: 7.56.0 -> 7.56.1

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -21,11 +21,11 @@ assert scpSupport -> libssh2 != null;
 assert c-aresSupport -> c-ares != null;
 
 stdenv.mkDerivation rec {
-  name = "curl-7.56.0";
+  name = "curl-7.56.1";
 
   src = fetchurl {
     url = "http://curl.haxx.se/download/${name}.tar.bz2";
-    sha256 = "1pvr2bqfhk46bzq2x2hskmnq3wc8qxlps7apm9q1qiixb9ra8q6y";
+    sha256 = "142zidvlmrz31yx480nrhh47hl01d7jbaagin23pspl7cw1ng515";
   };
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];


### PR DESCRIPTION
###### Motivation for this change

Update curl to the last version in staging branch

> - imap: if a FETCH response has no size, don't call write callback
> - ftp: UBsan fixup 'pointer index expression overflowed
> - failf: skip the sprintf() if there are no consumers
> - fuzzer: move to using external curl-fuzzer
> - lib/Makefile.m32: allow customizing dll suffixes
> - docs: fix typo in curl_mime_data_cb man page
> - darwinssl: add support for TLSv1.3
> - build: fix --disable-crypto-auth
> - lib/config-win32.h: let SMB/SMBS be enabled with OpenSSL/NSS
> - openssl: fix build without HAVE_OPAQUE_EVP_PKEY
> - strtoofft: Remove extraneous null check
> - multi_cleanup: call DONE on handles that never got that
> - tests: added flaky keyword to tests 587 and 644
> - pingpong: return error when trying to send without connection
> - remove_handle: call multi_done() first, then clear dns cache pointer
> - mime: be tolerant about setting the same header list twice in a part
> - mime: improve unbinding top multipart from easy handle
> - mime: avoid resetting a part's encoder when part's contents change
> - mime: refuse to add subparts to one of their own descendants
> - RTSP: avoid integer overflow on funny RTSP responses
> - curl: don't pass semicolons when parsing Content-Disposition
> - openssl: enable PKCS12 support for !BoringSSL
> - FAQ: s/CURLOPT_PROGRESSFUNCTION/CURLOPT_XFERINFOFUNCTION
> - CURLOPT_NOPROGRESS.3: also refer to xferinfofunction
> - CURLOPT_XFERINFODATA.3: fix duplicate see also
> - test298: verify --ftp-method nowcwd with URL encoded path
> - FTP: URL decode path for dir listing in nocwd mode
> - smtp_done: fix memory leak on send failure
> - ftpserver: support case insensitive commands
> - test950; verify SMTP with custom request
> - openssl: don't use old BORINGSSL_YYYYMM macros
> - setopt: update current connection SSL verify params
> - winbuild/BUILD.WINDOWS.txt: mention WITH_NGHTTP2
> - curl: reimplement stdin buffering in -F option
> - mime: keep "text/plain" content type if user-specified
> - mime: fix the content reader to handle >16K data properly
> - configure: remove the C++ compiler check
> - memdebug: trace send, recv and socket
> - runtests: use valgrind for torture as well
> - ldap: silence clang warning
> - makefile.m32: allow to override gcc, ar and ranlib
> - setopt: avoid integer overflows when setting millsecond values
> - setopt: range check most long options
> - ftp: reject illegal IP/port in PASV 227 response
> - mime: do not reuse previously computed multipart size
> - vtls: change struct Curl_ssl `close' field name to `close_one'
> - os400: add missing symbols in config file
> - mime: limit bas64-encoded lines length to 76 characters
> - mk-ca-bundle: Remove URL for aurora
> - mk-ca-bundle: Fix URL for NSS


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

