### PR TITLE
virtualbox: 5.1.26 -> 5.2.0

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -19,10 +19,10 @@ let
   python = python2;
   buildType = "release";
   # Manually sha256sum the extensionPack file, must be hex!
-  extpack = "14f152228495a715f526eb74134d43c960919cc534d2bc67cfe34a63e6cf7721";
-  extpackRev = "117224";
-  main = "1af8h3d3sdpcxcp5g75qfq10z81l7m8gk0sz8zqix8c1wqsm0wdm";
-  version = "5.1.26";
+  extpack = "005ba9211862643e2516d549e98b80942918047f1f6c55fcfe08c490dd1947bc";
+  extpackRev = "118431";
+  main = "0m6y98pvkngprw5iaswvkbbfxmzvfl8yvgi984p1866zwap77z16";
+  version = "5.2.0";
 
   # See https://github.com/NixOS/nixpkgs/issues/672 for details
   extensionPack = requireFile rec {
@@ -94,14 +94,6 @@ in stdenv.mkDerivation {
   postPatch = ''
     sed -i -e 's|/sbin/ifconfig|${nettools}/bin/ifconfig|' \
       src/VBox/HostDrivers/adpctl/VBoxNetAdpCtl.cpp
-    patch -p0 < ${
-      fetchurl { # for glibc-2.26
-        name = "conflicting-types-for-greg_t.patch";
-        url = "http://www.linuxquestions.org/questions/"
-            + "attachment.php?attachmentid=25801&d=1504099531";
-        sha256 = "1bcyf9qrqxizyjp1s662k6n1cfyfjbl7256r4n20kbr65yxcydps";
-      }
-    }
   '';
 
   # first line: ugly hack, and it isn't yet clear why it's a problem

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/fix_kerndir.patch
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/fix_kerndir.patch
@@ -1,0 +1,38 @@
+diff --git a/install/src/vboxguest-5.2.0/vboxsf/Makefile.include.header b/install/src/vboxguest-5.2.0/vboxsf/Makefile.include.header
+index 8df1eb4d25..5a3e5604e7 100644
+--- a/install/src/vboxguest-5.2.0/vboxsf/Makefile.include.header
++++ b/install/src/vboxguest-5.2.0/vboxsf/Makefile.include.header
+@@ -117,7 +117,6 @@ else # neq($(KERNELRELEASE),)
+ endif # neq($(KERNELRELEASE),)
+
+ # Kernel build folder
+-KERN_DIR := /lib/modules/$(KERN_VER)/build
+ ifneq ($(shell if test -d $(KERN_DIR); then echo yes; fi),yes)
+  $(error Error: unable to find the headers of the Linux kernel to build against. \
+           Specify KERN_VER=<version> and run Make again)
+
+diff --git a/install/src/vboxguest-5.2.0/vboxguest/Makefile.include.header b/install/src/vboxguest-5.2.0/vboxguest/Makefile.include.header
+index 8df1eb4d25..5a3e5604e7 100644
+--- a/install/src/vboxguest-5.2.0/vboxguest/Makefile.include.header
++++ b/install/src/vboxguest-5.2.0/vboxguest/Makefile.include.header
+@@ -117,7 +117,6 @@ else # neq($(KERNELRELEASE),)
+ endif # neq($(KERNELRELEASE),)
+
+ # Kernel build folder
+-KERN_DIR := /lib/modules/$(KERN_VER)/build
+ ifneq ($(shell if test -d $(KERN_DIR); then echo yes; fi),yes)
+  $(error Error: unable to find the headers of the Linux kernel to build against. \
+           Specify KERN_VER=<version> and run Make again)
+
+diff --git a/install/src/vboxguest-5.2.0/vboxvideo/Makefile.include.header b/install/src/vboxguest-5.2.0/vboxvideo/Makefile.include.header
+index 8df1eb4d25..5a3e5604e7 100644
+--- a/install/src/vboxguest-5.2.0/vboxvideo/Makefile.include.header
++++ b/install/src/vboxguest-5.2.0/vboxvideo/Makefile.include.header
+@@ -117,7 +117,6 @@ else # neq($(KERNELRELEASE),)
+ endif # neq($(KERNELRELEASE),)
+
+ # Kernel build folder
+-KERN_DIR := /lib/modules/$(KERN_VER)/build
+ ifneq ($(shell if test -d $(KERN_DIR); then echo yes; fi),yes)
+  $(error Error: unable to find the headers of the Linux kernel to build against. \
+           Specify KERN_VER=<version> and run Make again)

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/fix_kernincl.patch
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/fix_kernincl.patch
@@ -1,0 +1,12 @@
+diff --git a/install/src/vboxguest-5.2.0/vboxvideo/Makefile.include.header b/install/src/vboxguest-5.2.0/vboxvideo/Makefile.include.header
+index 8df1eb4d25..5a3e5604e7 100644
+--- a/install/src/vboxguest-5.2.0/vboxvideo/Makefile.include.header
++++ b/install/src/vboxguest-5.2.0/vboxvideo/Makefile.include.header
+@@ -122,7 +122,6 @@ ifneq ($(shell if test -d $(KERN_DIR); then echo yes; fi),yes)
+           Specify KERN_VER=<version> and run Make again)
+ endif
+ # Kernel include folder
+-KERN_INCL := $(KERN_DIR)/include
+ # module install folder
+ INSTALL_MOD_DIR ?= misc
+ MODULE_DIR := $(INSTALL_MOD_PATH)/lib/modules/$(KERN_VER)/$(INSTALL_MOD_DIR)

--- a/pkgs/applications/virtualization/virtualbox/hardened.patch
+++ b/pkgs/applications/virtualization/virtualbox/hardened.patch
@@ -24,7 +24,7 @@ index 8bd42bc..2c23d3e 100644
 +++ b/include/iprt/path.h
 @@ -1064,6 +1064,15 @@ RTDECL(int) RTPathCalcRelative(char *pszPathDst, size_t cbPathDst,
  RTDECL(int) RTPathExecDir(char *pszPath, size_t cchPath);
- 
+
  /**
 + * Gets the path to the NixOS setuid wrappers directory.
 + *
@@ -44,7 +44,7 @@ index 043653e..1070280 100644
 +++ b/include/iprt/process.h
 @@ -327,6 +327,16 @@ RTR3DECL(const char *) RTProcShortName(void);
  RTR3DECL(char *) RTProcGetExecutablePath(char *pszExecPath, size_t cbExecPath);
- 
+
  /**
 + * Gets the path to the NixOS setuid wrappers directory.
 + *
@@ -63,13 +63,13 @@ diff --git a/src/VBox/HostDrivers/Support/SUPR3HardenedVerify.cpp b/src/VBox/Hos
 index ce0f288..6193108 100644
 --- a/src/VBox/HostDrivers/Support/SUPR3HardenedVerify.cpp
 +++ b/src/VBox/HostDrivers/Support/SUPR3HardenedVerify.cpp
-@@ -1489,9 +1489,9 @@ static int supR3HardenedVerifyFsObject(PCSUPR3HARDENEDFSOBJSTATE pFsObjState, bo
+@@ -1502,9 +1502,9 @@ static int supR3HardenedVerifyFsObject(PCSUPR3HARDENEDFSOBJSTATE pFsObjState, bo
          bool fBad = !fRelaxed || pFsObjState->Stat.st_gid != 2 /*bin*/ || suplibHardenedStrCmp(pszPath, "/usr/lib/iconv");
- #else
+ # else
          NOREF(fRelaxed);
 -        bool fBad = true;
 +        bool fBad = !(fDir && pFsObjState->Stat.st_mode & S_ISVTX && !suplibHardenedStrCmp(pszPath, "/nix/store"));
- #endif
+ # endif
 -        if (fBad)
 +        if (fBad && suplibHardenedStrCmp(pszPath, "/nix/store"))
              return supR3HardenedSetError3(VERR_SUPLIB_WRITE_NON_SYS_GROUP, pErrInfo,
@@ -80,7 +80,7 @@ index 320c569..9bfe41f 100644
 --- a/src/VBox/Main/src-server/MachineImpl.cpp
 +++ b/src/VBox/Main/src-server/MachineImpl.cpp
 @@ -7543,7 +7543,7 @@ HRESULT Machine::i_launchVMProcess(IInternalSessionControl *aControl,
- 
+
      /* get the path to the executable */
      char szPath[RTPATH_MAX];
 -    RTPathAppPrivateArch(szPath, sizeof(szPath) - 1);
@@ -93,7 +93,7 @@ index 1e38d99..5e43dda 100644
 --- a/src/VBox/Main/src-server/NetworkServiceRunner.cpp
 +++ b/src/VBox/Main/src-server/NetworkServiceRunner.cpp
 @@ -85,7 +85,7 @@ int NetworkServiceRunner::start(bool aKillProcOnStop)
- 
+
      /* get the path to the executable */
      char exePathBuf[RTPATH_MAX];
 -    const char *exePath = RTProcGetExecutablePath(exePathBuf, RTPATH_MAX);
@@ -107,7 +107,7 @@ index 98dc91a..43a819f 100644
 +++ b/src/VBox/Main/src-server/generic/NetIf-generic.cpp
 @@ -47,7 +47,7 @@ static int NetIfAdpCtl(const char * pcszIfName, const char *pszAddr, const char
      const char *args[] = { NULL, pcszIfName, pszAddr, pszOption, pszMask, NULL };
- 
+
      char szAdpCtl[RTPATH_MAX];
 -    int rc = RTPathExecDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME));
 +    int rc = RTPathSuidDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME));
@@ -125,7 +125,7 @@ index 98dc91a..43a819f 100644
          LogRel(("NetIfAdpCtlOut: Failed to get program path, rc=%Rrc\n", rc));
 @@ -201,7 +201,7 @@ int NetIfCreateHostOnlyNetworkInterface(VirtualBox *pVirtualBox,
              progress.queryInterfaceTo(aProgress);
- 
+
              char szAdpCtl[RTPATH_MAX];
 -            int rc = RTPathExecDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME " add"));
 +            int rc = RTPathSuidDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME " add"));
