### PR TITLE
Add a branch-restore.sh script for restoring branches after accidental deletion

### DIFF
--- a/maintainers/scripts/branch-restore.sh
+++ b/maintainers/scripts/branch-restore.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+
+sendto="git@github.com:nixos/nixpkgs.git"
+
+IFS=$'\n'
+for branch in $(git branch -r | grep origin | grep -v master | grep -v HEAD); do
+    origin=$(echo "$branch" | xargs echo)
+    branch=$(echo "$branch" | xargs echo | sed -e 's#^origin/##')
+
+    echo "Starting $origin -> $branch"
+    git checkout "$origin"
+    git checkout -b "$branch"
+    git push "$sendto" "$branch"
+
+
+    printf "\n\n\n\n"
+done


### PR DESCRIPTION
It has happened a few times that branches get accidentally deleted in
mass. This script pushes all branches that are known to be at `origin`
and pushes them back to `origin`.
