### PR TITLE
usync: init at 0.0.3

### DIFF
--- a/pkgs/applications/misc/usync/default.nix
+++ b/pkgs/applications/misc/usync/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, scsh, rsync, unison }:
+
+stdenv.mkDerivation rec {
+  pname = "usync";
+  version = "0.0.3";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ebzzry";
+    repo = pname;
+    rev = "9c87ea8a707a47c3d7f6ef94d07591c5ab594282";
+    sha256 = "1r05gw041fz9dkkb70zd6kqw9dd8dhpv87407qxqg43pd7x47kf4";
+  };
+
+  installPhase = ''
+    install -m 555 -Dt $out/bin $pname
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/bin/$pname --replace "/usr/bin/env scsh" "${scsh}/bin/scsh"
+    substituteInPlace $out/bin/$pname --replace "(rsync " "(${rsync}/bin/rsync "
+    substituteInPlace $out/bin/$pname --replace "(unison " "(${unison}/bin/unison "
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/ebzzry/usync;
+    description = "A simple site-to-site synchronization tool";
+    license = licenses.mit;
+    maintainers = [ maintainers.ebzzry ];
+    platforms = platforms.unix;
+  };
+
+  dontBuild = true;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4808,6 +4808,8 @@ with pkgs;
 
   usbmuxd = callPackage ../tools/misc/usbmuxd {};
 
+  usync = callPackage ../applications/misc/usync { };
+
   uwsgi = callPackage ../servers/uwsgi {
     plugins = [];
     withPAM = stdenv.isLinux;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

