### PR TITLE
libgit2: fix hash

### DIFF
--- a/pkgs/development/libraries/git2/default.nix
+++ b/pkgs/development/libraries/git2/default.nix
@@ -1,13 +1,15 @@
-{ stdenv, fetchurl, pkgconfig, cmake, zlib, python, libssh2, openssl, curl, http-parser, libiconv }:
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, zlib, python, libssh2, openssl
+, curl, http-parser, libiconv }:
 
 stdenv.mkDerivation (rec {
   version = "0.25.1";
   name = "libgit2-${version}";
 
-  src = fetchurl {
-    name = "${name}.tar.gz";
-    url = "https://github.com/libgit2/libgit2/tarball/v${version}";
-    sha256 = "100bah8picqjzyhpw4wd7z5vyidcb8aggin50bhbpn607h8n8bml";
+  src = fetchFromGitHub {
+    owner = "libgit2";
+    repo = "libgit2";
+    rev = "v${version}";
+    sha256 = "1jhikg0gqpdzfzhgv44ybdpm24lvgkc7ki4306lc5lvmj1s2nylj";
   };
 
   # TODO: `cargo` (rust's package manager) surfaced a serious bug in


### PR DESCRIPTION
###### Motivation for this change

Fix libgit2 hash.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

