### PR TITLE
security.sudo: introduce `package` option

### DIFF
--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -54,6 +54,19 @@ in
         Extra configuration text appended to <filename>sudoers</filename>.
       '';
     };
+
+    security.sudo.package = mkOption {
+      type = types.package;
+      default = sudo;
+      example = literalExample ''
+        sudo.override {
+          withInsults = true;
+        }
+      '';
+      description = ''
+        The package which contains the `sudo` binary.
+      '';
+    };
   };
 
 
@@ -78,11 +91,11 @@ in
       '';
 
     security.wrappers = {
-      sudo.source = "${pkgs.sudo.out}/bin/sudo";
-      sudoedit.source = "${pkgs.sudo.out}/bin/sudoedit";
+      sudo.source = "${cfg.package.out}/bin/sudo";
+      sudoedit.source = "${cfg.package.out}/bin/sudoedit";
     };
 
-    environment.systemPackages = [ sudo ];
+    environment.systemPackages = [ cfg.package ];
 
     security.pam.services.sudo = { sshAgentAuth = true; };
 
@@ -92,7 +105,7 @@ in
           { src = pkgs.writeText "sudoers-in" cfg.configFile; }
           # Make sure that the sudoers file is syntactically valid.
           # (currently disabled - NIXOS-66)
-          "${pkgs.sudo}/sbin/visudo -f $src -c && cp $src $out";
+          "${cfg.package}/sbin/visudo -f $src -c && cp $src $out";
         target = "sudoers";
         mode = "0440";
       };


### PR DESCRIPTION
###### Motivation for this change

This makes it way easier to override the sudo package when using the `security.sudo` module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

