### PR TITLE
Go: 1.9.1 -> 1.9.2 && Go: 1.8.4 -> 1.8.5

### DIFF
--- a/pkgs/development/compilers/go/1.8.nix
+++ b/pkgs/development/compilers/go/1.8.nix
@@ -25,13 +25,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";
-  version = "1.8.4";
+  version = "1.8.5";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "go";
     rev = "go${version}";
-    sha256 = "0p0m63y39pja3fkj43sdq0qv8kqljkz7d58bf9jbw0rjw2c9ml4a";
+    sha256 = "1ab021l3v29ciaxp738cjpbkh1chlsl6928672q3i82anmdzn5m5";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.9.nix
+++ b/pkgs/development/compilers/go/1.9.nix
@@ -25,13 +25,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";
-  version = "1.9.1";
+  version = "1.9.2";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "go";
     rev = "go${version}";
-    sha256 = "1p226lgsmiwgcvmiakac9i08304cq5ick23vmsk1vjcsh6dvz9i3";
+    sha256 = "07p4ld07r2nml2bsbfb8h51hqilbqyhhdlia99y1gk7ibvhybv8i";
   };
 
   # perl is used for testing go vet
@@ -122,10 +122,6 @@ stdenv.mkDerivation rec {
       (fetchpatch {
         url = "https://github.com/golang/go/commit/29415eb2b92e78481897c4161ba99f5b09fa6102.patch";
         sha256 = "01jkm4b2dazzjnfla7rdd0w2clzplga3zza6ybpmkjkk3i4bp73d";
-      })
-      (fetchpatch {
-        url = "https://github.com/golang/go/commit/27e80f7c4d8001598367e15a1617fa524bd0fb11.patch";
-        sha256 = "1250nrc79jwcagkjqffn5srn78isykvjhvmqhwipwyqb99q85wcz";
       })
     ];
 


### PR DESCRIPTION
###### Motivation for this change
Golang bugfix releases

Needs backport to 17.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

