### PR TITLE
robo3t: change .desktop name

### DIFF
--- a/pkgs/applications/misc/robo3t/default.nix
+++ b/pkgs/applications/misc/robo3t/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   };
 
   desktopItem = makeDesktopItem {
-    name = "Robo3T";
+    name = "robo3t";
     exec = "robo3t";
     icon = icon;
     comment = "Query GUI for mongodb";


### PR DESCRIPTION
###### Motivation for this change
Gnome does not permit to add the application to favorites if the .desktop name is different than the binary name.
See https://unix.stackexchange.com/questions/58824/how-do-i-add-eclipse-to-my-gnome-shell-favorites.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

