### PR TITLE
xfce4-panel: patch gettext in xfce4-popup-* scripts, fixes #30033

### DIFF
--- a/pkgs/desktops/xfce/core/xfce4-panel.nix
+++ b/pkgs/desktops/xfce/core/xfce4-panel.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, intltool, gtk, libxfce4util, libxfce4ui
 , libxfce4ui_gtk3, libwnck, exo, garcon, xfconf, libstartup_notification
 , makeWrapper, xfce4mixer, hicolor_icon_theme
-, withGtk3 ? false, gtk3
+, withGtk3 ? false, gtk3, gettext
 }:
 let
   inherit (stdenv.lib) optional;
@@ -19,6 +19,12 @@ stdenv.mkDerivation rec {
 
   patches = [ ./xfce4-panel-datadir.patch ];
   patchFlags = "-p1";
+
+  postPatch = ''
+    for f in $(find . -name \*.sh); do
+      substituteInPlace $f --replace gettext ${gettext}/bin/gettext
+    done
+  '';
 
   outputs = [ "out" "dev" "devdoc" ];
 
@@ -47,4 +53,3 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.eelco ];
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

Fixes #30033.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