@@ -138,8 +138,8 @@ index 944848e..744a261 100644
 +++ b/src/VBox/Runtime/r3/path.cpp
 @@ -81,6 +81,12 @@ RTDECL(int) RTPathExecDir(char *pszPath, size_t cchPath)
  }
- 
- 
+
+
 +RTDECL(int) RTPathSuidDir(char *pszPath, size_t cchPath)
 +{
 +    return RTStrCopy(pszPath, cchPath, "/run/wrappers/bin");
@@ -156,7 +156,7 @@ index 2aab645..9795f21 100644
 @@ -111,6 +111,26 @@ RTR3DECL(char *) RTProcGetExecutablePath(char *pszExecPath, size_t cbExecPath)
      return NULL;
  }
- 
+
 +/*
 + * Note the / at the end! This is important, because the functions using this
 + * will cut off everything after the rightmost / as this function is analogous
@@ -177,6 +177,6 @@ index 2aab645..9795f21 100644
 +    return NULL;
 +}
 +
- 
+
  RTR3DECL(const char *) RTProcShortName(void)
  {

--- a/pkgs/applications/virtualization/virtualbox/qtx11extras.patch
+++ b/pkgs/applications/virtualization/virtualbox/qtx11extras.patch
@@ -2,7 +2,7 @@ diff --git a/kBuild/units/qt5.kmk b/kBuild/units/qt5.kmk
 index 71b96a3..73391f0 100644
 --- a/kBuild/units/qt5.kmk
 +++ b/kBuild/units/qt5.kmk
-@@ -994,9 +994,10 @@ else
+@@ -1019,9 +1019,10 @@ else
     $(eval $(target)_LIBS   += $(PATH_SDK_QT5_LIB)/$(qt_prefix)qtmain$(qt_infix)$(SUFF_LIB) )
    endif
   else
@@ -14,18 +14,18 @@ index 71b96a3..73391f0 100644
 + $(eval $(target)_INCS     += $(addprefix $(PATH_SDK_QT5_INC)/Qt,$(qt_modules)) $(PATH_SDK_QT5_INC) $(PATH_QT5_X11_EXTRAS_INC)/QtX11Extras )
  endif
  $(eval $(target)_DEFS      += $(foreach module,$(toupper $(qt_modules)), QT_$(module)_LIB) )
- 
+
 diff --git a/src/VBox/Frontends/VirtualBox/Makefile.kmk b/src/VBox/Frontends/VirtualBox/Makefile.kmk
-index 38db6b0..7dd446b 100644
+index 3295bfefe7..796370623c 100644
 --- a/src/VBox/Frontends/VirtualBox/Makefile.kmk
 +++ b/src/VBox/Frontends/VirtualBox/Makefile.kmk
-@@ -912,9 +912,6 @@ VirtualBox_QT_MODULES = Core Gui
- ifdef VBOX_WITH_QTGUI_V5
-  # Qt5 requires additional modules:
-  VirtualBox_QT_MODULES += Widgets PrintSupport
-- VirtualBox_QT_MODULES.linux   += X11Extras
-- VirtualBox_QT_MODULES.solaris += X11Extras
-- VirtualBox_QT_MODULES.freebsd += X11Extras
-  VirtualBox_QT_MODULES.darwin  += MacExtras
-  VirtualBox_QT_MODULES.win     += WinExtras
- endif # VBOX_WITH_QTGUI_V5
+@@ -916,9 +916,6 @@ endif
+ # The Qt modules we're using.
+ # (The include directory and lib/framework for each module will be added by the Qt unit.)
+ VirtualBox_QT_MODULES = Core Gui Widgets PrintSupport
+-VirtualBox_QT_MODULES.linux   += X11Extras
+-VirtualBox_QT_MODULES.solaris += X11Extras
+-VirtualBox_QT_MODULES.freebsd += X11Extras
+ VirtualBox_QT_MODULES.darwin  += MacExtras
+ VirtualBox_QT_MODULES.win     += WinExtras
+ if defined(VBOX_WITH_VIDEOHWACCEL) || defined(VBOX_GUI_USE_QGL)

--- a/pkgs/os-specific/linux/virtualbox/default.nix
+++ b/pkgs/os-specific/linux/virtualbox/default.nix
@@ -7,6 +7,14 @@ stdenv.mkDerivation {
     "fortify" "pic" "stackprotector"
   ];
 
+  patches = [
+    ./fix_kerndir.patch
+    ./fix_kbuild.patch
+  ];
+
+  KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  INCLUDE_BASE = "${virtualbox.modsrc}";
+
   makeFlags = [
     "-C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)"

--- a/pkgs/os-specific/linux/virtualbox/fix_kbuild.patch
+++ b/pkgs/os-specific/linux/virtualbox/fix_kbuild.patch
@@ -1,0 +1,85 @@
+diff --git a/vboxdrv/Makefile b/vboxdrv/Makefile
+index e262c61..4af8dac 100644
+--- a/vboxdrv/Makefile
++++ b/vboxdrv/Makefile
+@@ -131,7 +131,7 @@ ifdef VBOX_WITH_NATIVE_DTRACE
+  MOD_OBJS += SUPDrvDTrace.o
+ endif
+
+-MOD_INCL  = $(addprefix -I$(KBUILD_EXTMOD),/ /include /r0drv/linux)
++MOD_INCL  = $(addprefix -I$(INCLUDE_BASE)/$(MOD_NAME),/ /include /r0drv/linux)
+ ifdef VBOX_WITH_NATIVE_DTRACE
+  MOD_INCL += -I/usr/include/linux -I/usr/include
+ endif
+@@ -157,7 +157,7 @@ ifdef VBOX_WITH_TEXT_MODMEM_HACK
+ endif
+
+ # build defs
+-MOD_CFLAGS = -include $(KBUILD_EXTMOD)/include/VBox/SUPDrvMangling.h \
++MOD_CFLAGS = -include include/VBox/SUPDrvMangling.h \
+	-fno-omit-frame-pointer -fno-pie
+
+ include $(obj)/Makefile.include.footer
+diff --git a/vboxnetadp/Makefile b/vboxnetadp/Makefile
+index e262c61..4af8dac 100644
+--- a/vboxnetadp/Makefile
++++ b/vboxnetadp/Makefile
+@@ -34,7 +34,7 @@ MOD_OBJS += math/gcc/divdi3.o \
+	math/gcc/umoddi3.o
+ endif
+
+-MOD_INCL = $(addprefix -I$(KBUILD_EXTMOD),/ /include /r0drv/linux)
++MOD_INCL = $(addprefix -I$(INCLUDE_BASE)/$(MOD_NAME),/ /include /r0drv/linux)
+ MOD_DEFS = -DRT_OS_LINUX -DIN_RING0 -DIN_RT_R0 -DIN_SUP_R0 -DVBOX \
+	    -DRT_WITH_VBOX -DVBOX_WITH_HARDENING \
+	    -Wno-declaration-after-statement
+@@ -59,6 +59,6 @@ ifdef VBOX_USE_INSERT_PAGE
+ endif
+
+ # build defs
+-MOD_CFLAGS = -include $(KBUILD_EXTMOD)/include/VBox/SUPDrvMangling.h -fno-pie
++MOD_CFLAGS = -include include/VBox/SUPDrvMangling.h -fno-pie
+
+ include $(obj)/Makefile.include.footer
+diff --git a/vboxnetflt/Makefile b/vboxnetflt/Makefile
+index e262c61..4af8dac 100644
+--- a/vboxnetflt/Makefile
++++ b/vboxnetflt/Makefile
+@@ -38,7 +38,7 @@ MOD_OBJS += math/gcc/divdi3.o \
+	math/gcc/umoddi3.o
+ endif
+
+-MOD_INCL = $(addprefix -I$(KBUILD_EXTMOD),/ /include /r0drv/linux)
++MOD_INCL = $(addprefix -I$(INCLUDE_BASE)/$(MOD_NAME),/ /include /r0drv/linux)
+ MOD_DEFS = -DRT_OS_LINUX -DIN_RING0 -DIN_RT_R0 \
+	-DIN_SUP_R0 -DVBOX -DRT_WITH_VBOX -DVBOX_WITH_HARDENING \
+	-Wno-declaration-after-statement
+@@ -63,6 +63,6 @@ ifdef VBOX_USE_INSERT_PAGE
+ endif
+
+ # build defs
+-MOD_CFLAGS = -include $(KBUILD_EXTMOD)/include/VBox/SUPDrvMangling.h -fno-pie
++MOD_CFLAGS = -include include/VBox/SUPDrvMangling.h -fno-pie
+
+ include $(obj)/Makefile.include.footer
+diff --git a/vboxpci/Makefile b/vboxpci/Makefile
+index e262c61..4af8dac 100644
+--- a/vboxpci/Makefile
++++ b/vboxpci/Makefile
+@@ -38,7 +38,7 @@ MOD_OBJS += math/gcc/divdi3.o       \
+	math/gcc/umoddi3.o
+ endif
+
+-MOD_INCL = $(addprefix -I$(KBUILD_EXTMOD),/ /include /r0drv/linux)
++MOD_INCL = $(addprefix -I$(INCLUDE_BASE)/$(MOD_NAME),/ /include /r0drv/linux)
+ MOD_DEFS = -DRT_OS_LINUX -DIN_RING0 -DIN_RT_R0 -DIN_SUP_R0 -DVBOX \
+	-DRT_WITH_VBOX -DVBOX_WITH_HARDENING
+ ifeq ($(BUILD_TARGET_ARCH),amd64)
+@@ -60,6 +60,6 @@ ifdef VBOX_USE_INSERT_PAGE
+ endif
+
+ # build defs
+-MOD_CFLAGS = -include $(KBUILD_EXTMOD)/include/VBox/SUPDrvMangling.h -fno-pie
++MOD_CFLAGS = -include include/VBox/SUPDrvMangling.h -fno-pie
+
+ include $(obj)/Makefile.include.footer

--- a/pkgs/os-specific/linux/virtualbox/fix_kerndir.patch
+++ b/pkgs/os-specific/linux/virtualbox/fix_kerndir.patch
@@ -1,0 +1,48 @@
+diff --git a/vboxdrv/Makefile.include.header b/vboxdrv/Makefile.include.header
+index 8df1eb4d25..5a3e5604e7 100644
+--- a/vboxdrv/Makefile.include.header
++++ b/vboxdrv/Makefile.include.header
+@@ -117,7 +117,6 @@ else # neq($(KERNELRELEASE),)
+ endif # neq($(KERNELRELEASE),)
+
+ # Kernel build folder
+-KERN_DIR := /lib/modules/$(KERN_VER)/build
+ ifneq ($(shell if test -d $(KERN_DIR); then echo yes; fi),yes)
+  $(error Error: unable to find the headers of the Linux kernel to build against. \
+           Specify KERN_VER=<version> and run Make again)
+diff --git a/vboxnetadp/Makefile.include.header b/vboxnetadp/Makefile.include.header
+index 8df1eb4d25..5a3e5604e7 100644
+--- a/vboxnetadp/Makefile.include.header
++++ b/vboxnetadp/Makefile.include.header
+@@ -117,7 +117,6 @@ else # neq($(KERNELRELEASE),)
+ endif # neq($(KERNELRELEASE),)
+
+ # Kernel build folder
+-KERN_DIR := /lib/modules/$(KERN_VER)/build
+ ifneq ($(shell if test -d $(KERN_DIR); then echo yes; fi),yes)
+  $(error Error: unable to find the headers of the Linux kernel to build against. \
+           Specify KERN_VER=<version> and run Make again)
+diff --git a/vboxnetflt/Makefile.include.header b/vboxnetflt/Makefile.include.header
+index 8df1eb4d25..5a3e5604e7 100644
+--- a/vboxnetflt/Makefile.include.header
++++ b/vboxnetflt/Makefile.include.header
+@@ -117,7 +117,6 @@ else # neq($(KERNELRELEASE),)
+ endif # neq($(KERNELRELEASE),)
+
+ # Kernel build folder
+-KERN_DIR := /lib/modules/$(KERN_VER)/build
+ ifneq ($(shell if test -d $(KERN_DIR); then echo yes; fi),yes)
+  $(error Error: unable to find the headers of the Linux kernel to build against. \
+           Specify KERN_VER=<version> and run Make again)
+diff --git a/vboxpci/Makefile.include.header b/vboxpci/Makefile.include.header
+index 8df1eb4d25..5a3e5604e7 100644
+--- a/vboxpci/Makefile.include.header
++++ b/vboxpci/Makefile.include.header
+@@ -117,7 +117,6 @@ else # neq($(KERNELRELEASE),)
+ endif # neq($(KERNELRELEASE),)
+
+ # Kernel build folder
+-KERN_DIR := /lib/modules/$(KERN_VER)/build
+ ifneq ($(shell if test -d $(KERN_DIR); then echo yes; fi),yes)
+  $(error Error: unable to find the headers of the Linux kernel to build against. \
+           Specify KERN_VER=<version> and run Make again)


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Something is wrong with QT, I'll try to take a look

```
./result/bin/VirtualBox
Qt FATAL: This application failed to start because it could not find or load the Qt platform plugin "xcb"
in "".
Reinstalling the application may fix this problem.
[1]    2156 abort      ./result/bin/VirtualBox
```