### PR TITLE
zanshin: don't use stdenv

### DIFF
--- a/pkgs/applications/office/zanshin/default.nix
+++ b/pkgs/applications/office/zanshin/default.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  mkDerivation, lib,
   fetchurl, fetchpatch,
   extra-cmake-modules,
   qtbase, boost,
@@ -7,7 +7,7 @@
   krunner, kwallet
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "zanshin";
   version = "0.4.1";
   name = "${pname}-${version}";
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     krunner kwallet
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A powerful yet simple application to manage your day to day actions, getting your mind like water";
     homepage = https://zanshin.kde.org/;
     maintainers = with maintainers; [ zraexy ];


### PR DESCRIPTION
###### Motivation for this change

Use `libsForQt5.callPackage`'s `mkDerivation` instead of `stdenv.mkDerivation`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

