### PR TITLE
nixUnstable: rename to nix-unstable

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -160,7 +160,7 @@ in rec {
   }) // { perl-bindings = nixStable; };
 
   nixUnstable = (lib.lowPrio (common rec {
-    name = "nix-1.12${suffix}";
+    name = "nix-unstable-1.12${suffix}";
     suffix = "pre5663_c7af84ce";
     src = fetchFromGitHub {
       owner = "NixOS";


### PR DESCRIPTION
@edolstra @shlevy The fact that `nixStable` and `nixUnstable` are both named `nix` confuses users of nixpkgs who do selective updates: they always see e.g. `nix-1.11.8 < 1.12pre5619_346aeee1` in `nix-env -qc` and never update it: #30834 (another report in IRC). Could we rename unstable Nix to `nix-unstable`?