### PR TITLE
xfce4-settings: build w/ xorg-libinput, make some dependencies optional

### DIFF
--- a/pkgs/desktops/xfce/core/xfce4-settings.nix
+++ b/pkgs/desktops/xfce/core/xfce4-settings.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--enable-pluggable-dialogs" "--enable-sound-settings" ];
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     homepage = http://www.xfce.org/projects/xfce4-settings;
     description = "Settings manager for Xfce";

--- a/pkgs/desktops/xfce/core/xfce4-settings.nix
+++ b/pkgs/desktops/xfce/core/xfce4-settings.nix
@@ -1,5 +1,7 @@
-{ stdenv, fetchurl, pkgconfig, intltool, exo, gtk, libxfce4util, libxfce4ui
-, libglade, xfconf, xorg, libwnck, libnotify, libxklavier, garcon, upower }:
+{ stdenv, fetchurl, pkgconfig, intltool, exo, gtk, garcon, libxfce4util
+, libxfce4ui, xfconf, libXi, upower ? null, libnotify ? null
+, libXcursor ? null, xf86inputlibinput ? null, libxklavier ? null }:
+
 let
   p_name  = "xfce4-settings";
   ver_maj = "4.12";
@@ -15,14 +17,28 @@ stdenv.mkDerivation rec {
 
   patches = [ ./xfce4-settings-default-icon-theme.patch ];
 
-  nativeBuildInputs =
-    [ pkgconfig intltool
-    ];
+  postPatch = ''
+    for f in $(find . -name \*.c); do
+      substituteInPlace $f --replace \"libinput-properties.h\" '<xorg/libinput-properties.h>'
+    done
+  '';
 
-  buildInputs =
-    [ exo gtk libxfce4util libxfce4ui libglade upower xfconf
-      xorg.libXi xorg.libXcursor libwnck libnotify libxklavier garcon
-    ]; #TODO: optional packages
+  nativeBuildInputs = [ pkgconfig intltool ];
+
+  buildInputs = [
+    exo
+    gtk
+    garcon
+    libxfce4util
+    libxfce4ui
+    xfconf
+    libXi
+    upower
+    libnotify
+    libXcursor
+    xf86inputlibinput
+    libxklavier
+  ];
 
   configureFlags = [ "--enable-pluggable-dialogs" "--enable-sound-settings" ];
 
@@ -34,4 +50,3 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.eelco ];
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

Closes #30148. After this change "Mouse and Touchpad" settings tab can be used to change libinput settings (scroll direction reversal, tap-to-click, scrolling mode all respond, I don't see much difference with higher acceleration values but if that's the case that'd be certainly an upstream issue).

This also makes optional packages nullable (as per `TODO` comment).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

