### PR TITLE
mysql: package updates

### DIFF
--- a/pkgs/servers/sql/mysql/5.5.x.nix
+++ b/pkgs/servers/sql/mysql/5.5.x.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "mysql-${version}";
-  version = "5.5.57";
+  version = "5.5.58";
 
   src = fetchurl {
     url = "mirror://mysql/MySQL-5.5/${name}.tar.gz";
-    sha256 = "113kynpfj45fffr62xack2657pds8mkhsgg77zj94ksj3qrbvhn1";
+    sha256 = "1f890376ld1qapl038sjh2ialdizys3sj96vfn4mqmb1ybx14scv";
   };
 
   patches = if stdenv.isCygwin then [

--- a/pkgs/servers/sql/mysql/5.7.x.nix
+++ b/pkgs/servers/sql/mysql/5.7.x.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "mysql-${version}";
-  version = "5.7.19";
+  version = "5.7.20";
 
   src = fetchurl {
     url = "mirror://mysql/MySQL-5.7/${name}.tar.gz";
-    sha256 = "1c8y54yk756179nx4dgg79dijmjdq5n8l057cnqsg70pjdpyfl9y";
+    sha256 = "11v4g3igigv3zvknv67qml8in6fjrbs2vnr3q6bg6f62nydm95sk";
   };
 
   preConfigure = stdenv.lib.optional stdenv.isDarwin ''


### PR DESCRIPTION
###### Motivation for this change

New upstream releases are available.

- [5.5 changelog](https://dev.mysql.com/doc/relnotes/mysql/5.5/en/news-5-5-58.html)
- [5.7 changelog](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-20.html)
- [summary of security fixes](http://www.oracle.com/technetwork/security-advisory/cpuoct2017-3236626.html#AppendixMSQL)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

