### PR TITLE
kanboard: 1.0.46 -> 1.0.48

### DIFF
--- a/pkgs/applications/misc/kanboard/default.nix
+++ b/pkgs/applications/misc/kanboard/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "kanboard-${version}";
-  version = "1.0.46";
+  version = "1.0.48";
 
   src = fetchzip {
-    url = "https://kanboard.net/${name}.zip";
-    sha256 = "00fzzijibj7x8pz8xwc601fcrzvdwz5fv45f2zzmbygl86khp82a";
+    url = "https://github.com/kanboard/kanboard/releases/download/v${version}/${name}.zip";
+    sha256 = "0ipyijlfcnfqlz9n20wcnaf9pw404a675x404pm9h2n4ld8x6m5v";
   };
 
   dontBuild = true;


### PR DESCRIPTION
###### Motivation for this change

New upstream release available, includes fixes for CVE-2017-15195, CVE-2017-15196, CVE-2017-15197, CVE-2017-15198, CVE-2017-15199, CVE-2017-15200, CVE-2017-15201, CVE-2017-15202, CVE-2017-15203, CVE-2017-15204, CVE-2017-15205, CVE-2017-15206, CVE-2017-15207, CVE-2017-15208, CVE-2017-15209, CVE-2017-15210, CVE-2017-15211, CVE-2017-15212 as part of 1.0.47 release.

- [1.0.47 changelog](https://kanboard.net/news/version-1.0.47)
- [1.0.48 changelog](https://kanboard.net/news/version-1.0.48)

/cc @fpletz

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

