### PR TITLE
You get:remove duplicate definition

### DIFF
--- a/pkgs/applications/misc/home-manager/default.nix
+++ b/pkgs/applications/misc/home-manager/default.nix
@@ -1,0 +1,48 @@
+#Taken directly from
+#https://github.com/rycee/home-manager/blob/9c1b3735b402346533449efc741f191d6ef578dd/home-manager/default.nix
+
+{ pkgs
+
+  # Extra path to the Home Manager modules. If set then this path will
+  # be tried before `$HOME/.config/nixpkgs/home-manager/modules` and
+  # `$HOME/.nixpkgs/home-manager/modules`.
+, modulesPath ? null
+}:
+
+let
+
+  modulesPathStr = if modulesPath == null then "" else modulesPath;
+
+in
+
+pkgs.stdenv.mkDerivation rec{
+  name = "home-manager-${version}";
+  version="2017-10-11";
+  src=pkgs.fetchFromGitHub{
+    owner="rycee";
+    repo="home-manager";
+    rev="7e6f3364bcf0a0ec838aa4853f550a9a7b5ed027";
+    sha256="04wl0jpha19fsnyc5a8y4pkss9by468k0i5w5bjswnaz792yji6v";
+  };
+  phases = [ "installPhase" ];
+
+  installPhase = let
+    dot = "${src}/home-manager/home-manager" ;
+
+  in ''
+    install -v -D -m755 ${dot} $out/bin/home-manager
+
+    substituteInPlace $out/bin/home-manager \
+      --subst-var-by bash "${pkgs.bash}" \
+      --subst-var-by coreutils "${pkgs.coreutils}" \
+      --subst-var-by less "${pkgs.less}" \
+      --subst-var-by MODULES_PATH '${modulesPathStr}' \
+      --subst-var-by HOME_MANAGER_EXPR_PATH "${dot}.nix"
+  '';
+
+  meta = with pkgs.stdenv.lib; {
+    description = "A user environment configurator";
+    maintainers = [ maintainers.rycee ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1115,6 +1115,8 @@ with pkgs;
 
   hid-listen = callPackage ../tools/misc/hid-listen { };
 
+  home-manager = callPackage ../applications/misc/home-manager {};
+
   hostsblock = callPackage ../tools/misc/hostsblock { };
 
   hr = callPackage ../applications/misc/hr { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22626,7 +22626,7 @@ EOF
     propagateBuildInputs= [pkgs.ffmpeg];
     doCheck=false;#checks require working sites
   };
-  
+
   zbase32 = buildPythonPackage (rec {
     name = "zbase32-1.1.2";
 
@@ -22752,28 +22752,6 @@ EOF
     };
   };
 
-  you-get = buildPythonApplication rec {
-    version = "0.4.390";
-    name = "you-get-${version}";
-    disabled = !isPy3k;
-
-    # Tests aren't packaged, but they all hit the real network so
-    # probably aren't suitable for a build environment anyway.
-    doCheck = false;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/y/you-get/${name}.tar.gz";
-      sha256 = "17hs0g9yvgvkmr7p1cz39mbbvb40q65qkc31j3ixc2f873gahagw";
-    };
-
-    meta = {
-      description = "A tiny command line utility to download media contents from the web";
-      homepage = https://you-get.org;
-      license = licenses.mit;
-      maintainers = with maintainers; [ ryneeverett ];
-      platforms = platforms.all;
-    };
-  };
 
   zetup = callPackage ../development/python-modules/zetup { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22221,6 +22221,26 @@ in modules // {
     pandoc = null;
   };
 
+  you-get=buildPythonPackage rec {
+    name="you-get-${version}";
+    version="0.4.293";
+    src = pkgs.fetchFromGitHub {
+      owner = "soimort";
+      repo = "you-get";
+      rev = "v${version}";
+      sha256 = "16g1lfjhjaai1k2vfa7fw577bvar20nz8zw75nsz3qy6knla3mzn";
+    };
+    meta={
+      licenses="MIT";
+      description="A tiny command-line utility to download media contents (videos, audios, images) from the Web.";
+      homepage="https://you-get.org/";
+    };
+    disabled=!isPy3k;
+    #namePrefix="";
+    propagateBuildInputs= [pkgs.ffmpeg];
+    doCheck=false;#checks require working sites
+  };
+  
   zbase32 = buildPythonPackage (rec {
     name = "zbase32-1.1.2";
 


### PR DESCRIPTION
###### Motivation for this change
A duplicate definition of you-get in python-packaages.nix causes every build to fail.This commit removes the second definition

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

