### PR TITLE
pavucontrol-qt: use libsForQt5.callPackage

### DIFF
--- a/pkgs/desktops/lxqt/core/pavucontrol-qt/default.nix
+++ b/pkgs/desktops/lxqt/core/pavucontrol-qt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, qt5, lxqt, libpulseaudio, pcre }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt, libpulseaudio, pcre, qtbase, qttools, qtx11extras }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -19,9 +19,9 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    qt5.qtbase
-    qt5.qttools
-    qt5.qtx11extras
+    qtbase
+    qttools
+    qtx11extras
     libpulseaudio
     pcre
   ];

--- a/pkgs/desktops/lxqt/default.nix
+++ b/pkgs/desktops/lxqt/default.nix
@@ -27,7 +27,7 @@ let
     lxqt-session = callPackage ./core/lxqt-session { };
     lxqt-sudo = callPackage ./core/lxqt-sudo { };
     lxqt-themes = callPackage ./core/lxqt-themes { };
-    pavucontrol-qt = callPackage ./core/pavucontrol-qt { };
+    pavucontrol-qt = libsForQt5.callPackage ./core/pavucontrol-qt { };
     qtermwidget = callPackage ./core/qtermwidget { };
     # for now keep version 0.7.1 because virt-manager-qt currently does not compile with qtermwidget-0.8.0
     qtermwidget_0_7_1 = callPackage ./core/qtermwidget/0.7.1.nix { };


### PR DESCRIPTION
###### Motivation for this change

I started using pavucontrol-qt on xmonad and noticed that it was pulling a previous version of Qt (5.9.1 instead of 5.9.2).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

