### PR TITLE
ncmpcpp: 0.8 -> 0.8.1

### DIFF
--- a/pkgs/applications/audio/ncmpcpp/default.nix
+++ b/pkgs/applications/audio/ncmpcpp/default.nix
@@ -12,11 +12,11 @@ assert taglibSupport -> (taglib != null);
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "ncmpcpp-${version}";
-  version = "0.8";
+  version = "0.8.1";
 
   src = fetchurl {
-    url = "http://ncmpcpp.rybczak.net/stable/${name}.tar.bz2";
-    sha256 = "0nj6ky805a55acj0w57sbn3vfmmkbqp97rhbi0q9848n10f2l3rg";
+    url = "https://ncmpcpp.rybczak.net/stable/${name}.tar.bz2";
+    sha256 = "1zw8d07b2bkssbsybg6jnmpq001w525viajrnz4jvfml3l55gyad";
   };
 
   configureFlags = [ "BOOST_LIB_SUFFIX=" ]
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A featureful ncurses based MPD client inspired by ncmpc";
-    homepage    = http://ncmpcpp.rybczak.net/;
+    homepage    = https://ncmpcpp.rybczak.net/;
     license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ jfrankenau koral lovek323 mornfall ];
     platforms   = platforms.all;


### PR DESCRIPTION
###### Motivation for this change

Update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

