### PR TITLE
python-cffi: fix clang build

### DIFF
--- a/pkgs/development/python-modules/cffi/clang.patch
+++ b/pkgs/development/python-modules/cffi/clang.patch
@@ -1,0 +1,13 @@
+diff --git a/testing/cffi1/test_recompiler.py b/testing/cffi1/test_recompiler.py
+index a3277b0..0d6e2c3 100644
+--- a/testing/cffi1/test_recompiler.py
++++ b/testing/cffi1/test_recompiler.py
+@@ -2270,7 +2270,7 @@ def test_char16_char32_type(no_cpp=False):
+         char32_t foo_4bytes(char32_t);
+     """)
+     lib = verify(ffi, "test_char16_char32_type" + no_cpp * "_nocpp", """
+-    #if !defined(__cplusplus) || __cplusplus < 201103L
++    #if !defined(__cplusplus)
+     typedef uint_least16_t char16_t;
+     typedef uint_least32_t char32_t;
+     #endif

--- a/pkgs/development/python-modules/cffi/default.nix
+++ b/pkgs/development/python-modules/cffi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, isPyPy, fetchPypi, libffi, pycparser, pytest }:
+{ stdenv, buildPythonPackage, isPy27, isPyPy, fetchPypi, libffi, pycparser, pytest }:
 
 if isPyPy then null else buildPythonPackage rec {
   pname = "cffi";
@@ -10,13 +10,15 @@ if isPyPy then null else buildPythonPackage rec {
     sha256 = "ab87dd91c0c4073758d07334c1e5f712ce8fe48f007b86f8238773963ee700a6";
   };
 
+  patches = stdenv.lib.optional isPy27 ./clang.patch;
+
   outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [ libffi pycparser ];
   buildInputs = [ pytest ];
 
   # The tests use -Werror but with python3.6 clang detects some unreachable code.
-  NIX_CFLAGS_COMPILE = stdenv.lib.optional stdenv.cc.isClang "-Wno-unreachable-code";
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionals stdenv.cc.isClang [ "-Wno-unused-command-line-argument" "-Wno-unreachable-code" ];
 
   checkPhase = ''
     py.test


### PR DESCRIPTION
###### Motivation for this change

cffi broke on darwin with the last update.


@FRidh any idea why the patch is necessary for 2.7?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
