### PR TITLE
Two bower2nix bug fixes

### DIFF
--- a/pkgs/build-support/fetchbower/default.nix
+++ b/pkgs/build-support/fetchbower/default.nix
@@ -4,13 +4,13 @@ let
     let
       components = lib.splitString "#" version;
       hash = lib.last components;
-      ver = if builtins.length components == 1 then version else hash;
+      ver = if builtins.length components == 1 then (cleanName version) else hash;
     in ver;
 
-  bowerName = name: lib.replaceStrings ["/"] ["-"] name;
+  cleanName = name: lib.replaceStrings ["/" ":"] ["-" "-"] name;
 
   fetchbower = name: version: target: outputHash: stdenv.mkDerivation {
-    name = "${bowerName name}-${bowerVersion version}";
+    name = "${cleanName name}-${bowerVersion version}";
     SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
     buildCommand = ''
       fetch-bower --quiet --out=$PWD/out "${name}" "${target}" "${version}"

--- a/pkgs/development/node-packages/default-v4.nix
+++ b/pkgs/development/node-packages/default-v4.nix
@@ -1,4 +1,4 @@
-{pkgs, system, nodejs}:
+{pkgs, system, nodejs, stdenv}:
 
 let
   nodePackages = import ./composition-v4.nix {
@@ -43,7 +43,7 @@ nodePackages // {
     buildInputs = oldAttrs.buildInputs ++ [ pkgs.makeWrapper ];
     postInstall = ''
       for prog in bower2nix fetch-bower; do
-        wrapProgram "$out/bin/$prog" --prefix PATH : "${pkgs.git}/bin"
+        wrapProgram "$out/bin/$prog" --prefix PATH : ${stdenv.lib.makeBinPath [ pkgs.git pkgs.nix ]}
       done
     '';
   });

--- a/pkgs/development/node-packages/default-v6.nix
+++ b/pkgs/development/node-packages/default-v6.nix
@@ -1,4 +1,4 @@
-{pkgs, system, nodejs}:
+{pkgs, system, nodejs, stdenv}:
 
 let
   nodePackages = import ./composition-v6.nix {
@@ -41,7 +41,7 @@ nodePackages // {
     buildInputs = oldAttrs.buildInputs ++ [ pkgs.makeWrapper ];
     postInstall = ''
       for prog in bower2nix fetch-bower; do
-        wrapProgram "$out/bin/$prog" --prefix PATH : "${pkgs.git}/bin"
+        wrapProgram "$out/bin/$prog" --prefix PATH : ${stdenv.lib.makeBinPath [ pkgs.git pkgs.nix ]}
       done
     '';
   });

--- a/pkgs/top-level/node-packages.nix
+++ b/pkgs/top-level/node-packages.nix
@@ -66,7 +66,7 @@ in rec {
     bower2nix.buildInputs = [ pkgs.makeWrapper ];
     bower2nix.postInstall = ''
       for prog in bower2nix fetch-bower; do
-        wrapProgram "$out/bin/$prog" --prefix PATH : "${pkgs.git}/bin"
+        wrapProgram "$out/bin/$prog" --prefix PATH : ${stdenv.lib.makeBinPath [ pkgs.git pkgs.nix ]}
       done
     '';
   } // args.overrides or {};


### PR DESCRIPTION
###### Motivation for this change

* rvl/bower2nix#16 - fix running under pure nix shell
* rvl/bower2nix#18 - fix derivation name of bower dependencies which don't have version

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @jluttine @shlevy @svanderburg 
