### PR TITLE
sbt-extras: init at 77686b3

### DIFF
--- a/pkgs/development/tools/build-managers/sbt-extras/default.nix
+++ b/pkgs/development/tools/build-managers/sbt-extras/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub }:
+
+let
+  rev = "77686b3dfa20a34270cc52377c8e37c3a461e484";
+  version = stdenv.lib.strings.substring 0 7 rev;
+in
+stdenv.mkDerivation {
+  name = "sbt-extras-${version}";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "paulp";
+    repo = "sbt-extras";
+    inherit rev;
+    sha256 = "1bhqigm0clv3i1gvn4gsllywcnwfsa73xvqp8m7pbvn8g7i2ws6x";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install bin/sbt $out/bin
+  '';
+
+  meta = {
+    description = "A more featureful runner for sbt, the simple/scala/standard build tool";
+    homepage = https://github.com/paulp/sbt-extras;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ puffnfresh ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7546,6 +7546,8 @@ with pkgs;
   sbt-with-scala-native = callPackage ../development/tools/build-managers/sbt/scala-native.nix { };
   simpleBuildTool = sbt;
 
+  sbt-extras = callPackage ../development/tools/build-managers/sbt-extras { };
+
   shallot = callPackage ../tools/misc/shallot { };
 
   shards = callPackage ../development/tools/build-managers/shards { };


### PR DESCRIPTION
Fixes #21783

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

