### PR TITLE
 firefox-beta-bin: 57.0b10 -> 57.0b11

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,955 +1,955 @@
 {
-  version = "57.0b10";
+  version = "57.0b11";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/ach/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ach/firefox-57.0b11.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "11ddaea89af1e10184a30e691bbac711928b3e9319dd28d208a6ac7338d56ade9a096f1301eeddc1ddd591a9fa58d3b3fcd248ad6232e6a0622440a7b41a5038";
+      sha512 = "298e523e55916ea7c6fb31ad383aaa6eeb582440aca98519d6abc3e44201b60f3e382be7947dd434b47e13f7e2d2c88b62009bbb4298a7085d0512307d37b4ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/af/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/af/firefox-57.0b11.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "f725a89d99adbd3d11c85b8354b1bccd423e51aa08c26c0f593433e794ea30d01034bad710010f263fa98afc5cb020dd0f3020b7a99fcc78b0a1e0c809bdadf2";
+      sha512 = "00e31d736101e3cd5c8f1b999f9b4342369bce56c061271e952022459e80ea8b77ca356cdf28ff0255bf09984caa059ee0e62a2dc0f2cb31f1156224e7eaa4ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/an/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/an/firefox-57.0b11.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "0bcb5fecc974373ad5fec8ad4eee4c8647e6cf0cfbc5590238d8b369cb3ffa8ad048c67a9b1bc5dd4feb900011f79e521fd9adc7c5c74c32d837b20a651c4a6c";
+      sha512 = "7dec20660dbd4bf0a88742b58f4282d10b8f8778aa8b8b2b7847485039fe266b2ae4dcdc76ff1a37a516d2f0c16a2db2c2fbbab1e79d6eb8a79c63561da2539c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/ar/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ar/firefox-57.0b11.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "a2a9659b085cd47174913bb481c61c6df24e702ce4e03040d5280a64a985bf302b5163c9e9edafab59599144a2ff804d8fee275d7ef5d3bb2480de299126a34b";
+      sha512 = "05e8c1271f5e3f297e927bd08ef3308d57067d18116b98010c3cb2025e7b0a9ca608d046cd592a4afa3949b9a3244127a44ad90e89ce4b651397e95f5bd4a29e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/as/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/as/firefox-57.0b11.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "c1289cd1e7675f804842486b79a9bbf9ce4845ddf8d625a00f614b84cb8331b111677b802dd74a2a908363c4ba175276b3816ee3b8cb77ca4c560e9c578fbc17";
+      sha512 = "fc2986315e7514e51be8ab082be42be9b7f7f878c0c1d7cbdf36f3d7b5dccf59a39ea44329c3aa9afdd7118a29706308118c89937dfdd3d8f6109f8722c5646d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/ast/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ast/firefox-57.0b11.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "23b316a187c409317939c4208fcc75c473eaa18c5063ade7aa8df7f70919f9a3942c8bb306abc2a012915eb2cd153ed5dca024cef39397a7c7ab604f1d0e2271";
+      sha512 = "8dc4d3aa8935b61f90b21a059a97a6ffbaa90f13aeeb204b7eb28dd0ea33b899934ab162b7ba8ea00cd3c341d0f61de30ae2b3af052cd420246a891a2d902563";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/az/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/az/firefox-57.0b11.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "24e5f8868e89aba56366e62cf9cccafe7c284c44425b4a29ee8882715401d62a296395b14552e7fe34ab4983e1f6c7c87fa356f4d351fc7ca73652f8d006a6f2";
+      sha512 = "9fb126c09f39b6c943fcc30636b19e3b566cb5fd78b1ce68ae78b1c94d68198bfd391bdab6474ce7d616ddb114b5ff7bf54caabed94e2e3dc4557c95832e1c8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/be/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/be/firefox-57.0b11.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "361e1923bb59f21bd5fa16d3b94f487cc8da241914369cef925b838da63391e865061ce160390dc79b862e99b50a4e7a01178ac6c21e05aea7190b2dfa35bbd4";
+      sha512 = "ba5250a70bf92c555f87fe2376c6c415678e5d065ae7c0fdcfe613a53119173a7231f5c711dc1451cb6fdd77a94c5077c98019f0441f0f0ecb97ec16aed8bffc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/bg/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/bg/firefox-57.0b11.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "506f933b1871e0a9913aacb0c79dcdf432dee6546190f08b48087ce9e292a90ebe9cda2bf047645e47d6faaeb93c0274322a908d928273b63c4a258f02b21a7d";
+      sha512 = "aa38dca42bb1ed7472e10db04e4346918c7d495c24d484a9182c8b1651d1ae2f68188d12f133581a6b1a7463f559320283ab0877b2c51a1b93edb195706a1ed0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/bn-BD/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/bn-BD/firefox-57.0b11.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "805fde6efde1f6d452315b3df401a4d65cf5a807bf8528ada41c1005817c0bfd2cb924b5fd9d34bec131e4a2c0aedb7d059e49d58af6d4b68ffd29844b7ae05b";
+      sha512 = "11ba74486259041c06dc0c806c6b21332fbddfc525eaadd9a6eb37b1a8498bf25bd34b42155f642c8daa840040dbaeebb0721b541239656df4fe518d1cba3aab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/bn-IN/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/bn-IN/firefox-57.0b11.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "ac964e94f4a3dbb93f812712961439af7d7db6db4fdc3e054d17b99bae605658db40c974c58aa566f455cb4965b5d5bd378d03270b7237783adddb2bfb5ef7e5";
+      sha512 = "25ae74c773a9d525497c9d0c7d3e14cafe490fc8dbcd363f7daa102bbddafe06c4999f84847545da5c8dd974528613a5c6e1468b323f60eb0e3ba79e360b88a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/br/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/br/firefox-57.0b11.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "f6d30d417c0eb2fecdbb31821b8414e318e2a3f042489fbcaf96faef544005d7fb32c3c02fc2bdc2633acf7c7b76b8c24fba966c8539d6d3e9e928c2cdb3b1d9";
+      sha512 = "4f3dc389261f384238fc622d5ab1059cca0a5a4eb02daad0233bac7addd118bfc2c4c95a5bf5b7cf66053b049bc3150358593eafeb5026be47d676db212aeece";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/bs/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/bs/firefox-57.0b11.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "fc04a70c597082726b6b01759eb79d844a05d9bd0beff12b3802e9708b710cbc72b71f830ff561bccfd901116d8cad44384e7661695f0b6df00f6b1d8d2025c6";
+      sha512 = "91b13a19dacd457db11f78955bad518c2e590433ee1951e2951566f6609293da7195940de7daf97004021ae5229e887bc3c52832be21ae514c6a4afff3a365ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/ca/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ca/firefox-57.0b11.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "fd0bec7ae04fa945556ccc01cae9a3848c2cceb3ebd40f56a83ce3269b943b1dcb42c0de000bf20395e34277aab258f19c9d9678da6f4b9a59932ba6a904abec";
+      sha512 = "037eb9153e9f05a0c9cb2d80f39ae08ad8d425f349753ae2113e6a98a96950c6ddf3784fe2859383a5ed8a7450de02e6c2d344e20b851923c91576ad0d2de9b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/cak/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/cak/firefox-57.0b11.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "5a22e5b260919d9d85976be09947fdd74b29d5821ed0110857c9f94997b2c54572c95568a87d115dfd049eac358c8cf7bcc6b41de92d278cea5de87468274b50";
+      sha512 = "990d5f8637d4386e698cfa070118ef1e39d77065a54ff8293460caecf319707402e1f043c3ae9a46a7a58e2ddeabc312708cde361709835453a22d7826a46d1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/cs/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/cs/firefox-57.0b11.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "deb041e2adee7dc7467b1fdd302545bee1ee6b08a03a9bf3c030096ae0507f0956c32f64c6731be95782ca4b6835e8066ee384bfc9c08e35f2aa386d3fb84cab";
+      sha512 = "50422d5a16c205e10c1657eacad657403836ebeb5c1de656e12c4ad7b65776f0377faf55c6ea5b586be8f8694ee5952c289257d119aa3fae1860d5565f89643f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/cy/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/cy/firefox-57.0b11.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "b837d159b13fa448cf13737e163d2202904b25dbef9bfd43c8f0f0e96e4ec7e65196885bb93575682c5c29267f07b07471e2861ae3cbd2f732d611dbec4dbb24";
+      sha512 = "a78d86f637729089f5cf86778032c8093f07b03974a32444b1866f25a286b7e903630f3e836ef12a4c9df6025037885b0140a39680ffa6e6473f023fa3153155";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/da/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/da/firefox-57.0b11.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "c341351d5693518d22ea1ff2f1a46ac187c933355e8e106b446b8a200a0eea6ed108d582917f99cd4f9dd2f376216b0e773c87485eba56e4b7ed8957a4c19fbb";
+      sha512 = "50eaa3e29c322af80df70c3a52df53698c984187b8f8db86cf922fb38d61bea65dda2ecb6d6889a2f1a07c5f8b0d6026590d37c71df74068df0403f91998a584";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/de/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/de/firefox-57.0b11.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "e39b6dd52fa1eb10ad46e3cb54dc13a79722bdc5fa7a2addaae10a9ad1417b548767bb589a23efb8b5e0188f3a086f39de24c9e7a652882414533c439db219a4";
+      sha512 = "213227706f35dca646f3938044387aa42097d131cb6a2f361ec5d114f2c78b37b2298d9de3b289cd504c6559f37758324cdd7e59e5535caf3f8b8c8d71e701f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/dsb/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/dsb/firefox-57.0b11.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "37f858da1b528071b22ee1c3e3cfba6d20f54cb89397f844e648c9962b3f3a32a610012c0b51b12e2fdf9539cac8e7dd9c1f629d5dd840c401fab9982b1f8d32";
+      sha512 = "67406fe340fdd8107a36755bc75b05560540421cb1000b47d89a6492c38c0904dda5ba17686ec01e1f77a0f8b6a52878042a9f0d999766847eed54fcea0ee470";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/el/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/el/firefox-57.0b11.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "db560a967583e6913226c08baa44d1be12a6c7d158e260b7dece52703a5e46e62e8773699e27cbfdf14076b34094284099ef077ea7cef03cdf51707b32ff1d48";
+      sha512 = "60a67bb618aba13377c10e3d798fc370e633070c30d50e7180244667449308ceea4571e7a997c80af80ad027e27074f6b3fc670e5253f6159ed10653f8abd798";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/en-GB/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/en-GB/firefox-57.0b11.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "40f67b3ac7c3a3e557b60d6edd57d2754256f2776818c25846aa55b5a7048cfb1e775cac44b2c5459038454cbe0c544b796fa0c86e751866a011fdb4c79ffa9b";
+      sha512 = "4bed5620eb52e080379044e3785a318e131387181748414367b02a5b6dd2a4dcf43b55a794d9add241b5a438a79ecf1cfc15eeeb82d6c188baf18914d722542f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/en-US/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/en-US/firefox-57.0b11.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "03762f3354ced1aba8c0ac09d04cbb4d796fd63ba659ff0fd8ec50f9b63658cf3e009eb4e3965b91872feb43d6c15d2b853a49f3c69d9310a81b8c9f1756bba3";
+      sha512 = "85d751cfc31fbc330292aebc1fe8e7563d726a91242708b85104dde6a8043726e647628ee084b71c3f922eb0d40cbd7e1381a9a1b47aaf641edbd7401f3ec24a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/en-ZA/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/en-ZA/firefox-57.0b11.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "b83a44cb172247d81943ada3526f4151ffe2c4245bca7f0243ddae8d136dcc988f02c7d6aa7dd5088717575431cafa66d9f15fee78a7f6d1529cff6a86c6defa";
+      sha512 = "ebf2cc4e016e3623e2cda742d468fb0ebf0b6ff05c90d32e9eb5bad131fbbe12c46e667a21d1f446eca897ee65a8ec7ebd59b56951cf12e5ee44ce89e7bc147e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/eo/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/eo/firefox-57.0b11.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "fd6228801a9f4d09bf3de655603bd152c4799eecfc43a1701bf29f54d64be5228cf0a0644b1501ca68d445a0154e539574e16cd294aeaf24d7e4edf1a55c6ef6";
+      sha512 = "e3719652420eb97abe0097aed9736370dd55c572e7745f862d4b031fc84e84611f0c08bf8a2b7fc830a6759ff73183b02269dd7cd1b9eee5076e7d26155c77f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/es-AR/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/es-AR/firefox-57.0b11.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "e6527adc411f6fff1e2ccba4adc156db94f8a62b26c7453cf667434a30966db2bc06267d84a5760578d1c79b0f7f24751effc45e65f56cfc6651fb90213b40e7";
+      sha512 = "4cc08c7b8b242d671ec85dc46761f546479d2e207628d68de4186ac48b619013ba39005ce3b67ea08eee6df8ac46effececc83c8fe5cb2f184d9d56d36f98f41";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/es-CL/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/es-CL/firefox-57.0b11.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "47414369c504526d19d952157b14410f820c9cd08b7f026ec07ca10933efe3ae88463fd98cf8d04c1bc9c1b4b194fd4ddc0cb1b8973b658d31da5e13878ad92d";
+      sha512 = "5c6f753e119198ef1633a1a7039199f00c891d43ee5b49b95a4a1e8d5d20ada55ae03ef30e380fa50de4b777d4ad9dd5aa8bde9d0186265a6af9d7c277858ebf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/es-ES/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/es-ES/firefox-57.0b11.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "d1931cd9a0206384d10dbc1b2438a581fc466952657a82d8d46558981363f0c615c86ce06c285ea9c50949bb7ed1980de16a78cab95877a048152748a44a3a4c";
+      sha512 = "702ec0d89777a6a9c4a54a9542a0d2e89b352643eb5854db83600a7a93ca41b5d811de21d1de1f33c976b9ce5b19492d2fed12be1f570aa66dd09d21aebdcc5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/es-MX/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/es-MX/firefox-57.0b11.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "e5befcb9749d65b3386140e15ba0dc16c72ea9d5036cf324d833ffe1fde79727adb45a7c2d23306dc023caffd533609bc50ae99e91c1a4bad255c9d27c09deed";
+      sha512 = "2066be080187a297a2156d9953de0b9c38ff4c18e509f56884f596e37ef21e4a832bd0644f4e2df872d22a6fe3925b72b0548187d64e88974cfd50f9f1c18c54";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/et/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/et/firefox-57.0b11.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "65160be903f009d4704e8f2d36d7e95e83bb8a70d7368b78673f576ababcaf813297af794086a980928c721c9222f4f5d4882fe92b2e1376c65ca0031a7dfc1b";
+      sha512 = "0ec67c6a1186fb686f67075dbe1f07b34f2a0f45d3631b7f6b3a144b7d6ac89bc7d34bf98088826cbd908aa05a38a410fbe32135203595e604483f465d4f8af1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/eu/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/eu/firefox-57.0b11.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "a434cae9cee1a4625bacef653bb4681df4ee9b149319092f10dcb69365e4fd259258c70af8340ee1c3e689a656f683afb2c8c135c970323e1fba06f53ec2aa24";
+      sha512 = "2da25d33b6fff7bb463b65a866ec5bc89a39886e66022dc9b0ce7752d962cf3852158f1ef79bf4df0d7587729e295637b9c27c99840e3f2dc0ebaf6cbdc7a3c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/fa/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/fa/firefox-57.0b11.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "94faccd5a129d7e7043b78b03c9988d7fd1385ce12e05d97fe98c3df1def44e175219874ca8d38257f0053fa350fba4abe3bcb072498fdf8e4ee971ca6f47a2d";
+      sha512 = "d3e17c82f7020af45b50215f39d78826a5072dd94be5bf3cdd61ed7f67a45593765efd7f65b071ec3b00be86f90ed65f15bd6a5bc2a4906c2eed9b0cac23ee6c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/ff/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ff/firefox-57.0b11.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "7c0b7ebdf42f70929a6b04e9d710b228f85c0646d8fc89ea9b967c66c62555a68582c8017e55cffac2e29e1659b4789e6704594652d4570a9013836a544dbf85";
+      sha512 = "2a17680f7a595a35aff6f2a6a25eb9aeb8497ed7ab2cd2cf95e1894ea29cf99fd3c222144e3a0feee660cf0fc31d21c54d572483544267c8bc5312f0b31b9c3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/fi/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/fi/firefox-57.0b11.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "f6edf2f09d3c4b8fbe8af896ea32040a7d27b7ef22cd08c78fe4fa8e15c15c47e23db734440e73bc88a2f3527193955b685b0178b132b1c91595509dad94a6ee";
+      sha512 = "a54e8c300ff17a0b2f1124b5c637fc2b07f47761b5df71e219a8bb77b21f67542b19ab6051bca5c542cd30bd3517817fb5f44250990d683a997a6f9d925f6b93";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/fr/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/fr/firefox-57.0b11.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "468a21a47102e9d508e17e5d4f612ad528cd2b0de03c3744e185a7c988f6db77370d2e08fdeab1282bdcaf35b32ad8a3530f338f7040d33d48a1df7ef616196d";
+      sha512 = "50a58b205bd0d7ecddeeb4011ac9c499b35b32659f567cf27954561dac91b6bbc2a79e37e19b1fec07aa7459dc114d4cb8641847118fe50efd7d6c98e66a6203";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/fy-NL/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/fy-NL/firefox-57.0b11.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "a440f43d36e623de0af15d0f1eae1fdb0b533146524d30ff7256a257047e10c7b73ae3448b6ff70e033898cba58e178e03d2895f9873694dff7ae95d897b3a82";
+      sha512 = "22025a263c986be90ab5dc05138c2a8b58108bd39de83fe8266969cc1742358c2cd0730315904a1a35adcab94bd499e8d688d65920c346c28f76b650395838d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/ga-IE/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ga-IE/firefox-57.0b11.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "d6291fbc6a0190922164b5ce61f8b2b27d0db272b5eb3e01d230f7128198e131b07521d78e0ba5904285682fd0bf6f700637feaa0d45ae54d258b225fa141feb";
+      sha512 = "a1fd88907a14be9eda4e392762dcdcb009701baeac908a4cce664c8dce3c6957cc889add929b26fb48e592001c2e6e1f34ced9bbe137b0ceb7d230dbbc102f3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/gd/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/gd/firefox-57.0b11.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "636d2a8931f60687d93a94b937a57cf3047149c6809a865345da76023ba692d4e2b070a8bf35706aae030fbf7bef470d4b853ce9485e2ff456012e27edc8c063";
+      sha512 = "eb8331550bb43251a5d66c5f108568de1fed964a8360cccb9426b6d163f47764d34c79224026c058aefb2a526475c6b406fc1717a588a61c65d73098f217df8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/gl/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/gl/firefox-57.0b11.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "b32f50d930fade62a185adf90a35356de33d7a377b15f80b52fad10b737d66561db04177d7c1b3e4c5a26f213355af8a9d553a6eea9eb9ab4aa44e9b557a0480";
+      sha512 = "e7326fbe2c6b9e10a3fae76d27ec0de8856f9aef95a31db1ae5481ea43d895ccb220337b68deaf8a76fd110d6d1f74209dd27e8726ced57a635befb8e27c0e7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/gn/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/gn/firefox-57.0b11.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "dcca8976607b4f0cc67190cb57b4a5147a7e73c4f60c6334c89657a20ac1b583f33041d430d5582717883c398a6dda40889f9fac543ea2d08f67fddef84ad4f4";
+      sha512 = "cb81a34ee5f87636b5519c9804f65d714c5ea4406a05c465c5ee2bc29381e8235a1788111dacc78066e420f2583f004b3dc4841df9aeef848dc7a48accb3c9c5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/gu-IN/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/gu-IN/firefox-57.0b11.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "367e8cff652fa85bc546f095f9079dcc7b95c86db32379b6303188de62d396be65caacc9e602b21ea87abcc1cb7b588fb9aee280518bffe1e72d4223b7c5f224";
+      sha512 = "e26a80e9aa0e72892d79d0cbbee8473208342d3bd966cb034fbabfa6c3e844490184089ead6dddcd2f655c1577b66da239a24a636a651a8ad7951478e3dced9f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/he/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/he/firefox-57.0b11.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "f63a6c97b577d1d4c7970a496dd7ceda7672563f477cbe3b378ce2f7d24a96d8f9ed80f99bf6b28547ed8b2bddb6f8f788eff9bbf52bc4b4b8ec744fe9d8bd00";
+      sha512 = "13814b3b670a92013c08dbc8e37169fe758e378db0ac464f9b1d061ef5ba48063a1bc9284686317f4fb5b791a133b773bfda4db2ca25a154da258b81e2ba7bc7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/hi-IN/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/hi-IN/firefox-57.0b11.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "7ec57ba1fef3c771a057a156f9779cf168ddb33530ad1644bbec09431965dbf94e4b0933df500dfd271ee28288f0639ac36bbc80cd49b7d1e051a317c10cfcfe";
+      sha512 = "51f0fd4d50751559e0590340da3f3561f3526792965aa9cd86ba2b83866ac3342b5b4b225da2f2a2724b937c7ea00ea16881f27c8bee3deacebaeabdcc446c3d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/hr/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/hr/firefox-57.0b11.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "d50c0c5e6e512d25c3724dcacff7a86fb14a5402aa9fc44247a162c8b5cb470cd4df747650fb40f6a40c5793590d77efcc72c1983a9cb1b0b5c75173b63474a8";
+      sha512 = "fe9febf45bb0b79c131868a16a4139a7e885923eadd8ec07f0aa5262e66c06c5c188d4e6b8b4d6164bb32195f27330abc199b79a8d2a524fe4699f9c02ed66be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/hsb/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/hsb/firefox-57.0b11.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "3282b44db976ced30fc26ae7dbd7c6ac0c76711a3c759ed7be22f6d7c19065860998d779f5bdf569fe73a35b28a247db6223e8a3da7585cba15142e6b1f65e74";
+      sha512 = "fbfaa755ed9ea1f86f1f27216fa6925957b3fc48ae847534ad289361722e8c70e28beb83b9b30a447c0acc06703fd2642c652a88ec8ddd215dc3538ea0baa819";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/hu/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/hu/firefox-57.0b11.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "6cceeea7200eaf8fc7d73778021ee2522d84cc5499985d629aa8f81c24af540482420808d2f418d7e64fb211a3dbece0764a18652369f708fa6f444bad008e79";
+      sha512 = "b51b7ef5f2b0ed15796abffc299bf633af897393b17d12b2cd6dce5bcd6fb9165c2ee001b44eb89b91e68e616b2265b1fa307d90e68e35c34f425254a0135dab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/hy-AM/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/hy-AM/firefox-57.0b11.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "a4c01b86a8a0b5fff08190ac19d5cf338debe053d8499b3db44c96db92c41bd0c20e2d8a86cd9e0389e50999199b979e9b1a827cb79c58068a4b7b1b65c41366";
+      sha512 = "b2f781a77542c754185bd4f3aa040eb0d0aabbd773f27a422db87c8cb0cb60d1173c5e32e02886f608e03f2ef8ff84dc8a3cab7d55305fc36d9b11b96ec11485";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/id/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/id/firefox-57.0b11.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "e52e79a57239b145724d400e28af0fdc77b469f8c5b1c5d2cefd3409543c52bd135e165023d22de2af24563e4777a1e19c2a1cca41067e175c108d34140d6be6";
+      sha512 = "6e251aa02c0ec21272cf8bc4bbccc9e8d3b1d512a0a1bc90ea90e4d3844fd90c03989b102d9129348ced8734a40576b2dd294e8a85422e215b01b025e48180d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/is/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/is/firefox-57.0b11.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "6f7d50cdb623fe0097f1fead84b96d97abe548e46cd2c9617d6e285ae6474593d3d75739fda803770ee269277698c46857242feeefd63aaea78264ba18395d46";
+      sha512 = "5fe16a677f6413b0229c67b46e7831fadc0a9ef04395ea7c928d1149fc262cb9f28bf3c40b7d57eec09fd821a37286177a19f1a608a062b84ab9d82897560994";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/it/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/it/firefox-57.0b11.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "b765aaed36acd834687196992488b169d72239254a1ce7569f469537f681197b2c95b5f7fa409da3270b86d0e1e05fed3d23ada8d80c0dcaa995840ccf3cd79f";
+      sha512 = "f0ed83b63ea8df081f9110b5e8a5f848e9b4e89ff5ad7ee685f9792fa4438cdceae34b0e1bf265454f966f6a6f9d00bf47d665e6553c3c786bf48f4fbceefe4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/ja/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ja/firefox-57.0b11.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "26227fe542adeb789d9ad3a75e27cf2dec2f393af8d1ae1f1f39dbe2bc81f4bf233bfb2f9db22c23dc07226a7a3f2d29d4bad633959476e7973910e0c238b649";
+      sha512 = "8e9d0e446bd4b46b267001f1d24563ff5eb064bcb72be2ff30f42834d91658664e96683d680ec03fb62b8ae3f5e6d68b4a18800d6f4fe1b93692b1e4ab7258e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/ka/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ka/firefox-57.0b11.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "5b55ef6f8ebc2184be952f4a7d83cb714bc2afb3f52c7369e92007c4e8151c6a46ac9d02c9559632b820acadc52ae243a5927abeb6f678797e56f64ad8c270c0";
+      sha512 = "b557a2da452b41685e4ef61dbacd8a4563c4016b16946e197eeb60f39523dce87942f38659047a284ba2f8dc78ebd4ce5d377a86d54366e0f0c49176e29b3255";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/kab/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/kab/firefox-57.0b11.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "4fd51f54876d8ed1e23c73e36bd3e862541ae7c18269736f89f8c5190840a3daecb4b2e0347805854324753f2312ae66c67584c8722b9047f5da39cf96fdfa1e";
+      sha512 = "cab2e7df696e67a290aadeba8553e65880156f33b4cc57feedc971517496e8a8beb2ada6f8dcf4fd963a034cae4bcdc03bd970c6a9b27af720f64ce1aa9bf8b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/kk/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/kk/firefox-57.0b11.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "4014e1882473d52a05fdae5550a52800af16f31689c4fae47d530a4be228c2cb59b0ce23dcb2cf96e1a23b153de2f5b766208c422d0ea7bb54faac1dea6da6ee";
+      sha512 = "ea92799a2896013796459e8b8e3f5cbb8e2da528eda74091d22c93fad5791d8669d8f092842090ed5ccfb9ee39e7c09b44502c752d29a956b5e9cbc793ff74d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/km/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/km/firefox-57.0b11.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "67c0a62b308b707fde6a4499e3ff48ba010cff2cf5eb084712e5795b0e6be7eeefb4d65fb65a471de1e734fef990271185a303bb143c6ab0bb223c596bf54dab";
+      sha512 = "76f3d509693148cc94949a786697a6bd3bdda894bc4692715e33397e24aba446d94f9e364e159c4504bc0317adba5388ccdf3698f1226cb0bfa6bee2f00fb4e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/kn/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/kn/firefox-57.0b11.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "f8a6759bf2ee73209bb8abf65c0acff57959791b946e82e42e2ee4011f67192797e5f66575ca492b82239df8a444ea5adc544d1de0cd407ae1f67385c2a20e29";
+      sha512 = "3de7da4fa42a74b0187dec9b28cea76e3ca1bf80827f374bdf895461477a67478761c2059572da14c1e5660586a07239ed22d066e548c5271ab563713a3e0ef4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/ko/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ko/firefox-57.0b11.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "dc0b12e24ed0f68ad22e386eef6f2c3184aa23210d9b2f208185db76788ca8d54342476830adddc3aa0e7139e678046fafeb1fb331207ab0e5298b77a52a11cf";
+      sha512 = "fbe8b5a9a196a08f56408f57eaab71e3bb7ffec53bc05c4db0bfde4478267975aac5b876923c915a0a182d54fc1bc99f6361117fe659cc9e998e98f3a9aa122e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/lij/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/lij/firefox-57.0b11.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "8bcb2fbb9689bcd73903cfd7582f5421d6c4eeaf0feb95079ce8c6c008e120110b981aa638d831030e20696b062b251d0be552c1867431fc6ae5220f38a0a75c";
+      sha512 = "031ec2684ac7aee9a02e7aba789707b8aa6937fea27e191612b7cac6b0aa7bdf996c3f3cac1379d7ccce0a53701238f4379d691f29e2d4ad4c5b27a518d1d2b7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/lt/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/lt/firefox-57.0b11.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "7299042c6a29d70b38dffdc5b1d842e841bd3e7ab70a57ecbcc0d4c75ca087606aab1a73680e1566401112123cdde3d4a7f0908b7f54ff0c82fa66ea16579454";
+      sha512 = "ab056e37c0159b7b62e4d20e6fac5de190c3e7b53919bfc29cadad90c664c800e233abae58d1e7c1b8ded76af6da7603ea187da6510bac904bc2d32f9f37feda";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/lv/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/lv/firefox-57.0b11.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "3173dca01bc34c51ac775b70424a78f1bf5cc7edde3fb30f43eb67c4d73b6ca70bef28438683115906ae45bca731be3cbfed4d8b21dad255f15bc5d9141a458b";
+      sha512 = "c4a498bd7832c9ee93d0d98730c962176775b347e95241e0e307a97e8d53fc21dd943143e880f994d81d4fe15a7d24a480a07ed41efc10d1f816549c5b37ebac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/mai/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/mai/firefox-57.0b11.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "a185b31c33b3a7a120d7bd6e9b7236b7f2c8fc080ad4607ed0c25b451716ecb26dcc36ce6970722b76e9025826964ccfaa93ddc75aa4656174fe25f13665d3f8";
+      sha512 = "81f85952c2966471f4c74fe7092b7b614f33130ca19c74842084aecc6b53f8dc975d05ff0d9e7a8d692096e1f9cf2a49576bb9d4625904ae1074c5e0476e4bf1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/mk/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/mk/firefox-57.0b11.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "269ed71e11458ddf930b701a0b1ca6477723790868381188ae30bfff6bf310048d931a792050b18bb914809e48f867b1274cb25f3d19613a2b1875fe048ec554";
+      sha512 = "c9ddf832f7da91e15ce16fa46777e2458ade47c68dbc0c5a368e5e2b8a26682487449e51ee46057724c422ced2715754a4b5f459f6598e342ac0d553f2fba267";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/ml/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ml/firefox-57.0b11.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "e39c80c81520e5d00a7d1e1ad94a1f4480c3d791f412673b7c3a1443d03e830802cfc1fff581eebbb986d83e1b38fb6b144cbcec30e60ad124692884cdf4b2be";
+      sha512 = "55b8c4e2152fadd17d21ae060532ad078dc83f92c383058d1ea979dfaafbea58f9c7c7d5852688f619c6332a8ffaa37e2bbea47517f4bee71af5696a21593611";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/mr/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/mr/firefox-57.0b11.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "0996deb736677c9b3b3cc9e192835f3760103b868f6a449df4675ea8eae812f5ff9d2f4fd33a3dd8be9a13ea44e383cfa1de4d5982fb63475fe0d709ff48f8fa";
+      sha512 = "713455cb6defd82c93ef80d92803923bc5049014b2409f1903056e0c04c2316a5606c9fcd13e96c9aed79224e24ee491e24ab31366a22c5ea74b55c556cca2a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/ms/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ms/firefox-57.0b11.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "612d8e6c21116190c15a1ef945f179450bb6667d4e83268c51e88a150efcc5acd9b04ffd1d80eeea13e65d3bc3fd9c925bf0f19738ef542187be913c9396de4a";
+      sha512 = "53402320cf458dd250bcbd967381df5d5901fd62fb34943b18f86137f338e96d5b7175698d57ed3169ba138fe303c21365baaa56cd40dbe05717a82bb14d4c26";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/my/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/my/firefox-57.0b11.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "5824bc5759c9223c68c888ae9fbb2393f8d6b02f7a12f48918dd6b331abd2fae043474999d55864cae75d12fe55e29fdb94ccc4ad716c0fd780d0f63fcca974d";
+      sha512 = "92b06c4aff57149610269474dcf242e58e0a9676a04a01e843bdb71cffbd24f222d0f65bc73751cc0807c6efd84149e7d241687c66413f76f75031edadce60d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/nb-NO/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/nb-NO/firefox-57.0b11.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "111c1ec84ebcd06c1563e2f74ad28a9461044a4c75ec66e0f9d0b497305041e94176ea1eadf9f202e1ed35eeee7c81328debf3de9f9d32984d20ecaf007a0237";
+      sha512 = "52d82c8194062ec95b06f8956b52f7ef47df60436c40f3ae00358cec47034ebbc61fb2f0cb27a93dc96afd3aea5e3c7e8ebb92268f7fab01ae21d78d45f15994";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/nl/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/nl/firefox-57.0b11.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "635bf72cd6b18e82cadd8268bb97301bc3d82f6720ea6a33aaacdb671e01447ea348cda0351236600f226e673884f6f2d495bdcebc3a0a87a5d389d82b2f4715";
+      sha512 = "75689e5e642b82e97f734b3997984d805794b9ee07a44314a6cdbfa36f7caef3840f02daa13cd1338ed8bb435aea59c14b634e269211cba3b31babbf594f8f27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/nn-NO/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/nn-NO/firefox-57.0b11.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "03f0b9bad6ef0f1fdd1507733c6a059ba35350f33cb8c636b7acff4239f5e1e5b86acf1a29cf8b5edf102c4a20a7af4ed5f4026e44dc56f5dd97d08715d7410f";
+      sha512 = "5000b5497707614d74210aa372697c38db2997fa1fdced45e885de3838abdddde402e4282f32517e2b75f25b8d21d03149ec9621affe2e84f3dc34aac5ade534";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/or/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/or/firefox-57.0b11.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "a9506ab8cdf3adcffab1406c895ea229c97ab515b5b866f19eed43cbdec8bf877eb22fbb3d29ec429b9624e4f8a962a13a5da033a87bed8f9e67b0f83fbc1348";
+      sha512 = "123b0de9d2fea6509566df36fd2c2d0e540fada2b226e824c914cfd02ad964b37c34c3d1846aae0fe13e8bed1b01b267cb396a25f9bab1db9a6b0db420addf11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/pa-IN/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/pa-IN/firefox-57.0b11.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "b0eeddc8b3b421fb7b4215b146d644c1541a05f928258bed17991a0bf7c91eb5d64d834dd1ce4ecbc7735fb6fe104558a4a41592d4a284cfd7166ac015177bc3";
+      sha512 = "38618f7df36e1044bbcc32d50e6158e47a0e98cb171d03082a1874b990722d535f2dc4c8df5177475ae8c33bad9407ad480925158e6f74077a977c5abeb4b4ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/pl/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/pl/firefox-57.0b11.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "c3c1094cb2e7f4698da8d05ff85bdf6fa127ad91c07af13f9139dd9f36a99d542edf5b58b7ced08b8af277e9b5748d085468eab6ca45c9770461d2e0621d243e";
+      sha512 = "54b384c63c0c017898ab5df66ccf5176c6d69c1a55c3470d3f16fb2e654854da802d4c15206f7419e26572871b09c700e6caa8cb1d85ecfccc364796d8595824";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/pt-BR/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/pt-BR/firefox-57.0b11.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "e80d2810f3f77d090a1b11bfb808ec6e159134e52838cfabda83e31164049fec54c2a6142be127eb745c79413955d5ffb59a314b26b3c38b5c18b10f8a2fc714";
+      sha512 = "11c908bd35ded6e5dbf4df7c518534fe321cddcc1de9ae55db4ec1557ed9df5228e085c5947117ecb50fffd7af3365455e8ba6c98dfb587c8edfb53fa7a330a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/pt-PT/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/pt-PT/firefox-57.0b11.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "357959313de47ee9637e1b492d88f92e340b22f7ab1c512df483fd31aba55e83265feac6cc0ef9698b1e08c9070384bf94b1c54f9fcc613aa87b81f307baa37e";
+      sha512 = "54d9dcdcda3cc5cbacdb4bf6d5e697a0f1ed257ac8650573655485342db89fdb7ec6b98675d7255b600f76284a510b11e53c6bc9a2896d2f3656f2420f252ebc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/rm/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/rm/firefox-57.0b11.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "fb45631df64eb1796627cbf3fbf4f0748d145e05fb0cf1fcf3136dda89efe3b0b1e54d7bb346c275d8ccb1ab3d30aff343021d26a218e15aa8d5b052cd598794";
+      sha512 = "9f5565b6692fdb5fc7c9004261f4b1bf2b6b51e75fd6397018f2c5eb8699cfe93eed15e9564ab89ea3f643898ea55c98245ff8da713e479477356de645c87da7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/ro/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ro/firefox-57.0b11.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "394ab7b62ef980390d278a297dbfaa2730dc3211e537959ecb7110c6b061aa434f647a0457619a6239c01d9e08f97fb53ebf925d7f47fb582919b7bee812829f";
+      sha512 = "402afbb1552668d7efe27faa3895ef8f2edac40a389d5694de04a0b74f01087659503e46cc9c49c57c35dee3f8079943efc2d655b3f8eb3fff3281d4ea6972aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/ru/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ru/firefox-57.0b11.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "462e706c702be21109cf11ee275ec2683e448fddd99861461aed3e1aaec307d526f692adb8b09d3a813adeb86a3b80fc5c561ef56275593b6ab8145fbc11694e";
+      sha512 = "fea3a0c0192a5c74cc47c8355f7b78500cf20a0c1deccb2adc3e3639404f07cbd9edfce9960a1e84a41887e1175e2643af6d2c6027f3aabcc840226f2940c153";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/si/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/si/firefox-57.0b11.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "0fb26e2d6700998d199cd743252d981bcb119562f10c63de589a8bdc81759d593070c1b6e961230d9203f5d4a4a25fb96bf88eb58a29654de41e2d5130bcb574";
+      sha512 = "b57c8c5327d6393b841f0d4b1b327a5816560a7ad2744182bf99cab8a333b3fb833c14cc0587d1111529876e89b9de24005084967b327c3376543e0284223ebd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/sk/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/sk/firefox-57.0b11.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "fa35b0c5722c237b06e2d9954256c4cd84fc8752d2705e429b21c3800ea6a163b598281b29347596ec30d9fe7c706fc3de0e075519a65221eb459dc671b6f541";
+      sha512 = "221ee97c377002033a46564d8707308ab9c730eccb9dea3c93fa03d9f952cccab745298a8cc6ca4eba11fd171c92ffc159ce8fc004e9cb4710ff3553781635d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/sl/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/sl/firefox-57.0b11.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "7ae6a7676cf281e773de163eda410c19497b5c099f675328a7a75882e3326c7734c0ed12ae224be368b922b8f207667962de5024281de1291d1cbc59a19f6c4e";
+      sha512 = "c9264bccf0c5c9c02c674349e641330e3a2a55807fd44d964c1bb50622597958278ce22c64e10ba5bdb3623d14d283ce91d61385bf0e58bd784e46f5e81b10ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/son/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/son/firefox-57.0b11.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "e548b454499f0067c03758af8d32aab3ad50e6e9625abec2220af11052e056de965686ea9ae6bda2b4aa88e49aad9d5388b39aba77ef00ef6a1b91cb36caaab2";
+      sha512 = "e0c93706e7ebf5e054beee0827fedf620b10b3c41140bb999e722cd5dbf8c9227d478ee689fdc88d77bf85b9e41414dbdf33017ac26b3d026ffea3d3cfe94415";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/sq/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/sq/firefox-57.0b11.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "15ad7a9f7a08f257d3db1ef1e454cfeb9fb82dee05e4d12a4c6e6711c5ff1640fe5a5e0638340429778ec135eec3003518fc6e739372fe2055be2003e3b795df";
+      sha512 = "faad9344981f9b9a4f978a53156825bc49c88084ebeb0cf14a950a11f7d0468e3fa00a3306f48d58c18c8ae0622299b3abd428390863101678cc4ad146094451";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/sr/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/sr/firefox-57.0b11.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "9175b246684ef4377045302c0ba7389e45d6d90673739b6be4fee7d7ebc582e69607c0417c311aa924fea0e94c685cefa35fa764b5c033885868829b087892f0";
+      sha512 = "cb8926a04f9c5563821ede2bca7e409ebe14c4f00c90c0edc5afa6668f9eac9e2225412cd8ec8cdbc530bc0c4988e5ab82d6a659cc19c127fb5db70d1fa898fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/sv-SE/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/sv-SE/firefox-57.0b11.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "661e508900ed982749ad961283d82b1430ae9f81f352109986b918f68e07d60760469c17ac831fe8dfc5f249d9096bb800ac4319e9be123f772d3a414ebe1630";
+      sha512 = "e20c6b93249abb71c3550623603c2a20e1ef4eff5530c1b3971f1190f00ac60539a54d17cbe8964fa91d7edc377e16c54970901077526f3964521c3aff0dea68";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/ta/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ta/firefox-57.0b11.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "586ba071cf1ae05dfd71f42a2be169bba5229edd25aaa9f3f40660f9984c204387a325fbee2763775f340b459d1ffb79f0f2cbd9bec5a07db9f184e1218349de";
+      sha512 = "1cd968168f9b496046c0a10fc75bb0265deb964644098afe118f0d56f8bdc5dd038f23f78e94fe8f5585ab27f2bfbf85beb9771ca93ab9049e8d7947dd99d83d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/te/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/te/firefox-57.0b11.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "8c5eae33d036a6cab73f680992428134dfd78bfe18aa9b0c28d4a9b145c23b9087179fc377728b870749fc3b5899cae3f961cc4ea079830c2571ca49514093a4";
+      sha512 = "b7270f188b747ef0a833c29e9155bc58d1bbf38b9e97bc8a073df70b026751bf303b424ceb295746b3529775b8eaf0d9e3112970b5fad9673adbe435af9cf16a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/th/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/th/firefox-57.0b11.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "cdc0460ff16406f5c3368c07ded2fa131db8ac0b3aff4fdaaff76b326b34484a66e898c857e95b645477915f34a4fd14f07aee883085923e20beeb20d26761ef";
+      sha512 = "9dd0b419c71e6f8229973ce0738bd69247488786c1be9818930d24ba9506f40eef6fb9e4ab56b38136149755b217e8353eb07d3bbf11a673d34c485d4672b967";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/tr/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/tr/firefox-57.0b11.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "0b9cd2192131817f012117cf721064f073fe6e36cb282ec4473102403501507c282bad16494c8590e63788395db3fe584746e1f8c67de76b14cd78a0547ff9d5";
+      sha512 = "de7b9bd2cc817662a7975ff95bc34773f940d2b2a491b85df4bc3d19dc02dee75cb6305e9fc2441e3dd3d9ab746ae2de6d8984187f7276f988354a447a6096be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/uk/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/uk/firefox-57.0b11.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "92f64f9df846f1113732a94a4b613f33580f7e6ea084b3eb4039428040b175b573a9a847f62e9cfd443aca556b0088a1ad5904e08f56e3c6827d6959c18acf36";
+      sha512 = "13ee663e62cd68b92083b001b2a3753e4c5a6c15aa5e1187c01e6cad8692a6f53b6e25cbb0d294a62a3986421bcfdafc8bb82dc167118c213e9f4939bc991ad7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/ur/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ur/firefox-57.0b11.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "68078ed247e3896fec7ae1233194d5ffae3aa18ada09243ea00ed0ec0037f9d26cbf62b87d5563ce34d5d6b0b1b117de15255ef91787fe5db2be67365bd206fa";
+      sha512 = "d913ddbf3e10f048226f3fdb5e8524e2599b236379e6def3786789b767e9359ef2d47e2ea025a508467d7c47101b922150866984d91dfc41d525876b72ed4549";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/uz/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/uz/firefox-57.0b11.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "8ac6ff11ab3d1e351b3a84c5cb12a6e822ed7c57878e286a68189edd1ad432369befddbeae535825db3ca4570d25c89fc3be7eb8a97af1a4737cc13d6aece918";
+      sha512 = "107db43aa14f63c0b7ff4fa4bfd43b0343b657c3791fe29b07812af2c810bbc5343eeb90cd43028259c40dc79b0a763cd770b1f4954bdbadffa598bf0885ce83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/vi/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/vi/firefox-57.0b11.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "2c4a73c0ba10334fa5beeec9682ec716a82662b84a371f4e5943f5e2daa3bf225029ce2ccec82c6b024f18c3f6e68a763545a30147be954f187660ddc45c701b";
+      sha512 = "851f0e5fd8d057a3d55807ad8cd215dc378dcbe71b4c416bd8b88d0f0cfdd9d4febd7e93dd562affa0890d6aef9818970773f95ed76fa136c034459eecd977d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/xh/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/xh/firefox-57.0b11.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "16972b57c56d028be0c64c91809aa99bf7bbc62944f966c868c5624d1e0683a865212cee6c0e940d5f755b32f7b8ee34d6d8747324e1000e3f7b72ddcdee11a4";
+      sha512 = "195e35390839059a49e6c4ae03c1d6d4f085f7cff5b1c7963455bf73904303946c0926158a0bff4024c03be96b9570eb0e18c19ffb42081609f5812cbcc2e941";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/zh-CN/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/zh-CN/firefox-57.0b11.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "7fcff685808bae83933b16a9c3512c466e63c0dc3d9ecbced5c8ef4a02f031d0574e12059086b2cdfc89628e23e6954bf687eba620d47ace390d1648d66ab26d";
+      sha512 = "2ceb83e0e1182c756ccf30ca95f252ed8e81d293f2c33cc2d325bc091fccae183bf3e75dec67bf6f497b257d4037d8715b12b540bac95427289ea0baa2bdabcb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-x86_64/zh-TW/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/zh-TW/firefox-57.0b11.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "58a9fb93f1481193586a6b80af25dae35749584a9b1ef2529cf4f5732f0d4e10ad98c7d3fb5496a64d113050b451ffed25a8f726104ac4c92fe0ada73003a06c";
+      sha512 = "44597eb5fa3eb073a04a5fa36d92055ae9bff41049e4c8c3762ce2166d8af5974bb232ae244830d32d51a56e132cee3afee55f23704d389be78bc48063aef1b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/ach/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ach/firefox-57.0b11.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "9dd0661ca1901626478449f30ec6718f359c810d9f85a06abda0df4eaf0c3ed8b84f7a5924ac80c1f6a9b4be8cb964572dd1224f2643ed9381b7fdb7b13e5ac8";
+      sha512 = "9809327388821a5aaea4e8c4d85b61608f677c2af3842108b27d3786dacfb36ea82eb29458a7acf9337eea51f6f850c4ac0398dc67fb503d5fcc3cbbbfecfef3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/af/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/af/firefox-57.0b11.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "c86e56ef1f5eb4872fd0ebda3703b3c5e6e365628bcb45a42404bae8ded8574580683e557f8c16943d23caad60df3528882b19323d0589b56dbd12e4a5e534c4";
+      sha512 = "7bbb60c0bc784c4e58b2537b47e7b4b7ebcbf0a4fd63ab6db8ee0ddc1948ba9117c08baed37e5743ea90d28395dbf4df0bc512aa8bafcd810ac4e2b11ea220c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/an/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/an/firefox-57.0b11.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "ff9495dcef2ec58650e1373b0fa2741cd61d90926618bda08058d92f23d7f8fe86862b62986ef2d18603d2f38af7f4247e7537e17d37d66c430c44bc8c1a3ea6";
+      sha512 = "d2dcadaee4456e112edaaca783c91e9c78246aa742835a3d4cd074c612bbe1b85b28ecac222550eb920f09a96249e36bcb49a274c28352a6896d8beebbcbfbd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/ar/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ar/firefox-57.0b11.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "7f66d056000ab52143843cdb6cb4b1ea0ab393dba611f14a5cad0c111e6ec78890950d8f287f7d1b8c167a88efb38de302b100cb833f28fd5c54d7435d103566";
+      sha512 = "c993eda8d34a3b5f656a7d4cf616f820bb2230a734df6c2f0b4270d5403e8d6d23bd4bf003ae9b115acd1f7925d46b89c3cccc9345ddc7f9d73a269e3c243431";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/as/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/as/firefox-57.0b11.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "7a73fa66a1d6d00790d0438233ac75e740f5bbf3fc824e87d6d0c003f6a6307437f01049ec414f7e655b371de59a0c8e84a9bcdafca53192bb08e0f155f12bbe";
+      sha512 = "5112aa43ee870c3fd8f13378a4159977cf4dae3b1792ef983325a0d1f0134f377e6e4c473b27406f2722c138309a1af175f4bc9ff4e37f08696abf4b8f001fc2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/ast/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ast/firefox-57.0b11.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "bd7d6d9c0aca3e2636e74dcbec5614da134b29f13908e230abb209fc9765445a4f701761fec8de43f71e7229b5f984cb1888d10a17d8f8d94b657f9ad0e56f52";
+      sha512 = "cb7fa643c742ac1062f34acb1498a7e903dde4c8b685ba48b997cf0247aa70157ce2317b5e25660748294757f0d0fde7d08dddd6581726c8f33db1cef3767878";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/az/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/az/firefox-57.0b11.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "15a2d4d6d80979cd26b383e61957a5848974971d43a3bbbba2059bd16164231131a64b7c8be4d83d684daf3cac0b5898c64883766574b92af07663a9307dcd71";
+      sha512 = "267fe9b5398ec432e684efed10624819eee7a1729c8480a4acd616cf4dc988295c069a62f6e3f2936a9e822f45fc459d8aee2d94549fc77d3f2fdc6a23aa9ec6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/be/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/be/firefox-57.0b11.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "ed3bafbd2719ea2829f6fe4400a12d28f0e7ff3206f5869de60996a097b6a7a876dbb50b65352b3a8b7adc246f8255e8a9c5deed40fe8f6f7f4f640b79385738";
+      sha512 = "35977b89eed0a7e7401bad75eb20e7acd07ea52ac252ffb73a464f7d7c7f44fdb9dd6bfd1418324cf8834165825ebde256704e7822734077a68c0a3ceecb8b56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/bg/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/bg/firefox-57.0b11.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "2cf11489bfbe182768e5c7f3848df7bd4f07a4d5858d854e80ee26e258f7de631f5b4aad3b375075619defbc404fded93bcbc6769798342eac5af0ba0094237d";
+      sha512 = "dabb67aad05867acd8fc5226f1adc91168f70d68926a7d9e8407feb8795a9fa56121234c639b03cf10cd2ad44f638b6f96003e48977ecd07b8f267c9da10b943";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/bn-BD/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/bn-BD/firefox-57.0b11.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "26913074c0e0de2269f26409ee2518a6f3fcad7d42f535c0ff415361ced91f57785636b4553d7838549b9772173323fae02808cd1646c080c5a3d44dc054438f";
+      sha512 = "f6185c2eceae26618c3ddbb09f87cf120f300d8c3642d36b257fc8c6c0fbe7a0d0f0e409b53bf3fceb2158497be91b9dd70e3605a5177d858a115cb4cb065683";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/bn-IN/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/bn-IN/firefox-57.0b11.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "c85729aa0ded6f03c590c309bd502bb8bc86ba0e90a369c32ca11dccc938504f8590e93d932dd6a31409ad5d6237832002b132c008f0ff6695a415257d4cc5fc";
+      sha512 = "50730081c97abb504f76f2e4c5bfc42258473b5b1cd4393a09be927156e626ede088f7ee6242ecaf9b641345cb4f28fb9f0a5276bd781882aa047adb4d1281c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/br/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/br/firefox-57.0b11.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "458459e0ea0323d32ea256c1b1678a315acefeca0286a0b05f9e39cf9ac1f89cbae69d8717ebb8e227204bc78d72e023a08789059c7cb0fe0883db5395894a5d";
+      sha512 = "6a1cbf642c85abe216854a45d371dd8463c37a3d30a9cc0e7b88aef19baf4695def56c9ff61110868c1359c7b6b082ea9862ab4026fda70ddef05c304f805fe9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/bs/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/bs/firefox-57.0b11.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "3640842fced020ed3216c2711c0276bf563519d3b4f68a942b20b2cdd7a2a3d50c0247bf440d915a6c1d3af2b4d9662badcb37e9b12f23e3e5c02a4d91610711";
+      sha512 = "f62dfafbccb28abda10bdda208ff161e5db06eaf4bb3291c4a2149c990ac28a80ff4eaa28bd300c296e349c762c1baade01f5881b8e079e0e690a9c3fdc302b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/ca/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ca/firefox-57.0b11.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "60848bd684c2e7fa5c67fd6c1dcd8467d39b6dde9e7121f5cef26e3225e155641fda7c68745ed02e2d1e3ed91dab3c813771254940ffe6dde4b77a1e206af350";
+      sha512 = "990e3c75c387050c728bb6fb2dff2040e53b0ecdd73fba6ed27c6c66206597fd2ac099d561ba8a9cae1875ff38628a562143dd5802c7ab67221e2837de4ee0e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/cak/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/cak/firefox-57.0b11.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "a95f74d3ad5cc7e1c58b6b6762104c59eb0d0ce4a9bcd08967b32204c259bf71bd567cda8cfa019bc62d5c46439359f53d85fc8e07da7c8e5cefc571e13ddd35";
+      sha512 = "698fac4d2a06a5057cb81a57608eea45752e6ab787ce8264e5d3e0a1c11469d1e0b2c97a5ae34ccdce7e6221f6367dc4682154c6b013105750c854c1340252f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/cs/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/cs/firefox-57.0b11.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "ba510c00e7903187943560bc468d90a6b723fe6c0887777157efd33b2e97e1274f36948db092e0d1b6b28e9c0abb7f67d900b3137cf94e310996945f955a439c";
+      sha512 = "ae2e138b886fc3c2350437a57fff8f29a5018b78dc2b31a45dc981ffdf233d6ad11be5df8602cd7de4ff9df6868701b296ee42d1e41922da1db7aa5f1c1dfabb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/cy/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/cy/firefox-57.0b11.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "7f2541b14108d922e0a32b28a7ce3abde63c2b365ee16114fd280d8984f69f83d31d33f7fa243896ffc84f46b070be231816f7c2394e6c6a8e2ffc8330670b02";
+      sha512 = "fff159c8d07c544a8cb66b4cb52ffed3f8975d362c0b69ee83a26490eda68bebdfce45ff71147198a2ee94841deb9115a6a2ced6ff7a583d09c6dad8edc87d99";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/da/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/da/firefox-57.0b11.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "7221ae31d54e85fe9cf6b58f6eace9f1ac8ddd37ee43f7f29409eb82f4c09fcb8c1ffae3cfc92f515a426ea200911c92a784312ca5573a4fd3aa3793e3bf5fd6";
+      sha512 = "32d5bfb5293e1d5346d189638b1e0269fc0d6aa2ebf3e7ca2f018533744d96868eed09797e8222102a6afe66d0b7e2f6ffcae5e72fcd2f249fc66f8af30e5bbe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/de/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/de/firefox-57.0b11.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "b592f17e95b28224f58d2cbc41baa4dbc2bf7fc631a0a7a21aaa5a357ffd8813fbe15932f9338641f431838e5db745eb580ce1443b62fd000f552a9851af8030";
+      sha512 = "63b9b1ef0c83c91406c165034f0429c9c2ecac617d4f69dce40b9d12fd5f0583fb88148f6d14858e21a71ec0f59cc22c18abc296d0c561624d584fe6e6967b18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/dsb/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/dsb/firefox-57.0b11.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "2d0e0f0efd3d4b842f8b8511d44e194efcc7fcd9512b361174f097287ee40784377985e516a1c87cc26a7f691b6e9c7c38e8805608993de437008f343d8755c8";
+      sha512 = "c902b5bfbefeeeccd7b49dfdcff94f3219ab42398ff2e73aa166846b7265b896838754719f1e84d0662660bd03ec14737183e60e653721840cc53b4bbd6d6658";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/el/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/el/firefox-57.0b11.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "0a9ebb584ec52aa22ce51b18a92c8be2d29a916795a52060ac1663e4bd892006a464e2c2a99bb89a4d16796591fd0b452c2a114b42a99502317081c659c12037";
+      sha512 = "85b2c08615e034ed9f1aba837bd73564e877f3385e3c3989ce864b1848f79f72e30a5bf06d6b32358a7f296137207a785fb343874fcf551f6f0b98515a52fb14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/en-GB/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/en-GB/firefox-57.0b11.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "eaf2bc3bdd55114fe5226d877c9cc9d5f5f78f07363327995271d863286b6534e0d9ba9cefc6efcdf7fb1ec1091e943ff9bfa41b7090be4365ebb6a7dde35c6c";
+      sha512 = "d14d1d17020b8a79dc580f7f526403e17cf0337fdd567b464097bb3796e752a669208b2a94a0fa4d1834816153230be67ce815bf440e1acb9220c951fe84cfa2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/en-US/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/en-US/firefox-57.0b11.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "7a937c9fa67ee0d7bfd7bdd6d504cdc81c4afd6642a2d9888489845376c1975fb5e1129a9f0b55d5000d400f79049365e6a1433d0e8ca9cc2d7ddf3fe312b7a4";
+      sha512 = "fdaef350da4b8eda52c70c613f8c5e6a5c80522d5afc8f6bdd9590c91bfce43d2d2034ea095b377b47f8da65d950fe4c203c2cdfa9bd880d3f6253fcd0b252a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/en-ZA/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/en-ZA/firefox-57.0b11.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "ef75b4bcd4eb37349058ea9020ecb7bbdbde2873d3f15a01e9b727e4fbb58c32f09112fa1947b38b6343a004e0c2a45336f99f8534afe736120e7c92dff0e080";
+      sha512 = "c4ce10a2ad4d8ac8cff1e87a408caba7c1736f84ad2e228b45b7f9d0f87e5c9f6a4adb0a0ade89fa88c54c38a68189f7e203370890eaf69b6bd033b90afda8c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/eo/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/eo/firefox-57.0b11.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "9ae6501dc2bb47de897aa61a633048279cba4a9545a3250a58cd9688ee546857a7c5c69e661d78b595051f76e7afb9de60ba929c68468bbd568f76c848a2fba5";
+      sha512 = "37f75ab35b3ecb080dfd7c3b5edb65df950d260edb0156bb09887e8f30f1ef1d66016f6b07eaed0288be1c5c92dcd5c18b88fb0a9e742ced375ecf661a3ff5b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/es-AR/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/es-AR/firefox-57.0b11.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "19dc4c760481997aa9554a101263030ed1a322ddd0b2e4fa743f4b572305dd6cc69fc27b2196e586308c96c73dde8e5f155f1aa0f8f0239cfe64113b12586943";
+      sha512 = "8f2603e1d4942e6c6d4f7bb5823473a0e44f820805301aa2b0faefca6540f4a8078d43b6b9427e581d9720f6ee47ce4af82113c113753fa7131d6971ec10441e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/es-CL/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/es-CL/firefox-57.0b11.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "0be6855e33910446d0216eb96a258e65db60dbb5820805c63cb4202c76adb25180c4fc343dec78cc3ac6030b476a77c87441343884e97013cb439daac45c84ca";
+      sha512 = "9a6845eeecb831cbc3d804377ef11ccebe513307a72f4b542968d1851e54679ce202e5c6e5b1b2efc767451a0202737837f564f146862791c53d9880e42a2565";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/es-ES/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/es-ES/firefox-57.0b11.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "83164bef1ba1790ca2b9ffbdc89362e1f8b9c3d42aea938567841cf12b59f02bf30ecb3146a596b83715277bedeb8fc15b9f07ae1e34c9eb75cf7d464c7c2de1";
+      sha512 = "4d94719060001c3e4fdabb0a08e977079a3ac05d5a5f006d724dc0d6a7bd31646f5603be8236b6cb0ceba10eef64697044cc104bcb10b4308b28fe4883e89167";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/es-MX/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/es-MX/firefox-57.0b11.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "4a404f137b9d736d275672bb38eb7231d5d95f3538df3a320f573ba8d6a9e68ca8e02d3b89fe3a36ec08fc30dfafc9b57eb744f8bba25663b16575dfda5b4d3c";
+      sha512 = "38d46eaf7b40f753b9fd6fdffda3b21c5f4ea9a554488277cf55f97e230911606c98fb4e5b6b188621db24c552236aa67b1ebc880630c74f6c57777c6c0aabc1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/et/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/et/firefox-57.0b11.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "e86f05f93c3e1e1c388f72248d79ab5d382610af3e2a23387a816cb76e3a670c22a3363d88187f83807d1d28b182775696d03c92869867217abe5bfa2561dfe7";
+      sha512 = "3babcc9f0bf78b491d11d96be70a62b409729180e3ebb0fc97ea0eecfa3caaa2db1f6956f8becd97066d8b7216101804d2fccd249ccea335b92bbbfe12b99d89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/eu/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/eu/firefox-57.0b11.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "fc93e9d91a7a9408f7e950b873630526ed2012849e7735bdfb4c63d7ac95bce3dc11327538845d58f83b70014095bf1e48f12bc29741a3b56462147fec244ce4";
+      sha512 = "f2b1b2befbafdfcd2467822b7834c5a03ec380c2876d6641addffc5852453232c350273d310e734e7071d2dbe35c94779eea858ecda49411b6a8520629394c62";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/fa/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/fa/firefox-57.0b11.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "241df02aa26144dbf6f22ea9b6c8a7de4fd5e86ba7999db5cf23be9e409172c565466686a8901525dc514e322a445ca9b9c0b367d2a0569edb13a2dc3d66c7cb";
+      sha512 = "05d1bc4004261475c6b806fd2327d2d1f0a1246769cf9de0755ac0cffad99c270064699b5d05cbc9353c5ce77be9810546f59b0d47a0f88c96d6296d4e51a358";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/ff/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ff/firefox-57.0b11.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "03f5240e53c36e847dd23b007f9b419bdf238a03b92678d702d0d13059516a306eb15f45c9469def50baf35dc43f420c924744d0ba862a614ad7d9860fe6cbed";
+      sha512 = "448fc135f815bf79fbb62e2b4ca799bfae3891f9d1197ec8febb441f2a13dee8405add2c54a12d2eb11fad6eb291d7cacbdc31fd5af1978a253a5672444fd30e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/fi/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/fi/firefox-57.0b11.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "f30ef14edaf8df27cff44349a34eab0fc45c90fdbb091bcffa6da89d7142be85f40d471a040b7d6340f03754e49c9c30e072b3800ea9133b194e5566cb87fa61";
+      sha512 = "06f995e53b88f32fadbed3d0b3b22c11117515b2e926b6ce7e9763ec6fa29bea6a05292ad8325368badd4a0a6b3f5ec8c49a147a7f864c238c814c4f53d99082";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/fr/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/fr/firefox-57.0b11.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "121e98383848129538fc9fd82d49c9aa7238576e89f639c1886a9c3fe23a9b01a084eeb398791bb584b09dc9efbdc803d2574177276cf74b0581e7aea194f684";
+      sha512 = "dfd06c21d7dd83309f9d6d11fea295bfb1f942e9bfd19a5a1c45b63466eada5ed75b88fab5d4730b13db0522b3a977eb85164cb0c4121242a975462dd9518acf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/fy-NL/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/fy-NL/firefox-57.0b11.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "88879caa704f3169d548aba70392cf4a733c6ed49a32b6e34f0b25a40edfdabb37f7bbd2881fecd2028169477fc779a438f81a140dcc89ffa4fb70c0bb0fc17a";
+      sha512 = "ab381fb599161dd7df10db3a1c93f1e71d96ef1364a59518e1413c17f7a26b524c02ce54a33f8ea54a02829e519f8e8c475b9579b69bea62f44c76e909079e3d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/ga-IE/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ga-IE/firefox-57.0b11.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "9cbd9f42540e1a1d35f6de300a1e4946ce1331010b1089d8a6f366896cb732775c8ecb312fdf9a32488b3d27c4dafb0453a9c525b341b98142cded87f351c9ba";
+      sha512 = "9054ad0c2184063e6c42ac23004c9c63438368c03fdd7bf9bc0610d1a2d4a47b9bc4cf4762a0cafc633ae397c38ff64e050409c5d6fa0ca1ac869d918dae547d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/gd/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/gd/firefox-57.0b11.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "fa51ec9542d3c53d571045c6ab0afa49e880dd1aa5cebf831cbea3f780dc71d462b13f790438053e926828c53675eb6b0933fd7bac6605254c69570e415e6bb7";
+      sha512 = "3844132a9433fbcb107f380200d9b57756820a9a3495c805622b7f3952c59feb8b3599c774d844f57bd38aabe01eeb45cc35d8e06073350f884ddd0a0a18d3fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/gl/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/gl/firefox-57.0b11.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "c5ba307b857b02a9ddc61ce8d342e8c7b95a6cbf81b8849746a0020da4a3abce1953d2818940deb4e853c2aafdf1b12fcb8bf04de04d5f07334a9428f8accc6d";
+      sha512 = "2d864cda23c59108866f6e8f473bf98d8c328f24202130d9168ca0588f43a9cc49c8df1ee4872601608cd27422d7243666b5a1dd006ae5ba101773b7334cdc15";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/gn/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/gn/firefox-57.0b11.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "5547e86e15715271a1ea6f00dba37a6d82c8c51cd4ee619d7f31e70462aebace55a52ad00bba0720d7f90d7d8d37cf1254281e283dadb1d37d6362e4bc4c7c4e";
+      sha512 = "fb23767c66deed8f0ef97fa5b8044654740b8952bd7b76da9d6074e22c91301fffd3006c5f9c09ee7e7b3ee3001e70b31a6c09a096e3dc73fcb867f15251a553";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/gu-IN/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/gu-IN/firefox-57.0b11.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "d9283d7ed1b8e5fa3becac5db518fc49a9503d11b88f58ecbea2b8b623a9c6b2837a0a08f682453d476445397cc9b8ac3a6fdf29de74368fdb0ded9ff1e52e2c";
+      sha512 = "7e146f4b6c3eb1c96be1d95ce8502aa62b1483befbd7aaf9fb945fdee4e8b8f62088841057bb81d9d5f8d2163b25bf17797d5af5eb6d6f32ee77b0b7b84aecd8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/he/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/he/firefox-57.0b11.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "f95b7982911b1412828131ab5ee151a5e88ee6710c77779c761dd25051ec7eeee930c1d6693d51d7bebe281e489a7e66123c5e40a707645b569b340621becd74";
+      sha512 = "3ecc278918acc5f65c0552f9108bd167a9ed3f55b39b4f3ec41175bf9a1cb1d84e32b57ab208e6c6816cfd66b33b5d2846d5a776a79510c7186e0d5ce6bd25bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/hi-IN/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/hi-IN/firefox-57.0b11.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "ddfa3141ad4e8fb3f6ca55f207a477de4f410795257866db7709986c8615e3e919fb6409ff4557ae658f33cbe2f7b19a1c282e4125b1ea084142d2effd002546";
+      sha512 = "7aac53bb08c527b1c199bfffc5edc25e8d49082dc7df453439775afc07722bb126f95955aec799909818cfdc949efd5a9f987942a4655440c0ac26691a0bfd9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/hr/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/hr/firefox-57.0b11.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "46a460c41d038dde02dc1a3d60e2eb75310239cebdf58559ecb7213f2cf65d97de4e46f24dfe63ca8256b0507f20a9301aea527d8af6020e141fd62d94a3732d";
+      sha512 = "ea03e4f1370fcf59c9022c7f4019484ebaea8e295e2c3ff3ad8f44aad9336ba809cda22fc0f98df2f5ed7ec536ed9ba349d5ee57bea3c4626ba5fcf41fe83be0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/hsb/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/hsb/firefox-57.0b11.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "a9b3bfeb32b632b716e9a849da4507f3620363bb25daad44451d6b4115260b91dc35cdc313d15f39abf9f53d3df30a80d16c90514c473f4341e2168fc7f08d5f";
+      sha512 = "71ee5338b776daa0e9b33834079c94e3e9582b50d7b0e92f64e25546167838852ab606c2c2f9abb1f3480755a653b091e60c97babee00e66d4140600ae4d2612";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/hu/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/hu/firefox-57.0b11.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "7a6fb1b9e0adadf7e0a7bd6f2c85ca0b71c0daef2373a3cfe5221c3af730862d5146aebc46911cc1de5dbe3abd279fc3405a216d7b58354706eaf103544ead46";
+      sha512 = "defae5f9c7164bb5150af1fdd6c0b262fc88c63b9c7ed09753af5a361815ffce9ed43d0d79bad65bdf2e0de775d17660ff0c31a39134f9ebd2b6f60ca4a02d23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/hy-AM/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/hy-AM/firefox-57.0b11.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "9dad05aebf522b930533216a11621c599c8a232608c3d275763680463da2a9d1747632548825742f3dff4efc59e7badb04b306add7e63cf03cadbf619c29ef4e";
+      sha512 = "924efdc4e8584d89b60d98117a229c4c9a619b42f0a713b0fbf9fab2ed63b5761a9b5051e7cfa825459cb3d499eb4679363b13a76dee2973ef6b843c7ee9fd9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/id/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/id/firefox-57.0b11.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "a1fcdce6da2346c79a93a964b36d1abd9c79d7528622dc591a244855b8d3fc66194f8e16caf7d1f2085cd4fa2c6b223e20c0c78b10222bbc08868831607bfdf3";
+      sha512 = "508c42fff4f6ba5e39cf757a1a306c7404e3c133308d6bf4d734f4d2c53fe79998724f861843d2ad76af2dc5482f108ddfa11026b8351a8786d814eacbbf839a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/is/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/is/firefox-57.0b11.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "8cfe06869122f5c03e650807a449b125d5694b7d0c6febe761d7f2779fa16af5190a4deecb497578564ed10bfe375a634f1b50eeddcf25d896af35ece936e1c3";
+      sha512 = "9930f784440abd54b53fbe94f7eeb0e26ff2b1e2b16ba30fe1a7d298195db58fc32a25624444df89176072a9344088cbff188b73b9d7fa8e8b571b4390a481b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/it/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/it/firefox-57.0b11.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "ece3ee07a11fa6ddc6479a3627b0fd77b083820244c216cdadba3554f3f3d63ae7ddab351b48b6168da5bf741aedc62fd8f294b4cde98aa32bd5ed2a3ccb93be";
+      sha512 = "4bd98c6c17a3cc3f883e7c2cf8a76a5423aeba67c6c22a50befaa8d4efe0e8dab495598e17789dbe078c75aec7e612ce959ef8f82254ccfab460b273456ca50c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/ja/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ja/firefox-57.0b11.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "313b186761211111e357d87afbbfdb76c48f57b397b434d4ebf9ccc30d675a2c5b8b177b0325fb7ecce0796b5e5c5342e7cccb716217e11f5bcd8dd5a4b67d1a";
+      sha512 = "f034c703ab191fb39fd61859df9ec14040764a8e22502277d11447add96ab3b060931efc4f7dc1277519c47315c40793a7a7b8da161892b13fd433aae4f723dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/ka/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ka/firefox-57.0b11.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "a02e9fb44ad5c373f95e8c3f4f880e10c2ed594f5d200a6c3f37bae4aed9135de510607291061e18fa954f98e15314c112b60587fb70bbaec2eb5b4cc7f2d7a2";
+      sha512 = "8ed142d84d31914f638daec87ad64cf1aab76e110bc7bc147630df019f1a6cfec8cfffdafa139cdde91a06b65966741aefaeaf3d16c63aeb94c4f2945e04ba8d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/kab/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/kab/firefox-57.0b11.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "5a621e60fff68f07d97cd8be0cb4dccee7723eeda74a3520d70e819c844eccc3f5a06234718e4e4b2e48e6aa417d4adb977e2d4a88471e9a54538d7852832215";
+      sha512 = "435e8dedbc0014ac19a37d0450537d7b9c2d4e7de993644991c58640edbfeeba17c6a59ab5eedaf1318bb8c71cefb5d30adf01528bcbd8e043e0eefa63296be3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/kk/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/kk/firefox-57.0b11.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "3ec65e3fb9e9c4d1e77501341cbaa83b2822fdb44d4fbd18ad7777a39ad98ce0a36f0166ab10cc53e2c55833572feabf3f5a7b4c47e75439b376d7e457748594";
+      sha512 = "3b059e976cc10eb97b10ac4bd9e4dd2b8cbc24b805e23ec125d42ab731c5cc6f97bed8ecf222b1ed3e2c84a422a677cb938239110a38d6e34efa2a9f2472bbfe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/km/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/km/firefox-57.0b11.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "c3fdd47cbb311ec76b2ff1e48094e5e4797d7bd92db4eda142fc18fb01ed9810c78c9b25efe277fabe2626e9ce7ca5a61727aeb7096dc246ebf389214903a6ab";
+      sha512 = "aacd4ce2f5a8152916b2a9b8f532cdd09c382e0e365de297082e5bc16f6c19136430504bd74e51422db530c66a13af45721c01b5cce3a7b4fa31e08beb852539";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/kn/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/kn/firefox-57.0b11.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "15efbaec5edabedc7161c2c914257835fdb6c5a6ee9a7249fdcc2242ae60d415ec539a2862342060023f081318cb8806ca655e5fcded9068956e2008a8c5a2e2";
+      sha512 = "10993f98c96e83b8010957af8467c4434070ed5b3c52311aa67596621f415d6ef5d7946a6fa5112ad7fdbaea00675bb07f6845c6553774e1a9666716505778ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/ko/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ko/firefox-57.0b11.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "f6a77588d8409ce88f82e7b37cbc4def38ecbdd87e2d79915b3c3cf5441f4115c7d85844b19623cba9ac628fd37de9741dc709c8680c792dc3bbed3f89cac0b9";
+      sha512 = "c31ea13732f5b2d14f7089d71923287be8fc99bc60db396757f1a8a2936d9ca5aa5f1e2c447cfde0f90683038868dae95eabd55ca16df17742b2f7bbbc89e7be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/lij/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/lij/firefox-57.0b11.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "a0b8b995897dbb8bce215022d611169fa1bef4cadd0e347c36b3cc025715e8224f4b3684094586bd04e6a4461572a1d8261ad193addfe6f4524c106177d3c8e7";
+      sha512 = "b7febb474eb13034eaf9ec555202153562b8dc34cebd0c03d680757c19b2b8fc5f7060e66b115d0080cd3510a56033597409222eb56024ba136d9ab50cfb246e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/lt/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/lt/firefox-57.0b11.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "d47509d0c2b18d00f867658befcb63d14c786f5e94d2c40ab93e78014330cce5a441edc42735157cc8bff5033246f0e0aeaeb99011b782f98baf1331a383f899";
+      sha512 = "d07c56a82054d1238a8a5678b65efbb88b7807aaefb327eaeaa393218ae280ef4e134d4a3ac28694458470611610e3bde2be68f3df325a496d9f922d985681fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/lv/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/lv/firefox-57.0b11.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "ec3aaf962aa5e7a935ac3da0f79ee74a3dd0e42f3141d339f728b503cd723972f7c87cbaf7c79471ef716343c28acefee9d905c121f872fccde7fc1da83345d2";
+      sha512 = "fd8adc196bded44b80d6875a0cfc270cd8672a19b8911753a7b62545823262c34381c3e1d72d21af695c273242093b4df45188bf6b07f83ba5a73aa7a8e5e528";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/mai/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/mai/firefox-57.0b11.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "33bab56345c4a4fb95297549d5e365eaf1eae617510d951a5c80a3970e37fe855f86ffe7ec6344bf444aacc68fe0e4c0e04478ccb4f5b4f3f40de371ea1de3bb";
+      sha512 = "c31e747aa29393f12b4d32131b4a9134f57fcc88235258dabcec99583494832cf61079b8980171be2ea952121f3c5568c42e006e2bb9b1c0e6f6fd05d2204dc9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/mk/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/mk/firefox-57.0b11.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "6218a4c6a176690245173c10a5d46139a43a09fe0e7de30fee8416aa2554bf4140b9e754e27a2861b5d4693697aaf065febc9f441bd5fc84c622966d104f536e";
+      sha512 = "3e304e2a82640adfb7d15705ccf740de623995385618a351651005da3bc23edaed3707209594bc2b70a244f0ba86accb80c319ef4f55ba156f5487e694fe37ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/ml/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ml/firefox-57.0b11.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "4da4580be951839aa1dc9fa9e927677f964424e91431442b36784476be3ae342a0ae724ecedfd63be7e8e6e6e83977fa9146e0df0c70d409b4ddd0b6aab4aa6d";
+      sha512 = "d229529966b0890b78d53e221d2e809d003248e2e42dce182f3f761434da72362181edaa0db9ae255878d01118ccb38921af715a412408e60373a0a76f02b104";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/mr/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/mr/firefox-57.0b11.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "e6ac8fe111b31c64ae7e118ead56ab136bc199d2d0bc83f128128c1a9044bc8d7e9dca148f717bc5d015a746bcebbb2c2cbd8aa7905bceb30aae2ffda0f2cbf1";
+      sha512 = "d8e81fd44be727b8b72cfd5c4852df33f812b6c3fbf09c07a461c00b53bb41fa63a1e2cf9c17dc90ebbd630ef18541d4aea4d9cddf471fc52d9ba10952ec5ad5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/ms/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ms/firefox-57.0b11.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "701922f348cf2d8a853a34a6d08c947198a85f96d972a1a3d1968045f097fe503df84c4c0bb8c8a16ffa5afa729d26a8026f06809aff6724d3e2fd54899cc3cc";
+      sha512 = "e025f2b6a8724eabe4128d9e3567f0817c833a6fb2855b541e6a12208992c2586970b5adc422156bc00fc403714bfdaab762505308931584ed9ab8f9352e1183";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/my/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/my/firefox-57.0b11.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "b68ec863d9229da9c619ea924d182cee4a76d8cb9aaaad35c64ea31d4e03d46d025536d32408210abe6dd662398fe2b194b25b1a7b8ed52c77c99850582f01ab";
+      sha512 = "6518b67cc4ffe848a0e79fce56af5f9ba60f3338bad5dc65644d6064b51e1730182f4d6038c4deb64be852fac673229b75cf1fd0d1d7c37db62c830d018824fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/nb-NO/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/nb-NO/firefox-57.0b11.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "4c9ef671abb97fb49e3ce5f0d0dcea9f268566e7cb9a1650bedf8bd42648d92f45a0d70f2d5433e58cbe6c8796e67a9e443ab711e42543a45551653747d8dee1";
+      sha512 = "177f3638d429bc4b5d97796de91c39c3a5712ca3fe5f93d5e1801937d16b80faab94cdd75dd99ec7c6451f55a5a9282195a0deef8f5500833b83dc3ab46ab20c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/nl/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/nl/firefox-57.0b11.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "b51c079046412cdab0ada80205ceffa55c3b9e20f65f8378216b78797137b39fcc3ff9f6bdd15513de97f3d07c59afd1d803304e265f4f38e4118dbcaa20f422";
+      sha512 = "192f7cdededf9424631e96bd88d15fe66b7654cbf09701f361e0083b38106636df68f183aaf3b9a4894e432cf828f429ab5a62ee0b521956eed14e470c909aa1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/nn-NO/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/nn-NO/firefox-57.0b11.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "3336e336d5baee973887a11836f3253c80134fdbfa218a4cb8902bc7f1909bd40bed217818d2fb8f6bcca6274a67ddcdf6ee71926c36dbde7e5fbb76294c1bd9";
+      sha512 = "e1d9ad0238f5fbbbb95d08e01f95a9ba71ec35ed47d0609a49a9f76e9f9008f21932a12b9a342b9ad02fde563dcbe7779d43b9bfbfcfbe7f17c4f59d324808e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/or/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/or/firefox-57.0b11.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "44f8bf97e5e86e069a628cad3a3eacc98a9a9e271fd4732b313cfa60f8fd38f8f565fc476d6d18a2fde63f2a7298231613aa470db9426b65b9d2fe10af1c1121";
+      sha512 = "12012e659184136db31cad4448226eb4e70760b9234632c9fa1b71a54b0ca06608de7ffc62ecd018671fcb9ee7c3357ff18b7b5459b395a39eda59d1a44bbaf7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/pa-IN/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/pa-IN/firefox-57.0b11.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "37ae29a99719c6ede4e813f6e1f3646e69876ec5462c513dbce7f8c2f07c779ab10edec532cc7cb4177e53db13712e87863bdc8108c6975f56d1ac2323e85e33";
+      sha512 = "cc154c9b0d53ccfd515dacfcde3a55a75c16f542080770927533b9efba8bedb7f46adf0a54772f60ff8395c1e83d0ff602687d7b04998e9d9e0f6c3da2e95142";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/pl/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/pl/firefox-57.0b11.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "848a83da8419827903cefbbbea9872fb8bb35f4baa484fdd596985afab9b18017e8ba465bb10c9090e82fe6d25fa839109302338bd51e93127620d8a178ef026";
+      sha512 = "ffa0cd7b26d4fd48cbbb9b56b60937190dc271cc6f002fd4da11929945d064d4aa59788a756ea4226b15e1856434094e151fb92a96f3ca9d14141fc1bf98d037";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/pt-BR/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/pt-BR/firefox-57.0b11.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "e3f17dff2ca325516e16a834fbf7a312dd5204a56762ae81c0aab154ec515075bcd9cd003771ea6b5addd5d063d4d2ae74116509d12fa6468bce49727ddbbfb3";
+      sha512 = "6e227b96787f07b9e04632d54ad33ffe17931e787d1e0212a3419bace1cf8fb062178adf6a2ae8d11a851d3de2eae983b086850e8df775c0a33d518dc0306b51";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/pt-PT/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/pt-PT/firefox-57.0b11.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "40bba3f30c76964e1524f5740bc1bae353b6c3c3db1baa5b6031bc025280caa482f8e85e146bac1eab22fd95a2624d08101a2cb93c40aa57beb165aa448a721d";
+      sha512 = "fad503b60076143c5941ea7c280212570896aebe39e594e4af4b2c258b387a5489a63be17730e4c31628b96661d8deef7aad6ebd31eafd3bb52f841e4a344a39";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/rm/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/rm/firefox-57.0b11.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "a72d7922cd2adfc9a08c997c29e03ad4135ecd5403ef044331e8e08032fc7d5fcba32d43745b2eda22a2ea062c6e9a470dbafbdb15831fa270220191bf07e2be";
+      sha512 = "737c4cd8234d87f96b1970f1ddead34eb4b109e201f794942bf2ae0603cafefce7b38f2900bea2d08d058766e8d1851d96052ed5f23fa46e351179c9ddae1c91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/ro/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ro/firefox-57.0b11.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "5cc76ffa6e74ae54e1b49777e431c88d60df8d2e62cd7facc452ae4e186af66cd1c59720633f69f8340bca0900be2441aac0b10b58757d2835638ae554853a66";
+      sha512 = "506c842023cd3fd3bc0a6a57abf7b2b822253b0ef4bf2d3f511bb3ce5407d310cc976803f6959b8678899b38ffcda582da21a887d8608fe8d42c46ac70cbf133";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/ru/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ru/firefox-57.0b11.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "4cedb1b7b31be69c2e47ac6ec5a5d8d46fbf052130e7a7b3f12b3439fae293498cee78d972c2eb3e3fcb97a080a70318cad43eec82c3a06d7ed4bd2362d9d38e";
+      sha512 = "94213fe894d4d6222b321aa6d9d37f3cf32f257c0e021f8d6f122c4e8c458f9845ab5abbfcab1b043b4d8aa72f83307081685a63ce7569194fc15e2ea655cd27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/si/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/si/firefox-57.0b11.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "46855faed2fe0c27f821e61aa58e418eb926deb48142b44e9cd529b5023e11d3d37fdfd6c52d3fb7ef93361eb71cc4776941f9459c03041bc806f37e75f9c7b2";
+      sha512 = "2174dc7cc1a8e8cf96550199d70e279c85a91671fe1b1a71161aa73acffc8a0c818dee6d0f2c3490384eff4de5175eb6c04cbe04ae92c60da72f5bb987bf60fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/sk/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/sk/firefox-57.0b11.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "784e6a4f0ebffda6d53f66d8294e5e044dbf74230738d260c685dbc1d0ce8ef594383f41a658b3144c1b5ab8217389377387e5f6bf4c5b13590e7284be0c96e6";
+      sha512 = "f9a30f631ea892c1362eb17652213cdb603eddbb0a687f4ccaffe70949b8692e637a35c4d90e27f5f823da59ba01de45f810bce1ac33a0243a5c96f470f13ffd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/sl/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/sl/firefox-57.0b11.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "a9423053a6ae8443b1fbabbfbf6e1cfb04b2cb8bd7ec5d020fb54000547ffc9e58fbf977897a0ccae2f27170b9180446a1812c37b47b04cc5475a72d2e39eb27";
+      sha512 = "abb5746927a53331da0604e4259a97b8d836c489a3c777ebcefb9d3c724503772474a2551c7347c8466e007fd248ca4b96c8e334272c958089abedd60f810a50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/son/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/son/firefox-57.0b11.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "ffb5061b2852c7e0ae89a4d251dbf681c45f7fc150d92e00a7fa9f358b2b7c63b7ee5963db473b53412aab5d50418e59ea666b1e0b423730522002aed39f1384";
+      sha512 = "a88ec432a39c197d4b312b8eade6b5b1c27e2909dcf27c309844fddf6a21255a1bfe7f666f3287c6662a0985c75810eaf67bbac20a0b871bdb583da30beebf96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/sq/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/sq/firefox-57.0b11.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "77a7f68fc2aa93bb95419a2a17a8b2b2f3deaeefe33e061eca09e2cb1f938a6639603eb9936c967fc8af01461ae485362b6bba2e8b34cae4d4c146b5adc372c7";
+      sha512 = "32054a108dd8beef5dc9dedfdcddc4b37ec854ce32f65f6f69e1a4506e45931909391182ea61a9eefc4e3bd354027fd6cfda0d71d996906397d833a27b07cc55";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/sr/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/sr/firefox-57.0b11.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "28c5c3bc8d57fdb2c76ec1c40cbe2a96ac1e7bdc734b23410b16e0950a26d082372edaf29f784c4cb55db6f3f34bb2f96cfefd3ddef72b703d4cfa7c43d8782c";
+      sha512 = "adc284dba815ef84d2b99b90730d15ebb2a8974601cddbf38053356c8e7464f13d0e1fd764c8dc34e0cba0ca1bae427c2e1ec31bf0553f834d0213426295917b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/sv-SE/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/sv-SE/firefox-57.0b11.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "b4998b2f2ac1b77353bdd91d9b580d5ca9e2bda1d90fa0306493e31e57b16e4cc3f32e88e7ced1d6b3f486b256344ea689163c422ca3fede581b902e45b73cb8";
+      sha512 = "51f3a397e95f39fc2da2349b25d625114d02bb0444e56fa09c8246d57a93575ba9cb83479681c73ae1b257269ad9100949829aced4c1567b167dfb5ea680bee4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/ta/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ta/firefox-57.0b11.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "79a6f7cd615ac1a3cbc2989d8b59aa390bce485826b44338edad92f151f345f9a9e5a59a20e36215962010c36dab6ef0200880d6433dd00c2e301b9f63c6283a";
+      sha512 = "a1a5a458d540be0a5359c15f2a70770b39bf983d1f19a469c8caf1f7c2d61688a2650bfcdfd2d41321788b63d5a900ca1cc36fac4a62b67087182d9c1c3fa84c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/te/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/te/firefox-57.0b11.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "057b4eb4109f9d73e401d06502028be4875684136edd3f0b474ccb4b95629ce0f1d84aab08abe1382b5bc241842eb2a5d540202def12c4ee9bcde6eb940bc9c1";
+      sha512 = "a948071e0f1ad4e29483a87765a307a1cc4d2af629125025e71439875144535bf0d6d69be5100a8ec6f5be6b8b9a7c7d10e851486ae41ea5c8517dea932c54e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/th/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/th/firefox-57.0b11.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "20bb176c481ef473787f6cbb848a5a7f3d0610d6e24ade116d60565f2afe632c71651378850d144b20a1884562f87792a5609bbdae03a9120830fcfe4aafe983";
+      sha512 = "1340d951f126571e3d3fbdfb91e478ae914aeba9251da35b253a67f62b4148f0e5b9452495a7bf23e918c9fb3ab88db37f4f0fd11f28330957dc23bc65cbfe5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/tr/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/tr/firefox-57.0b11.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "ed1b30e3264b75dad2b44be7021ca98f6212b7286d1bb35e72f8bbcc6d2a260ebaf1971c403994e91df3cdb21e82991cc13e60788ebfc729a6a9bc74a51313f4";
+      sha512 = "37e37e3679ffb5ebf93e3e7410c5bc9e1f85fe8bbecc83a7a33dd5b1c7d7f7150ffff3d91fc200f4c378a253627d5dd8ec90f46692b01f72cbf9f48bea84742d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/uk/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/uk/firefox-57.0b11.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "26ca1bd905fd7c3a888dd8d094bfe5eb33056ed156857331b2b03de7474528ed2c05c0c75246c8e20f81ac9cb943ac2b67d0db671bb8589a584b29ea8d6a59de";
+      sha512 = "067353b9d466bcff799f6c1ae46a91ffe9150a6c429a117464cf1289433fa2fed6a0f0a6e773f8b27d3618ffae233c7ebd56841f97d3c82b97ed24f038c7e4ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/ur/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ur/firefox-57.0b11.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "301a4658a3f5833afc05222667202cc4ad8314e4539a2cc138bfdde954842b8ccbc0c2ec12822a2715de5f4e2bbfb089b5e1b3fea3b74de04277be2937454839";
+      sha512 = "a868433b2b18ca92bd6a6b765ec0fe072a44043a12f75ec4bbc16f4dac29577698b1fd7618e5c0876ff14742656263c0bffc2ae5ba0826a55df70c139275f9f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/uz/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/uz/firefox-57.0b11.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "81f3851e88fcfd329b48ee44c812c72f58f6ebebc45f0aea2075d1138e27406eed4cf6ee4cfaaebceb812c9d6f5ecaf0196b32a8e06d2b5b10221ab271a8901c";
+      sha512 = "33603cb219121d06a97cc5c62865bdb9ad4f9acd0de6c14ef86acc16d818faf3e21b24f9f497dafd20639b81edbe7affa1fedd7a2aaf99a1a9d137b02e2b77d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/vi/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/vi/firefox-57.0b11.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "f8d0458f10009b623241b69084402ed0e52ee191c9076c659d341a5574cd52f0acf18eb9e89bcbe25ff398704354f19ae516bd6b0e068c6850e64ea5d44176d0";
+      sha512 = "a841c65cade257e6b5708b3de3c6109004f54a295e6b6fea97e6b3959cb70620844f8a4029dcf908d6fbba1ae71d038cd2adc0724180e22959edadc549bf8d12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/xh/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/xh/firefox-57.0b11.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "8d0e01339e7f1ee17f932a0db799d4f8b05eb588513deef38624077da061d9240f28aab5b43bdb029081b7b2936a94bb4c519044f57e9058965cfb32b71bc44c";
+      sha512 = "9d8338b04f2d8f43a096049b11b8d359a1a09a22a2074bb0fb4364e8a551976810cef148405fb45800a4d751d2321e4d9492a79549d076a8dad3db33d22dafb1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/zh-CN/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/zh-CN/firefox-57.0b11.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "1420ad33af75efd58c57e4376ea1d755945d2bba0cf65a6f8d33a3d22662418a76baf1911557886fe85e4263ae2212ad0587eb9ea9ea5fee19d6d24ad7833680";
+      sha512 = "d3f4dab15e4293cff13be4da142169c18b2d672c9af141287c388a31fd1aec4305ce178af1dad6a21fbeef571445cc15ee15c38464bccefb4eae80dbb03177b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b10/linux-i686/zh-TW/firefox-57.0b10.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/zh-TW/firefox-57.0b11.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "a42937bbd8fee40d58752c8347d5138181da11342fa533e6941b39302547e828c84242d8c953cb101acadada555ffd14ffe4c17d97ae22fe062fcead384df57b";
+      sha512 = "4b82c8291dda948e1f63dcce2c8803c1ed1db862e585612c0c2de96e14c7442c2a845cf896c5fb9492cb4424c05f14ca5a546b30c6491f557c511f936153cac2";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,955 +1,955 @@
 {
-  version = "57.0b8";
+  version = "57.0b11";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/ach/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/ach/firefox-57.0b11.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "669b52b7784d7d02178ae2e3aef14fc4197705749ecb5eaff197ea71aae90b399811029da527964cc2f428707a29706bb0cc3911fc77db3c5001c994b1a2a770";
+      sha512 = "ba86d5610b286bf392c94e7dd5436500fedf033946c34bc56a53b1e9b4e934379e5ac82a989168a1d339b4de0819f273cee48d688899c34cb353f83376201183";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/af/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/af/firefox-57.0b11.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "d2b96148c787bef4db0f0f5c288ebfdcfbd24b43dfbb890b90fb2f490cb08096ee18f990e2e130d5ef78ad8965bd3e719eaaffb9263d7d94e3b6edfc6867e832";
+      sha512 = "7cbf2ad3b2775b2edebb6b789896d9c2cf63c6a59272dafd1548c20b6ea592396b9f5b622f09305dce199146a23f98a16c8a8b6835115edded902114aa938be9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/an/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/an/firefox-57.0b11.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "db3f9b3470173b176ab2d91807dba82fdd938a00eb2a8cbfc27ad9fdae6d7ba5f5c6af11b5ad191168d958aa8972a1c2404a190d6a1b4d14e09cf9e366a64152";
+      sha512 = "4befe56ebeadccc674cad25d5c58ba8d330b8ca79f7deda3a86314ddf289404b8e167f31e3717ab360c78163940a90361bdbcbf112ae4830eb15f0103ec40442";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/ar/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/ar/firefox-57.0b11.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "a86f18c7fe63098b56ec160982438bfacc4a7f93ac27f17ff7a34b179419e0d4a98d180517d2f3af621e14567ecda01805b8dec9df4b35eeab137a73f681b56c";
+      sha512 = "8aabaa49507ce8036b4c921c78697973e69cfeab9a1091bf830c085f9b8287e41b026bd237590f2e2a89255b4fa4db47e563f726f945d15ac4ae5b790335a2ac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/as/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/as/firefox-57.0b11.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "78471fa0e2a27101e919efa371be09175b3216174fe321c5258d6b2e02e35cb1b194da1700a7b4392fda6e66ba5034edf70f5b6cc55164327b1f694afda7abd0";
+      sha512 = "68915c8a35cec3b9a2c9afb8f2c8e1cf5db0874c23195241fac7b75d317af0a23f53170d6f9169eeda3210202430c56e9fe47cb0fab434300236186d60d4e04f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/ast/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/ast/firefox-57.0b11.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "69b7626e236b45549aa11e7fd98ed5dd9be2b705869bff521cf6c4d3834846728682fdbb0848bb3fc9c74a42fd1614327f4875c6161408773bf3e5eb29a61f8c";
+      sha512 = "f72a8fcc4cef1522f91e70158541a1328202a7dfeb467662deaf70ca62b049c942e664301f99314c3940b9cdb6bcdb663c3175c81d32c31a4a547954907813d2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/az/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/az/firefox-57.0b11.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "d41c8f045b2ff59949297c6d6f8ee4316eb6f7da4d17a670e8c53d5a69fd70ff0b518d5bc6bc1704991a72ae2c43d7718a21966fc56ee4bd27e330fb2d411061";
+      sha512 = "4246cf3fd34a9824dd61d488966902086b51b68b5895b491cd7c3db81e4cdc0de8f06f74ffc77bedb80e5069e594f49eda524145c2f66c2fa8fc86db8177bfe9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/be/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/be/firefox-57.0b11.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "23e83c6929b13e4738677376832edfc0beae95593f56a18ac359dbbfec0fd9e0280c113f39b53a4b489b5d7a90ec3010bcedc62b5718e5d97905ac402160ae6a";
+      sha512 = "9858669e11bbbe6f56bbddc2f3c94f0586a46fa5fbbde2a4439d6aeaff5bd28c9affaebdee4a2903ff1bd29392f10df0ca84a9695065c9dc60e8066627465d0a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/bg/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/bg/firefox-57.0b11.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "4319f4c81b740907aee2fc3149a818b5cf031bf6f002d4eeaaa6e96b5232da5accfcc0dc9beae9505e8b34541743f347914adf044248c504a5edb37602df0dd4";
+      sha512 = "8e01fe5f5c02e9af5cb06a2f29860e1b7157c44ab10f21060bebb9561c9810d8a779e3c54a585cfeb2ec3647d2312b55263ad3cf5408ea36bd380caefd0a8688";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/bn-BD/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/bn-BD/firefox-57.0b11.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "62b1b6dc18a418546ae5fc038eb327889ef44344b1abdfda6714f1564a2173af4ad7ae1fddfa0d495e8f32cf740b0e615549c6a2cb17a92cf1db1cc525a7eb86";
+      sha512 = "adce1d58ebf4994ddb89db06c79411e7d2bd3b49a8e55f2bfc5a4a9968245973f1b01f30c74a84fb09310dd589076865f2d10b17b418d390ce5ed0898fbb5cc9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/bn-IN/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/bn-IN/firefox-57.0b11.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "c829a39e7666c6211948ee8a41298d42cfbd3a9c76265846462a220a136ebdb387e764655820d6b2835424433a2f94d974072e6c91962a343fb9f5544181bc68";
+      sha512 = "23910c2086cade899f596f22d0f9476f5cec5481b90467a90710711eadf54b04a1c1a6455ab741374df64076c633a70ea8b375e2aa280c14a193ab204a4d8609";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/br/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/br/firefox-57.0b11.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "c9c9ad941fd32e3bd15e1f84ba27691846cd6730b8f1bbfb70d3eabcdb0820087f22419c1c9efd654687d030f663b87bc1cec512da63bd531c99d67df2a80146";
+      sha512 = "31ec45b6ec424202a04287cb97ee24aa45968a41a1dab47cc7411b865dd8d3c9fd6882482d771cbc9e6c0196dec4323fd17ab5e095eb0ac436e2726896aa6a26";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/bs/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/bs/firefox-57.0b11.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "3fb8b36ededdf18a0e73d3656d063eaa9b68448c4130d3887c554cebd81fe523b986bf82c04e7319a8476ba9b8f1165e30b5f556923099c1503951f5a9a912df";
+      sha512 = "cb90a2470143abcc536e9f737cd655e2f0c4157088837ce2194213baba6957e34f76a974133be81f201d2db649901f33e3143e4432b5f7d59401c1baa09b5d30";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/ca/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/ca/firefox-57.0b11.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "502087f8485ba252c0f9ff8bb6e33c8981b3139ef032178984053ed39ff7f82f66c95755e72d14855d1a09e9db29b83d2be9cc8750da80a5c7eb641233005336";
+      sha512 = "a395e2a36990025b74a7cf2d3f58339e9f98ececedf6371fbbaf8b97afe2ddd0471231c1577044b7b030586c7ab92512aa3a2a51e77532c17678932d4fb69615";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/cak/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/cak/firefox-57.0b11.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "d037360832abf0d7545d1e43e7327dc26e8e009cbb9c8c027d1475f04a02262789acb44f41c45dcf5a3171452cb247b14e60f2e2f4d4a0ecddc45990b5a4b27d";
+      sha512 = "2e04f7b530ffa28af838974d278a1aade3613df7a17a0b2e5ff8854972a1071f376a2bbc974ea529b392de11662028ad05a4341504e9194a02dd983d8d011991";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/cs/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/cs/firefox-57.0b11.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "c8d2c9b9347c8b393181ba1021c0f062c711bc2d1316f0512c0374525e3f9e6ea9bcdf8ba5b0466b87493f43ca54c13142528b420df0ca25322b3db68dc1b219";
+      sha512 = "1e060e7c001b2bd4b722611b5f2ee7d9be5ec93581bf6fb4c5eefb4188a569716a1855fb175dcb489f12b630133374cd0879a0401027e043e04e0c2d060b4c72";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/cy/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/cy/firefox-57.0b11.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "8e538100f7707b4ec71318f637af0c880bd411e1d5e2c7dfbd3269e40c5a6360e03c97d28e23b66a91c5dd56b236171566d8f6c75e399deda4e3ec17b8baaae3";
+      sha512 = "770b1bb389a356c5e99e371f1a1c7389d45f461a5d18f73685de289dc48f2f1686f39d44b8435133925e21659bda9053bf88f5094a332f69166dda468da40d01";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/da/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/da/firefox-57.0b11.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "d5c21abf48a38f5eb7c3b2c3d70f051be4fa75f1a939023a2d863fe1d17cf567d4371f82f62343017510092cac061ab74b7aba3a15ded5fe039d1b16352be81a";
+      sha512 = "f659f860640b029f0f254154d7f8a21bf011d2025113e701a2894d35acce8f345513c2792b5ec0460921765a73efc5a2d6f5ae52a09d6b6a46d45cf72af769c1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/de/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/de/firefox-57.0b11.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "96f6fccff058ea5b4db4b9ec6aa15337788c7ec4b3a9d6af6d63bd2e3342ec4f01f4ab839ea52033322efe0929b683ed73ec31175e82ee2a9a5e18f8c075a81c";
+      sha512 = "123f3e65735317da980a57026cbf83b2ca30d8cf07dbf58f7cecab8edf805b05f0ceb2828176e8dd123cc3cfe33028357b53233add467c899d6878c1b2330c07";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/dsb/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/dsb/firefox-57.0b11.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "4e3e82a2deb88cd2f26a9eb154e94c6f0cdfd1b2dcc2ba67f5a5eb4998cf555e615471b6f9d82a83c4abc36e98235218212eada1dd1bf18ab1660a5e143dd1a6";
+      sha512 = "e4f54c55fa7b66ee1bdbfe1b17f839a81c8fde5c5e0c18c9b02f779716c901adb0c01b774a470b0c6bd7971577bd0c29429284fb35402fa6c4ddfc9069d97f27";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/el/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/el/firefox-57.0b11.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "29602ee19947e2123758e0f7c3c1a7ab98a113ff87d867f8cf888c0736570fec7461da23f50b1326aac421f8670acb87979b2ccbf22fb6c42da6094010fb3041";
+      sha512 = "9fcc084e2ae0d0775d6357d9f3134cb1c60e9ee94be87d15ef90aafe7d74349684093c844c9ccbb648bc36066022762e859d21f179f074ba03ffb8ce7d7cc6c4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/en-GB/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/en-GB/firefox-57.0b11.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "9f8b429a3acc453f143dc36d71e158d0b3473c566790d753a62aff91f9598ce27eea710d6734a205b354d681ea52c4a2ff1c39a6cb1abb2a9c99646718943b96";
+      sha512 = "44b834bb9461d69ddc74aea8bdab6ad0c9f9184c5ddee037441b648da869ef584029f6c49119d22f96b43960ed17b96e82e466e42c7660ff990519928eea1aa6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/en-US/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/en-US/firefox-57.0b11.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "28a8d28566b79b787ca675221ee918dadbd03b839717eb3bb18b8d9a9b8fae036d6e9e84d68450fe9a6976d856e7a8607edbe71563f7fd4217e75f4c3fb5e952";
+      sha512 = "d9ecf0ff474a71910b1611c0c8dba01e99b588719024776f27ad468718db5e6c54459da1efd648b31e69f6c3cc2bf87e31b65d5dc7cb373b2f141cfada5a2312";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/en-ZA/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/en-ZA/firefox-57.0b11.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "63853638b5708931f9d8d3b5b6ca995ecd2bb1a15e26341d2b2dcf588bfe306b14758a97384cb03ff9e55cc84d038c74e6735d2c2250a6656bd77859fb25d830";
+      sha512 = "811e666873a3211cbd31fafe3253328782053479caa3f117b27a64364b6d815e9c294f1e0ee08c3394cb9a87e7364a8b5dc2a934b394e119aef0c0ba70c713c8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/eo/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/eo/firefox-57.0b11.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "027c169cebcd4a165b4eb7dee9512f7b46dbf0c31a9f45936d2550dcd80188a4cb9d486cea1c9730a4bdecf555039171d14e887edad77d403e8d877ce55ed1e3";
+      sha512 = "13513b8f3d288009c16d06dc3cd0505ff66ed3df9d90706c8f48986be9122b3e46b0f2e1d38b2a715f6b043a15575ea05405b8d1564891291afb6bf79d90ce91";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/es-AR/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/es-AR/firefox-57.0b11.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "fd12bb4da416497eef2ffa824ded23698ac98d83ade117ab758534c1133f3f5b9073d95d84fe2ac518fd4782eaec337d97c60316f0ee1e510f7526cf05c76475";
+      sha512 = "d9435c6fd5b6653173c2e32b6c8f88a4673eb4427821d5d0b01fcdd7f21bf93e42b02336325e4d6c295afe09a62d184d8b875eae4eb5337680ac9ed97dd17d3d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/es-CL/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/es-CL/firefox-57.0b11.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "05c42be62f9855c56163319f5da721cb2dfec9f0a36d380620e2a4310d1fe3d3adb6c67f4974b057488f569fcb3c0ec97fea17147b1f8ee3d30dbaae3f1f3433";
+      sha512 = "13623e646ccd100e3c9dbf373de2a039e5fab955c1c0fd1d35f0c20eea6e32aa519eb4a9fe57682c953bf79a7d5a766f4aca45b17c5b00eea403add4ec28a70a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/es-ES/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/es-ES/firefox-57.0b11.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "a081e0ab787190d185259456034266fbac06d8732ad10d608a14871070ff82bb7fa86fbeec8c1fd47df4b2f5b4903da1746762f8c105095dbc09552e8894a7b3";
+      sha512 = "e1fb2a54cad6acd6ed7937dbb6c606b58261efa73a821ee2bb846d8cb32c2a89a57c52c2e5dfde8cf6571b0d23f6ec516444f9ef563e18c92b1ed60402f69d35";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/es-MX/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/es-MX/firefox-57.0b11.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "7159d4ccd541bb5fc0128cf0f9e08ae202a4afc9b9a38a88b5d87f7fe456af8e43cc5a95ded085a327060d1a6c9586489ee2387a872a6777f2b207c4cd4a54cc";
+      sha512 = "a1b2cacb14ce0f78aa41de552a53dacf04162a69f852cc11930e58ab8dcd5168e860b59310d761a63f2ff8edfec91b7b340316a708e6d2aa61b6321c82df5901";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/et/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/et/firefox-57.0b11.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "e76ff5a5d1ed68dede803b3f299ac7e3aa61d6cd40d1863b624c074a1c9c837458cc1b34d78c932e94da7dc5d928c38c645ecfb721d8e8b7edd37b0fc8e3d664";
+      sha512 = "6e4ffc6431cf650380344aac96be846a48e0aadae8d089d21784ba9a9944a3a1c9aa4f0d374d59023355d12cec2b38396aba0caf527088e58f6593bf5fd59bed";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/eu/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/eu/firefox-57.0b11.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "c673d2a1375c371bfe50288f94cd6879ccf290dce7ba5e755109b67fcbdfd96ced5363a129d0bf0ec6490b322a1d90beb8bab62ea6392d0120b0275d8c86254c";
+      sha512 = "29fa095b868337dfe531538bcd4b24d16346f19277be1c6ce3e579f9cd696b5134662b58afa0d9089da37f6b312d54d19575c68b0f57a8782d2c6e46f1487d25";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/fa/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/fa/firefox-57.0b11.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "cb9b3fee5334bfb11e53f9fe4c3edbab8e8db8cc916046bc21f6abe6a0a134191f1e9921e89c443376dd76475ca1521f8e7b39550a151a3f25f9bfa6312d2082";
+      sha512 = "9f6a5daa3485a1d1194a43da4d8c0d8e740cd36d10effd8dd5360297253ed2c37cd2749ee9e1d4e7446f3c84b8c985ad30128d84abdb4518e442dfc274afe770";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/ff/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/ff/firefox-57.0b11.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "d8926743a7a15fc7144656ccbf3035ea1ca542421bdfeb0edc0b0a84343236e2cbf19635dcefe68efc44f4afd14697d2a833b9e85e587abb2a65b816cda74d7e";
+      sha512 = "a7d8f16d8edc997eb55823b8327bb057bc97bf480bff88c7c67085f601a81744b7a61f0e6364304774950f87686a5bd192937de33feb338a0de1c336d6b9773f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/fi/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/fi/firefox-57.0b11.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "08b35f12b9182f5a6edf9759e30bdd4b8e8f801e427edbfd53b3c85ddf2f4e28cc7097b1cd08572e79d59a736474353c2bd90dd166eb7f50ca4e713b85f093a3";
+      sha512 = "e43a7e74de01d5e6145cb2b1f2757ad9692801701884079ce678768b98777a972e5ca65e037f3b1cc20ddfd7206d7582674104c4601780c02c71afa077e93a37";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/fr/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/fr/firefox-57.0b11.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "71e01d15790d27e6466dadbb55965a9f1e5df6409eba80ed6f429f45eb03bd21b0cdeca0b2a162beaf9435c9b75fab57f7ae3a663c944de297b8ab432baeaa8a";
+      sha512 = "ab407a6f84324cc7bf302cfcdbf683f006cb9170a5d23932287392d626f3473a7b717bcfe87e09f8f7a7f7a7563dc61731474c8b4fba5e89df2d34b2b4ca1cfe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/fy-NL/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/fy-NL/firefox-57.0b11.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "c86e34b5d16a2915d3c80fb6c69a444343c8993aa39d4589b899d702c029804f1a790fe093bca608c9d7fb6a3ce1e90a37696ad069b2075067c2000323b17262";
+      sha512 = "7f418fa811acddd2dd6b0a7c3c24b47359c1e80485d80812d8e11d6843914fdcb0314b1acc0e2e1a7a6df703df155849f468d2217fe5f99729b7c4e4a1b0f082";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/ga-IE/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/ga-IE/firefox-57.0b11.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "dc1d58d4b1e480f5dd5883783cb30431fcafdee0612dd1a73585db34a8e42add6a1683b10f3e94765b11637037199eae4517ff416d9db4d12e9126ae07e44a93";
+      sha512 = "ed03c7411b9cd7df2cce532481d2336cc296889ee25c23a387f47f920bdc21b477571ae313b6bb3c9967a48bfa025869110b398f1c4249732611fabc8c96110b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/gd/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/gd/firefox-57.0b11.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "456b1790f10dec64ce6cff08b7629121710870eab2331019071730a9141b72d714a177a4018847cd66db145a1d3eec5c7fe7d64cd950d106e9fac06fa763af2d";
+      sha512 = "421c17f1401a02793d8b5d888b7994be9638d3a62f39794f887b6e328a89a8311696ba272eaeab85a9200f9027312aa293796c48749eed8f62a60482e3513b91";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/gl/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/gl/firefox-57.0b11.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "68e62e4ca5a77e7552e0eada7d82910c00032b77160dcd7a5d054951778600f898fcd1aec690c38388c82b485ff988ceea7b71d67b715c28aab8f2ce02abff65";
+      sha512 = "970a6175e192046a9bb701bea9a80c83d09d73a7440bde2d94e740ab985808e8934c6b3df1121777b84282becfa4362c5595f977ba2650c235e235f9077e3776";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/gn/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/gn/firefox-57.0b11.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "25a9a5d82c54129f4a995cde97bac927f499fecf451d4bc6124a845c0a210ae51d3f73ea7ada0c7e336b016f8a779d46bd8adcc82a2af7c8b7ce886ace779449";
+      sha512 = "0cde258644b323b23e1810b8ea5dcf13dccd14292898d780cd24a1d2488f604d3dda4abf50a9840ca665d02bdb2b6bdb0186f0a434e0a350a71939c7fc7513ca";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/gu-IN/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/gu-IN/firefox-57.0b11.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "ba8f2cc4b4576f6a9ecd6d7f41a0f36b465a62131041b4ba60171ec86ba9609852af12b1f3b3a96dff5d1a2ce62cbcd9116791db760e5581abb7689c8eaf2380";
+      sha512 = "ca20b858dc312f43844d3aaaef8de8f677bbb4409a8412d3d9ba77e0f98805aceeb0513307dafe6425fb9cc8d935f24732558fd68ad3f6d408094fe1db3a46a0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/he/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/he/firefox-57.0b11.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "4e67737700cf23ee51c5023fb7fe19eecd546eed20eb52ed4402a247c060bae29a3bdbcb5a0ed88024b1c501d03d11f195ae36d265c30abc228434fe0f4d7b69";
+      sha512 = "176d427cde28a1f69c90aecba0fb6459fc102d2a10d1be91ec7114643356ed60eab8cb2701802dc3641445bd8b5595ac454dd3b310a8e59f99f6467dd39bf050";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/hi-IN/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/hi-IN/firefox-57.0b11.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "855db36604b8cf08ec74ae74c36fa3c02b26638d48394d9fdcdc42a6d914b5a214b56e121e26cb28b8cafe1d3488cd153c11a8c717ff36557ea77e31d281187a";
+      sha512 = "01bb047e7f5d259da175ec008a562d1a09ac3a327d481bc9604cb754ffd52cca861113b87a5fb6420858cf5a3be262933c8d4d35ec3be4e6c7b6ca98019afa52";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/hr/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/hr/firefox-57.0b11.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "252e9162dd4ebca701425b3c251ca3eaebd6802929049e9087f0e472b60daf645c6a6eebf9d56d2b28dfca97308954e1992c442f2cca5cf21092957af75f03b4";
+      sha512 = "d4779d34de6248f911bd52f13fb2b701e3d0d30327d79090175d665e684e9267d7a529635e855c0d4d98c04b668347d6c92fac8e027aa05eb66403757064cec4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/hsb/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/hsb/firefox-57.0b11.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "c554fb601f4764e5518ad78c6c78996b6795926b5a9434cdaa734f88d6debb01b20db6648e3fea77cf02739ca22fdfe2ae953c9c2b26ed5204190f7b05c24eb0";
+      sha512 = "c497e1fe9840623adcc29caf6240c84666fde14da86567f20b43901c6f519e52b11f774feaf3990ce3e192da5966ad399cff6bb2618bafb355ec2746040a05bb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/hu/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/hu/firefox-57.0b11.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "f0a3edb3a55fc25f1ba94a5b372f4f7f284f405be03059f86096119f9077450e53e72ce9144ff1ef075d39f3eea291b3aadd9dcb80efbd67af4681aa8f8afe68";
+      sha512 = "b3e49356510e4e4cc3eee442b87ee8fb757ac9c6285e5ec89824a9a32ce8af72ffba96874813e2162cc0673f08e206b1b9cbe32d0fa4e7ef87ffafe41bdc7b67";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/hy-AM/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/hy-AM/firefox-57.0b11.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "2f3f9058f7e7b35bfe9b8203d89696f66b2d9e8985bc563161b38333e6f9065a661452aa41d859094788312c59fdae56c67b15ed11279251f888ba92b038321a";
+      sha512 = "fc998684acfefbf64c8da70bb01cd76943132701b635763509eb264d04630f34089a306106a70c60638e4747ef08058f7e0a44400fdbd0048e9ab64cf7b8a84c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/id/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/id/firefox-57.0b11.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "100c57b91262c1e7a8ea1c3c4a604c1dbb4b3c3e8c5686c26ce3fbab8c5483e08ea2696b8abd55a19cde310f5b2a41b5327e0c95c5d9daf5c98240cd9cb4b1d5";
+      sha512 = "9ab41fb2057d749fe86c9c578bdaca62218e83209cbc5803a8072e26a21bf3496c6f7267c7a01680ef3d7c1f6da5a402920a3bb5e83f76fde9465d9b2635deb7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/is/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/is/firefox-57.0b11.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "e57db256ad1555d6d4d0aef0542b3a1bc9dd91a41431a914585bf748b924bf045212435dea6e06e72c04d6a16b9f30f1f99289514044f2ddb0260b5149f76cd5";
+      sha512 = "6f6cd48c5122337109e55ba2ac7fe4ac0a0ad0424732414adc7ff3b95f5d5e07cfb603aad0463f006316526b3a07b7270426c8d31b43b530ba27313b609820bf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/it/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/it/firefox-57.0b11.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "662038be5e6317a97530fbae53200d4285cc197e37dc0676bbd0ffec6719f594ae4d6190df5e157635ba922fbb4c37865deb4e2931f3604411bd23ead6713036";
+      sha512 = "c409812a276eb9491e7e764c215eb0093db7e4863ae3da01fb878c838ebd0d379210924a7cae9b9a58c88eae43c317c54618005e1ab4f9e7c28ef10281d8dbbd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/ja/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/ja/firefox-57.0b11.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "a51fda61928771c55d2ba7ea73fe30837bb70e0aae7bfd51403422afa290b7b89ea5450eaf71c93b26b5f16f47bc7295d3ab47c4eba0dc823256609ae7f12a72";
+      sha512 = "0325da2fa80de439d878b03635e934ec9445e8f6b48db620ae5de273181578a41b4b94db105f0b0e2567a12039fc2c25d46eb50fa95db4745bce9633d874348b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/ka/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/ka/firefox-57.0b11.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "936f9794719ca9c25255eecdded55838190f0277a2ee56d1165b066cfa36f517c1c5ffde024791e73f2e7b1cd4172c7fb230f447ae8237f18ed3e4d98d5a765d";
+      sha512 = "fb664987b2cfb2806acfed73664425ac73bed0646fd5c55dd40b64f3883c666c40fe7a3e26d3887641055385e1561ab47dc5517ff536fe2f132a6ae0ef0cef19";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/kab/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/kab/firefox-57.0b11.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "3d26c9892a8bee295156b6f7357acddf3f7ff6785e4e78ef6fb4c3f1a86c0a453b914eb026f0314e36d9713e901684b06359c143995356623d77e35bdc11a8ac";
+      sha512 = "a0035b46bf35bc0d79fa2f9f065d0a80447438a56bb7f8653a56ff137a351abcacb0934d7402b70e4eb18da330aa43704d31530fddcaed115b3ab4666fc66468";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/kk/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/kk/firefox-57.0b11.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "56b3d70858225aa7b10d711e8fafe34b0c5efa65a7afbdc0aef02bbf6fa0195d4670611f401b541df8be038ed07b202fa53abb421a1d1dbebe0042ecf413d347";
+      sha512 = "3a9cbb1fcefaa47f49b7f98a612e019c07b5b838d54709a6f8b70e530665a06cbf7344ba09939e0ab89cb1cfc195a31ef60fc1524fb7d2a0dd88b87776a784b8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/km/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/km/firefox-57.0b11.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "f3e29ce7109b22c2f4c1c14698907e1bd00e689386b3cc8a3b21c188ae5f902b7820911908cb2d740028d6e0eb44cb87ef30aef585d8bd110008f4d57e2de0d5";
+      sha512 = "a681711346e29e9bfd8ac25b0a3b625c1e7eb7a08d502e66bc592fc4188878af0063974cf6dd60cbc9724ab489596561caabe80a91ae89ee0618a5a37c30ddfd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/kn/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/kn/firefox-57.0b11.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "cbd3dc1bc3043450ae175703a34790334c2a0be8ed71703db29c1d31aaa0cf0f7facdf26603cb04d423a905e6ee527750f2e3783377d5466eadc9cb818b2fb04";
+      sha512 = "7034448aafc92ada6ec4ffd974c9c15b8bcd2104ede74f58853c5e988cf4f4a10147d75e4c96730302a8bcb4a3403304ed6b379d369c2d1ebef7e37ca947e911";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/ko/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/ko/firefox-57.0b11.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "dab096fd4baf083a9bbe22c6c88fdb0278748e34a32dbf0df947c00d0462788d72860ea88baf84bbd524d808e87cc6d153f24c2bba6ea3400b409abb4459748a";
+      sha512 = "14bec92a098c0398f75fcd2caadfd0c817bc5d1293b6cbbd667b76ae6cf4f9585aaafe85741ea297e6d994146586da348b7f576bac8af043f8d1918bccb85fcb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/lij/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/lij/firefox-57.0b11.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "c1b52bff2b4943b790ae5088db20472a5d51f103722894a57b77c607ceacf68901f5bc8eb3eed50b1d5039f878a3763fe9d629437e1e598eab2533302078789d";
+      sha512 = "7972f52851eec48e16037fa3fedaa2745be72dff2d147d6eadb1167ad664d7cb2620227d5acd0954a1036c7f55ea8b25f5a1da5cf0bd9e13a81b567208330eda";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/lt/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/lt/firefox-57.0b11.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "1cead7d21f0e0535de752038aeb1ea9fc620f84de1f7ec3be49293ed9ac2777fe14ead838c47154ee5e123a010ecf51c9f3effd4f23ebf53fde49196fd9e388f";
+      sha512 = "cbcd1637e7e9abfa847f9a44c59702adf887da8e109a280eb2e2f41e5624d2c64d3e8c6fd0d7855497ddd89b38f6485464cc6cdf10934d5752ee57f919db0aa8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/lv/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/lv/firefox-57.0b11.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "52dd4ac89d587d9a486742fbd95dc9bb62ca87818ee252e5795bcbb94de379edcca472f5d666c2f0d2867f6ac342dd6b1c282829373eea90577e32d791d77d25";
+      sha512 = "323b8973ee237d34790c9febc46030ae1386a7038524c67f77c19344b55350a5b921694679761de5049d9b39710e6dc16c829423c969856cc619902cdec9ba4b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/mai/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/mai/firefox-57.0b11.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "ddb5f557241b070a068e26d0b93b0b1755820af1bb58c2dea47efb131ab94fcbedef5482770ec32153aaf676b86aa08642f1e2994cd747a7019b545be8978747";
+      sha512 = "0456dea7409fc7f646b89a86adcbd9769e4191fb9fd2491d9e0a09a05d7a8181ade50ad84c98522c9958437ed53dab24aded457333b5b694ebc5884ec324ad8b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/mk/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/mk/firefox-57.0b11.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "e15d64801baf977b0ad25e3f36dc5745a649dd435f462161f333c6a6ded6430b49a072622574ca17d1a699f65d809badee2f4e0a51b29fe24d03377cb0cd2497";
+      sha512 = "3363dbd1913eff92a40325d61189130ceebec1994e762efc044cbb02539185697b2f4eaeb2627f77920efd84efe6da8f6e6bcb379283422d8dd276b3ac5598e1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/ml/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/ml/firefox-57.0b11.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "7cd72cd4656f84c9bd4a97e4569e1409c483fadb91c4acd94f9b728834646ee006b402f8b608164f6f9bd8bbd76084eeaec75dacabaca94707047a99038082dc";
+      sha512 = "a5aa74b8c2cc081fa62d98a4476550f3c570e58da3c6bbb01216da2c290e85adccbcea5410ff48c814ee362b7194ab5f3b0ac1d00bd531726771caa2cd449c6c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/mr/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/mr/firefox-57.0b11.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "10ea9136e20f2243412b73f5180d08eb0082fe66ecb8e445417db126d0c7a774a9721a1038bdc332751ab87222b3e5c45c89b21afa4aa307be6fbef82c7df9c1";
+      sha512 = "3ba3d0a66c560e00bf4531b0dd9c2d0e1bce29f0fc890cc93511fd00298ab06f1268cfbc8ab2d759dffcabd8fae22ddf516e69b1de2b5c18ae8ea9a0313ee35b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/ms/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/ms/firefox-57.0b11.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "ee4bec5b6398a2d6e59d2cd5664fc688d6beccb18c75ee2071052680587829ca80aeb320d7ea23dc687c16b3108ef34b33e62d21683cdf698eb9b572716d6e63";
+      sha512 = "5f1275956930a50b91b6ce8641f3616ecdfd12c7ce291b50e616d9dbc92da92863cc26eb3422ffc0210963ca17d3fc621456b0acae41a5891a307c9d32dcb569";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/my/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/my/firefox-57.0b11.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "5a239afefe69f6ea857c225358b7569feaa6c5a8eb8442e6a4e194d9e0c902ad8c4faf1ffeb376f87a3cba0bb624363a34f96f53f6e1831c49e4c5b64ba8d24a";
+      sha512 = "5ca368da2411fb199f737c0718876f4f8c44de2f2f738e689c40e55398e29b1ab3cea61e9af463341ef36baa96793b2767f30d268162ac598e5d075719db9f76";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/nb-NO/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/nb-NO/firefox-57.0b11.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "88e9ee275d203caadaaf271974b6a2173302c855c6c61d59e1f01461477800f0eabbb9c2b181961eb27a253ce4343fca56d4bbaf8efefa4289ec990b9426910f";
+      sha512 = "dfde18c2ea0071db8353e36b7b6578701429b7f7c6130f7986443d8d922876e7f6b532c57c987de789167e3e6eca66b523329dddd120f458bf05a703e49aabee";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/nl/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/nl/firefox-57.0b11.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "c04c96ed3922026afa158aad3fb44649f50f1a77afe6b5245b65e852d720f441a86e9d3330cdd0e9115e5f97fb0d641c3fbd924f1e287712245fd19cbbb5cd99";
+      sha512 = "9253d483ffc866737a3c5cc2dd22deb6269c31c1c413459860ff7f0f0a2716899fb788ca1b754354e4498ec6ce9488086083071bf13772eaab247131bb33851c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/nn-NO/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/nn-NO/firefox-57.0b11.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "e8013252993b58910fc2aa0ce907e187e357007499cc93342ae9002490dfb49ddeb51121dd4194b4c12915542e8759b0d30faabe54afb0b32919ef636bcd549b";
+      sha512 = "5bf67fd3411a246cbae4eb039e6d8c228df712f6ac8c01fc106feca2f64b77e6088ef9c06e059ae4ccd03477aeea40010c4b3a953216f980973b84934284bf9b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/or/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/or/firefox-57.0b11.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "f758d21aa24459750cb7d2cc37668d5f92ef372ca72b166c7376cd0a92db907cc79531748deb4e4418bfdba82c6c5f14e8c1e066e90e0cc64707497458f7465a";
+      sha512 = "a2e23e8e70733939dd39162864a1fc67a2870eff5b20e9de9ca028d4d619841fa2800fa7e8621c2e7f6cd16056fb58650c249e9214cb6f25fa5348b39a2de4d5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/pa-IN/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/pa-IN/firefox-57.0b11.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "19f701e52912da03b68fd99a7e8d76de25287bd46b97616c37d3b7d2703d19e45dbcc42038742ee4b533482c89b8e70aa807b4b11c38660e5a7b3af0ebf1ec79";
+      sha512 = "a87d34b6f50ab7001696b5c64577aab9cf0363f064a601cd527bab7a8181f9e5fd54bf4ed33552959ff0ef8dd8682ebd7b54d7d5de2b63150c852616897f1e57";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/pl/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/pl/firefox-57.0b11.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "01339648c867b7f5daf3932ea54febd2130a86e8ff78db6f00a6dd3a7c3b2b474745548a256d8868107a84c005ff73d395c67b2a4e14ec2d9a5d0873ba5b7b24";
+      sha512 = "3c748f22568a34d99a72e7630182d731ba9e46b7659334e4c5105d586d76fc13cc96cd3da7e1bf928be6b71c8e523ddd325abd7f06407845b894273a67716929";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/pt-BR/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/pt-BR/firefox-57.0b11.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "4c04df5d84d833e5f35be55cfe6f4fb28f74108043065019c11cd8add64fcd0669d47d0925ba8a9f076e83f00ea2b25695c9ff279cbc05dfdb8dd6a821da15a7";
+      sha512 = "a2239a7783497818a2c5f3b810c213ca2152fff3ee1cd2d8e57bfcb08f781cd8c588936182645c5eb9281bb41f80be493b119382f59e7fc83808e848a4d9b582";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/pt-PT/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/pt-PT/firefox-57.0b11.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "6a7c1d406c620fce6020941bfad7d7623dbd7372eea45d1c8fec1f7553be33b758ffe88e39af0cef59eec02af9d9dd48e540c9cf8e129e70dd33b006f686f842";
+      sha512 = "1e1ca4b80c9defa67221f642c7a79ce8b6ae350b9221269f89b252b6e150ec081780f0c6043ae015216a4986dcee4a515cc26b562c73d6ed2a274f0966f0b279";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/rm/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/rm/firefox-57.0b11.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "000b1df519f0fd275f58d2cd30f8c826c01c5c1874c16e3e0faab0fa3edeb66000a5c34794c03b88eff16da0c0bf4212c31b1d6097af00ecb1140e03ba50a694";
+      sha512 = "6a598e71a3da18d23bbeba744d6e8bc6b85263fef93d72edfcec66f3bd6b80b48d328e9b3cca90573352ed3a8407a98d0a2e1c61a9a56258b55df0984f21cf2b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/ro/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/ro/firefox-57.0b11.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "6100f64ae76c8c6c370018403bc72479e9d3e0eb28339637d682d1891eb25fdddb9cba9502fdcc278850a957922572b8e451277b21ceb003a896217b69a5d732";
+      sha512 = "3ac6ef4b82630b697b239dc972522aaa8d58829be15be41bfc91fec2b7b3fa36a4a24c2b6a0208a13ff2d0d190be3c72cebedf037f4023666c76704f1b2ea0f7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/ru/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/ru/firefox-57.0b11.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "ff87b10a51db21299b673b753143be28ad5db9680dfe2aebe9dac65ae88ec5445ca47052c553c626fc5819e42c991ef57d504af05738db2b440e9cdcfee6ca8e";
+      sha512 = "4c8122918cc65958504a6b014e3729321f8d440f79605ea22d90dc3c49f4134220c2b4463fe08737854b62a76d8e67461b3c1a41ea9999c78eed95a99bb2c524";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/si/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/si/firefox-57.0b11.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "1d777698daaaab61ed451510ebc905d1b385e4f6f22a32237ff7fba2593173688a4a51fbaa363c8e51a9f957b5efc1c5fe90fef25588c4962184c8749ec00358";
+      sha512 = "e915c9acd651036a196f3845e34707a9622e5b49e2ef5614d5426849bfd809c9ab65fa0d80aa9865b7dc3bd9cfe906109b590173c545e84bb2b04d5edd2e943d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/sk/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/sk/firefox-57.0b11.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "dfaaf1f5e79df8e53b84763542e987f2630d5bd13b4b1b0c73a463fe16029ea8004512e57e8657dcbd00ec3b5f295073327a82fdb8e870ffb84f9edf2c9117c9";
+      sha512 = "ab7c52be7a4b0bfbaf8a52b7189407218df48c73aba5d5ddb569f6ebdf67d12c8da014e300045a51d535279571241985a21901c1c9cde9c32eb9cdbf3956ba95";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/sl/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/sl/firefox-57.0b11.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "50ac0f9a58b13c26ed7f2368290fd45aafbe991ed0011295e6b7ffffbe1e3deb35c4952b7f107bf195f9e604029da51d3d0f6d00d94348bc9838540be5cc619a";
+      sha512 = "b9cde14b2886aa10b09cc862ac4882eaeae69ae5295625a9db046baf66ef16a76655c23b82d85eb95bed3985d13527c6eb210d006d5808dac0917b3e2a1b94ef";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/son/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/son/firefox-57.0b11.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "9bbdb11dca6271f8e1dbe5d96704ea63f55d7d778779d8b06206fdfb25ffaff4216d4266a1f463d343220c2badac6462c7af53afba57561b640bfb0681689c07";
+      sha512 = "2ba989588f9c294718c6b2cad196a0b4631d3f189a5877ef817ac1b4b2af767531bab7ba1691dae21ceb29fbf63128cc38805db6412ce07af21d179c40ddafc5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/sq/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/sq/firefox-57.0b11.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "31a6b5bccf5a976732bd2cfddc384923221bb59df027b67cf688fa7c81d67682617e7617b4418a42191decd65d46b0c8cc5db5ce4cb47bbf665de248e4291a91";
+      sha512 = "07e478a5f07184d5730665b52a3cc162569553d7fc43b37579d4a33bde5b70f8ebf2deab9f6b144b961222fbced4f1fe204865dad46222c94b850ed3600e3a0d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/sr/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/sr/firefox-57.0b11.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "7679aa019569d2dc583dba19165da84e0453de6f26c86e11196f5d25ac1f25b3040b375f7a944ddd3550ff4678783efae2dac7990695d9f805a20773196ff287";
+      sha512 = "255f62d5f88214320dc1febe610f547b2bba08817e8eb7ec0c23dbcf5d900f47307aafe63193f93f1a3c1dabff3b7f49130df1cdde940dfdcec521553c4733a9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/sv-SE/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/sv-SE/firefox-57.0b11.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "834a14562bdb8280072daf8ae520296f8ead6278a27048b9cd95b4e31eff83334f7e75369db0febb6b88f333b972eabac94522b1c1dcc1993b51979a9d28da12";
+      sha512 = "4fb0f74ed4b7d221dd75c8e767b0f021c8bdda27388392c2b55cafc3ae48757b0bcc506061d59bf430fc2841ccd3aae0cb92627de00809bdd8fd536c860def24";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/ta/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/ta/firefox-57.0b11.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "5d1b2e8c9e5329c0d3dbf73bafade644b797961e0ca91aa0bda65dbcb6ca7a7dccc063cfce29084a3d66016806bbaf643e74e37049b66293151b727f423128de";
+      sha512 = "02214d133855b544246c930ac834c4076ba32a2f490deaf9e53cb8ed61ea6d9cf77d04b2ecc41d25eb1cd8dc87515725cb7446e85876b66ffc954d1cc8dc88ee";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/te/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/te/firefox-57.0b11.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "27dcbc709ff7b203688ada657936428eccad4969875b8416d20963c8aaf146e89dcbc50bd18f343df15c25c89f89078d530f242a0711ea4bad6e74dd83f4e06a";
+      sha512 = "94d8bdd506216e56ab6b866b9f9a8158101b961e32e691217e16eddb748533fc39d312415e005f05656b877590487d5a5c340d4cb66f5fc9f7c97d9959206ea9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/th/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/th/firefox-57.0b11.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "b6fc169928f968db1dd0ed6510be4a4bbce447a100df03bd405c1020e74062f1cfbee22aeb737ff1453a22e596d91a14f3cae309d551532aec2ebd1db98668d9";
+      sha512 = "305bfebb6a51ce94561a25e19acf82ca4efc3093a8de97ac352dce248140c9eb50212ca11cda550118f6bef6829ef3d6614c4696e09c662cd28b05b6d592f4a2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/tr/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/tr/firefox-57.0b11.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "3d139c2ac6efe0de5c4c58e1e029831e93e49ba40831f38fe7e2d88a8a001302971b0d232bdfae49cdc97d5cce422d4fdd9c8ea47e467c16c2ff5465590ab6e2";
+      sha512 = "37effb1cc8d59c6b6d556c1c99eef05f5bee3a31e9afe9e606790d1f901c40a20d34099d62ec610a495e9fa7a84060de5203349af4899f9da92f705fd59e9942";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/uk/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/uk/firefox-57.0b11.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "27a75956fe9b4e0a68ee14797b941fab1d2a48e5d78dde9cdae7cfa15395c06268fc9a5b2c9fb7ec52007e7e3662c4b3c5622c41acb8547e362771a4cd6722dd";
+      sha512 = "2e7fc820dc9af6da8bc9af01d18c17138676e89d5e5d7e11e1bec938aee7db5d1ae16fa8b4aa03fba85adb4c9a31447fda87369b1b6b4ad7af4d265604ab9c13";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/ur/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/ur/firefox-57.0b11.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "b732a652583e99526f2e5d542d09e7f19447683dd30f1674fbcb2b06bf19ada87b66831a0b0e008dfb47be9c581a5981bdc2b6d8642d9c8e40805cfc327578a7";
+      sha512 = "1698260ed76ecace3f65063e0e076a37fe4d780743c63512994826138cf43e60a9617c36d514d5b3a349938e7ef7b9e670d7a819cdebdc10ac5ffd00aaed5ca8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/uz/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/uz/firefox-57.0b11.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "8552d4c8d8f39e993c2d35804a9aa00fa39bf294623acbb6362259d8545f5aee1b52b96e5cb8f3d438981da3503b5a31bac008da70c2557ca05d19615efa72ca";
+      sha512 = "99da803303a3269bc510fa82e278448e38ea20b73f6dad40682ac4037b23cc6869d2b6bf4f7f07ecc1b18ff3b759ba2ba4e13555a61cc9282bd29651571ec1df";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/vi/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/vi/firefox-57.0b11.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "6aeae2edd0fbc60f5bb83abd5cafbe860494dab193315fc1154a820e4dcb1ea35b88eedea5a3f5c6aea424e0f662d42c38eb0fcac1ee233158c9dbe16173f954";
+      sha512 = "dc967eb9b8f5f53a233212d5c9f05a7304bff7d2d9b8175e4f197eb54ec3c28ff6d8b634033651b20fc98a68e2d585338e6c3b50b9f22e4bfdf9b55096740d9f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/xh/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/xh/firefox-57.0b11.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "6824264b337517f497c78f6aa6485606c239588d0729a53a9d9333c836051b7f0f65b852eb10c0abf81c57b166b65d99f09ba0f17b55503c836ad6d9ff82a25e";
+      sha512 = "7a47ebc63b02734c2ecf53ea98fa246a3d6612c203c9393cf8958230c583e0150b5da9fa3b315131d21576d6028565ab15eaed509848da850b7dbea65f580637";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/zh-CN/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/zh-CN/firefox-57.0b11.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "9dcffaf3db7f7f4cccbd36f5e77276faaab2808dd5b70058820d9bb932b2e4ea4176a52c6850cd7f46953596d6b157eede8c5f20b6bd304fe2ab8263378e19b6";
+      sha512 = "e6c7864bec03ae6ec3f5293373ef5b5ad04f1430cba8433b7e6d4d40ed4c40eb78ae48fd85e954c16a8dc5ad7c95d509cc3892832002ffef3b99dec161b4795c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-x86_64/zh-TW/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-x86_64/zh-TW/firefox-57.0b11.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "9ccd29e7a9e2dce5294cceb2932ccfb7219570e570b58be350fe915464e0cafb7c739c86fdcbe8bbdc8f5112a769cc43dfaf44a292bbe821766d30e11075d20f";
+      sha512 = "18cc76259b7f9b50d1dad72d76d4e9fbd140df85101a480a078840f22f8f778b90debe246e953591a7c531a64050569cc1162be30c8dd0054602d46b1e3f7ec1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/ach/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/ach/firefox-57.0b11.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "6c4c5c80365d2b5fb2070528f4072cd6962b7fcbcf4a2444e8af1433c60220a764ed75ba868be95b6f6cb045f76c40903130c354e262e93cb83a94b671cc1243";
+      sha512 = "731d0a857e84a66729efc652c0b562d683f12b847df3aacafba14b6b8c9f17a3b6f7c60c40dd68d85ce81c9bd876dddb98e677fd532cc4801769683530948761";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/af/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/af/firefox-57.0b11.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "9d36a15f517f582303ff10ae09c7eb4e709d19a0b98bb9afb6f1a511ec787121676d749c93b46e301ee3a41010c883aa76b1ce5b248c2141086dd4551c4e9887";
+      sha512 = "ab2bfa2e51c36e254b9a410fa1b0ad1a5d4f2fe39b3b09c403a923ffaadcf339e71eefdf22dfa67af7a9b4c0ee543c9f507e49f9ec1ff424ec8f741950617ea9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/an/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/an/firefox-57.0b11.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "aecf7149169b784593234906230f632d1d6d56efe37d6d2a060090ee2823f837551fdfbd5944960c05c436bb2768f529ba581ebeb6afca6f1b05a77c3a56f26a";
+      sha512 = "61bb9e3e5d8341316888c8c8ac5df92791256181e7873db98e9ac4ccb40524552569c7b028105124c549a3ae2a62c056b310d89a2489a931be6a41d5ffbc291a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/ar/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/ar/firefox-57.0b11.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "1a49d7c9819a35f1bb5012191009efcb9c0738bf949bffc48f78f24e57ae9289129922e9beb850a919d6f7a19a86639d9681e4abd2b0f7ab882e4038a1653bae";
+      sha512 = "132fb475429664ae4df2d5d2dc08274c7b8e253fdddec3e6ee2f0d11b5662b11553642dfc3ce69dfb2c1658efd16ed8568c0cab9ad626acf223979306e7132b0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/as/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/as/firefox-57.0b11.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "a0309c07f5f8e4ba7283e6d852eb3527145f7e756cb7376acf560a17dd56171269d722b8cfd673ddf8107009c8657daba2c66f48f70c262404e1a349de65abcf";
+      sha512 = "86658f39915ab733cee46f19929101c50168f8ce78cb6e61a9d7814830a2eb7c8b7936db858c63beee7e06a94be9043b80975382cc2ae8623198afe8b65226df";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/ast/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/ast/firefox-57.0b11.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "a3bb2ab70eccabac6f27df4595dbab2fcb63a0978b6fc1ef965db8d4bf0228eabee91f771c67c5e7b7fc5e322c50c8fb8e35e7b95e5d2e913a0c8f19f8619db8";
+      sha512 = "1cd4a682a831772b32b603edb6277b07b3f0de78b33246c2deec2c75a023060f24de2cd6c5ee05b6eaffa20b617fc8f7a6f413f502bd99c39086b689ac817444";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/az/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/az/firefox-57.0b11.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "2c17f965753ef834a010e00055120282e003cec20290a90050a6ef9a6b2e134c6553aa33c247cd15962408fa67e654dc50603fc02b04a43a3584c7ade477a9f1";
+      sha512 = "45e91932826645df3265152fa3c80fd74ac729f97fdea29059a2e778ea04af1cadb8a0a7df8a8935ee9e70af480762d256888c4fad1be43101eebd95672dcbab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/be/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/be/firefox-57.0b11.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "da69fd5a5e50b870d76754f81c8d492b75c239d44ae36ffb92ce3fa3504b35105c5a08a0c6228041a24d61763c616dca44c2ed2d4cc941fae59d521d6d3ce064";
+      sha512 = "a3a7dbc02eb8b3d64c67638a71e53a98a30092e03eac97c382aee8f2aa1cf099493c65aec5ba96aece30deb50bb5cee2f35f1ebbadbf38c93e8f9f9917b79406";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/bg/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/bg/firefox-57.0b11.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "f85962ffbcb8f01c896cbf56ccabcf9bb6261b0989b40452e0e3e1bd297c31f6ad30d228d2c733498a6cb97c52b468269a4f76892b495a1c19e43f1294ce0830";
+      sha512 = "7b52a3bf5a2be9f4de6f609ca11a7f7e9c219a9cb84d503e892e1b51868dfa10e650f6d75aeddbd0edf8fa54b48aa3d3c4852e0e4615efdac78912709b162591";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/bn-BD/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/bn-BD/firefox-57.0b11.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "dcc23f3fe7df774b752018153161376cd768eed4dd6b3d0842959f5762145a0bcef3e328e77f6cc021c57c95f2d90fa296579565c21c70cc126c29a5e4a43838";
+      sha512 = "84c687130785782f9b900249db6d108e160c36dcc90eb2fc10ea9661cc91b19c8da262189e72b3259f987c05dee4e2e83c870cb2b3e3fc21178a4dbc19598981";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/bn-IN/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/bn-IN/firefox-57.0b11.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "e530547e5d30f8a450f84558d65709568615644373c42e3f442b615742c6d0089f52f04fe15baa8d3b8bc9d1bdc95769f64bb0c555c93d26329968e542944e5c";
+      sha512 = "3d269322796c2384ddb03ccb07ebc0fc6ca04409d1fadd6c11a1ee436092139929f414ff9c46883379e9c92441189da386723b8ef7dad5f6599b1b522a3984a9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/br/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/br/firefox-57.0b11.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "7a0e21ec418a344d9df7daf1efc14319ab5b44d22701acfe2d15fc04b32fd2c41aa80c592d4357f6fa531c64b74aac6c6bd7cdf2bfad4f1fb90f91c2c966b932";
+      sha512 = "95f77bc8d74e8b6fba6ae6ee59f12cfada50572aae4aba4e3b519290dca20c6ca45111b5b7e58f5fa2a96cba4d35af4ef20dda4b908e607f00ab7c2d7ffe7834";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/bs/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/bs/firefox-57.0b11.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "e5eee2dd28d47efe3dd629826d90ad7ac496bea3f2a750389cce8bd7c3fb03587d52bffb1885fbe21ea2b1078e97bada39ea839573b9821340a4e23626a845b4";
+      sha512 = "0f171ae78a2f5c3939827afd61dae0c96fe3e062a77be6e2de172e5e7b3110e953bc282ae353d1629daf9996798db65a163e4d74e6a727a734753708545a2d0c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/ca/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/ca/firefox-57.0b11.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "ee039ecf51f5548615e5af41e3e77be015bdb679f00355601849c826cd18a1ea422a5f9a7bfc0ed9db72a0e321e52148362a79d1515daa9d8980872e04627f26";
+      sha512 = "31243cdce440f556b8588b53c29c8a9140b43c9259c6c16c520773b5a5aaee1944a8f29b427d443701924075547d39f8eeb4eb61b683bd467a911cb59d549e91";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/cak/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/cak/firefox-57.0b11.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "effb915c80355bda7e6d58befda98ff7e92d8cb70af09182f987d3125127a3c06a830fd55976f0d9b0791cfb910aabe7582fe029e0a5e94b3da84b17f797e4f1";
+      sha512 = "c8d4bc2e74ba30cdf18b09911c464b026781933d234ab8421c2b41e19753191ffff7fb73a5b77283d372b2e6496edf818e8f9ad4e06faec184370c7b31c9b3d8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/cs/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/cs/firefox-57.0b11.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "78987c7192835c39caf8ece474f3778bf7b12a20acfedb544bc5a76c41521dee0b9cf240314cf954e6d2f1964e60ea93ae700c63b97260781db03bcc6026d982";
+      sha512 = "2b64d4d1e94ad36439fa95ea97915ae920fd4f2c0e749efa7d1367a9298a6e8ef96a177b0c435a96120644f8baddb76492827164add7caca100c80f7d11d3a9d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/cy/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/cy/firefox-57.0b11.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "822ddc34f737d023e833ba4cc156c4f25ab7715e1b80431cb29226d3427a354f16ffe0b98b571a71b0dcf23f6fa35dfa7a8032ad2ba478a08169d44fc89cb802";
+      sha512 = "70accb1975ffeb4fb3de11171c603e2fc5be7f9873a0d584f906e324d7b64a885efa5ec46739575abf97ede95d40299f1d30f5facf36c3073284d79485a701b9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/da/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/da/firefox-57.0b11.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "1379fe59e87b8046373810489af69f4c946b6f28569b684c381a8c573044d81141b7fd88893c211404f3f59b66d65365e0d1a33fd7a2e2cd09d8174c6ee6e1cf";
+      sha512 = "54d63d2248d253e70fd5d69f8507878cd35bac533b77378cc700df3be14e90d551f9cdb2c5e5ccef570cc8d0a27a827c45166ab5ee8a50376d03c447583a5583";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/de/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/de/firefox-57.0b11.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "dc9cbc7c428704f2f17b50e1b95169e0e922fcefb9d60df73f455384d8cfe37ac56a4e3310de7ec6f29e855ec2f486ebae86544551f91d46f5e7df97566242aa";
+      sha512 = "faedb51772813930a29e639bc11d713e484e79fd220ccb0c72b0071d74eeee238f92a337cb8a00c3ea86f1892baa5211e1dfa7a1d102c2869de1743963c176d6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/dsb/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/dsb/firefox-57.0b11.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "1a2cf9e55547aa47205a83d3dd95183c3f8aaa9d9005dbd3cb47cf629ee9e240a7564f69ce6b3b51a6f320fabbc3f53665a7e739a75480f7d2ac86d9f21a5145";
+      sha512 = "9f409b32ff72b5039481cfe88db1245f1ad626b0f1f8a500d16c24e5b8deacf2188d5a436259e0920667059d090700c4db1997bdf875938da26863a3096fdd95";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/el/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/el/firefox-57.0b11.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "b48a7bc131cd0206bd4e024575df5557b848b4f1f7734c59e1101d34c5617fcbb740a8fb0e75cfd957f6f84757588087fccf5923b6e5b58cfaa6371a416a2a89";
+      sha512 = "069b856c0b4e5b232572bd838ff9fde813c72d14bd731a08ab7acb579f32eed3beb6402ff0669a1789b9e3a486fb76ccae593ac94975828d13350b3a24baa696";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/en-GB/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/en-GB/firefox-57.0b11.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "2f8b0c7c6fc4525dffc05f2a74b182e93bbedc45f2c44369bc8a00d889c9b50ef5d0a4db842555663cb3b88c65b4177c946930ff747796d3a60eda87800514a1";
+      sha512 = "fcb89801772ec01f7863016d82c0f5aa430b90231c7c46fbbc0185246cacbcebf033227fdb90a2395f3c21012bdcddf1e745c1fe3c857add303ee475c2320f9b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/en-US/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/en-US/firefox-57.0b11.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "a37875973326916e2f83f9b5ceb625e3fa3d714d5fb5335d33ae59bf8b196a55a1a9aa24b553ceb6c5048c15eade78e0f1e050f253cf580020a9d24c8227bd74";
+      sha512 = "ee3c3048b6644cbeb32ab784834b7f9c8c900d3a68da5d531fe4d7808876013f0990b2329cee04dbc1ca8b5cf3b4b10c39e19659b09d298961f1706024427a78";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/en-ZA/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/en-ZA/firefox-57.0b11.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "a35bc33e37b1a2eb9591f2a454c228beddcc1231fba8e7f4dba605b00b93077f031d34ba24da84838dff568fca6fcea686273b75f9c1a09fa3b3cf919dffae8c";
+      sha512 = "c31db87c3714bf29e19a25e4791e7d60c140598b7c64d3e47a413bb8ac95ecdfb67e97d6c5491b76ee355ed46bd907b736109bc64930629dbed4adb91ab07aed";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/eo/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/eo/firefox-57.0b11.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "f52b1b7a86a6819ecb9b978653113a9ca6200d1e2933998bfcc2d71caa2a3b29cbe44c5585d4aa5725ccb74c4fa1d2bc0e7cd51191122a927ffac7c7c83bb332";
+      sha512 = "e84d9ecdbd2f03bb0d6673da736c618dc6b5dc7844384f3e1bb73041d8f7d1b85ac5f8b2cdc9c6a316a931ad34830a3a1873b6f0c517c97eee5d6fd1507b8df2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/es-AR/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/es-AR/firefox-57.0b11.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "95e8ba066380a32901f264b1c45905ffed067df81195a717d4d0677b10a54750ddc8946ac8c6528c7919cfd894297ee20f17f4ff3cc765b7946ce246417a24a2";
+      sha512 = "d3f4b7711f81707a195e00ad532a5383a9d47d86681e882bdbb5d2d1145035b0d901abee5908daa607d3b6df27fb8eabfb163b6c800a4cae15b2211fd18d8209";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/es-CL/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/es-CL/firefox-57.0b11.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "8d90f38a6d7b91ed7e63da154ed4a8030ac8648989b3308590153db8c6506e5bd09e4689aedfe785d113d094d8d3b6321aa448755ab236dc2b6513d6ca5aea99";
+      sha512 = "c2d32c0666c7aeb41006720d7d10e55fb8f4f3e0e053ef43f8ef06c2644b79d51a47417cb4d84a7028cdb83d4d74bfee982dcce9e7399ab292f00665f31c7c18";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/es-ES/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/es-ES/firefox-57.0b11.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "fff2d992821815bf09a9bd0dd00100a0a9798b5a546a17d5bfef05a18506b37f84d643fde0d3de34871eddf1563c89549e53d5c826bab5b069998102df924ca8";
+      sha512 = "b3a0e567aaf8defed6cceef8832bc188a4cc47599be7a02b6a63cdea2fabfa5380433b75d48d62d9f4fe8818160239455e7374e6a3958d4853208e4cc7b16e07";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/es-MX/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/es-MX/firefox-57.0b11.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "048b6037291c13ba355177e0a335d4b48409588612791bd5ed3d43d6d69fadfc6228242339dcdeedcce78e91ac8c6ac366ad1f378e5165576cc48dcdcea0bde4";
+      sha512 = "a073552f46c031259bc4f3b05af5a9692ec4b4266d993468900ab912bea88ae0767a2c1e4ec16ccfb33293081f83aae7ce71dc0472efe6340ea62ec65513ea18";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/et/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/et/firefox-57.0b11.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "fcef0b940eb21cac6e9c28f4bc13497865539fa24ac7f83fe24fce2e14318f667dfd16c855ab3a7485e9f0f103da60903987a7c6bf275e87a7ecda997775a395";
+      sha512 = "b24a6b6a3246685d41a303c56ccbefc4596e6a09a9690f8fb0e522c3d25e3fd2fd087bc99647d4e3035057fd4245e00eee9abf639f06612dc4b7928c4092fad0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/eu/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/eu/firefox-57.0b11.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "781aec0d080a00ff86c56af7c626fefc6351e86f23059791dc026858ea5cd7f18c2ee63832f75590bbbe43d8fb50b525f115471c1481f84f6c201c4161a086bc";
+      sha512 = "36cd0b76748edac4a2af813fe1ae06de166501eb765521cd1abf4b05bc55b0460b74e09a45d7e39910b1cf6dc6750848e64e288f27a23466dcb76ed4107da637";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/fa/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/fa/firefox-57.0b11.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "94d0b6c20048db72df1bac942c348e9f4b7907620507b65ad7e3bbde08a590d10c556f817f2830a8813723f01826c0fbf68925b35a49a4647f3da5dba3cababd";
+      sha512 = "66108dc33aa1eaa305ccec598c6539795b06fad7ffc29f5da3576f770f8669345d3856f589bd6fce6eff3c446713b69913d1914946c0fa74d1c9f9dc3322964e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/ff/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/ff/firefox-57.0b11.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "669d03edde5124cf1d4c6531e65b62c6948afe3a2710f2d16638fe2aaab85108dde864df49ebc34dc628976782770b5413f33b836a76162edca459c85d19e1fa";
+      sha512 = "8c8c3cc9224bc4b1aaeba0037c09185ac8e7ca6702e73df125d4103c3bd4e8ed95509c922d81afb25c8704bac08003b44d637d00962c000a56a5370539b780be";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/fi/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/fi/firefox-57.0b11.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "475e298d214356b01938ed692853e982a2dc5b40d15c2b029db81525164444e96a1c537279939ce6c7cab283f535aeb246d28d5d75ecc13750becf16870aba87";
+      sha512 = "74642dfdb24453ff4e25ca74abc772ad30bb6072cd81c1e597df1b689b59e64bcf8fb36fcb366be6b3eb5378c5d682460ebd27ffd9ee069f5649a2657138c2cf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/fr/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/fr/firefox-57.0b11.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "81c0f51da6cfa79e6de8cfb422b41a0851bfda2c4bb114f72662bec504f302b8f3fe40067fbc712aebd3281ef256a9d3e5c4c901f5ebc7ea3fcf271094ebf34b";
+      sha512 = "e0e555d2e7f31a49124a2e5cdb28dca04ac1d67400ba897df52716dc705f478e0ba6928ec8cadf5e82431c754a1559fa838649f0cc5cab15994d75d86d64a12d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/fy-NL/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/fy-NL/firefox-57.0b11.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "66f68daf373a3a2a610914f05ec0273e9e5ba795f947e08301bfdea6122cd1684a1fc7c3aae3f40b534dbe24f6cac5ec613aa239fcb5e52af9e231257e04b3c0";
+      sha512 = "c6a508bb5fc7e8350a0200da8aa189805d2af1c98bf623327404811205dfbae9365a3e4acb167d5867b48f2c28b9d1ec98edb6e7b9204d31fd0364b763e249e7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/ga-IE/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/ga-IE/firefox-57.0b11.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "4fce38ceac5b1186fb0acf5be6d24bc16d246b4a4ba4b7ae37072c3066de7e9d90638e43875fa7d7fd2cb3b5b88e17b1ce8050b8632f4668ee4a2aed2f5ac6a0";
+      sha512 = "76235f086a5159d51579d772f223b694660a7c64b3701165f2f11317ab35969a3dbc8f77ced8cbd97cb0219545e10f5165e8786de0fba2a4ff0eaa87a1ee9253";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/gd/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/gd/firefox-57.0b11.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "40574404c29ad847503d3ced707e7ac21cdaec0fca40dba3e31e27f260ae7faf6da07d3852978e3cc190f3ec2102fc151c723d185f626e01e6a21d13e0ba6008";
+      sha512 = "1f0cb2ee88a34caa16865cf9e86744eb5a71c7133bc6735293bcbb5f4ef9aca7f9a3b4f8d1ec353728c3a7332c2804278ea58dcfd02a12328e5b3937e3761f39";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/gl/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/gl/firefox-57.0b11.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "aeb96aaf9da366ce06e7453f09cda9ee62e576c1ea8b492e71ace5a35b5bc8e2c7239efd733ba565c3c91a9c9e48bba40db3c5b3f39c321b4c3ae8cb1a759218";
+      sha512 = "3980aa2a37547a8e8c3d4f083cec9f69539ae0388dc342847b09b789f35ba7fc9cb83c5bd3e94eef1d56a7788dbafa0d9fd6aef305043d9a83b24598ddb750d7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/gn/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/gn/firefox-57.0b11.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "f5a2b9dbeb8d128eb15621d087a753769d40f219c8235eccc3074c014eadd041df5d146d7f43fb15e31990dbca4f138e983ca7ffbf4aaf249c9c58aaa3f03591";
+      sha512 = "1859234d55f1e5a11be57e4fda90608c40842025b37cd047f5c924071006dadb3933752ce72fd7287c941caf707b14f66159af5a48e34677c017fdce6f1e9a78";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/gu-IN/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/gu-IN/firefox-57.0b11.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "7afac4dd885bafa5cd07ef661f307c0ca30cc2cd65b10d5789090709637d3e744198a3624308cbdf2049899ee4b407934777867c471f2424bcbccb8c025ed40a";
+      sha512 = "e8da8d37f6a86522592084e267bb0ab3a2b26159aae08af59369091aed28b071bd3c1413ed80c3c3be4a41ed91ce3ca38a4aa4a4bddbfe924649aa382027bd32";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/he/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/he/firefox-57.0b11.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "3b572a06423d16f1b925608d5690d88e6870b0644f12b48abe5f084fec8f90bafd573d2e80b4aa06ddc7dfee3104880f98fca843148124fa15e3b524a80875af";
+      sha512 = "6165ba93179ebc019ccaecda1ebe7b68bddacb583ccb417bbc50346ca5fd68f8d882c3723361f8334cf9159567c01adb620ea8dcbf01b7ed03da7d5efedba198";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/hi-IN/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/hi-IN/firefox-57.0b11.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "734d372db67c55f9992b209a7a36438f04f277fd76be4ae0b04c308dcd538274fc92a9971f1a150b7395341fc42b75dd2073fcbe1ad535e5c373d415a4d7c49f";
+      sha512 = "230bf538f7498e9536d3057a6321f41d54b366f1d0debf79360a6ea6fdeeda97895ffd5e4c77c2874c97b5a642e6c5a3d2193270417198a0cb383ea349e01a62";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/hr/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/hr/firefox-57.0b11.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "bea351913f51977add077afcf79dc3595133631ba35c594dbf0bec5811a7483a6e4e25e10b6c24aa176a07e27142a2668e66bb93da4531e0f9d0dcdcb32551e1";
+      sha512 = "617c8e4cd572f896b3c0094e74482e8fee5e0e924cc18f06f16e87f217b712de7665c38069be59f22d1b269951157634e11def128e0c5164a119bd23981ba9bd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/hsb/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/hsb/firefox-57.0b11.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "8afbf4d5d1beba8dcc3a4ba8e4181cb854e863d8026ffd4b4a56686d8b8007c3e6b68fca9e3a93b11970124a10dfb5ae369fe15971ac96f91759b5c37b1cc7d7";
+      sha512 = "da7f1f00ed6b741129dac9a82b5116652e2d0f406d9ea535ece8907e1aea60c9393195882bf59557041c14ebb604456bbdd5514800d7b6a66700558bd256ff6b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/hu/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/hu/firefox-57.0b11.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "e3d08f02d76f701ed6f390998a7a14be1636cbaf30bff79c803708d1b389153acfd392f094e17ef3fa84835b7f73e8de16273ac6dc9950f36b6f5f1ec87ae150";
+      sha512 = "d6b2f966aec0e7c529d86916bebdd06a21850f32a436837c9efc4da5bd18ddbfc937697f758796b8e68ff79281b35186620e29bc93dbc885d6f9b135d028519c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/hy-AM/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/hy-AM/firefox-57.0b11.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "97bf44b70f307d4a513dc51d5227e7a6763ad0d76ed4d835ae29067831ddd91648a3c03dd4837914f32fb2c8d6c3c23ff0f754cdcc51e7ad6f743981e2f4f9f4";
+      sha512 = "cc9df9dab12511549daeb011c50c20c563eff9df7ff3ad0b351fa6362cdc35817f9b5c1c204c1e484a82022d6eb4dbb196c78b43a1429a8bcd92bb22e9c757d0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/id/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/id/firefox-57.0b11.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "3be0b9be46f1cff625281d30b729016095305bc47af511c6ab9964b7770731d37d956cfffacdf6833c8d30e3ee7357bf4231abcfebabe1a5e9d814e2b1ddbb22";
+      sha512 = "1d3027f632f4a7d74adb54da6c15d51af85a6713dbf91c3a01272cee6a4692c4fd130eb66757230ab7e9dd9da7dbeff7c889bb98681fc6cb193b1094d69f31ba";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/is/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/is/firefox-57.0b11.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "e2235cbbfa0ca2c52eda62a9112229dd4e523daea4fdcfc1227cddf69c4f857a433e2cd6f830908ab9fc8660630b873ba4ce269384b89b40bcfb03f024a14873";
+      sha512 = "45ca6f394b47890157680d7d0ee58b8ed75de1623491e38b0d31b79fc2940e7fef00cc2a5e7ab7ee7931261c6575122cd7ace209f94a4574e189b1acc0814755";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/it/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/it/firefox-57.0b11.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "1ba58f0668f2890717d18435f7d8d209d523ed368ca06a85514bdaa0ab4c5f822c0dbe4bd398a55bd14d27a7b88b01e557bf76ce00069772f797a8d3265684e4";
+      sha512 = "38b002021a2f68dcecbaa745944fec1af41b440615a04eb8ecac30923dba0514db70f505670db35d22fef794f682de03d16fb2e03888cb4e045e3d997ecddbf4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/ja/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/ja/firefox-57.0b11.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "723427d8af078aa1be6149d1e495385233f8ac8c6c79a80e2ffd3884dcee5a4f0ccbc0fb81bdef787fabba98d3bf40e12e31f93134237354590a9f58704b0080";
+      sha512 = "201681b0e830834add6bc3dffe883388fb9ca8e1d5995405224057ac3a2dd044f74c800c48c42bb1f77f493bcbc92c0e10a751b3d5871309455efac26e4c4ef0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/ka/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/ka/firefox-57.0b11.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "7a4aafc51948adceb81d7eed2846320bef587d2b1cf004e75cc2a62c31ada7b02f893a371abbeb2e7a21a51ff39e175610487cb16360736ba601cbbd0dabd412";
+      sha512 = "9298bdf3fac725ec59d4d358be141696c4bcb2079e4689da191ef2b52569cffdeee7e6f3454922b784d3ab02a0339eeab4969140457cd4b6e2533c72c740bd71";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/kab/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/kab/firefox-57.0b11.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "af33b16216c12ffecbb4033c94b8a6225a9ad3d0a6061b0aa417aa118a7123167378c196355788aad853fbe84d87aba7f7a5cf9dac06606d5e4ec576a3e45420";
+      sha512 = "65ed8e7902b0a0342f03f95fa0a51fafa5f902b3ba870e3d1fd783b366a0af257a47588981290cd9a0ec369f43aa3e72021122ab9fd8cd46c4eaa69ab726b194";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/kk/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/kk/firefox-57.0b11.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "52b2544a46297a5b6286bbf87a1062155bc843f60ca97cdd5dfe39744caffabca5baf221301bc45666e939d2f8df51f9de3a4230dc5d2ea89f89b8cf1a355d96";
+      sha512 = "fb3dff8ae89e8b59a74474eddc21dfe5f5e69e7f087731f93d775c092895b38f69b39f66a7298a8b3417ab87bc01b144a5fbe6ea3f7385b395c3a82e2e5df026";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/km/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/km/firefox-57.0b11.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "45344b0494274f8f8d17f39e8d5ff6a76143b426e5c7c3ebd2f1ed01c9a4fbb301e16440358d246c8f3c31f7e3a7dc593ee1b6f5bdbe6b453c32ee2b54307b54";
+      sha512 = "3dcd608f361056ae87882d5a28171af8ce24a16184952f0f5abe148cc341e056fa2b9abd583b835026992e60f316952b9d61b9b7920b5e65b50e3b9905517e60";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/kn/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/kn/firefox-57.0b11.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "80fe5cb4c47b6e4fe6fb374492abaa509c6ee53f535c7a4b8c894c4b0e78dd592617ca19826e31b1b6d053dd8a3e91bfcd20e4f13ed0afd8f91ef1499ba609aa";
+      sha512 = "7215efc6c893389fc0137b5bf21a9a7b215fdda0fc556d1f1a1f84169797a4495aff29bb9777978699134aa59653c4e53d57e06ab785c07acb293c37d4cd7962";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/ko/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/ko/firefox-57.0b11.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "5c87c5fba5a2212a7194bca3e4fcdea1a098690ccc89e376389e41a7f78e5fd0218a1366811cd76e5561c76ed9f75165bc5b0cd99ca7645e3d7a3c11eb67c519";
+      sha512 = "144eddbbc7fd3d3cf213cf411ac94707e2fb50cc10e981df169fbedc4c971084fc0e153ffbbc9242184f906bb4d0a412d1447e7b5e5d7136bf10633bf825bbff";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/lij/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/lij/firefox-57.0b11.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "d772ee65fb31f00fd77b7d748a79bd4199711c9853552af47de1d1981a7bc79279240c517e89c830bd8ca1ce7301e285d24d994621ae668f9bf53dd9c8656ea5";
+      sha512 = "7a90a94c35a0e1f00e3e55d34227cfa614469017355285cf053fae404807523b3e1a3146d8710b46de7c1296f9cee08bfe0eb0de9a215895ce3bfa99c06dbba5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/lt/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/lt/firefox-57.0b11.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "f8d3816c6ea946cb96e8dcad1d3c1f0d624a669ef46a48440919ccd9e87c67ac48abf4b7d78119302107eb7ee098a0e344336a4f0a2ffe80d970b238fdf1416b";
+      sha512 = "71d61ebc3961011dfe60e5915176d3c361f9809b1953afdad5eca2a3e9b543958eb7bd64ad3f2d64c788ec2478d32fd3da5a172afa4790b06cec7996c4a2c5b8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/lv/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/lv/firefox-57.0b11.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "0af6cce7117be80b400880d05163d6ac777a6a7d2260c68f51ecfdf30ea8693c0d63c5b69dcc0dec2a3be1767761ad23104aac5bc79ab088c770fb678886790a";
+      sha512 = "66af0c13de2bc1c24c2635106bcc482b53f872e937ed9e6ecfbbad3b6b59a0c12d05f18cfa7136d96ffe3991faad3649a45acb8a8e9d92e8ef6e3f0392d3d151";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/mai/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/mai/firefox-57.0b11.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "a53ac3a64f7b8158858acb52b33d188c695633dd2f06ab92839aaf98adfa3eb79668de07b7bac006fbbd884b76342608d3100a284ee638c161f2307cf241d3d9";
+      sha512 = "fddbd82c7de07c143c4cbb5005a88f595e38c0b6261adb534d8b0fed42233974e09d394a65359155652cf8be5ecf5a47af588f4e8f65ce649efecaca6394be72";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/mk/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/mk/firefox-57.0b11.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "a5732502199793959a3595c080c5f146bac8f445ad11becc841f806c8ea11a37ad8ff9d9fb8815af89f38aadb5e4402cf7473a8be56302d6f99b0468651928f3";
+      sha512 = "10f027a08ce2fee653503dcac38f7d9afd9f888d1f904e63252dd1514dca8c471bf071f4ffaff37a9bad50c59eb833b8e5490a840593db3def2ca362cafc85ff";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/ml/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/ml/firefox-57.0b11.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "fdde429df1c1328f33fe42e5392cb2322350b508deca1467cc14d4f896a32cbc093b43c33e945ddd9199c146ce16676907e2eb458a981618e0871f54124716ff";
+      sha512 = "09f79b235b65c0ecde67f6207459660dad444c28c336e8a6df3cf958fc3eed4bb35f18adcfa61d48298a9c43076577d0edc49963a6b00fc221f69f30f5c69245";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/mr/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/mr/firefox-57.0b11.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "874b37e2d93870bbf3ef47e8f70bb881e5ed1b0516c266535e627197ae6f2013a63b3405b673c695973097197596572736dfa97e6e913308e619e4b899c8c516";
+      sha512 = "86e1c01e504cde26a044fc2a288e3419785e93d46a6cf9deb2c49cb18e87149a486cf9bc06129c83f1387b7d7c62018930fdac77d4fce98da4fe5b5c78d061c0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/ms/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/ms/firefox-57.0b11.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "f510ae946e97f23ae278da12e67aa293741d145680ae084fa0ec00d02945939b354003e8e08f32929603ba9dd9c54109b2fda957e6d8b20af3e04774e0eecd3c";
+      sha512 = "24a7cc19585c510737ccca398f31ac3181df6601f8400187861791a564b13154b825b78427229a9ec97c7441be38f36d4d15510d1b6720b7a29d9e71b7eecf1a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/my/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/my/firefox-57.0b11.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "c107591dbc83704aec6945ce3758c4c3ce809cbb2c4c1a9ad6ce7efce5f2da5fd1226599a083f0008f597bd108e146bebcd1f2fb5be89b078b7bde07c2391e4e";
+      sha512 = "1c3a160af7c960cbd2fe31407acbb93a1e31702460572315dd6c45f6dd6c2efdf419789c638551055e01bd8ed9652a8b4cb76c96b0f509348eeaf7fc548b9b68";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/nb-NO/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/nb-NO/firefox-57.0b11.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "18b0e51c9c7ea25dbfd083acf5e0b5220866c0becdfa968e9ee4bd5a431e90db48b61b7e11f1b8854812bbd1ca1e089445a1790d3888295f3d8e3fbce21f205c";
+      sha512 = "74ed8467b0678c9478c24c15fddcf22b839e0256f5e0f15379d5df8eaea59e928a42637517f6b4ef77b2136bacac8ef1477fc0b97390c20c7c09418ee9ec06b1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/nl/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/nl/firefox-57.0b11.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "1032fe9f7fab5bcd8358eb7862722c2201654a8bf2f30e6b050771a15a5b5db6d183cd8d467107f6e855943f1e85113d3b8ef8c8db38b41b2445e74230ec4d0b";
+      sha512 = "30cb204b285d9f8ee321fada6fd7eb2b490ff8fc1735ed61631e1136648c78a58b06d7e0487543e8f7e99f77d03fba43667a7ca9b9d7e2860b21c1d2f6baaf71";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/nn-NO/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/nn-NO/firefox-57.0b11.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "448c8bce480ea9893b73f92d4151b30e76a3896044121d4f65bae554aec7f945f6498c97bbd458657a2093a16858f7c889da40761e99ed9b3de2edb83bf6bb29";
+      sha512 = "870f52b1388b881a306f13b2ce7483ec1b07e603c5b1e9b5ecdd55263015e3b892d4343b3683e514bf58fd567466ce6d2b7da34a105ca805cb72455a17f0a48d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/or/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/or/firefox-57.0b11.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "530ffadeba0627ed67af234b282c670c52f8dfee77ba6b43f86e97409d67dee0cc1895ddb8b94c076de8280bba1931427064b5a6f3d9e43892e009fa52dd4070";
+      sha512 = "6441180343f8ae93b2544981bbfae7b29abfd47d59a8688e3da4f257da5c8cc95d225762c1633442908a4e3a0ebb29159491ef8cf583433913dbefdb39630273";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/pa-IN/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/pa-IN/firefox-57.0b11.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "bb66b9942c6ec1132b70eb54da3b4d9b918cf44e55e6099571c7df4bfcb670a89c4dd5059cc8402002234bd075643a6d6078a1d8b668a5bac28db3f23e6b388e";
+      sha512 = "e9cc4097cb504ae0de523318afa8a5cd9fa7a1cb3348641cfe0538e039a4dc681d53bdb3976116f171018804c641450f3645af1d0d4502b3358bf4a3beb259d0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/pl/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/pl/firefox-57.0b11.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "146afe4d60e53b7da1f02588f9a6e3b2f6b5d8df81b7a9c857a9d071874dec633b59d7a14dfd2f4a82d9be2eaf1999b4ded98c326add899bbcf825b2c660b9ab";
+      sha512 = "5a5003b3e04cffe5d76a9badf8f0a8c15c2d00b26be6486b871129c9111b4b53e7aa9cb2b83cf88de9c2928e17c09e548b89bc140889da7134f3195a91983f89";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/pt-BR/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/pt-BR/firefox-57.0b11.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "b24382c3a8badbae0d2b1c4814a3247c66031ed8a9044979dc59117b7d2bff99d08cfaa238b6ab470d34a5625723dde668beca6dce7601e7184bc3afc7d07050";
+      sha512 = "9478a60bf2d3e2ec7a67a1e49c786664767ddbcb284775ad08750b0bb39a049183ba8e3feb04ec19d6e6aea6666cf280e2d90a7648c15bda1e05f5bc22f8da82";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/pt-PT/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/pt-PT/firefox-57.0b11.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "bdbb14b3bd0bcee1182454b54f1c6193e282b3317e715dbe0e1c5314789aefaca248615c1061582e0b3b901173250926e0eababeb4a640865f00dbeafb40e9df";
+      sha512 = "b9703a29b083beb649654e526d0438a388fac253b6d0093c366742504652f88d68993f2641cb62e5c90972b9c7dcfa7d6a2e28ea32bb52d5a6ffceea34d650fd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/rm/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/rm/firefox-57.0b11.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "84820d377d569c7bc55060b9c1c17f7a2b37f2ee7b079f76515d2b66cb5bd4860a96f840393a75c01e30a21350ffff22c8c00195c341778188be53c5f0f05828";
+      sha512 = "13ea09d2b80c421852b84ec8a2a7513ac5b9d51c0920ebb282a47087e384d15d8b7e7cb01638b4857fc26ac6ac54509f368f85d7b1ec3cd70f0b3e21fea6ebbd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/ro/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/ro/firefox-57.0b11.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "1b00c3f902993a10f764a258c3317c55fa8fb1461a5d88fca8fc24538dc6ccf9e87026410f196900bf2f4d58b2baa725f3c9257d800040b750eb99b7a080e433";
+      sha512 = "af210682a5380c324b542244cb74f1a0b39b659d93ad166b01026f55995fd281124cd8a2f5b3bceef85f2f5545972a0199ff9460a7f881fb807842596057f17a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/ru/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/ru/firefox-57.0b11.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "24b28fbf5031c87ac9051208e931f712fb1edc22edcaf632e7e42e79fcc93a7e75fd336497eeb3ecc1049b0088f75a28f4671f94308feabdf6cefa01490fd26b";
+      sha512 = "ba01c0e7a5595fb8dc7a3534640dc87c1baf45e70d45a490605d4f81b897f7633d322be060a575dd75cb89a7e319efbfe15461e7b43893c1956de536d4c05288";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/si/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/si/firefox-57.0b11.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "946a782caa0da5897cdb776b8256b7c1bca6084b73e27075046232e2361e2a402decbafff916ce1196bf12d4ddde73dee4c32bf9fc3af28b6294f7079e744e47";
+      sha512 = "42f647309456efa6195cf045c7ba2dae3bcd824884b2a645d6372ea8eb8cd9678076bfd555795acc463bcac550973b317a12500f8fd494ed7ea007c540c2d085";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/sk/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/sk/firefox-57.0b11.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "a61de035d6c3fbd5d2765f66e3cc0b43b55ec570f841fab19ce28949f68121ffa578db01b89c707e62558dd34e4633de03dd5d9050d805a50e2e22ba2d6cbb06";
+      sha512 = "ef08e41d68cd1496efbbdae6575e3c0529440b1b2d80b421aef1dd7abd2b383b31fc5091d6949f52d5b9146505d14033779188154705ed2882c1243e893713f5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/sl/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/sl/firefox-57.0b11.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "edfc9a836efd8b1a168f1950e47f26c5eb22d7c3e7faf8c6411171271cc0c6c1b7efdc107aeb154b03506ee6997c7805a9f40cc3bb7953a42b952e803988a2c5";
+      sha512 = "0e4aa9a51305c5f03e1e2ab953e600d922493e851d18c83927303b78cb178e0e0759e314fe6889fc7216f4af9dd82afc0288ceaeaaccf562ccc949be05525b86";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/son/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/son/firefox-57.0b11.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "e13065f25c6212a9f46cec484c4b532e7c8d7e2985b61f00985a6c03d4f579c057332a889280a07f04a8a73010ac9b07214494913f9dbaf23668d5282f1f37c1";
+      sha512 = "3fcd85bcd3e85bf0114678a86776b8e7fb8bf0828b27f6e321af17f3b79f0235ee7269e36f7d3262c60f92946866084596d5dbf475cd15c459be3b7b014ccea4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/sq/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/sq/firefox-57.0b11.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "fb4820cb33efb10211507ff61caedd569fda0d8c59a49de61bd3c6bc1546865084daa0c477ea1b213c6089eea5508b5e11610df81411b5bbccdd10760ba46daa";
+      sha512 = "a5b6c3c7918839aedbf87e3eda194dff5bf7e0c3f107b3c71763e731448eccd7aa1671ba43df45bbfa5e29e07d243f5309b1e18858c4dd21278093f37f722804";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/sr/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/sr/firefox-57.0b11.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "898ca5ad052760db2f4115c7215107ff77295ff56a33e7b9141a491a6a228be88f9c94cf7dab6938c886137ea3aad6e2e4b01db87122c4c05830bdd6a75fc05d";
+      sha512 = "9cf631abedc27fb87bbc1fd3c65e748ebdc77169d4529d7cf6bc67266cae322635e1c2d7bdbc42b59c572af2105f5f0604b7eed899eedaec9c251ebfbf0c7507";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/sv-SE/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/sv-SE/firefox-57.0b11.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "55c6e54b316f4649e99d305bae059ca844ee48052ce4e89aac75fb850a0f5e255fdc1654fabff7d3fa1de88092f940f3c77f7c142096a76184a0bed668cd254f";
+      sha512 = "71cb182020a6152af64ce709cf391ee70c18669081599101c34b69ef81bd3eca62024938d6c3fa121289a7e5588b2253ec536b35e7d5ed7d94190e247893b1f3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/ta/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/ta/firefox-57.0b11.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "b90c2da5176a07a25521ad510cd77da9171e57608517c89c5a056294fc5237a967355d66979840672bdafe62324405db0da7dd4d6f25ab7b28b37f44f737a5d0";
+      sha512 = "f6298909d8fdd4335d891de594c7f27fe0f181f90c4493c32fdbaa7f8d5ae5190de328b5e8904f99b413b244d14d956d887ab33c19355942d810d56d0700c604";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/te/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/te/firefox-57.0b11.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "86dc71e9df0524ee3219b614154373a473a54f1132ca5c3997125f28cfb3db2710f630a4d614ddfb0765eb58292d33ee328abdbcc8fd8485f79501f68fcb52cd";
+      sha512 = "b24f0feacf4a484e6413ada972b1570a76c78f87dbb829f085dadf3a922d87d31d1a50c092bb45508a67267eedf3caca09d0efe10d9c329d2e46671730a30c5b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/th/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/th/firefox-57.0b11.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "f1a8fdbe928fefb9c7118c3066521cac4dc45819423c687b12576003db9aa318df5a818ed5c56842b3855009974d3fe7a208493614607771813bca29e655be73";
+      sha512 = "d063097273e2f4345baf63d9502b3485bae78664d855e0ae1f33ebcbc18d49f4f5af0537bb141796cdc2c3fa35d90a6937303f4a4f54f6277f88456c3779017b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/tr/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/tr/firefox-57.0b11.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "1611f4fc7e935d7e5fe8fe7ec08e7dfce1fc9cc82814d39077d7c4a32913dbaa6307131833da8665bc8c01b248c437f826e10fdf2db8859ce788f39fd4c20d6a";
+      sha512 = "c44e4b90c37484ee2050f219c5ea1f37d42ca9a3f683d8aed95cf94c412138c795011960af06d1b51ac7a44fb99f373ed28f0dfb9a8f81edc7e2675defdeca80";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/uk/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/uk/firefox-57.0b11.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "271f54090f7e31dc84c4b8298e4db752a12d3eef7b267aac9ec1ed9958baa78cc6178395ff54306b548163acd5428077423ce0cfa5c69449029cb026aa2a8dc5";
+      sha512 = "a1fbc8ed8441138e6e70e925598f1a620218d6102386b67f84b32e87b8203fb229a20ab6ac631018a196451be9db93e1cf303e2a4aea9b9c065545b6aafe9083";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/ur/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/ur/firefox-57.0b11.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "51fa2ee142181727c92fac9044068d28cba20e9c88a1bdac27f2a3b58139ed826a73d7b5a3fff23a0228b964f497e0aec3512a809222fffeec0dce6fa06e4e8d";
+      sha512 = "7500eed932e4f892ab0e96e9e43fb0301616204859eea955c7700b7b804f87bd1cdb8ea490330b989c3e191d3d837a777830d02daacb4486cd38b565d4579282";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/uz/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/uz/firefox-57.0b11.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "324696a348ae491f9b3d51a3880a6dec8e78017ac38b613b8c4d405cc7e4a91dcae4191701be821a693eca4d7726b841a0cd8d9e8163a09a5db754896b6526cc";
+      sha512 = "2de4ced396b54c9a683dfac862eea893800980bc61d21dcc5a5aba727936f8d7c0c72941068a1e088061fc4a78b8437b10e97f4e41478048fbd702db64a1461a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/vi/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/vi/firefox-57.0b11.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "c118e1695938881be2f7c4dfe34273fcd5d8cd6bfa300758de67b220d0f77c8e2d669af8805717dd5ff42ee37e35e3997a37f023361301816243434fe3930a5a";
+      sha512 = "f3fb64b828d8319354630afb4e8239830d471edc4b76e074d8ad30d0802d0d0529abc265183c2b60223fadfedc8189715065d980d15489afa7c297c7ab5c7863";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/xh/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/xh/firefox-57.0b11.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "44ae616c12b08e2a962944af56ad5ff5845dd44f67cbd634451b3ad5bfb254e91b02b4b73b3d131d88ab0ed7240458312187e1744b4409e6b8012a0bbc809eb1";
+      sha512 = "447b17edec8fb04b8460b9ce2b5a00aca48ef162288944746bb9a3fe52c1365a01ac51f13d853c27b5071c7d92db7beb6dc73a12dfcafbf9bd1f65a0d3b41214";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/zh-CN/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/zh-CN/firefox-57.0b11.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "0f39b59fadc0a1ffb5a34dc99db1b6f0c4cb4b3f839a36643d8ca0fa7eaffbb8e638f9f95f5fdcaee09671c6a28f4fdc14e7123aaf8de51dbe3ad2a69cd83a5e";
+      sha512 = "918d2ce4543eefe6c304e51988b1af5e6de3fadbf04585ae45d5344555620619327b858755201f5b300e2e11b7696ccc6d2fff81f965b2f58615426585b128f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b8/linux-i686/zh-TW/firefox-57.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b11/linux-i686/zh-TW/firefox-57.0b11.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "57ebfa7473bed8bac3682f74ef66a1235c9be500c5048ecebaf56bd97513bed69a38c69f098296133f842f1243fb46a845816b56ee637764155eb9e36cb59b3d";
+      sha512 = "a2fff5569721bbe2455b320f057595c2c26986d26654be00a90f4ce269124a6c7328664287e73472df8fc13c44fd5e42614e992904dd86cb6caa3b0d05145ca0";
     }
     ];
 }


### PR DESCRIPTION
###### Motivation for this change
New Firefox beta

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

