### PR TITLE
luajit: do not override INSTALL_INC

### DIFF
--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -26,7 +26,7 @@ rec {
     homepage    = http://luajit.org;
     license     = licenses.mit;
     platforms   = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers ; [ thoughtpolice smironov vcunat ];
+    maintainers = with maintainers ; [ thoughtpolice smironov vcunat andir ];
   };
 
   generic =
@@ -61,7 +61,10 @@ rec {
       enableParallelBuilding = true;
 
       installPhase   = ''
-        make install INSTALL_INC="$out"/include PREFIX="$out"
+        make install PREFIX="$out"
+        for file in "$out"/include/luajit-*/*.h; do
+          ln -s $file  "$out"/include/.
+        done
         ln -s "$out"/bin/luajit-* "$out"/bin/lua
       ''
         + stdenv.lib.optionalString (!isStable)


### PR DESCRIPTION
Overriding INSTALL_INC caused luajit to be installed directly into the
`include/` directory instead of `include/luajit-${version}` as normally
expected. Previously the path indicated in the pkg-config file also did
not match the actual header file location.

Since `luajit` is expected to work as a drop-in replacement for standard lua the include files in `include/` are retained via symlinks to the sub-directory.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  **This changes tries to recompile everything that could possible be bundled with `luajit`. Many of those packages already failed before this change so I am not able to guarantee that everything does still compile/execute.**
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

