### PR TITLE
ibus: fix emoji hashes

### DIFF
--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -10,11 +10,11 @@ let
     srcs = {
       data = fetchurl {
         url = "http://unicode.org/Public/emoji/5.0/emoji-data.txt";
-        sha256 = "0zfn3z61xy76yah3d24dd745qjssrib009m4nvqpnx4sf1r13i2x";
+        sha256 = "11jfz5rrvyc2ixliqfcjgmch4cn9mfy0x96qnpfcyz5fy1jvfyxf";
       };
       sequences = fetchurl {
         url = "http://unicode.org/Public/emoji/5.0/emoji-sequences.txt";
-        sha256 = "0xzk7hi2a8macx9s5gj2pb36d38y8fa9001sj71g6kw25c2h94cn";
+        sha256 = "09bii7f5mmladg0kl3n80fa9qaix6bv5ylm92x52j7wygzv0szb1";
       };
       variation-sequences = fetchurl {
         url = "http://unicode.org/Public/emoji/5.0/emoji-variation-sequences.txt";
@@ -22,11 +22,11 @@ let
       };
       zwj-sequences = fetchurl {
         url = "http://unicode.org/Public/emoji/5.0/emoji-zwj-sequences.txt";
-        sha256 = "0rrnk94mhm3k9vs74pvyvs4ir7f31f1libx7c196fmdqvp1qfafw";
+        sha256 = "16gvzv76mjv9g81lm1m6cr3rpfqyn2k4hb9a62xd329252dhl25q";
       };
       test = fetchurl {
         url = "http://unicode.org/Public/emoji/5.0/emoji-test.txt";
-        sha256 = "1dvxw5xp1xiy13c1p1c7l2xc9q8f8znk47kb7q8g7bbgbi21cq5m";
+        sha256 = "031qk2v8xdnba7hfinmgrmpglc9l8ll2hds6mw885p0hngdb3dgw";
       };
     };
   in stdenv.mkDerivation {


### PR DESCRIPTION
###### Motivation for this change

Fix ibus emoji hashes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

