### PR TITLE
skk-dicts: init at 2017-10-26

### DIFF
--- a/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
+++ b/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
@@ -1,0 +1,73 @@
+{ stdenv, fetchurl , skktools }:
+
+let
+  # kana to kanji
+  small = fetchurl {
+    url = "https://raw.githubusercontent.com/skk-dev/dict/f61be71246602a49e9f05ded6ac4f9f82031a521/SKK-JISYO.S";
+    sha256 = "15kp4iwz58fp1zg0i13x7w9wwm15v8n2hhm0nf2zsl7az5mn5yi4";
+  };
+  medium = fetchurl {
+    url = "https://raw.githubusercontent.com/skk-dev/dict/f61be71246602a49e9f05ded6ac4f9f82031a521/SKK-JISYO.M";
+    sha256 = "1vhagixhrp9lq5x7dldxcanhznawazp00xivpp1z52kx10lnkmv0";
+  };
+  large = fetchurl {
+    url = "https://raw.githubusercontent.com/skk-dev/dict/f61be71246602a49e9f05ded6ac4f9f82031a521/SKK-JISYO.L";
+    sha256 = "07cv0j95iajkr48j4ln411vnhl3z93yx96zjc03bgs10dbpagaaz";
+  };
+
+  # english to japanese
+  edict = fetchurl {
+    url = "https://raw.githubusercontent.com/skk-dev/dict/f61be71246602a49e9f05ded6ac4f9f82031a521/SKK-JISYO.edict";
+    sha256 = "18k8z1wkgwgfwbs6sylf39h1nc1p5l2b00h7mfjlb8p91plkb45w";
+  };
+  # misc
+  assoc = fetchurl {
+    url = "https://raw.githubusercontent.com/skk-dev/dict/f61be71246602a49e9f05ded6ac4f9f82031a521/SKK-JISYO.assoc";
+    sha256 = "12d6xpp1bfin9nwl35ydl5yc6vx0qpwhxss0khi19n1nsbyqnixm";
+  };
+in
+
+stdenv.mkDerivation rec {
+  name = "skk-dicts-unstable-${version}";
+  version = "2017-10-26";
+  srcs = [ small medium large edict assoc ];
+  nativeBuildInputs = [ skktools ];
+
+  phases = [ "installPhase" ];
+  installPhase = ''
+    function dictname() {
+      src=$1
+      name=$(basename $src)          # remove dir name
+      dict=$(echo $name | cut -b34-) # remove sha256 prefix
+      echo $dict
+    }
+    mkdir -p $out/share
+
+    for src in $srcs; do
+      dst=$out/share/$(dictname $src)
+      echo ";;; -*- coding: utf-8 -*-" > $dst  # libskk requires this on the first line
+      iconv -f EUC-JP -t UTF-8 $src |\
+        ${skktools}/bin/skkdic-expr2 >> $dst
+    done
+
+    # combine .L .edict and .assoc for convenience
+    dst=$out/share/SKK-JISYO.combined
+    echo ";;; -*- coding: utf-8 -*-" > $dst
+    ${skktools}/bin/skkdic-expr2 \
+      $out/share/$(dictname ${large}) + \
+      $out/share/$(dictname ${edict}) + \
+      $out/share/$(dictname ${assoc}) >> $dst
+  '';
+
+  meta = {
+    description = "A collection of standard SKK dictionaries";
+    longDescription = ''
+      This package provides a collection of standard kana-to-kanji
+      dictionaries for the SKK Japanese input method.
+    '';
+    homepage = https://github.com/skk-dev/dict;
+    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = with stdenv.lib.maintainers; [ yuriaisaka ];
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
+++ b/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl , skktools }:
+{ stdenv, fetchurl, skktools }:
 
 let
   # kana to kanji
@@ -68,6 +68,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/skk-dev/dict;
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = with stdenv.lib.maintainers; [ yuriaisaka ];
-    platforms = with stdenv.lib.platforms; linux ++ darwin;
+    platforms = with stdenv.lib.platforms; linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1489,6 +1489,7 @@ with pkgs;
   m17n_lib = callPackage ../tools/inputmethods/m17n-lib { };
 
   skktools = callPackage ../tools/inputmethods/skk/skktools { };
+  skk-dicts = callPackage ../tools/inputmethods/skk/skk-dicts { };
 
   ibus = callPackage ../tools/inputmethods/ibus {
     inherit (gnome3) dconf glib;


### PR DESCRIPTION
###### Motivation for this change

(This is a sequel to the pull request `skktools: init at 1.3.3 #30778`.)

In this package `skk-dicts`, we collect some standard dictionaries that can be used
by various SKK Japanese input methods.

The motivation for having `skk-dicts` in `nixpkgs` comes from the desire to have
`fcitx-skk` in `fcitx-engines`, which depends on `libskk`
( https://github.com/ueno/libskk ), which in turn depends on one or more SKK dictionaries.

We could have fetched SKK dictionaries from within `libskk` package, but we've
decided to factor out the dictionaries as a standalone package, as they can
in principle be utilized by other SKK input methods, such as `ibus-skk`, `scim-skk` etc.

Further pull requests are planned for `libskk` and `fcitx-skk` (a fcitx engine).

Note: 
The SKK openlab site ( http://openlab.ring.gr.jp/skk/dic.html ) used to be the primary
distribution site for these dictionary files, but it does not appear to be actively maintained
any longer. Furthermore, the files on the openlab site are not version controlled.
We therefore fetch dictionary files from a (semi-official?) fork on github
( https://github.com/skk-dev/dict ), which at least is version controlled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

