### PR TITLE
install documentation: document boot.loader.grub.useOSProber

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -140,6 +140,11 @@
     the GRUB boot loader is to be installed.  Without it, NixOS cannot
     boot.</para>
 
+    <para>If there are other operating systems running on the machine before
+    installing NixOS, the
+    <option>boot.loader.grub.useOSProber</option> option can be set to
+    <literal>true</literal> to automatically add them to the grub menu.</para>
+
     <para>Another critical option is <option>fileSystems</option>,
     specifying the file systems that need to be mounted by NixOS.
     However, you typically don’t need to set it yourself, because


### PR DESCRIPTION
###### Motivation for this change
addresses #30876

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

