### PR TITLE
lxqt-panel: fix patch hash

### DIFF
--- a/pkgs/desktops/lxqt/core/lxqt-panel/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-panel/default.nix
@@ -1,5 +1,5 @@
 {
-  stdenv, fetchFromGitHub, fetchurl, standardPatch,
+  stdenv, fetchFromGitHub, fetchpatch, standardPatch,
   cmake, pkgconfig, lxqt-build-tools,
   qtbase, qttools, qtx11extras, qtsvg, libdbusmenu, kwindowsystem, solid,
   kguiaddons, liblxqt, libqtxdg, lxqt-common, lxqt-globalkeys, libsysstat,
@@ -50,9 +50,10 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-    (fetchurl {
+    (fetchpatch {
        url = https://github.com/lxde/lxqt-panel/commit/ec62109e0fa678875a9b10fc6f1975267432712d.patch;
-       sha256 = "1ywwk8gb6gbvs8z9gwgsnb13z1jvyvjij349nq7ij6iyhyld0jlr";
+       name = "fix-compile-explicit-keyword.patch";
+       sha256 = "1grda0dw175kbsfq90lr5qaf79akwikzxw85jhd5f339nnramp81";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Fix hash of lxqt-panel patch and switch to `fetchpatch` to avoid GitHub hash changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

