### PR TITLE
Update bpython to 0.17

### DIFF
--- a/pkgs/development/python-modules/bpython/default.nix
+++ b/pkgs/development/python-modules/bpython/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchurl, pygments, greenlet, curtsies, urwid, requests, mock }:
+
+buildPythonPackage rec {
+  pname = "bpython";
+  version = "0.17";
+  name  = "${pname}-${version}";
+
+  # 0.17 is still missing on PyPI, https://github.com/bpython/bpython/issues/706
+  src = fetchurl {
+    url = "https://bpython-interpreter.org/releases/${pname}-${version}.tar.gz";
+    sha256 = "13fyyx06645ikvmj9zmkixr12kzk1c3a3f9s9i2rvaczjycn82lz";
+  };
+
+  propagatedBuildInputs = [ curtsies greenlet pygments requests urwid ];
+
+  checkInputs = [ mock ];
+
+  # tests fail: https://github.com/bpython/bpython/issues/712
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A fancy curses interface to the Python interactive interpreter";
+    homepage = "https://bpython-interpreter.org/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ flokli ];
+  };
+}

--- a/pkgs/development/python-modules/curtsies/default.nix
+++ b/pkgs/development/python-modules/curtsies/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchPypi, blessings, mock, nose, pyte, pytest, wcwidth }:
+
+buildPythonPackage rec {
+  pname = "curtsies";
+  version = "0.2.11";
+  name  = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1vljmw3sy6lrqahhpyg4gk13mzcx3mwhvg8s41698ms3cpgkjipc";
+  };
+
+  propagatedBuildInputs = [ blessings wcwidth pyte ];
+
+  checkInputs = [ nose mock pytest ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Curses-like terminal wrapper, with colored strings!";
+    homepage = https://pypi.python.org/pypi/curtsies;
+    license = licenses.mit;
+    maintainers = with maintainers; [ flokli ];
+  };
+}

--- a/pkgs/development/python-modules/pyte/default.nix
+++ b/pkgs/development/python-modules/pyte/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest, pytestrunner, wcwidth }:
+
+buildPythonPackage rec {
+  pname = "pyte";
+  version = "0.7.0";
+  name  = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1an54hvyjm8gncx8cgabz9mkpgjkdb0bkyjlkh7g7f94nr3wnfl7";
+  };
+
+  propagatedBuildInputs = [ wcwidth ];
+
+  checkInputs = [ pytest pytestrunner ];
+
+  # tries to write to os.path.dirname(__file__) in test_input_output
+  checkPhase = ''
+    py.test -k "not test_input_output"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple VTXXX-compatible linux terminal emulator";
+    homepage = https://github.com/selectel/pyte;
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ flokli ];
+  };
+}

--- a/pkgs/development/python-modules/urwid/default.nix
+++ b/pkgs/development/python-modules/urwid/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage (rec {
+  pname = "urwid";
+  version = "1.3.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "18cnd1wdjcas08x5qwa5ayw6jsfcn33w4d9f7q3s29fy6qzc1kng";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A full-featured console (xterm et al.) user interface library";
+    homepage = http://excess.org/urwid;
+    repositories.git = git://github.com/wardi/urwid.git;
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ garbas ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3367,6 +3367,8 @@ in {
     doCheck = false;
   };
 
+  curtsies = callPackage ../development/python-modules/curtsies { };
+
   oslo-vmware = buildPythonPackage rec {
     name = "oslo.vmware-${version}";
     version = "1.22.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2078,23 +2078,7 @@ in {
     };
   };
 
-
-  bpython = buildPythonPackage rec {
-     name = "bpython-0.12";
-     src = pkgs.fetchurl {
-       url = "http://www.bpython-interpreter.org/releases/bpython-0.12.tar.gz";
-       sha256 = "1ilf58qq7sazmcgg4f1wswbhcn2gb8qbbrpgm6gf0j2lbm60gabl";
-     };
-
-     propagatedBuildInputs = with self; [ pygments ];
-     doCheck = false;
-
-     meta = {
-       description = "UNKNOWN";
-       homepage = "UNKNOWN";
-       maintainers = with maintainers; [ domenkozar ];
-     };
-   };
+  bpython = callPackage ../development/python-modules/bpython {};
 
   bsddb3 = buildPythonPackage rec {
     name = "bsddb3-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12493,6 +12493,8 @@ in {
     };
   };
 
+  pyte = callPackage ../development/python-modules/pyte { };
+
   graphviz = buildPythonPackage rec {
     name = "graphviz-${version}";
     version = "0.5.2";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21977,25 +21977,7 @@ in {
 
   urlgrabber = callPackage ../development/python-modules/urlgrabber {};
 
-  urwid = buildPythonPackage (rec {
-    name = "urwid-1.3.1";
-
-    # multiple:  NameError: name 'evl' is not defined
-    doCheck = false;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/u/urwid/${name}.tar.gz";
-      sha256 = "18cnd1wdjcas08x5qwa5ayw6jsfcn33w4d9f7q3s29fy6qzc1kng";
-    };
-
-    meta = {
-      description = "A full-featured console (xterm et al.) user interface library";
-      homepage = http://excess.org/urwid;
-      repositories.git = git://github.com/wardi/urwid.git;
-      license = licenses.lgpl21;
-      maintainers = with maintainers; [ garbas ];
-    };
-  });
+  urwid = callPackage ../development/python-modules/urwid {};
 
   urwidtrees = buildPythonPackage rec {
     name = "urwidtrees-${rev}";


### PR DESCRIPTION
###### Motivation for this change
As mentioned by @adisbladis, `pythonPackages` is a mess and needs to be cleaned up.

I bumped the `bpython` package to 0.17, cleaned it up, and added `curtsies` and `pyte`, which are both dependencies of `bpython` (at least now)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

