### PR TITLE
pypi2nix: 1.8.0 -> 1.8.1

### DIFF
--- a/pkgs/development/tools/pypi2nix/default.nix
+++ b/pkgs/development/tools/pypi2nix/default.nix
@@ -4,11 +4,11 @@
 
 let
 
-  version = "1.8.0";
+  version = "1.8.1";
 
   src = fetchurl {
     url = "https://github.com/garbas/pypi2nix/archive/v${version}.tar.gz";
-    sha256 = "133sjx8r1jdb5gi3caawa9m7v496jv4id2c3zqnx8hria22425za";
+    sha256 = "1ynqfm77a2icbqx2y7srgx8agzxqc7y171h9f36mabjh2ph0p02a";
   };
 
   click = fetchurl {

--- a/pkgs/development/tools/pypi2nix/default.nix
+++ b/pkgs/development/tools/pypi2nix/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pythonPackages, zip, makeWrapper, nix, nix-prefetch-git
+{ stdenv, fetchFromGitHub, fetchurl, pythonPackages, zip, makeWrapper, nix, nix-prefetch-git
 , nix-prefetch-hg
 }:
 
@@ -6,9 +6,11 @@ let
 
   version = "1.8.1";
 
-  src = fetchurl {
-    url = "https://github.com/garbas/pypi2nix/archive/v${version}.tar.gz";
-    sha256 = "1ynqfm77a2icbqx2y7srgx8agzxqc7y171h9f36mabjh2ph0p02a";
+  src = fetchFromGitHub {
+    owner = "garbas";
+    repo = "pypi2nix";
+    rev = "v${version}";
+    sha256 = "039a2ys7ijzi2sa2haa6a8lbhncvd1wfsi6gcy9vm02gi31ghzyb";
   };
 
   click = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
There was new release upstream so we probably want to have the newest version of `pypi2nix`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

