### PR TITLE
xorg.xf86inputlibinput: Split dev output

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -321,8 +321,9 @@ in
       url = "mirror://xorg/individual/driver/${name}.tar.bz2";
       sha256 = "0yrqs88b7yn9nljwlxzn76jfmvf0sh939kzij5b2jvr2qa7mbjmb";
     };
+    outputs = [ "out" "dev" ];
     buildInputs = attrs.buildInputs ++ [ args.libinput ];
-    installFlags = "sdkdir=\${out}/include/xorg";
+    installFlags = "sdkdir=\${dev}/include/xorg";
   };
 
   xf86inputsynaptics = attrs: attrs // {


### PR DESCRIPTION
Closure goes from 160M -> 42M

It builds but I haven't had time to try restarting the X server with this change yet.