### PR TITLE
luastdlib: 41.2.0 -> 41.2.1

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -438,12 +438,15 @@ let
   };
 
 
-  luastdlib = buildLuaPackage {
-    name = "stdlib";
+  luastdlib = buildLuaPackage rec {
+    name = "stdlib-${version}";
+    version = "41.2.1";
 
-    src = fetchzip {
-      url = "https://github.com/lua-stdlib/lua-stdlib/archive/release.zip";
-      sha256 = "0636absdfjx8ybglwydmqxwfwmqz1c4b9s5mhxlgm4ci18lw3hms";
+    src = fetchFromGitHub {
+      owner = "lua-stdlib";
+      repo = "lua-stdlib";
+      rev = "release-v${version}";
+      sha256 = "03wd1qvkrj50fjszb2apzdkc8d5bpfbbi9pajl0vbrlzzmmi3jlq";
     };
 
     nativeBuildInputs = [ autoreconfHook unzip ];


### PR DESCRIPTION
###### Motivation for this change

Replace the link to the latest release with a specific version. https://github.com/NixOS/nixpkgs/pull/31004#issuecomment-340605130

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).