### PR TITLE
xorg.bitmap: init at 1.0.8

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -67,6 +67,18 @@ let
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit ;};
 
+  bitmap = (mkDerivation "bitmap" {
+    name = "bitmap-1.0.8";
+    builder = ./builder.sh;
+    src = fetchurl {
+      url = mirror://xorg/individual/app/bitmap-1.0.8.tar.gz;
+      sha256 = "1z06a1sn3iq72rmh73f11xgb7n46bdav1fvpgczxjp6al88bsbqs";
+    };
+    nativeBuildInputs = [ pkgconfig ];
+    buildInputs = [ libX11 libXaw xbitmaps libXmu xproto libXt ];
+    meta.platforms = stdenv.lib.platforms.unix;
+  }) // {inherit libX11 libXaw xbitmaps libXmu xproto libXt ;};
+
   compositeproto = (mkDerivation "compositeproto" {
     name = "compositeproto-0.4.2";
     builder = ./builder.sh;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -24,6 +24,21 @@ let
   compose = f: g: x: f (g x);
 in
 {
+  bitmap = attrs: attrs // {
+    nativeBuildInputs = attrs.nativeBuildInputs ++ [ makeWrapper ];
+    postInstall = ''
+      paths=(
+        "$out/share/X11/%T/%N"
+        "$out/include/X11/%T/%N"
+        "${xorg.xbitmaps}/include/X11/%T/%N"
+      )
+      wrapProgram "$out/bin/bitmap" \
+        --suffix XFILESEARCHPATH : $(IFS=:; echo "''${paths[*]}")
+      makeWrapper "$out/bin/bitmap" "$out/bin/bitmap-color" \
+        --suffix XFILESEARCHPATH : "$out/share/X11/%T/%N-color"
+    '';
+  };
+
   encodings = attrs: attrs // {
     buildInputs = attrs.buildInputs ++ [ xorg.mkfontscale ];
   };

--- a/pkgs/servers/x11/xorg/tarballs-7.7.list
+++ b/pkgs/servers/x11/xorg/tarballs-7.7.list
@@ -1,6 +1,7 @@
 mirror://xorg/X11R7.7/src/everything/applewmproto-1.4.2.tar.bz2
 mirror://xorg/individual/app/bdftopcf-1.0.5.tar.bz2
 mirror://xorg/X11R7.7/src/everything/bigreqsproto-1.1.2.tar.bz2
+mirror://xorg/individual/app/bitmap-1.0.8.tar.gz
 mirror://xorg/X11R7.7/src/everything/compositeproto-0.4.2.tar.bz2
 mirror://xorg/X11R7.7/src/everything/damageproto-1.2.1.tar.bz2
 mirror://xorg/X11R7.7/src/everything/dmxproto-2.3.1.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
I wanted to make old-school desktop backgrounds

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s)
- [x] Tested compilation of all pkgs that depend on this change (none)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Issues

The application is working but the layout seems broken. I'm not sure how it's supposed to look but the buttons are missing labels/icons and clicking on the save buttons yields 

    Warning: MenuButton:  Could not find menu widget named menu.

Is it missing some dependency?