### PR TITLE
joker: init at 0.8.6

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -44,6 +44,7 @@
   anderspapitto = "Anders Papitto <anderspapitto@gmail.com>";
   andir = "Andreas Rammhold <andreas@rammhold.de>";
   andres = "Andres Loeh <ksnixos@andres-loeh.de>";
+  andrestylianos = "Andre S. Ramos <andre.stylianos@gmail.com>";
   andrewrk = "Andrew Kelley <superjoe30@gmail.com>";
   andsild = "Anders Sildnes <andsild@gmail.com>";
   aneeshusa = "Aneesh Agrawal <aneeshusa@gmail.com>";

--- a/pkgs/development/interpreters/joker/default.nix
+++ b/pkgs/development/interpreters/joker/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "joker-${version}";
+  version = "0.8.6";
+
+  goPackagePath = "github.com/candid82/joker";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "candid82";
+    repo = "joker";
+    sha256 = "0m6xi1jgss6f4maxqpwjyyhyyc71wy5a7jpm908m49xx80mz5ams";
+  };
+
+  preBuild = "go generate ./...";
+
+  dontInstallSrc = true;
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/candid82/joker;
+    description = "A small Clojure interpreter and linter written in Go";
+    license = licenses.epl10;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ andrestylianos ];
+  };
+}

--- a/pkgs/development/interpreters/joker/default.nix
+++ b/pkgs/development/interpreters/joker/default.nix
@@ -17,6 +17,8 @@ buildGoPackage rec {
 
   dontInstallSrc = true;
 
+  excludedPackages = "gen"; # Do not install private generators.
+
   goDeps = ./deps.nix;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/interpreters/joker/deps.nix
+++ b/pkgs/development/interpreters/joker/deps.nix
@@ -1,0 +1,11 @@
+[
+  {
+    goPackagePath = "github.com/chzyer/readline";
+    fetch = {
+      type = "git";
+      url = "https://github.com/chzyer/readline";
+      rev = "6a4bc7b4feaeff8feb63f87d5fb2cf3e3610a559";
+      sha256 = "1ny3rws671sa9bj5phg6k1rprlgzys73kfdr14vxq4wnwz84zbrc";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6451,6 +6451,8 @@ with pkgs;
 
   jmeter = callPackage ../applications/networking/jmeter {};
 
+  joker = callPackage ../development/interpreters/joker {};
+
   davmail = callPackage ../applications/networking/davmail {};
 
   kanif = callPackage ../applications/networking/cluster/kanif { };


### PR DESCRIPTION
###### Motivation for this change

Adding Joker, a Clojure interpreter/linter written in go.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

