### PR TITLE
graphite: fix the graphiteApi service

### DIFF
--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -22,8 +22,8 @@ let
   );
 
   graphiteApiConfig = pkgs.writeText "graphite-api.yaml" ''
-    time_zone: ${config.time.timeZone}
     search_index: ${dataDir}/index
+    ${optionalString (!isNull config.time.timeZone) ''time_zone: ${config.time.timeZone}''}
     ${optionalString (cfg.api.finders != []) ''finders:''}
     ${concatMapStringsSep "\n" (f: "  - " + f.moduleName) cfg.api.finders}
     ${optionalString (cfg.api.functions != []) ''functions:''}
@@ -536,7 +536,7 @@ in {
         environment = {
           PYTHONPATH = let
               aenv = pkgs.python.buildEnv.override {
-                extraLibs = [ cfg.api.package pkgs.cairo ] ++ cfg.api.finders;
+                extraLibs = [ cfg.api.package pkgs.cairo pkgs.pythonPackages.cffi ] ++ cfg.api.finders;
               };
             in "${aenv}/${pkgs.python.sitePackages}";
           GRAPHITE_API_CONFIG = graphiteApiConfig;

--- a/nixos/tests/graphite.nix
+++ b/nixos/tests/graphite.nix
@@ -4,22 +4,28 @@ import ./make-test.nix ({ pkgs, ...} :
   nodes = {
     one =
       { config, pkgs, ... }: {
+        time.timeZone = "UTC";
         services.graphite = {
-          web = {
+          web.enable = true;
+          api = {
             enable = true;
+            port = 8082;
           };
-          carbon = {
-            enableCache = true;
-          };
+          carbon.enableCache = true;
+          seyren.enable = true;
+          pager.enable = true;
         };
       };
-    };
+  };
 
   testScript = ''
     startAll;
     $one->waitForUnit("default.target");
     $one->requireActiveUnit("graphiteWeb.service");
+    $one->requireActiveUnit("graphiteApi.service");
+    $one->requireActiveUnit("graphitePager.service");
     $one->requireActiveUnit("carbonCache.service");
+    $one->requireActiveUnit("seyren.service");
     $one->succeed("echo \"foo 1 `date +%s`\" | nc -q0 localhost 2003");
     $one->waitUntilSucceeds("curl 'http://localhost:8080/metrics/find/?query=foo&format=treejson' --silent | grep foo")
   '';


### PR DESCRIPTION
###### Motivation for this change

This fixes the `graphiteApi` service which previously crashed.

###### Things done

The following completes successfully: `nix build -f nixos/release.nix tests.graphite`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

