### PR TITLE
uvcdynctrl: init at 0.2

### DIFF
--- a/pkgs/os-specific/linux/uvcdynctrl/default.nix
+++ b/pkgs/os-specific/linux/uvcdynctrl/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, libxml2 }:
+
+stdenv.mkDerivation rec {
+  version = "0.3.0";
+  name = "uvcdynctrl-${version}";
+
+  src = fetchFromGitHub {
+    owner = "cshorler";
+    repo = "webcam-tools";
+    rev = "bee2ef3c9e350fd859f08cd0e6745871e5f55cb9";
+    sha256 = "0s15xxgdx8lnka7vi8llbf6b0j4rhbjl6yp0qxaihysf890xj73s";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ libxml2 ];
+
+  prePatch = ''
+    sed -i "s|/etc/udev|$out/etc/udev|g" uvcdynctrl/CMakeLists.txt
+    sed -i "s|/lib/udev|$out/lib/udev|g" uvcdynctrl/CMakeLists.txt
+  '';
+
+  meta = {
+    description = "A simple interface for devices supported by the linux UVC driver";
+    homepage = http://guvcview.sourceforge.net;
+    license = stdenv.lib.licenses.gpl3Plus;
+    maintainers = [ stdenv.lib.maintainers.puffnfresh ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/uvcdynctrl/default.nix
+++ b/pkgs/os-specific/linux/uvcdynctrl/default.nix
@@ -15,15 +15,16 @@ stdenv.mkDerivation rec {
   buildInputs = [ libxml2 ];
 
   prePatch = ''
-    sed -i "s|/etc/udev|$out/etc/udev|g" uvcdynctrl/CMakeLists.txt
-    sed -i "s|/lib/udev|$out/lib/udev|g" uvcdynctrl/CMakeLists.txt
+    substituteInPlace uvcdynctrl/CMakeLists.txt \
+      --replace "/etc/udev" "$out/etc/udev" \
+      --replace "/lib/udev" "$out/lib/udev"
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A simple interface for devices supported by the linux UVC driver";
     homepage = http://guvcview.sourceforge.net;
-    license = stdenv.lib.licenses.gpl3Plus;
-    maintainers = [ stdenv.lib.maintainers.puffnfresh ];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.puffnfresh ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17003,6 +17003,8 @@ with pkgs;
       else null;
   };
 
+  uvcdynctrl = callPackage ../os-specific/linux/uvcdynctrl { };
+
   vkeybd = callPackage ../applications/audio/vkeybd {};
 
   vlc = callPackage ../applications/video/vlc {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

