### PR TITLE
ansible_2_3: 2.3.1.0 -> 2.3.2.0

### DIFF
--- a/pkgs/tools/admin/ansible/2.3.nix
+++ b/pkgs/tools/admin/ansible/2.3.nix
@@ -6,12 +6,12 @@
 
 pythonPackages.buildPythonPackage rec {
   pname = "ansible";
-  version = "2.3.1.0";
+  version = "2.3.2.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "http://releases.ansible.com/ansible/${name}.tar.gz";
-    sha256 = "1xdr82fy8gahxh3586wm5k1bxksys7yl1f2n24shrk8gf99qyjyd";
+    sha256 = "1sv8666vw6fi93jlgkwd4lxkfn75yqczfvk129zlh8ll4wjv8qq5";
   };
 
   prePatch = ''
@@ -30,7 +30,7 @@ pythonPackages.buildPythonPackage rec {
   meta = with stdenv.lib; {
     homepage = http://www.ansible.com;
     description = "A simple automation tool";
-    license = with licenses; [ gpl3] ;
+    license = with licenses; [ gpl3 ] ;
     maintainers = with maintainers; [
       jgeerds
       joamaki


### PR DESCRIPTION
###### Motivation for this change

Bump to the latest upstream release version in the `2.3.x` branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] **N/A** ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

