### PR TITLE
ZODB: fix broken tests in 5.3.0

### DIFF
--- a/pkgs/development/python-modules/zodb/ZODB-5.3.0-fix-tests.patch
+++ b/pkgs/development/python-modules/zodb/ZODB-5.3.0-fix-tests.patch
@@ -1,0 +1,29 @@
+Tests are kind of broken in ZODB-5.3.0. Fix setup code and disable one
+especially problematic test.
+
+diff -u ZODB-5.3.0/setup.py ZODB-5.3.0/setup.py
+--- ZODB-5.3.0/setup.py	2017-08-30 14:55:10.000000000 +0200
++++ ZODB-5.3.0/setup.py	2017-10-29 11:34:17.277953730 +0100
+@@ -85,7 +85,10 @@
+                     mod = __import__(
+                         _modname(dirpath, base, os.path.splitext(filename)[0]),
+                         {}, {}, ['*'])
+-                    _unittests_only(suite, mod.test_suite())
++                    try:
++                        _unittests_only(suite, mod.test_suite())
++                    except AttributeError:
++                        pass
+         elif 'tests.py' in filenames:
+             mod = __import__(_modname(dirpath, base, 'tests'), {}, {}, ['*'])
+             _unittests_only(suite, mod.test_suite())
+diff -u ZODB-5.3.0/src/ZODB/scripts/tests/test_repozo.py ZODB-5.3.0/src/ZODB/scripts/tests/test_repozo.py
+--- ZODB-5.3.0/src/ZODB/scripts/tests/test_repozo.py	2017-08-30 14:55:10.000000000 +0200
++++ ZODB-5.3.0/src/ZODB/scripts/tests/test_repozo.py	2017-10-29 11:35:10.348240386 +0100
+@@ -1184,7 +1184,4 @@
+         #unittest.makeSuite(Test_do_backup),  #TODO
+         unittest.makeSuite(Test_do_recover),
+         unittest.makeSuite(Test_do_verify),
+-        # N.B.:  this test take forever to run (~40sec on a fast laptop),
+-        # *and* it is non-deterministic.
+-        unittest.makeSuite(MonteCarloTests),
+     ])

--- a/pkgs/development/python-modules/zodb/default.nix
+++ b/pkgs/development/python-modules/zodb/default.nix
@@ -25,6 +25,10 @@ buildPythonPackage rec {
       sha256 = "633c2f89481d8ebc55639b59216f7d16d07b44a94758850c0b887006967214f3";
     };
 
+    patches = [
+      ./ZODB-5.3.0-fix-tests.patch
+    ];
+
     propagatedBuildInputs = [
       manuel
       transaction


### PR DESCRIPTION
###### Motivation for this change

ZODB does not build on master due to broken tests. Some tests seem to be broken upstream, too. Patch 2 tests away (one known to be unreliable). All other tests succeed.

Fixes #30892

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested dependent package "vulnix"
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

