### PR TITLE
Fix idrisPackages.with-packages

### DIFF
--- a/pkgs/development/idris-modules/with-packages.nix
+++ b/pkgs/development/idris-modules/with-packages.nix
@@ -10,7 +10,7 @@
 
     installIdrisLib () {
       if [ -d $1/lib/${idris.name} ]; then
-        ln -sv $1/lib/${idris.name}/* $out/lib/${idris.name}
+        ln -fsv $1/lib/${idris.name}/* $out/lib/${idris.name}
       fi
     }
 
@@ -34,7 +34,7 @@
   '';
 
   buildPhase = ''
-    gcc -O3 -o idris idris.c
+    $CC -O3 -o idris idris.c
   '';
 
   installPhase = ''


### PR DESCRIPTION
1. The ln step was failing due to a file already existing
2. gcc was invoked directly which caused failure on OS X.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

