### PR TITLE
e17gtk: 3.22.1 -> 3.22.2

### DIFF
--- a/pkgs/misc/themes/e17gtk/default.nix
+++ b/pkgs/misc/themes/e17gtk/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "e17gtk-${version}";
-  version = "3.22.1";
+  version = "3.22.2";
 
   src = fetchFromGitHub {
     owner = "tsujan";
     repo = "E17gtk";
     rev = "V${version}";
-    sha256 = "0y1v5hamssgzgcmwbr60iz7wipb9yzzj3ypzkc6i65mp4pyazrv8";
+    sha256 = "1qwj1hmdlk8sdqhkrh60p2xg4av1rl0lmipdg5j0i40318pmiml1";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Update to version [3.22.2](https://github.com/tsujan/E17gtk/releases/tag/V3.22.2)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).