### PR TITLE
Math classes 1.0.7

### DIFF
--- a/pkgs/development/coq-modules/bignums/default.nix
+++ b/pkgs/development/coq-modules/bignums/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, coq }:
+
+let rev_and_sha = {
+  "8.6" = {
+    rev = "v8.6.0";
+    sha256 = "0553pcsy21cyhmns6k9qggzb67az8kl31d0lwlnz08bsqswigzrj";
+  };
+  "8.7" = {
+    rev = "V8.7.0";
+    sha256 = "11c4sdmpd3l6jjl4v6k213z9fhrmmm1xnly3zmzam1wrrdif4ghl";
+  };
+};
+in
+
+if ! (rev_and_sha ? "${coq.coq-version}") then
+  throw "bignums is not available for Coq ${coq.coq-version}"
+else with rev_and_sha."${coq.coq-version}";
+
+stdenv.mkDerivation rec {
+
+  name = "coq${coq.coq-version}-bignums";
+
+  src = fetchFromGitHub {
+    owner = "coq";
+    repo = "bignums";
+    inherit rev sha256;
+  };
+
+  buildInputs = [ coq.ocaml coq.camlp5 coq.findlib coq ];
+
+  installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
+
+  meta = with stdenv.lib; {
+    license = licenses.lgpl2;
+    platforms = coq.meta.platforms;
+  };
+
+}

--- a/pkgs/development/coq-modules/math-classes/default.nix
+++ b/pkgs/development/coq-modules/math-classes/default.nix
@@ -1,21 +1,22 @@
-{ stdenv, fetchurl, coq }:
+{ stdenv, fetchFromGitHub, coq, coqPackages }:
 
-stdenv.mkDerivation {
-  name = "coq${coq.coq-version}-math-classes-1.0.6";
+if ! stdenv.lib.versionAtLeast coq.coq-version "8.6" then
+  throw "Math-Classes requires Coq 8.6 or later."
+else
 
-  src = fetchurl {
-    url = https://github.com/math-classes/math-classes/archive/1.0.6.tar.gz;
-    sha256 = "071hgjk4bz2ybci7dp2mw7xqmxmm2zph7kj28xcdg28iy796lf02";
+stdenv.mkDerivation rec {
+
+  name = "coq${coq.coq-version}-math-classes-${version}";
+  version = "1.0.7";
+
+  src = fetchFromGitHub {
+    owner = "math-classes";
+    repo = "math-classes";
+    rev = version;
+    sha256 = "0wgnczacvkb2pc3vjbni9bwjijfyd5jcdnyyjg8185hkf9zzabgi";
   };
 
-  # src = fetchFromGitHub {
-  #   owner  = "math-classes";
-  #   repo   = "math-classes";
-  #   rev    = "1d426a08c2fbfd68bd1b3622fe8f31dd03712e6c";
-  #   sha256 = "3kjc2wzb6n9hcqb2ijx2pckn8jk5g09crrb87yb4s9m0mrw79smr";
-  # };
-
-  buildInputs = [ coq ];
+  buildInputs = [ coq coqPackages.bignums ];
   enableParallelBuilding = true;
   installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18606,6 +18606,7 @@ with pkgs;
     coqPackages = self;
 
     autosubst = callPackage ../development/coq-modules/autosubst {};
+    bignums = callPackage ../development/coq-modules/bignums {};
     coq-ext-lib = callPackage ../development/coq-modules/coq-ext-lib {};
     coquelicot = callPackage ../development/coq-modules/coquelicot {};
     dpdgraph = callPackage ../development/coq-modules/dpdgraph {};


### PR DESCRIPTION
###### Motivation for this change

Introduces compatibility with Coq 8.7.0.
Also adds the bignums package which is a dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

