### PR TITLE
lame: 3.99.5 -> 3.100

### DIFF
--- a/pkgs/development/libraries/lame/default.nix
+++ b/pkgs/development/libraries/lame/default.nix
@@ -23,14 +23,12 @@ in
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "lame-${version}";
-  version = "3.99.5";
+  version = "3.100";
 
   src = fetchurl {
     url = "mirror://sourceforge/lame/${name}.tar.gz";
-    sha256 = "1zr3kadv35ii6liia0bpfgxpag27xcivp571ybckpbz4b10nnd14";
+    sha256 = "07nsn5sy3a8xbmw1bidxnsj5fj6kg9ai04icmqw40ybkp353dznx";
   };
-
-  patches = [ ./gcc-4.9.patch ];
 
   outputs = [ "out" "lib" "doc" ]; # a small single header
   outputMan = "out";


### PR DESCRIPTION
###### Motivation for this change
CVEs

As per vulnix:

        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-13712
        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-9870
        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-9101
        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-9869
        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-15018
        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-15045
        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-9411
        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-15046
        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-9872
        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-9099
        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-9100
        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-15019
        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-9412
        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-11720
        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-9871
        https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-9410


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

