### PR TITLE
beamPackages.hex: 0.14.0 => 0.17.1

### DIFF
--- a/pkgs/development/beam-modules/hex/default.nix
+++ b/pkgs/development/beam-modules/hex/default.nix
@@ -8,13 +8,13 @@ let
 
   pkg = self: stdenv.mkDerivation rec {
     name = "hex";
-    version = "v0.14.0";
+    version = "v0.17.1";
 
     src = fetchFromGitHub {
         owner = "hexpm";
         repo = "hex";
         rev = "${version}";
-        sha256 = "042rcwznb6cf9khn4l969axf7vhk53gy3rp23y6c8fhfp1472pai";
+        sha256 = "1s4asar1mcavzj3w37jcz243ka0z5jm0r42yws3h4aagawxxg02z";
     };
 
     setupHook = writeText "setupHook.sh" ''


### PR DESCRIPTION
###### Motivation for this change


Simple version bump of the hex package manager, since the application I needed to work with asked for that newer version.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

