### PR TITLE
nodejs: 8.8.0 -> 8.8.1

### DIFF
--- a/pkgs/development/web/nodejs/v8.nix
+++ b/pkgs/development/web/nodejs/v8.nix
@@ -10,11 +10,11 @@ let
   baseName = if enableNpm then "nodejs" else "nodejs-slim";
 in
   stdenv.mkDerivation (nodejs // rec {
-    version = "8.8.0";
+    version = "8.8.1";
     name = "${baseName}-${version}";
     src = fetchurl {
       url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
-      sha256 = "1ksfj6h6vwaws52055mg80pm2bslw23kpx3a7ahraa6ngk934kw5";
+      sha256 = "0ymmhw41n5a81qkxvq7lrssis4y53jh5gxs2k6s2v6brnxxc9qjw";
     };
 
     patches = stdenv.lib.optionals stdenv.isDarwin [ ./no-xcode-v7.patch ];


### PR DESCRIPTION
###### Motivation for this change

This fixes a regression introduced with nodejs 8.8.0.

[Release Notes](https://nodejs.org/en/blog/release/v8.8.1/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

