### PR TITLE
modules: Add a way to forward submodules definitions to the parent.

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -104,7 +104,8 @@ let
       mkFixStrictness mkOrder mkBefore mkAfter mkAliasDefinitions
       mkAliasAndWrapDefinitions fixMergeModules mkRemovedOptionModule
       mkRenamedOptionModule mkMergedOptionModule mkChangedOptionModule
-      mkAliasOptionModule doRename filterModules;
+      mkAliasOptionModule mkForwardSubmoduleOptionDefinitions doRename
+      filterModules;
     inherit (options) isOption mkEnableOption mkSinkUndeclaredOptions
       mergeDefaultOption mergeOneOption mergeEqualOption getValues
       getFiles optionAttrSetToDocList optionAttrSetToDocList'

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -128,6 +128,19 @@ checkConfigOutput "\"42\"" config.value ./declare-coerced-value.nix
 checkConfigOutput "\"24\"" config.value ./declare-coerced-value.nix ./define-value-string.nix
 checkConfigError 'The option value .* in .* is not a string or integer.' config.value ./declare-coerced-value.nix ./define-value-list.nix
 
+# Check that mkForwardSubmoduleOptionDefinitions is capable of extracting
+# option definitions from the submodules.
+set -- config.enable ./declare-enable.nix ./declare-loaOfSub-any-enable.nix
+checkConfigOutput "false" "$@"
+checkConfigOutput "false" "$@" ./define-forward-loaOfSub-enable.nix
+checkConfigOutput "false" "$@" ./define-loaOfSub-foo.nix
+checkConfigOutput "false" "$@" ./define-loaOfSub-foo.nix ./define-forward-loaOfSub-enable.nix
+checkConfigOutput "false" "$@"  ./define-loaOfSub-foo-enable.nix
+checkConfigOutput "true" "$@"  ./define-loaOfSub-foo-enable.nix ./define-forward-loaOfSub-enable.nix
+checkConfigOutput "true" "$@"  ./define-loaOfSub-foo-enable.nix ./define-loaOfSub-bar-enable.nix ./define-forward-loaOfSub-enable.nix
+
+
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/define-forward-loaOfSub-enable.nix
+++ b/lib/tests/modules/define-forward-loaOfSub-enable.nix
@@ -1,0 +1,8 @@
+{ lib, config, ... }:
+
+{
+  config = {
+    enable = lib.mkForwardSubmoduleOptionDefinitions
+      (lib.attrValues config.loaOfSub) (cfg: cfg.enable);
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

This change is made to fill a gap in the module system, which is the ability to forward the content of a submodule option to the parent module system.

The motivation for this change comes from  the last rewrite of the httpd services that I made (not commited), which are extending the `extraConfig` of `httpd`, by re-defining the merge logic.

This change avoid the merge logic duplication by forwarding the definitions of the submodules to the parent module.  Thus, the merge logic does not have to be manually written to merge the content of the different submodules in the parent module.  More over, this modification takes the option definition before they are being processed by the merge & apply functions, which prevent issues in case of non-re-entrant merge functions.

###### Things done

- Built on platform
   - [x] NixOS
- [x] Tested via library tests
