### PR TITLE
pwgen: 2.07 -> 2.08

### DIFF
--- a/pkgs/tools/security/pwgen/default.nix
+++ b/pkgs/tools/security/pwgen/default.nix
@@ -1,11 +1,14 @@
-{stdenv, fetchurl}:
+{stdenv, fetchurl, autoreconfHook}:
 stdenv.mkDerivation {
-  name = "pwgen-2.07";
+  name = "pwgen-2.08";
 
   src = fetchurl {
-    url = mirror://sourceforge/pwgen/pwgen-2.07.tar.gz;
-    sha256 = "0mhmw700kkh238fzivcwnwi94bj9f3h36yfh3k3j2v19b0zmjx7b";
+    url = https://github.com/tytso/pwgen/archive/v2.08.tar.gz;
+    sha256 = "8d6e94f28655e61d6126290e3eafad4d17d7fba0d0d354239522a740a270bb2f";
   };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
   meta = {
     description = "Password generator which creates passwords which can be easily memorized by a human";
     platforms = stdenv.lib.platforms.all;


### PR DESCRIPTION
###### Motivation for this change

Update

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
