### PR TITLE
jsawk: init at 1.5-pre

### DIFF
--- a/pkgs/tools/text/jsawk/default.nix
+++ b/pkgs/tools/text/jsawk/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, makeWrapper, spidermonkey }:
+
+stdenv.mkDerivation rec {
+  name = "jsawk-${version}";
+  version = "1.5-pre";
+  src = fetchFromGitHub {
+    owner = "micha";
+    repo = "jsawk";
+    rev = "5a14c4af3c7b59807701b70a954ecefc6f77e978";
+    sha256 = "0z3vdr3c8nvdrrxkjv9b4xg47mdb2hsknxpimw6shgwbigihapyr";
+  };
+  dontBuild = true;
+  buildInputs = [ makeWrapper ];
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/jsawk $out/bin/
+    wrapProgram $out/bin/jsawk \
+      --prefix PATH : "${spidermonkey}/bin"
+  '';
+
+  meta = {
+    description = "Jsawk is like awk, but for JSON";
+    homepage = https://github.com/micha/jsawk;
+    license = stdenv.lib.licenses.publicDomain;
+    maintainers = with stdenv.lib.maintainers; [ puffnfresh ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2814,6 +2814,8 @@ with pkgs;
 
   jrnl = callPackage ../applications/misc/jrnl { };
 
+  jsawk = callPackage ../tools/text/jsawk { };
+
   jscoverage = callPackage ../development/tools/misc/jscoverage { };
 
   jsduck = callPackage ../development/tools/jsduck { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

