### PR TITLE
pythonPackages.py3exiv2: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/py3exiv2/default.nix
+++ b/pkgs/development/python-modules/py3exiv2/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage, isPy3k, fetchPypi, stdenv, exiv2, boost, libcxx }:
+
+buildPythonPackage rec {
+  pname = "py3exiv2";
+  version = "0.2.1";
+  name = "${pname}-${version}";
+  disabled = !(isPy3k);
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06q7mlqy05c3jr61nmz93fxb6ilizfyggbh5sg0krwjap2sw1fr8";
+  };
+
+  buildInputs = [ exiv2 boost ];
+
+  # work around python distutils compiling C++ with $CC (see issue #26709)
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
+
+  # fix broken libboost_python3 detection
+  patches = [ ./setup.patch ];
+
+  meta = {
+    homepage = "https://launchpad.net/py3exiv2";
+    description = "A Python3 binding to the library exiv2";
+    license = with stdenv.lib.licenses; [ gpl3 ];
+    maintainers = with stdenv.lib.maintainers; [ vinymeuh ];
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/development/python-modules/py3exiv2/setup.patch
+++ b/pkgs/development/python-modules/py3exiv2/setup.patch
@@ -1,0 +1,11 @@
+--- a/setup.py	2017-10-16 22:03:02.000000000 +0200
++++ b/setup.py	2017-10-16 22:03:34.000000000 +0200
+@@ -39,7 +39,7 @@
+                 if '3' in l[2:]:
+                     return l.replace('libboost', 'boost')
+ 
+-libboost = get_libboost_name()
++libboost = 'boost_python3'
+ 
+ setup(
+     name='py3exiv2',

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -232,6 +232,8 @@ in {
 
   pyexiv2 = if (!isPy3k) then callPackage ../development/python-modules/pyexiv2 {} else throw "pyexiv2 not supported for interpreter ${python.executable}";
 
+  py3exiv2 = callPackage ../development/python-modules/py3exiv2 { };
+
   pygame = callPackage ../development/python-modules/pygame { };
 
   pygame-git = callPackage ../development/python-modules/pygame/git.nix { };


### PR DESCRIPTION
###### Motivation for this change

Add py3exiv3 for Python 3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

