### PR TITLE
Treewide: abandon Google Code homepages

### DIFF
--- a/pkgs/applications/misc/quicksynergy/default.nix
+++ b/pkgs/applications/misc/quicksynergy/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
       Remember to open port 24800 (used by synergys program) if you want to
       host mouse and keyboard.";
-    homepage = https://code.google.com/p/quicksynergy/;
+    homepage = https://sourceforge.net/projects/quicksynergy/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.spinus ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/networking/browsers/arora/default.nix
+++ b/pkgs/applications/networking/browsers/arora/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.11.0";
 
   src = fetchurl {
-    url = "http://arora.googlecode.com/files/${name}.tar.gz";
+    url = "https://github.com/Arora/arora/archive/${version}.tar.gz";
     sha256 = "1ffkranxi93lrg5r7a90pix9j8xqmf0z1mb1m8579v9m34cyypvg";
   };
 
@@ -16,6 +16,6 @@ stdenv.mkDerivation rec {
     platforms = qt4.meta.platforms;
     maintainers = [ maintainers.phreedom ];
     description = "A cross-platform Qt4 Webkit browser";
-    homepage = http://arora.googlecode.com;
+    homepage = https://github.com/Arora/arora;
   };
 }

--- a/pkgs/applications/version-management/gource/default.nix
+++ b/pkgs/applications/version-management/gource/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
                        "-std=c++11"; # fix build with glm >= 0.9.6.0
 
   meta = with stdenv.lib; {
-    homepage = http://code.google.com/p/gource/;
+    homepage = http://gource.io/;
     description = "A Software version control visualization tool";
     license = licenses.gpl3Plus;
     longDescription = ''

--- a/pkgs/applications/window-managers/wmii-hg/default.nix
+++ b/pkgs/applications/window-managers/wmii-hg/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   makeFlags = "WMII_HGVERSION=hg${rev}";
 
   meta = {
-    homepage = https://code.google.com/archive/p/wmii/;
+    homepage = https://suckless.org/; # https://wmii.suckless.org/ does not exist anymore
     description = "A small window manager controlled by a 9P filesystem";
     maintainers = with stdenv.lib.maintainers; [ kovirobi ];
     license = stdenv.lib.licenses.mit;

--- a/pkgs/development/compilers/gwt/2.4.0.nix
+++ b/pkgs/development/compilers/gwt/2.4.0.nix
@@ -4,8 +4,8 @@ stdenv.mkDerivation {
   name = "gwt-java-2.4.0";
 
   src = fetchurl {
-    url=http://google-web-toolkit.googlecode.com/files/gwt-2.4.0.zip;
-    sha1 = "a91ac20db0ddd5994ac3cbfb0e8061d5bbf66f88";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/google-web-toolkit/gwt-2.4.0.zip";
+    sha256 = "1gvyg00vx7fdqgfl2w7nhql78clg3abs6fxxy7m03pprdm5qmm17";
   };
 
   buildInputs = [ unzip ];
@@ -17,8 +17,9 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = http://code.google.com/webtoolkit/;
+    homepage = http://www.gwtproject.org/;
     description = "A development toolkit for building and optimizing complex browser-based applications";
+    license = stdenv.lib.licenses.asl20;
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/compilers/teyjus/default.nix
+++ b/pkgs/development/compilers/teyjus/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "teyjus-2.0b2";
 
   src = fetchurl {
-    url = "https://teyjus.googlecode.com/files/teyjus-source-2.0-b2.tar.gz";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/teyjus/teyjus-source-2.0-b2.tar.gz";
     sha256 = "f589fb460d7095a6e674b7a6413772c41b98654c38602c3e8c477a976da99052";
   };
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "An efficient implementation of the Lambda Prolog language";
-    homepage = https://code.google.com/p/teyjus/;
+    homepage = https://github.com/teyjus/teyjus;
     license = stdenv.lib.licenses.gpl3;
     maintainers = [ maintainers.bcdarwin ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/bullet/default.nix
+++ b/pkgs/development/libraries/bullet/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
       Bullet 3D Game Multiphysics Library provides state of the art collision
       detection, soft body and rigid body dynamics.
     '';
-    homepage = http://code.google.com/p/bullet/;
+    homepage = http://bulletphysics.org;
     license = stdenv.lib.licenses.zlib;
     maintainers = with stdenv.lib.maintainers; [ aforemny ];
     platforms = with stdenv.lib.platforms; unix;

--- a/pkgs/development/libraries/garmintools/default.nix
+++ b/pkgs/development/libraries/garmintools/default.nix
@@ -2,12 +2,12 @@
 stdenv.mkDerivation {
   name = "garmintools-0.10";
   src = fetchurl {
-    url = https://garmintools.googlecode.com/files/garmintools-0.10.tar.gz;
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/garmintools/garmintools-0.10.tar.gz";
     sha256 = "1vjc8h0z4kx2h52yc3chxn3wh1krn234fg12sggbia9zjrzhpmgz";
   };
   buildInputs = [ libusb ];
   meta = {
-    homepage = https://code.google.com/p/garmintools;
+    homepage = https://code.google.com/archive/p/garmintools/; # community clone at https://github.com/ianmartin/garmintools
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.ocharles ];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/glog/default.nix
+++ b/pkgs/development/libraries/glog/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "glog-${version}";
   version = "0.3.4";
-  
+
   src = fetchFromGitHub {
     owner = "Google";
     repo = "glog";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
 
   meta = with stdenv.lib; {
-    homepage = http://code.google.com/p/google-glog/;
+    homepage = https://github.com/google/glog;
     license = licenses.bsd3;
     description = "Library for application-level logging";
     platforms = platforms.unix;

--- a/pkgs/development/libraries/gperftools/default.nix
+++ b/pkgs/development/libraries/gperftools/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = https://code.google.com/p/gperftools/;
+    homepage = https://github.com/gperftools/gperftools;
     description = "Fast, multi-threaded malloc() and nifty performance analysis tools";
     platforms = with platforms; linux ++ darwin;
     license = licenses.bsd3;

--- a/pkgs/development/libraries/gtest/default.nix
+++ b/pkgs/development/libraries/gtest/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Google's framework for writing C++ tests";
-    homepage = https://code.google.com/p/googletest/;
+    homepage = https://github.com/google/googletest;
     license = licenses.bsd3;
     platforms = platforms.all;
     maintainers = with maintainers; [ zoomulator ivan-tkatchev ];

--- a/pkgs/development/libraries/java/junixsocket/default.nix
+++ b/pkgs/development/libraries/java/junixsocket/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "junixsocket-1.3";
 
   src = fetchurl {
-    url = "http://junixsocket.googlecode.com/files/${name}-src.tar.bz2";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/junixsocket/${name}-src.tar.bz2";
     sha256 = "0c6p8vmiv5nk8i6g1hgivnl3mpb2k3lhjjz0ss9dlirisfrxf1ym";
   };
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A Java/JNI library for using Unix Domain Sockets from Java";
-    homepage = https://code.google.com/p/junixsocket/;
+    homepage = https://github.com/kohlschutter/junixsocket;
     license = stdenv.lib.licenses.asl20;
     platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
   };

--- a/pkgs/development/libraries/leveldb/default.nix
+++ b/pkgs/development/libraries/leveldb/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   ";
 
   meta = with stdenv.lib; {
-    homepage = https://code.google.com/p/leveldb/;
+    homepage = https://github.com/google/leveldb;
     description = "Fast and lightweight key/value database library by Google";
     license = licenses.bsd3;
     platforms = platforms.all;

--- a/pkgs/development/libraries/libcredis/default.nix
+++ b/pkgs/development/libraries/libcredis/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "libcredis-0.2.3";
 
   src = fetchurl {
-    url = "https://credis.googlecode.com/files/credis-0.2.3.tar.gz";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/credis/credis-0.2.3.tar.gz";
     sha256 = "1l3hlw9rrc11qggbg9a2303p3bhxxx2vqkmlk8avsrbqw15r1ayr";
   };
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "C client library for Redis (key-value database)";
-    homepage = https://code.google.com/p/credis/;
+    homepage = https://code.google.com/archive/p/credis/;
     license = licenses.bsd3; # from homepage
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/libraries/libctemplate/default.nix
+++ b/pkgs/development/libraries/libctemplate/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       emphasizes separating logic from presentation: it is impossible to
       embed application logic in this template language.
     '';
-    homepage = http://code.google.com/p/google-ctemplate/;
-    license = "bsd";
+    homepage = https://github.com/OlafvdSpek/ctemplate;
+    license = stdenv.lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/libraries/libdivsufsort/default.nix
+++ b/pkgs/development/libraries/libdivsufsort/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation {
   name = "libdivsufsort-2.0.1";
-  
+
   src = fetchurl {
-    url = http://libdivsufsort.googlecode.com/files/libdivsufsort-2.0.1.tar.bz2;
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libdivsufsort/libdivsufsort-2.0.1.tar.bz2";
     sha256 = "1g0q40vb2k689bpasa914yi8sjsmih04017mw20zaqqpxa32rh2m";
   };
 
   meta = {
-    homepage = http://code.google.com/p/libdivsufsort/;
+    homepage = https://github.com/y-256/libdivsufsort;
     license = stdenv.lib.licenses.mit;
     description = "Library to construct the suffix array and the BW transformed string";
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/libdnet/default.nix
+++ b/pkgs/development/libraries/libdnet/default.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   src = fetchurl {
-    url = http://libdnet.googlecode.com/files/libdnet-1.12.tgz;
-    sha1 = "71302be302e84fc19b559e811951b5d600d976f8";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libdnet/libdnet-1.12.tgz";
+    sha256 = "09mhbr8x66ykhf5581a5zjpplpjxibqzgkkpx689kybwg0wk1cw3";
   };
 
   buildInputs = [ automake autoconf libtool ];
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Provides a simplified, portable interface to several low-level networking routines";
-    homepage = http://code.google.com/p/libdnet/;
+    homepage = https://github.com/dugsong/libdnet;
     license = stdenv.lib.licenses.bsd3;
     maintainers = [stdenv.lib.maintainers.marcweber];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/libfreefare/default.nix
+++ b/pkgs/development/libraries/libfreefare/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.4.0";
 
   src = fetchurl {
-    url = "https://libfreefare.googlecode.com/files/libfreefare-0.4.0.tar.bz2";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libfreefare/libfreefare-0.4.0.tar.bz2";
     sha256 = "0r5wfvwgf35lb1v65wavnwz2wlfyfdims6a9xpslf4lsm4a1v8xz";
   };
 
@@ -15,8 +15,8 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The libfreefare project aims to provide a convenient API for MIFARE card manipulations";
-    license = licenses.gpl3;
-    homepage = http://code.google.com/p/libfreefare/;
+    license = licenses.lgpl3;
+    homepage = https://github.com/nfc-tools/libfreefare;
     maintainers = with maintainers; [bobvanderlinden];
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/libhangul/default.nix
+++ b/pkgs/development/libraries/libhangul/default.nix
@@ -4,13 +4,13 @@ stdenv.mkDerivation {
   name = "libhangul-0.1.0";
 
   src = fetchurl {
-    url = "https://libhangul.googlecode.com/files/libhangul-0.1.0.tar.gz";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libhangul/libhangul-0.1.0.tar.gz";
     sha256 = "0ni9b0v70wkm0116na7ghv03pgxsfpfszhgyj3hld3bxamfal1ar";
   };
 
   meta = with stdenv.lib; {
     description = "Core algorithm library for Korean input routines";
-    homepage = https://code.google.com/p/libhangul;
+    homepage = https://github.com/choehwanjin/libhangul;
     license = licenses.lgpl21;
     maintainers = [ maintainers.ianwookim ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libixp-hg/default.nix
+++ b/pkgs/development/libraries/libixp-hg/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ unzip txt2tags ];
 
   meta = {
-    homepage = https://code.google.com/archive/p/libixp/;
+    homepage = http://repo.cat-v.org/libixp/; # see also https://libs.suckless.org/deprecated/libixp
     description = "Portable, simple C-language 9P client and server libary";
     maintainers = with stdenv.lib.maintainers; [ kovirobi ];
     license = stdenv.lib.licenses.mit;

--- a/pkgs/development/libraries/libkate/default.nix
+++ b/pkgs/development/libraries/libkate/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "libkate-0.3.8";
 
   src = fetchurl {
-    url = "http://libkate.googlecode.com/files/${name}.tar.gz";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libkate/${name}.tar.gz";
     sha256 = "00d6561g31la9bb8q99b7l4rvi67yiwm50ky8dhlsjd88h7rks2n";
   };
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
       bitstream format. Kate is a karaoke and text codec meant for encapsulation
       in an Ogg container. It can carry Unicode text, images, and animate
       them.'';
-    homepage = http://code.google.com/p/libkate;
+    homepage = https://code.google.com/archive/p/libkate/;
     maintainers = [ ];
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/libraries/libnfc/default.nix
+++ b/pkgs/development/libraries/libnfc/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Open source library libnfc for Near Field Communication";
     license = licenses.gpl3;
-    homepage = http://code.google.com/p/libnfc/;
+    homepage = https://github.com/nfc-tools/libnfc;
     maintainers = with maintainers; [offline];
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/libofa/default.nix
+++ b/pkgs/development/libraries/libofa/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   name = "libofa-${version}";
 
   src = fetchurl {
-    url = "http://musicip-libofa.googlecode.com/files/${name}.tar.gz";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/musicip-libofa/${name}.tar.gz";
     sha256 = "184ham039l7lwhfgg0xr2vch2xnw1lwh7sid432mh879adhlc5h2";
   };
 
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ expat curl fftw ];
 
   meta = {
-    homepage = http://code.google.com/musicip-libofa/;
+    homepage = https://code.google.com/archive/p/musicip-libofa/;
     description = "Library Open Fingerprint Architecture";
     longDescription = ''
       LibOFA (Library Open Fingerprint Architecture) is an open-source audio

--- a/pkgs/development/libraries/libtiger/default.nix
+++ b/pkgs/development/libraries/libtiger/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "libtiger-0.3.4";
 
   src = fetchurl {
-    url = "http://libtiger.googlecode.com/files/${name}.tar.gz";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libtiger/${name}.tar.gz";
     sha256 = "0rj1bmr9kngrgbxrjbn4f4f9pww0wmf6viflinq7ava7zdav4hkk";
   };
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libkate pango cairo ];
 
   meta = {
-    homepage = http://code.google.com/p/libtiger/;
+    homepage = https://code.google.com/archive/p/libtiger/;
     description = "A rendering library for Kate streams using Pango and Cairo";
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/libraries/marisa/default.nix
+++ b/pkgs/development/libraries/marisa/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage    = https://code.google.com/p/marisa-trie/;
+    homepage    = https://github.com/s-yata/marisa-trie;
     description = "Static and space-efficient trie data structure library";
     license     = licenses.bsd3;
     maintainers = with maintainers; [ sifmelcara ];

--- a/pkgs/development/libraries/mdds/0.12.1.nix
+++ b/pkgs/development/libraries/mdds/0.12.1.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    homepage = https://code.google.com/p/multidimalgorithm/;
+    homepage = https://gitlab.com/mdds/mdds;
     description = "A collection of multi-dimensional data structure and indexing algorithm";
     platforms = stdenv.lib.platforms.all;
   };

--- a/pkgs/development/libraries/mdds/0.7.1.nix
+++ b/pkgs/development/libraries/mdds/0.7.1.nix
@@ -5,12 +5,12 @@ stdenv.mkDerivation rec {
   name = "mdds-${version}";
 
   src = fetchurl {
-    url = "http://multidimalgorithm.googlecode.com/files/mdds_${version}.tar.bz2";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/multidimalgorithm/mdds_${version}.tar.bz2";
     sha256 = "0zhrx7m04pknc8i2cialmbna1hmwa0fzs8qphan4rdxibf0c4yzy";
   };
 
   meta = {
-    homepage = https://code.google.com/p/multidimalgorithm/;
+    homepage = https://gitlab.com/mdds/mdds/;
     description = "A collection of multi-dimensional data structure and indexing algorithm";
     platforms = stdenv.lib.platforms.all;
   };

--- a/pkgs/development/libraries/mp4v2/default.nix
+++ b/pkgs/development/libraries/mp4v2/default.nix
@@ -19,8 +19,9 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   meta = {
-    homepage = http://code.google.com/p/mp4v2;
+    homepage = https://code.google.com/archive/p/mp4v2/;
     maintainers = [ ];
     platforms = stdenv.lib.platforms.linux;
+    license = stdenv.lib.licenses.mpl11;
   };
 }

--- a/pkgs/development/libraries/npapi-sdk/default.nix
+++ b/pkgs/development/libraries/npapi-sdk/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A bundle of NPAPI headers by Mozilla";
 
-    homepage = https://code.google.com/p/npapi-sdk/;
+    homepage = https://bitbucket.org/mgorny/npapi-sdk; # see also https://github.com/mozilla/npapi-sdk
     license = licenses.bsd3;
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/ogrepaged/default.nix
+++ b/pkgs/development/libraries/ogrepaged/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Paged Geometry for Ogre3D";
-    homepage = http://code.google.com/p/ogre-paged/;
+    homepage = https://github.com/RigsOfRods/ogre-paged;
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/development/libraries/qtscriptgenerator/default.nix
+++ b/pkgs/development/libraries/qtscriptgenerator/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "qtscriptgenerator-0.1.0";
   src = fetchurl {
-    url = http://qtscriptgenerator.googlecode.com/files/qtscriptgenerator-src-0.1.0.tar.gz;
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/qtscriptgenerator/qtscriptgenerator-src-0.1.0.tar.gz";
     sha256 = "0h8zjh38n2wfz7jld0jz6a09y66dbsd2jhm4f2024qfgcmxcabj6";
   };
   buildInputs = [ qt4 ];
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
     cd generator
     qmake
     make
-    # Set QTDIR, see http://code.google.com/p/qtscriptgenerator/issues/detail?id=38
+    # Set QTDIR, see https://code.google.com/archive/p/qtscriptgenerator/issues/38
     QTDIR=${qt4} ./generator
     cd ../qtbindings
     qmake
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "QtScript bindings generator";
-    homepage = http://code.google.com/p/qtscriptgenerator/;
+    homepage = https://code.qt.io/cgit/qt-labs/qtscriptgenerator.git/;
     inherit (qt4.meta) platforms;
     maintainers = [ ];
   };

--- a/pkgs/development/libraries/snappy/default.nix
+++ b/pkgs/development/libraries/snappy/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "snappy-${version}";
   version = "1.1.4";
-  
+
   src = fetchurl {
     url = "http://github.com/google/snappy/releases/download/${version}/"
         + "snappy-${version}.tar.gz";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   doCheck = !stdenv.isDarwin;
 
   meta = with stdenv.lib; {
-    homepage = http://code.google.com/p/snappy/;
+    homepage = https://google.github.io/snappy/;
     license = licenses.bsd3;
     description = "Compression/decompression library for very high speeds";
     platforms = platforms.unix;

--- a/pkgs/development/libraries/sparsehash/default.nix
+++ b/pkgs/development/libraries/sparsehash/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://code.google.com/p/sparsehash/;
+    homepage = https://github.com/sparsehash/sparsehash;
     description = "An extremely memory-efficient hash_map implementation";
     platforms = platforms.all;
     license = licenses.bsd3;

--- a/pkgs/development/ocaml-modules/bitstring/default.nix
+++ b/pkgs/development/ocaml-modules/bitstring/default.nix
@@ -20,7 +20,7 @@ buildOcaml rec {
 
   meta = with stdenv.lib; {
     description = "This library adds Erlang-style bitstrings and matching over bitstrings as a syntax extension and library for OCaml";
-    homepage = http://code.google.com/p/bitstring/;
+    homepage = https://github.com/xguerin/bitstring;
     license = licenses.lgpl21Plus;
     maintainers = [ maintainers.maurer ];
   };

--- a/pkgs/development/tools/misc/gtkdialog/default.nix
+++ b/pkgs/development/tools/misc/gtkdialog/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "gtkdialog-0.8.3";
 
   src = fetchurl {
-    url = http://gtkdialog.googlecode.com/files/gtkdialog-0.8.3.tar.gz;
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/gtkdialog/gtkdialog-0.8.3.tar.gz";
     sha256 = "ff89d2d7f1e6488e5df5f895716ac1d4198c2467a2a5dc1f51ab408a2faec38e";
   };
 
@@ -12,7 +12,8 @@ stdenv.mkDerivation {
   buildInputs = [ gtk2 hicolor_icon_theme ];
 
   meta = {
-    homepage = http://gtkdialog.googlecode.com/;
+    homepage = https://code.google.com/archive/p/gtkdialog/;
+    # community links: http://murga-linux.com/puppy/viewtopic.php?t=111923 -> https://github.com/01micko/gtkdialog
     description = "Small utility for fast and easy GUI building from many scripted and compiled languages";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/tools/misc/stm32flash/default.nix
+++ b/pkgs/development/tools/misc/stm32flash/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "stm32flash-1.0";
 
   src = fetchurl {
-    url = https://stm32flash.googlecode.com/files/stm32flash.tar.gz;
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/stm32flash/stm32flash.tar.gz";
     sha256 = "04k631g9lzvp9xr4sw51xpq1g542np61s1l8fpwx9rbsc8m5l0i6";
   };
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Open source flash program for the STM32 ARM processors using the ST bootloader";
-    homepage = https://code.google.com/p/stm32flash/;
+    homepage = https://sourceforge.net/projects/stm32flash/;
     license = stdenv.lib.licenses.gpl2;
     platforms = platforms.all; # Should work on all platforms
     maintainers = [ maintainers.the-kenny ];

--- a/pkgs/development/tools/selenium/server/default.nix
+++ b/pkgs/development/tools/selenium/server/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = https://code.google.com/p/selenium;
+    homepage = http://www.seleniumhq.org/;
     description = "Selenium Server for remote WebDriver";
     maintainers = with maintainers; [ coconnor offline ];
     platforms = platforms.all;

--- a/pkgs/misc/emulators/wine/winetricks.nix
+++ b/pkgs/misc/emulators/wine/winetricks.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A script to install DLLs needed to work around problems in Wine";
     license = stdenv.lib.licenses.lgpl21;
-    homepage = http://code.google.com/p/winetricks/;
+    homepage = https://github.com/Winetricks/winetricks;
     maintainers = with stdenv.lib.maintainers; [ the-kenny ];
     platforms = with stdenv.lib.platforms; linux;
   };

--- a/pkgs/os-specific/linux/ftop/default.nix
+++ b/pkgs/os-specific/linux/ftop/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.0";
 
   src = fetchurl {
-    url = "http://ftop.googlecode.com/files/${name}.tar.bz2";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ftop/${name}.tar.bz2";
     sha256 = "3a705f4f291384344cd32c3dd5f5f6a7cd7cea7624c83cb7e923966dbcd47f82";
   };
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Show progress of open files and file systems";
-    homepage = https://code.google.com/p/ftop/;
+    homepage = https://code.google.com/archive/p/ftop/;
     license = licenses.gpl3Plus;
     longDescription = ''
       ftop is to files what top is to processes. The progress of all open files

--- a/pkgs/os-specific/linux/i7z/default.nix
+++ b/pkgs/os-specific/linux/i7z/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "i7z-0.27.2";
 
   src = fetchurl {
-    url = "http://i7z.googlecode.com/files/${name}.tar.gz";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/i7z/${name}.tar.gz";
     sha256 = "1wa7ix6m75wl3k2n88sz0x8cckvlzqklja2gvzqfw5rcfdjjvxx7";
   };
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A better i7 (and now i3, i5) reporting tool for Linux";
-    homepage = http://code.google.com/p/i7z;
+    homepage = https://github.com/ajaiantilal/i7z;
     repositories.git = https://github.com/ajaiantilal/i7z.git;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.bluescreen303 ];

--- a/pkgs/os-specific/linux/jujuutils/default.nix
+++ b/pkgs/os-specific/linux/jujuutils/default.nix
@@ -4,14 +4,14 @@ stdenv.mkDerivation {
   name = "jujuutils-0.2";
 
   src = fetchurl {
-    url = "http://jujuutils.googlecode.com/files/jujuutils-0.2.tar.gz";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/jujuutils/jujuutils-0.2.tar.gz";
     sha256 = "1r74m7s7rs9d6y7cffi7mdap3jf96qwm1v6jcw53x5cikgmfxn4x";
   };
 
   buildInputs = [ linuxHeaders ];
 
   meta = {
-    homepage = http://code.google.com/p/jujuutils/;
+    homepage = https://github.com/cladisch/linux-firewire-utils;
     description = "Utilities around FireWire devices connected to a Linux computer";
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/servers/http/apache-modules/mod_wsgi/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_wsgi/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://code.google.com/p/modwsgi/;
+    homepage = https://github.com/GrahamDumpleton/mod_wsgi;
     description = "Host Python applications in Apache through the WSGI interface";
     license = stdenv.lib.licenses.asl20;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/servers/kippo/default.nix
+++ b/pkgs/servers/kippo/default.nix
@@ -63,8 +63,8 @@ in stdenv.mkDerivation rec {
     name = "kippo-${version}";
     version = "0.8";
     src = fetchurl {
-      url = "https://kippo.googlecode.com/files/kippo-${version}.tar.gz";
-      sha1 = "f57a5cf88171cb005afe44a4b33cb16f825c33d6";
+      url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/kippo/${name}.tar.gz";
+      sha256 = "0rd2mk36d02qd24z8s4xyy64fy54rzpar4379iq4dcjwg7l7f63d";
     };
     buildInputs = with pythonPackages; [ pycrypto pyasn1 twisted_13 ];
     installPhase = ''
@@ -76,17 +76,17 @@ in stdenv.mkDerivation rec {
             --replace "data_path = data" "data_path = /var/lib/kippo/data" \
             --replace "txtcmds_path = txtcmds" "txtcmds_path = /var/lib/kippo/txtcmds" \
             --replace "public_key = public.key" "public_key = /var/lib/kippo/keys/public.key" \
-            --replace "private_key = private.key" "private_key = /var/lib/kippo/keys/private.key" 
+            --replace "private_key = private.key" "private_key = /var/lib/kippo/keys/private.key"
         mkdir -p $out/bin
         mkdir -p $out/src
-        mv ./* $out/src 
+        mv ./* $out/src
         mv $out/src/utils/* $out/bin
         '';
 
     passthru.twisted = twisted_13;
 
     meta = with stdenv.lib; {
-      homepage = https://code.google.com/p/kippo;
+      homepage = https://github.com/desaster/kippo;
       description = "SSH Honeypot";
       longDescription = ''
         Default port is 2222. Recommend using something like this for port redirection to default SSH port:

--- a/pkgs/servers/shellinabox/default.nix
+++ b/pkgs/servers/shellinabox/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://code.google.com/p/shellinabox;
+    homepage = https://github.com/shellinabox/shellinabox;
     description = "Web based AJAX terminal emulator";
     license = licenses.gpl2;
     maintainers = with maintainers; [ tomberek lihop ];

--- a/pkgs/tools/compression/lz4/default.nix
+++ b/pkgs/tools/compression/lz4/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
       multiple GB/s per core, typically reaching RAM speed limits on
       multi-core systems.
     '';
-    homepage = https://code.google.com/p/lz4/;
+    homepage = https://lz4.github.io/lz4/;
     license = with licenses; [ bsd2 gpl2Plus ];
     platforms = platforms.unix;
     maintainers = with maintainers; [ nckx ];

--- a/pkgs/tools/filesystems/mtpfs/default.nix
+++ b/pkgs/tools/filesystems/mtpfs/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    homepage = https://code.google.com/p/mtpfs/;
+    homepage = https://github.com/cjd/mtpfs;
     description = "FUSE Filesystem providing access to MTP devices";
     platforms = stdenv.lib.platforms.all;
     maintainers = [ stdenv.lib.maintainers.qknight ];

--- a/pkgs/tools/filesystems/s3backer/default.nix
+++ b/pkgs/tools/filesystems/s3backer/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://code.google.com/p/s3backer/;
+    homepage = https://github.com/archiecobbs/s3backer;
     description = "FUSE-based single file backing store via Amazon S3";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ nckx ];

--- a/pkgs/tools/graphics/logstalgia/default.nix
+++ b/pkgs/tools/graphics/logstalgia/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
                   glm freetype ];
 
   meta = with stdenv.lib; {
-    homepage = http://code.google.com/p/logstalgia;
+    homepage = http://logstalgia.io/;
     description = "Website traffic visualization tool";
     license = licenses.gpl3Plus;
 

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-mozc/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-mozc/default.nix
@@ -33,7 +33,7 @@ in clangStdenv.mkDerivation rec {
   '';
 
   patch_version = "2.18.2612.102.1";
-  patches = [ 
+  patches = [
     (fetchpatch rec {
       name   = "fcitx-mozc-${patch_version}.patch";
       url    = "https://download.fcitx-im.org/fcitx-mozc/${name}";
@@ -43,7 +43,7 @@ in clangStdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/unix/fcitx/mozc.conf \
-      --replace "/usr/share/fcitx/mozc/icon/mozc.png" "mozc" 
+      --replace "/usr/share/fcitx/mozc/icon/mozc.png" "mozc"
   '';
 
   configurePhase = ''
@@ -91,7 +91,7 @@ in clangStdenv.mkDerivation rec {
   meta = with clangStdenv.lib; {
     isFcitxEngine = true;
     description   = "Fcitx engine for Google japanese input method";
-    homepage      = http://code.google.com/p/mozc/;
+    homepage      = https://github.com/google/mozc;
     downloadPage  = "http://download.fcitx-im.org/fcitx-mozc/";
     license       = licenses.free;
     platforms     = platforms.linux;

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
@@ -15,7 +15,7 @@ in clangStdenv.mkDerivation rec {
   meta = with clangStdenv.lib; {
     isIbusEngine = true;
     description  = "Japanese input method from Google";
-    homepage     = http://code.google.com/p/mozc/;
+    homepage     = https://github.com/google/mozc;
     license      = licenses.free;
     platforms    = platforms.linux;
     maintainers  = with maintainers; [ gebner ericsagnes ];

--- a/pkgs/tools/inputmethods/nabi/default.nix
+++ b/pkgs/tools/inputmethods/nabi/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "nabi-1.0.0";
 
   src = fetchurl {
-    url = "http://nabi.googlecode.com/files/nabi-1.0.0.tar.gz";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/nabi/nabi-1.0.0.tar.gz";
     sha256 = "0craa24pw7b70sh253arv9bg9sy4q3mhsjwfss3bnv5nf0xwnncw";
   };
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "The Easy Hangul XIM";
-    homepage = https://code.google.com/p/nabi;
+    homepage = https://github.com/choehwanjin/nabi;
     license = licenses.gpl2;
     maintainers = [ maintainers.ianwookim ];
     platforms = platforms.linux;

--- a/pkgs/tools/inputmethods/touchegg/default.nix
+++ b/pkgs/tools/inputmethods/touchegg/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "touchegg-${version}";
   version = "1.1.1";
   src = fetchurl {
-    url = "https://touchegg.googlecode.com/files/${name}.tar.gz";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/touchegg/${name}.tar.gz";
     sha256 = "95734815c7219d9a71282f3144b3526f2542b4fa270a8e69d644722d024b4038";
   };
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = https://code.google.com/p/touchegg/;
+    homepage = https://github.com/JoseExposito/touchegg;
     description = "Macro binding for touch surfaces";
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/inputmethods/uim/default.nix
+++ b/pkgs/tools/inputmethods/uim/default.nix
@@ -38,12 +38,12 @@ stdenv.mkDerivation rec {
   dontUseCmakeConfigure = true;
 
   src = fetchurl {
-    url = "http://uim.googlecode.com/files/uim-${version}.tar.bz2";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/uim/uim-${version}.tar.bz2";
     sha1 = "43b9dbdead6797880e6cfc9c032ecb2d37d42777";
   };
 
   meta = with stdenv.lib; {
-    homepage    = "http://code.google.com/p/uim/";
+    homepage    = "https://github.com/uim/uim";
     description = "A multilingual input method framework";
     license     = stdenv.lib.licenses.bsd3;
     platforms   = stdenv.lib.platforms.linux;

--- a/pkgs/tools/networking/pdsh/default.nix
+++ b/pkgs/tools/networking/pdsh/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
   inherit name;
 
   src = fetchurl {
-    url = "http://pdsh.googlecode.com/files/${name}.tar.bz2";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/pdsh/${name}.tar.bz2";
     sha256 = "1kvzz01fyaxfqmbh53f4ljfsgvxdykh5jyr6fh4f1bw2ywxr1w2p";
   };
 
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = http://code.google.com/p/pdsh/;
+    homepage = https://github.com/chaos/pdsh;
     description = "High-performance, parallel remote shell utility";
     license = stdenv.lib.licenses.gpl2;
 

--- a/pkgs/tools/networking/reaver-wps/default.nix
+++ b/pkgs/tools/networking/reaver-wps/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Brute force attack against Wifi Protected Setup";
-    homepage = http://code.google.com/p/reaver-wps;
+    homepage = https://code.google.com/archive/p/reaver-wps/;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ nico202 volth ];

--- a/pkgs/tools/networking/slimrat/default.nix
+++ b/pkgs/tools/networking/slimrat/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "slimrat-1.0";
   src = fetchurl {
-    url = http://slimrat.googlecode.com/files/slimrat-1.0.tar.bz2;
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/slimrat/slimrat-1.0.tar.bz2";
     sha256 = "139b71d45k4b1y47iq62a9732cnaqqbh8s4knkrgq2hx0jxpsk5a";
   };
 
@@ -24,9 +24,10 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = http://code.google.com/p/slimrat/;
+    homepage = https://code.google.com/archive/p/slimrat/;
     description = "Linux Rapidshare downloader";
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.unix;
+    broken = true; # officially abandonned upstream
   };
 }

--- a/pkgs/tools/networking/udptunnel/default.nix
+++ b/pkgs/tools/networking/udptunnel/default.nix
@@ -4,8 +4,8 @@ stdenv.mkDerivation {
   name = "udptunnel-19";
 
   src = fetchurl {
-    url = http://udptunnel.googlecode.com/files/udptunnel-r19.tar.gz;
-    sha1 = "51edec3b63b659229bcf92f6157568d3b074ede0";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/udptunnel/udptunnel-r19.tar.gz";
+    sha256 = "1hkrn153rdyrp9g15z4d5dq44cqlnby2bfplp6z0g3862lnv7m3l";
   };
 
   installPhase = ''
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = http://code.google.com/p/udptunnel/;
+    homepage = https://code.google.com/archive/p/udptunnel/;
     description = "Tunnels TCP over UDP packets";
     license = stdenv.lib.licenses.gpl3Plus;
     maintainers = with stdenv.lib.maintainers; [viric];

--- a/pkgs/tools/package-management/opkg/default.nix
+++ b/pkgs/tools/package-management/opkg/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A lightweight package management system based upon ipkg";
-    homepage = http://code.google.com/p/opkg/;
+    homepage = https://git.yoctoproject.org/cgit/cgit.cgi/opkg/;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ pSub ];

--- a/pkgs/tools/security/mfcuk/default.nix
+++ b/pkgs/tools/security/mfcuk/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.3.8";
 
   src = fetchurl {
-    url = "http://mfcuk.googlecode.com/files/mfcuk-0.3.8.tar.gz";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/mfcuk/mfcuk-0.3.8.tar.gz";
     sha256 = "0m9sy61rsbw63xk05jrrmnyc3xda0c3m1s8pg3sf8ijbbdv9axcp";
   };
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "MiFare Classic Universal toolKit";
     license = licenses.gpl2;
-    homepage = http://code.google.com/p/mfcuk/;
+    homepage = https://github.com/nfc-tools/mfcuk;
     maintainers = with maintainers; [ offline ];
     platforms = platforms.unix;
   };

--- a/pkgs/tools/security/mfoc/default.nix
+++ b/pkgs/tools/security/mfoc/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.10.6";
 
   src = fetchurl {
-    url = "http://mfoc.googlecode.com/files/${name}.tar.gz";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/mfoc/${name}.tar.gz";
     sha1 = "3adce3029dce9124ff3bc7d0fad86fa0c374a9e3";
   };
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Mifare Classic Offline Cracker";
     license = licenses.gpl2;
-    homepage = http://code.google.com/p/mfoc/;
+    homepage = https://github.com/nfc-tools/mfoc;
     maintainers = with maintainers; [ offline ];
     platforms = platforms.unix;
   };

--- a/pkgs/tools/security/omapd/default.nix
+++ b/pkgs/tools/security/omapd/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.9.2";
 
   src = fetchurl {
-    url = "http://omapd.googlecode.com/files/${name}.tgz";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/omapd/${name}.tgz";
     sha256 = "0d7lgv957jhbsav60j50jhdy3rpcqgql74qsniwnnpm3yqj9p0xc";
   };
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://code.google.com/p/omapd;
+    homepage = https://code.google.com/archive/p/omapd/;
     description = "IF-MAP Server that implements the IF-MAP v1.1 and v2.0 specifications published by the Trusted Computing Group (TCG)";
     license = licenses.gpl3;
     maintainers = [ maintainers.tstrobel ];

--- a/pkgs/tools/security/tmin/default.nix
+++ b/pkgs/tools/security/tmin/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.05";
 
   src = fetchurl {
-    url    = "https://tmin.googlecode.com/files/${name}.tar.gz";
+    url    = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/tmin/${name}.tar.gz";
     sha256 = "0166kcfs4b0da4hs2aqyn41f5l09i8rwxpi20k7x17qsxbmjbpd5";
   };
 
@@ -16,9 +16,13 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Fuzzing tool test-case optimizer";
-    homepage    = "https://code.google.com/p/tmin";
+    longDescription = ''
+      This project is obsolete and replaced by the afl-tmin tool bundled with american fuzzy lop (<literal>afl</literal>)
+    '';
+    homepage    = "https://code.google.com/archive/p/tmin/";
     license     = stdenv.lib.licenses.asl20;
     platforms   = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+    broken      = true; # officially deprecated upstream in favor of afl-tmin (afl package)
   };
 }

--- a/pkgs/tools/security/tor/torsocks.nix
+++ b/pkgs/tools/security/tor/torsocks.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description      = "Wrapper to safely torify applications";
-    homepage         = http://code.google.com/p/torsocks/;
+    homepage         = https://github.com/dgoulet/torsocks;
     repositories.git = https://git.torproject.org/torsocks.git;
     license          = stdenv.lib.licenses.gpl2;
     platforms        = stdenv.lib.platforms.unix;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4056,7 +4056,7 @@ let self = _self // overrides; _self = with self; {
     };
     propagatedBuildInputs = [ FileWhich JSONMaybeXS TestDifferences ];
     meta = {
-      homepage = https://code.google.com/p/perl-devel-nytprof/;
+      homepage = https://github.com/timbunce/devel-nytprof;
       description = "Powerful fast feature-rich Perl source code profiler";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15441,7 +15441,7 @@ in {
 
     meta = {
       description = "Process and system utilization information interface for python";
-      homepage = http://code.google.com/p/psutil/;
+      homepage = https://github.com/giampaolo/psutil;
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change
Part of the #30636 effort

This PR updates homepages of packages that were hosted on Google Code.

When necessary I also updated the source URL in order to use the Google API storage archive: `https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/projectname/filename`

It returns the same file so hashes were not updated but it may still trigger some rebuilds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

