### PR TITLE
mkShell: add builder

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -50,6 +50,10 @@ pkgs.stdenv.mkDerivation {
       useChapters = true;
     }
   + toDocbook {
+      inputFile = ./shell.md;
+      outputFile = "shell.xml";
+    }
+  + toDocbook {
       inputFile = ./languages-frameworks/python.md;
       outputFile = "./languages-frameworks/python.xml";
     }

--- a/doc/shell.md
+++ b/doc/shell.md
@@ -1,0 +1,20 @@
+---
+title: stdenv.mkShell
+author: zimbatm
+date: 2017-10-30
+---
+
+stdenv.mkShell is a special kind of derivation that is only useful when using
+it combined with nix-shell. It will in fact fail to instantiate when invoked
+with nix-build.
+
+## Usage
+
+```nix
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.mkShell {
+  # this will make all the build inputs from hello and gnutar available to the shell environment
+  inputsFrom = with pkgs; [ hello gnutar ];
+  buildInputs = [ pkgs.gnumake ];
+}
+```

--- a/pkgs/build-support/mkshell/default.nix
+++ b/pkgs/build-support/mkshell/default.nix
@@ -1,0 +1,46 @@
+{ lib, stdenv }:
+
+# A special kind of derivation that is only meant to be consumed by the
+# nix-shell.
+{
+  inputsFrom ? [], # a list of derivations whose inputs will be made available to the environment
+  buildInputs ? [],
+  nativeBuildInputs ? [],
+  propagatedBuildInputs ? [],
+  propagatedNativeBuildInputs ? [],
+  ...
+}@attrs:
+let
+  mergeInputs = name:
+    let
+      op = item: sum: sum ++ item."${name}" or [];
+      nul = [];
+      list = [attrs] ++ inputsFrom;
+    in
+      lib.foldr op nul list;
+
+  rest = builtins.removeAttrs attrs [
+    "inputsFrom"
+    "buildInputs"
+    "nativeBuildInputs"
+    "propagatedBuildInputs"
+    "propagatedNativeBuildInputs"
+  ];
+in
+
+stdenv.mkDerivation ({
+  name = "nix-shell";
+  phases = ["nobuildPhase"];
+
+  buildInputs = mergeInputs "buildInputs";
+  nativeBuildInputs = mergeInputs "nativeBuildInputs";
+  propagatedBuildInputs = mergeInputs "propagatedBuildInputs";
+  propagatedNativeBuildInputs = mergeInputs "propagatedNativeBuildInputs";
+
+  nobuildPhase = ''
+    echo
+    echo "This derivation is not meant to be built, aborting";
+    echo
+    exit 1
+  '';
+} // rest)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -311,6 +311,8 @@ with pkgs;
       inherit kernel rootModules allowMissing;
     };
 
+  mkShell = callPackage ../build-supports/mkshell { };
+
   nixBufferBuilders = import ../build-support/emacs/buffer.nix { inherit (pkgs) lib writeText; inherit (emacsPackagesNg) inherit-local; };
 
   pathsFromGraph = ../build-support/kernel/paths-from-graph.pl;


### PR DESCRIPTION
###### Motivation for this change

For nix-shell-only scenarios, this is a small optimization to make it nicer such that:
```nix
{ pkgs ? import <nixpkgs> {} }:
pkgs.stdenv.mkDerivation {
  name = "forced-to-add-but-i-dont-care";
  src = null; # irrelevant
}
```

Is simplified to:
```nix
{ pkgs ? import <nixpkgs> {} }:
pkgs.mkShell { }
```

It also fails when trying to build it directly:
```
$ nix-build shell.nix
...
This derivation is only meant to be used in nix-shell, aborting
...
```

And finally, it supports the scenario where one wants to compose the shell with different inputs from various packages:

```nix
{ pkgs ? import <nixpkgs> {}}:
pkgs.mkShell {
  mergeInputs = [ pkgs.hello pkgs.gnutar ];
}
```
