### PR TITLE
Revert "vc: Broken on i686"

### DIFF
--- a/pkgs/development/libraries/vc/default.nix
+++ b/pkgs/development/libraries/vc/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "Library for multiprecision complex arithmetic with exact rounding";
     homepage = https://github.com/VcDevel/Vc;
     license = licenses.bsd3;
-    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    platforms = platforms.all;
     maintainers = with maintainers; [ abbradar ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Not broken

This reverts commit c58c1f3b501731e3289fdae387b1c875c4e9cc8e.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
