### PR TITLE
nat-traverse: init at 0.7

### DIFF
--- a/pkgs/tools/networking/nat-traverse/default.nix
+++ b/pkgs/tools/networking/nat-traverse/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, makeWrapper }:
+{ stdenv, fetchurl, perl }:
 
 stdenv.mkDerivation rec {
   name = "nat-traverse-${version}";
@@ -9,13 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "0knwnqsjwv7sa5wjb863ghabs7s269a73qwkmxpsbngjw9s0j2ih";
   };
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ perl ];
 
   installPhase = ''
     mkdir -p $out/bin $out/share/man/man1
     cp nat-traverse $out/bin
     gzip -c nat-traverse.1 > $out/share/man/man1/nat-traverse.1.gz
-    wrapProgram $out/bin/nat-traverse --prefix PATH : "${stdenv.lib.makeBinPath [ perl ]}"
   '';
 
   meta = with stdenv.lib; {
@@ -31,8 +30,8 @@ stdenv.mkDerivation rec {
       nat-traverse works out-of-the-box.
     '';
     homepage = https://www.speicherleck.de/iblech/nat-traverse/;
-    license = stdenv.lib.licenses.gpl3Plus;
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
     maintainers = [ maintainers.iblech ];
   };
 }

--- a/pkgs/tools/networking/nat-traverse/default.nix
+++ b/pkgs/tools/networking/nat-traverse/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, perl, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "nat-traverse-${version}";
+  version = "0.7";
+
+  src = fetchurl {
+    url = "https://www.speicherleck.de/iblech/nat-traverse/nat-traverse-${version}.tar.bz2";
+    sha256 = "0knwnqsjwv7sa5wjb863ghabs7s269a73qwkmxpsbngjw9s0j2ih";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/man/man1
+    cp nat-traverse $out/bin
+    gzip -c nat-traverse.1 > $out/share/man/man1/nat-traverse.1.gz
+    wrapProgram $out/bin/nat-traverse --prefix PATH : "${stdenv.lib.makeBinPath [ perl ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "NAT gateway traversal utility";
+    longDescription = ''
+      nat-traverse establishes direct connections between nodes which are
+      behind NAT gateways, i.e. hosts which do not have public IP addresses.
+      This is done using an UDP NAT traversal technique. Additionally, it's
+      possible to setup a small VPN by using pppd on top of nat-traverse.
+
+      nat-traverse does not need an external server on the Internet, and it
+      isn't necessary to reconfigure the involved NAT gateways, either.
+      nat-traverse works out-of-the-box.
+    '';
+    homepage = https://www.speicherleck.de/iblech/nat-traverse/;
+    license = stdenv.lib.licenses.gpl3Plus;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = [ maintainers.iblech ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3458,6 +3458,8 @@ with pkgs;
 
   nasty = callPackage ../tools/security/nasty { };
 
+  nat-traverse = callPackage ../tools/networking/nat-traverse { };
+
   nawk = callPackage ../tools/text/nawk { };
 
   nbd = callPackage ../tools/networking/nbd { };


### PR DESCRIPTION
###### Motivation for this change

nat-traverse establishes direct connections between nodes behind NAT gateways using an UDP NAT traversal technique. We don't yet have a package for this small tool of mine. Debian and other distributions have.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

