### PR TITLE
datefudge: 1.21 => 1.22

### DIFF
--- a/pkgs/tools/system/datefudge/default.nix
+++ b/pkgs/tools/system/datefudge/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "datefudge";
-  version = "1.2.1";
+  version = "1.22";
   name = "${pname}-${version}";
 
   src = fetchgit {
-    sha256 = "0l83kn6c3jr3wzs880zfa64rw81cqjjk55gjxz71rjf2balp64ps";
+    sha256 = "1fmd05r00wx4zc90lbi804jl7xwdl11jq2a1kp5lqimk3yyvfw4c";
     url = "git://anonscm.debian.org/users/robert/datefudge.git";
-    rev = "cd141c63bebe9b579109b2232b5e83db18f222c2";
+    rev = "fe27db47a0f250fb56164114fff8ae8d5af47ab6";
   };
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change

New upstream version.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions => Debian
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

