### PR TITLE
quagga: 1.2.1 -> 1.2.2 (CVE-2017-16227)

### DIFF
--- a/pkgs/servers/quagga/default.nix
+++ b/pkgs/servers/quagga/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "quagga-${version}";
-  version = "1.2.1";
+  version = "1.2.2";
 
   src = fetchurl {
     url = "mirror://savannah/quagga/${name}.tar.gz";
-    sha256 = "1kgvcr9cfgys5asvb5lh5h95silkr624apqm5x68xva19xfvmpda";
+    sha256 = "0c99rjjc62xl5kwvx2pwyvs0709vbwax1qydqbqf6r7fpvr24bjj";
   };
 
   buildInputs =


### PR DESCRIPTION
fixes CVE-2017-16227 & several other issues see [1] for details
 
[1] https://download-mirror.savannah.gnu.org/releases/quagga/quagga-1.2.2.changelog.txt

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

