### PR TITLE
add pythonPackages.root_numpy, bump python2Packages.rootpy

### DIFF
--- a/pkgs/development/python-modules/root_numpy/default.nix
+++ b/pkgs/development/python-modules/root_numpy/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchPypi, isPy3k, buildPythonPackage, numpy, root }:
+
+buildPythonPackage rec {
+  pname = "root_numpy";
+  version = "4.7.3";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0vy6mqmkddfv46yc4hp43fvaisn3yw92ryaw031k841hhj73q0xg";
+  };
+
+  disabled = isPy3k; # blocked by #27649
+
+  propagatedBuildInputs = [ numpy root ];
+
+  meta = with lib; {
+    homepage = http://scikit-hep.org/root_numpy;
+    license = licenses.bsd3;
+    description = "The interface between ROOT and NumPy";
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/python-modules/rootpy/default.nix
+++ b/pkgs/development/python-modules/rootpy/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchPypi, isPy3k, buildPythonPackage, numpy, matplotlib, root, root_numpy, tables }:
+
+buildPythonPackage rec {
+  pname = "rootpy";
+  version = "1.0.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0zp2bh87l3f0shiqslbvfmavfdj8m80y8fsrz8rsi5pzqj7zr1bx";
+  };
+
+  disabled = isPy3k;
+
+  propagatedBuildInputs = [ matplotlib numpy root root_numpy tables ];
+
+  meta = with lib; {
+    homepage = http://www.rootpy.org;
+    license = licenses.bsd3;
+    description = "Pythonic interface to the ROOT framework";
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18919,6 +18919,8 @@ in {
     };
   };
 
+  root_numpy = callPackage ../development/python-modules/root_numpy { };
+
   rootpy = buildPythonPackage rec {
     version = "0.9.0";
     name = "rootpy-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18921,25 +18921,7 @@ in {
 
   root_numpy = callPackage ../development/python-modules/root_numpy { };
 
-  rootpy = buildPythonPackage rec {
-    version = "0.9.0";
-    name = "rootpy-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/r/rootpy/${name}.tar.gz";
-      sha256 = "04alx6afiyahhv816f6zpwnm0sx2jxgqpgqcn6kdw0wnpc9625cr";
-    };
-
-    disabled = isPy3k;
-
-    propagatedBuildInputs = with self; [ pkgs.root numpy matplotlib ];
-
-    meta = {
-      homepage = "http://www.rootpy.org";
-      license = licenses.gpl3;
-      description = "Pythonic interface to the ROOT framework";
-    };
-  };
+  rootpy = callPackage ../development/python-modules/rootpy { };
 
   rope = buildPythonPackage rec {
     version = "0.10.2";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

