### PR TITLE
wordpress: 4.7.4 -> 4.8.3

### DIFF
--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -2,11 +2,12 @@
 { fetchFromGitHub, lib } : fetchFromGitHub {
   owner = "WordPress";
   repo = "WordPress";
-  rev = "4.7.4";
-  sha256 = "1ia9d3n085x2r6pvdrv4rk6gdp6xhjhpsq5g7a6448xzv9hf14ri";
+  rev = "4.8.3";
+  sha256 = "077bdx22sj29v8q493b49xfzxpc38q45pjhmn4znw2fmkjilih5p";
   meta = {
     homepage = https://wordpress.org;
     description = "WordPress is open source software you can use to create a beautiful website, blog, or app.";
     license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.basvandijk ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://wordpress.org/news/2017/10/wordpress-4-8-3-security-release/

###### Things done

The following succeeds: `nix build -f nixos/release.nix tests.wordpress`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

