### PR TITLE
ansible: 2.4.0.0 -> 2.4.1.0

### DIFF
--- a/pkgs/tools/admin/ansible/2.4.nix
+++ b/pkgs/tools/admin/ansible/2.4.nix
@@ -6,12 +6,12 @@
 
 pythonPackages.buildPythonPackage rec {
   pname = "ansible";
-  version = "2.4.0.0";
+  version = "2.4.1.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "http://releases.ansible.com/ansible/${name}.tar.gz";
-    sha256 = "0xkwnx817rygb1922gncv9ivgvb7hjg8g53r39hfdm3jgzp6y9qs";
+    sha256 = "0spv0kjaicwss4q52s727b6grdizcxpa0bbsfg26pgf5kjrayqfs";
   };
 
   prePatch = ''


### PR DESCRIPTION
###### Motivation for this change

Bump to the latest upstream release version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] **N/A** ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---