### PR TITLE
pythonPackages.tensorflow: add flags for efficent math on CPU

### DIFF
--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -7,6 +7,9 @@
 , cudaSupport ? false, nvidia_x11 ? null, cudatoolkit ? null, cudnn ? null
 # Default from ./configure script
 , cudaCapabilities ? [ "3.5" "5.2" ]
+, sse42Support ? false
+, avx2Support ? false
+, fmaSupport ? false
 }:
 
 assert cudaSupport -> cudatoolkit != null
@@ -77,6 +80,9 @@ let
     hardeningDisable = [ "all" ];
 
     bazelFlags = [ "--config=opt" ]
+                 ++ lib.optional sse42Support "--copt=-msse4.2"
+                 ++ lib.optional avx2Support "--copt=-mavx2"
+                 ++ lib.optional fmaSupport "--copt=-mfma"
                  ++ lib.optional cudaSupport "--config=cuda";
 
     bazelTarget = "//tensorflow/tools/pip_package:build_pip_package";


### PR DESCRIPTION
###### Motivation for this change

Make tensorflow more efficient on CPU

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

