### PR TITLE
gpodder: build XDG files

### DIFF
--- a/pkgs/applications/audio/gpodder/default.nix
+++ b/pkgs/applications/audio/gpodder/default.nix
@@ -51,6 +51,13 @@ python2Packages.buildPythonApplication rec {
     feedparser dbus-python mygpoclient pygtk eyeD3 podcastparser html5lib
   ] ++ stdenv.lib.optional ipodSupport libgpod;
 
+  preBuild = ''
+    make PREFIX="$out" \
+      share/applications/gpodder-url-handler.desktop \
+      share/applications/gpodder.desktop \
+      share/dbus-1/services/org.gpodder.service
+  '';
+
   checkPhase = ''
     LC_ALL=C python -m gpodder.unittests
   '';


### PR DESCRIPTION
###### Motivation for this change
Installing desktop files will enable running the app from DE launchers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc maintainers @svenkeidel and @mic92