### PR TITLE
bchunk: fix recent CVEs, simplify installPhase

### DIFF
--- a/pkgs/tools/cd-dvd/bchunk/CVE-2017-15953.patch
+++ b/pkgs/tools/cd-dvd/bchunk/CVE-2017-15953.patch
@@ -1,0 +1,25 @@
+--- a/bchunk.c	2017-10-30 18:03:58.658741629 +0000
++++ b/bchunk.c	2017-10-30 19:40:25.558131619 +0000
+@@ -18,6 +18,7 @@
+   *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+   */
+
++#define _GNU_SOURCE
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+@@ -271,11 +272,10 @@
+ 	int16_t i;
+ 	float fl;
+ 	
+-	if (!(fname = malloc(strlen(bname) + 8))) {
+-		fprintf(stderr, "main(): malloc() failed, out of memory\n");
++	if (asprintf(&fname, "%s%2.2d.%s", bname, track->num, track->extension) == -1) {
++		fprintf(stderr, "writetrack(): asprintf() failed, out of memory\n");
+ 		exit(4);
+ 	}
+-	sprintf(fname, "%s%2.2d.%s", bname, track->num, track->extension);
+ 	
+ 	printf("%2d: %s ", track->num, fname);
+ 	
+

--- a/pkgs/tools/cd-dvd/bchunk/CVE-2017-15955.patch
+++ b/pkgs/tools/cd-dvd/bchunk/CVE-2017-15955.patch
@@ -1,0 +1,33 @@
+diff -urNZ bchunk-1.2.0.orig/bchunk.c bchunk-1.2.0/bchunk.c
+--- a/bchunk.c	2017-10-30 18:03:58.658741629 +0000
++++ b/bchunk.c	2017-10-30 19:17:36.732855884 +0000
+@@ -426,11 +426,11 @@
+ 			printf("\nTrack ");
+ 			if (!(p = strchr(p, ' '))) {
+ 				fprintf(stderr, "... ouch, no space after TRACK.\n");
+-				continue;
++				exit(3);
+ 			}
+ 			p++;
+ 			if (!(t = strchr(p, ' '))) {
+ 				fprintf(stderr, "... ouch, no space after track number.\n");
+-				continue;
++				exit(3);
+ 			}
+ 			*t = '\0';
+
+@@ -460,12 +460,12 @@
+ 		} else if ((p = strstr(s, "INDEX"))) {
+ 			if (!(p = strchr(p, ' '))) {
+ 				printf("... ouch, no space after INDEX.\n");
+-				continue;
++				exit(3);
+ 			}
+ 			p++;
+ 			if (!(t = strchr(p, ' '))) {
+ 				printf("... ouch, no space after index number.\n");
+-				continue;
++				exit(3);
+ 			}
+ 			*t = '\0';
+ 			t++;

--- a/pkgs/tools/cd-dvd/bchunk/default.nix
+++ b/pkgs/tools/cd-dvd/bchunk/default.nix
@@ -8,20 +8,16 @@ stdenv.mkDerivation rec {
     sha256 = "0pcbyx3689cbl23dcij497hb3q5f1wmki7cxic5nzldx71g9vp5g";
   };
 
-  preConfigure =
-    ''
-      substituteInPlace Makefile \
-        --replace "-o root -g root" "" \
-        --replace "-o bin -g bin" ""
-    '';
+  patches = [ ./CVE-2017-15953.patch ./CVE-2017-15955.patch ];
 
-  makeFlags = "PREFIX=$(out) MAN_DIR=$(out)/share/man";
+  installPhase = ''
+    install -Dt $out/bin bchunk
+    install -Dt $out/share/man/man1 bchunk.1    
+  '';
 
-  preInstall = "mkdir -p $out/bin $out/share/man/man1";
-
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://he.fi/bchunk/;
-    description = "A program that converts CD-ROM images in BIN/CUE format into a set of ISO and CDR tracks";
-    platforms = stdenv.lib.platforms.linux;
+    description = "A program that converts CD images in BIN/CUE format into a set of ISO and CDR tracks";
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

See: https://bugs.gentoo.org/635898, gentoo/gentoo#6094

CVE-2017-15953: https://nvd.nist.gov/vuln/detail/CVE-2017-15953, https://github.com/extramaster/bchunk/issues/2
CVE-2017-15954: https://nvd.nist.gov/vuln/detail/CVE-2017-15954, https://github.com/extramaster/bchunk/issues/3
CVE-2017-15955: https://nvd.nist.gov/vuln/detail/CVE-2017-15955, https://github.com/extramaster/bchunk/issues/4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

