### PR TITLE
kmplayer: fix desktop file exec

### DIFF
--- a/pkgs/applications/video/kmplayer/default.nix
+++ b/pkgs/applications/video/kmplayer/default.nix
@@ -21,6 +21,11 @@ mkDerivation rec {
     ./no-docs.patch # Don't build docs due to errors (kdelibs4support propagates kdoctools)
   ];
 
+  postPatch = ''
+    sed -i src/kmplayer.desktop \
+      -e "s,^Exec.*,Exec=$out/bin/kmplayer -qwindowtitle %c %i %U,"
+  '';
+
   nativeBuildInputs = [ extra-cmake-modules makeWrapper ];
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Fix so that `kmplayer` can be launched via the desktop file

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

