### PR TITLE
duckmarines: 1.0b => 1.0c

### DIFF
--- a/pkgs/games/duckmarines/default.nix
+++ b/pkgs/games/duckmarines/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "duckmarines";
-  version = "1.0b";
+  version = "1.0c";
 
   icon = fetchurl {
     url = "http://tangramgames.dk/img/thumb/duckmarines.png";


### PR DESCRIPTION
###### Motivation for this change

Version bump to new upstream version of this addictive game as per https://repology.org/metapackage/duckmarines/versions.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions 
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

