### PR TITLE
maven: 3.5.0 -> 3.5.2

### DIFF
--- a/pkgs/development/tools/build-managers/apache-maven/default.nix
+++ b/pkgs/development/tools/build-managers/apache-maven/default.nix
@@ -2,7 +2,7 @@
 
 assert jdk != null;
 
-let version = "3.5.0"; in
+let version = "3.5.2"; in
 stdenv.mkDerivation rec {
   name = "apache-maven-${version}";
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://apache/maven/maven-3/${version}/binaries/${name}-bin.tar.gz";
-    sha256 = "0d7hjnj77hc7qqnnfmqlwij8n6pcldfavvd6lilvv5ak4hci9fdy";
+    sha256 = "1zza5kjf69hnx41gy3yhvsk1kz259nig5njcmzjbsr8a75p1yyvh";
   };
 
   buildInputs = [ makeWrapper ];
@@ -22,5 +22,6 @@ stdenv.mkDerivation rec {
     homepage = http://maven.apache.org/;
     license = licenses.asl20;
     platforms = platforms.unix;
+    maintainers = with maintainers; [ cko ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

Updated Maven version

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

