### PR TITLE
gradio: init at 6.0.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -550,6 +550,7 @@
   ryneeverett = "Ryne Everett <ryneeverett@gmail.com>";
   rzetterberg = "Richard Zetterberg <richard.zetterberg@gmail.com>";
   s1lvester = "Markus Silvester <s1lvester@bockhacker.me>";
+  samdroid-apps = "Sam Parkinson <sam@sam.today>";
   samuelrivas = "Samuel Rivas <samuelrivas@gmail.com>";
   sander = "Sander van der Burg <s.vanderburg@tudelft.nl>";
   sargon = "Daniel Ehlers <danielehlers@mindeye.net>";

--- a/pkgs/applications/audio/gradio/0001-Remove-post-install-script-that-hardcodes-paths.patch
+++ b/pkgs/applications/audio/gradio/0001-Remove-post-install-script-that-hardcodes-paths.patch
@@ -1,0 +1,23 @@
+From 184c64718ee68b2738647f4a106b260c47f00437 Mon Sep 17 00:00:00 2001
+From: Sam Parkinson <sam@sam.today>
+Date: Thu, 26 Oct 2017 14:50:13 +1100
+Subject: [PATCH] Remove post-install script that hardcodes paths
+
+---
+ meson.build | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 25f3e1a..18b43bd 100644
+--- a/meson.build
++++ b/meson.build
+@@ -21,4 +21,5 @@ subdir('src')
+ # subdir('tests')
+ # TODO: unit tests
+ 
+-meson.add_install_script('meson_post_install.sh')
++# This does not work for nixos; it hard-codes paths
++# meson.add_install_script('meson_post_install.sh')
+-- 
+2.14.2
+

--- a/pkgs/applications/audio/gradio/default.nix
+++ b/pkgs/applications/audio/gradio/default.nix
@@ -1,0 +1,72 @@
+{ stdenv, fetchFromGitHub, pkgconfig
+, gcc
+, python3
+, gsettings_desktop_schemas
+, desktop_file_utils
+, glib
+, gtk3
+, intltool
+, libsoup
+, json_glib
+, wrapGAppsHook
+, meson
+, ninja
+, vala
+, sqlite
+, gst_all_1
+, gst_plugins ? with gst_all_1; [ gst-plugins-good gst-plugins-ugly ]
+}:
+let
+  version = "6.0.2";
+
+in stdenv.mkDerivation rec {
+  name = "gradio-${version}";
+
+  src = fetchFromGitHub {
+    owner = "haecker-felix";
+    repo = "gradio";
+    rev = "v${version}";
+    sha256 = "05hg26yr7splgpkl8wjxcsdks9sm1is3hcnp7f5mjnp2ch0nn57s";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+
+    meson
+    ninja
+    vala
+
+    python3
+  ];
+  buildInputs = [
+    sqlite
+
+    glib
+    intltool
+    libsoup
+    json_glib
+
+    gtk3
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+
+    wrapGAppsHook
+    desktop_file_utils
+    gsettings_desktop_schemas
+  ] ++ gst_plugins;
+
+  enableParallelBuilding = true;
+  postInstall = ''
+    ${glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
+  '';
+
+  patches = [ ./0001-Remove-post-install-script-that-hardcodes-paths.patch ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/haecker-felix/gradio;
+    description = "A GTK3 app for finding and listening to internet radio stations";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.samdroid-apps ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14617,6 +14617,8 @@ with pkgs;
 
   rhythmbox = callPackage ../applications/audio/rhythmbox { };
 
+  gradio = callPackage ../applications/audio/gradio { };
+
   puddletag = callPackage ../applications/audio/puddletag { };
 
   w_scan = callPackage ../applications/video/w_scan { };


### PR DESCRIPTION
###### Motivation for this change

[Gradio is a very nicely made app for listening to internet radio](https://github.com/haecker-felix/gradio).  This commit makes it easier to install on NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS  (N/A)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

