### PR TITLE
sshlatex: init at 0.7

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -268,6 +268,7 @@
   htr = "Hugo Tavares Reis <hugo@linux.com>";
   iand675 = "Ian Duncan <ian@iankduncan.com>";
   ianwookim = "Ian-Woo Kim <ianwookim@gmail.com>";
+  iblech = "Ingo Blechschmidt <iblech@speicherleck.de>";
   igsha = "Igor Sharonov <igor.sharonov@gmail.com>";
   ikervagyok = "Balázs Lengyel <ikervagyok@gmail.com>";
   infinisil = "Silvan Mosberger <infinisil@icloud.com>";

--- a/pkgs/tools/typesetting/sshlatex/default.nix
+++ b/pkgs/tools/typesetting/sshlatex/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, inotify-tools, openssh, perl, gnutar, bash, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "sshlatex-${version}";
+  version = "0.7";
+
+  src = fetchFromGitHub {
+    owner = "iblech";
+    repo = "sshlatex";
+    rev = "${version}";
+    sha256 = "02h81i8n3skg9jnlfrisyg5bhqicrn6svq64kp20f70p64s3d7ix";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = let
+    binPath = stdenv.lib.makeBinPath [ openssh perl gnutar bash inotify-tools ];
+  in ''
+    mkdir -p $out/bin
+    cp sshlatex $out/bin
+    wrapProgram $out/bin/sshlatex --prefix PATH : "${binPath}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A collection of hacks to efficiently run LaTeX via ssh";
+    longDescription = ''
+      sshlatex is a tool which uploads LaTeX source files to a remote, runs
+      LaTeX there, and streams the resulting PDF file to the local host.
+      Because sshlatex prestarts LaTeX with the previous run's preamble,
+      thereby preloading the required LaTeX packages, it is also useful in a
+      purely local setting.
+    '';
+    homepage = https://github.com/iblech/sshlatex;
+    license = stdenv.lib.licenses.gpl3Plus;  # actually dual-licensed gpl3Plus | lppl13cplus
+    platforms = stdenv.lib.platforms.all;
+    maintainers = [ maintainers.iblech ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4486,6 +4486,8 @@ with pkgs;
 
   sshfs-fuse = callPackage ../tools/filesystems/sshfs-fuse { };
 
+  sshlatex = callPackage ../tools/typesetting/sshlatex { };
+
   sshuttle = callPackage ../tools/security/sshuttle { };
 
   ssldump = callPackage ../tools/networking/ssldump { };


### PR DESCRIPTION
###### Motivation for this change

sshlatex is a tool which uploads LaTeX source files to a remote, runs LaTeX there, and streams the resulting PDF file to the local host. Because sshlatex prestarts LaTeX with the previous run's preamble, thereby preloading the required LaTeX packages, it is also useful in a purely local setting.

This pull request adds sshlatex to the Nix package database.


###### Things done

I'm a first-time contributor to NixOS and not yet familiar with the culture. Please don't refrain from criticizing this pull request! I'm happy to work on it so it meets the usual standards.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
