### PR TITLE
[RFC/RDY] make l2tp work with Strongswan 

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -335,6 +335,7 @@ in {
 
       preStart = ''
         mkdir -m 700 -p /etc/NetworkManager/system-connections
+        mkdir -m 700 -p /etc/ipsec.d
         mkdir -m 755 -p ${stateDirs}
       '';
     };

--- a/pkgs/tools/networking/network-manager/l2tp.nix
+++ b/pkgs/tools/networking/network-manager/l2tp.nix
@@ -22,6 +22,9 @@ stdenv.mkDerivation rec {
   postPatch = ''
     sed -i -e 's%"\(/usr/sbin\|/usr/pkg/sbin\|/usr/local/sbin\)/[^"]*",%%g' ./src/nm-l2tp-service.c
 
+    substituteInPlace ./Makefile.am \
+      --replace '$(sysconfdir)/dbus-1/system.d' "$out/etc/dbus-1/system.d"
+
     substituteInPlace ./src/nm-l2tp-service.c \
       --replace /sbin/ipsec  ${strongswan}/bin/ipsec \
       --replace /sbin/xl2tpd ${xl2tpd}/bin/xl2tpd
@@ -38,11 +41,16 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
+  configureFlags = [
+    "--with-gnome=${if withGnome then "yes" else "no"}"
+    "--localstatedir=/var"
+  ] ;
+
 
   meta = with stdenv.lib; {
     description = "L2TP plugin for NetworkManager";
     inherit (networkmanager.meta) platforms;
-    homepage = https://github.com/nm-l2tp/network-manager-l2tp;
+    homepage = http://github.com/nm-l2tp/network-manager-l2tp;
     license = licenses.gpl2;
     maintainers = with maintainers; [ abbradar obadz ];
   };

--- a/pkgs/tools/networking/network-manager/l2tp.nix
+++ b/pkgs/tools/networking/network-manager/l2tp.nix
@@ -41,16 +41,11 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
-  configureFlags = [
-    "--with-gnome=${if withGnome then "yes" else "no"}"
-    "--localstatedir=/var"
-  ] ;
-
 
   meta = with stdenv.lib; {
     description = "L2TP plugin for NetworkManager";
     inherit (networkmanager.meta) platforms;
-    homepage = http://github.com/nm-l2tp/network-manager-l2tp;
+    homepage = https://github.com/nm-l2tp/network-manager-l2tp;
     license = licenses.gpl2;
     maintainers = with maintainers; [ abbradar obadz ];
   };

--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -76,6 +76,11 @@ stdenv.mkDerivation rec {
          "--enable-sqlite" ]
     ++ optional enableNetworkManager "--enable-nm";
 
+  postInstall = ''
+    # this is needed for l2tp
+    echo "include /etc/ipsec.secrets" >> $out/etc/ipsec.secrets
+  '';
+
   NIX_LDFLAGS = "-lgcc_s" ;
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
I badly needed l2tp VPN to work for my job so I fought hard with 0 experience on the matter. After a 1-month struggle (https://github.com/NixOS/nixpkgs/issues/30147), here is the PR.

I hope this is how it should be done, I am not sure yet on which nixos files should go where (concerning /etc files).
This is definitely the kind of setup that could use some tests but I've already spent way too much time on this so.

Big thanks to the l2tp maintainer who has been immensely helpful.

###### Things done
- bump l2tp module
- create missing pieces for strongswan to work with l2tp

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

