### PR TITLE
emojione: add fontconfig module

### DIFF
--- a/nixos/modules/config/fonts/fontconfig-emojione.nix
+++ b/nixos/modules/config/fonts/fontconfig-emojione.nix
@@ -1,0 +1,56 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let fcBool = x: if x then "<bool>true</bool>" else "<bool>false</bool>";
+
+    cfg = config.fonts.fontconfig.emojione;
+
+    latestVersion  = pkgs.fontconfig.configVersion;
+
+    # The configuration to be included in /etc/font/
+    confPkg = pkgs.runCommand "font-emojione-conf" {} ''
+      support_folder=$out/etc/fonts/conf.d
+      latest_folder=$out/etc/fonts/${latestVersion}/conf.d
+
+      mkdir -p $support_folder
+      mkdir -p $latest_folder
+
+
+      # fontconfig emojione configuration file
+      ln -s ${pkgs.emojione}/etc/fonts/conf.d/56-emojione-color.conf \
+            $support_folder
+      ln -s ${pkgs.emojione}/etc/fonts/conf.d/56-emojione-color.conf \
+            $latest_folder
+    '';
+
+in
+{
+
+  options = {
+
+    fonts = {
+
+      fontconfig = {
+
+        emojione = {
+          enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Enable emojione settings.
+            '';
+          };
+        };
+      };
+    };
+
+  };
+
+  config = mkIf (config.fonts.fontconfig.enable && cfg.enable) {
+
+    fonts.fontconfig.confPackages = [ confPkg ];
+
+  };
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -2,6 +2,7 @@
   ./config/debug-info.nix
   ./config/fonts/corefonts.nix
   ./config/fonts/fontconfig.nix
+  ./config/fonts/fontconfig-emojione.nix
   ./config/fonts/fontconfig-penultimate.nix
   ./config/fonts/fontconfig-ultimate.nix
   ./config/fonts/fontdir.nix

--- a/pkgs/data/fonts/emojione/default.nix
+++ b/pkgs/data/fonts/emojione/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     install -Dm755 build/EmojiOneColor-SVGinOT.ttf $out/share/fonts/truetype/EmojiOneColor-SVGinOT.ttf
+    install -Dm755 linux/fontconfig/56-emojione-color.conf $out/etc/fonts/conf.d/56-emojione-color.conf
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
It add a new NixOS option to add emojjione's config to fontconfig. When enabled emoji characters are render with only one font –emojione– and not several as it is currently. It can be seen here: http://getemoji.com/
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

