### PR TITLE
ahoviewer: 1.4.8 -> 1.4.9

### DIFF
--- a/pkgs/applications/graphics/ahoviewer/default.nix
+++ b/pkgs/applications/graphics/ahoviewer/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "ahoviewer-${version}";
-  version = "1.4.8";
+  version = "1.4.9";
 
   src = fetchFromGitHub {
     owner = "ahodesuka";
     repo = "ahoviewer";
     rev = version;
-    sha256 = "0fsak22hpi2r8zqysswdyngaf3n635qvclqh1p0g0wrkfza4dbc4";
+    sha256 = "194h3k5zvd8gjrbs91qba7d9h7i30yh4rjk4w3aa1vwvv0qm2amx";
   };
 
   enableParallelBuilding = true; 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/ahodesuka/ahoviewer;
     description = "A GTK2 image viewer, manga reader, and booru browser";
-    maintainers = [ maintainers.skrzyp ];
+    maintainers = with maintainers; [ skrzyp xzfc ];
     license = licenses.mit;
     platforms = platforms.allBut [ "darwin" "cygwin" ];
   };


### PR DESCRIPTION
###### Motivation for this change

New upstream version.
Also, add myself to maintainers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

