### PR TITLE
network-interfaces-scripted: fix NixOS/nixops#640

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -93,6 +93,7 @@ let
             after = [ "network-pre.target" "systemd-udevd.service" "systemd-sysctl.service" ];
             before = [ "network.target" "shutdown.target" ];
             wants = [ "network.target" ];
+            partOf = map (i: "network-addresses-${i.name}.service") interfaces;
             conflicts = [ "shutdown.target" ];
             wantedBy = [ "multi-user.target" ] ++ optional hasDefaultGatewaySet "network-online.target";
 
@@ -171,8 +172,6 @@ let
               "network-link-${i.name}.service"
               "network.target"
             ];
-            # propagate stop and reload from network-setup
-            partOf = [ "network-setup.service" ];
             # order before network-setup because the routes that are configured
             # there may need ip addresses configured
             before = [ "network-setup.service" ];


### PR DESCRIPTION
###### Motivation for this change

This fixes NixOS/nixops#640 by reversing the PartOf dependency between network-setup and network-addresses-*.

This was joint work of: @nh2, @domenkozar, @fpletz, @aszlig and @basvandijk at the NixCon 2017 hackathon.

###### Things done

We tested this by running a loop which at each iteration deploys a configuration (using nixops) which changes the network-setup service and then deploys a configuration which removes that change. We ran the loop for 60 iterations and the Hetzner machine didn't loose its network connection.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

