### PR TITLE
skktools: init at 1.3.3

### DIFF
--- a/pkgs/tools/inputmethods/skk/skktools/default.nix
+++ b/pkgs/tools/inputmethods/skk/skktools/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, pkgconfig, gdbm, glib }:
+
+# Note (2017-10-24, yuriaisaka):
+# - Version 1.3.3 dates from Jul. 19, 2013.
+# - The latest commit to the github repo dates from Mar. 05, 2017
+# - The repo since appears to have become a kitchen sink place to keep
+#   misc tools to handle SKK dictionaries, and these tools have runtime
+#   dependencies on a Ruby interpreter etc.
+# - We for the moment do not package them to keep the dependencies slim.
+#   Probably, shall package the newer tools as skktools-extra in the future.
+stdenv.mkDerivation rec {
+  name = "skktools";
+  version = "1.3.3";
+  src = fetchFromGitHub {
+    owner = "skk-dev";
+    repo = "skktools";
+    rev = "c8816fe720604d4fd79f3552e99e0430ca6f2769";
+    sha256 = "11v1i5gkxvfsipigc1w1m16ijzh85drpl694kg6ih4jfam1q4vdh";
+  };
+  # # See "12.2. Package naming"
+  # name = "skktools-unstable-${version}";
+  # version = "2017-03-05";
+  # src = fetchFromGitHub {
+  #   owner = "skk-dev";
+  #   repo = "skktools";
+  #   rev = "e14d98e734d2fdff611385c7df65826e94d929db";
+  #   sha256 = "1k9zxqybl1l5h0a8px2awc920qrdyp1qls50h3kfrj3g65d08aq2";
+  # };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ gdbm glib ];
+
+  meta = {
+    description = "A collection of tools to edit SKK dictionaries";
+    longDescription = ''
+      This package provides a collection of tools to manipulate
+      (merge, sort etc.) the dictionaries formatted for SKK Japanese
+      input method.
+    '';
+    homepage = https://github.com/skk-dev/skktools;
+    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = with stdenv.lib.maintainers; [ yuriaisaka ];
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/tools/inputmethods/skk/skktools/default.nix
+++ b/pkgs/tools/inputmethods/skk/skktools/default.nix
@@ -9,7 +9,7 @@
 # - We for the moment do not package them to keep the dependencies slim.
 #   Probably, shall package the newer tools as skktools-extra in the future.
 stdenv.mkDerivation rec {
-  name = "skktools";
+  name = "skktools-${version}";
   version = "1.3.3";
   src = fetchFromGitHub {
     owner = "skk-dev";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1470,6 +1470,8 @@ with pkgs;
 
   m17n_lib = callPackage ../tools/inputmethods/m17n-lib { };
 
+  skktools = callPackage ../tools/inputmethods/skk/skktools { };
+
   ibus = callPackage ../tools/inputmethods/ibus {
     inherit (gnome3) dconf glib;
   };


### PR DESCRIPTION
###### Motivation for this change

`skktools` is a collection of tools to manipulate (merge, sort etc.)
dictionaries formatted for SKK Japanese input method.

The main motivation for having `skktools` in nixpkgs comes from the desire to have
`fcitx-skk` in `fcitx-engines`, which depends on `libskk`
(https://github.com/ueno/libskk), which in turn has a (mild build time) dependency on a
tool like `skktools` for preparation of a default dictionary.
(Technically, `libskk` can be built without `skktools`, but is virtually useless without
a preprocessor for publicly available dictionaries.)

Further pull requests are planned for `libskk` and `fcitx-skk` (a `fcitx` engine) as
well as some standard dictionaries that can be used by `libskk` and/or `fcitx-skk`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

