### PR TITLE
mht2htm: init at 1.8.1.35

### DIFF
--- a/pkgs/tools/misc/mht2htm/default.nix
+++ b/pkgs/tools/misc/mht2htm/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, unzip, fpc, lazarus }:
+
+let
+  date = "07.apr.2016";
+
+in stdenv.mkDerivation rec {
+  name = "mht2mht-${version}";
+  version = "1.8.1.35";
+
+  src = fetchurl {
+    # there is a disconnect between the directory name date and file name date
+    # you should verify if that is still then case when the next version is released
+    url    = "mirror://sourceforge/mht2htm/mht2htm/1.8.1%20%2805.apr.2016%29/mht2htmcl-${version}_${date}.source.zip";
+    sha256 = "16r6zkihp84yqllp2hyaf0nvymdn9ji3g30mc5scfwycdfanja6f";
+  };
+
+  sourceRoot = ".";
+
+  buildInputs = [ fpc lazarus ];
+
+  nativeBuildInputs = [ unzip ];
+
+  buildPhase = ''
+    runHook preBuild
+    lazbuild --lazarusdir=${lazarus}/share/lazarus mht2htmcl.lpi
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 -t $out/bin               mht2htmcl
+    install -Dm644 -t $out/share/doc/mht2htm CHANGELOG COPYING README
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Convert .mht files to .html";
+    homepage    = http://pgm.bpalanka.com/mht2htm.html;
+    license     = licenses.gpl3;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -163,6 +163,8 @@ with pkgs;
 
   packer = callPackage ../development/tools/packer { };
 
+  mht2htm = callPackage ../tools/misc/mht2htm { };
+
   fetchpatch = callPackage ../build-support/fetchpatch { };
 
   fetchs3 = callPackage ../build-support/fetchs3 { };


### PR DESCRIPTION
###### Motivation for this change

This is the first derivation to use ```lazbuild``` from lazarus to build a lazarus/fpc project so I'm throwing this out there to @7c6f434c.

Should we create a proper builder for these types of projects (there doesn't seem to many admittedly) or is the manual lazbuild invocation OK with you?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

