### PR TITLE
display-managers: make lightdm the default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -521,6 +521,13 @@ inherit (pkgs.nixos {
       all user units for each authenticated user.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      The default display manager is now LightDM.
+      To use SLiM set <literal>services.xserver.displayManager.slim.enable</literal>
+      to <literal>true</literal>.
+    </para>
+  </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -132,6 +132,7 @@ in {
 
     fonts.fonts = [ pkgs.dejavu_fonts pkgs.cantarell-fonts ];
 
+    services.xserver.displayManager.gdm.enable = mkDefault true;
     services.xserver.displayManager.extraSessionFilePackages = [ pkgs.gnome3.gnome-session ];
 
     services.xserver.displayManager.sessionCommands = ''
@@ -160,6 +161,8 @@ in {
     # Let nautilus find extensions
     # TODO: Create nautilus-with-extensions package
     environment.variables.NAUTILUS_EXTENSION_DIR = "${config.system.path}/lib/nautilus/extensions-3.0";
+
+    services.xserver.updateDbusEnvironment = true;
 
     environment.variables.GIO_EXTRA_MODULES = [ "${lib.getLib pkgs.gnome3.dconf}/lib/gio/modules"
                                                 "${pkgs.gnome3.glib-networking.out}/lib/gio/modules"

--- a/nixos/modules/services/x11/display-managers/auto.nix
+++ b/nixos/modules/services/x11/display-managers/auto.nix
@@ -41,10 +41,12 @@ in
 
   config = mkIf cfg.enable {
 
-    services.xserver.displayManager.slim = {
+    services.xserver.displayManager.lightdm = {
       enable = true;
-      autoLogin = true;
-      defaultUser = cfg.user;
+      autoLogin = {
+        enable = true;
+        user = cfg.user;
+      };
     };
 
   };

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -87,7 +87,7 @@ in
       }
     ];
 
-    services.xserver.displayManager.slim.enable = false;
+    services.xserver.displayManager.lightdm.enable = false;
 
     users.users.gdm =
       { name = "gdm";

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -191,8 +191,6 @@ in
       }
     ];
 
-    services.xserver.displayManager.slim.enable = false;
-
     services.xserver.displayManager.job = {
       logToFile = true;
 

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -206,8 +206,6 @@ in
       }
     ];
 
-    services.xserver.displayManager.slim.enable = false;
-
     services.xserver.displayManager.job = {
       logToFile = true;
 

--- a/nixos/modules/services/x11/display-managers/slim.nix
+++ b/nixos/modules/services/x11/display-managers/slim.nix
@@ -49,7 +49,7 @@ in
 
       enable = mkOption {
         type = types.bool;
-        default = config.services.xserver.enable;
+        default = false;
         description = ''
           Whether to enable SLiM as the display manager.
         '';

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -535,6 +535,15 @@ in
 
   config = mkIf cfg.enable {
 
+    services.xserver.displayManager.lightdm.enable =
+      let dmconf = cfg.displayManager;
+          default = !( dmconf.auto.enable
+                    || dmconf.gdm.enable
+                    || dmconf.sddm.enable
+                    || dmconf.slim.enable
+                    || dmconf.xpra.enable );
+      in mkIf (default) true;
+
     hardware.opengl.enable = mkDefault true;
 
     services.xserver.videoDrivers = mkIf (cfg.videoDriver != null) [ cfg.videoDriver ];

--- a/nixos/tests/gnome3-gdm.nix
+++ b/nixos/tests/gnome3-gdm.nix
@@ -11,7 +11,6 @@ import ./make-test.nix ({ pkgs, ...} : {
 
       services.xserver.enable = true;
 
-      services.xserver.displayManager.slim.enable = false;
       services.xserver.displayManager.gdm = {
         enable = true;
         autoLogin = {

--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -11,6 +11,7 @@ import ./make-test.nix ({ pkgs, ...} : {
 
       services.xserver.enable = true;
 
+      services.xserver.displayManager.gdm.enable = false;
       services.xserver.displayManager.lightdm.enable = true;
       services.xserver.displayManager.lightdm.autoLogin.enable = true;
       services.xserver.displayManager.lightdm.autoLogin.user = "alice";


### PR DESCRIPTION
###### Motivation for this change

SLiM is unmaintained since 2014-06-09 and lightdm seems be the most reasonable alternative.

