### PR TITLE
Python: remove $out/bin/__pycache__ in fixup phase

### DIFF
--- a/pkgs/development/interpreters/python/build-python-package-common.nix
+++ b/pkgs/development/interpreters/python/build-python-package-common.nix
@@ -29,4 +29,8 @@ attrs // {
 
     runHook postInstall
   '';
+
+  fixupPhase = attrs.fixupPhase or ''
+    rm -rf $out/bin/__pycache__
+  '';
 }


### PR DESCRIPTION
###### Motivation for this change

This fixes #29896.

###### Things done

- [x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested by creating a minimal `configuration.nix` which, when built, produced `result/sw/bin/__pycache__`.

Then rebased this diff on top of it and rebuilt, and `__pycache__` was gone.

I'm slightly concerned about testing here. This seems like a safe diff, but it potentially effects every python package. Also, this will likely lead to everything under the sun getting rebuilt, so it's hard to test fully.