### PR TITLE
strip: --strip-all in libexec, bin, sbin

### DIFF
--- a/pkgs/build-support/setup-hooks/strip.sh
+++ b/pkgs/build-support/setup-hooks/strip.sh
@@ -23,12 +23,12 @@ _doStrip() {
         if [[ "$dontStrip" || "$flag" ]] || ! type -f "$stripCmd" 2>/dev/null
         then continue; fi
 
-        stripDebugList=${stripDebugList:-lib lib32 lib64 libexec bin sbin}
+        stripDebugList=${stripDebugList:-lib lib32 lib64}
         if [ -n "$stripDebugList" ]; then
             stripDirs "$stripCmd" "$stripDebugList" "${stripDebugFlags:--S}"
         fi
 
-        stripAllList=${stripAllList:-}
+        stripAllList=${stripAllList:-libexec bin sbin}
         if [ -n "$stripAllList" ]; then
             stripDirs "$stripCmd" "$stripAllList" "${stripAllFlags:--s}"
         fi


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/21667#issuecomment-271054516
https://github.com/NixOS/nixpkgs/issues/21667#issuecomment-271083104

I haven't rebuilt system with this patch yet, but @peterhoeg has.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

