### PR TITLE
sxiv: installs .desktop file

### DIFF
--- a/pkgs/applications/graphics/sxiv/default.nix
+++ b/pkgs/applications/graphics/sxiv/default.nix
@@ -23,6 +23,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libX11 imlib2 giflib libexif ];
 
+  postInstall = ''
+    mkdir -p $out/share/applications/
+    cp -v sxiv.desktop $out/share/applications/
+  '';
+
   meta = {
     description = "Simple X Image Viewer";
     homepage = https://github.com/muennich/sxiv;


### PR DESCRIPTION
sxiv won't appear in meus as it has NoDisplay but it can be used to
generate the mimetypes.

###### Motivation for this change
my pngs opened with wrong program

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

