### PR TITLE
autofs: do not strip needed symbols

### DIFF
--- a/pkgs/os-specific/linux/autofs/default.nix
+++ b/pkgs/os-specific/linux/autofs/default.nix
@@ -24,6 +24,8 @@ in stdenv.mkDerivation {
     export E2FSCK=${e2fsprogs}/bin/fsck.ext2
     export E3FSCK=${e2fsprogs}/bin/fsck.ext3
     export E4FSCK=${e2fsprogs}/bin/fsck.ext4
+
+    unset STRIP # Makefile.rules defines a usable STRIP only without the env var.
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Fixes #28282 after #27415. See https://github.com/NixOS/nixpkgs/issues/28282#issuecomment-334203866 and https://github.com/NixOS/nixpkgs/issues/28282#issuecomment-340774320 .

@Ericson2314 Is this fine or should we not unset STRIP here? Maybe export `STRIP="${STRIP:-strip} --strip-debug`?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).