### PR TITLE
gmailieer: init at 0.3

### DIFF
--- a/pkgs/applications/networking/gmailieer/default.nix
+++ b/pkgs/applications/networking/gmailieer/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  name = "gmailieer";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "gauteh";
+    repo = "gmailieer";
+    rev = "v${version}";
+    sha256 = "1app783gf0p9p196nqsgbyl6s1bp304dfav86fqiq86h1scld787";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    notmuch
+    oauth2client
+    google_api_python_client
+    tqdm
+  ];
+
+  meta = with stdenv.lib; {
+    description      = "Fast email-fetching and two-way tag synchronization between notmuch and GMail";
+    longDescription  = ''
+      This program can pull email and labels (and changes to labels)
+      from your GMail account and store them locally in a maildir with
+      the labels synchronized with a notmuch database. The changes to
+      tags in the notmuch database may be pushed back remotely to your
+      GMail account.
+    '';
+    homepage         = https://github.com/gauteh/gmailieer;
+    repositories.git = https://github.com/gauteh/gmailieer.git;
+    license          = licenses.gpl3Plus;
+    maintainers      = with maintainers; [ kaiha ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12270,6 +12270,8 @@ with pkgs;
 
   gfxtablet = callPackage ../os-specific/linux/gfxtablet {};
 
+  gmailieer = callPackage ../applications/networking/gmailieer {};
+
   gpm = callPackage ../servers/gpm {
     ncurses = null;  # Keep curses disabled for lack of value
   };


### PR DESCRIPTION
###### Motivation for this change

Add _gmailier_, a fast email-fetching and two-way tag synchronization between notmuch and GMail.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

