### PR TITLE
mpg321: add pkg option to set libao default audio driver

### DIFF
--- a/pkgs/applications/audio/mpg321/default.nix
+++ b/pkgs/applications/audio/mpg321/default.nix
@@ -1,4 +1,8 @@
-{stdenv, fetchurl, libao, libmad, libid3tag, zlib, alsaLib}:
+{stdenv, fetchurl, libao, libmad, libid3tag, zlib, alsaLib
+# Specify default libao output plugin to use (e.g. "alsa", "pulse" …).
+# If null, it will use the libao system default.
+, defaultAudio ? null
+}:
 
 stdenv.mkDerivation rec {
   name = "mpg321-${version}";
@@ -11,9 +15,10 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  configureFlags = [
-    ("--enable-alsa=" + (if stdenv.isLinux then "yes" else "no"))
-  ];
+  configureFlags =
+    [ ("--enable-alsa=" + (if stdenv.isLinux then "yes" else "no")) ]
+    ++ (stdenv.lib.optional (defaultAudio != null)
+         "--with-default-audio=${defaultAudio}");
 
   buildInputs = [libao libid3tag libmad zlib]
     ++ stdenv.lib.optional stdenv.isLinux alsaLib;


### PR DESCRIPTION
Tested manually with "alsa" and "pulse" drivers.

- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)

