### PR TITLE
plexpy: init at 1.4.25

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -136,6 +136,7 @@
   cryptix = "Henry Bubert <cryptix@riseup.net>";
   CrystalGamma = "Jona Stubbe <nixos@crystalgamma.de>";
   cstrahan = "Charles Strahan <charles@cstrahan.com>";
+  csingley = "Christopher Singley <csingley@gmail.com>";
   cwoac = "Oliver Matthews <oliver@codersoffortune.net>";
   DamienCassou = "Damien Cassou <damien@cassou.me>";
   danbst = "Danylo Hlynskyi <abcz2.uprola@gmail.com>";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -328,6 +328,7 @@
   ./services/misc/parsoid.nix
   ./services/misc/phd.nix
   ./services/misc/plex.nix
+  ./services/misc/plexpy.nix
   ./services/misc/pykms.nix
   ./services/misc/radarr.nix
   ./services/misc/redmine.nix

--- a/nixos/modules/services/misc/plexpy.nix
+++ b/nixos/modules/services/misc/plexpy.nix
@@ -1,0 +1,81 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.plexpy;
+in
+{
+  options = {
+    services.plexpy = {
+      enable = mkEnableOption "PlexPy Plex Monitor";
+
+      dataDir = mkOption {
+        type = types.str;
+        default = "/var/lib/plexpy";
+        description = "The directory where PlexPy stores its data files.";
+      };
+
+      configFile = mkOption {
+        type = types.str;
+        default = "/var/lib/plexpy/config.ini";
+        description = "The location of PlexPy's config file.";
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = 8181;
+        description = "TCP port where PlexPy listens.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "plexpy";
+        description = "User account under which PlexPy runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "nogroup";
+        description = "Group under which PlexPy runs.";
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.plexpy;
+        defaultText = "pkgs.plexpy";
+        description = ''
+          The PlexPy package to use.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.plexpy = {
+      description = "PlexPy Plex Monitor";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      preStart = ''
+        test -d "${cfg.dataDir}" || {
+          echo "Creating initial PlexPy data directory in \"${cfg.dataDir}\"."
+          mkdir -p "${cfg.dataDir}"
+          chown ${cfg.user}:${cfg.group} "${cfg.dataDir}"
+        }
+     '';
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        PermissionsStartOnly = "true";
+        GuessMainPID = "false";
+        ExecStart = "${cfg.package}/bin/plexpy --datadir ${cfg.dataDir} --config ${cfg.configFile} --port ${toString cfg.port} --pidfile ${cfg.dataDir}/plexpy.pid --nolaunch";
+        Restart = "on-failure";
+      };
+    };
+
+    users.extraUsers = mkIf (cfg.user == "plexpy") {
+      plexpy = { group = cfg.group; uid = config.ids.uids.plexpy; };
+    };
+  };
+}

--- a/pkgs/servers/plexpy/default.nix
+++ b/pkgs/servers/plexpy/default.nix
@@ -1,0 +1,41 @@
+{stdenv, fetchFromGitHub, python}:
+
+stdenv.mkDerivation rec {
+  version = "1.4.25";
+  pname = "plexpy";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "JonnyWong16";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0a4ynrfamlwkgqil4n61v47p21czxpjdzg0mias4kdjam2nnwnjx";
+  };
+
+  buildPhase = ":";
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R * $out/
+
+    # Remove superfluous Python checks from main script;
+    # prepend shebang
+    echo "#!${python.interpreter}" > $out/PlexPy.py
+    tail -n +7 PlexPy.py >> $out/PlexPy.py
+
+    mkdir $out/bin
+    # Can't just symlink to the main script, since it uses __file__ to
+    # import bundled packages and manage the service
+    echo "#!/bin/bash" > $out/bin/plexpy
+    echo "$out/PlexPy.py \$*" >> $out/bin/plexpy
+    chmod +x $out/bin/plexpy
+  '';
+
+  meta  = with stdenv.lib; {
+    description = "A Python based monitoring and tracking tool for Plex Media Server.";
+    homepage = http://jonnywong16.github.io/plexpy/;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ csingley ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3966,6 +3966,8 @@ with pkgs;
 
   plex = callPackage ../servers/plex { enablePlexPass = config.plex.enablePlexPass or false; };
 
+  plexpy = callPackage ../servers/plexpy { python = python2; };
+
   ploticus = callPackage ../tools/graphics/ploticus {
     libpng = libpng12;
   };


### PR DESCRIPTION
###### Motivation for this change
PlexPy is a monitoring daemon for Plex Media Server, which is already in nixpkgs.  It's popular with Plex users because it adds significant functionality.  It's pretty good code and it's actively maintained.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

