### PR TITLE
[RFC] A large batch of cross-compilation fixes

### DIFF
--- a/nixos/modules/installer/cd-dvd/sd-image.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image.nix
@@ -63,7 +63,7 @@ in
     system.build.sdImage = pkgs.stdenv.mkDerivation {
       name = "sd-image-${pkgs.stdenv.system}.img";
 
-      buildInputs = with pkgs; [ dosfstools e2fsprogs mtools libfaketime utillinux ];
+      nativeBuildInputs = with pkgs; [ dosfstools e2fsprogs mtools libfaketime utillinux ];
 
       buildCommand = ''
         # Create the image file sized to fit /boot and /, plus 20M of slack

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -142,6 +142,14 @@ in
         Ignored when <code>nixpkgs.pkgs</code> is set.
       '';
     };
+
+    crossSystem = mkOption {
+      default = null;
+      example = "i686-linux";
+      description = ''
+        TODO
+      '';
+    };
   };
 
   config = {

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -558,6 +558,7 @@
   ./services/networking/ssh/lshd.nix
   ./services/networking/ssh/sshd.nix
   ./services/networking/strongswan.nix
+  ./services/networking/strongswan-swanctl/module.nix
   ./services/networking/stunnel.nix
   ./services/networking/supplicant.nix
   ./services/networking/supybot.nix

--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -56,6 +56,7 @@ in
 
       setXAuthLocation = mkOption {
         type = types.bool;
+        default = false;
         description = ''
           Whether to set the path to <command>xauth</command> for X11-forwarded connections.
           This causes a dependency on X11 packages.

--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -54,7 +54,7 @@ let
     '';
 
   writeShScript = name: text: let dir = pkgs.writeScriptBin name ''
-    #! ${pkgs.stdenv.shell} -e
+    #! ${pkgs.bash} -e
     ${text}
   ''; in "${dir}/bin/${name}";
 

--- a/nixos/modules/services/networking/strongswan-swanctl/module.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/module.nix
@@ -1,0 +1,80 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+with (import ./param-lib.nix lib);
+
+let
+  cfg = config.services.strongswan-swanctl;
+
+  # TODO: auto-generate these files using:
+  # https://github.com/strongswan/strongswan/tree/master/conf
+  # IDEA: extend the format-options.py script to output these Nix files.
+  strongswanParams = import ./strongswan-params.nix lib;
+  swanctlParams    = import ./swanctl-params.nix    lib;
+in  {
+  options.services.strongswan-swanctl = {
+    enable = mkEnableOption "strongswan-swanctl service";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.strongswan;
+      defaultText = "pkgs.strongswan";
+      description = ''
+        The strongswan derivation to use.
+      '';
+    };
+
+    strongswan = paramsToOptions strongswanParams;
+    swanctl    = paramsToOptions swanctlParams;
+  };
+
+  config = mkIf cfg.enable {
+
+    assertions = [
+      { assertion = !config.services.strongswan.enable;
+        message = "cannot enable both services.strongswan and services.strongswan-swanctl. Choose either one.";
+      }
+    ];
+
+    environment.etc."swanctl/swanctl.conf".text =
+      paramsToConf cfg.swanctl swanctlParams;
+
+    # The swanctl command complains when the following directories don't exist:
+    # See: https://wiki.strongswan.org/projects/strongswan/wiki/Swanctldirectory
+    system.activationScripts.strongswan-swanctl-etc = stringAfter ["etc"] ''
+      mkdir -p '/etc/swanctl/x509'     # Trusted X.509 end entity certificates
+      mkdir -p '/etc/swanctl/x509ca'   # Trusted X.509 Certificate Authority certificates
+      mkdir -p '/etc/swanctl/x509ocsp'
+      mkdir -p '/etc/swanctl/x509aa'   # Trusted X.509 Attribute Authority certificates
+      mkdir -p '/etc/swanctl/x509ac'   # Attribute Certificates
+      mkdir -p '/etc/swanctl/x509crl'  # Certificate Revocation Lists
+      mkdir -p '/etc/swanctl/pubkey'   # Raw public keys
+      mkdir -p '/etc/swanctl/private'  # Private keys in any format
+      mkdir -p '/etc/swanctl/rsa'      # PKCS#1 encoded RSA private keys
+      mkdir -p '/etc/swanctl/ecdsa'    # Plain ECDSA private keys
+      mkdir -p '/etc/swanctl/bliss'
+      mkdir -p '/etc/swanctl/pkcs8'    # PKCS#8 encoded private keys of any type
+      mkdir -p '/etc/swanctl/pkcs12'   # PKCS#12 containers
+    '';
+
+    systemd.services.strongswan-swanctl = {
+      description = "strongSwan IPsec IKEv1/IKEv2 daemon using swanctl";
+      wantedBy = [ "multi-user.target" ];
+      after    = [ "network-online.target" "keys.target" ];
+      wants    = [ "keys.target" ];
+      path = with pkgs; [ kmod iproute iptables utillinux ];
+      environment.STRONGSWAN_CONF = pkgs.writeTextFile {
+        name = "strongswan.conf";
+        text = paramsToConf cfg.strongswan strongswanParams;
+      };
+      restartTriggers = [ config.environment.etc."swanctl/swanctl.conf".source ];
+      serviceConfig = {
+        ExecStart     = "${cfg.package}/sbin/charon-systemd";
+        Type          = "notify";
+        ExecStartPost = "${cfg.package}/sbin/swanctl --load-all --noprompt";
+        ExecReload    = "${cfg.package}/sbin/swanctl --reload";
+        Restart       = "on-abnormal";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/networking/strongswan-swanctl/param-constructors.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/param-constructors.nix
@@ -1,0 +1,162 @@
+# In the following context a parameter is an attribute set that
+# contains a NixOS option and a render function. It also contains the
+# attribute: '_type = "param"' so we can distinguish it from other
+# sets.
+#
+# The render function is used to convert the value of the option to a
+# snippet of strongswan.conf. Most parameters simply render their
+# value to a string. For example, take the following parameter:
+#
+#   threads = mkIntParam 10 "Threads to use for request handling.";
+#
+# When a users defines the corresponding option as for example:
+#
+#   services.strongswan-swanctl.strongswan.threads = 32;
+#
+# It will get rendered to the following snippet in strongswan.conf:
+#
+#   threads = 32
+#
+# Some parameters however need to be able to change the attribute
+# name. For example, take the following parameter:
+#
+#   id = mkPrefixedAttrsOfParam (mkOptionalStrParam "") "...";
+#
+# A user can define the corresponding option as for example:
+#
+#   id = {
+#     "foo" = "bar";
+#     "baz" = "qux";
+#   };
+#
+# This will get rendered to the following snippet:
+#
+#   foo-id = bar
+#   baz-id = qux
+#
+# For this reason the render function is not simply a function from
+# value -> string but a function from a value to an attribute set:
+# { "${name}" = string }. This allows parameters to change the attribute
+# name like in the previous example.
+
+lib :
+
+with lib;
+with (import ./param-lib.nix lib);
+
+rec {
+  mkParamOfType = type : strongswanDefault : description : {
+    _type = "param";
+    option = mkOption {
+      type = types.nullOr type;
+      default = null;
+      description = documentDefault description strongswanDefault;
+    };
+    render = single toString;
+  };
+
+  documentDefault = description : strongswanDefault :
+    if isNull strongswanDefault
+    then description
+    else description + ''
+      </para><para>
+      StrongSwan default: <literal><![CDATA[${builtins.toJSON strongswanDefault}]]></literal>
+    '';
+
+  single = f: name: value: { "${name}" = f value; };
+
+  mkStrParam         = mkParamOfType types.str;
+  mkOptionalStrParam = mkStrParam null;
+
+  mkEnumParam = values : mkParamOfType (types.enum values);
+
+  mkIntParam         = mkParamOfType types.int;
+  mkOptionalIntParam = mkIntParam null;
+
+  # We should have floats in Nix...
+  mkFloatParam = mkStrParam;
+
+  # TODO: Check for hex format:
+  mkHexParam         = mkStrParam;
+  mkOptionalHexParam = mkOptionalStrParam;
+
+  # TODO: Check for duration format:
+  mkDurationParam         = mkStrParam;
+  mkOptionalDurationParam = mkOptionalStrParam;
+
+  mkYesNoParam = strongswanDefault : description : {
+    _type = "param";
+    option = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = documentDefault description strongswanDefault;
+    };
+    render = single (b: if b then "yes" else "no");
+  };
+  yes = true;
+  no  = false;
+
+  mkSpaceSepListParam = mkSepListParam " ";
+  mkCommaSepListParam = mkSepListParam ",";
+
+  mkSepListParam = sep : strongswanDefault : description : {
+    _type = "param";
+    option = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      default = null;
+      description = documentDefault description strongswanDefault;
+    };
+    render = single (value: concatStringsSep sep value);
+  };
+
+  mkAttrsOfParams = params :
+    mkAttrsOf params (types.submodule {options = paramsToOptions params;});
+
+  mkAttrsOfParam = param :
+    mkAttrsOf param param.option.type;
+
+  mkAttrsOf = param : option : description : {
+    _type = "param";
+    option = mkOption {
+      type = types.attrsOf option;
+      default = {};
+      inherit description;
+    };
+    render = single (attrs:
+      (paramsToRenderedStrings attrs
+        (mapAttrs (_n: _v: param) attrs)));
+  };
+
+  mkPrefixedAttrsOfParams = params :
+    mkPrefixedAttrsOf params (types.submodule {options = paramsToOptions params;});
+
+  mkPrefixedAttrsOfParam = param :
+    mkPrefixedAttrsOf param param.option.type;
+
+  mkPrefixedAttrsOf = p : option : description : {
+    _type = "param";
+    option = mkOption {
+      type = types.attrsOf option;
+      default = {};
+      inherit description;
+    };
+    render = prefix: attrs:
+      let prefixedAttrs = mapAttrs' (name: nameValuePair "${prefix}-${name}") attrs;
+      in paramsToRenderedStrings prefixedAttrs
+           (mapAttrs (_n: _v: p) prefixedAttrs);
+  };
+
+  mkPostfixedAttrsOfParams = params : description : {
+    _type = "param";
+    option = mkOption {
+      type = types.attrsOf (types.submodule {options = paramsToOptions params;});
+      default = {};
+      inherit description;
+    };
+    render = postfix: attrs:
+      let postfixedAttrs = mapAttrs' (name: nameValuePair "${name}-${postfix}") attrs;
+      in paramsToRenderedStrings postfixedAttrs
+           (mapAttrs (_n: _v: params) postfixedAttrs);
+  };
+
+}

--- a/nixos/modules/services/networking/strongswan-swanctl/param-lib.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/param-lib.nix
@@ -1,0 +1,82 @@
+lib :
+
+with lib;
+
+rec {
+  paramsToConf = cfg : ps : mkConf 0 (paramsToRenderedStrings cfg ps);
+
+  # mkConf takes an indentation level (which usually starts at 0) and a nested
+  # attribute set of strings and will render that set to a strongswan.conf style
+  # configuration format. For example:
+  #
+  #   mkConf 0 {a = "1"; b = { c = { "foo" = "2"; "bar" = "3"; }; d = "4";};}   =>   ''
+  #   a = 1
+  #   b {
+  #     c {
+  #       foo = 2
+  #       bar = 3
+  #     }
+  #     d = 4
+  #   }''
+  mkConf = indent : ps :
+    concatMapStringsSep "\n"
+      (name:
+        let value = ps."${name}";
+            indentation = replicate indent " ";
+        in
+        indentation + (
+          if isAttrs value
+          then "${name} {\n" +
+                 mkConf (indent + 2) value + "\n" +
+               indentation + "}"
+          else "${name} = ${value}"
+        )
+      )
+      (attrNames ps);
+
+  replicate = n : c : concatStrings (builtins.genList (_x : c) n);
+
+  # `paramsToRenderedStrings cfg ps` converts the NixOS configuration `cfg`
+  # (typically the "config" argument of a NixOS module) and the set of
+  # parameters `ps` (an attribute set where the values are constructed using the
+  # parameter constructors in ./param-constructors.nix) to a nested attribute
+  # set of strings (rendered parameters).
+  paramsToRenderedStrings = cfg : ps :
+    filterEmptySets (
+      (mapParamsRecursive (path: name: param:
+        let value = attrByPath path null cfg;
+        in optionalAttrs (!isNull value) (param.render name value)
+      ) ps));
+
+  filterEmptySets = set : filterAttrs (n: v: !(isNull v)) (mapAttrs (name: value:
+    if isAttrs value
+    then let value' = filterEmptySets value;
+         in if value' == {}
+            then null
+            else value'
+    else value
+  ) set);
+
+  # Recursively map over every parameter in the given attribute set.
+  mapParamsRecursive = mapAttrsRecursiveCond' (as: (!(as ? "_type" && as._type == "param")));
+
+  mapAttrsRecursiveCond' = cond: f: set:
+    let
+      recurse = path: set:
+        let
+          g =
+            name: value:
+            if isAttrs value && cond value
+              then { "${name}" = recurse (path ++ [name]) value; }
+              else f (path ++ [name]) name value;
+        in mapAttrs'' g set;
+    in recurse [] set;
+
+  mapAttrs'' = f: set:
+    foldl' (a: b: a // b) {} (map (attr: f attr set.${attr}) (attrNames set));
+
+  # Extract the options from the given set of parameters.
+  paramsToOptions = ps :
+    mapParamsRecursive (_path: name: param: { "${name}" = param.option; }) ps;
+
+}

--- a/nixos/modules/services/networking/strongswan-swanctl/strongswan-charon-params.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/strongswan-charon-params.nix
@@ -1,0 +1,568 @@
+lib: with (import ./param-constructors.nix lib);
+
+let loglevelParams = import ./strongswan-loglevel-params.nix lib;
+in {
+  accept_unencrypted_mainmode_messages = mkYesNoParam no ''
+    Accept unencrypted ID and HASH payloads in IKEv1 Main Mode. Some
+    implementations send the third Main Mode message unencrypted, probably
+    to find the PSKs for the specified ID for authentication. This is very
+    similar to Aggressive Mode, and has the same security implications: A
+    passive attacker can sniff the negotiated Identity, and start brute
+    forcing the PSK using the HASH payload. It is recommended to keep this
+    option to no, unless you know exactly what the implications are and
+    require compatibility to such devices (for example, some SonicWall
+    boxes).
+  '';
+
+  block_threshold = mkIntParam 5 ''
+    Maximum number of half-open IKE_SAs for a single peer IP.
+  '';
+
+  cache_crls = mkYesNoParam no ''
+    Whether Certicate Revocation Lists (CRLs) fetched via HTTP or LDAP
+    should be saved under a unique file name derived from the public
+    key of the Certification Authority (CA) to
+    <literal>/etc/ipsec.d/crls</literal> (stroke) or
+    <literal>/etc/swanctl/x509crl</literal> (vici), respectively.
+  '';
+
+  cert_cache = mkYesNoParam yes ''
+    Whether relations in validated certificate chains should be cached in memory.
+  '';
+
+  cisco_unity = mkYesNoParam no ''
+    Send Cisco Unity vendor ID payload (IKEv1 only), see unity plugin.
+  '';
+
+  close_ike_on_child_failure = mkYesNoParam no ''
+    Close the IKE_SA if setup of the CHILD_SA along with IKE_AUTH failed.
+  '';
+
+  cookie_threshold = mkIntParam 10 ''
+    Number of half-open IKE_SAs that activate the cookie mechanism.
+  '';
+
+  crypto_test.bench = mkYesNoParam no ''
+    Benchmark crypto algorithms and order them by efficiency.
+  '';
+
+  crypto_test.bench_size = mkIntParam 1024 ''
+    Buffer size used for crypto benchmark.
+  '';
+
+  crypto_test.bench_time = mkIntParam 50 ''
+    Number of iterations to test each algorithm.
+  '';
+
+  crypto_test.on_add = mkYesNoParam no ''
+    Test crypto algorithms during registration
+    (requires test vectors provided by the test-vectors plugin).
+  '';
+
+  crypto_test.on_create = mkYesNoParam no ''
+    Test crypto algorithms on each crypto primitive instantiation.
+  '';
+
+  crypto_test.required = mkYesNoParam no ''
+    Strictly require at least one test vector to enable an algorithm.
+  '';
+
+  crypto_test.rng_true = mkYesNoParam no ''
+    Whether to test RNG with TRUE quality; requires a lot of entropy.
+  '';
+
+  delete_rekeyed = mkYesNoParam no ''
+    Delete CHILD_SAs right after they got successfully rekeyed (IKEv1 only).
+    Reduces the number of stale CHILD_SAs in scenarios with a lot of rekeyings.
+    However, this might cause problems with implementations that continue
+    to use rekeyed SAs until they expire.
+  '';
+
+  delete_rekeyed_delay = mkIntParam 5 ''
+    Delay in seconds until inbound IPsec SAs are deleted after rekeyings
+    (IKEv2 only).
+    </para><para>
+    To process delayed packets the inbound part of a CHILD_SA is kept
+    installed up to the configured number of seconds after it got replaced
+    during a rekeying. If set to 0 the CHILD_SA will be kept installed until
+    it expires (if no lifetime is set it will be destroyed immediately).
+  '';
+
+  dh_exponent_ansi_x9_42 = mkYesNoParam yes ''
+    Use ANSI X9.42 DH exponent size or optimum size matched to
+    cryptographical strength.
+  '';
+
+  dlopen_use_rtld_now = mkYesNoParam no ''
+    Use RTLD_NOW with dlopen() when loading plugins and IMV/IMCs to reveal
+    missing symbols immediately. Useful during development of custom plugins.
+  '';
+
+  dns1 = mkOptionalStrParam ''
+    DNS server assigned to peer via configuration payload (CP), see attr plugin.
+  '';
+
+  dns2 = mkOptionalStrParam ''
+    DNS server assigned to peer via configuration payload (CP).
+  '';
+
+  dos_protection = mkYesNoParam yes ''
+    Enable Denial of Service protection using cookies and aggressiveness checks.
+  '';
+
+  ecp_x_coordinate_only = mkYesNoParam yes ''
+    Compliance with the errata for RFC 4753.
+  '';
+
+  filelog = mkAttrsOfParams ({
+    append = mkYesNoParam yes ''
+      If this option is enabled log entries are appended to the existing file.
+    '';
+
+    flush_line = mkYesNoParam no ''
+      Enabling this option disables block buffering and enables line
+      buffering. That is, a flush to disk is enforced for each logged line.
+    '';
+
+    ike_name = mkYesNoParam no ''
+      Prefix each log entry with the connection name and a unique numerical
+      identifier for each IKE_SA.
+    '';
+
+    time_format = mkOptionalStrParam ''
+      Prefix each log entry with a timestamp. The option accepts a format string
+      as passed to strftime(3).
+    '';
+
+    time_add_ms = mkYesNoParam no ''
+      Adds the milliseconds within the current second after the timestamp
+      (separated by a dot, so time_format should end with %S or %T)
+    '';
+  } // loglevelParams) ''Section to define file loggers, see LoggerConfiguration.'';
+
+  flush_auth_cfg = mkYesNoParam no ''
+    If enabled objects used during authentication (certificates, identities
+    etc.) are released to free memory once an IKE_SA is
+    established. Enabling this might conflict with plugins that later need
+    access to e.g. the used certificates.
+  '';
+
+  follow_redirects = mkYesNoParam yes ''
+    Whether to follow IKEv2 redirects (RFC 5685).
+  '';
+
+  fragment_size = mkIntParam 1280 ''
+    Maximum size (complete IP datagram size in bytes) of a sent IKE fragment
+    when using proprietary IKEv1 or standardized IKEv2 fragmentation,
+    defaults to 1280 (use 0 for address family specific default values,
+    which uses a lower value for IPv4). If specified this limit is used for
+    both IPv4 and IPv6.
+  '';
+
+  group = mkOptionalStrParam ''
+    Name of the group the daemon changes to after startup.
+  '';
+
+  half_open_timeout = mkIntParam 30 ''
+    Timeout in seconds for connecting IKE_SAs, also see IKE_SA_INIT dropping.
+  '';
+
+  hash_and_url = mkYesNoParam no ''
+    Enable hash and URL support.
+  '';
+
+  host_resolver.max_threads = mkIntParam 3 ''
+    Maximum number of concurrent resolver threads (they are terminated if unused).
+  '';
+
+  host_resolver.min_threads = mkIntParam 0 ''
+    Minimum number of resolver threads to keep around.
+  '';
+
+  i_dont_care_about_security_and_use_aggressive_mode_psk = mkYesNoParam no ''
+    If enabled responders are allowed to use IKEv1 Aggressive Mode with
+    pre-shared keys, which is discouraged due to security concerns (offline
+    attacks on the openly transmitted hash of the PSK).
+  '';
+
+  ignore_acquire_ts = mkYesNoParam no ''
+    If this is disabled the traffic selectors from the kernel's acquire
+    events, which are derived from the triggering packet, are prepended to
+    the traffic selectors from the configuration for IKEv2 connection. By
+    enabling this, such specific traffic selectors will be ignored and only
+    the ones in the config will be sent. This always happens for IKEv1
+    connections as the protocol only supports one set of traffic selectors
+    per CHILD_SA.
+  '';
+
+  ignore_routing_tables = mkSpaceSepListParam [] ''
+    A space-separated list of routing tables to be excluded from route lookup.
+  '';
+
+  ikesa_limit = mkIntParam 0 ''
+    Maximum number of IKE_SAs that can be established at the same time
+    before new connection attempts are blocked.
+  '';
+
+  ikesa_table_segments = mkIntParam 1 ''
+    Number of exclusively locked segments in the hash table, see IKE_SA
+    lookup tuning.
+  '';
+
+  ikesa_table_size = mkIntParam 1 ''
+    Size of the IKE_SA hash table, see IKE_SA lookup tuning.
+  '';
+
+  inactivity_close_ike = mkYesNoParam no ''
+    Whether to close IKE_SA if the only CHILD_SA closed due to inactivity.
+  '';
+
+  init_limit_half_open = mkIntParam 0 ''
+    Limit new connections based on the current number of half open IKE_SAs,
+    see IKE_SA_INIT dropping.
+  '';
+
+  init_limit_job_load = mkIntParam 0 ''
+    Limit new connections based on the number of jobs currently queued for
+    processing, see IKE_SA_INIT dropping.
+  '';
+
+  initiator_only = mkYesNoParam no ''
+    Causes charon daemon to ignore IKE initiation requests.
+  '';
+
+  install_routes = mkYesNoParam yes ''
+    Install routes into a separate routing table for established IPsec
+    tunnels. If disabled a more efficient lookup for source and next-hop
+    addresses is used since 5.5.2.
+  '';
+
+  install_virtual_ip = mkYesNoParam yes ''
+    Install virtual IP addresses.
+  '';
+
+  install_virtual_ip_on = mkOptionalStrParam ''
+    The name of the interface on which virtual IP addresses should be
+    installed. If not specified the addresses will be installed on the
+    outbound interface.
+  '';
+
+  integrity_test = mkYesNoParam no ''
+    Check daemon, libstrongswan and plugin integrity at startup.
+  '';
+
+  interfaces_ignore = mkCommaSepListParam [] ''
+    List of network interfaces that should be ignored, if
+    <option>interfaces_use</option> is specified this option has no effect.
+  '';
+
+  interfaces_use = mkCommaSepListParam [] ''
+    List of network interfaces that should be used by
+    charon. All other interfaces are ignored.
+  '';
+
+  keep_alive = mkIntParam 20 ''
+    NAT keep alive interval in seconds.
+  '';
+
+  leak_detective.detailed = mkYesNoParam yes ''
+    Includes source file names and line numbers in leak detective output.
+  '';
+
+  leak_detective.usage_threshold = mkIntParam 10240 ''
+    Threshold in bytes for leaks to be reported (0 to report all).
+  '';
+
+  leak_detective.usage_threshold_count = mkIntParam 0 ''
+    Threshold in number of allocations for leaks to be reported (0 to report
+    all).
+  '';
+
+  load = mkSpaceSepListParam [] ''
+    Plugins to load in IKEv2 charon daemon, see PluginLoad.
+  '';
+
+  load_modular = mkYesNoParam no ''
+    If enabled the list of plugins to load is determined by individual load
+    settings for each plugin, see PluginLoad.
+  '';
+
+  make_before_break = mkYesNoParam no ''
+    Initiate IKEv2 reauthentication with a make-before-break instead of a
+    break-before-make scheme. Make-before-break uses overlapping IKE and
+    CHILD_SA during reauthentication by first recreating all new SAs before
+    deleting the old ones. This behavior can be beneficial to avoid
+    connectivity gaps during reauthentication, but requires support for
+    overlapping SAs by the peer. strongSwan can handle such overlapping SAs
+    since 5.3.0.
+  '';
+
+  max_ikev1_exchanges = mkIntParam 3 ''
+    Maximum number of IKEv1 phase 2 exchanges per IKE_SA to keep state about
+    and track concurrently.
+  '';
+
+  max_packet = mkIntParam 10000 ''
+    Maximum packet size accepted by charon.
+  '';
+
+  multiple_authentication = mkYesNoParam yes ''
+    Enable multiple authentication exchanges (RFC 4739).
+  '';
+
+  nbns1 = mkOptionalStrParam ''
+    WINS server assigned to peer via configuration payload (CP), see attr
+    plugin.
+  '';
+
+  nbns2 = mkOptionalStrParam ''
+    WINS server assigned to peer via configuration payload (CP).
+  '';
+
+  port = mkIntParam 500 ''
+    UDP port used locally. If set to 0 a random port will be allocated.
+  '';
+
+  port_nat_t = mkIntParam 4500 ''
+    UDP port used locally in case of NAT-T. If set to 0 a random port will
+    be allocated. Has to be different from charon.port, otherwise a random
+    port will be allocated.
+  '';
+
+  prefer_best_path = mkYesNoParam no ''
+    By default, charon keeps SAs on the routing path with addresses it
+    previously used if that path is still usable. By enabling this option,
+    it tries more aggressively to update SAs with MOBIKE on routing priority
+    changes using the cheapest path. This adds more noise, but allows to
+    dynamically adapt SAs to routing priority changes. This option has no
+    effect if MOBIKE is not supported or disabled.
+  '';
+
+  prefer_configured_proposals = mkYesNoParam yes ''
+    Prefer locally configured proposals for IKE/IPsec over supplied ones as
+    responder (disabling this can avoid keying retries due to
+    INVALID_KE_PAYLOAD notifies).
+  '';
+
+  prefer_temporary_addrs = mkYesNoParam no ''
+    By default public IPv6 addresses are preferred over temporary ones
+    (according to RFC 4941), to make connections more stable. Enable this
+    option to reverse this.
+  '';
+
+  process_route = mkYesNoParam yes ''
+    Process RTM_NEWROUTE and RTM_DELROUTE events.
+  '';
+
+  processor.priority_threads = {
+    critical = mkIntParam 0 ''
+      Threads reserved for CRITICAL priority class jobs.
+    '';
+
+    high = mkIntParam 0 ''
+      Threads reserved for HIGH priority class jobs.
+    '';
+
+    medium = mkIntParam 0 ''
+      Threads reserved for MEDIUM priority class jobs.
+    '';
+
+    low = mkIntParam 0 ''
+      Threads reserved for LOW priority class jobs.
+    '';
+  };
+
+  receive_delay = mkIntParam 0 ''
+    Delay in ms for receiving packets, to simulate larger RTT.
+  '';
+
+  receive_delay_response = mkYesNoParam yes ''
+    Delay response messages.
+  '';
+
+  receive_delay_request = mkYesNoParam yes ''
+    Delay request messages.
+  '';
+
+  receive_delay_type = mkIntParam 0 ''
+    Specific IKEv2 message type to delay, 0 for any.
+  '';
+
+  replay_window = mkIntParam 32 ''
+    Size of the AH/ESP replay window, in packets.
+  '';
+
+  retransmit_base = mkFloatParam "1.8" ''
+    Base to use for calculating exponential back off, see Retransmission.
+  '';
+
+  retransmit_jitter = mkIntParam 0 ''
+    Maximum jitter in percent to apply randomly to calculated retransmission
+    timeout (0 to disable).
+  '';
+
+  retransmit_limit = mkIntParam 0 ''
+    Upper limit in seconds for calculated retransmission timeout (0 to
+    disable).
+  '';
+
+  retransmit_timeout = mkFloatParam "4.0" ''
+    Timeout in seconds before sending first retransmit.
+  '';
+
+  retransmit_tries = mkIntParam 5 ''
+    Number of times to retransmit a packet before giving up.
+  '';
+
+  retry_initiate_interval = mkIntParam 0 ''
+    Interval in seconds to use when retrying to initiate an IKE_SA (e.g. if
+    DNS resolution failed), 0 to disable retries.
+  '';
+
+  reuse_ikesa = mkYesNoParam yes ''
+    Initiate CHILD_SA within existing IKE_SAs (always enabled for IKEv1).
+  '';
+
+  routing_table = mkIntParam 220 ''
+    Numerical routing table to install routes to.
+  '';
+
+  routing_table_prio = mkIntParam 220 ''
+    Priority of the routing table.
+  '';
+
+  send_delay = mkIntParam 0 ''
+    Delay in ms for sending packets, to simulate larger RTT.
+  '';
+
+  send_delay_request = mkYesNoParam yes ''
+    Delay request messages.
+  '';
+
+  send_delay_response = mkYesNoParam yes ''
+    Delay response messages.
+  '';
+
+  send_delay_type = mkIntParam 0 ''
+    Specific IKEv2 message type to delay, 0 for any.
+  '';
+
+  send_vendor_id = mkYesNoParam no ''
+    Send strongSwan vendor ID payload.
+  '';
+
+  signature_authentication = mkYesNoParam yes ''
+    Whether to enable Signature Authentication as per RFC 7427.
+  '';
+
+  signature_authentication_constraints = mkYesNoParam yes ''
+    If enabled, signature schemes configured in rightauth, in addition to
+    getting used as constraints against signature schemes employed in the
+    certificate chain, are also used as constraints against the signature
+    scheme used by peers during IKEv2.
+  '';
+
+  spi_min = mkHexParam "0xc0000000" ''
+    The lower limit for SPIs requested from the kernel for IPsec SAs. Should
+    not be set lower than 0x00000100 (256), as SPIs between 1 and 255 are
+    reserved by IANA.
+  '';
+
+  spi_max = mkHexParam "0xcfffffff" ''
+    The upper limit for SPIs requested from the kernel for IPsec SAs.
+  '';
+
+  start-scripts = mkAttrsOfParam (mkStrParam "" "") ''
+    Section containing a list of scripts (name = path) that are executed
+    when the daemon is started.
+  '';
+
+  stop-scripts = mkAttrsOfParam (mkStrParam "" "") ''
+    Section containing a list of scripts (name = path) that are executed
+    when the daemon is terminated.
+  '';
+
+  syslog = loglevelParams // {
+    identifier = mkOptionalStrParam ''
+      Identifier for use with openlog(3).
+      </para><para>
+      Global identifier used for an openlog(3) call, prepended to each log
+      message by syslog.  If not configured, openlog(3) is not called, so
+      the value will depend on system defaults (often the program name).
+    '';
+
+    ike_name = mkYesNoParam no ''
+      Prefix each log entry with the connection name and a unique numerical
+      identifier for each IKE_SA.
+    '';
+  };
+
+  threads = mkIntParam 16 ''
+    Number of worker threads in charon. Several of these are reserved for
+    long running tasks in internal modules and plugins. Therefore, make sure
+    you don't set this value too low. The number of idle worker threads
+    listed in ipsec statusall might be used as indicator on the number of
+    reserved threads (JobPriority has more on this).
+  '';
+
+  user = mkOptionalStrParam ''
+    Name of the user the daemon changes to after startup.
+  '';
+
+  x509.enforce_critical = mkYesNoParam yes ''
+    Discard certificates with unsupported or unknown critical extensions.
+  '';
+
+  plugins = import ./strongswan-charon-plugins-params.nix lib;
+
+  imcv = {
+    assessment_result = mkYesNoParam yes ''
+      Whether IMVs send a standard IETF Assessment Result attribute.
+    '';
+
+    database = mkOptionalStrParam ''
+      Global IMV policy database URI. If it contains a password, make sure to
+      adjust the permissions of the config file accordingly.
+    '';
+
+    os_info.default_password_enabled = mkYesNoParam no ''
+      Manually set whether a default password is enabled.
+    '';
+
+    os_info.name = mkOptionalStrParam ''
+      Manually set the name of the client OS (e.g. <literal>NixOS</literal>).
+    '';
+
+    os_info.version = mkOptionalStrParam ''
+      Manually set the version of the client OS (e.g. <literal>17.09</literal>).
+    '';
+
+    policy_script = mkStrParam "ipsec _imv_policy" ''
+      Script called for each TNC connection to generate IMV policies.
+    '';
+  };
+
+  tls = {
+    cipher = mkSpaceSepListParam [] ''
+      List of TLS encryption ciphers.
+    '';
+
+    key_exchange = mkSpaceSepListParam [] ''
+      List of TLS key exchange methods.
+    '';
+
+    mac = mkSpaceSepListParam [] ''
+      List of TLS MAC algorithms.
+    '';
+
+    suites = mkSpaceSepListParam [] ''
+      List of TLS cipher suites.
+    '';
+  };
+
+  tnc = {
+    libtnccs.tnc_config = mkStrParam "/etc/tnc_config" ''
+      TNC IMC/IMV configuration file.
+    '';
+  };
+}

--- a/nixos/modules/services/networking/strongswan-swanctl/strongswan-charon-params.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/strongswan-charon-params.nix
@@ -431,6 +431,10 @@ in {
     Priority of the routing table.
   '';
 
+  rsa_pss = mkYesNoParam no ''
+    Whether to use RSA with PSS padding instead of PKCS#1 padding by default.
+  '';
+
   send_delay = mkIntParam 0 ''
     Delay in ms for sending packets, to simulate larger RTT.
   '';

--- a/nixos/modules/services/networking/strongswan-swanctl/strongswan-charon-plugins-params.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/strongswan-charon-plugins-params.nix
@@ -1,0 +1,1070 @@
+lib : with (import ./param-constructors.nix lib); {
+  addrblock.strict = mkYesNoParam yes ''
+    If enabled, a subject certificate without an RFC 3779 address block
+    extension is rejected if the issuer certificate has such an addrblock
+    extension. If disabled, subject certificates issued without addrblock
+    extension are accepted without any traffic selector checks and no policy
+    is enforced by the plugin.
+  '';
+
+  android_log.loglevel = mkIntParam 1 ''
+    Loglevel for logging to Android specific logger.
+  '';
+
+  attr = mkAttrsOfParam (mkCommaSepListParam [] "") ''
+    Section to specify arbitrary attributes that are assigned to a peer
+    via configuration payload, see attr plugin.
+    </para><para>
+    The attribute can be either
+    <literal>address</literal>,
+    <literal>netmask</literal>,
+    <literal>dns</literal>,
+    <literal>nbns</literal>,
+    <literal>dhcp</literal>,
+    <literal>subnet</literal>,
+    <literal>split-include</literal>,
+    <literal>split-exclude</literal>
+    or the numeric identifier of the attribute type. The assigned value can be
+    an IPv4/IPv6 address, a subnet in CIDR notation or an arbitrary value
+    depending on the attribute type. Since some attribute types accept multiple
+    values all values must be specified as a list.
+  '';
+
+  attr-sql.crash_recovery = mkYesNoParam yes ''
+    Release all online leases during startup. Disable this to share the DB
+    between multiple VPN gateways.
+  '';
+
+  attr-sql.database  = mkOptionalStrParam ''
+    Database URI for attr-sql plugin used by charon. If it contains a
+    password, make sure to adjust the permissions of the config file
+    accordingly.
+  '';
+
+  attr-sql.lease_history = mkYesNoParam yes ''
+    Enable logging of SQL IP pool leases.
+  '';
+
+  bliss.use_bliss_b = mkYesNoParam yes ''
+    Use the enhanced BLISS-B key generation and signature algorithm.
+  '';
+
+  bypass-lan.interfaces_ignore = mkCommaSepListParam [] ''
+    List of network interfaces for which connected subnets
+    should be ignored, if interfaces_use is specified this option has no
+    effect.
+  '';
+
+  bypass-lan.interfaces_use = mkCommaSepListParam [] ''
+    List of network interfaces for which connected subnets
+    should be considered. All other interfaces are ignored.
+  '';
+
+  certexpire.csv.cron = mkOptionalStrParam ''
+    Cron style string specifying CSV export times, see certexpire for
+    details.
+  '';
+
+  certexpire.csv.empty_string = mkOptionalStrParam ''
+    String to use in empty intermediate CA fields.
+  '';
+
+  certexpire.csv.fixed_fields = mkYesNoParam yes ''
+    Use a fixed intermediate CA field count.
+  '';
+
+  certexpire.csv.force = mkYesNoParam yes ''
+    Force export of all trustchains we have a private key for.
+  '';
+
+  certexpire.csv.format = mkStrParam "%d:%m:%Y" ''
+    strftime(3) format string to export expiration dates as.
+  '';
+
+  certexpire.csv.local = mkOptionalStrParam ''
+    strftime(3) format string for the CSV file name to export local
+    certificates to.
+  '';
+
+  certexpire.csv.remote = mkOptionalStrParam ''
+    strftime(3) format string for the CSV file name to export remote
+    certificates to.
+  '';
+
+  certexpire.csv.separator = mkStrParam "," ''
+    CSV field separator.
+  '';
+
+  coupling.file = mkOptionalStrParam ''
+    File to store coupling list to, see certcoupling plugin for details.
+  '';
+
+  coupling.hash = mkStrParam "sha1" ''
+    Hashing algorithm to fingerprint coupled certificates.
+  '';
+
+  coupling.max = mkIntParam 1 ''
+    Maximum number of coupling entries to create.
+  '';
+
+  curl.redir = mkIntParam (-1) ''
+    Maximum number of redirects followed by the plugin, set to 0 to disable
+    following redirects, set to -1 for no limit.
+  '';
+
+  dhcp.force_server_address = mkYesNoParam no ''
+    Always use the configured server address, see DHCP plugin for details.
+  '';
+
+  dhcp.identity_lease = mkYesNoParam no ''
+    Derive user-defined MAC address from hash of IKEv2 identity.
+  '';
+
+  dhcp.interface = mkOptionalStrParam ''
+    Interface name the plugin uses for address allocation. The default is to
+    bind to any and let the system decide which way to route the packets to
+    the DHCP server.
+  '';
+
+  dhcp.server = mkStrParam "255.255.255.255" ''
+    DHCP server unicast or broadcast IP address.
+  '';
+
+  dnscert.enable = mkYesNoParam no ''
+    Enable fetching of CERT RRs via DNS.
+  '';
+
+  duplicheck.enable = mkYesNoParam yes ''
+    Enable duplicheck plugin (if loaded).
+  '';
+
+  duplicheck.socket = mkStrParam "unix://\${piddir}/charon.dck" ''
+    Socket provided by the duplicheck plugin.
+  '';
+
+  eap-aka.request_identity = mkYesNoParam yes "";
+
+  eap-aka-3ggp2.seq_check = mkOptionalStrParam ''
+    Enable to activate sequence check of the AKA SQN values in order to trigger
+    resync cycles.
+  '';
+
+  eap-dynamic.prefer_user = mkYesNoParam no ''
+    If enabled, the eap-dynamic plugin will prefer the order of the EAP
+    methods in an EAP-Nak message sent by a client over the one configured
+    locally.
+  '';
+
+  eap-dynamic.preferred = mkCommaSepListParam [] ''
+    The preferred EAP method(s) to be used by the eap-dynamic plugin. If it is
+    not set, the first registered method will be used initially. The methods
+    are tried in the given order before trying the rest of the registered
+    methods.
+  '';
+
+  eap-gtc.backend = mkStrParam "pam" ''
+    XAuth backend to be used for credential verification, see EAP-GTC.
+  '';
+
+  eap-peap.fragment_size = mkIntParam 1024 ''
+    Maximum size of an EAP-PEAP packet.
+  '';
+
+  eap-peap.max_message_count = mkIntParam 32 ''
+    Maximum number of processed EAP-PEAP packets.
+  '';
+
+  eap-peap.include_length = mkYesNoParam no ''
+    Include length in non-fragmented EAP-PEAP packets.
+  '';
+
+  eap-peap.phase2_method = mkStrParam "mschapv2" ''
+    Phase2 EAP client authentication method.
+  '';
+
+  eap-peap.phase2_piggyback = mkYesNoParam no ''
+    Phase2 EAP Identity request piggybacked by server onto TLS Finished
+    message.
+  '';
+
+  eap-peap.phase2_tnc = mkYesNoParam no ''
+    Start phase2 EAP-TNC protocol after successful client authentication.
+  '';
+
+  eap-peap.request_peer_auth = mkYesNoParam no ''
+    Request peer authentication based on a client certificate.
+  '';
+
+  eap-radius.accounting = mkYesNoParam no ''
+    Enable EAP-RADIUS accounting.
+  '';
+
+  eap-radius.accounting_close_on_timeout = mkYesNoParam yes ''
+    Close the IKE_SA if there is a timeout during interim RADIUS accounting
+    updates.
+  '';
+
+  eap-radius.accounting_interval = mkIntParam 0 ''
+    Interval in seconds for interim RADIUS accounting updates, if not
+    specified by the RADIUS server in the Access-Accept message.
+  '';
+
+  eap-radius.accounting_requires_vip = mkYesNoParam no ''
+    If enabled, accounting is disabled unless an IKE_SA has at least one
+    virtual IP.
+  '';
+
+  eap-radius.class_group = mkYesNoParam no ''
+    Use the class attribute sent in the Access-Accept message as group
+    membership information, see EapRadius.
+  '';
+
+  eap-radius.close_all_on_timeout = mkYesNoParam no ''
+    Closes all IKE_SAs if communication with the RADIUS server times out. If
+    it is not set only the current IKE_SA is closed.
+  '';
+
+  eap-radius.dae.enable = mkYesNoParam no ''
+    Enables support for the Dynamic Authorization Extension (RFC 5176).
+  '';
+
+  eap-radius.dae.listen = mkStrParam "0.0.0.0" ''
+    Address to listen for DAE messages from the RADIUS server.
+  '';
+
+  eap-radius.dae.port = mkIntParam 3799 ''
+    Port to listen for DAE requests.
+  '';
+
+  eap-radius.dae.secret = mkOptionalStrParam ''
+    Shared secret used to verify/sign DAE messages.If set, make sure to
+    adjust the permissions of the config file accordingly.
+  '';
+
+  eap-radius.eap_start = mkYesNoParam no ''
+    Send EAP-Start instead of EAP-Identity to start RADIUS conversation.
+  '';
+
+  eap-radius.filter_id = mkYesNoParam no ''
+    Use the filter_id attribute sent in the RADIUS-Accept message as group
+    membership if the RADIUS tunnel_type attribute is set to ESP.
+  '';
+
+  eap-radius.forward.ike_to_radius = mkOptionalStrParam ''
+    RADIUS attributes to be forwarded from IKEv2 to RADIUS (can be defined
+    by name or attribute number, a colon can be used to specify
+    vendor-specific attributes, e.g. Reply-Message, or 11, or 36906:12).
+  '';
+
+  eap-radius.forward.radius_to_ike = mkOptionalStrParam ''
+    Same as above but from RADIUS to IKEv2, a strongSwan specific private
+    notify (40969) is used to transmit the attributes.
+  '';
+
+  eap-radius.id_prefix = mkOptionalStrParam ''
+    Prefix to EAP-Identity, some AAA servers use a IMSI prefix to select the
+    EAP method.
+  '';
+
+  eap-radius.nas_identifier = mkStrParam "strongSwan" ''
+    NAS-Identifier to include in RADIUS messages.
+  '';
+
+  eap-radius.port = mkIntParam 1812 ''
+    Port of RADIUS server (authentication).
+  '';
+
+  eap-radius.retransmit_base = mkFloatParam "1.4" ''
+    Base to use for calculating exponential back off.
+  '';
+
+  eap-radius.retransmit_timeout = mkFloatParam "2.0" ''
+    Timeout in seconds before sending first retransmit.
+  '';
+
+  eap-radius.retransmit_tries = mkIntParam 4 ''
+    Number of times to retransmit a packet before giving up.
+  '';
+
+  eap-radius.secret = mkOptionalStrParam ''
+    Shared secret between RADIUS and NAS. If set, make sure to adjust the
+    permissions of the config file accordingly.
+  '';
+
+  eap-radius.server = mkOptionalStrParam ''
+    IP/Hostname of RADIUS server.
+  '';
+
+  eap-radius.servers = mkAttrsOfParams {
+    nas_identifier = mkStrParam "strongSwan" ''
+      The nas_identifer (default: strongSwan) identifies the gateway against the
+      RADIUS server and allows it to enforce a policy, for example.
+    '';
+
+    secret = mkOptionalStrParam "";
+
+    sockets = mkIntParam 1 ''
+      The number of pre-allocated sockets to use. A value of 5 allows the
+      gateway to authentication 5 clients simultaneously over RADIUS.
+    '';
+
+    auth_port = mkIntParam 1812 ''
+      RADIUS UDP port
+    '';
+
+    address = mkOptionalStrParam ''
+      The server's IP/Hostname.
+    '';
+
+    acct_port = mkIntParam 1813 ''
+      Accounting port.
+    '';
+
+    preference = mkIntParam 0 ''
+      With the preference paramter of a server, priorities for specific servers
+      can be defined. This allows to use a secondary RADIUS server only if the
+      first gets unresponsive, or if it is overloaded.
+    '';
+  } ''Section to specify multiple RADIUS servers, see EapRadius.'';
+
+  eap-radius.sockets = mkIntParam 1 ''
+    Number of sockets (ports) to use, increase for high load.
+  '';
+
+  eap-radius.xauth = mkAttrsOfParams {
+    nextpin  = mkOptionalStrParam "";
+    password = mkOptionalStrParam "";
+    passcode = mkOptionalStrParam "";
+    answer   = mkOptionalStrParam "";
+  } ''
+    Section to configure multiple XAuth authentication rounds via RADIUS.
+  '';
+
+  eap-sim.request_identity = mkYesNoParam yes "";
+
+  eap-simaka-sql.database = mkOptionalStrParam "";
+
+  eap-simaka-sql.remove_used = mkOptionalStrParam "";
+
+  eap-tls.fragment_size = mkIntParam  1024 ''
+    Maximum size of an EAP-TLS packet.
+  '';
+
+  eap-tls.include_length = mkYesNoParam yes ''
+    Include length in non-fragmented EAP-TLS packets.
+  '';
+
+  eap-tls.max_message_count = mkIntParam 32 ''
+    Maximum number of processed EAP-TLS packets (0 = no limit).
+  '';
+
+  eap-tnc.max_message_count = mkIntParam 10 ''
+    Maximum number of processed EAP-TNC packets (0 = no limit).
+  '';
+
+  eap-tnc.protocol = mkStrParam "tnccs-2.0" ''
+    IF-TNCCS protocol version to be used (tnccs-1.1, tnccs-2.0,
+    tnccs-dynamic).
+  '';
+
+  eap-ttls.fragment_size = mkIntParam 1024 ''
+    Maximum size of an EAP-TTLS packet.
+  '';
+
+  eap-ttls.include_length = mkYesNoParam yes ''
+    Include length in non-fragmented EAP-TTLS packets.
+  '';
+
+  eap-ttls.max_message_count = mkIntParam 32 ''
+    Maximum number of processed EAP-TTLS packets (0 = no limit).
+  '';
+
+  eap-ttls.phase2_method = mkStrParam "md5" ''
+    Phase2 EAP client authentication method.
+  '';
+
+  eap-ttls.phase2_piggyback = mkYesNoParam no ''
+    Phase2 EAP Identity request piggybacked by server onto TLS Finished
+    message.
+  '';
+
+  eap-ttls.phase2_tnc = mkYesNoParam no ''
+    Start phase2 EAP TNC protocol after successful client authentication.
+  '';
+
+  eap-ttls-phase2_tnc_method = mkEnumParam ["pt" "legacy"] "pt" ''
+    Phase2 EAP TNC transport protocol (pt as IETF standard or legacy tnc)
+  '';
+
+  eap-ttls.request_peer_auth = mkYesNoParam no ''
+    Request peer authentication based on a client certificate.
+  '';
+
+  error-notify.socket = mkStrParam "unix://\${piddir}/charon.enfy" ''
+    Socket provided by the error-notify plugin.
+  '';
+
+  ext-auth.script = mkOptionalStrParam ''
+    Shell script to invoke for peer authorization (see ext-auth).
+  '';
+
+  gcrypt.quick_random = mkYesNoParam no ''
+    Use faster random numbers in gcrypt. For testing only, produces weak
+    keys!
+  '';
+
+  ha.autobalance = mkIntParam 0 ''
+    Interval in seconds to automatically balance handled segments between
+    nodes. Set to 0 to disable.
+  '';
+
+  ha.fifo_interface = mkYesNoParam yes "";
+
+  ha.heartbeat_delay = mkIntParam 1000 "";
+
+  ha.heartbeat_timeout = mkIntParam 2100 "";
+
+  ha.local = mkOptionalIntParam "";
+
+  ha.monitor = mkYesNoParam yes "";
+
+  ha.pools = mkOptionalStrParam "";
+
+  ha.remote = mkOptionalStrParam "";
+
+  ha.resync = mkYesNoParam yes "";
+
+  ha.secret = mkOptionalStrParam "";
+
+  ha.segment_count = mkIntParam 1 "";
+
+  ipseckey.enable = mkYesNoParam no ''
+    Enable fetching of IPSECKEY RRs via DNS.
+  '';
+
+  kernel-libipsec.allow_peer_ts = mkYesNoParam no ''
+    Allow that the remote traffic selector equals the IKE peer (see
+    kernel-libipsec for details).
+  '';
+
+  kernel-netlink.buflen = mkOptionalIntParam ''
+    Buffer size for received Netlink messages. Defaults to
+    <literal>min(PAGE_SIZE, 8192)</literal>.
+  '';
+
+  kernel-netlink.force_receive_buffer_size = mkYesNoParam no ''
+    If the maximum Netlink socket receive buffer in bytes set by
+    receive_buffer_size exceeds the system-wide maximum from
+    <literal>/proc/sys/net/core/rmem_max</literal>, this option can be used to
+    override the limit. Enabling this option requires special priviliges
+    (CAP_NET_ADMIN).
+  '';
+
+  kernel-netlink.fwmark = mkOptionalStrParam ''
+    Firewall mark to set on the routing rule that directs traffic to our own
+    routing table. The format is <literal>[!]mark[/mask]</literal>, where the
+    optional exclamation mark inverts the meaning (i.e. the rule only applies to
+    packets that don't match the mark). A possible use case are host-to-host
+    tunnels with kernel-libipsec. When set to !&#60;mark&#62; a more efficient
+    lookup for source and next-hop addresses may also be used since 5.3.3.
+  '';
+
+  kernel-netlink.mss = mkIntParam 0 ''
+    MSS to set on installed routes, 0 to disable.
+  '';
+
+  kernel-netlink.mtu = mkIntParam 0 ''
+    MTU to set on installed routes, 0 to disable.
+  '';
+
+  kernel-netlink.receive_buffer_size = mkIntParam 0 ''
+    Maximum Netlink socket receive buffer in bytes. This value controls how many
+    bytes of Netlink messages can be received on a Netlink socket. The default
+    value is set by <literal>/proc/sys/net/core/rmem_default</literal>. The
+    specified value cannot exceed the system-wide maximum from
+    <literal>/proc/sys/net/core/rmem_max</literal>, unless
+    <option>force_receive_buffer_size</option> is enabled.
+  '';
+
+  kernel-netlink.roam_events = mkYesNoParam yes ''
+    Whether to trigger roam events when interfaces, addresses or routes
+    change.
+  '';
+
+  kernel-netlink.set_proto_port_transport_sa = mkYesNoParam no ''
+    Whether to set protocol and ports in the selector installed on transport
+    mode IPsec SAs in the kernel. While doing so enforces policies for
+    inbound traffic, it also prevents the use of a single IPsec SA by more
+    than one traffic selector.
+  '';
+
+  kernel-netlink.spdh_thresh.ipv4.lbits = mkIntParam 32 ''
+    Local subnet XFRM policy hashing threshold for IPv4.
+  '';
+
+  kernel-netlink.spdh_thresh.ipv4.rbits = mkIntParam 32 ''
+    Remote subnet XFRM policy hashing threshold for IPv4.
+  '';
+
+  kernel-netlink.spdh_thresh.ipv6.lbits = mkIntParam 128 ''
+    Local subnet XFRM policy hashing threshold for IPv6.
+  '';
+
+  kernel-netlink.spdh_thresh.ipv6.rbits = mkIntParam 128 ''
+    Remote subnet XFRM policy hashing threshold for IPv6.
+  '';
+
+  kernel-netlink.xfrm_acq_expires = mkIntParam 165 ''
+    Lifetime of XFRM acquire state created by the kernel when traffic matches a
+    trap policy. The value gets written to
+    <literal>/proc/sys/net/core/xfrm_acq_expires</literal>. Indirectly controls
+    the delay between XFRM acquire messages triggered by the kernel for a trap
+    policy. The same value is used as timeout for SPIs allocated by the
+    kernel. The default value equals the default total retransmission timeout
+    for IKE messages (since 5.5.3 this value is determined dynamically based on
+    the configuration).
+  '';
+
+  kernel-pfkey.events_buffer_size = mkIntParam 0 ''
+    Size of the receive buffer for the event socket (0 for default
+    size). Because events are received asynchronously installing e.g. lots
+    of policies may require a larger buffer than the default on certain
+    platforms in order to receive all messages.
+  '';
+
+  kernel-pfroute.vip_wait = mkIntParam 1000 ''
+    Time in ms to wait until virtual IP addresses appear/disappear before
+    failing.
+  '';
+
+  led.activity_led = mkOptionalStrParam "";
+
+  led.blink_time = mkIntParam 50 "";
+
+  load-tester = {
+    addrs = mkAttrsOfParam (mkOptionalStrParam "") ''
+      Section that contains key/value pairs with address pools (in CIDR
+      notation) to use for a specific network interface e.g.
+      <literal>eth0 = 10.10.0.0/16</literal>.
+   '';
+
+    addrs_keep = mkYesNoParam no ''
+      Whether to keep dynamic addresses even after the associated SA got
+      terminated.
+    '';
+
+    addrs_prefix = mkIntParam 16 ''
+      Network prefix length to use when installing dynamic addresses.
+      If set to -1 the full address is used (i.e. 32 or 128).
+    '';
+
+    ca_dir = mkOptionalStrParam ''
+      Directory to load (intermediate) CA certificates from.
+    '';
+
+    child_rekey = mkIntParam 600 ''
+      Seconds to start CHILD_SA rekeying after setup.
+    '';
+
+    crl = mkOptionalStrParam ''
+      URI to a CRL to include as certificate distribution point in generated
+      certificates.
+    '';
+
+    delay = mkIntParam 0 ''
+      Delay between initiatons for each thread.
+    '';
+
+    delete_after_established = mkYesNoParam no ''
+      Delete an IKE_SA as soon as it has been established.
+    '';
+
+    digest = mkStrParam "sha1" ''
+      Digest algorithm used when issuing certificates.
+    '';
+
+    dpd_delay = mkIntParam 0 ''
+      DPD delay to use in load test.
+    '';
+
+    dynamic_port = mkIntParam 0 ''
+      Base port to be used for requests (each client uses a different port).
+    '';
+
+    eap_password = mkStrParam "default-pwd" ''
+      EAP secret to use in load test.
+    '';
+
+    enable = mkYesNoParam no ''
+      Enable the load testing plugin. **WARNING**: Never enable this plugin on
+      productive systems. It provides preconfigured credentials and allows an
+      attacker to authenticate as any user.
+    '';
+
+    esp = mkStrParam "aes128-sha1" ''
+      CHILD_SA proposal to use for load tests.
+    '';
+
+    fake_kernel = mkYesNoParam no ''
+      Fake the kernel interface to allow load-testing against self.
+    '';
+
+    ike_rekey = mkIntParam 0 ''
+      Seconds to start IKE_SA rekeying after setup.
+    '';
+
+    init_limit = mkIntParam 0 ''
+      Global limit of concurrently established SAs during load test.
+    '';
+
+    initiator = mkStrParam "0.0.0.0" ''
+      Address to initiate from.
+    '';
+
+    initiators = mkIntParam 0 ''
+      Number of concurrent initiator threads to use in load test.
+    '';
+
+    initiator_auth = mkStrParam "pubkey" ''
+      Authentication method(s) the intiator uses.
+    '';
+
+    initiator_id = mkOptionalStrParam ''
+      Initiator ID used in load test.
+    '';
+
+    initiator_match = mkOptionalStrParam ''
+      Initiator ID to match against as responder.
+    '';
+
+    initiator_tsi = mkOptionalStrParam ''
+      Traffic selector on initiator side, as proposed by initiator.
+    '';
+
+    initiator_tsr = mkOptionalStrParam ''
+      Traffic selector on responder side, as proposed by initiator.
+    '';
+
+    iterations = mkIntParam 1 ''
+      Number of IKE_SAs to initiate by each initiator in load test.
+    '';
+
+    issuer_cert = mkOptionalStrParam ''
+      Path to the issuer certificate (if not configured a hard-coded default
+      value is used).
+    '';
+
+    issuer_key = mkOptionalStrParam ''
+      Path to private key that is used to issue certificates (if not configured
+      a hard-coded default value is used).
+    '';
+
+    mode = mkEnumParam ["tunnel" "transport" "beet"] "tunnel" ''
+      IPsec mode to use.
+    '';
+
+    pool = mkOptionalStrParam ''
+      Provide INTERNAL_IPV4_ADDRs from a named pool.
+    '';
+
+    preshared_key = mkStrParam "<default-psk>" ''
+      Preshared key to use in load test.
+    '';
+
+    proposal = mkStrParam "aes128-sha1-modp768" ''
+      IKE proposal to use in load test.
+    '';
+
+    responder = mkStrParam "127.0.0.1" ''
+      Address to initiation connections to.
+    '';
+
+    responder_auth = mkStrParam "pubkey" ''
+      Authentication method(s) the responder uses.
+    '';
+
+    responder_id = mkOptionalStrParam ''
+      Responder ID used in load test.
+    '';
+
+    responder_tsi = mkStrParam "initiator_tsi" ''
+      Traffic selector on initiator side, as narrowed by responder.
+    '';
+
+    responder_tsr = mkStrParam "initiator_tsr" ''
+      Traffic selector on responder side, as narrowed by responder.
+    '';
+
+    request_virtual_ip = mkYesNoParam no ''
+      Request an INTERNAL_IPV4_ADDR from the server.
+    '';
+
+    shutdown_when_complete = mkYesNoParam no ''
+      Shutdown the daemon after all IKE_SAs have been established.
+    '';
+
+    socket = mkStrParam "unix://\\\${piddir}/charon.ldt" ''
+      Socket provided by the load-tester plugin.
+    '';
+
+    version = mkIntParam 0 ''
+      IKE version to use (0 means use IKEv2 as initiator and accept any version
+      as responder).
+    '';
+  };
+
+  lookip.socket = mkStrParam "unix://\\\${piddir}/charon.lkp" ''
+    Socket provided by the lookip plugin.
+  '';
+
+  ntru.max_drbg_requests = mkIntParam 4294967294 ''
+    Number of pseudo-random bit requests from the DRBG before an automatic
+    reseeding occurs.
+  '';
+
+  ntru.parameter_set =
+    mkEnumParam ["x9_98_speed" "x9_98_bandwidth" "x9_98_balance" "optimum"] "optimum" ''
+      The following parameter sets are available:
+      <literal>x9_98_speed</literal>, <literal>x9_98_bandwidth</literal>,
+      <literal>x9_98_balance</literal> and <literal>optimum</literal>, the last
+      set not being part of the X9.98 standard but having the best performance.
+    '';
+
+  openssl.engine_id = mkStrParam "pkcs11" ''
+    ENGINE ID to use in the OpenSSL plugin.
+  '';
+
+  openssl.fips_mode = mkIntParam 0 ''
+    Set OpenSSL FIPS mode:
+    <itemizedlist>
+    <listitem><para>disabled (0),</para></listitem>
+    <listitem><para>enabled (1),</para></listitem>
+    <listitem><para>Suite B enabled (2).</para></listitem>
+    </itemizedlist>
+    Defaults to the value configured with the
+    <literal>--with-fips-mode</literal> option.
+
+  '';
+
+  osx-attr.append = mkYesNoParam yes ''
+    Whether DNS servers are appended to existing entries, instead of
+    replacing them.
+  '';
+
+  pkcs11.load_certs = mkYesNoParam yes ''
+    Whether to load certificates from tokens.
+  '';
+
+  pkcs11.modules = mkAttrsOfParams {
+    path = mkOptionalStrParam ''
+      Full path to the shared object file of this PKCS#11 module
+    '';
+
+    os_locking = mkYesNoParam no ''
+      Whether OS locking should be enabled for this module
+    '';
+
+    load_certs = mkYesNoParam no ''
+      Whether the PKCS#11 modules should load certificates from tokens (since 5.0.2)
+    '';
+  } ''
+    List of available PKCS#11 modules, see SmartCardsIKEv2.
+  '';
+
+  pkcs11.reload_certs = mkYesNoParam no ''
+    Reload certificates from all tokens if charon receives a SIGHUP.
+  '';
+
+  pkcs11.use_dh = mkYesNoParam no ''
+    Whether the PKCS#11 modules should be used for DH and ECDH.
+  '';
+
+  pkcs11.use_ecc = mkYesNoParam no ''
+    Whether the PKCS#11 modules should be used for ECDH and ECDSA public key
+    operations. ECDSA private keys are used regardless of this option.
+  '';
+
+  pkcs11.use_hasher = mkYesNoParam no ''
+    Whether the PKCS#11 modules should be used to hash data.
+  '';
+
+  pkcs11.use_pubkey = mkYesNoParam no ''
+    Whether the PKCS#11 modules should be used for public key operations,
+    even for keys not stored on tokens.
+  '';
+
+  pkcs11.use_rng = mkYesNoParam no ''
+    Whether the PKCS#11 modules should be used as RNG.
+  '';
+
+  radattr.dir = mkOptionalStrParam ''
+    Directory where RADIUS attributes are stored in client-ID specific
+    files, see radattr.
+  '';
+
+  radattr.message_id = mkIntParam (-1) ''
+    RADIUS attributes are added to all IKE_AUTH messages by default (-1), or
+    only to the IKE_AUTH message with the given IKEv2 message ID.
+  '';
+
+  random.random = mkStrParam "/dev/random" ''
+    File to read random bytes from.
+  '';
+
+  random.urandom = mkStrParam "/dev/urandom" ''
+    File to read pseudo random bytes from.
+  '';
+
+  random.strong_equals_true = mkYesNoParam no ''
+    If enabled the RNG_STRONG class reads random bytes from the same source
+    as the RNG_TRUE class.
+  '';
+
+  resolve.file = mkStrParam "/etc/resolv.conf" ''
+    File used by the resolve plugin to write DNS server entries to.
+  '';
+
+  resolve.resolvconf.iface_prefix = mkStrParam "lo.inet.ipsec." ''
+    Prefix used by the resolve plugin for interface names sent to
+    resolvconf(8). The name server address is appended to this prefix to
+    make it unique. The result has to be a valid interface name according to
+    the rules defined by resolvconf. Also, it should have a high priority
+    according to the order defined in interface-order(5).
+  '';
+
+  revocation.enable_crl = mkYesNoParam yes ''
+    Whether CRL validation should be enabled.
+  '';
+
+  revocation.enable_ocsp = mkYesNoParam yes ''
+    Whether OCSP validation should be enabled.
+  '';
+
+  socket-default.fwmark = mkOptionalStrParam ''
+    Firewall mark to set on outbound packets (a possible use case are
+    host-to-host tunnels with kernel-libipsec).
+  '';
+
+  socket-default.set_source = mkYesNoParam yes ''
+    Set source address on outbound packets, if possible.
+  '';
+
+  socket-default.set_sourceif = mkYesNoParam no ''
+    Force sending interface on outbound packets, if possible. This allows
+    using IPv6 link-local addresses as tunnel endpoints.
+  '';
+
+  socket-default.use_ipv4 = mkYesNoParam yes ''
+    Listen on IPv4, if possible.
+  '';
+
+  socket-default.use_ipv6 = mkYesNoParam yes ''
+    Listen on IPv6, if possible.
+  '';
+
+  sql.database = mkOptionalStrParam ''
+    Database URI for charon's SQL plugin. If it contains a password, make
+    sure to adjust the permissions of the config file accordingly.
+  '';
+
+  sql.loglevel = mkIntParam (-1) ''
+    Loglevel for logging to SQL database.
+  '';
+
+  stroke.allow_swap = mkYesNoParam yes ''
+    Analyze addresses/hostnames in left/right to detect which side is local
+    and swap configuration options if necessary. If disabled left is always
+    local.
+  '';
+
+  stroke.ignore_missing_ca_basic_constraint = mkYesNoParam no ''
+    Treat certificates in ipsec.d/cacerts and ipsec.conf ca sections as CA
+    certificates even if they don't contain a CA basic constraint.
+  '';
+
+  stroke.max_concurrent = mkIntParam 4 ''
+    Maximum number of stroke messages handled concurrently.
+  '';
+
+  stroke.secrets_file = mkStrParam "\${sysconfdir}/ipsec.secrets" ''
+    Location of the ipsec.secrets file.
+  '';
+
+  stroke.socket = mkStrParam "unix://\${piddir}/charon.ctl" ''
+    Socket provided by the stroke plugin.
+  '';
+
+  stroke.timeout = mkIntParam 0 ''
+    Timeout in ms for any stroke command. Use 0 to disable the timeout.
+  '';
+
+  systime-fix.interval = mkIntParam 0 ''
+    Interval in seconds to check system time for validity. 0 disables the
+    check. See systime-fix plugin.
+  '';
+
+  systime-fix.reauth = mkYesNoParam no ''
+    Whether to use reauth or delete if an invalid cert lifetime is detected.
+  '';
+
+  systime-fix.threshold = mkOptionalStrParam ''
+    Threshold date where system time is considered valid. Disabled if not
+    specified.
+  '';
+
+  systime-fix.threshold_format = mkStrParam "%Y" ''
+    strptime(3) format used to parse threshold option.
+  '';
+
+  tnc-ifmap.client_cert = mkOptionalStrParam ''
+    Path to X.509 certificate file of IF-MAP client.
+  '';
+
+  tnc-ifmap.client_key = mkOptionalStrParam ''
+    Path to private key file of IF-MAP client.
+  '';
+
+  tnc-ifmap.device_name = mkOptionalStrParam ''
+    Unique name of strongSwan server as a PEP and/or PDP device.
+  '';
+
+  tnc-ifmap.renew_session_interval = mkIntParam 150 ''
+    Interval in seconds between periodic IF-MAP RenewSession requests.
+  '';
+
+  tnc-ifmap.server_cert = mkOptionalStrParam ''
+    Path to X.509 certificate file of IF-MAP server.
+  '';
+
+  tnc-ifmap.server_uri = mkStrParam "https://localhost:8444/imap" ''
+    URI of the form <literal>[https://]servername[:port][/path]</literal>.
+  '';
+
+  tnc-ifmap.username_password = mkOptionalStrParam ''
+    Credentials of IF-MAP client of the form
+    <literal>username:password</literal>. If set, make sure to adjust the
+    permissions of the config file accordingly.
+  '';
+
+  tnc-imc.dlcose = mkYesNoParam yes ''
+    Unload IMC after use.
+  '';
+
+  tnc-imc.preferred_language = mkStrParam "en" ''
+    Preferred language for TNC recommendations.
+  '';
+
+  tnc-imv.dlcose = mkYesNoParam yes ''
+    Unload IMV after use.
+  '';
+
+  tnc-imv.recommendation_policy = mkEnumParam ["default" "any" "all"] "default" ''
+    default TNC recommendation policy.
+  '';
+
+  tnc-pdp.pt_tls.enable = mkYesNoParam yes ''
+    Enable PT-TLS protocol on the strongSwan PDP.
+  '';
+
+  tnc-pdp.pt_tls.port = mkIntParam 271 ''
+    PT-TLS server port the strongSwan PDP is listening on.
+  '';
+
+  tnc-pdp.radius.enable = mkYesNoParam yes ''
+    Enable RADIUS protocol on the strongSwan PDP.
+  '';
+
+  tnc-pdp.radius.method = mkStrParam "ttls" ''
+    EAP tunnel method to be used.
+  '';
+
+  tnc-pdp.radius.port = mkIntParam 1812 ''
+    RADIUS server port the strongSwan PDP is listening on.
+  '';
+
+  tnc-pdp.radius.secret = mkOptionalStrParam ''
+    Shared RADIUS secret between strongSwan PDP and NAS. If set, make sure
+    to adjust the permissions of the config file accordingly.
+  '';
+
+  tnc-pdp.server = mkOptionalStrParam ''
+    Name of the strongSwan PDP as contained in the AAA certificate.
+  '';
+
+  tnc-pdp.timeout = mkOptionalIntParam ''
+    Timeout in seconds before closing incomplete connections.
+  '';
+
+  tnccs-11.max_message_size = mkIntParam 45000 ''
+    Maximum size of a PA-TNC message (XML &#38; Base64 encoding).
+  '';
+
+  tnccs-20.max_batch_size = mkIntParam 65522 ''
+    Maximum size of a PB-TNC batch (upper limit via PT-EAP = 65529).
+  '';
+
+  tnccs-20.max_message_size = mkIntParam 65490 ''
+    Maximum size of a PA-TNC message (upper limit via PT-EAP = 65497).
+  '';
+
+  tnccs-20.mutual = mkYesNoParam no ''
+    Enable PB-TNC mutual protocol.
+  '';
+
+  tpm.use_rng = mkYesNoParam no ''
+    Whether the TPM should be used as RNG.
+  '';
+
+  unbound.dlv_anchors = mkOptionalStrParam ''
+    File to read trusted keys for DLV from. It uses the same format as
+    <option>trust_anchors</option>. Only one DLV can be configured, which is
+    then used as a root trusted DLV, this means that it is a lookaside for the
+    root.
+  '';
+
+  unbound.resolv_conf = mkStrParam "/etc/resolv.conf" ''
+    File to read DNS resolver configuration from.
+  '';
+
+  unbound.trust_anchors = mkStrParam "/etc/ipsec.d/dnssec.keys" ''
+    File to read DNSSEC trust anchors from (usually root zone KSK). The
+    format of the file is the standard DNS Zone file format, anchors can be
+    stored as DS or DNSKEY entries in the file.
+  '';
+
+  updown.dns_handler = mkYesNoParam no ''
+    Whether the updown script should handle DNS servers assigned via IKEv1
+    Mode Config or IKEv2 Config Payloads (if enabled they can't be handled
+    by other plugins, like resolve).
+  '';
+
+  vici.socket = mkStrParam "unix://\${piddir}/charon.vici" ''
+    Socket the vici plugin serves clients.
+  '';
+
+  whitelist.enable = mkYesNoParam yes ''
+    Enable loaded whitelist plugin.
+  '';
+
+  whitelist.socket = mkStrParam "unix://\${piddir}/charon.wlst" ''
+    Socket provided by the whitelist plugin.
+  '';
+
+  xauth-eap.backend = mkStrParam "radius" ''
+    EAP plugin to be used as backend for XAuth credential verification, see
+    XAuthEAP.
+  '';
+
+  xauth-pam.pam_service = mkStrParam "login" ''
+    PAM service to be used for authentication, see XAuthPAM.
+  '';
+
+  xauth-pam.session = mkYesNoParam no ''
+    Open/close a PAM session for each active IKE_SA.
+  '';
+
+  xauth-pam.trim_email = mkYesNoParam yes ''
+    If an email address is given as an XAuth username, trim it to just the
+    username part.
+  '';
+}

--- a/nixos/modules/services/networking/strongswan-swanctl/strongswan-charon-plugins-params.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/strongswan-charon-plugins-params.nix
@@ -214,6 +214,11 @@ lib : with (import ./param-constructors.nix lib); {
     virtual IP.
   '';
 
+  eap-radius.accounting_send_class = mkYesNoParam no ''
+    If enabled, adds the Class attributes received in Access-Accept
+    message to the RADIUS accounting messages.
+  '';
+
   eap-radius.class_group = mkYesNoParam no ''
     Use the class attribute sent in the Access-Accept message as group
     membership information, see EapRadius.
@@ -914,6 +919,11 @@ lib : with (import ./param-constructors.nix lib); {
 
   systime-fix.threshold_format = mkStrParam "%Y" ''
     strptime(3) format used to parse threshold option.
+  '';
+
+  systime-fix.timeout = mkDurationParam "0s" ''
+    How long to wait for a valid system time if an interval is
+    configured. 0 to recheck indefinitely.
   '';
 
   tnc-ifmap.client_cert = mkOptionalStrParam ''

--- a/nixos/modules/services/networking/strongswan-swanctl/strongswan-libimcv-params.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/strongswan-libimcv-params.nix
@@ -1,0 +1,291 @@
+lib : with (import ./param-constructors.nix lib); {
+  debug_level = mkIntParam 1 ''
+    Debug level for a stand-alone libimcv library.
+  '';
+
+  load = mkSpaceSepListParam ["random" "nonce" "gmp" "pubkey" "x509"] ''
+    Plugins to load in IMC/IMVs with stand-alone libimcv library.
+  '';
+
+  stderr_quiet = mkYesNoParam no ''
+    Disable the output to stderr with a stand-alone libimcv library.
+  '';
+
+  swid_gen = {
+    command = mkStrParam "/usr/local/bin/swid_generator" ''
+      SWID generator command to be executed.
+    '';
+
+    tag_creator = {
+      name = mkStrParam "strongSwan Project" ''
+        Name of the tagCreator entity.
+      '';
+
+      regid = mkStrParam "strongswan.org" ''
+        regid of the tagCreator entity.
+      '';
+    };
+  };
+
+  plugins = {
+
+    imc-attestation = {
+      aik_blob = mkOptionalStrParam ''
+        AIK encrypted private key blob file.
+      '';
+
+      aik_cert = mkOptionalStrParam ''
+        AIK certificate file.
+      '';
+
+      aik_handle = mkOptionalStrParam ''
+        AIK object handle, e.g. 0x81010003.
+      '';
+
+      aik_pubkey = mkOptionalStrParam ''
+        AIK public key file.
+      '';
+
+      mandatory_dh_groups = mkYesNoParam yes ''
+        Enforce mandatory Diffie-Hellman groups
+      '';
+
+      nonce_len = mkIntParam 20 ''
+        DH nonce length.
+      '';
+
+      pcr_info = mkYesNoParam no ''
+        Whether to send pcr_before and pcr_after info.
+      '';
+
+      use_quote2 = mkYesNoParam yes ''
+        Use Quote2 AIK signature instead of Quote signature.
+      '';
+
+      use_version_info = mkYesNoParam no ''
+        Version Info is included in Quote2 signature.
+      '';
+    };
+
+    imc-hcd.push_info = mkYesNoParam yes ''
+      Send quadruple info without being prompted.
+    '';
+
+    imc-hcd.subtypes = let
+      imcHcdSubtypeParams = let
+        softwareParams = mkAttrsOfParams {
+          name = mkOptionalStrParam ''
+            Name of the software installed on the hardcopy device.
+          '';
+
+          patches = mkOptionalStrParam ''
+            String describing all patches applied to the given software on this
+            hardcopy device. The individual patches are separated by a newline
+            character '\\n'.
+          '';
+
+          string_version = mkOptionalStrParam ''
+            String describing the version of the given software on this hardcopy device.
+          '';
+
+          version = mkOptionalStrParam ''
+            Hex-encoded version string with a length of 16 octets consisting of
+            the fields major version number (4 octets), minor version number (4
+            octets), build number (4 octets), service pack major number (2
+            octets) and service pack minor number (2 octets).
+          '';
+        } ''
+          Defines a software section having an arbitrary name.
+        '';
+      in {
+        firmware             = softwareParams;
+        resident_application = softwareParams;
+        user_application     = softwareParams;
+        attributes_natural_language = mkStrParam "en" ''
+          Variable length natural language tag conforming to RFC 5646 specifies
+          the language to be used in the health assessment message of a given
+          subtype.
+        '';
+      };
+    in {
+      system = imcHcdSubtypeParams // {
+        certification_state = mkOptionalStrParam ''
+          Hex-encoded certification state.
+        '';
+
+        configuration_state = mkOptionalStrParam ''
+          Hex-encoded configuration state.
+        '';
+
+        machine_type_model = mkOptionalStrParam ''
+          String specifying the machine type and model of the hardcopy device.
+        '';
+
+        pstn_fax_enabled = mkYesNoParam no ''
+          Specifies if a PSTN facsimile interface is installed and enabled on the
+          hardcopy device.
+        '';
+
+        time_source = mkOptionalStrParam ''
+          String specifying the hostname of the network time server used by the
+          hardcopy device.
+        '';
+
+        user_application_enabled = mkYesNoParam no ''
+          Specifies if users can dynamically download and execute applications on
+          the hardcopy device.
+        '';
+
+        user_application_persistence_enabled = mkYesNoParam no ''
+          Specifies if user dynamically downloaded applications can persist outside
+          the boundaries of a single job on the hardcopy device.
+        '';
+
+        vendor_name = mkOptionalStrParam ''
+          String specifying the manufacturer of the hardcopy device.
+        '';
+
+        vendor_smi_code = mkOptionalIntParam ''
+          Integer specifying the globally unique 24-bit SMI code assigned to the
+          manufacturer of the hardcopy device.
+        '';
+      };
+      control   = imcHcdSubtypeParams;
+      marker    = imcHcdSubtypeParams;
+      finisher  = imcHcdSubtypeParams;
+      interface = imcHcdSubtypeParams;
+      scanner   = imcHcdSubtypeParams;
+    };
+
+    imc-os = {
+      device_cert = mkOptionalStrParam ''
+        Manually set the path to the client device certificate
+        (e.g. /etc/pts/aikCert.der)
+      '';
+
+      device_id = mkOptionalStrParam ''
+        Manually set the client device ID in hexadecimal format
+        (e.g. 1083f03988c9762703b1c1080c2e46f72b99cc31)
+      '';
+
+      device_pubkey = mkOptionalStrParam ''
+        Manually set the path to the client device public key
+        (e.g. /etc/pts/aikPub.der)
+      '';
+
+      push_info = mkYesNoParam yes ''
+        Send operating system info without being prompted.
+      '';
+    };
+
+    imc-scanner.push_info = mkYesNoParam yes ''
+      Send open listening ports without being prompted.
+    '';
+
+    imc-swid = {
+      swid_full = mkYesNoParam no ''
+        Include file information in the XML-encoded SWID tags.
+      '';
+
+      swid_pretty = mkYesNoParam no ''
+        Generate XML-encoded SWID tags with pretty indentation.
+      '';
+
+      swid_directory = mkStrParam "\${prefix}/share" ''
+        Directory where SWID tags are located.
+      '';
+    };
+
+    imc-swima = {
+      eid_epoch = mkHexParam "0x11223344" ''
+        Set 32 bit epoch value for event IDs manually if software collector
+        database is not available.
+      '';
+
+      swid_database = mkOptionalStrParam ''
+        URI to software collector database containing event timestamps, software
+        creation and deletion events and collected software identifiers.  If it
+        contains a password, make sure to adjust the permissions of the config
+        file accordingly.
+      '';
+
+      swid_directory = mkStrParam "\${prefix}/share" ''
+        Directory where SWID tags are located.
+      '';
+
+      swid_pretty = mkYesNoParam no ''
+        Generate XML-encoded SWID tags with pretty indentation.
+      '';
+
+      swid_full = mkYesNoParam no ''
+        Include file information in the XML-encoded SWID tags.
+      '';
+    };
+
+    imc-test = {
+      additional_ids = mkIntParam 0 ''
+        Number of additional IMC IDs.
+      '';
+
+      command = mkStrParam "none" ''
+        Command to be sent to the Test IMV.
+      '';
+
+      dummy_size = mkIntParam 0 ''
+        Size of dummy attribute to be sent to the Test IMV (0 = disabled).
+      '';
+
+      retry = mkYesNoParam no ''
+        Do a handshake retry.
+      '';
+
+      retry_command = mkOptionalStrParam ''
+        Command to be sent to the IMV Test in the handshake retry.
+      '';
+    };
+
+    imv-attestation = {
+      cadir = mkOptionalStrParam ''
+        Path to directory with AIK cacerts.
+      '';
+
+      dh_group = mkStrParam "ecp256" ''
+        Preferred Diffie-Hellman group.
+      '';
+
+      hash_algorithm = mkStrParam "sha256" ''
+        Preferred measurement hash algorithm.
+      '';
+
+      min_nonce_len = mkIntParam 0 ''
+        DH minimum nonce length.
+      '';
+
+      remediation_uri = mkOptionalStrParam ''
+        URI pointing to attestation remediation instructions.
+      '';
+    };
+
+    imv-os.remediation_uri = mkOptionalStrParam ''
+      URI pointing to operating system remediation instructions.
+    '';
+
+    imv-scanner.remediation_uri = mkOptionalStrParam ''
+      URI pointing to scanner remediation instructions.
+    '';
+
+    imv-swima.rest_api = {
+      uri = mkOptionalStrParam ''
+        HTTP URI of the SWID REST API.
+      '';
+
+      timeout = mkIntParam 120 ''
+        Timeout of SWID REST API HTTP POST transaction.
+      '';
+    };
+
+    imv-test.rounds = mkIntParam 0 ''
+      Number of IMC-IMV retry rounds.
+    '';
+  };
+}

--- a/nixos/modules/services/networking/strongswan-swanctl/strongswan-loglevel-params.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/strongswan-loglevel-params.nix
@@ -1,0 +1,29 @@
+lib : with (import ./param-constructors.nix lib);
+
+let mkJournalParam = description :
+      mkEnumParam [(-1) 0 1 2 3 4] 0 "Logging level for ${description}";
+in {
+  default = mkIntParam 1 ''
+    Specifies the default loglevel to be used for subsystems for which no
+    specific loglevel is defined.
+  '';
+
+  app = mkJournalParam "applications other than daemons.";
+  asn = mkJournalParam "low-level encoding/decoding (ASN.1, X.509 etc.)";
+  cfg = mkJournalParam "configuration management and plugins.";
+  chd = mkJournalParam "CHILD_SA/IPsec SA.";
+  dmn = mkJournalParam "main daemon setup/cleanup/signal handling.";
+  enc = mkJournalParam "packet encoding/decoding encryption/decryption operations.";
+  esp = mkJournalParam "libipsec library messages.";
+  ike = mkJournalParam "IKE_SA/ISAKMP SA.";
+  imc = mkJournalParam "integrity Measurement Collector.";
+  imv = mkJournalParam "integrity Measurement Verifier.";
+  job = mkJournalParam "jobs queuing/processing and thread pool management.";
+  knl = mkJournalParam "IPsec/Networking kernel interface.";
+  lib = mkJournalParam "libstrongwan library messages.";
+  mgr = mkJournalParam "IKE_SA manager, handling synchronization for IKE_SA access.";
+  net = mkJournalParam "IKE network communication.";
+  pts = mkJournalParam "platform Trust Service.";
+  tls = mkJournalParam "libtls library messages.";
+  tnc = mkJournalParam "trusted Network Connect.";
+}

--- a/nixos/modules/services/networking/strongswan-swanctl/strongswan-params.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/strongswan-params.nix
@@ -1,0 +1,228 @@
+# See: https://wiki.strongswan.org/projects/strongswan/wiki/StrongswanConf
+#
+# When strongSwan is upgraded please update the parameters in this file. You can
+# see which parameters should be deleted, changed or added by diffing
+# the strongswan conf directory:
+#
+#   git clone https://github.com/strongswan/strongswan.git
+#   cd strongswan
+#   git diff 5.5.3..5.6.0 conf/
+
+lib: with (import ./param-constructors.nix lib);
+
+let charonParams = import ./strongswan-charon-params.nix lib;
+in {
+  aikgen = {
+    load = mkSpaceSepListParam [] ''
+      Plugins to load in ipsec aikgen tool.
+    '';
+  };
+  attest = {
+    database = mkOptionalStrParam ''
+      File measurement information database URI. If it contains a password,
+      make sure to adjust the permissions of the config file accordingly.
+    '';
+
+    load = mkSpaceSepListParam [] ''
+      Plugins to load in ipsec attest tool.
+    '';
+  };
+
+  charon = charonParams;
+
+  charon-nm = {
+    ca_dir = mkStrParam "<default>" ''
+      Directory from which to load CA certificates if no certificate is
+      configured.
+    '';
+  };
+
+  charon-systemd = charonParams // {
+    journal = import ./strongswan-loglevel-params.nix lib;
+  };
+
+  imv_policy_manager = {
+    command_allow = mkOptionalStrParam ''
+      Shell command to be executed with recommendation allow.
+    '';
+
+    command_block = mkOptionalStrParam ''
+      Shell command to be executed with all other recommendations.
+    '';
+
+    database = mkOptionalStrParam ''
+      Database URI for the database that stores the package information. If it
+      contains a password, make sure to adjust permissions of the config file
+      accordingly.
+    '';
+
+    load = mkSpaceSepListParam ["sqlite"] ''
+      Plugins to load in IMV policy manager.
+    '';
+  };
+
+  libimcv = import ./strongswan-libimcv-params.nix lib;
+
+  manager = {
+    database = mkOptionalStrParam ''
+      Credential database URI for manager. If it contains a password, make
+      sure to adjust the permissions of the config file accordingly.
+    '';
+
+    debug = mkYesNoParam no ''
+      Enable debugging in manager.
+    '';
+
+    load = mkSpaceSepListParam [] ''
+      Plugins to load in manager.
+    '';
+
+    socket = mkOptionalStrParam ''
+      FastCGI socket of manager, to run it statically.
+    '';
+
+    threads = mkIntParam 10 ''
+      Threads to use for request handling.
+    '';
+
+    timeout = mkDurationParam "15m" ''
+      Session timeout for manager.
+    '';
+  };
+
+  medcli = {
+    database = mkOptionalStrParam ''
+      Mediation client database URI. If it contains a password, make sure to
+      adjust the permissions of the config file accordingly.
+    '';
+
+    dpd = mkDurationParam "5m" ''
+      DPD timeout to use in mediation client plugin.
+    '';
+
+    rekey = mkDurationParam "20m" ''
+      Rekeying time on mediation connections in mediation client plugin.
+    '';
+  };
+
+  medsrv = {
+    database = mkOptionalStrParam ''
+      Mediation server database URI. If it contains a password, make sure to
+      adjust the permissions of the config file accordingly.
+    '';
+
+    debug = mkYesNoParam no ''
+      Debugging in mediation server web application.
+    '';
+
+    dpd = mkDurationParam "5m" ''
+      DPD timeout to use in mediation server plugin.
+    '';
+
+    load = mkSpaceSepListParam [] ''
+      Plugins to load in mediation server plugin.
+    '';
+
+    password_length = mkIntParam 6 ''
+      Minimum password length required for mediation server user accounts.
+    '';
+
+    rekey = mkDurationParam "20m" ''
+      Rekeying time on mediation connections in mediation server plugin.
+    '';
+
+    socket = mkOptionalStrParam ''
+      Run Mediation server web application statically on socket.
+    '';
+
+    threads = mkIntParam 5 ''
+      Number of thread for mediation service web application.
+    '';
+
+    timeout = mkDurationParam "15m" ''
+      Session timeout for mediation service.
+    '';
+  };
+
+  pacman.database = mkOptionalStrParam ''
+    Database URI for the database that stores the package information. If it
+    contains a password, make sure to adjust the permissions of the config
+    file accordingly.
+  '';
+
+  pki.load = mkSpaceSepListParam [] ''
+    Plugins to load in ipsec pki tool.
+  '';
+
+  pool = {
+    database = mkOptionalStrParam ''
+      Database URI for the database that stores IP pools and configuration
+      attributes. If it contains a password, make sure to adjust the
+      permissions of the config file accordingly.
+    '';
+
+    load = mkSpaceSepListParam [] ''
+      Plugins to load in ipsec pool tool.
+    '';
+  };
+
+  pt-tls-client.load = mkSpaceSepListParam [] ''
+    Plugins to load in ipsec pt-tls-client tool.
+  '';
+
+  scepclient.load = mkSpaceSepListParam [] ''
+    Plugins to load in ipsec scepclient tool.
+  '';
+
+  starter = {
+    config_file = mkStrParam "\${sysconfdir}/ipsec.conf" ''
+      Location of the ipsec.conf file.
+    '';
+
+    load_warning = mkYesNoParam yes ''
+      Show charon.load setting warning, see
+      https://wiki.strongswan.org/projects/strongswan/wiki/PluginLoad
+    '';
+  };
+
+  sw-collector = {
+    database = mkOptionalStrParam ''
+      URI to software collector database containing event timestamps,
+      software creation and deletion events and collected software
+      identifiers. If it contains a password, make sure to adjust the
+      permissions of the config file accordingly.
+    '';
+
+    first_file = mkStrParam "/var/log/bootstrap.log" ''
+      Path pointing to file created when the Linux OS was installed.
+    '';
+
+    first_time = mkStrParam "0000-00-00T00:00:00Z" ''
+      Time in UTC when the Linux OS was installed.
+    '';
+
+    history = mkOptionalStrParam ''
+      Path pointing to apt history.log file.
+    '';
+
+    rest_api = {
+      uri = mkOptionalStrParam ''
+        HTTP URI of the central collector's REST API.
+      '';
+
+      timeout = mkIntParam 120 ''
+        Timeout of REST API HTTP POST transaction.
+      '';
+    };
+
+    load = mkSpaceSepListParam [] "Plugins to load in sw-collector tool.";
+  };
+
+  swanctl = {
+    load = mkSpaceSepListParam [] "Plugins to load in swanctl.";
+
+    socket = mkStrParam "unix://\${piddir}/charon.vici" ''
+      VICI socket to connect to by default.
+    '';
+  };
+}

--- a/nixos/modules/services/networking/strongswan-swanctl/strongswan-params.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/strongswan-params.nix
@@ -144,12 +144,6 @@ in {
     '';
   };
 
-  pacman.database = mkOptionalStrParam ''
-    Database URI for the database that stores the package information. If it
-    contains a password, make sure to adjust the permissions of the config
-    file accordingly.
-  '';
-
   pki.load = mkSpaceSepListParam [] ''
     Plugins to load in ipsec pki tool.
   '';
@@ -173,6 +167,41 @@ in {
   scepclient.load = mkSpaceSepListParam [] ''
     Plugins to load in ipsec scepclient tool.
   '';
+
+  sec-updater = {
+    database = mkOptionalStrParam ''
+      Global IMV policy database URI. If it contains a password, make
+      sure to adjust the permissions of the config file accordingly.
+    '';
+
+    swid_gen.command = mkStrParam "/usr/local/bin/swid_generator" ''
+      SWID generator command to be executed.
+    '';
+
+    swid_gen.tag_creator.name = mkStrParam "strongSwan Project" ''
+      Name of the tagCreator entity.
+    '';
+
+    swid_gen.tag_creator.regid = mkStrParam "strongswan.org" ''
+      regid of the tagCreator entity.
+    '';
+
+    tnc_manage_command = mkStrParam "/var/www/tnc/manage.py" ''
+      strongTNC manage.py command used to import SWID tags.
+    '';
+
+    tmp.deb_file = mkStrParam "/tmp/sec-updater.deb" ''
+      Temporary storage for downloaded deb package file.
+    '';
+
+    tmp.tag_file = mkStrParam "/tmp/sec-updater.tag" ''
+      Temporary storage for generated SWID tags.
+    '';
+
+    load =  mkSpaceSepListParam [] ''
+      Plugins to load in sec-updater tool.
+    '';
+  };
 
   starter = {
     config_file = mkStrParam "\${sysconfdir}/ipsec.conf" ''

--- a/nixos/modules/services/networking/strongswan-swanctl/strongswan-params.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/strongswan-params.nix
@@ -28,7 +28,8 @@ in {
     '';
   };
 
-  charon = charonParams;
+  # Since we only use charon-systemd we don't need to generate options for charon.
+  # charon = charonParams;
 
   charon-nm = {
     ca_dir = mkStrParam "<default>" ''

--- a/nixos/modules/services/networking/strongswan-swanctl/swanctl-params.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/swanctl-params.nix
@@ -1,0 +1,1145 @@
+# See: https://wiki.strongswan.org/projects/strongswan/wiki/Swanctlconf
+#
+# When strongSwan is upgraded please update the parameters in this file. You can
+# see which parameters should be deleted, changed or added by diffing
+# swanctl.opt:
+#
+#   git clone https://github.com/strongswan/strongswan.git
+#   cd strongswan
+#   git diff 5.5.3..5.6.0 src/swanctl/swanctl.opt
+
+lib: with (import ./param-constructors.nix lib);
+
+let
+  certParams = {
+    file = mkOptionalStrParam ''
+      Absolute path to the certificate to load. Passed as-is to the daemon, so
+      it must be readable by it.
+      </para><para>
+      Configure either this or <option>handle</option>, but not both, in one section.
+    '';
+
+    handle = mkOptionalHexParam ''
+      Hex-encoded CKA_ID or handle of the certificate on a token or TPM,
+      respectively.
+      </para><para>
+      Configure either this or <option>file</option>, but not both, in one section.
+    '';
+
+    slot = mkOptionalIntParam ''
+      Optional slot number of the token that stores the certificate.
+    '';
+
+    module = mkOptionalStrParam ''
+      Optional PKCS#11 module name.
+    '';
+  };
+in {
+  authorities = mkAttrsOfParams ({
+
+    cacert = mkOptionalStrParam ''
+      The certificates may use a relative path from the swanctl
+      <literal>x509ca</literal> directory or an absolute path.
+      </para><para>
+      Configure one of <option>cacert</option>,
+      <option>file</option>, or
+      <option>handle</option> per section.
+    '';
+
+    cert_uri_base = mkOptionalStrParam ''
+      Defines the base URI for the Hash and URL feature supported by
+      IKEv2. Instead of exchanging complete certificates, IKEv2 allows one to
+      send an URI that resolves to the DER encoded certificate. The certificate
+      URIs are built by appending the SHA1 hash of the DER encoded certificates
+      to this base URI.
+    '';
+
+    crl_uris = mkCommaSepListParam [] ''
+      List of CRL distribution points (ldap, http, or file URI).
+    '';
+
+    ocsp_uris = mkCommaSepListParam [] ''
+      List of OCSP URIs.
+    '';
+
+  } // certParams) ''
+    Section defining complementary attributes of certification authorities, each
+    in its own subsection with an arbitrary yet unique name
+  '';
+
+  connections = mkAttrsOfParams {
+
+    version = mkIntParam 0 ''
+      IKE major version to use for connection.
+      <itemizedlist>
+      <listitem><para>1 uses IKEv1 aka ISAKMP,</para></listitem>
+      <listitem><para>2 uses IKEv2.</para></listitem>
+      <listitem><para>A connection using the default of 0 accepts both IKEv1 and IKEv2 as
+      responder, and initiates the connection actively with IKEv2.</para></listitem>
+      </itemizedlist>
+    '';
+
+    local_addrs	= mkCommaSepListParam [] ''
+      Local address(es) to use for IKE communication. Takes
+      single IPv4/IPv6 addresses, DNS names, CIDR subnets or IP address ranges.
+      </para><para>
+      As initiator, the first non-range/non-subnet is used to initiate the
+      connection from. As responder, the local destination address must match at
+      least to one of the specified addresses, subnets or ranges.
+      </para><para>
+      If FQDNs are assigned they are resolved every time a configuration lookup
+      is done. If DNS resolution times out, the lookup is delayed for that time.
+    '';
+
+    remote_addrs = mkCommaSepListParam [] ''
+      Remote address(es) to use for IKE communication. Takes
+      single IPv4/IPv6 addresses, DNS names, CIDR subnets or IP address ranges.
+      </para><para>
+      As initiator, the first non-range/non-subnet is used to initiate the
+      connection to. As responder, the initiator source address must match at
+      least to one of the specified addresses, subnets or ranges.
+      </para><para>
+      If FQDNs are assigned they are resolved every time a configuration lookup
+      is done. If DNS resolution times out, the lookup is delayed for that time.
+      To initiate a connection, at least one specific address or DNS name must
+      be specified.
+    '';
+
+    local_port = mkIntParam 500 ''
+      Local UDP port for IKE communication. By default the port of the socket
+      backend is used, which is usually <literal>500</literal>. If port
+      <literal>500</literal> is used, automatic IKE port floating to port
+      <literal>4500</literal> is used to work around NAT issues.
+      </para><para>
+      Using a non-default local IKE port requires support from the socket
+      backend in use (socket-dynamic).
+    '';
+
+    remote_port = mkIntParam 500 ''
+      Remote UDP port for IKE communication. If the default of port
+      <literal>500</literal> is used, automatic IKE port floating to port
+      <literal>4500</literal> is used to work around NAT issues.
+    '';
+
+    proposals = mkCommaSepListParam ["default"] ''
+      A proposal is a set of algorithms. For non-AEAD algorithms, this includes
+      for IKE an encryption algorithm, an integrity algorithm, a pseudo random
+      function and a Diffie-Hellman group. For AEAD algorithms, instead of
+      encryption and integrity algorithms, a combined algorithm is used.
+      </para><para>
+      In IKEv2, multiple algorithms of the same kind can be specified in a
+      single proposal, from which one gets selected. In IKEv1, only one
+      algorithm per kind is allowed per proposal, more algorithms get implicitly
+      stripped. Use multiple proposals to offer different algorithms
+      combinations in IKEv1.
+      </para><para>
+      Algorithm keywords get separated using dashes. Multiple proposals may be
+      specified in a list. The special value <literal>default</literal> forms a
+      default proposal of supported algorithms considered safe, and is usually a
+      good choice for interoperability.
+    '';
+
+    vips = mkCommaSepListParam [] ''
+      List of virtual IPs to request in IKEv2 configuration payloads or IKEv1
+      Mode Config. The wildcard addresses <literal>0.0.0.0</literal> and
+      <literal>::</literal> request an arbitrary address, specific addresses may
+      be defined. The responder may return a different address, though, or none
+      at all.
+    '';
+
+    aggressive = mkYesNoParam no ''
+      Enables Aggressive Mode instead of Main Mode with Identity
+      Protection. Aggressive Mode is considered less secure, because the ID and
+      HASH payloads are exchanged unprotected. This allows a passive attacker to
+      snoop peer identities, and even worse, start dictionary attacks on the
+      Preshared Key.
+    '';
+
+    pull = mkYesNoParam yes ''
+      If the default of yes is used, Mode Config works in pull mode, where the
+      initiator actively requests a virtual IP. With no, push mode is used,
+      where the responder pushes down a virtual IP to the initiating peer.
+      </para><para>
+      Push mode is currently supported for IKEv1, but not in IKEv2. It is used
+      by a few implementations only, pull mode is recommended.
+    '';
+
+    dscp = mkStrParam "000000" ''
+      Differentiated Services Field Codepoint to set on outgoing IKE packets for
+      this connection. The value is a six digit binary encoded string specifying
+      the Codepoint to set, as defined in RFC 2474.
+    '';
+
+    encap = mkYesNoParam no ''
+      To enforce UDP encapsulation of ESP packets, the IKE daemon can fake the
+      NAT detection payloads. This makes the peer believe that NAT takes place
+      on the path, forcing it to encapsulate ESP packets in UDP.
+      </para><para>
+      Usually this is not required, but it can help to work around connectivity
+      issues with too restrictive intermediary firewalls.
+    '';
+
+    mobike = mkYesNoParam yes ''
+      Enables MOBIKE on IKEv2 connections. MOBIKE is enabled by default on IKEv2
+      connections, and allows mobility of clients and multi-homing on servers by
+      migrating active IPsec tunnels.
+      </para><para>
+      Usually keeping MOBIKE enabled is unproblematic, as it is not used if the
+      peer does not indicate support for it. However, due to the design of
+      MOBIKE, IKEv2 always floats to port 4500 starting from the second
+      exchange. Some implementations don't like this behavior, hence it can be
+      disabled.
+    '';
+
+    dpd_delay = mkDurationParam "0s" ''
+      Interval to check the liveness of a peer actively using IKEv2
+      INFORMATIONAL exchanges or IKEv1 R_U_THERE messages. Active DPD checking
+      is only enforced if no IKE or ESP/AH packet has been received for the
+      configured DPD delay.
+    '';
+
+    dpd_timeout = mkDurationParam "0s" ''
+      Charon by default uses the normal retransmission mechanism and timeouts to
+      check the liveness of a peer, as all messages are used for liveness
+      checking. For compatibility reasons, with IKEv1 a custom interval may be
+      specified; this option has no effect on connections using IKEv2.
+    '';
+
+    fragmentation = mkEnumParam ["yes" "accept" "force" "no"] "yes" ''
+      Use IKE fragmentation (proprietary IKEv1 extension or RFC 7383 IKEv2
+      fragmentation). Acceptable values are <literal>yes</literal> (the default
+      since 5.5.1), <literal>accept</literal> (since versions:5.5.3),
+      <literal>force</literal> and <literal>no</literal>.
+      <itemizedlist>
+      <listitem><para>If set to <literal>yes</literal>, and the peer
+      supports it, oversized IKE messages will be sent in fragments.</para></listitem>
+      <listitem><para>If set to
+      <literal>accept</literal>, support for fragmentation is announced to the peer but the daemon
+      does not send its own messages in fragments.</para></listitem>
+      <listitem><para>If set to <literal>force</literal> (only
+      supported for IKEv1) the initial IKE message will already be fragmented if
+      required.</para></listitem>
+      <listitem><para>Finally, setting the option to <literal>no</literal> will disable announcing
+      support for this feature.</para></listitem>
+      </itemizedlist>
+      </para><para>
+      Note that fragmented IKE messages sent by a peer are always processed
+      irrespective of the value of this option (even when set to no).
+    '';
+
+    send_certreq = mkYesNoParam yes ''
+      Send certificate request payloads to offer trusted root CA certificates to
+      the peer. Certificate requests help the peer to choose an appropriate
+      certificate/private key for authentication and are enabled by default.
+      Disabling certificate requests can be useful if too many trusted root CA
+      certificates are installed, as each certificate request increases the size
+      of the initial IKE packets.
+   '';
+
+    send_cert = mkEnumParam ["always" "never" "ifasked" ] "ifasked" ''
+      Send certificate payloads when using certificate authentication.
+      <itemizedlist>
+      <listitem><para>With the default of <literal>ifasked</literal> the daemon sends
+      certificate payloads only if certificate requests have been received.</para></listitem>
+      <listitem><para><literal>never</literal> disables sending of certificate payloads
+      altogether,</para></listitem>
+      <listitem><para><literal>always</literal> causes certificate payloads to be sent
+      unconditionally whenever certificate authentication is used.</para></listitem>
+      </itemizedlist>
+    '';
+
+    keyingtries = mkIntParam 1 ''
+      Number of retransmission sequences to perform during initial
+      connect. Instead of giving up initiation after the first retransmission
+      sequence with the default value of <literal>1</literal>, additional
+      sequences may be started according to the configured value. A value of
+      <literal>0</literal> initiates a new sequence until the connection
+      establishes or fails with a permanent error.
+    '';
+
+    unique = mkEnumParam ["no" "never" "keep" "replace"] "no" ''
+      Connection uniqueness policy to enforce. To avoid multiple connections
+      from the same user, a uniqueness policy can be enforced.
+      </para><para>
+      <itemizedlist>
+      <listitem><para>
+      The value <literal>never</literal> does never enforce such a policy, even
+      if a peer included INITIAL_CONTACT notification messages,
+      </para></listitem>
+      <listitem><para>
+      whereas <literal>no</literal> replaces existing connections for the same
+      identity if a new one has the INITIAL_CONTACT notify.
+      </para></listitem>
+      <listitem><para>
+      <literal>keep</literal> rejects new connection attempts if the same user
+      already has an active connection,
+      </para></listitem>
+      <listitem><para>
+      <literal>replace</literal> deletes any existing connection if a new one
+      for the same user gets established.
+      </para></listitem>
+      </itemizedlist>
+      To compare connections for uniqueness, the remote IKE identity is used. If
+      EAP or XAuth authentication is involved, the EAP-Identity or XAuth
+      username is used to enforce the uniqueness policy instead.
+      </para><para>
+      On initiators this setting specifies whether an INITIAL_CONTACT notify is
+      sent during IKE_AUTH if no existing connection is found with the remote
+      peer (determined by the identities of the first authentication
+      round). Only if set to keep or replace will the client send a notify.
+    '';
+
+    reauth_time	= mkDurationParam "0s" ''
+      Time to schedule IKE reauthentication. IKE reauthentication recreates the
+      IKE/ISAKMP SA from scratch and re-evaluates the credentials. In asymmetric
+      configurations (with EAP or configuration payloads) it might not be
+      possible to actively reauthenticate as responder. The IKEv2
+      reauthentication lifetime negotiation can instruct the client to perform
+      reauthentication.
+      </para><para>
+      Reauthentication is disabled by default. Enabling it usually may lead to
+      small connection interruptions, as strongSwan uses a break-before-make
+      policy with IKEv2 to avoid any conflicts with associated tunnel resources.
+    '';
+
+    rekey_time = mkDurationParam "4h" ''
+      IKE rekeying refreshes key material using a Diffie-Hellman exchange, but
+      does not re-check associated credentials. It is supported in IKEv2 only,
+      IKEv1 performs a reauthentication procedure instead.
+      </para><para>
+      With the default value IKE rekeying is scheduled every 4 hours, minus the
+      configured rand_time. If a reauth_time is configured, rekey_time defaults
+      to zero, disabling rekeying; explicitly set both to enforce rekeying and
+      reauthentication.
+    '';
+
+    over_time = mkOptionalDurationParam ''
+      Hard IKE_SA lifetime if rekey/reauth does not complete, as time. To avoid
+      having an IKE/ISAKMP kept alive if IKE reauthentication or rekeying fails
+      perpetually, a maximum hard lifetime may be specified. If the IKE_SA fails
+      to rekey or reauthenticate within the specified time, the IKE_SA gets
+      closed.
+      </para><para>
+      In contrast to CHILD_SA rekeying, over_time is relative in time to the
+      rekey_time and reauth_time values, as it applies to both.
+      </para><para>
+      The default is 10% of the longer of <option>rekey_time</option> and
+      <option>reauth_time</option>.
+    '';
+
+    rand_time = mkOptionalDurationParam ''
+      Time range from which to choose a random value to subtract from
+      rekey/reauth times. To avoid having both peers initiating the rekey/reauth
+      procedure simultaneously, a random time gets subtracted from the
+      rekey/reauth times.
+      </para><para>
+      The default is equal to the configured <option>over_time</option>.
+    '';
+
+    pools = mkCommaSepListParam [] ''
+      List of named IP pools to allocate virtual IP addresses
+      and other configuration attributes from. Each name references a pool by
+      name from either the pools section or an external pool.
+    '';
+
+    mediation = mkYesNoParam no ''
+      Whether this connection is a mediation connection, that is, whether this
+      connection is used to mediate other connections using the IKEv2 Mediation
+      Extension. Mediation connections create no CHILD_SA.
+    '';
+
+    mediated_by = mkOptionalStrParam ''
+      The name of the connection to mediate this connection through. If given,
+      the connection will be mediated through the named mediation
+      connection. The mediation connection must have mediation enabled.
+    '';
+
+    mediation_peer = mkOptionalStrParam ''
+      Identity under which the peer is registered at the mediation server, that
+      is, the IKE identity the other end of this connection uses as its local
+      identity on its connection to the mediation server. This is the identity
+      we request the mediation server to mediate us with. Only relevant on
+      connections that set mediated_by. If it is not given, the remote IKE
+      identity of the first authentication round of this connection will be
+      used.
+    '';
+
+    local = mkPrefixedAttrsOfParams {
+
+      round = mkIntParam 0 ''
+        Optional numeric identifier by which authentication rounds are
+        sorted. If not specified rounds are ordered by their position in the
+        config file/vici message.
+      '';
+
+      certs = mkCommaSepListParam [] ''
+        List of certificate candidates to use for
+        authentication. The certificates may use a relative path from the
+        swanctl <literal>x509</literal> directory or an absolute path.
+        </para><para>
+        The certificate used for authentication is selected based on the
+        received certificate request payloads. If no appropriate CA can be
+        located, the first certificate is used.
+      '';
+
+      cert = mkPostfixedAttrsOfParams certParams ''
+        Section for a certificate candidate to use for
+        authentication. Certificates in certs are transmitted as binary blobs,
+        these sections offer more flexibility.
+      '';
+
+      pubkeys = mkCommaSepListParam [] ''
+        List of raw public key candidates to use for
+        authentication. The public keys may use a relative path from the swanctl
+        <literal>pubkey</literal> directory or an absolute path.
+        </para><para>
+        Even though multiple local public keys could be defined in principle,
+        only the first public key in the list is used for authentication.
+      '';
+
+      auth = mkStrParam "pubkey" ''
+        Authentication to perform locally.
+        <itemizedlist>
+        <listitem><para>
+        The default <literal>pubkey</literal> uses public key authentication
+        using a private key associated to a usable certificate.
+        </para></listitem>
+        <listitem><para>
+        <literal>psk</literal> uses pre-shared key authentication.
+        </para></listitem>
+        <listitem><para>
+        The IKEv1 specific <literal>xauth</literal> is used for XAuth or Hybrid
+        authentication,
+        </para></listitem>
+        <listitem><para>
+        while the IKEv2 specific <literal>eap</literal> keyword defines EAP
+        authentication.
+        </para></listitem>
+        <listitem><para>
+        For <literal>xauth</literal>, a specific backend name may be appended,
+        separated by a dash. The appropriate <literal>xauth</literal> backend is
+        selected to perform the XAuth exchange. For traditional XAuth, the
+        <literal>xauth</literal> method is usually defined in the second
+        authentication round following an initial <literal>pubkey</literal> (or
+        <literal>psk</literal>) round. Using <literal>xauth</literal> in the
+        first round performs Hybrid Mode client authentication.
+        </para></listitem>
+        <listitem><para>
+        For <literal>eap</literal>, a specific EAP method name may be appended, separated by a
+        dash. An EAP module implementing the appropriate method is selected to
+        perform the EAP conversation.
+        </para></listitem>
+        <listitem><para>
+        Since 5.4.0, if both peers support RFC 7427 ("Signature Authentication
+        in IKEv2") specific hash algorithms to be used during IKEv2
+        authentication may be configured. To do so use <literal>ike:</literal>
+        followed by a trust chain signature scheme constraint (see description
+        of the <option>remote</option> section's <option>auth</option>
+        keyword). For example, with <literal>ike:pubkey-sha384-sha256</literal>
+        a public key signature scheme with either SHA-384 or SHA-256 would get
+        used for authentication, in that order and depending on the hash
+        algorithms supported by the peer. If no specific hash algorithms are
+        configured, the default is to prefer an algorithm that matches or
+        exceeds the strength of the signature key. If no constraints with
+        <literal>ike:</literal> prefix are configured any signature scheme
+        constraint (without <literal>ike:</literal> prefix) will also apply to
+        IKEv2 authentication, unless this is disabled in
+        <literal>strongswan.conf</literal>.
+        </para></listitem>
+        </itemizedlist>
+      '';
+
+      id = mkOptionalStrParam ''
+        IKE identity to use for authentication round. When using certificate
+        authentication, the IKE identity must be contained in the certificate,
+        either as subject or as subjectAltName.
+      '';
+
+      eap_id = mkOptionalStrParam ''
+        Client EAP-Identity to use in EAP-Identity exchange and the EAP method.
+      '';
+
+      aaa_id = mkOptionalStrParam ''
+        Server side EAP-Identity to expect in the EAP method. Some EAP methods,
+        such as EAP-TLS, use an identity for the server to perform mutual
+        authentication. This identity may differ from the IKE identity,
+        especially when EAP authentication is delegated from the IKE responder
+        to an AAA backend.
+        </para><para>
+        For EAP-(T)TLS, this defines the identity for which the server must
+        provide a certificate in the TLS exchange.
+      '';
+
+      xauth_id = mkOptionalStrParam ''
+        Client XAuth username used in the XAuth exchange.
+      '';
+
+    } ''
+      Section for a local authentication round. A local authentication round
+      defines the rules how authentication is performed for the local
+      peer. Multiple rounds may be defined to use IKEv2 RFC 4739 Multiple
+      Authentication or IKEv1 XAuth.
+      </para><para>
+      Each round is defined in a section having <literal>local</literal> as
+      prefix, and an optional unique suffix. To define a single authentication
+      round, the suffix may be omitted.
+    '';
+
+    remote = mkPrefixedAttrsOfParams {
+
+      round = mkIntParam 0 ''
+        Optional numeric identifier by which authentication rounds are
+        sorted. If not specified rounds are ordered by their position in the
+        config file/vici message.
+      '';
+
+      id = mkStrParam "%any" ''
+        IKE identity to expect for authentication round. When using certificate
+        authentication, the IKE identity must be contained in the certificate,
+        either as subject or as subjectAltName.
+      '';
+
+      eap_id = mkOptionalStrParam ''
+        Identity to use as peer identity during EAP authentication. If set to
+        <literal>%any</literal> the EAP-Identity method will be used to ask the
+        client for an EAP identity.
+      '';
+
+      groups = mkCommaSepListParam [] ''
+        Authorization group memberships to require. The peer
+        must prove membership to at least one of the specified groups. Group
+        membership can be certified by different means, for example by
+        appropriate Attribute Certificates or by an AAA backend involved in the
+        authentication.
+      '';
+
+      cert_policy = mkCommaSepListParam [] ''
+        List of certificate policy OIDs the peer's certificate
+        must have. OIDs are specified using the numerical dotted representation.
+      '';
+
+      certs = mkCommaSepListParam [] ''
+        List of certificates to accept for authentication. The certificates may
+        use a relative path from the swanctl <literal>x509</literal> directory
+        or an absolute path.
+      '';
+
+      cert = mkPostfixedAttrsOfParams certParams ''
+        Section for a certificate candidate to use for
+        authentication. Certificates in certs are transmitted as binary blobs,
+        these sections offer more flexibility.
+      '';
+
+      cacerts = mkCommaSepListParam [] ''
+        List of CA certificates to accept for
+        authentication. The certificates may use a relative path from the
+        swanctl <literal>x509ca</literal> directory or an absolute path.
+      '';
+
+      cacert = mkPostfixedAttrsOfParams certParams ''
+        Section for a CA certificate to accept for authentication. Certificates
+        in cacerts are transmitted as binary blobs, these sections offer more
+        flexibility.
+      '';
+
+      pubkeys = mkCommaSepListParam [] ''
+        List of raw public keys to accept for
+        authentication. The public keys may use a relative path from the swanctl
+        <literal>pubkey</literal> directory or an absolute path.
+      '';
+
+      revocation = mkEnumParam ["strict" "ifuri" "relaxed"] "relaxed" ''
+        Certificate revocation policy for CRL or OCSP revocation.
+        <itemizedlist>
+        <listitem><para>
+        A <literal>strict</literal> revocation policy fails if no revocation information is
+        available, i.e. the certificate is not known to be unrevoked.
+        </para></listitem>
+        <listitem><para>
+        <literal>ifuri</literal> fails only if a CRL/OCSP URI is available, but certificate
+        revocation checking fails, i.e. there should be revocation information
+        available, but it could not be obtained.
+        </para></listitem>
+        <listitem><para>
+        The default revocation policy <literal>relaxed</literal> fails only if a certificate is
+        revoked, i.e. it is explicitly known that it is bad.
+        </para></listitem>
+        </itemizedlist>
+      '';
+
+      auth = mkStrParam "pubkey" ''
+        Authentication to expect from remote. See the <option>local</option>
+        section's <option>auth</option> keyword description about the details of
+        supported mechanisms.
+        </para><para>
+        Since 5.4.0, to require a trustchain public key strength for the remote
+        side, specify the key type followed by the minimum strength in bits (for
+        example <literal>ecdsa-384</literal> or
+        <literal>rsa-2048-ecdsa-256</literal>). To limit the acceptable set of
+        hashing algorithms for trustchain validation, append hash algorithms to
+        pubkey or a key strength definition (for example
+        <literal>pubkey-sha1-sha256</literal> or
+        <literal>rsa-2048-ecdsa-256-sha256-sha384-sha512</literal>). Unless
+        disabled in <literal>strongswan.conf</literal>, or explicit IKEv2
+        signature constraints are configured (refer to the description of the
+        <option>local</option> section's <option>auth</option> keyword for
+        details), such key types and hash algorithms are also applied as
+        constraints against IKEv2 signature authentication schemes used by the
+        remote side.
+        </para><para>
+        To specify trust chain constraints for EAP-(T)TLS, append a colon to the
+        EAP method, followed by the key type/size and hash algorithm as
+        discussed above (e.g. <literal>eap-tls:ecdsa-384-sha384</literal>).
+      '';
+
+    } ''
+      Section for a remote authentication round. A remote authentication round
+      defines the constraints how the peers must authenticate to use this
+      connection. Multiple rounds may be defined to use IKEv2 RFC 4739 Multiple
+      Authentication or IKEv1 XAuth.
+      </para><para>
+      Each round is defined in a section having <literal>remote</literal> as
+      prefix, and an optional unique suffix. To define a single authentication
+      round, the suffix may be omitted.
+    '';
+
+    children = mkAttrsOfParams {
+      ah_proposals = mkCommaSepListParam [] ''
+        AH proposals to offer for the CHILD_SA. A proposal is a set of
+        algorithms. For AH, this includes an integrity algorithm and an optional
+        Diffie-Hellman group. If a DH group is specified, CHILD_SA/Quick Mode
+        rekeying and initial negotiation uses a separate Diffie-Hellman exchange
+        using the specified group (refer to esp_proposals for details).
+        </para><para>
+        In IKEv2, multiple algorithms of the same kind can be specified in a
+        single proposal, from which one gets selected. In IKEv1, only one
+        algorithm per kind is allowed per proposal, more algorithms get
+        implicitly stripped. Use multiple proposals to offer different algorithms
+        combinations in IKEv1.
+        </para><para>
+        Algorithm keywords get separated using dashes. Multiple proposals may be
+        specified in a list. The special value <literal>default</literal> forms
+        a default proposal of supported algorithms considered safe, and is
+        usually a good choice for interoperability. By default no AH proposals
+        are included, instead ESP is proposed.
+     '';
+
+      esp_proposals = mkCommaSepListParam ["default"] ''
+        ESP proposals to offer for the CHILD_SA. A proposal is a set of
+        algorithms. For ESP non-AEAD proposals, this includes an integrity
+        algorithm, an encryption algorithm, an optional Diffie-Hellman group and
+        an optional Extended Sequence Number Mode indicator. For AEAD proposals,
+        a combined mode algorithm is used instead of the separate
+        encryption/integrity algorithms.
+        </para><para>
+        If a DH group is specified, CHILD_SA/Quick Mode rekeying and initial
+        negotiation use a separate Diffie-Hellman exchange using the specified
+        group. However, for IKEv2, the keys of the CHILD_SA created implicitly
+        with the IKE_SA will always be derived from the IKE_SA's key material. So
+        any DH group specified here will only apply when the CHILD_SA is later
+        rekeyed or is created with a separate CREATE_CHILD_SA exchange. A
+        proposal mismatch might, therefore, not immediately be noticed when the
+        SA is established, but may later cause rekeying to fail.
+        </para><para>
+        Extended Sequence Number support may be indicated with the
+        <literal>esn</literal> and <literal>noesn</literal> values, both may be
+        included to indicate support for both modes. If omitted,
+        <literal>noesn</literal> is assumed.
+        </para><para>
+        In IKEv2, multiple algorithms of the same kind can be specified in a
+        single proposal, from which one gets selected. In IKEv1, only one
+        algorithm per kind is allowed per proposal, more algorithms get
+        implicitly stripped. Use multiple proposals to offer different algorithms
+        combinations in IKEv1.
+        </para><para>
+        Algorithm keywords get separated using dashes. Multiple proposals may be
+        specified as a list. The special value <literal>default</literal> forms
+        a default proposal of supported algorithms considered safe, and is
+        usually a good choice for interoperability. If no algorithms are
+        specified for AH nor ESP, the default set of algorithms for ESP is
+        included.
+      '';
+
+      sha256_96 = mkYesNoParam no ''
+        HMAC-SHA-256 is used with 128-bit truncation with IPsec. For
+        compatibility with implementations that incorrectly use 96-bit truncation
+        this option may be enabled to configure the shorter truncation length in
+        the kernel. This is not negotiated, so this only works with peers that
+        use the incorrect truncation length (or have this option enabled).
+      '';
+
+      local_ts = mkCommaSepListParam ["dynamic"] ''
+        List of local traffic selectors to include in CHILD_SA. Each selector is
+        a CIDR subnet definition, followed by an optional proto/port
+        selector. The special value <literal>dynamic</literal> may be used
+        instead of a subnet definition, which gets replaced by the tunnel outer
+        address or the virtual IP, if negotiated. This is the default.
+        </para><para>
+        A protocol/port selector is surrounded by opening and closing square
+        brackets. Between these brackets, a numeric or getservent(3) protocol
+        name may be specified. After the optional protocol restriction, an
+        optional port restriction may be specified, separated by a slash. The
+        port restriction may be numeric, a getservent(3) service name, or the
+        special value <literal>opaque</literal> for RFC 4301 OPAQUE
+        selectors. Port ranges may be specified as well, none of the kernel
+        backends currently support port ranges, though.
+        </para><para>
+        When IKEv1 is used only the first selector is interpreted, except if the
+        Cisco Unity extension plugin is used. This is due to a limitation of the
+        IKEv1 protocol, which only allows a single pair of selectors per
+        CHILD_SA. So to tunnel traffic matched by several pairs of selectors when
+        using IKEv1 several children (CHILD_SAs) have to be defined that cover
+        the selectors.  The IKE daemon uses traffic selector narrowing for IKEv1,
+        the same way it is standardized and implemented for IKEv2. However, this
+        may lead to problems with other implementations. To avoid that, configure
+        identical selectors in such scenarios.
+      '';
+
+      remote_ts = mkCommaSepListParam ["dynamic"] ''
+        List of remote selectors to include in CHILD_SA. See
+        <option>local_ts</option> for a description of the selector syntax.
+      '';
+
+      rekey_time = mkDurationParam "1h" ''
+        Time to schedule CHILD_SA rekeying. CHILD_SA rekeying refreshes key
+        material, optionally using a Diffie-Hellman exchange if a group is
+        specified in the proposal.  To avoid rekey collisions initiated by both
+        ends simultaneously, a value in the range of <option>rand_time</option>
+        gets subtracted to form the effective soft lifetime.
+        </para><para>
+        By default CHILD_SA rekeying is scheduled every hour, minus
+        <option>rand_time</option>.
+      '';
+
+      life_time = mkOptionalDurationParam ''
+        Maximum lifetime before CHILD_SA gets closed. Usually this hard lifetime
+        is never reached, because the CHILD_SA gets rekeyed before. If that fails
+        for whatever reason, this limit closes the CHILD_SA.  The default is 10%
+        more than the <option>rekey_time</option>.
+      '';
+
+      rand_time = mkOptionalDurationParam ''
+        Time range from which to choose a random value to subtract from
+        <option>rekey_time</option>. The default is the difference between
+        <option>life_time</option> and <option>rekey_time</option>.
+      '';
+
+      rekey_bytes = mkIntParam 0 ''
+        Number of bytes processed before initiating CHILD_SA rekeying. CHILD_SA
+        rekeying refreshes key material, optionally using a Diffie-Hellman
+        exchange if a group is specified in the proposal.
+        </para><para>
+        To avoid rekey collisions initiated by both ends simultaneously, a value
+        in the range of <option>rand_bytes</option> gets subtracted to form the
+        effective soft volume limit.
+        </para><para>
+        Volume based CHILD_SA rekeying is disabled by default.
+      '';
+
+      life_bytes = mkOptionalIntParam ''
+        Maximum bytes processed before CHILD_SA gets closed. Usually this hard
+        volume limit is never reached, because the CHILD_SA gets rekeyed
+        before. If that fails for whatever reason, this limit closes the
+        CHILD_SA.  The default is 10% more than <option>rekey_bytes</option>.
+      '';
+
+      rand_bytes = mkOptionalIntParam ''
+        Byte range from which to choose a random value to subtract from
+        <option>rekey_bytes</option>. The default is the difference between
+        <option>life_bytes</option> and <option>rekey_bytes</option>.
+      '';
+
+      rekey_packets = mkIntParam 0 ''
+        Number of packets processed before initiating CHILD_SA rekeying. CHILD_SA
+        rekeying refreshes key material, optionally using a Diffie-Hellman
+        exchange if a group is specified in the proposal.
+        </para><para>
+        To avoid rekey collisions initiated by both ends simultaneously, a value
+        in the range of <option>rand_packets</option> gets subtracted to form
+        the effective soft packet count limit.
+        </para><para>
+        Packet count based CHILD_SA rekeying is disabled by default.
+      '';
+
+      life_packets = mkOptionalIntParam ''
+        Maximum number of packets processed before CHILD_SA gets closed. Usually
+        this hard packets limit is never reached, because the CHILD_SA gets
+        rekeyed before. If that fails for whatever reason, this limit closes the
+        CHILD_SA.
+        </para><para>
+        The default is 10% more than <option>rekey_bytes</option>.
+      '';
+
+      rand_packets = mkOptionalIntParam ''
+        Packet range from which to choose a random value to subtract from
+        <option>rekey_packets</option>. The default is the difference between
+        <option>life_packets</option> and <option>rekey_packets</option>.
+      '';
+
+      updown = mkOptionalStrParam ''
+        Updown script to invoke on CHILD_SA up and down events.
+      '';
+
+      hostaccess = mkYesNoParam yes ''
+        Hostaccess variable to pass to <literal>updown</literal> script.
+      '';
+
+      mode = mkEnumParam [ "tunnel"
+                           "transport"
+                           "transport_proxy"
+                           "beet"
+                           "pass"
+                           "drop"
+                         ] "tunnel" ''
+        IPsec Mode to establish CHILD_SA with.
+        <itemizedlist>
+        <listitem><para>
+        <literal>tunnel</literal> negotiates the CHILD_SA in IPsec Tunnel Mode,
+        </para></listitem>
+        <listitem><para>
+        whereas <literal>transport</literal> uses IPsec Transport Mode.
+        </para></listitem>
+        <listitem><para>
+        <literal>transport_proxy</literal> signifying the special Mobile IPv6
+        Transport Proxy Mode.
+        </para></listitem>
+        <listitem><para>
+        <literal>beet</literal> is the Bound End to End Tunnel mixture mode,
+        working with fixed inner addresses without the need to include them in
+        each packet.
+        </para></listitem>
+        <listitem><para>
+        Both <literal>transport</literal> and <literal>beet</literal> modes are
+        subject to mode negotiation; <literal>tunnel</literal> mode is
+        negotiated if the preferred mode is not available.
+        </para></listitem>
+        <listitem><para>
+        <literal>pass</literal> and <literal>drop</literal> are used to install
+        shunt policies which explicitly bypass the defined traffic from IPsec
+        processing or drop it, respectively.
+        </para></listitem>
+        </itemizedlist>
+      '';
+
+      policies = mkYesNoParam yes ''
+        Whether to install IPsec policies or not. Disabling this can be useful in
+        some scenarios e.g. MIPv6, where policies are not managed by the IKE
+        daemon. Since 5.3.3.
+      '';
+
+      policies_fwd_out = mkYesNoParam no ''
+        Whether to install outbound FWD IPsec policies or not. Enabling this is
+        required in case there is a drop policy that would match and block
+        forwarded traffic for this CHILD_SA. Since 5.5.1.
+      '';
+
+      dpd_action = mkEnumParam ["clear" "trap" "restart"] "clear" ''
+        Action to perform for this CHILD_SA on DPD timeout. The default clear
+        closes the CHILD_SA and does not take further action. trap installs a
+        trap policy, which will catch matching traffic and tries to re-negotiate
+        the tunnel on-demand. restart immediately tries to re-negotiate the
+        CHILD_SA under a fresh IKE_SA.
+      '';
+
+      ipcomp = mkYesNoParam no ''
+        Enable IPComp compression before encryption. If enabled, IKE tries to
+        negotiate IPComp compression to compress ESP payload data prior to
+        encryption.
+      '';
+
+      inactivity = mkDurationParam "0s" ''
+        Timeout before closing CHILD_SA after inactivity. If no traffic has been
+        processed in either direction for the configured timeout, the CHILD_SA
+        gets closed due to inactivity. The default value of 0 disables inactivity
+        checks.
+      '';
+
+      reqid = mkIntParam 0 ''
+        Fixed reqid to use for this CHILD_SA. This might be helpful in some
+        scenarios, but works only if each CHILD_SA configuration is instantiated
+        not more than once. The default of 0 uses dynamic reqids, allocated
+        incrementally.
+      '';
+
+      priority = mkIntParam 0 ''
+        Optional fixed priority for IPsec policies. This could be useful to
+        install high-priority drop policies. The default of 0 uses dynamically
+        calculated priorities based on the size of the traffic selectors.
+      '';
+
+      interface = mkOptionalStrParam ''
+        Optional interface name to restrict outbound IPsec policies.
+      '';
+
+      mark_in = mkStrParam "0/0x00000000" ''
+        Netfilter mark and mask for input traffic. On Linux Netfilter may
+        require marks on each packet to match an SA having that option set. This
+        allows Netfilter rules to select specific tunnels for incoming
+        traffic. The special value <literal>%unique</literal> sets a unique mark
+        on each CHILD_SA instance, beyond that the value
+        <literal>%unique-dir</literal> assigns a different unique mark for each
+        CHILD_SA direction (in/out).
+        </para><para>
+        An additional mask may be appended to the mark, separated by
+        <literal>/</literal>. The default mask if omitted is
+        <literal>0xffffffff</literal>.
+      '';
+
+      mark_out = mkStrParam "0/0x00000000" ''
+        Netfilter mark and mask for output traffic. On Linux Netfilter may
+        require marks on each packet to match a policy having that option
+        set. This allows Netfilter rules to select specific tunnels for outgoing
+        traffic. The special value <literal>%unique</literal> sets a unique mark
+        on each CHILD_SA instance, beyond that the value
+        <literal>%unique-dir</literal> assigns a different unique mark for each
+        CHILD_SA direction (in/out).
+        </para><para>
+        An additional mask may be appended to the mark, separated by
+        <literal>/</literal>. The default mask if omitted is
+        <literal>0xffffffff</literal>.
+      '';
+
+      tfc_padding = mkParamOfType (with lib.types; either int (enum ["mtu"])) 0 ''
+        Pads ESP packets with additional data to have a consistent ESP packet
+        size for improved Traffic Flow Confidentiality. The padding defines the
+        minimum size of all ESP packets sent.  The default value of
+        <literal>0</literal> disables TFC padding, the special value
+        <literal>mtu</literal> adds TFC padding to create a packet size equal to
+        the Path Maximum Transfer Unit.
+      '';
+
+      replay_window = mkIntParam 32 ''
+        IPsec replay window to configure for this CHILD_SA. Larger values than
+        the default of <literal>32</literal> are supported using the Netlink
+        backend only, a value of <literal>0</literal> disables IPsec replay
+        protection.
+      '';
+
+      hw_offload = mkYesNoParam no ''
+        Enable hardware offload for this CHILD_SA, if supported by the IPsec
+        implementation.
+      '';
+
+      start_action = mkEnumParam ["none" "trap" "start"] "none" ''
+        Action to perform after loading the configuration.
+        <itemizedlist>
+        <listitem><para>
+        The default of <literal>none</literal> loads the connection only, which
+        then can be manually initiated or used as a responder configuration.
+        </para></listitem>
+        <listitem><para>
+        The value <literal>trap</literal> installs a trap policy, which triggers
+        the tunnel as soon as matching traffic has been detected.
+        </para></listitem>
+        <listitem><para>
+        The value <literal>start</literal> initiates the connection actively.
+        </para></listitem>
+        </itemizedlist>
+        When unloading or replacing a CHILD_SA configuration having a
+        <option>start_action</option> different from <literal>none</literal>,
+        the inverse action is performed. Configurations with
+        <literal>start</literal> get closed, while such with
+        <literal>trap</literal> get uninstalled.
+      '';
+
+      close_action = mkEnumParam ["none" "trap" "start"] "none" ''
+        Action to perform after a CHILD_SA gets closed by the peer.
+        <itemizedlist>
+        <listitem><para>
+        The default of <literal>none</literal> does not take any action,
+        </para></listitem>
+        <listitem><para>
+        <literal>trap</literal> installs a trap policy for the CHILD_SA.
+        </para></listitem>
+        <listitem><para>
+        <literal>start</literal> tries to re-create the CHILD_SA.
+        </para></listitem>
+        </itemizedlist>
+        </para><para>
+        <option>close_action</option> does not provide any guarantee that the
+        CHILD_SA is kept alive. It acts on explicit close messages only, but not
+        on negotiation failures. Use trap policies to reliably re-create failed
+        CHILD_SAs.
+      '';
+
+    } ''
+      CHILD_SA configuration sub-section. Each connection definition may have
+      one or more sections in its <option>children</option> subsection. The
+      section name defines the name of the CHILD_SA configuration, which must be
+      unique within the connection (denoted &#60;child&#62; below).
+    '';
+  } ''
+    Section defining IKE connection configurations, each in its own subsection
+    with an arbitrary yet unique name
+  '';
+
+  secrets = let
+    mkEapXauthParams = mkPrefixedAttrsOfParams {
+      secret = mkOptionalStrParam ''
+        Value of the EAP/XAuth secret. It may either be an ASCII string, a hex
+        encoded string if it has a 0x prefix or a Base64 encoded string if it
+        has a 0s prefix in its value.
+      '';
+
+      id = mkPrefixedAttrsOfParam (mkOptionalStrParam "") ''
+        Identity the EAP/XAuth secret belongs to. Multiple unique identities may
+        be specified, each having an <literal>id</literal> prefix, if a secret
+        is shared between multiple users.
+      '';
+
+    } ''
+      EAP secret section for a specific secret. Each EAP secret is defined in a
+      unique section having the <literal>eap</literal> prefix. EAP secrets are
+      used for XAuth authentication as well.
+    '';
+
+  in {
+
+    eap   = mkEapXauthParams;
+    xauth = mkEapXauthParams;
+
+    ntlm = mkPrefixedAttrsOfParams {
+      secret = mkOptionalStrParam ''
+        Value of the NTLM secret, which is the NT Hash of the actual secret,
+        that is, MD4(UTF-16LE(secret)). The resulting 16-byte value may either
+        be given as a hex encoded string with a 0x prefix or as a Base64 encoded
+        string with a 0s prefix.
+      '';
+
+      id = mkPrefixedAttrsOfParam (mkOptionalStrParam "") ''
+        Identity the NTLM secret belongs to. Multiple unique identities may be
+        specified, each having an id prefix, if a secret is shared between
+        multiple users.
+      '';
+    } ''
+      NTLM secret section for a specific secret. Each NTLM secret is defined in
+      a unique section having the <literal>ntlm</literal> prefix. NTLM secrets
+      may only be used for EAP-MSCHAPv2 authentication.
+    '';
+
+    ike = mkPrefixedAttrsOfParams {
+      secret = mkOptionalStrParam ''
+        Value of the IKE preshared secret. It may either be an ASCII string, a
+        hex encoded string if it has a 0x prefix or a Base64 encoded string if
+        it has a 0s prefix in its value.
+      '';
+
+      id = mkPrefixedAttrsOfParam (mkOptionalStrParam "") ''
+        IKE identity the IKE preshared secret belongs to. Multiple unique
+        identities may be specified, each having an <literal>id</literal>
+        prefix, if a secret is shared between multiple peers.
+      '';
+    } ''
+      IKE preshared secret section for a specific secret. Each IKE PSK is
+      defined in a unique section having the <literal>ike</literal> prefix.
+    '';
+
+    private = mkPrefixedAttrsOfParams {
+      file = mkPrefixedAttrsOfParam (mkOptionalStrParam "") ''
+        File name in the private folder for which this passphrase should be used.
+      '';
+
+      secret = mkOptionalStrParam ''
+        Value of decryption passphrase for private key.
+      '';
+    } ''
+      Private key decryption passphrase for a key in the
+      <literal>private</literal> folder.
+    '';
+
+    rsa = mkPrefixedAttrsOfParams {
+      file = mkPrefixedAttrsOfParam (mkOptionalStrParam "") ''
+        File name in the <literal>rsa</literal> folder for which this passphrase
+        should be used.
+      '';
+      secret = mkOptionalStrParam ''
+        Value of decryption passphrase for RSA key.
+      '';
+    } ''
+      Private key decryption passphrase for a key in the <literal>rsa</literal>
+      folder.
+    '';
+
+    ecdsa = mkPrefixedAttrsOfParams {
+      file = mkPrefixedAttrsOfParam (mkOptionalStrParam "") ''
+        File name in the <literal>ecdsa</literal> folder for which this
+        passphrase should be used.
+      '';
+      secret = mkOptionalStrParam ''
+        Value of decryption passphrase for ECDSA key.
+      '';
+    } ''
+      Private key decryption passphrase for a key in the
+      <literal>ecdsa</literal> folder.
+    '';
+
+    pkcs8 = mkPrefixedAttrsOfParams {
+      file = mkPrefixedAttrsOfParam (mkOptionalStrParam "") ''
+        File name in the <literal>pkcs8</literal> folder for which this
+        passphrase should be used.
+      '';
+      secret = mkOptionalStrParam ''
+        Value of decryption passphrase for PKCS#8 key.
+      '';
+    } ''
+      Private key decryption passphrase for a key in the
+      <literal>pkcs8</literal> folder.
+    '';
+
+    pkcs12 = mkPrefixedAttrsOfParams {
+      file = mkPrefixedAttrsOfParam (mkOptionalStrParam "") ''
+        File name in the <literal>pkcs12</literal> folder for which this
+        passphrase should be used.
+      '';
+      secret = mkOptionalStrParam ''
+        Value of decryption passphrase for PKCS#12 container.
+      '';
+    } ''
+      PKCS#12 decryption passphrase for a container in the
+      <literal>pkcs12</literal> folder.
+    '';
+
+    token = mkPrefixedAttrsOfParams {
+      handle = mkOptionalHexParam ''
+        Hex-encoded CKA_ID or handle of the private key on the token or TPM,
+        respectively.
+      '';
+
+      slot = mkOptionalIntParam ''
+        Optional slot number to access the token.
+      '';
+
+      module = mkOptionalStrParam ''
+        Optional PKCS#11 module name to access the token.
+      '';
+
+      pin = mkOptionalStrParam ''
+        Optional PIN required to access the key on the token. If none is
+        provided the user is prompted during an interactive
+        <literal>--load-creds</literal> call.
+      '';
+    } ''Definition for a private key that's stored on a token/smartcard/TPM.'';
+
+  };
+
+  pools = mkAttrsOfParams {
+    addrs = mkOptionalStrParam ''
+      Subnet or range defining addresses allocated in pool. Accepts a single
+      CIDR subnet defining the pool to allocate addresses from or an address
+      range (&#60;from&#62;-&#60;to&#62;). Pools must be unique and non-overlapping.
+    '';
+
+    dns           = mkCommaSepListParam [] "Address or CIDR subnets";
+    nbns          = mkCommaSepListParam [] "Address or CIDR subnets";
+    dhcp          = mkCommaSepListParam [] "Address or CIDR subnets";
+    netmask       = mkCommaSepListParam [] "Address or CIDR subnets";
+    server        = mkCommaSepListParam [] "Address or CIDR subnets";
+    subnet        = mkCommaSepListParam [] "Address or CIDR subnets";
+    split_include = mkCommaSepListParam [] "Address or CIDR subnets";
+    split_exclude = mkCommaSepListParam [] "Address or CIDR subnets";
+  } ''
+    Section defining named pools. Named pools may be referenced by connections
+    with the pools option to assign virtual IPs and other configuration
+    attributes. Each pool must have a unique name (denoted &#60;name&#62; below).
+  '';
+}

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -37,7 +37,7 @@ let
   # we just copy what we need from Glibc and use patchelf to make it
   # work.
   extraUtils = pkgs.runCommandCC "extra-utils"
-    { buildInputs = [pkgs.nukeReferences];
+    { nativeBuildInputs = [pkgs.nukeReferences pkgs.glibc.bin];
       allowedReferences = [ "out" ]; # prevent accidents like glibc being included in the initrd
     }
     ''

--- a/nixos/modules/system/boot/stage-2.nix
+++ b/nixos/modules/system/boot/stage-2.nix
@@ -10,6 +10,7 @@ let
   bootStage2 = pkgs.substituteAll {
     src = ./stage-2-init.sh;
     shellDebug = "${pkgs.bashInteractive}/bin/bash";
+    shell = "${pkgs.bash}/bin/bash";
     isExecutable = true;
     inherit (config.nix) readOnlyStore;
     inherit (config.networking) useHostResolvConf;

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -241,37 +241,37 @@ let
         }
         (mkIf (config.preStart != "")
           { serviceConfig.ExecStartPre = makeJobScript "${name}-pre-start" ''
-              #! ${pkgs.stdenv.shell} -e
+              #! ${pkgs.bash}/bin/bash -e
               ${config.preStart}
             '';
           })
         (mkIf (config.script != "")
           { serviceConfig.ExecStart = makeJobScript "${name}-start" ''
-              #! ${pkgs.stdenv.shell} -e
+              #! ${pkgs.bash}/bin/bash -e
               ${config.script}
             '' + " " + config.scriptArgs;
           })
         (mkIf (config.postStart != "")
           { serviceConfig.ExecStartPost = makeJobScript "${name}-post-start" ''
-              #! ${pkgs.stdenv.shell} -e
+              #! ${pkgs.bash}/bin/bash -e
               ${config.postStart}
             '';
           })
         (mkIf (config.reload != "")
           { serviceConfig.ExecReload = makeJobScript "${name}-reload" ''
-              #! ${pkgs.stdenv.shell} -e
+              #! ${pkgs.bash}/bin/bash -e
               ${config.reload}
             '';
           })
         (mkIf (config.preStop != "")
           { serviceConfig.ExecStop = makeJobScript "${name}-pre-stop" ''
-              #! ${pkgs.stdenv.shell} -e
+              #! ${pkgs.bash}/bin/bash -e
               ${config.preStop}
             '';
           })
         (mkIf (config.postStop != "")
           { serviceConfig.ExecStopPost = makeJobScript "${name}-post-stop" ''
-              #! ${pkgs.stdenv.shell} -e
+              #! ${pkgs.bash}/bin/bash -e
               ${config.postStop}
             '';
           })

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -352,6 +352,7 @@ in rec {
   tests.smokeping = callTest tests/smokeping.nix {};
   tests.snapper = callTest tests/snapper.nix {};
   tests.statsd = callTest tests/statsd.nix {};
+  tests.strongswan-swanctl = callTest tests/strongswan-swanctl.nix {};
   tests.sudo = callTest tests/sudo.nix {};
   tests.switchTest = callTest tests/switch-test.nix {};
   tests.taskserver = callTest tests/taskserver.nix {};

--- a/nixos/tests/strongswan-swanctl.nix
+++ b/nixos/tests/strongswan-swanctl.nix
@@ -1,0 +1,154 @@
+# This strongswan-swanctl test is based on:
+# https://www.strongswan.org/testing/testresults/swanctl/rw-psk-ipv4/index.html
+# https://github.com/strongswan/strongswan/tree/master/testing/tests/swanctl/rw-psk-ipv4
+#
+# The roadwarrior carol sets up a connection to gateway moon. The authentication
+# is based on pre-shared keys and IPv4 addresses. Upon the successful
+# establishment of the IPsec tunnels, the specified updown script automatically
+# inserts iptables-based firewall rules that let pass the tunneled traffic. In
+# order to test both tunnel and firewall, carol pings the client alice behind
+# the gateway moon.
+#
+#     alice                       moon                        carol
+#      eth1------vlan_0------eth1        eth2------vlan_1------eth1
+#   192.168.0.1         192.168.0.3  192.168.1.3           192.168.1.2
+#
+# See the NixOS manual for how to run this test:
+# https://nixos.org/nixos/manual/index.html#sec-running-nixos-tests-interactively
+
+import ./make-test.nix ({ pkgs, ...} :
+
+let
+  ifAddr = node: iface: (pkgs.lib.head node.config.networking.interfaces.${iface}.ip4).address;
+
+  allowESP = "iptables --insert INPUT --protocol ESP --jump ACCEPT";
+
+  # Shared VPN settings:
+  vlan0         = "192.168.0.0/24";
+  version       = 2;
+  secret        = "0sFpZAZqEN6Ti9sqt4ZP5EWcqx";
+  esp_proposals = [ "aes128gcm128-x25519" ];
+  proposals     = [ "aes128-sha256-x25519" ];
+in {
+  name = "strongswan-swanctl";
+  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ basvandijk ];
+  nodes = {
+
+    alice = { nodes, ... } : {
+      virtualisation.vlans = [ 0 ];
+      networking = {
+        dhcpcd.enable = false;
+        defaultGateway = ifAddr nodes.moon "eth1";
+      };
+    };
+
+    moon = {pkgs, config, nodes, ...} :
+      let
+        carolIp = ifAddr nodes.carol "eth1";
+        moonIp  = ifAddr nodes.moon  "eth2";
+        strongswan = config.services.strongswan-swanctl.package;
+      in {
+        virtualisation.vlans = [ 0 1 ];
+        networking = {
+          dhcpcd.enable = false;
+          firewall = {
+            allowedUDPPorts = [ 4500 500 ];
+            extraCommands = allowESP;
+          };
+          nat = {
+            enable             = true;
+            internalIPs        = [ vlan0 ];
+            internalInterfaces = [ "eth1" ];
+            externalIP         = moonIp;
+            externalInterface  = "eth2";
+          };
+        };
+        environment.systemPackages = [ strongswan ];
+        services.strongswan-swanctl = {
+          enable = true;
+          swanctl = {
+            connections = {
+              "rw" = {
+                local_addrs = [ moonIp ];
+                local."main" = {
+                  auth = "psk";
+                };
+                remote."main" = {
+                  auth = "psk";
+                };
+                children = {
+                  "net" = {
+                    local_ts = [ vlan0 ];
+                    updown = "${strongswan}/libexec/ipsec/_updown iptables";
+                    inherit esp_proposals;
+                  };
+                };
+                inherit version;
+                inherit proposals;
+              };
+            };
+            secrets = {
+              ike."carol" = {
+                id."main" = carolIp;
+                inherit secret;
+              };
+            };
+          };
+        };
+      };
+
+    carol = {pkgs, config, nodes, ...} :
+      let
+        carolIp = ifAddr nodes.carol "eth1";
+        moonIp  = ifAddr nodes.moon  "eth2";
+        strongswan = config.services.strongswan-swanctl.package;
+      in {
+        virtualisation.vlans = [ 1 ];
+        networking = {
+          dhcpcd.enable = false;
+          firewall.extraCommands = allowESP;
+        };
+        environment.systemPackages = [ strongswan ];
+        services.strongswan-swanctl = {
+          enable = true;
+          swanctl = {
+            connections = {
+              "home" = {
+                local_addrs = [ carolIp ];
+                remote_addrs = [ moonIp ];
+                local."main" = {
+                  auth = "psk";
+                  id = carolIp;
+                };
+                remote."main" = {
+                  auth = "psk";
+                  id = moonIp;
+                };
+                children = {
+                  "home" = {
+                    remote_ts = [ vlan0 ];
+                    start_action = "trap";
+                    updown = "${strongswan}/libexec/ipsec/_updown iptables";
+                    inherit esp_proposals;
+                  };
+                };
+                inherit version;
+                inherit proposals;
+              };
+            };
+            secrets = {
+              ike."moon" = {
+                id."main" = moonIp;
+                inherit secret;
+              };
+            };
+          };
+        };
+      };
+
+  };
+  testScript = ''
+    startAll();
+    $carol->waitUntilSucceeds("ping -c 1 alice");
+  '';
+})

--- a/pkgs/applications/audio/a2jmidid/default.nix
+++ b/pkgs/applications/audio/a2jmidid/default.nix
@@ -28,6 +28,6 @@ in stdenv.mkDerivation rec {
     description = "Daemon for exposing legacy ALSA sequencer applications in JACK MIDI system";
     license = licenses.gpl2;
     maintainers = [ maintainers.goibhniu ];
-    platforms = platforms.linux;
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/audio/meterbridge/default.nix
+++ b/pkgs/applications/audio/meterbridge/default.nix
@@ -2,12 +2,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.9.2";
+  version = "0.9.3";
   name = "meterbridge-${version}";
 
   src = fetchurl {
     url = "http://plugin.org.uk/meterbridge/${name}.tar.gz";
-    sha256 = "0jb6g3kbfyr5yf8mvblnciva2bmc01ijpr51m21r27rqmgi8gj5k";
+    sha256 = "0s7n3czfpil94vsd7iblv4xrck9c7zvsz4r3yfbkqcv85pjz1viz";
   };
 
   patches = [ ./buf_rect.patch ./fix_build_with_gcc-5.patch];

--- a/pkgs/applications/editors/ed/default.nix
+++ b/pkgs/applications/editors/ed/default.nix
@@ -11,9 +11,18 @@ stdenv.mkDerivation (rec {
     sha256 = "1nqhk3n1s1p77g2bjnj55acicsrlyb2yasqxqwpx0w0djfx64ygm";
   };
 
+  unpackCmd = "tar --lzip -xf";
+
   nativeBuildInputs = [ lzip ];
 
   doCheck = true; # not cross;
+
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  configureFlags = [
+    "--exec-prefix=${stdenv.cc.targetPrefix}"
+    "CC=${stdenv.cc.targetPrefix}cc"
+  ];
 
   meta = {
     description = "An implementation of the standard Unix editor";

--- a/pkgs/applications/editors/mg/default.nix
+++ b/pkgs/applications/editors/mg/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mg-${version}";
-  version = "20170828";
+  version = "20171014";
 
   src = fetchurl {
     url = "http://homepage.boetes.org/software/mg/${name}.tar.gz";
-    sha256 = "139nc58l5ifj3d3478nhqls0lic52skmxfxggznzxaz9camqd20z";
+    sha256 = "0hakfikzsml7z0hja8m8mcahrmfy2piy81bq9nccsjplyfc9clai";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation rec {
     "ac_cv_sizeof_int=4"
     "vim_cv_memmove_handles_overlap=yes"
     "vim_cv_memmove_handles_overlap=yes"
+    "vim_cv_tgent=zero"
   ];
 
   postInstall = ''

--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     "ac_cv_sizeof_int=4"
     "vim_cv_memmove_handles_overlap=yes"
     "vim_cv_memmove_handles_overlap=yes"
-    "vim_cv_tgent=zero"
+    "vim_cv_tgetent=zero"
   ];
 
   postInstall = ''

--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -2,11 +2,11 @@
 , desktop-file-utils, libSM, imagemagick }:
 
 stdenv.mkDerivation rec {
-  version = "17.10";
+  version = "17.12";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
     url = "https://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "1yvh4r19kk3bzzgnr4ikrjxqldr6860s35sh4bqr51c7l77k048c";
+    sha256 = "1pxdf0ny3c38gl513zdiaagpvk4bqnsc2fn7476yjdpv2lxsw56f";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/applications/networking/browsers/w3m/default.nix
+++ b/pkgs/applications/networking/browsers/w3m/default.nix
@@ -40,8 +40,8 @@ stdenv.mkDerivation rec {
     })
   ] ++ optional (graphicsSupport && !x11Support) [ ./no-x11.patch ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ncurses boehmgc gettext zlib ]
+  nativeBuildInputs = [ pkgconfig gettext stdenv.cc ];
+  buildInputs = [ ncurses boehmgc zlib ]
     ++ optional sslSupport openssl
     ++ optional mouseSupport gpm-ncurses
     ++ optional graphicsSupport imlib2
@@ -57,10 +57,15 @@ stdenv.mkDerivation rec {
     [ "--with-ssl=${openssl.dev}" "--with-gc=${boehmgc.dev}" ]
     ++ optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
       "ac_cv_func_setpgrp_void=yes"
+      "AR=${stdenv.cc.bintools.targetPrefix}arc"
     ]
     ++ optional graphicsSupport "--enable-image=${optionalString x11Support "x11,"}fb";
 
   preConfigure = ''
+    substituteInPlace Makefile.in --replace "AR=ar" ""
+    substituteInPlace libwc/Makefile.in --replace "AR=ar" ""
+    substituteInPlace w3mimg/Makefile.in --replace "AR=ar" ""
+
     substituteInPlace ./configure --replace "/lib /usr/lib /usr/local/lib /usr/ucblib /usr/ccslib /usr/ccs/lib /lib64 /usr/lib64" /no-such-path
     substituteInPlace ./configure --replace /usr /no-such-path
   '';

--- a/pkgs/applications/networking/browsers/w3m/default.nix
+++ b/pkgs/applications/networking/browsers/w3m/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     [ "--with-ssl=${openssl.dev}" "--with-gc=${boehmgc.dev}" ]
     ++ optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
       "ac_cv_func_setpgrp_void=yes"
-      "AR=${stdenv.cc.bintools.targetPrefix}arc"
+      "AR=${stdenv.cc.bintools.targetPrefix}ar"
     ]
     ++ optional graphicsSupport "--enable-image=${optionalString x11Support "x11,"}fb";
 

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -7,6 +7,7 @@ let
     svnSupport = false;         # for git-svn support
     guiSupport = false;         # requires tcl/tk
     sendEmailSupport = false;   # requires plenty of perl libraries
+    perlSupport = true;
     perlLibs = [perlPackages.LWP perlPackages.URI perlPackages.TermReadKey];
     smtpPerlLibs = [
       perlPackages.NetSMTP perlPackages.NetSMTPSSL

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -4,7 +4,6 @@
 args @ {pkgs}: with args; with pkgs;
 let
   gitBase = callPackage ./git {
-    texinfo = texinfo5;
     svnSupport = false;         # for git-svn support
     guiSupport = false;         # requires tcl/tk
     sendEmailSupport = false;   # requires plenty of perl libraries

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -43,10 +43,11 @@ stdenv.mkDerivation {
     done
   '';
 
+  nativeBuildInputs =
+    stdenv.lib.optionals withManual [ asciidoc texinfo xmlto docbook2x
+         docbook_xsl docbook_xml_dtd_45 libxslt ];
   buildInputs = [curl openssl zlib expat gettext cpio makeWrapper libiconv]
     ++ stdenv.lib.optional perlSupport perl
-    ++ stdenv.lib.optionals withManual [ asciidoc texinfo xmlto docbook2x
-         docbook_xsl docbook_xml_dtd_45 libxslt ]
     ++ stdenv.lib.optionals guiSupport [tcl tk]
     ++ stdenv.lib.optionals withpcre2 [ pcre2 ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.Security ];

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -68,6 +68,7 @@ stdenv.mkDerivation {
     ++ stdenv.lib.optional (!guiSupport) "NO_TCLTK=1 "
     ++ (if perlSupport then ["PERL_PATH=${perl}/bin/perl"] else ["NO_PERL=1"])
     ++ (if pythonSupport then ["PYTHON_PATH=${python}/bin/python"] else ["NO_PYTHON=1"])
+    ++ stdenv.lib.optional withpcre2 "USE_LIBPCRE2=1"
     ++ stdenv.lib.optionals stdenv.isSunOS ["INSTALL=install" "NO_INET_NTOP=" "NO_INET_PTON="]
     ++ (if stdenv.isDarwin then ["NO_APPLE_COMMON_CRYPTO=1"] else ["sysconfdir=/etc/"]);
     # XXX: USE_PCRE2 might be useful in general, look into it
@@ -86,9 +87,7 @@ stdenv.mkDerivation {
   # so that `SPARSE_FLAGS' corresponds to the current architecture...
   #doCheck = true;
 
-  installFlags = "NO_INSTALL_HARDLINKS=1"
-    + (if withpcre2 then " USE_LIBPCRE2=1" else "");
-
+  installFlags = "NO_INSTALL_HARDLINKS=1";
 
   preInstall = stdenv.lib.optionalString stdenv.isDarwin ''
     mkdir -p $out/bin

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -70,10 +70,10 @@ stdenv.mkDerivation {
     ++ (if pythonSupport then ["PYTHON_PATH=${python}/bin/python"] else ["NO_PYTHON=1"])
     ++ stdenv.lib.optional withpcre2 "USE_LIBPCRE2=1"
     ++ stdenv.lib.optionals stdenv.isSunOS ["INSTALL=install" "NO_INET_NTOP=" "NO_INET_PTON="]
-    ++ (if stdenv.isDarwin then ["NO_APPLE_COMMON_CRYPTO=1"] else ["sysconfdir=/etc/"]);
+    ++ (if stdenv.isDarwin then ["NO_APPLE_COMMON_CRYPTO=1"] else ["sysconfdir=/etc/"])
     # XXX: USE_PCRE2 might be useful in general, look into it
     # XXX other alpine options?
-    ++ stdenv.optionals stdenv.hostPlatform.isMusl ["NO_SYS_POLL_H=1" "NO_GETTEXT=YesPlease"];
+    ++ stdenv.lib.optionals stdenv.hostPlatform.isMusl ["NO_SYS_POLL_H=1" "NO_GETTEXT=YesPlease"];
 
 
   # build git-credential-osxkeychain if darwin

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -147,6 +147,21 @@ stdenv.mkDerivation {
         ln -s $ldPath/${targetPrefix}as $out/bin/${targetPrefix}as
       fi
 
+      # Create a symlink to ar (the archiver).
+      if [ -e $ldPath/${targetPrefix}ar ]; then
+        ln -s $ldPath/${targetPrefix}ar $out/bin/${targetPrefix}ar
+      fi
+
+      # Create a symlink to ranlib (the archive indexer).
+      if [ -e $ldPath/${targetPrefix}ranlib ]; then
+        ln -s $ldPath/${targetPrefix}ranlib $out/bin/${targetPrefix}ranlib
+      fi
+
+      # Create a symlink to strip
+      if [ -e $ldPath/${targetPrefix}strip ]; then
+        ln -s $ldPath/${targetPrefix}strip $out/bin/${targetPrefix}strip
+      fi
+
     '' + (if !useMacosReexportHack then ''
       wrap ${targetPrefix}ld ${./ld-wrapper.sh} ''${ld:-$ldPath/${targetPrefix}ld}
     '' else ''

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -162,6 +162,11 @@ stdenv.mkDerivation {
         ln -s $ldPath/${targetPrefix}strip $out/bin/${targetPrefix}strip
       fi
 
+      # Create a symlink to nm
+      if [ -e $ldPath/${targetPrefix}nm ]; then
+        ln -s $ldPath/${targetPrefix}nm $out/bin/${targetPrefix}nm
+      fi
+
     '' + (if !useMacosReexportHack then ''
       wrap ${targetPrefix}ld ${./ld-wrapper.sh} ''${ld:-$ldPath/${targetPrefix}ld}
     '' else ''

--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -120,7 +120,11 @@ then
                     -l?*)
                         libs["lib${p:2}.so"]=1
                         ;;
-                    "${NIX_STORE:-}"/*.so | "${NIX_STORE:-}"/*.so.*)
+                    # Note that we used to only look at shared libraries in /nix/store.
+                    # However, some packages (libssh2) build non-installed executables
+                    # in their build trees which link against shared libraries
+                    # in their tree. Linking these breaks if we are so restrictive.
+                    */*.so | */*.so.*)
                         # This is a direct reference to a shared library.
                         libDirs+=("${p%/*}")
                         libs["${p##*/}"]=1

--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -170,7 +170,7 @@ if [ "$NIX_@infixSalt@_DONT_SET_RPATH" != 1 ]; then
                 # should be found in a later directory, so we add all
                 # directories that contain any of the libraries to rpath.
                 rpaths["$dir"]=1
-                extraAfter+=(-rpath "$dir")
+                extraAfter+=(-rpath "$dir" -rpath-link "$dir")
                 break
             fi
         done

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -31,7 +31,8 @@ let
   #
   # TODO(@Ericson2314) Make unconditional, or optional but always true by
   # default.
-  targetPrefix = targetPlatform.config + "-";
+  targetPrefix = stdenv.lib.optionalString (targetPlatform != hostPlatform)
+                                           (targetPlatform.config + "-");
 
   ccVersion = (builtins.parseDrvName cc.name).version;
   ccName = (builtins.parseDrvName cc.name).name;
@@ -142,74 +143,62 @@ stdenv.mkDerivation {
         ln -s "$bbin" "$out/bin/$(basename $bbin)"
       done
 
-      for prefix in "" "${targetPrefix}"; do
-          # We export environment variables pointing to the wrapped nonstandard
-          # cmds, lest some lousy configure script use those to guess compiler
-          # version.
-          export named_cc=''${prefix}cc
-          export named_cxx=''${prefix}c++
+      # We export environment variables pointing to the wrapped nonstandard
+      # cmds, lest some lousy configure script use those to guess compiler
+      # version.
+      export named_cc=${targetPrefix}cc
+      export named_cxx=${targetPrefix}c++
 
-          export default_cxx_stdlib_compile="${default_cxx_stdlib_compile}"
+      export default_cxx_stdlib_compile="${default_cxx_stdlib_compile}"
 
-          if [ -e $ccPath/''${prefix}gcc ]; then
-            wrap ''${prefix}gcc ${./cc-wrapper.sh} $ccPath/''${prefix}gcc
-            ln -s ''${prefix}gcc $out/bin/''${prefix}cc
-            export named_cc=''${prefix}gcc
-            export named_cxx=''${prefix}g++
-          # bootstrapping compilers may not have a prefix; accept this and use
-          # them to produce prefixed wrappers
-          elif [ -e $ccPath/gcc ]; then
-            wrap ''${prefix}gcc ${./cc-wrapper.sh} $ccPath/gcc
-            ln -s gcc $out/bin/''${prefix}cc
-            export named_cc=gcc
-            export named_cxx=g++
-          elif [ -e $ccPath/clang ]; then
-            wrap ''${prefix}clang ${./cc-wrapper.sh} $ccPath/clang
-            ln -s ''${prefix}clang $out/bin/''${prefix}cc
-            export named_cc=''${prefix}clang
-            export named_cxx=''${prefix}clang++
-          fi
+      if [ -e $ccPath/${targetPrefix}gcc ]; then
+        wrap ${targetPrefix}gcc ${./cc-wrapper.sh} $ccPath/${targetPrefix}gcc
+        ln -s ${targetPrefix}gcc $out/bin/${targetPrefix}cc
+        export named_cc=${targetPrefix}gcc
+        export named_cxx=${targetPrefix}g++
+      elif [ -e $ccPath/clang ]; then
+        wrap ${targetPrefix}clang ${./cc-wrapper.sh} $ccPath/clang
+        ln -s ${targetPrefix}clang $out/bin/${targetPrefix}cc
+        export named_cc=${targetPrefix}clang
+        export named_cxx=${targetPrefix}clang++
+      fi
 
-          if [ -e $ccPath/''${prefix}g++ ]; then
-            wrap ''${prefix}g++ ${./cc-wrapper.sh} $ccPath/''${prefix}g++
-            ln -s ''${prefix}g++ $out/bin/''${prefix}c++
-          elif [ -e $ccPath/clang++ ]; then
-            wrap ''${prefix}clang++ ${./cc-wrapper.sh} $ccPath/clang++
-            ln -s ''${prefix}clang++ $out/bin/''${prefix}c++
-          fi
+      if [ -e $ccPath/${targetPrefix}g++ ]; then
+        wrap ${targetPrefix}g++ ${./cc-wrapper.sh} $ccPath/${targetPrefix}g++
+        ln -s ${targetPrefix}g++ $out/bin/${targetPrefix}c++
+      elif [ -e $ccPath/clang++ ]; then
+        wrap ${targetPrefix}clang++ ${./cc-wrapper.sh} $ccPath/clang++
+        ln -s ${targetPrefix}clang++ $out/bin/${targetPrefix}c++
+      fi
 
-          if [ -e $ccPath/cpp ]; then
-            wrap ''${prefix}cpp ${./cc-wrapper.sh} $ccPath/cpp
-          fi
-        ''
+      if [ -e $ccPath/cpp ]; then
+        wrap ${targetPrefix}cpp ${./cc-wrapper.sh} $ccPath/cpp
+      fi
+    ''
 
-        + optionalString cc.langFortran or false ''
-          wrap ''${prefix}gfortran ${./cc-wrapper.sh} $ccPath/''${prefix}gfortran
-          ln -sv ''${prefix}gfortran $out/bin/''${prefix}g77
-          ln -sv ''${prefix}gfortran $out/bin/''${prefix}f77
-        ''
+    + optionalString cc.langFortran or false ''
+      wrap ${targetPrefix}gfortran ${./cc-wrapper.sh} $ccPath/${targetPrefix}gfortran
+      ln -sv ${targetPrefix}gfortran $out/bin/${targetPrefix}g77
+      ln -sv ${targetPrefix}gfortran $out/bin/${targetPrefix}f77
+    ''
 
-        + optionalString cc.langJava or false ''
-          wrap ''${prefix}gcj ${./cc-wrapper.sh} $ccPath/''${prefix}gcj
-        ''
+    + optionalString cc.langJava or false ''
+      wrap ${targetPrefix}gcj ${./cc-wrapper.sh} $ccPath/${targetPrefix}gcj
+    ''
 
-        + optionalString cc.langGo or false ''
-          wrap ''${prefix}gccgo ${./cc-wrapper.sh} $ccPath/''${prefix}gccgo
-        ''
+    + optionalString cc.langGo or false ''
+      wrap ${targetPrefix}gccgo ${./cc-wrapper.sh} $ccPath/${targetPrefix}gccgo
+    ''
 
-        + optionalString cc.langAda or false ''
-          wrap ''${prefix}gnatgcc ${./cc-wrapper.sh} $ccPath/''${prefix}gnatgcc
-          wrap ''${prefix}gnatmake ${./gnat-wrapper.sh} $ccPath/''${prefix}gnatmake
-          wrap ''${prefix}gnatbind ${./gnat-wrapper.sh} $ccPath/''${prefix}gnatbind
-          wrap ''${prefix}gnatlink ${./gnatlink-wrapper.sh} $ccPath/''${prefix}gnatlink
-        ''
+    + optionalString cc.langAda or false ''
+      wrap ${targetPrefix}gnatgcc ${./cc-wrapper.sh} $ccPath/${targetPrefix}gnatgcc
+      wrap ${targetPrefix}gnatmake ${./gnat-wrapper.sh} $ccPath/${targetPrefix}gnatmake
+      wrap ${targetPrefix}gnatbind ${./gnat-wrapper.sh} $ccPath/${targetPrefix}gnatbind
+      wrap ${targetPrefix}gnatlink ${./gnatlink-wrapper.sh} $ccPath/${targetPrefix}gnatlink
+    ''
 
-        + optionalString cc.langVhdl or false ''
-          ln -s $ccPath/''${prefix}ghdl $out/bin/''${prefix}ghdl
-        ''
-
-        + ''
-      done
+    + optionalString cc.langVhdl or false ''
+      ln -s $ccPath/${targetPrefix}ghdl $out/bin/${targetPrefix}ghdl
     '';
 
   propagatedBuildInputs = [ bintools ];

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -31,8 +31,7 @@ let
   #
   # TODO(@Ericson2314) Make unconditional, or optional but always true by
   # default.
-  targetPrefix = stdenv.lib.optionalString (targetPlatform != hostPlatform)
-                                           (targetPlatform.config + "-");
+  targetPrefix = targetPlatform.config + "-";
 
   ccVersion = (builtins.parseDrvName cc.name).version;
   ccName = (builtins.parseDrvName cc.name).name;
@@ -143,62 +142,74 @@ stdenv.mkDerivation {
         ln -s "$bbin" "$out/bin/$(basename $bbin)"
       done
 
-      # We export environment variables pointing to the wrapped nonstandard
-      # cmds, lest some lousy configure script use those to guess compiler
-      # version.
-      export named_cc=${targetPrefix}cc
-      export named_cxx=${targetPrefix}c++
+      for prefix in "" "${targetPrefix}"; do
+          # We export environment variables pointing to the wrapped nonstandard
+          # cmds, lest some lousy configure script use those to guess compiler
+          # version.
+          export named_cc=''${prefix}cc
+          export named_cxx=''${prefix}c++
 
-      export default_cxx_stdlib_compile="${default_cxx_stdlib_compile}"
+          export default_cxx_stdlib_compile="${default_cxx_stdlib_compile}"
 
-      if [ -e $ccPath/${targetPrefix}gcc ]; then
-        wrap ${targetPrefix}gcc ${./cc-wrapper.sh} $ccPath/${targetPrefix}gcc
-        ln -s ${targetPrefix}gcc $out/bin/${targetPrefix}cc
-        export named_cc=${targetPrefix}gcc
-        export named_cxx=${targetPrefix}g++
-      elif [ -e $ccPath/clang ]; then
-        wrap ${targetPrefix}clang ${./cc-wrapper.sh} $ccPath/clang
-        ln -s ${targetPrefix}clang $out/bin/${targetPrefix}cc
-        export named_cc=${targetPrefix}clang
-        export named_cxx=${targetPrefix}clang++
-      fi
+          if [ -e $ccPath/''${prefix}gcc ]; then
+            wrap ''${prefix}gcc ${./cc-wrapper.sh} $ccPath/''${prefix}gcc
+            ln -s ''${prefix}gcc $out/bin/''${prefix}cc
+            export named_cc=''${prefix}gcc
+            export named_cxx=''${prefix}g++
+          # bootstrapping compilers may not have a prefix; accept this and use
+          # them to produce prefixed wrappers
+          elif [ -e $ccPath/gcc ]; then
+            wrap ''${prefix}gcc ${./cc-wrapper.sh} $ccPath/gcc
+            ln -s gcc $out/bin/''${prefix}cc
+            export named_cc=gcc
+            export named_cxx=g++
+          elif [ -e $ccPath/clang ]; then
+            wrap ''${prefix}clang ${./cc-wrapper.sh} $ccPath/clang
+            ln -s ''${prefix}clang $out/bin/''${prefix}cc
+            export named_cc=''${prefix}clang
+            export named_cxx=''${prefix}clang++
+          fi
 
-      if [ -e $ccPath/${targetPrefix}g++ ]; then
-        wrap ${targetPrefix}g++ ${./cc-wrapper.sh} $ccPath/${targetPrefix}g++
-        ln -s ${targetPrefix}g++ $out/bin/${targetPrefix}c++
-      elif [ -e $ccPath/clang++ ]; then
-        wrap ${targetPrefix}clang++ ${./cc-wrapper.sh} $ccPath/clang++
-        ln -s ${targetPrefix}clang++ $out/bin/${targetPrefix}c++
-      fi
+          if [ -e $ccPath/''${prefix}g++ ]; then
+            wrap ''${prefix}g++ ${./cc-wrapper.sh} $ccPath/''${prefix}g++
+            ln -s ''${prefix}g++ $out/bin/''${prefix}c++
+          elif [ -e $ccPath/clang++ ]; then
+            wrap ''${prefix}clang++ ${./cc-wrapper.sh} $ccPath/clang++
+            ln -s ''${prefix}clang++ $out/bin/''${prefix}c++
+          fi
 
-      if [ -e $ccPath/cpp ]; then
-        wrap ${targetPrefix}cpp ${./cc-wrapper.sh} $ccPath/cpp
-      fi
-    ''
+          if [ -e $ccPath/cpp ]; then
+            wrap ''${prefix}cpp ${./cc-wrapper.sh} $ccPath/cpp
+          fi
+        ''
 
-    + optionalString cc.langFortran or false ''
-      wrap ${targetPrefix}gfortran ${./cc-wrapper.sh} $ccPath/${targetPrefix}gfortran
-      ln -sv ${targetPrefix}gfortran $out/bin/${targetPrefix}g77
-      ln -sv ${targetPrefix}gfortran $out/bin/${targetPrefix}f77
-    ''
+        + optionalString cc.langFortran or false ''
+          wrap ''${prefix}gfortran ${./cc-wrapper.sh} $ccPath/''${prefix}gfortran
+          ln -sv ''${prefix}gfortran $out/bin/''${prefix}g77
+          ln -sv ''${prefix}gfortran $out/bin/''${prefix}f77
+        ''
 
-    + optionalString cc.langJava or false ''
-      wrap ${targetPrefix}gcj ${./cc-wrapper.sh} $ccPath/${targetPrefix}gcj
-    ''
+        + optionalString cc.langJava or false ''
+          wrap ''${prefix}gcj ${./cc-wrapper.sh} $ccPath/''${prefix}gcj
+        ''
 
-    + optionalString cc.langGo or false ''
-      wrap ${targetPrefix}gccgo ${./cc-wrapper.sh} $ccPath/${targetPrefix}gccgo
-    ''
+        + optionalString cc.langGo or false ''
+          wrap ''${prefix}gccgo ${./cc-wrapper.sh} $ccPath/''${prefix}gccgo
+        ''
 
-    + optionalString cc.langAda or false ''
-      wrap ${targetPrefix}gnatgcc ${./cc-wrapper.sh} $ccPath/${targetPrefix}gnatgcc
-      wrap ${targetPrefix}gnatmake ${./gnat-wrapper.sh} $ccPath/${targetPrefix}gnatmake
-      wrap ${targetPrefix}gnatbind ${./gnat-wrapper.sh} $ccPath/${targetPrefix}gnatbind
-      wrap ${targetPrefix}gnatlink ${./gnatlink-wrapper.sh} $ccPath/${targetPrefix}gnatlink
-    ''
+        + optionalString cc.langAda or false ''
+          wrap ''${prefix}gnatgcc ${./cc-wrapper.sh} $ccPath/''${prefix}gnatgcc
+          wrap ''${prefix}gnatmake ${./gnat-wrapper.sh} $ccPath/''${prefix}gnatmake
+          wrap ''${prefix}gnatbind ${./gnat-wrapper.sh} $ccPath/''${prefix}gnatbind
+          wrap ''${prefix}gnatlink ${./gnatlink-wrapper.sh} $ccPath/''${prefix}gnatlink
+        ''
 
-    + optionalString cc.langVhdl or false ''
-      ln -s $ccPath/${targetPrefix}ghdl $out/bin/${targetPrefix}ghdl
+        + optionalString cc.langVhdl or false ''
+          ln -s $ccPath/''${prefix}ghdl $out/bin/''${prefix}ghdl
+        ''
+
+        + ''
+      done
     '';
 
   propagatedBuildInputs = [ bintools ];

--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -7,7 +7,7 @@ source $mirrorsFile
 # servers to need them during redirects, and work on SSL without a
 # certificate (this isn't a security problem because we check the
 # cryptographic hash of the output anyway).
-curl="curl \
+curl="$CURL \
  --location --max-redirs 20 \
  --retry 3 \
  --disable-epsv \

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -133,6 +133,8 @@ stdenvNoCC.mkDerivation {
 
   inherit curlOpts showURLs mirrorsFile postFetch downloadToTemp executable;
 
+  CURL = "${(stdenvNoCC.lib.getBin curl).outPath}/bin/curl";
+
   impureEnvVars = impureEnvVars ++ netrcImpureEnvVars;
 
   # Doing the download on a remote machine just duplicates network

--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -67,10 +67,11 @@ makeWrapper() {
             value="${params[$((n + 3))]}"
             n=$((n + 3))
             if test -n "$value"; then
+                stem="$varName:+'${separator}'"
                 if test "$p" = "--suffix"; then
-                    echo "export $varName=\$$varName\${$varName:+${separator@Q}}${value@Q}" >> "$wrapper"
+                    echo "export $varName=\$$varName\${$stem}'$value'" >> "$wrapper"
                 else
-                    echo "export $varName=${value@Q}\${$varName:+${separator@Q}}\$$varName" >> "$wrapper"
+                    echo "export $varName='$value'\${$stem}\$$varName" >> "$wrapper"
                 fi
             fi
         elif [[ "$p" == "--suffix-each" ]]; then

--- a/pkgs/data/documentation/man-pages/default.nix
+++ b/pkgs/data/documentation/man-pages/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "man-pages-${version}";
-  version = "4.14";
+  version = "4.15";
 
   src = fetchurl {
     url = "mirror://kernel/linux/docs/man-pages/${name}.tar.xz";
-    sha256 = "0wf9ymqxk1k5xwcl3n919p66a1aayif3x4cahj4w04y3k1wbhlih";
+    sha256 = "01n1rq1kvambax85xamriawbga94mh63s5mgjmjljjgf50m7yw6f";
   };
 
   makeFlags = [ "MANDIR=$(out)/share/man" ];

--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, buildPackages }:
 
 stdenv.mkDerivation rec {
   name = "tzdata-${version}";
@@ -14,9 +14,11 @@ stdenv.mkDerivation rec {
         sha256 = "1dvrq0b2hz7cjqdyd7x21wpy4qcng3rvysr61ij0c2g64fyb9s41";
       })
     ];
+  patches = [ ./fix-toolchain-paths.patch ];
 
   sourceRoot = ".";
 
+  nativeBuildPackages = [ buildPackages.stdenv.cc ];
   outputs = [ "out" "man" "dev" ];
   propagatedBuildOutputs = [];
 
@@ -27,6 +29,9 @@ stdenv.mkDerivation rec {
     "LIBDIR=$(dev)/lib"
     "MANDIR=$(man)/share/man"
     "AWK=awk"
+    # FIXME: The absolute paths shouldn't be necessary
+    "CC=${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc"
+    "AR=${buildPackages.stdenv.cc.bintools}/bin/${buildPackages.stdenv.cc.bintools.targetPrefix}ar"
     "CFLAGS=-DHAVE_LINK=0"
   ];
 

--- a/pkgs/data/misc/tzdata/fix-toolchain-paths.patch
+++ b/pkgs/data/misc/tzdata/fix-toolchain-paths.patch
@@ -1,0 +1,17 @@
+diff --git a/Makefile b/Makefile
+index c92edc0..612ac74 100644
+--- a/Makefile
++++ b/Makefile
+@@ -395,10 +395,10 @@ GZIPFLAGS=	-9n
+ 
+ #MAKE=		make
+ 
+-cc=		cc
++#cc=		cc
+ CC=		$(cc) -DTZDIR=\"$(TZDIR)\"
+ 
+-AR=		ar
++#AR=		ar
+ 
+ # ':' on typical hosts; 'ranlib' on the ancient hosts that still need ranlib.
+ RANLIB=		:

--- a/pkgs/development/compilers/dtc/default.nix
+++ b/pkgs/development/compilers/dtc/default.nix
@@ -10,8 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "10y5pbkcj5gkijcgnlvrh6q2prpnvsgihb9asz3zfp66mcjwzsy3";
   };
 
-  nativeBuildInputs = [ flex bison pkgconfig swig which ];
-  buildInputs = [ python2 ];
+  nativeBuildInputs = [ flex bison pkgconfig swig which python2 ];
 
   patches = [
     # Fix 32-bit build

--- a/pkgs/development/compilers/gambit/bootstrap.nix
+++ b/pkgs/development/compilers/gambit/bootstrap.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name    = "gambit-bootstrap-${version}";
-  version = "4.8.8";
-  tarball_version = "v4_8_8";
+  version = "4.8.9";
+  tarball_version = "v4_8_9";
 
   src = fetchurl {
     url    = "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.8/source/gambit-${tarball_version}-devel.tgz";
-    sha256 = "075k2z04d6svxqf9paj3xvp0mm0xzy0vbma1y61s0lkywdim8xjz";
+    sha256 = "b7f86c794711792ca556ce41f8bc7043dffc395c01bb6d8d119bc2f454f89fbf";
   };
 
   buildInputs = [ autoconf ];

--- a/pkgs/development/compilers/gambit/default.nix
+++ b/pkgs/development/compilers/gambit/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name    = "gambit-${version}";
-  version = "4.8.8-435-gd1991ba7";
+  version = "4.8.9";
   bootstrap = import ./bootstrap.nix ( pkgs );
 
   src = fetchgit {
     url = "https://github.com/feeley/gambit.git";
-    rev = "d1991ba7e90ed0149964320f7cafa1a8289e61f0";
-    sha256 = "02harwcsqxxcxgn2yc1y9kyxdp32mampyvnbxrzg2jzfmnp5g6cm";
+    rev = "dd54a71dfc0bd09813592f1645d755867a02195d";
+    sha256 = "120kg73k39gshrwas8a3xcrxgnq1c7ww92wgy4d3mmrwy3j9nzzc";
   };
 
   # Use makeStaticLibraries to enable creation of statically linked binaries

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -326,7 +326,44 @@ stdenv.mkDerivation ({
   + stdenv.lib.optionalString (langJava || langGo) ''
     export lib=$out;
   ''
-  ;
+  + stdenv.lib.optionalString (buildPlatform != hostPlatform)
+  (let yesFuncs = [
+        "asprintf" "atexit"
+        "basename" "bcmp" "bcopy" "bsearch" "bzero"
+        "calloc" "canonicalize_file_name" "clock"
+        "dup3"
+        "ffs" "fork" "__fsetlocking"
+        "getcwd" "getpagesize" "getrlimit" "getrusage" "gettimeofday"
+        "index" "insque"
+        "memchr" "memcmp" "mempcpy" "memcpy" "memmem" "memmove" "memset" "mkstemps"
+        "on_exit"
+        "psignal" "putenv"
+        "random" "realpath" "rename" "rindex"
+        "sbrk" "setenv" "setrlimit" "sigsetmask" "snprintf"
+        "stpcpy" "stpncpy" "strcasecmp" "strchr" "strdup"
+        "strerror" "strncasecmp" "strndup" "strnlen" "strrchr" "strsignal" "strstr"
+        "strtod" "strtol" "strtoul" "strtoll" "strtoull" "strverscmp"
+        "sysconf" "sysctl"
+        "times" "tmpnam"
+        "vfork" "vasprintf" "vfprintf" "vprintf" "vsprintf" "vsnprintf"
+        "wait3" "wait4" "waitpid"
+      ];
+      noFuncs = [
+        "_doprnt"
+        "getsysinfo"
+        "pstat_getdynamic" "pstat_getstatic"
+        "setproctitle" "spawnvpe" "spawnve" "sysmp"
+        "table"
+      ];
+   in stdenv.lib.concatStringsSep "\n"
+        ([ ''
+           export ac_cv_search_strerror=""
+           export libiberty_cv_var_sys_errlist=yes
+           export libiberty_cv_var_sys_nerr=yes
+           export libiberty_cv_var_sys_siglist=yes
+         ''] ++ map (func: "export ac_cv_func_${func}=yes") yesFuncs
+         ++ map (func: "export ac_cv_func_${func}=no") noFuncs)
+  );
 
   dontDisableStatic = true;
 

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -62,7 +62,8 @@ let version = "6.4.0";
     enableParallelBuilding = true;
 
     patches =
-      [ ../use-source-date-epoch.patch ]
+      [ ../use-source-date-epoch.patch
+        ./explicit-fallthrus.patch ]
       ++ optional (targetPlatform != hostPlatform) ../libstdc++-target.patch
       ++ optional noSysDirs ../no-sys-dirs.patch
       # The GNAT Makefiles did not pay attention to CFLAGS_FOR_TARGET for its

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -177,7 +177,7 @@ let version = "6.4.0";
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
-    bootstrap = targetPlatform == hostPlatform;
+    bootstrap = targetPlatform == hostPlatform && buildPlatform == hostPlatform;
 
 in
 
@@ -366,12 +366,7 @@ stdenv.mkDerivation ({
 
   dontDisableStatic = true;
 
-  # TODO(@Ericson2314): Always pass "--target" and always prefix.
-  configurePlatforms =
-    # TODO(@Ericson2314): Figure out what's going wrong with Arm
-    if buildPlatform == hostPlatform && hostPlatform == targetPlatform && targetPlatform.isArm
-    then []
-    else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
+  configurePlatforms = [ "build" "host" "target" ];
 
   configureFlags =
     # Basic dependencies

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, targetPackages, fetchurl, noSysDirs
+{ stdenv, buildPackages, targetPackages, fetchurl, noSysDirs
 , langC ? true, langCC ? true, langFortran ? false
 , langObjC ? targetPlatform.isDarwin
 , langObjCpp ? targetPlatform.isDarwin
@@ -34,7 +34,6 @@
 , cloog # unused; just for compat with gcc4, as we override the parameter on some places
 , darwin ? null
 , buildPlatform, hostPlatform, targetPlatform
-, buildPackages
 }:
 
 assert langJava     -> zip != null && unzip != null
@@ -440,6 +439,11 @@ stdenv.mkDerivation ({
     platformFlags ++
     optional (targetPlatform != hostPlatform) crossConfigureFlags ++
     optional (!bootstrap) "--disable-bootstrap" ++
+    optionals (targetPlatform == hostPlatform) platformFlags ++
+    [
+      "CC_FOR_BUILD=${buildPackages.stdenv.cc.targetPrefix}gcc"
+      "CXX_FOR_BUILD=${buildPackages.stdenv.cc.targetPrefix}g++"
+    ] ++
 
     # Platform-specific flags
     optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++

--- a/pkgs/development/compilers/gcc/6/explicit-fallthrus.patch
+++ b/pkgs/development/compilers/gcc/6/explicit-fallthrus.patch
@@ -1,0 +1,16 @@
+--- libiberty/cp-demangle.c.old	2018-02-24 12:06:13.627323349 -0500
++++ libiberty/cp-demangle.c	2018-02-24 12:07:39.323206522 -0500
+@@ -5794,11 +5794,13 @@
+     case DEMANGLE_COMPONENT_REFERENCE_THIS:
+       /* For the ref-qualifier, put a space before the &.  */
+       d_append_char (dpi, ' ');
++      /* FALLTHRU */
+     case DEMANGLE_COMPONENT_REFERENCE:
+       d_append_char (dpi, '&');
+       return;
+     case DEMANGLE_COMPONENT_RVALUE_REFERENCE_THIS:
+       d_append_char (dpi, ' ');
++      /* FALLTHRU */
+     case DEMANGLE_COMPONENT_RVALUE_REFERENCE:
+       d_append_string (dpi, "&&");
+       return;

--- a/pkgs/development/compilers/gcc/6/explicit-fallthrus.patch
+++ b/pkgs/development/compilers/gcc/6/explicit-fallthrus.patch
@@ -1,5 +1,5 @@
---- libiberty/cp-demangle.c.old	2018-02-24 12:06:13.627323349 -0500
-+++ libiberty/cp-demangle.c	2018-02-24 12:07:39.323206522 -0500
+--- a/libiberty/cp-demangle.c	2018-02-24 12:06:13.627323349 -0500
++++ b/libiberty/cp-demangle.c	2018-02-24 12:07:39.323206522 -0500
 @@ -5794,11 +5794,13 @@
      case DEMANGLE_COMPONENT_REFERENCE_THIS:
        /* For the ref-qualifier, put a space before the &.  */

--- a/pkgs/development/compilers/gerbil/default.nix
+++ b/pkgs/development/compilers/gerbil/default.nix
@@ -8,11 +8,11 @@
 stdenv.mkDerivation rec {
   name    = "gerbil-${version}";
 
-  version = "0.12-DEV-1404-g0a266db";
+  version = "0.12-RELEASE";
   src = fetchgit {
     url = "https://github.com/vyzo/gerbil.git";
-    rev = "0a266db5e2e241272711bc150cc2607204bf2b78";
-    sha256 = "1lvawqn8havfyxkkgfqffc213zq2pgm179l42yj49fy3fhpzia4m";
+    rev = "5618892d7939e1cb4ef5247912e0bc1ec99f6b52";
+    sha256 = "0b2valahf5k81r4sp6y12d44fb286p92s7k6dphij0kmvg0dp818";
   };
 
   # Use makeStaticLibraries to enable creation of statically linked binaries

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -130,8 +130,8 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--datadir=$doc/share/doc/ghc"
     "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
-  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && ! enableIntegerSimple) [
-    "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
+  ] ++ stdenv.lib.optional (! enableIntegerSimple) [
+    "--with-gmp-includes=${targetPackages.gmp.dev}/include" "--with-gmp-libraries=${targetPackages.gmp.out}/lib"
   ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.libc != "glibc") [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
@@ -154,8 +154,6 @@ stdenv.mkDerivation rec {
 
   # For building runtime libs
   depsBuildTarget = toolsForTarget;
-
-  buildInputs = libDeps hostPlatform;
 
   propagatedBuildInputs = [ targetPackages.stdenv.cc ]
     ++ stdenv.lib.optional useLLVM llvmPackages.llvm;

--- a/pkgs/development/compilers/llvm/4/llvm.nix
+++ b/pkgs/development/compilers/llvm/4/llvm.nix
@@ -1,4 +1,5 @@
 { stdenv
+, buildPackages
 , fetch
 , fetchpatch
 , cmake
@@ -114,6 +115,13 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DCAN_TARGET_i386=false"
   ]
+  ++ stdenv.lib.optionals crossCompiling [
+    "-DCMAKE_CROSSCOMPILING=True"
+    "-DLLVM_TABLEGEN=${buildPackages.llvm.dev}/tablegen"
+    "-DCLANG_TABLEGEN=${buildPackages.llvm.dev}/tablegen"
+    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.triple}"
+    "-DLLVM_TARGET_ARCH=${stdenv.targetPlatform.arch}"
+    "-DLLVM_TARGETS_TO_BUILD=${stdenv.targetPlatform.arch}"
   ++ stdenv.lib.optionals stdenv.hostPlatform.isMusl [
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"

--- a/pkgs/development/interpreters/guile/default.nix
+++ b/pkgs/development/interpreters/guile/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, libtool, readline, gmp, pkgconfig, boehmgc, libunistring
+{ fetchurl, stdenv, lib, buildPackages, libtool, readline, gmp, pkgconfig, boehmgc, libunistring
 , libffi, gawk, makeWrapper, fetchpatch, coverageAnalysis ? null, gnu ? null
 , hostPlatform
 }:
@@ -20,7 +20,9 @@
   outputs = [ "out" "dev" "info" ];
   setOutputFlags = false; # $dev gets into the library otherwise
 
-  nativeBuildInputs = [ makeWrapper gawk pkgconfig ];
+  nativeBuildInputs = [ makeWrapper gawk pkgconfig ]
+    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform)
+       [ buildPackages.guile buildPackages.stdenv.cc ];
   buildInputs = [ readline libtool libunistring libffi ];
 
   propagatedBuildInputs = [ gmp boehmgc ]
@@ -29,9 +31,6 @@
     # the needed `-L' flags.  As for why the `.la' file lacks the `-L' flags,
     # see below.
     ++ [ libtool libunistring ];
-
-  # A native Guile 2.0 is needed to cross-build Guile.
-  selfNativeBuildInput = true;
 
   enableParallelBuilding = true;
 
@@ -46,8 +45,15 @@
   # don't have "libgcc_s.so.1" on darwin
   LDFLAGS = stdenv.lib.optionalString (!stdenv.isDarwin) "-lgcc_s";
 
-  configureFlags = [ "--with-libreadline-prefix=${readline.dev}" ]
-    ++ stdenv.lib.optionals stdenv.isSunOS [
+  configureFlags = [
+    "--with-libreadline-prefix=${readline.dev}"
+  ] ++ stdenv.lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "CC_FOR_BUILD=${buildPackages.stdenv.cc.targetPrefix}gcc"
+    "GUILE_FOR_BUILD=${lib.getBin buildPackages.guile}/bin/guile"
+    "--with-libgmp-prefix=${gmp.dev}"
+    "--with-libltdl-prefix=${libtool}"
+    "--with-libunistring-prefix=${libunistring}"
+  ] ++ stdenv.lib.optionals stdenv.isSunOS [
       # Make sure the right <gmp.h> is found, and not the incompatible
       # /usr/include/mp.h from OpenSolaris.  See
       # <https://lists.gnu.org/archive/html/hydra-users/2012-08/msg00000.html>
@@ -60,6 +66,7 @@
       # See below.
       "--without-threads"
     ];
+  configurePlatforms = [ "build" "host" "target" ];
 
   postInstall = ''
     wrapProgram $out/bin/guile-snarf --prefix PATH : "${gawk}/bin"
@@ -108,4 +115,3 @@
     '';
   };
 })
-

--- a/pkgs/development/interpreters/perl-cross/default.nix
+++ b/pkgs/development/interpreters/perl-cross/default.nix
@@ -27,6 +27,8 @@ let common = {perlVersion, perlSha256}:
 
     enableParallelBuilding = false;
 
+    passthru.libPrefix = "lib/perl5/site_perl";
+
     meta = {
       homepage = https://arsv.github.io/perl-cross;
       description = "Cross-compilation standard implementation of the Perl 5 programmming language";

--- a/pkgs/development/interpreters/perl-cross/default.nix
+++ b/pkgs/development/interpreters/perl-cross/default.nix
@@ -1,0 +1,56 @@
+{ lib, stdenv, buildPackages, fetchurl }:
+
+let common = {perlVersion, perlSha256}:
+  stdenv.mkDerivation rec {
+    name = "perl-cross";
+    version = perlVersion;
+    crossVersion = "1.1.7";
+
+    srcs = [
+      (fetchurl {
+        url = "mirror://cpan/src/5.0/perl-${perlVersion}.tar.gz";
+        sha256 = perlSha256;
+      })
+
+      (fetchurl {
+        url = "https://github.com/arsv/perl-cross/releases/download/${crossVersion}/${name}-${crossVersion}.tar.gz";
+        sha256 = "0ps1x7wxi3b52igywhx4d6xyr26s87aqdjvkgsnjgxdmcvbyk75p";
+      })
+    ];
+    sourceRoot = "perl-${perlVersion}";
+
+    nativeBuildInputs = [ buildPackages.stdenv.cc ];
+
+    postUnpack = "cp -R perl-cross-${crossVersion}/* perl-${perlVersion}";
+
+    configurePlatforms = [ "build" "host" "target" ];
+
+    enableParallelBuilding = false;
+
+    meta = {
+      homepage = https://arsv.github.io/perl-cross;
+      description = "Cross-compilation standard implementation of the Perl 5 programmming language";
+      maintainers = [ ];
+      platforms = lib.platforms.all;
+    };
+  };
+
+in rec {
+
+  perl = perl524;
+
+  perl522 = common {
+    perlVersion = "5.22.2";
+    perlSha256 = "1yk1xn4wmnrf2ph02j28khqarpyr24qwysjzkjnjv7vh5dygb7ms";
+  };
+
+  perl524 = common {
+    perlVersion = "5.24.2";
+    perlSha256 = "1x4yj814a79lcarwb3ab6bbcb36hvb5n4ph4zg3yb0nabsjfi6v0";
+  };
+
+  perl526 = common {
+    perlVersion = "5.26.2";
+    perlSha256 = "1p81wwvr5jb81m41d07kfywk5gvbk0axdrnvhc2aghcdbr4alqz7";
+  };
+}

--- a/pkgs/development/interpreters/perl-cross/default.nix
+++ b/pkgs/development/interpreters/perl-cross/default.nix
@@ -19,7 +19,8 @@ let common = {perlVersion, perlSha256}:
     ];
     sourceRoot = "perl-${perlVersion}";
 
-    nativeBuildInputs = [ buildPackages.stdenv.cc ];
+    # gcc7 appears to miscompile, resulting in segmentation faults
+    nativeBuildInputs = [ buildPackages.gcc6 ];
 
     postUnpack = "cp -R perl-cross-${crossVersion}/* perl-${perlVersion}";
 

--- a/pkgs/development/interpreters/perl-cross/default.nix
+++ b/pkgs/development/interpreters/perl-cross/default.nix
@@ -4,7 +4,7 @@ let common = {perlVersion, perlSha256}:
   stdenv.mkDerivation rec {
     name = "perl-cross";
     version = perlVersion;
-    crossVersion = "1.1.7";
+    crossVersion = "1.1.8";
 
     srcs = [
       (fetchurl {
@@ -14,7 +14,7 @@ let common = {perlVersion, perlSha256}:
 
       (fetchurl {
         url = "https://github.com/arsv/perl-cross/releases/download/${crossVersion}/${name}-${crossVersion}.tar.gz";
-        sha256 = "0ps1x7wxi3b52igywhx4d6xyr26s87aqdjvkgsnjgxdmcvbyk75p";
+        sha256 = "072j491rpz2qx2sngbg4flqh4lx5865zyql7b9lqm6s1kknjdrh8";
       })
     ];
     sourceRoot = "perl-${perlVersion}";
@@ -42,17 +42,17 @@ in rec {
   perl = perl524;
 
   perl522 = common {
-    perlVersion = "5.22.2";
+    perlVersion = "5.22.4";
     perlSha256 = "1yk1xn4wmnrf2ph02j28khqarpyr24qwysjzkjnjv7vh5dygb7ms";
   };
 
   perl524 = common {
-    perlVersion = "5.24.2";
-    perlSha256 = "1x4yj814a79lcarwb3ab6bbcb36hvb5n4ph4zg3yb0nabsjfi6v0";
+    perlVersion = "5.24.3";
+    perlSha256 = "1m2px85kq2fyp2d4rx3bw9kg3car67qfqwrs5vlv96dx0x8rl06b";
   };
 
   perl526 = common {
-    perlVersion = "5.26.2";
+    perlVersion = "5.26.1";
     perlSha256 = "1p81wwvr5jb81m41d07kfywk5gvbk0axdrnvhc2aghcdbr4alqz7";
   };
 }

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -14,6 +14,9 @@ with lib;
 # use enableThreading = false there.
 assert enableThreading -> (stdenv ? glibc);
 
+# Perl really doesn't support cross-compilation.
+assert stdenv.buildPlatform == stdenv.hostPlatform;
+
 let
 
   libc = if stdenv.cc.libc or null != null then stdenv.cc.libc else "/usr";

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -84,7 +84,7 @@ toPythonModule (python.stdenv.mkDerivation (builtins.removeAttrs attrs [
 
   # Python packages don't have a checkPhase, only an installCheckPhase
   doCheck = false;
-  doInstallCheck = doCheck;
+  doInstallCheck = doCheck && (python.stdenv.buildPlatform == python.stdenv.hostPlatform);
 
   postFixup = lib.optionalString (!dontWrapPythonPrograms) ''
     wrapPythonPrograms

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -147,7 +147,7 @@ let
         postInstall = ''
           # Update rubygems
           pushd rubygems
-          ${buildRuby} setup.rb
+          $out/bin/ruby setup.rb
           popd
 
           # Remove unnecessary groff reference from runtime closure, since it's big

--- a/pkgs/development/libraries/avahi/default.nix
+++ b/pkgs/development/libraries/avahi/default.nix
@@ -20,13 +20,15 @@ stdenv.mkDerivation rec {
   buildInputs = [ libdaemon dbus perl perlXMLParser glib expat libiconv ]
     ++ (stdenv.lib.optional qt4Support qt4);
 
-  nativeBuildInputs = [ pkgconfig gettext intltool ];
+  nativeBuildInputs = [ pkgconfig gettext intltool glib ];
 
   configureFlags =
     [ "--disable-qt3" "--disable-gdbm" "--disable-mono"
       "--disable-gtk" "--disable-gtk3"
       "--${if qt4Support then "enable" else "disable"}-qt4"
-      "--disable-python" "--localstatedir=/var" "--with-distro=none" ]
+      "--disable-python" "--localstatedir=/var" "--with-distro=none"
+      # A systemd unit is provided by the avahi-daemon NixOS module
+      "--with-systemdsystemunitdir=no" ]
     ++ stdenv.lib.optional withLibdnssdCompat "--enable-compat-libdns_sd"
     # autoipd won't build on darwin
     ++ stdenv.lib.optional stdenv.isDarwin "--disable-autoipd";

--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -1,18 +1,19 @@
-{ lib, stdenv, fetchurl, openssl, openldap, kerberos, db, gettext,
+{ lib, stdenv, buildPackages, fetchurl, openssl, openldap, kerberos, db, gettext,
   pam, fixDarwinDylibNames, autoreconfHook, fetchpatch, enableLdap ? false }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "cyrus-sasl-${version}${optionalString (kerberos == null) "-without-kerberos"}";
-  version = "2.1.26";
+  version = "2.1.27rc3";
 
   src = fetchurl {
-    url = "ftp://ftp.cyrusimap.org/cyrus-sasl/${name}.tar.gz";
-    sha256 = "1hvvbcsg21nlncbgs0cgn3iwlnb3vannzwsp6rwvnn9ba4v53g4g";
+    url = "ftp://ftp.cyrusimap.org/cyrus-sasl/cyrus-sasl-${version}.tar.gz";
+    sha256 = "0aivwvkacfwhblqfl8xj006633dw85pxplgdy6wa64yk5822j3x5";
   };
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];
 
+  nativeBuildInputs = [ autoreconfHook buildPackages.stdenv.cc ];
   buildInputs =
     [ openssl db gettext kerberos ]
     ++ lib.optional enableLdap openldap
@@ -35,7 +36,9 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-openssl=${openssl.dev}"
-  ] ++ lib.optional enableLdap "--with-ldap=${openldap.dev}";
+  ] ++ lib.optional enableLdap "--with-ldap=${openldap.dev}"
+    # The GSSAPI configure checks require runtime checks.
+    ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "--disable-gssapi";
 
   # Set this variable at build-time to make sure $out can be evaluated.
   preConfigure = ''

--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -14,8 +14,9 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];
 
   nativeBuildInputs = [ autoreconfHook buildPackages.stdenv.cc ];
+  propagatedBuildInputs = [ kerberos ];
   buildInputs =
-    [ openssl db gettext kerberos ]
+    [ openssl db gettext ]
     ++ lib.optional enableLdap openldap
     ++ lib.optional stdenv.isFreeBSD autoreconfHook
     ++ lib.optional stdenv.isLinux pam

--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -4,11 +4,11 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "cyrus-sasl-${version}${optionalString (kerberos == null) "-without-kerberos"}";
-  version = "2.1.27rc3";
+  version = "2.1.27-rc5";
 
   src = fetchurl {
     url = "ftp://ftp.cyrusimap.org/cyrus-sasl/cyrus-sasl-${version}.tar.gz";
-    sha256 = "0aivwvkacfwhblqfl8xj006633dw85pxplgdy6wa64yk5822j3x5";
+    sha256 = "0pnkp00xlqrh5ph7j8m4xwfgcca5hr9xvrpvn8k1lxa8xhnh8d6p";
   };
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];
@@ -23,10 +23,6 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./missing-size_t.patch # https://bugzilla.redhat.com/show_bug.cgi?id=906519
-    (fetchpatch { # CVE-2013-4122
-      url = "http://sourceforge.net/projects/miscellaneouspa/files/glibc217/cyrus-sasl-2.1.26-glibc217-crypt.diff";
-      sha256 = "05l7dh1w9d5fvzg0pjwzqh0fy4ah8y5cv6v67s4ssbq8xwd4pkf2";
-    })
   ] ++ lib.optional stdenv.isFreeBSD (
       fetchurl {
         url = "http://www.linuxfromscratch.org/patches/blfs/svn/cyrus-sasl-2.1.26-fixes-3.patch";
@@ -49,6 +45,9 @@ stdenv.mkDerivation rec {
   '';
 
   installFlags = lib.optional stdenv.isDarwin [ "framedir=$(out)/Library/Frameworks/SASL2.framework" ];
+
+  # Due to format warnings in plugins/scram.c
+  hardeningDisable = [ "format" ];
 
   postInstall = ''
     for f in $out/lib/*.la $out/lib/sasl2/*.la; do

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, hostPlatform, fetchurl, libiconv, xz }:
+{ stdenv, lib, buildPackages, hostPlatform, fetchurl, libiconv, xz, acl}:
 
 stdenv.mkDerivation rec {
   name = "gettext-${version}";
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
   LDFLAGS = if stdenv.isSunOS then "-lm -lmd -lmp -luutil -lnvpair -lnsl -lidmap -lavl -lsec" else "";
 
   configureFlags = [ "--disable-csharp" "--with-xz" ]
+     ++ lib.optional (acl == null) "--disable-acl"
      # avoid retaining reference to CF during stdenv bootstrap
      ++ lib.optionals stdenv.isDarwin [
             "gt_cv_func_CFPreferencesCopyAppValue=no"
@@ -46,7 +47,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ xz xz.bin ];
   # HACK, see #10874 (and 14664)
-  buildInputs = stdenv.lib.optional (!stdenv.isLinux && !hostPlatform.isCygwin) libiconv;
+  buildInputs =
+    stdenv.lib.optional (!stdenv.isLinux && !hostPlatform.isCygwin) libiconv;
+    #++ stdenv.lib.optional (stdenv.isLinux) attr;
 
   setupHook = ./gettext-setup-hook.sh;
 

--- a/pkgs/development/libraries/giflib/5.1.nix
+++ b/pkgs/development/libraries/giflib/5.1.nix
@@ -7,7 +7,9 @@ stdenv.mkDerivation {
     sha256 = "1md83dip8rf29y40cm5r7nn19705f54iraz6545zhwa6y8zyq9yz";
   };
 
-  buildInputs = [ xmlto docbook_xml_dtd_412 docbook_xsl libxml2 ];
+  nativeBuildInputs = [ xmlto docbook_xml_dtd_412 docbook_xsl ];
+  buildInputs = [ libxml2 ];
+
   meta = {
     description = "A library for reading and writing gif images";
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -219,9 +219,4 @@ stdenv.mkDerivation ({
   dontStrip = true;
 
   separateDebugInfo = false; # this is currently broken for crossDrv
-
-  # To avoid a dependency on the build system 'bash'.
-  preFixup = ''
-    rm -f $bin/bin/{ldd,tzselect,catchsegv,xtrace}
-  '';
 })

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -42,7 +42,7 @@ let self = stdenv.mkDerivation rec {
       configureFlagsArray+=("--build=$(./configfsf.guess)")
     '';
 
-  doCheck = true; # not cross;
+  doCheck = false; # not cross;
 
   dontDisableStatic = withStatic;
 

--- a/pkgs/development/libraries/ldns/default.nix
+++ b/pkgs/development/libraries/ldns/default.nix
@@ -40,6 +40,9 @@ stdenv.mkDerivation rec {
     "--with-trust-anchor=${dns-root-data}/root.key"
     "--with-drill"
     "--disable-gost"
+  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "ac_cv_func_malloc_0_nonnull=yes"
+    "ac_cv_func_realloc_0_nonnull=yes"
   ];
 
   postInstall = ''

--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation rec {
       -e 's|-llzo2|-L${lzo}/lib -llzo2|'
   '';
 
+  enableParallelBuilding = true;
+
   meta = {
     description = "Multi-format archive and compression library";
     longDescription = ''

--- a/pkgs/development/libraries/libgpg-error/default.nix
+++ b/pkgs/development/libraries/libgpg-error/default.nix
@@ -28,6 +28,7 @@ in stdenv.mkDerivation (rec {
 
   postPatch = ''
     sed '/BUILD_TIMESTAMP=/s/=.*/=1970-01-01T00:01+0000/' -i ./configure
+    cp src/syscfg/lock-obj-pub.arm-unknown-linux-gnueabi.h src/syscfg/lock-obj-pub.linux-gnueabihf.h
   '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
     ln -s lock-obj-pub.x86_64-pc-linux-musl.h src/syscfg/lock-obj-pub.linux-musl.h
   '';
@@ -49,7 +50,7 @@ in stdenv.mkDerivation (rec {
     # Thus, re-run it with Bash.
       "${stdenv.shell} config.status";
 
-  doCheck = true; # not cross
+  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
 
   meta = with stdenv.lib; {
     homepage = https://www.gnupg.org/related_software/libgpg-error/index.html;

--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, libiconv, libunistring, help2man, ronn }:
+{ fetchurl, stdenv, buildPackages, libiconv, libunistring, help2man, ronn }:
 
 with stdenv.lib;
 
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libunistring ronn ]
     ++ optionals stdenv.isDarwin [ libiconv help2man ];
+  nativeBuildInputs = [ buildPackages.stdenv.cc ];
 
   meta = {
     homepage = "https://www.gnu.org/software/libidn/#libidn2";

--- a/pkgs/development/libraries/libnfsidmap/default.nix
+++ b/pkgs/development/libraries/libnfsidmap/default.nix
@@ -2,16 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "libnfsidmap-0.25";
-  
+
   src = fetchurl {
     url = "http://www.citi.umich.edu/projects/nfsv4/linux/libnfsidmap/${name}.tar.gz";
     sha256 = "1kzgwxzh83qi97rblcm9qj80cdvnv8kml2plz0q103j0hifj8vb5";
   };
 
-  preConfigure =
-    ''
-      configureFlags="--with-pluginpath=$out/lib/libnfsidmap"
-    '';
+  configureFlags = [
+    "--with-pluginpath=$out/lib/libnfsidmap"
+  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "ac_cv_func_malloc_0_nonnull=yes"
+    "ac_cv_func_realloc_0_nonnull=yes"
+  ];
 
   meta = {
     homepage = http://www.citi.umich.edu/projects/nfsv4/linux/;

--- a/pkgs/development/libraries/libnfsidmap/default.nix
+++ b/pkgs/development/libraries/libnfsidmap/default.nix
@@ -8,9 +8,10 @@ stdenv.mkDerivation rec {
     sha256 = "1kzgwxzh83qi97rblcm9qj80cdvnv8kml2plz0q103j0hifj8vb5";
   };
 
-  configureFlags = [
-    "--with-pluginpath=$out/lib/libnfsidmap"
-  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  preConfigure = ''
+    configureFlags="$configureFlags --with-pluginpath=$out/lib/libnfsidmap"
+  '';
+  configureFlags = stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"
   ];

--- a/pkgs/development/libraries/libssh2/default.nix
+++ b/pkgs/development/libraries/libssh2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurlBoot, openssl, zlib, windows
+{ stdenv, lib, fetchurlBoot, openssl, zlib, windows
 , hostPlatform
 }:
 
@@ -28,6 +28,14 @@ stdenv.mkDerivation rec {
       export LDFLAGS="-L${windows.mingw_w64}/lib $LDFLAGS"
     '';
   };
+
+  # Hack: when cross-compiling we need to manually add rpaths to ensure that
+  # the linker can find find zlib and openssl when linking the testsuite.
+  NIX_LDFLAGS =
+    if stdenv.hostPlatform != stdenv.buildPlatform
+    then '' -rpath-link ${lib.getLib zlib}/lib
+            -rpath-link ${lib.getLib openssl}/lib ''
+    else null;
 
   meta = {
     description = "A client-side C library implementing the SSH2 protocol";

--- a/pkgs/development/libraries/libtasn1/default.nix
+++ b/pkgs/development/libraries/libtasn1/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ texinfo ];
   buildInputs = [ perl ];
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
 
   meta = with stdenv.lib; {
     homepage = http://www.gnu.org/software/libtasn1/;

--- a/pkgs/development/libraries/libunistring/default.nix
+++ b/pkgs/development/libraries/libunistring/default.nix
@@ -17,7 +17,8 @@ stdenv.mkDerivation rec {
     "--with-libiconv-prefix=${libiconv}"
   ];
 
-  doCheck = !stdenv.hostPlatform.isMusl;
+  # TODO: investigate test-rwlock1 failure during cross-compilation.
+  doCheck = !stdenv.hostPlatform.isMusl && fallse;
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libunistring/default.nix
+++ b/pkgs/development/libraries/libunistring/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   ];
 
   # TODO: investigate test-rwlock1 failure during cross-compilation.
-  doCheck = !stdenv.hostPlatform.isMusl && fallse;
+  doCheck = !stdenv.hostPlatform.isMusl && false;
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   # These should be turned back on, but see https://github.com/NixOS/nixpkgs/issues/23651
   # For now the tests are just breaking large swaths of the nixpkgs binary cache for Darwin,
   # and I'd rather have everything else work at all than have stronger assurance here.
-  doCheck = !stdenv.isDarwin;
+  doCheck = !stdenv.isDarwin && stdenv.buildPlatform == stdenv.hostPlatform;
 
   meta = with lib; {
     description = "A multi-platform support library with a focus on asynchronous I/O";

--- a/pkgs/development/libraries/libvorbis/default.nix
+++ b/pkgs/development/libraries/libvorbis/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ libogg ];
 
-  doCheck = true;
+  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
 
   meta = with stdenv.lib; {
     homepage = https://xiph.org/vorbis/;

--- a/pkgs/development/libraries/lmdb/default.nix
+++ b/pkgs/development/libraries/lmdb/default.nix
@@ -11,14 +11,15 @@ stdenv.mkDerivation rec {
     sha256 = "026a6himvg3y4ssnccdbgr3c2pq3w2d47nayn05v512875z4f2w3";
   };
 
+  patches = [ ./fix-toolchain-paths.patch ];
   postUnpack = "sourceRoot=\${sourceRoot}/libraries/liblmdb";
 
   outputs = [ "bin" "out" "dev" ];
 
-  makeFlags = [ "prefix=$(out)" "CC=cc" ]
+  makeFlags = [ "prefix=$(out)" ]
     ++ stdenv.lib.optional stdenv.isDarwin "LDFLAGS=-Wl,-install_name,$(out)/lib/liblmdb.so";
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
   checkPhase = "make test";
 
   postInstall = ''

--- a/pkgs/development/libraries/lmdb/fix-toolchain-paths.patch
+++ b/pkgs/development/libraries/lmdb/fix-toolchain-paths.patch
@@ -1,0 +1,13 @@
+diff --git a/libraries/liblmdb/Makefile b/libraries/liblmdb/Makefile
+index f254511..0c76158 100644
+--- a/Makefile
++++ b/Makefile
+@@ -18,8 +18,6 @@
+ # There may be other macros in mdb.c of interest. You should
+ # read mdb.c before changing any of them.
+ #
+-CC	= gcc
+-AR	= ar
+ W	= -W -Wall -Wno-unused-parameter -Wbad-function-cast -Wuninitialized
+ THREADS = -pthread
+ OPT = -O2 -g

--- a/pkgs/development/libraries/menu-cache/default.nix
+++ b/pkgs/development/libraries/menu-cache/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, glib, pkgconfig, libfm-extra }:
 
-let name = "menu-cache-1.0.2";
+let name = "menu-cache-1.1.0";
 in
 stdenv.mkDerivation {
   inherit name;
   src = fetchurl {
     url = "mirror://sourceforge/lxde/${name}.tar.xz";
-    sha256 = "1m8j40npykfcfqs43kc0fmksal2jfmfi8lnb3mq3xy1lvvrfv0vg";
+    sha256 = "1iry4zlpppww8qai2cw4zid4081hh7fz8nzsp5lqyffbkm2yn0pd";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/openldap/fix-link-order.patch
+++ b/pkgs/development/libraries/openldap/fix-link-order.patch
@@ -1,0 +1,29 @@
+diff build/top.mk build/top.mk
+--- build/top.mk
++++ build/top.mk
+@@ -170,10 +170,9 @@ LDAP_LIBREWRITE_A = $(LDAP_LIBDIR)/librewrite/librewrite.a
+ LDAP_LIBLUNICODE_A = $(LDAP_LIBDIR)/liblunicode/liblunicode.a
+ LDAP_LIBLUTIL_A = $(LDAP_LIBDIR)/liblutil/liblutil.a
+ 
+-LDAP_L = $(LDAP_LIBLUTIL_A) \
+-	$(LDAP_LIBLDAP_LA) $(LDAP_LIBLBER_LA)
++LDAP_L = $(LDAP_LIBLDAP_LA) $(LDAP_LIBLBER_LA) $(LDAP_LIBLUTIL_A)
+ SLAPD_L = $(LDAP_LIBLUNICODE_A) $(LDAP_LIBREWRITE_A) \
+-	$(LDAP_LIBLUTIL_A) $(LDAP_LIBLDAP_R_LA) $(LDAP_LIBLBER_LA)
++  $(LDAP_LIBLDAP_R_LA) $(LDAP_LIBLBER_LA) $(LDAP_LIBLUTIL_A)
+ 
+ WRAP_LIBS = @WRAP_LIBS@
+ # AutoConfig generated 
+diff --git a/libraries/librewrite/Makefile.in b/libraries/librewrite/Makefile.in
+--- libraries/librewrite/Makefile.in
++++ libraries/librewrite/Makefile.in
+@@ -28,8 +28,7 @@ LDAP_LIBDIR= ../../libraries
+ 
+ LIBRARY = librewrite.a
+ PROGRAMS	= rewrite
+-XLIBS = $(LIBRARY) $(LDAP_LIBLUTIL_A) \
+-	$(LDAP_LIBLDAP_R_LA) $(LDAP_LIBLBER_LA)
++XLIBS = $(LIBRARY) $(LDAP_LIBLDAP_R_LA) $(LDAP_LIBLUTIL_A) $(LDAP_LIBLBER_LA)
+ XXLIBS  = $(SECURITY_LIBS) $(LUTIL_LIBS)
+ XXXLIBS = $(LTHREAD_LIBS)
+ 

--- a/pkgs/development/libraries/openldap/no-strip.patch
+++ b/pkgs/development/libraries/openldap/no-strip.patch
@@ -1,0 +1,12 @@
+diff --git build/top.mk build/top.mk
+--- build/top.mk
++++ build/top.mk
+@@ -59,7 +59,7 @@ INSTALL_PROGRAM = $(INSTALL)
+ INSTALL_DATA = $(INSTALL) -m 644
+ INSTALL_SCRIPT = $(INSTALL)
+ 
+-STRIP = -s
++STRIP =
+ 
+ LINT = lint
+ 5LINT = 5lint

--- a/pkgs/development/libraries/pixman/default.nix
+++ b/pkgs/development/libraries/pixman/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = stdenv.lib.optional stdenv.isArm "--disable-arm-iwmmxt";
 
-  doCheck = true;
+  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
 
   postInstall = glib.flattenInclude;
 

--- a/pkgs/development/libraries/readline/6.3.nix
+++ b/pkgs/development/libraries/readline/6.3.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   configureFlags =
     stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
-    [ # This test requires running host code
+    [ # This test requires running target code
       "bash_cv_wcwidth_broken=no"
     ];
 

--- a/pkgs/development/libraries/ti-rpc/default.nix
+++ b/pkgs/development/libraries/ti-rpc/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     sed -es"|/etc/netconfig|$out/etc/netconfig|g" -i doc/Makefile.in tirpc/netconfig.h
   '';
 
-  configureFlags = ''
+  configureFlags = stdenv.lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) ''
     KRB5_CONFIG=${libkrb5}/bin/krb5-config
   '';
 

--- a/pkgs/development/libraries/ti-rpc/default.nix
+++ b/pkgs/development/libraries/ti-rpc/default.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec {
     sed -es"|/etc/netconfig|$out/etc/netconfig|g" -i doc/Makefile.in tirpc/netconfig.h
   '';
 
+  configureFlags = ''
+    KRB5_CONFIG=${libkrb5}/bin/krb5-config
+  '';
+
   preInstall = "mkdir -p $out/etc";
 
   doCheck = true;

--- a/pkgs/development/libraries/uthash/default.nix
+++ b/pkgs/development/libraries/uthash/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = stdenv.lib.optional doCheck perl;
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
   checkTarget = "-C tests/";
 
   installPhase = ''

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -2,11 +2,12 @@ perl:
 
 { buildInputs ? [], name, ... } @ attrs:
 
-perl.stdenv.mkDerivation (
+with perl.stdenv;
+mkDerivation (
   {
     outputs = [ "out" "devdoc" ];
 
-    doCheck = true;
+    doCheck = hostPlatform == buildPlatform;
 
     checkTarget = "test";
 

--- a/pkgs/development/python-modules/kubernetes/default.nix
+++ b/pkgs/development/python-modules/kubernetes/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, buildPythonPackage, fetchPypi, pythonAtLeast,
+  ipaddress, websocket_client, urllib3, pyyaml, requests_oauthlib, python-dateutil, google_auth,
+  isort, pytest, coverage, mock, sphinx, autopep8, pep8, codecov, recommonmark, nose }:
+
+buildPythonPackage rec {
+  pname = "kubernetes";
+  version = "5.0.0";
+
+  prePatch = ''
+    sed -e 's/sphinx>=1.2.1,!=1.3b1,<1.4 # BSD/sphinx/' -i test-requirements.txt
+
+    # This is used to randomize tests, which is not reproducible. Drop it.
+    sed -e '/randomize/d' -i test-requirements.txt
+  ''
+  # This is a python2 and python3.2 only requiremet since it is a backport of a python-3.3 api.
+  + (if (pythonAtLeast "3.3")  then ''
+    sed -e '/ipaddress/d' -i requirements.txt
+  '' else "");
+
+  checkPhase = ''
+    py.test
+  '';
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1z8rrlq73bzli9rg57kj8ivz09vhsydyjq1ksbcis6j7h9c187zq";
+  };
+
+  checkInputs = [ isort coverage pytest mock sphinx autopep8 pep8 codecov recommonmark nose ];
+  propagatedBuildInputs = [ ipaddress websocket_client urllib3 pyyaml requests_oauthlib python-dateutil google_auth ];
+
+  meta = with stdenv.lib; {
+    description = "Kubernetes python client";
+    homepage = https://github.com/kubernetes-client/python;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lsix ];
+  };
+}

--- a/pkgs/development/python-modules/websockets_client/default.nix
+++ b/pkgs/development/python-modules/websockets_client/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, six }:
+buildPythonPackage rec {
+  pname = "websocket_client";
+  version = "0.47.0";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "0jb1446053ryp5p25wsr1hjfdzwfm04a6f3pzpcb63bfz96xqlx4";
+  };
+
+  prePatch = ''
+    # ssl.match_hostname exists in python2.7 version maintained in nixpkgs,
+    # the dependency is not necessary.
+    sed -e "s/\['backports.ssl_match_hostname'\]/\[\]/" -i setup.py
+  '';
+
+  propagatedBuildInputs = [ six ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/liris/websocket-client;
+    description = "Websocket client for python";
+    license = licenses.lgpl2;
+  };
+}

--- a/pkgs/development/tools/misc/autoconf/2.64.nix
+++ b/pkgs/development/tools/misc/autoconf/2.64.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, m4, perl }:
+{ stdenv, fetchurl, buildPackages, m4, perl }:
 
 stdenv.mkDerivation rec {
   name = "autoconf-2.64";
@@ -8,6 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0j3jdjpf5ly39dlp0bg70h72nzqr059k0x8iqxvaxf106chpgn9j";
   };
 
+  nativeBuildInputs = [ buildPackages.m4 ];
   buildInputs = [ m4 perl ];
 
   # Work around a known issue in Cygwin.  See
@@ -20,6 +21,10 @@ stdenv.mkDerivation rec {
   # Don't fixup "#! /bin/sh" in Autoconf, otherwise it will use the
   # "fixed" path in generated files!
   dontPatchShebangs = true;
+
+  # For some reason autoconf's configure doesn't find the host m4
+  # while cross-compiling unless we explicitly point it out.
+  configureFlags = '' M4=${buildPackages.m4}/bin/m4 '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -2,7 +2,12 @@
 , fetchurl, zlib
 , buildPlatform, hostPlatform, targetPlatform
 , noSysDirs, gold ? true, bison ? null
+  # Which ld implementation to use by default?
+, defaultLd ? null
 }:
+
+assert (builtins.elem defaultLd ["bfd" "gold" null]);
+assert defaultLd == "gold" -> gold;
 
 let
   # Note to whoever is upgrading this: 2.29 is broken.
@@ -106,7 +111,8 @@ stdenv.mkDerivation rec {
     "--enable-deterministic-archives"
     "--disable-werror"
     "--enable-fix-loongson2f-nop"
-  ] ++ optionals gold [ "--enable-gold" "--enable-plugins" ];
+  ] ++ optionals gold [ "--enable-gold" "--enable-plugins" ]
+  ++ optional (defaultLd == "gold") "--enable-gold=default";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ stdenv, buildPackages
 
 # Build time
 , fetchurl, pkgconfig, perl, texinfo, setupDebugInfoDirs
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./debug-info-from-env.patch ];
 
-  nativeBuildInputs = [ pkgconfig texinfo perl setupDebugInfoDirs ]
+  nativeBuildInputs = [ pkgconfig texinfo perl setupDebugInfoDirs buildPackages.stdenv.cc ]
     # TODO(@Ericson2314) not sure if should be host or target
     ++ stdenv.lib.optional targetPlatform.isHurd mig;
 

--- a/pkgs/development/tools/misc/gdbgui/default.nix
+++ b/pkgs/development/tools/misc/gdbgui/default.nix
@@ -5,14 +5,14 @@ in
 python27Packages.buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "gdbgui";
-  version = "0.11.0.0";
+  version = "0.11.1.2";
 
   buildInputs = [ gdb ];
   propagatedBuildInputs = builtins.attrValues deps.packages;
 
   src = python27Packages.fetchPypi {
     inherit pname version;
-    sha256 = "09bfrln16ai5azpjan1q24xz700sxsaa3ndynq8c8qdan82bfi1g";
+    sha256 = "15502fg90df183mcg6nic8fakf111pgrlp7f044g3136wpwgfln7";
   };
 
   postPatch = ''

--- a/pkgs/development/tools/misc/gperf/3.0.x.nix
+++ b/pkgs/development/tools/misc/gperf/3.0.x.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl}:
+{stdenv, fetchurl, autoreconfHook}:
 
 stdenv.mkDerivation rec {
   name = "gperf-3.0.4";
@@ -7,6 +7,10 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/gperf/${name}.tar.gz";
     sha256 = "0gnnm8iqcl52m8iha3sxrzrl9mcyhg7lfrhhqgdn4zj00ji14wbn";
   };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  autoreconfPhase = "libtoolize --install && autoreconf";
+  patches = [ ./fix-configure.patch ];
 
   meta = {
     description = "Perfect hash function generator";

--- a/pkgs/development/tools/misc/gperf/3.0.x.nix
+++ b/pkgs/development/tools/misc/gperf/3.0.x.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
   autoreconfPhase = "libtoolize --install && autoreconf";
+  prePatch = '' substituteInPlace lib/Makefile.in --replace 'AR = ar' "" '';
+  configureFlags = [ "AR=${stdenv.cc.bintools}/bin/${stdenv.cc.bintools.targetPrefix}ar" ];
   patches = [ ./fix-configure.patch ];
 
   meta = {

--- a/pkgs/development/tools/misc/gperf/default.nix
+++ b/pkgs/development/tools/misc/gperf/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1qispg6i508rq8pkajh26cznwimbnj06wq9sd85vg95v8nwld1aq";
   };
 
+  patches = [ ./fix-configure.patch ];
+
   meta = {
     description = "Perfect hash function generator";
 

--- a/pkgs/development/tools/misc/gperf/fix-configure.patch
+++ b/pkgs/development/tools/misc/gperf/fix-configure.patch
@@ -1,0 +1,54 @@
+diff --git a/doc/configure.ac b/doc/configure.ac
+index c4279dc..49ffe06 100644
+--- a/doc/configure.ac
++++ b/doc/configure.ac
+@@ -27,7 +27,7 @@ AC_PROG_MAKE_SET
+ dnl
+ dnl           checks for programs
+ dnl
+-CL_PROG_INSTALL
++AC_PROG_INSTALL
+                       dnl sets variables INSTALL, INSTALL_DATA, INSTALL_PROGRAM
+ dnl
+ dnl           That's it.
+diff --git a/lib/Makefile.in b/lib/Makefile.in
+index b7b96ee..fd819ef 100644
+--- a/lib/Makefile.in
++++ b/lib/Makefile.in
+@@ -41,7 +41,7 @@ CXXCPP = @CXXCPP@
+ # Both C and C++ compiler
+ OBJEXT = @OBJEXT@
+ # Other
+-AR = ar
++AR = @AR@
+ AR_FLAGS = rc
+ RANLIB = @RANLIB@
+ MV = mv
+diff --git a/lib/configure.ac b/lib/configure.ac
+index b3df1cd..abc469a 100644
+--- a/lib/configure.ac
++++ b/lib/configure.ac
+@@ -35,7 +35,9 @@ AC_PROG_CXXCPP
+                       dnl sets variable CXXCPP
+ AC_PROG_RANLIB
+                       dnl sets variable RANLIB
+-CL_PROG_INSTALL
++AC_CHECK_TOOL([AR],[ar])
++                      dnl sets variable AR
++AC_PROG_INSTALL
+                       dnl sets variables INSTALL, INSTALL_DATA, INSTALL_PROGRAM
+ dnl
+ dnl           That's it.
+diff --git a/src/configure.ac b/src/configure.ac
+index 33f4983..7594015 100644
+--- a/src/configure.ac
++++ b/src/configure.ac
+@@ -34,7 +34,7 @@ AC_PROG_CXX
+                       dnl sets variable CXX
+ AC_PROG_CXXCPP
+                       dnl sets variable CXXCPP
+-CL_PROG_INSTALL
++AC_PROG_INSTALL
+                       dnl sets variables INSTALL, INSTALL_DATA, INSTALL_PROGRAM
+ dnl
+ dnl           checks for compiler characteristics

--- a/pkgs/development/tools/misc/gperf/fix-configure.patch
+++ b/pkgs/development/tools/misc/gperf/fix-configure.patch
@@ -11,19 +11,6 @@ index c4279dc..49ffe06 100644
                        dnl sets variables INSTALL, INSTALL_DATA, INSTALL_PROGRAM
  dnl
  dnl           That's it.
-diff --git a/lib/Makefile.in b/lib/Makefile.in
-index b7b96ee..fd819ef 100644
---- a/lib/Makefile.in
-+++ b/lib/Makefile.in
-@@ -41,7 +41,7 @@ CXXCPP = @CXXCPP@
- # Both C and C++ compiler
- OBJEXT = @OBJEXT@
- # Other
--AR = ar
-+AR = @AR@
- AR_FLAGS = rc
- RANLIB = @RANLIB@
- MV = mv
 diff --git a/lib/configure.ac b/lib/configure.ac
 index b3df1cd..abc469a 100644
 --- a/lib/configure.ac

--- a/pkgs/development/tools/misc/strace/default.nix
+++ b/pkgs/development/tools/misc/strace/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, libunwind }:
+{ stdenv, buildPackages, fetchurl, perl, libunwind }:
 
 stdenv.mkDerivation rec {
   name = "strace-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0dsw6xcfrmygidp1dj2ch8cl8icrar7789snkb2r8gh78kdqhxjw";
   };
 
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [ perl buildPackages.stdenv.cc ];
 
   buildInputs = [ libunwind ]; # support -k
 

--- a/pkgs/development/tools/misc/swig/2.x.nix
+++ b/pkgs/development/tools/misc/swig/2.x.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, bison, pcre }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, bison, pcre }:
 
 stdenv.mkDerivation rec {
   name = "swig-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0khm9gh5pczfcihr0pbicaicc4v9kjm5ip2alvkhmbb3ga6njkcm";
   };
 
-  nativeBuildInputs = [ autoconf automake libtool bison ];
+  nativeBuildInputs = [ autoreconfHook bison ];
   buildInputs = [ pcre ];
 
   configureFlags = "--without-tcl";
@@ -21,9 +21,7 @@ stdenv.mkDerivation rec {
     sed -i '/man1/d' CCache/Makefile.in
   '';
 
-  preConfigure = ''
-    ./autogen.sh
-  '';
+  autoreconfPhase = '' ./autogen.sh '';
 
   meta = {
     description = "SWIG, an interface compiler that connects C/C++ code to higher-level languages";

--- a/pkgs/development/tools/misc/swig/2.x.nix
+++ b/pkgs/development/tools/misc/swig/2.x.nix
@@ -11,10 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "0khm9gh5pczfcihr0pbicaicc4v9kjm5ip2alvkhmbb3ga6njkcm";
   };
 
-  nativeBuildInputs = [ autoreconfHook bison ];
-  buildInputs = [ pcre ];
+  # Configure needs to the pcre-config script
+  nativeBuildInputs = [ autoreconfHook bison pcre.crossDrv.dev ];
+  buildInputs = [ pcre.crossDrv ];
 
-  configureFlags = "--without-tcl";
+  configureFlags = "--without-tcl --with-pcre=${lib.getLib pcre}";
 
   postPatch = ''
     # Disable ccache documentation as it need yodl

--- a/pkgs/development/tools/misc/swig/3.x.nix
+++ b/pkgs/development/tools/misc/swig/3.x.nix
@@ -12,9 +12,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook bison ];
-  buildInputs = [ pcre ];
+  buildInputs = [ pcre pcre.dev ];
 
-  configureFlags = "--without-tcl";
+  configureFlags = "--without-tcl --with-pcre=${lib.getLib pcre}";
 
   postPatch = ''
     # Disable ccache documentation as it need yodl

--- a/pkgs/development/tools/misc/swig/3.x.nix
+++ b/pkgs/development/tools/misc/swig/3.x.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, bison, pcre }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, bison, pcre }:
 
 stdenv.mkDerivation rec {
   name = "swig-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1wyffskbkzj5zyhjnnpip80xzsjcr3p0q5486z3wdwabnysnhn8n";
   };
 
-  nativeBuildInputs = [ autoconf automake libtool bison ];
+  nativeBuildInputs = [ autoreconfHook bison ];
   buildInputs = [ pcre ];
 
   configureFlags = "--without-tcl";
@@ -21,9 +21,7 @@ stdenv.mkDerivation rec {
     sed -i '/man1/d' CCache/Makefile.in
   '';
 
-  preConfigure = ''
-    ./autogen.sh
-  '';
+  autoreconfPhase = '' ./autogen.sh '';
 
   meta = with stdenv.lib; {
     description = "SWIG, an interface compiler that connects C/C++ code to higher-level languages";

--- a/pkgs/development/tools/misc/swig/3.x.nix
+++ b/pkgs/development/tools/misc/swig/3.x.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1wyffskbkzj5zyhjnnpip80xzsjcr3p0q5486z3wdwabnysnhn8n";
   };
 
-  nativeBuildInputs = [ autoreconfHook bison ];
-  buildInputs = [ pcre pcre.dev ];
+  nativeBuildInputs = [ autoreconfHook bison pcre.dev ];
+  buildInputs = [ pcre ];
 
   configureFlags = "--without-tcl --with-pcre=${lib.getLib pcre}";
 

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -13,11 +13,11 @@ let
            stdenv.mkDerivation (rec {
 
     name = "uboot-${defconfig}-${version}";
-    version = "2017.03";
+    version = "2017.09";
 
     src = fetchurl {
       url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2";
-      sha256 = "0gqihplap05dlpwdb971wsqyv01nz2vabwq5g5649gr5jczsyjzm";
+      sha256 = "0i4p12ar0zgyxs8hiqgp6p6shvbw4ikkvryd4mh70bppyln5zldj";
     };
 
     patches = [

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -201,4 +201,10 @@ in rec {
     targetPlatforms = ["armv7l-linux"];
     filesToInstall = ["u-boot.img" "SPL"];
   };
+
+  ubootMicrozed = buildUBoot rec {
+    defconfig = "zynq_microzed_defconfig";
+    targetPlatforms = ["armv7l-linux"];
+    filesToInstall = ["u-boot.elf"];
+  };
 }

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -14,11 +14,11 @@ let
             stdenv.mkDerivation (rec {
 
     name = "uboot-${defconfig}-${version}";
-    version = "2017.09";
+    version = "2017.11";
 
     src = fetchurl {
       url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2";
-      sha256 = "0i4p12ar0zgyxs8hiqgp6p6shvbw4ikkvryd4mh70bppyln5zldj";
+      sha256 = "01bcsah5imy6m3fbjwhqywxg0pfk5fl8ks9ylb7kv3zmrb9qy0ba";
     };
 
     patches = [

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, bc, dtc, openssl, python2
+{ stdenv, buildPackages, fetchurl, fetchpatch, bc, dtc, python2
 , hostPlatform
 }:
 
@@ -13,11 +13,11 @@ let
            stdenv.mkDerivation (rec {
 
     name = "uboot-${defconfig}-${version}";
-    version = "2017.11";
+    version = "2017.03";
 
     src = fetchurl {
       url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2";
-      sha256 = "01bcsah5imy6m3fbjwhqywxg0pfk5fl8ks9ylb7kv3zmrb9qy0ba";
+      sha256 = "0gqihplap05dlpwdb971wsqyv01nz2vabwq5g5649gr5jczsyjzm";
     };
 
     patches = [
@@ -43,7 +43,7 @@ let
       patchShebangs tools
     '';
 
-    nativeBuildInputs = [ bc dtc openssl python2 ];
+    nativeBuildInputs = [ bc dtc openssl python2 buildPackages.stdenv.cc ];
 
     hardeningDisable = [ "all" ];
 
@@ -65,12 +65,14 @@ let
     enableParallelBuilding = true;
     dontStrip = true;
 
-    crossAttrs = {
-      makeFlags = [
-        "ARCH=${hostPlatform.platform.kernelArch}"
+    makeFlags = stdenv.lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform)
+      [
+        "DTC=dtc"
         "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+        "HOSTCC=${buildPackages.stdenv.cc.targetPrefix}gcc"
+        "HOSTCFLAGS+=-I${stdenv.lib.getDev buildPackages.openssl}/include"
+        "HOSTLDFLAGS+=-L${stdenv.lib.getLib buildPackages.openssl}/lib"
       ];
-    };
 
     meta = with stdenv.lib; {
       homepage = http://www.denx.de/wiki/U-Boot/;

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -4,13 +4,14 @@
 
 let
   buildUBoot = { targetPlatforms
-            , filesToInstall
-            , installDir ? "$out"
-            , defconfig
+               , filesToInstall
+               , installDir ? "$out"
+               , defconfig
             , extraMakeFlags ? []
-            , extraMeta ? {}
-            , ... } @ args:
-           stdenv.mkDerivation (rec {
+               , extraMeta ? {}
+               , otherConfig ? ""
+               , ... } @ args:
+            stdenv.mkDerivation (rec {
 
     name = "uboot-${defconfig}-${version}";
     version = "2017.09";
@@ -50,7 +51,10 @@ let
     makeFlags = [ "DTC=dtc" ] ++ extraMakeFlags;
 
     configurePhase = ''
-      make ${defconfig}
+      make $makeFlags ${defconfig}
+      # Apply otherConfig
+      echo "${otherConfig}" >> .config
+      make $makeFlags oldconfig
     '';
 
     installPhase = ''
@@ -88,6 +92,16 @@ in rec {
 
   ubootTools = buildUBoot rec {
     defconfig = "allnoconfig";
+    # This is necessary otherwise the build fails with undefined symbols at link-time.
+    # This is likely a bug in u-boot.
+    otherConfig = ''
+      CONFIG_FIT=y
+      CONFIG_FIT_SIGNATURE=y
+      CONFIG_FIT_ENABLE_SHA256_SUPPORT=y
+      CONFIG_FIT_VERBOSE=y
+      CONFIG_FIT_BEST_MATCH=y
+      CONFIG_SPL_RSA=y
+    '';
     installDir = "$out/bin";
     buildFlags = "tools NO_SDL=1";
     dontStrip = false;

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -44,11 +44,9 @@ let
       patchShebangs tools
     '';
 
-    nativeBuildInputs = [ bc dtc openssl python2 buildPackages.stdenv.cc ];
+    nativeBuildInputs = [ bc dtc buildPackages.openssl python2 buildPackages.stdenv.cc ];
 
     hardeningDisable = [ "all" ];
-
-    makeFlags = [ "DTC=dtc" ] ++ extraMakeFlags;
 
     configurePhase = ''
       make $makeFlags ${defconfig}
@@ -73,10 +71,11 @@ let
       [
         "DTC=dtc"
         "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+      ] ++ [
         "HOSTCC=${buildPackages.stdenv.cc.targetPrefix}gcc"
         "HOSTCFLAGS+=-I${stdenv.lib.getDev buildPackages.openssl}/include"
         "HOSTLDFLAGS+=-L${stdenv.lib.getLib buildPackages.openssl}/lib"
-      ];
+      ] ++ extraMakeFlags;
 
     meta = with stdenv.lib; {
       homepage = http://www.denx.de/wiki/U-Boot/;

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -102,7 +102,7 @@ in rec {
       CONFIG_SPL_RSA=y
     '';
     installDir = "$out/bin";
-    buildFlags = "tools NO_SDL=1";
+    buildFlags = "tools envtools NO_SDL=1";
     dontStrip = false;
     targetPlatforms = stdenv.lib.platforms.linux;
     # build tools/kwboot
@@ -113,7 +113,11 @@ in rec {
       "tools/kwboot"
       "tools/mkenvimage"
       "tools/mkimage"
+      "tools/env/fw_printenv"
     ];
+    postInstall = ''
+      ln -s $out/bin/fw_printenv $out/bin/fw_setenv
+    '';
   };
 
   ubootA20OlinuxinoLime = buildUBoot rec {

--- a/pkgs/os-specific/linux/bridge-utils/default.nix
+++ b/pkgs/os-specific/linux/bridge-utils/default.nix
@@ -10,6 +10,9 @@ stdenv.mkDerivation rec {
 
   # Remove patch once the kernel headers are updated
   patches = [ ./add-ip6-header.patch ];
+  postPatch = ''
+    substituteInPlace libbridge/Makefile.in --replace "AR=ar" "AR=${stdenv.cc.targetPrefix}ar"
+  '';
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ ];

--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = if isFuse3
     then [ meson ninja pkgconfig ]
-    else [ autoconf automake libtool ];
+    else [ autoconf automake gettext libtool ];
   buildInputs = stdenv.lib.optional (!isFuse3) gettext;
 
   outputs = [ "out" ] ++ stdenv.lib.optional isFuse3 "common";

--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -31,7 +31,6 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = if isFuse3
     then [ meson ninja pkgconfig ]
     else [ autoconf automake gettext libtool ];
-  buildInputs = stdenv.lib.optional (!isFuse3) gettext;
 
   outputs = [ "out" ] ++ stdenv.lib.optional isFuse3 "common";
 

--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libnetfilter_conntrack libnftnl libmnl ];
 
   preConfigure = ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -lmnl -lnftnl"
+    export NIX_LDFLAGS="$NIX_LDFLAGS -lmnl -lnftnl -ldl"
   '';
 
   configureFlags = ''

--- a/pkgs/os-specific/linux/iputils/default.nix
+++ b/pkgs/os-specific/linux/iputils/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ libxslt docbook_xsl docbook_xml_dtd_45 ];
   buildInputs = [
     libsysfs openssl libcap libgcrypt libidn2 nettle
-  ] ++ stdenv.lib.optional (!stdenv.hostPlatform.isMusl) libidn;
+  ];
 
   buildFlags = "man all ninfod";
 

--- a/pkgs/os-specific/linux/iputils/default.nix
+++ b/pkgs/os-specific/linux/iputils/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl
+{ stdenv, fetchFromGitHub, SGMLSpm
 , libsysfs, gnutls, openssl
-, libcap, opensp, docbook_sgml_dtd_31
-, libidn, nettle
-, SGMLSpm, libgcrypt }:
+, libcap, libidn2, nettle, libgcrypt
+, libxslt, docbook_xsl, docbook_xml_dtd_45 }:
+
 
 let
   time = "20161105";
@@ -10,22 +10,22 @@ in
 stdenv.mkDerivation rec {
   name = "iputils-${time}";
 
-  src = fetchurl {
-    url = "https://github.com/iputils/iputils/archive/s${time}.tar.gz";
-    sha256 = "12mdmh4qbf5610csaw3rkzhpzf6djndi4jsl4gyr8wni0cphj4zq";
+  src = fetchFromGitHub {
+    owner = "iputils";
+    repo = "iputils";
+    rev = "9f7f1d4c4fd4fd90d2c5e66d6deb7f87f2eb1cea";
+    sha256 = null;
   };
 
   prePatch = ''
-    sed -e s/sgmlspl/sgmlspl.pl/ \
-        -e s/nsgmls/onsgmls/ \
-      -i doc/Makefile
+    substituteInPlace doc/Makefile --replace '/usr/bin/xsltproc' 'xsltproc'
   '';
 
-  # Disable idn usage w/musl: https://github.com/iputils/iputils/pull/111
-  makeFlags = [ "USE_GNUTLS=no" ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "USE_IDN=no";
+  makeFlags = "USE_GNUTLS=no";
 
+  nativeBuildInputs = [ libxslt docbook_xsl docbook_xml_dtd_45 ];
   buildInputs = [
-    libsysfs opensp openssl libcap docbook_sgml_dtd_31 SGMLSpm libgcrypt nettle
+    libsysfs openssl libcap libgcrypt libidn2 nettle
   ] ++ stdenv.lib.optional (!stdenv.hostPlatform.isMusl) libidn;
 
   buildFlags = "man all ninfod";

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -6,7 +6,7 @@
 , callPackage
 }:
 
-{ stdenv, buildPackages, perl, buildLinux
+{ stdenv, stdenvNoCC, buildPackages, perl, buildLinux
 
 , # The kernel source tarball.
   src
@@ -66,7 +66,9 @@ let
         map ({extraConfig ? "", ...}: extraConfig) kernelPatches;
     in lib.concatStringsSep "\n" ([baseConfig] ++ configFromPatches);
 
-  configfile = stdenv.mkDerivation {
+  # Use stdNoCC as we don't need a C compiler here; moreover, we otherwise
+  # run into hook issues. See #34366.
+  configfile = stdenvNoCC.mkDerivation {
     inherit ignoreConfigErrors;
     name = "linux-config-${version}";
 

--- a/pkgs/os-specific/linux/kernel/linux-4.13.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.13.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, stdenvNoCC, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
 buildLinux (args // rec {
   version = "4.13.16";

--- a/pkgs/os-specific/linux/kernel/linux-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, stdenvNoCC, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
 with stdenv.lib;
 

--- a/pkgs/os-specific/linux/kernel/linux-4.15.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.15.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, stdenvNoCC, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
 with stdenv.lib;
 

--- a/pkgs/os-specific/linux/kernel/linux-4.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.4.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, stdenvNoCC, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
 buildLinux (args // rec {
   version = "4.4.118";

--- a/pkgs/os-specific/linux/kernel/linux-4.9.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.9.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, stdenvNoCC, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
 buildLinux (args // rec {
   version = "4.9.84";

--- a/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
+++ b/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ubootTools, dtc, ... } @ args:
+{ stdenv, stdenvNoCC, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ubootTools, dtc, ... } @ args:
 
 let
   modDirVersion = "4.14.12";

--- a/pkgs/os-specific/linux/kernel/linux-copperhead-hardened.nix
+++ b/pkgs/os-specific/linux/kernel/linux-copperhead-hardened.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
+{ stdenv, stdenvNoCC, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
 with stdenv.lib;
 

--- a/pkgs/os-specific/linux/kernel/linux-mptcp.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
+{ stdenv, stdenvNoCC, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
 buildLinux (rec {
   mptcpVersion = "0.93";

--- a/pkgs/os-specific/linux/kernel/linux-riscv.nix
+++ b/pkgs/os-specific/linux/kernel/linux-riscv.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, libelf, utillinux, ... } @ args:
+{ stdenv, stdenvNoCC, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, libelf, utillinux, ... } @ args:
 
 buildLinux (args // rec {
   version = "4.16-rc2";

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
+{ stdenv, stdenvNoCC, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
 let
   modDirVersion = "4.9.59";

--- a/pkgs/os-specific/linux/kernel/linux-samus-4.12.nix
+++ b/pkgs/os-specific/linux/kernel/linux-samus-4.12.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ncurses, ... } @ args:
+{ stdenv, stdenvNoCC, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ncurses, ... } @ args:
 
 buildLinux (args // rec {
   version = "4.12.2";

--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, hostPlatform, fetchgit, perl, buildLinux, ... } @ args:
+{ stdenv, stdenvNoCC, buildPackages, hostPlatform, fetchgit, perl, buildLinux, ... } @ args:
 
 buildLinux (args // rec {
   version = "4.15.2018.02.09";

--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, libelf, utillinux, ... } @ args:
+{ stdenv, stdenvNoCC, buildPackages, hostPlatform, fetchurl, perl, buildLinux, libelf, utillinux, ... } @ args:
 
 buildLinux (args // rec {
   version = "4.16-rc1";

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -246,8 +246,8 @@ let
           maintainers.thoughtpolice
         ];
         platforms = platforms.linux;
-      } // extraMeta;
-    };
+      };
+    } // extraMeta;
 in
 
 assert stdenv.lib.versionAtLeast version "4.14" -> libelf != null;

--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -49,6 +49,10 @@ stdenv.mkDerivation {
       "-Wno-error=unused-const-variable" "-Wno-error=misleading-indentation"
     ];
 
+  makeFlags = if hostPlatform == buildPlatform
+    then null
+    else "CROSS_COMPILE=${stdenv.cc.prefix}";
+
   separateDebugInfo = true;
   installFlags = "install install-man ASCIIDOC8=1";
 

--- a/pkgs/os-specific/linux/libnl/default.nix
+++ b/pkgs/os-specific/linux/libnl/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation {
       sha256 = "0dd7xxikib201i99k2if066hh7gwf2i4ffckrjplq6lr206jn00r";
     });
 
+  enableParallelBuilding = true;
+
   nativeBuildInputs = [ autoreconfHook bison flex pkgconfig ];
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/mbpfan/default.nix
+++ b/pkgs/os-specific/linux/mbpfan/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "mbpfan-${version}";
-  version = "2.0.1";
+  version = "2.0.2";
   src = fetchFromGitHub {
     owner = "dgraziotin";
     repo = "mbpfan";
     rev = "v${version}";
-    sha256 = "1iri1py9ym0zz7fcacbf0d9y3i3ay77jmajckchagamkfha16zyp";
+    sha256 = "1l8fj92jxfp0sldvznsdsm3pn675b35clq3371h6d5wk4jx67fvg";
   };
   installPhase = ''
     mkdir -p $out/bin $out/etc

--- a/pkgs/os-specific/linux/mcelog/default.nix
+++ b/pkgs/os-specific/linux/mcelog/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "mcelog-${version}";
-  version = "153";
+  version = "154";
 
   src = fetchFromGitHub {
     owner  = "andikleen";
     repo   = "mcelog";
     rev    = "v${version}";
-    sha256 = "1wz55dzqdiam511d6p1958al6vzlhrhs73s7gly0mzm6kpji0gxa";
+    sha256 = "0vq7r3zknr62rmi9g0zd7mmxframm79vmrdw029pc7z6wrlv40cy";
   };
 
   postPatch = ''

--- a/pkgs/os-specific/linux/mmc-utils/default.nix
+++ b/pkgs/os-specific/linux/mmc-utils/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0hkdzc71pdnscbpdpgwljcchiyancarldjyd0w609sy18bky833x";
   };
 
+  makeFlags = "CC=${stdenv.cc.targetPrefix}cc";
+
   installPhase = ''
     make install prefix=$out
     mkdir -p $out/share/man/man1

--- a/pkgs/os-specific/linux/net-tools/default.nix
+++ b/pkgs/os-specific/linux/net-tools/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     '';
 
   makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "AR=${stdenv.cc.targetPrefix}ar"
     "BASEDIR=$(out)"
     "mandir=/share/man"
     "HAVE_ARP_TOOLS=1"

--- a/pkgs/os-specific/linux/nfs-utils/default.nix
+++ b/pkgs/os-specific/linux/nfs-utils/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, lib, pkgconfig, utillinux, libcap, libtirpc, libevent, libnfsidmap
+{ stdenv, fetchurl, buildPackages, lib
+, pkgconfig, utillinux, libcap, libtirpc, libevent, libnfsidmap
 , sqlite, kerberos, kmod, libuuid, keyutils, lvm2, systemd, coreutils, tcp_wrappers
 , buildEnv
 }:
@@ -21,7 +22,7 @@ in stdenv.mkDerivation rec {
     sha256 = "02dvxphndpm8vpqqnl0zvij97dq9vsq2a179pzrjcv2i91ll2a0a";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig buildPackages.stdenv.cc ];
 
   buildInputs = [
     libtirpc libcap libevent libnfsidmap sqlite lvm2
@@ -37,7 +38,10 @@ in stdenv.mkDerivation rec {
       "--with-systemd=$(out)/etc/systemd/system"
       "--enable-libmount-mount"
     ]
-    ++ lib.optional (stdenv ? glibc) "--with-rpcgen=${stdenv.glibc.bin}/bin/rpcgen";
+    ++ lib.optional (stdenv ? glibc) "--with-rpcgen=${stdenv.glibc.bin}/bin/rpcgen"
+    ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "CC_FOR_BUILD=${buildPackages.stdenv.cc.targetPrefix}gcc"
+    ];
 
   postPatch =
     ''

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -33,14 +33,14 @@ in
 
     nativeBuildInputs =
       [ pkgconfig intltool gperf libxslt gettext docbook_xsl docbook_xml_dtd_42 docbook_xml_dtd_45
-        ninja meson
+        ninja meson m4
         coreutils # meson calls date, stat etc.
         pythonLxmlEnv glibcLocales
         patchelf getent
       ];
     buildInputs =
       [ linuxHeaders libcap kmod xz pam acl
-        /* cryptsetup */ libuuid m4 glib libgcrypt libgpgerror libidn2
+        /* cryptsetup */ libuuid glib libgcrypt libgpgerror libidn2
         libmicrohttpd kexectools libseccomp libffi audit lz4 bzip2 libapparmor
         iptables gnu-efi
       ];

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -79,6 +79,11 @@ in
 
       "-Dsysvinit-path="
       "-Dsysvrcnd-path="
+      "-Dkmod-path=${kmod}/bin/kmod"
+      "-Dkexec-path=${kexectools}/bin/kexec"
+      "-Dsulogin-path=${utillinux.bin}/sbin/sulogin"
+      "-Dmount-path=${utillinux.bin}/bin/mount"
+      "-Dumount-path=${utillinux.bin}/bin/umount"
       ];
 
     preConfigure =

--- a/pkgs/os-specific/linux/tcp-wrappers/default.nix
+++ b/pkgs/os-specific/linux/tcp-wrappers/default.nix
@@ -20,6 +20,7 @@ in stdenv.mkDerivation rec {
   prePatch = ''
     tar -xaf $debian
     patches="$(cat debian/patches/series | sed 's,^,debian/patches/,') $patches"
+    substituteInPlace Makefile --replace "AR	= ar" "AR = ${stdenv.cc.targetPrefix}ar"
   '';
 
   buildInputs = [ libnsl ];

--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -28,15 +28,6 @@ in stdenv.mkDerivation rec {
       --replace "/bin/umount" "$out/bin/umount"
   '';
 
-  crossAttrs = {
-    # Work around use of `AC_RUN_IFELSE'.
-    preConfigure = "export scanf_cv_type_modifier=ms";
-  };
-
-  preConfigure = lib.optionalString (systemd != null) ''
-    configureFlags+=" --with-systemd --with-systemdsystemunitdir=$bin/lib/systemd/system/"
-  '';
-
   # !!! It would be better to obtain the path to the mount helpers
   # (/sbin/mount.*) through an environment variable, but that's
   # somewhat risky because we have to consider that mount can setuid
@@ -49,7 +40,12 @@ in stdenv.mkDerivation rec {
     "--enable-fs-paths-default=/run/wrappers/bin:/var/run/current-system/sw/bin:/sbin"
     "--disable-makeinstall-setuid" "--disable-makeinstall-chown"
   ]
-    ++ lib.optional (ncurses == null) "--without-ncurses";
+    ++ lib.optional (ncurses == null) "--without-ncurses"
+    ++ lib.optional (systemd != null) "--with-systemd --with-systemdsystemunitdir=$bin/lib/systemd/system/"
+    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+      # Work around use of `AC_RUN_IFELSE'.
+      "scanf_cv_type_modifier=ms"
+    ];
 
   makeFlags = "usrbin_execdir=$(bin)/bin usrsbin_execdir=$(bin)/sbin";
 

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
     "--without-python"
     "--with-randomdev=/dev/random"
     "--with-ecdsa=yes"
+    "--with-eddsa=no"  # FIXME: "yes" fails to build, incompatible openssl version?
     "--with-gost=yes"
     "AR=${stdenv.cc.bintools}/bin/${stdenv.cc.bintools.targetPrefix}ar"
   ] ++ lib.optional enableSeccomp "--enable-seccomp"

--- a/pkgs/servers/memcached/default.nix
+++ b/pkgs/servers/memcached/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, cyrus_sasl, libevent}:
 
 stdenv.mkDerivation rec {
-  version = "1.5.4";
+  version = "1.5.5";
   name = "memcached-${version}";
 
   src = fetchurl {
     url = "http://memcached.org/files/${name}.tar.gz";
-    sha256 = "1m03fhzq1f9byk2agccsr0x458niqqjpips5mbcgzhm4kylczhz0";
+    sha256 = "1v87gvhxih5jav20cp9zdddna31s968xdm2iskc9mqzb5li6di72";
   };
 
   buildInputs = [cyrus_sasl libevent];

--- a/pkgs/shells/mksh/default.nix
+++ b/pkgs/shells/mksh/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "mksh-${version}";
-  version = "56b";
+  version = "56c";
 
   src = fetchurl {
     urls = [
       "http://www.mirbsd.org/MirOS/dist/mir/mksh/mksh-R${version}.tgz"
       "http://pub.allbsd.org/MirOS/dist/mir/mksh/mksh-R${version}.tgz"
     ];
-    sha256 = "0zwsikj0gvbg693xydgmhq19hz7m5bics1w9w7j86r95xi779v20";
+    sha256 = "0xzv5b83b8ccn3d4qvwz3gk83fi1d42kphax1527nni1472fp1nx";
   };
 
   buildPhase = ''sh ./Build.sh -r -c lto'';

--- a/pkgs/tools/archivers/zip/default.nix
+++ b/pkgs/tools/archivers/zip/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   makefile = "unix/Makefile";
   buildFlags = if stdenv.isCygwin then "cygwin" else "generic";
-  installFlags = "prefix=$(out) INSTALL=cp";
+  installFlags = "prefix=$(out) CC=${stdenv.cc.targetPrefix}cc INSTALL=cp";
 
   patches = if (enableNLS && !stdenv.isCygwin) then [ ./natspec-gentoo.patch.bz2 ] else [];
 

--- a/pkgs/tools/audio/mpdas/default.nix
+++ b/pkgs/tools/audio/mpdas/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "mpdas-${version}";
-  version = "0.4.4";
+  version = "0.4.5";
 
   src = fetchFromGitHub {
     owner = "hrkfdn";
     repo = "mpdas";
     rev = version;
-    sha256 = "1i6i36jd582y3nm5plcrswqljf528hd23whp8zw06hwqnsgca5b6";
+    sha256 = "0fcqc4w6iwbi1n3cllcgj0k61zffhqkbr8668myxap21m35x8y1r";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/tools/compression/lzip/default.nix
+++ b/pkgs/tools/compression/lzip/default.nix
@@ -11,11 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "1abbch762gv8rjr579q3qyyk6c80plklbv2mw4x0vg71dgsw9bgz";
   };
 
-  configureFlags = "CPPFLAGS=-DNDEBUG CFLAGS=-O3 CXXFLAGS=-O3";
+  # This isn't an autoconf-based configure.
+  configureFlags = "CXX=${stdenv.cc.targetPrefix}g++ CPPFLAGS=-DNDEBUG CFLAGS=-O3 CXXFLAGS=-O3";
+  configurePlatforms = [];
 
   setupHook = ./lzip-setup-hook.sh;
 
-  doCheck = true;
+  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
   enableParallelBuilding = true;
 
   meta = {

--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" "man" "doc" ];
 
-  doCheck = true;
+  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
 
   # In stdenv-linux, prevent a dependency on bootstrap-tools.
   preConfigure = "CONFIG_SHELL=/bin/sh";

--- a/pkgs/tools/misc/getopt/default.nix
+++ b/pkgs/tools/misc/getopt/default.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation {
     sha256 = "1arvjfzw6p310zbgv629w5hkyslrj44imf3r3s2r4ry2jfcks221";
   };
   preBuild = ''
-    export buildFlags=CC="$CC" # for darwin
+    # for darwin
+    export buildFlags="CC=${stdenv.cc.targetPrefix}cc"
   '';
 
   meta = {

--- a/pkgs/tools/misc/parted/default.nix
+++ b/pkgs/tools/misc/parted/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   # Tests were previously failing due to Hydra running builds as uid 0.
   # That should hopefully be fixed now.
-  doCheck = true;
+  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
 
   preCheck =
     stdenv.lib.optionalString doCheck

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, perl
+{ stdenv, lib, fetchurl, pkgconfig, perl
 , http2Support ? true, nghttp2
 , idnSupport ? false, libidn ? null
 , ldapSupport ? false, openldap ? null
@@ -93,6 +93,16 @@ stdenv.mkDerivation rec {
         ( if gnutlsSupport then "--with-gnutls=${gnutls.crossDrv}" else "--without-gnutls" )
         "--with-random /dev/urandom"
       ];
+
+    # Hack: when cross-compiling we need to manually add rpaths to ensure that
+    # the linker can find find zlib and openssl when linking the libcurl shared
+    # object.
+    NIX_LDFLAGS = ''
+      -rpath-link ${lib.getLib openssl}/lib
+      -rpath-link ${lib.getLib libssh2}/lib
+      -rpath-link ${lib.getLib nghttp2}/lib
+    '';
+    makeFlags = "V=1";
   };
 
   passthru = {

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -73,8 +73,8 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional c-aresSupport "--enable-ares=${c-ares}"
     ++ stdenv.lib.optional gssSupport "--with-gssapi=${kerberos.dev}";
 
-  CXX = "c++";
-  CXXCPP = "c++ -E";
+  CXX = "${stdenv.cc.targetPrefix}c++";
+  CXXCPP = "${stdenv.cc.targetPrefix}c++ -E";
 
   postInstall = ''
     moveToOutput bin/curl-config "$dev"

--- a/pkgs/tools/networking/dnsperf/default.nix
+++ b/pkgs/tools/networking/dnsperf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, bind, libseccomp, zlib }:
+{ stdenv, fetchurl, bind, libseccomp, zlib, openssl }:
 
 stdenv.mkDerivation rec {
   name = "dnsperf-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "man" "doc" ];
 
-  buildInputs = [ bind libseccomp zlib ];
+  buildInputs = [ bind libseccomp zlib openssl ];
 
   postInstall = ''
     mkdir -p "$out/share/doc/"

--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -2,7 +2,7 @@
 , pkgconfig, autoreconfHook
 , gmp, python, iptables, ldns, unbound, openssl, pcsclite
 , openresolv
-, systemd, pam
+, systemd, pam, bash
 
 , enableTNC            ? false, curl, trousers, sqlite, libxml2
 , enableNetworkManager ? false, networkmanager
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   };
 
   dontPatchELF = true;
+  enableParallelBuilding = true;
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs =
@@ -45,6 +46,8 @@ stdenv.mkDerivation rec {
     substituteInPlace src/swanctl/swanctl.h --replace "SWANCTLDIR" "\"/etc/swanctl\""
     # glibc-2.26 reorganized internal includes
     sed '1i#include <stdint.h>' -i src/libstrongswan/utils/utils/memory.h
+    # The ipsec utility needs to use shell for the target
+    substituteInPlace src/ipsec/_ipsec.in --replace "@IPSEC_SHELL@" ${bash}/bin/bash
     '';
 
   preConfigure = ''

--- a/pkgs/tools/package-management/apt/default.nix
+++ b/pkgs/tools/package-management/apt/default.nix
@@ -24,18 +24,23 @@ stdenv.mkDerivation rec {
     sha256 = "0ahwhmscrmnpvl1r732wg93dzkhv8c1sph2yrqgsrhr73c1616ix";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [
+    pkgconfig
+  ] ++ lib.optionals withDocs [
+    doxygen Po4a w3m docbook_xml_dtd_45
+  ];
 
   buildInputs = [
     cmake perl curl gtest lzma bzip2 lz4 db dpkg libxslt.bin
-  ] ++ lib.optionals withDocs [
-    doxygen Po4a w3m docbook_xml_dtd_45
   ] ++ lib.optionals withNLS [
     gettext
   ];
 
   preConfigure = ''
     export PERL5LIB="$PERL5LIB''${PERL5LIB:+:}${Po4a}/lib/perl5";
+
+    # w3m will want to write to ~/.w3m
+    export HOME=$TMPDIR
 
     cmakeFlagsArray+=(
       -DBERKELEY_DB_INCLUDE_DIRS="${db}"/include

--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -1,7 +1,7 @@
 { stdenv, buildGoPackage, fetchFromGitHub, git, gnupg, makeWrapper }:
 
 buildGoPackage rec {
-  version = "1.6.7";
+  version = "1.6.11";
   name = "gopass-${version}";
 
   goPackagePath = "github.com/justwatchcom/gopass";
@@ -12,7 +12,7 @@ buildGoPackage rec {
     owner = "justwatchcom";
     repo = "gopass";
     rev = "v${version}";
-    sha256 = "0al2avdvmnnz7h21hnvlacr20k50my5l67plgf4cphy52p9461vp";
+    sha256 = "12pih414232bsdj1qqc04vck2p9254wjy044n5kbbdqbmfgap7sj";
   };
 
   wrapperPath = with stdenv.lib; makeBinPath ([

--- a/pkgs/tools/security/minisign/default.nix
+++ b/pkgs/tools/security/minisign/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "minisign-${version}";
-  version = "0.7";
+  version = "0.8";
 
   src = fetchFromGitHub {
     repo = "minisign";
     owner = "jedisct1";
     rev = version;
-    sha256 = "15w8fgplkxiw9757qahwmgnl4bwx9mm0rnwp1izs2jcy1wy35vp8";
+    sha256 = "0rgg9jb5108hd5psivlrfd8cxnjylawm0glcry8ba6zlmkv949r8";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/tools/security/rhash/default.nix
+++ b/pkgs/tools/security/rhash/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   # configure script is not autotools-based, doesn't support these options
   configurePlatforms = [ ];
 
+  makeFlags = "CC=${stdenv.cc.targetPrefix}cc AR=${stdenv.cc.bintools.targetPrefix}";
   installTargets = [ "install" "install-lib-shared" "install-lib-so-link" ];
   postInstall = "make -C librhash install-headers";
 

--- a/pkgs/tools/security/rng-tools/default.nix
+++ b/pkgs/tools/security/rng-tools/default.nix
@@ -9,6 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "13h7lc8wl9khhvkr0i3bl5j9bapf8anhqis1lcnwxg1vc2v058b0";
   };
 
+  # For cross-compilation
+  configureFlags = [ "AR=${stdenv.cc.bintools.targetPrefix}ar" ];
+  postPatch = ''
+    substituteInPlace Makefile.in --replace "AR = ar" ""
+  '';
+
   meta = {
     description = "A random number generator daemon";
 

--- a/pkgs/tools/system/runit/default.nix
+++ b/pkgs/tools/system/runit/default.nix
@@ -13,11 +13,15 @@ stdenv.mkDerivation rec {
     sha256 = "065s8w62r6chjjs6m9hapcagy33m75nlnxb69vg0f4ngn061dl3g";
   };
 
+  patches = [
+    ./fix-ar-ranlib.patch
+  ];
+
   outputs = [ "out" "man" ];
 
   sourceRoot = "admin/${name}";
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
 
   buildInputs = stdenv.lib.optionals static [ stdenv.cc.libc stdenv.cc.libc.static ];
 
@@ -34,8 +38,10 @@ stdenv.mkDerivation rec {
     cd src
 
     # Both of these are originally hard-coded to gcc
-    echo cc > conf-cc
-    echo cc > conf-ld
+    echo ${stdenv.cc.targetPrefix}cc > conf-cc
+    echo ${stdenv.cc.targetPrefix}cc > conf-ld
+    export AR=${stdenv.cc.targetPrefix}ar
+    export RANLIB=${stdenv.cc.targetPrefix}ranlib
   '';
 
   installPhase = ''

--- a/pkgs/tools/system/runit/fix-ar-ranlib.patch
+++ b/pkgs/tools/system/runit/fix-ar-ranlib.patch
@@ -1,0 +1,18 @@
+--- runit-2.1.2/src/print-ar.sh
++++ runit-2.1.2/src/print-ar.sh
+@@ -1,7 +1,7 @@
+ cat warn-auto.sh
+ echo 'main="$1"; shift'
+ echo 'rm -f "$main"'
+-echo 'ar cr "$main" ${1+"$@"}'
++echo '$AR cr "$main" ${1+"$@"}'
+ case "`cat systype`" in
+   sunos-5.*) ;;
+   unix_sv*) ;;
+@@ -10,5 +10,5 @@ case "`cat systype`" in
+   dgux-*) ;;
+   hp-ux-*) ;;
+   sco*) ;;
+-  *) echo 'ranlib "$main"' ;;
++  *) echo '$RANLIB "$main"' ;;
+ esac

--- a/pkgs/tools/text/sgml/opensp/default.nix
+++ b/pkgs/tools/text/sgml/opensp/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
   preConfigure = if stdenv.isCygwin then "autoreconf -fi" else null;
 
   # need autoconf, automake, gettext, and libtool for reconfigure
-  buildInputs = stdenv.lib.optionals stdenv.isCygwin [ autoconf automake gettext libiconv libtool ]
+  nativeBuildInputs = stdenv.lib.optionals stdenv.isCygwin [ autoconf automake gettext libiconv libtool ]
     ++ [ xmlto docbook_xml_dtd_412 libxslt docbook_xsl ];
 
   meta = {

--- a/pkgs/tools/typesetting/xmlto/default.nix
+++ b/pkgs/tools/typesetting/xmlto/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   # `libxml2' provides `xmllint', needed at build-time and run-time.
   # `libxslt' provides `xsltproc', used by `xmlto' at run-time.
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper getopt ];
   buildInputs = [ libxml2 libxslt docbook_xml_dtd_45 docbook_xsl getopt ];
 
   postInstall = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13772,6 +13772,7 @@ with pkgs;
     ubootRaspberryPi3_64bit
     ubootUtilite
     ubootWandboard
+    ubootMicrozed
     ;
 
   # Non-upstream U-Boots:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8234,7 +8234,8 @@ with pkgs;
 
   accountsservice = callPackage ../development/libraries/accountsservice { };
 
-  acl = callPackage ../development/libraries/acl { };
+  # There is a circular dependency between acl and gettext
+  acl = callPackage ../development/libraries/acl { gettext = gettext-boot; };
 
   activemq = callPackage ../development/libraries/apache-activemq { };
 
@@ -8787,6 +8788,9 @@ with pkgs;
   getdns = callPackage ../development/libraries/getdns { };
 
   gettext = callPackage ../development/libraries/gettext { };
+
+  # There is a circular dependency between acl and gettext
+  gettext-boot = callPackage ../development/libraries/gettext { acl = null; };
 
   gflags = callPackage ../development/libraries/gflags { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7386,6 +7386,7 @@ with pkgs;
   binutils-unwrapped = callPackage ../development/tools/misc/binutils {
     # FHS sys dirs presumably only have stuff for the build platform
     noSysDirs = (targetPlatform != buildPlatform) || noSysDirs;
+    defaultLd = config.defaultLd or null;
   };
   binutils-raw = wrapBintoolsWith {
     libc = if targetPlatform != hostPlatform then libcCross else stdenv.cc.libc;
@@ -7404,6 +7405,7 @@ with pkgs;
   binutils_nogold = lowPrio (binutils-raw.override {
     bintools = binutils-raw.bintools.override {
       gold = false;
+      defaultLd = "bfd";
     };
   });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6991,7 +6991,8 @@ with pkgs;
   inherit (
     if stdenv.buildPlatform == stdenv.hostPlatform
     then (callPackages ../development/interpreters/perl {})
-    else (callPackages ../development/interpreters/perl-cross {})
+    else (callPackages ../development/interpreters/perl-cross { stdenv = overrideCC stdenv gcc6; })
+         # perl-cross segfaults when built with gcc7
   ) perl perl522 perl524 perl526;
 
   pachyderm = callPackage ../applications/networking/cluster/pachyderm { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6988,7 +6988,11 @@ with pkgs;
 
   octopus = callPackage ../applications/science/chemistry/octopus { openblas=openblasCompat; };
 
-  inherit (callPackages ../development/interpreters/perl {}) perl perl522 perl524 perl526;
+  inherit (
+    if stdenv.buildPlatform == stdenv.hostPlatform
+    then (callPackages ../development/interpreters/perl {})
+    else (callPackages ../development/interpreters/perl-cross {})
+  ) perl perl522 perl524 perl526;
 
   pachyderm = callPackage ../applications/networking/cluster/pachyderm { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9202,6 +9202,8 @@ in {
 
   kitchen = callPackage ../development/python-modules/kitchen/default.nix { };
 
+  kubernetes = callPackage ../development/python-modules/kubernetes/default.nix { };
+
   pylast = callPackage ../development/python-modules/pylast/default.nix { };
 
   pylru = callPackage ../development/python-modules/pylru/default.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18590,22 +18590,7 @@ EOF
   };
 
 
-  websocket_client = buildPythonPackage rec {
-    name = "websocket_client-0.40.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/w/websocket-client/${name}.tar.gz";
-      sha256 = "1yz67wdjijrvwpx0a0f6wdfy8ajsvr9xbj5514ld452fqnh19b20";
-    };
-
-    propagatedBuildInputs = with self; [ six backports_ssl_match_hostname unittest2 argparse ];
-
-    meta = {
-      homepage = https://github.com/liris/websocket-client;
-      description = "Websocket client for python";
-      license = licenses.lgpl2;
-    };
-  };
+  websocket_client = callPackage ../development/python-modules/websockets_client { };
 
 
   webhelpers = buildPythonPackage rec {


### PR DESCRIPTION

*Note:* The prefix of commits authored by @Ericson2314 can be ignored for the purposes of this pull request. These are prerequisites for this work but I'll leave upstreaming these to @Ericson2314.


###### Motivation for this change
Allow Nix to cross-compile a basic system environment.

###### Things done
The only testing I have done thusfar is to build `systemd` and its dependencies with the following overlay:
```nix
self: super:                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                             
let                                                                                                                                                                                                                                                                                                                          
  pkgs = self.pkgs;                                                                                                                                                                                                                                                                                                          
  callPackage = self.pkgs.callPackage;                                                                                                                                                                                                                                                                                       
in rec {                                                                                                                                                                                                                                                                                                                     
  # guile 2.2 doesn't cross compile. See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=28920                                                                                                                                                                                                                                 
  guile = super.guile_2_0;                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                             
  # We really don't need libapparmor and it is a pain to cross compile due to                                                                                                                                                                                                                                                
  # its perl bindings                                                                                                                                                                                                                                                                                                        
  systemd = super.systemd.override { libapparmor = null; };                                                                                                                                                                                                                                                                  
}                                                                                                 
```
That being said, this was no small feat. I would like to start getting pieces of this work upstream but I'm a bit uncertain as to how to go about this as there are a few open questions. Namely,

 1. Are we okay with continuing to pepper expressions with `doCheck = stdenv.buildPlatform == stdenv.hostPlatform`?
 2. Why have I needed to add so many `buildPackages.` to `nativeBuildInputs`? Shouldn't this be redundant? Is there perhaps a bug, @Ericson2314?
 3. How do we guarantee that things like `fetchurl` always use build packages? Is the approach I took here acceptable? It seems something similar will need to be done with `unpackCmd`.
 4. Is the `Always search DT_RPATH` hack acceptable?
 5. Some packages' `configure` scripts have tests that want to run host programs on the build machine. This obviously isn't possible so I provide these test results manually (see, for instance, the `krb5` expression). These are of course guesses, but I believe they should apply in most sensible environments. Is this acceptable?

Whatever reviews you can offer are greatly appreciated but I really just wanted to raise a flag so people know this work exists.


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

