### PR TITLE
ecdsautils: init 0.4.0

### DIFF
--- a/pkgs/tools/security/ecdsautils/default.nix
+++ b/pkgs/tools/security/ecdsautils/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, pkgs }:
+
+stdenv.mkDerivation rec {
+  version = "0.4.0";
+  name = "ecdsautils-${version}";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "tcatm";
+    repo = "ecdsautils";
+    rev = "07538893fb6c2a9539678c45f9dbbf1e4f222b46";
+    sha256 = "18sr8x3qiw8s9l5pfi7r9i3ayplz4jqdml75ga9y933vj7vs0k4d";
+  };
+
+  nativeBuildInputs = with pkgs; [ cmake pkgconfig doxygen ];
+  buildInputs = with pkgs; [ libuecc  ];
+
+  meta = with stdenv.lib; {
+    description = "Tiny collection of programs used for ECDSA (keygen, sign, verify)";
+    homepage = https://github.com/tcatm/ecdsautils/;
+    license = with licenses; [ mit bsd2 ];
+    maintainers = with maintainers; [ andir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -574,6 +574,8 @@ with pkgs;
 
   dkimpy = pythonPackages.dkimpy;
 
+  ecdsautils = callPackage ../tools/security/ecdsautils { };
+
   elvish = callPackage ../shells/elvish { };
 
   encryptr = callPackage ../tools/security/encryptr {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

