### PR TITLE
nullmailer: 2.0 -> 2.1

### DIFF
--- a/pkgs/servers/mail/nullmailer/default.nix
+++ b/pkgs/servers/mail/nullmailer/default.nix
@@ -4,12 +4,12 @@ assert tls -> gnutls != null;
 
 stdenv.mkDerivation rec {
 
-  version = "2.0";
+  version = "2.1";
   name = "nullmailer-${version}";
 
   src = fetchurl {
     url = "http://untroubled.org/nullmailer/nullmailer-${version}.tar.gz";
-    sha256 = "112ghdln8q9yljc8kp9mc3843mh0fyb4rig2v4q2dzy1l324q3yp";
+    sha256 = "0gykh0qc86rk0knfvp8ndqkryal3pvqdfdya94wvb6n1cc8p3ild";
   };
 
   buildInputs = stdenv.lib.optional tls gnutls;


### PR DESCRIPTION
###### Motivation for this change

Version update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

