### PR TITLE
tbb: clang support

### DIFF
--- a/pkgs/development/libraries/tbb/default.nix
+++ b/pkgs/development/libraries/tbb/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, compiler ? if stdenv.cc.isClang then "clang" else null, stdver ? null }:
 
-stdenv.mkDerivation rec {
+with stdenv.lib; stdenv.mkDerivation rec {
   name = "tbb-${version}";
   version = "2018_U1";
 
@@ -10,6 +10,11 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "1lygz07va6hsv2vlx9zwz5d2n81rxsdhmh0pqxgj8n1bvb1rp0qw";
   };
+
+  makeFlags = concatStringsSep " " (
+    optional (compiler != null) "compiler=${compiler}" ++
+    optional (stdver != null) "stdver=${stdver}"
+  );
 
   installPhase = ''
     mkdir -p $out/{lib,share/doc}
@@ -21,7 +26,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "Intel Thread Building Blocks C++ Library";
     homepage = "http://threadingbuildingblocks.org/";
     license = licenses.asl20;


### PR DESCRIPTION
Added compiler and stdver parameters, to support non-gcc compilers, and enable
perfect exception forwarding (std::exception_ptr) on platforms where C++11 is not enabled by default

###### Motivation for this change
Add support for compiling tbb with clang. Support building tbb with std::exception_ptr enabled on platforms that don't support it by default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

