### PR TITLE
pythonPackages.ofxclient: Depend on beautifulsoup4 instead of beautifulsoup3

### DIFF
--- a/pkgs/development/python-modules/ofxclient/default.nix
+++ b/pkgs/development/python-modules/ofxclient/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi,
- ofxhome, ofxparse, beautifulsoup, lxml, keyring
+ ofxhome, ofxparse, beautifulsoup4, lxml, keyring
 }:
 
 buildPythonPackage rec {
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   # ImportError: No module named tests
   doCheck = false;
 
-  propagatedBuildInputs = [ ofxhome ofxparse beautifulsoup lxml keyring ];
+  propagatedBuildInputs = [ ofxhome ofxparse beautifulsoup4 lxml keyring ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/captin411/ofxclient;


### PR DESCRIPTION
###### Motivation for this change
Latest release depends on beatifulsoup4

https://github.com/captin411/ofxclient/blob/d8f87a07374f4e9f35f7089be9fa7a9f8c17fb85/ofxclient/institution.py#L13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

