### PR TITLE
Packaging cope

### DIFF
--- a/pkgs/applications/misc/cope/default.nix
+++ b/pkgs/applications/misc/cope/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, buildPerlPackage, perlPackages }:
+
+buildPerlPackage rec {
+    name = "cope";
+    src = fetchFromGitHub {
+      repo = "cope";
+      owner = "lotrfan";
+      rev = "0dc82a939a9498ff80caf472841c279dfe03efae";
+      sha256 = "11haq6lrjxais7jb788296yrzkg3hshqr7bvs80sb7cqrvlgcjsf";
+      # owner = "nichivo";
+      # rev = "4f458b7c39b6eb819e078871d75703fae4a19056";
+      # sha256 = "1273qf4pd0qf77f26n9paiwf3jvbpl5cswybhn8066gnwwfq5yqh";
+    };
+
+    meta = with stdenv.lib; {
+      description = "A colourful wrapper for terminal programs.";
+      # license = licenses.mit;
+      # maintainers = [ maintainers.afldcr ];
+      platforms = platforms.unix;
+    };
+
+    propagatedBuildInputs = with perlPackages; [EnvPath FileShareDir IOTty IOStty ListMoreUtils RegexpCommon RegexpIPv6];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19017,6 +19017,8 @@ with pkgs;
 
   colort = callPackage ../applications/misc/colort { };
 
+  cope = callPackage ../applications/misc/cope { };
+
   terminal-parrot = callPackage ../applications/misc/terminal-parrot { };
 
   e17gtk = callPackage ../misc/themes/e17gtk { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -7308,6 +7308,24 @@ let self = _self // overrides; _self = with self; {
   };
 
 
+  IOStty = buildPerlPackage rec {
+    name = "IO-Stty-0.03";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/T/TO/TODDR/${name}.tar.gz";
+      sha256 = "0llih2ywi693k5jqn855xflxanjmnssh1x31jwxd52ayp26m4ab9";
+    };
+    preConfigure = ''
+      touch Makefile.PL
+    '';
+    propagatedBuildInputs = [ ModuleBuild ];
+
+    buildPhase = "perl Build.PL --install_base=$out; ./Build build";
+    installPhase = "./Build install";
+
+    doCheck = false; /* there are no tests */
+    # installTargets = "install";
+  };
+
   IPCRun = buildPerlPackage {
     name = "IPC-Run-0.92";
     src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
I'm trying to package [cope](https://github.com/lotrfan/cope), a colourful wrapper for terminal programs. (This is my first time packaging something)

I added the IOStty perl dependency, but it is not found in the tests. What am I doing wrong?

```
building path(s) ‘/nix/store/858bnxnzn1dq76bkg5m0kc9ipqn5klwg-perl-cope-devdoc’, ‘/nix/store/yii3zklcrlwkcjppmiy8zziyxn5i27na-perl-cope’
unpacking sources
unpacking source archive /nix/store/mql2nsdzbq71y6429vrz5vy6sr8biiql-cope-0dc82a939a9498ff80caf472841c279dfe03efae-src
source root is cope-0dc82a939a9498ff80caf472841c279dfe03efae-src
patching sources
configuring
patching ./t/20-scripts.t...
patching ./t/12-buffering.t...
patching ./t/11-cope.t...
patching ./t/10-get.t...
patching ./t/00-load.t...
patching ./scripts/xrandr...
patching ./scripts/who...
...
patching ./install.sh...
patching ./depends.sh...
patching ./cope_path.pl...
patching ./config.sh...
patching ./build.sh...
*** Module::AutoInstall version 1.03
*** Checking for Perl dependencies...
[Core Features]
- Test::More          ...loaded. (1.001014)
- ExtUtils::MakeMaker ...loaded. (7.1002 >= 6.11)
- Env::Path           ...loaded. (0.19)
- File::ShareDir      ...loaded. (1.03)
- IO::Handle          ...loaded. (1.36)
- IO::Pty             ...loaded. (1.12)
- IO::Stty            ...missing.
- List::MoreUtils     ...loaded. (0.413)
- Regexp::Common      ...loaded. (2013031301)
- Term::ANSIColor     ...loaded. (4.04)
- Regexp::IPv6        ...loaded. (0.03)
*** Module::AutoInstall configuration finished.
Warning: prerequisite IO::Stty 0 not found.
Generating a Unix-style Makefile
Writing Makefile for Cope
Writing MYMETA.yml and MYMETA.json
no configure script, doing nothing
building
build flags: SHELL=/nix/store/h404wfcz8rzzlq8vr4z7plcijwzfci72-bash-4.4-p12/bin/bash
Installing blib/lib/auto/share/dist/Cope/acpi
Installing blib/lib/auto/share/dist/Cope/aptitude
...
Installing blib/lib/auto/share/dist/Cope/wget
Installing blib/lib/auto/share/dist/Cope/who
Installing blib/lib/auto/share/dist/Cope/xrandr
cp lib/App/Cope/Manual.pod blib/lib/App/Cope/Manual.pod
cp lib/App/Cope/Pty.pm blib/lib/App/Cope/Pty.pm
cp lib/App/Cope.pm blib/lib/App/Cope.pm
cp lib/App/Cope/Extra.pm blib/lib/App/Cope/Extra.pm
cp cope_path.pl blib/lib/cope_path.pl
Manifying 4 pod documents
running tests
check flags: SHELL=/nix/store/h404wfcz8rzzlq8vr4z7plcijwzfci72-bash-4.4-p12/bin/bash VERBOSE=y test
PERL_DL_NONLAZY=1 "/nix/store/raylbbdkg4yz21c44fwcv63bzvj7a1i1-perl-5.24.2/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'inc', 'blib/lib', 'blib/arch')" t/00-load.t t/10-get.t t/11-cope.t t/12-buffering.t t/20-scripts.t
# Testing App::Cope 0.99, Perl 5.024002, /nix/store/raylbbdkg4yz21c44fwcv63bzvj7a1i1-perl-5.24.2/bin/perl
t/00-load.t ....... ok
t/10-get.t ........ ok
t/11-cope.t ....... ok
Undefined subroutine &IO::Stty::stty called at /tmp/nix-build-perl-cope.drv-0/cope-0dc82a939a9498ff80caf472841c279dfe03efae-src/blib/lib/App/Cope/Pty.pm line 76.

#   Failed test at t/12-buffering.t line 48.
#          got: ''
#     expected: 'Opening--Closing
# '
Undefined subroutine &IO::Stty::stty called at /tmp/nix-build-perl-cope.drv-0/cope-0dc82a939a9498ff80caf472841c279dfe03efae-src/blib/lib/App/Cope/Pty.pm line 76.

#   Failed test at t/12-buffering.t line 48.
#          got: ''
#     expected: 'Opening--Closing
# '
# Looks like you failed 2 tests of 2.
t/12-buffering.t .. 
Dubious, test returned 2 (wstat 512, 0x200)
Failed 2/2 subtests 
t/20-scripts.t .... ok

Test Summary Report
-------------------
t/12-buffering.t (Wstat: 512 Tests: 2 Failed: 2)
  Failed tests:  1-2
  Non-zero exit status: 2
Files=5, Tests=89,  3 wallclock secs ( 0.05 usr  0.00 sys +  2.36 cusr  0.58 csys =  2.99 CPU)
Result: FAIL
Failed 1/5 test programs. 2/89 subtests failed.
make: *** [Makefile:796: test_dynamic] Error 255
builder for ‘/nix/store/r8343sddlnpi0ymgw7k6vfkiwl0pi4z6-perl-cope.drv’ failed with exit code 2
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

