### PR TITLE
cjdns: fix hash

### DIFF
--- a/pkgs/tools/networking/cjdns/default.nix
+++ b/pkgs/tools/networking/cjdns/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, fetchpatch, nodejs, which, python27, utillinux }:
+{ stdenv, fetchFromGitHub, nodejs, which, python27, utillinux }:
 
 let version = "20"; in
 stdenv.mkDerivation {
   name = "cjdns-"+version;
 
-  src = fetchurl {
-    url = "https://github.com/cjdelisle/cjdns/archive/cjdns-v${version}.tar.gz";
-    sha256 = "1dyqxi9l2pmrgm16a161909rg3vfzvib40frr7p6ddpk8yfh5888";
+  src = fetchFromGitHub {
+    owner = "cjdelisle";
+    repo = "cjdns";
+    rev = "cjdns-v${version}";
+    sha256 = "0gqcspiz1n0j711vwq807cy456dkcf03r376l04qc92173g2fzrx";
   };
 
   buildInputs = [ which python27 nodejs ] ++


### PR DESCRIPTION
###### Motivation for this change

Fix cjdns hash.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

