### PR TITLE
Revert "fetchzip and friends: Set "name" to "source" by default"

### DIFF
--- a/pkgs/build-support/fetchgit/gitrepotoname.nix
+++ b/pkgs/build-support/fetchgit/gitrepotoname.nix
@@ -1,0 +1,19 @@
+{ lib }:
+
+let
+  inherit (lib) removeSuffix hasPrefix removePrefix splitString stringToCharacters concatMapStrings last elem;
+
+  allowedChars = stringToCharacters "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+-._?=";
+  sanitizeStoreName = s:
+    let
+      s' = concatMapStrings (c: if elem c allowedChars then c else "") (stringToCharacters s);
+      s'' = if hasPrefix "." s' then "_${removePrefix "." s'}" else s';
+    in
+      s'';
+in
+  urlOrRepo: rev:
+    let
+      repo' = last (splitString ":" (baseNameOf (removeSuffix ".git" (removeSuffix "/" urlOrRepo))));
+      rev' = baseNameOf rev;
+    in
+     "${sanitizeStoreName repo'}-${sanitizeStoreName rev'}-src"

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -11,11 +11,10 @@
   stripRoot ? true
 , url
 , extraPostFetch ? ""
-, name ? "source"
 , ... } @ args:
 
 lib.overrideDerivation (fetchurl ({
-  inherit name;
+  name = args.name or (baseNameOf url);
 
   recursiveHash = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -195,8 +195,10 @@ with pkgs;
 
   fetchzip = callPackage ../build-support/fetchzip { };
 
+  gitRepoToName = callPackage ../build-support/fetchgit/gitrepotoname.nix { };
+
   fetchFromGitHub = {
-    owner, repo, rev, name ? "source",
+    owner, repo, rev, name ? gitRepoToName repo rev,
     fetchSubmodules ? false, private ? false,
     githubBase ? "github.com", varPrefix ? null,
     ... # For hash agility
@@ -229,7 +231,7 @@ with pkgs;
   in fetcher fetcherArgs // { meta.homepage = baseUrl; inherit rev; };
 
   fetchFromBitbucket = {
-    owner, repo, rev, name ? "source",
+    owner, repo, rev, name ? gitRepoToName repo rev,
     ... # For hash agility
   }@args: fetchzip ({
     inherit name;
@@ -240,7 +242,7 @@ with pkgs;
 
   # cgit example, snapshot support is optional in cgit
   fetchFromSavannah = {
-    repo, rev, name ? "source",
+    repo, rev, name ? gitRepoToName repo rev,
     ... # For hash agility
   }@args: fetchzip ({
     inherit name;
@@ -250,7 +252,7 @@ with pkgs;
 
   # gitlab example
   fetchFromGitLab = {
-    owner, repo, rev, name ? "source",
+    owner, repo, rev, name ? gitRepoToName repo rev,
     ... # For hash agility
   }@args: fetchzip ({
     inherit name;
@@ -260,7 +262,7 @@ with pkgs;
 
   # gitweb example, snapshot support is optional in gitweb
   fetchFromRepoOrCz = {
-    repo, rev, name ? "source",
+    repo, rev, name ? gitRepoToName repo rev,
     ... # For hash agility
   }@args: fetchzip ({
     inherit name;


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/commit/c3255fe8ec326d2c8fe9462d49ed83aa64d3e68f#commitcomment-25286020

This change invalidated all fetch* hashes, and nothing in staging could be built.