### PR TITLE
chez: 9.4 -> 9.5

### DIFF
--- a/pkgs/development/compilers/chez/default.nix
+++ b/pkgs/development/compilers/chez/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name    = "chez-scheme-${version}";
-  version = "9.4-${dver}";
-  dver    = "20160507";
+  version = "9.5-${dver}";
+  dver    = "20171012";
 
   src = fetchgit {
     url    = "https://github.com/cisco/chezscheme.git";
-    rev    = "65df1d1f7c37f5b5a93cd7e5b475dda9dbafe03c";
-    sha256 = "1b273il3njnn04z55w1hnygvcqllc6p5qg9mcwh10w39fwsd8fbs";
+    rev    = "adb3b7bb22ddaa1ba91b98b6f4a647427c3a4d9b";
+    sha256 = "0hiynf7g0q77ipqxjsqdm2zb0m15bl1hhp615fn3i2hv0qz5a4xr";
     fetchSubmodules = true;
   };
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   */
   patchPhase = ''
     substituteInPlace ./configure \
-      --replace "git submodule init && git submodule update || exit 1" ""
+      --replace "git submodule init && git submodule update || exit 1" "true"
 
     substituteInPlace ./workarea \
       --replace "/bin/ln" "${coreutils}/bin/ln" \


### PR DESCRIPTION
###### Motivation for this change

Package update to [9.5](https://github.com/cisco/ChezScheme/releases/tag/v9.5)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

