### PR TITLE
languagetool: add command for HTTP server

### DIFF
--- a/pkgs/tools/text/languagetool/default.nix
+++ b/pkgs/tools/text/languagetool/default.nix
@@ -20,6 +20,11 @@ stdenv.mkDerivation rec {
     EXE
     chmod +x $out/bin/$lt
     done
+    cat > $out/bin/languagetool-http-server <<EXE
+    #!${stdenv.shell}
+    ${jdk}/bin/java -cp $out/share/languagetool-server.jar org.languagetool.server.HTTPServer "\$@"
+    EXE
+    chmod +x $out/bin/languagetool-http-server
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

The LanguageTool extension for Firefox explains how to use it with your own local server: https://addons.mozilla.org/fr/firefox/addon/languagetool/

They recommend running an HTTP server. I have been unable to run an HTTP server using `languagetool-server` but following http://wiki.languagetool.org/http-server I was able to patch the derivation to add a `languagetool-http-server` command that accomplishes what I was aiming at.

Cc @edwtjo @jgeerds. You may know better ways to do this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

