### PR TITLE
clamav module: make services.clamav.daemon.enable actually work

### DIFF
--- a/nixos/modules/services/security/clamav.nix
+++ b/nixos/modules/services/security/clamav.nix
@@ -76,8 +76,9 @@ in
     };
   };
 
-  config = mkIf cfg.updater.enable or cfg.daemon.enable {
+  config = mkIf (cfg.updater.enable || cfg.daemon.enable) {
     environment.systemPackages = [ pkg ];
+
     users.extraUsers = singleton {
       name = clamavUser;
       uid = config.ids.uids.clamav;
@@ -94,7 +95,7 @@ in
     environment.etc."clamav/freshclam.conf".source = freshclamConfigFile;
     environment.etc."clamav/clamd.conf".source = clamdConfigFile;
 
-    systemd.services.clamav-daemon = mkIf cfg.daemon.enable {
+    systemd.services.clamav-daemon = optionalAttrs cfg.daemon.enable {
       description = "ClamAV daemon (clamd)";
       after = mkIf cfg.updater.enable [ "clamav-freshclam.service" ];
       requires = mkIf cfg.updater.enable [ "clamav-freshclam.service" ];
@@ -115,7 +116,7 @@ in
       };
     };
 
-    systemd.timers.clamav-freshclam = mkIf cfg.updater.enable {
+    systemd.timers.clamav-freshclam = optionalAttrs cfg.updater.enable {
       description = "Timer for ClamAV virus database updater (freshclam)";
       wantedBy = [ "timers.target" ];
       timerConfig = {
@@ -124,7 +125,7 @@ in
       };
     };
 
-    systemd.services.clamav-freshclam = mkIf cfg.updater.enable {
+    systemd.services.clamav-freshclam = optionalAttrs cfg.updater.enable {
       description = "ClamAV virus database updater (freshclam)";
       restartTriggers = [ freshclamConfigFile ];
 


### PR DESCRIPTION
Turning `services.clamav.daemon.enable = true` without `updater.enable` also to `true` had no effect. This PR fixes this and replaces some `mkIf`'s with `optionalAttrs`.

The issue seems to be that `mkIf cfg.updater.enable or cfg.daemon.enable { ... }` was parsed as `mkIf (cfg.updater.enable or cfg.daemon.enable) { ... }` (`or` binds stronger than function application), which then was always equivalent to `mkIf cfg.updater.enable { ... }`, as the option was always defined, be it with its default value or with its user-defined value.

Thanks @rycee for your help in understanding how it was actually able to parse and execute semi-correctly before this change! (I was convinced the `or` was nixpkgs' `lib.or`, before that)