### PR TITLE
nixos/acme: remove doc note about restarting nginx

### DIFF
--- a/nixos/modules/security/acme.xml
+++ b/nixos/modules/security/acme.xml
@@ -89,8 +89,5 @@ services.nginx = {
   };
 }
 </programlisting>
-
-<para>At the moment you still have to restart Nginx after the ACME
-certs arrive.</para>
 </section>
 </chapter>


### PR DESCRIPTION
Discussion from #30945 indicates that it is no longer true that you have to restart nginx.
