### PR TITLE
openntpd: fix constraints feature on NixOS

### DIFF
--- a/pkgs/tools/networking/openntpd/default.nix
+++ b/pkgs/tools/networking/openntpd/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     "--with-privsep-user=${privsepUser}"
     "--sysconfdir=/etc"
     "--localstatedir=/var"
+    "--with-cacert=/etc/ssl/certs/ca-certificates.crt"
   ];
 
   buildInputs = [ libressl ];


### PR DESCRIPTION
###### Motivation for this change

The OpenNTPD constraints feature requires a valid chain of SSL
certificates, but the default path in openntpd didn't match the one in
NixOS.

Unfortunately the configured certificate path becomes hardcoded into the
binary, so this feature will likely still fail on other
distributions/operating systems, unless the path coincides with the
NixOS path or the user sets up a symlink.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

