### PR TITLE
systemd: remove udev attributes

### DIFF
--- a/pkgs/misc/drivers/foo2zjs/default.nix
+++ b/pkgs/misc/drivers/foo2zjs/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     "PIXMAPS=$(out)/share/pixmaps"
     "UDEVBIN=$(out)/bin"
     "UDEVDIR=$(out)/etc/udev/rules.d"
-    "UDEVD=${systemd.udev.bin}/sbin/udevd"
+    "UDEVD=${systemd}/sbin/udevd"
     "LIBUDEVDIR=$(out)/lib/udev/rules.d"
     "USBDIR=$(out)/etc/hotplug/usb"
     "FOODB=$(out)/share/foomatic/db/source"

--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
   preConfigure =
     ''
       substituteInPlace scripts/lvm2_activation_generator_systemd_red_hat.c \
-        --replace /usr/bin/udevadm ${systemd.udev.bin}/bin/udevadm
+        --replace /usr/bin/udevadm ${systemd}/bin/udevadm
 
       sed -i /DEFAULT_SYS_DIR/d Makefile.in
       sed -i /DEFAULT_PROFILE_DIR/d conf/Makefile.in

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12956,11 +12956,7 @@ with pkgs;
 
   systemd = callPackage ../os-specific/linux/systemd {
     utillinux = utillinuxMinimal; # break the cyclic dependency
-  }
-    // {
-      udev.bin = systemd;     # ${systemd.udev.bin}/bin/udevadm
-      udev.lib = libudev.out; # ${systemd.udev.lib}/lib/libudev.*
-    };
+  };
 
   # standalone cryptsetup generator for systemd
   systemd-cryptsetup-generator = callPackage ../os-specific/linux/systemd/cryptsetup-generator.nix { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

