### PR TITLE
vulnix: 1.2.2 -> 1.3.4

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -116,6 +116,7 @@
   christopherpoole = "Christopher Mark Poole <mail@christopherpoole.net>";
   ciil = "Simon Lackerbauer <simon@lackerbauer.com>";
   ckampka = "Christian Kampka <christian@kampka.net>";
+  ckauhaus = "Christian Kauhaus <christian@kauhaus.de>";
   cko = "Christine Koppelt <christine.koppelt@gmail.com>";
   cleverca22 = "Michael Bishop <cleverca22@gmail.com>";
   cmcdragonkai = "Roger Qiu <roger.qiu@matrix.ai>";

--- a/pkgs/tools/security/vulnix/default.nix
+++ b/pkgs/tools/security/vulnix/default.nix
@@ -3,18 +3,14 @@
 pythonPackages.buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "vulnix";
-  version = "1.2.2";
+  version = "1.3.4";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "1ia9plziwach0bxnlcd33q30kcsf8sv0nf2jc78gsmrqnxjabr12";
+    sha256 = "1js1i86pgkkqc9yzp1rck7rmaz79klv4048r9z7v56fam0a6sg05";
   };
 
   buildInputs = with pythonPackages; [ flake8 pytest pytestcov ];
-
-  postPatch = ''
-    sed -i -e 's/==\([^=]\+\)/>=\1/g' setup.py
-  '';
 
   propagatedBuildInputs = [
     nix
@@ -27,12 +23,16 @@ pythonPackages.buildPythonApplication rec {
     zodb
   ]);
 
+  postPatch = ''
+    sed -i -e 's/==\([^=]\+\)/>=\1/g' setup.py
+  '';
+
   checkPhase = "py.test";
 
   meta = with stdenv.lib; {
     description = "NixOS vulnerability scanner";
     homepage = https://github.com/flyingcircusio/vulnix;
     license = licenses.bsd2;
-    maintainers = with maintainers; [ plumps ];
+    maintainers = with maintainers; [ ckauhaus plumps ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The vulnix build currently present in master is pretty old.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

