### PR TITLE
Fix some but not all errors in owncloud

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -302,6 +302,7 @@ in rec {
   tests.leaps = callTest tests/leaps.nix { };
   tests.nsd = callTest tests/nsd.nix {};
   tests.openssh = callTest tests/openssh.nix {};
+  tests.owncloud = callTest tests/owncloud.nix {};
   tests.pam-oath-login = callTest tests/pam-oath-login.nix {};
   #tests.panamax = hydraJob (import tests/panamax.nix { system = "x86_64-linux"; });
   tests.peerflix = callTest tests/peerflix.nix {};

--- a/nixos/tests/owncloud.nix
+++ b/nixos/tests/owncloud.nix
@@ -1,0 +1,39 @@
+import ./make-test.nix ({ pkgs, ... }:
+
+{
+  name = "owncloud";
+  nodes =
+    { web =
+        { config, pkgs, ... }:
+        {
+          services.postgresql.enable = true;
+          services.httpd = {
+            enable = true;
+            logPerVirtualHost = true;
+            adminAddr = "example@example.com";
+            virtualHosts = [
+              {
+                hostName = "owncloud";
+                extraSubservices =
+                  [
+                    {
+                      serviceType   = "owncloud";
+                      adminPassword = "secret";
+                      dbPassword    = "secret";
+                    }
+                  ];
+              }
+            ];
+          };
+        };
+    };
+
+  testScript = ''
+    startAll;
+
+    $web->waitForUnit("postgresql");
+    $web->waitForUnit("httpd");
+
+    $web->succeed("curl -L 127.0.0.1:80");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

The `owncloud` webapp has some issues. I fixed the following:

* Don't set timezone when it's null

* Don't create the postgres role because the postgresqsl service
  already does that.

* Fix documentation

* Add a test suite

The test-suite reports the following errors:

```
$ nix-build nixos/release.nix -A tests.owncloud
...
web# [   11.172532] postgresql-start[764]: ERROR:  column "appid" of relation "oc_appconfig_f75b475f3aa09" already exists
web# [   11.173599] postgresql-start[764]: STATEMENT:  ALTER TABLE oc_appconfig_f75b475f3aa09 ADD "appid" VARCHAR(32) DEFAULT '' NOT NULL
web# [   11.222334] sudo[976]:     root : TTY=unknown ; PWD=/ ; USER=postgres ; COMMAND=/nix/store/x8mdyv8yd78l62wd6y45lvdkfhc5amch-postgresql-9.6.5/bin/psql -h /tmp -U postgres -d owncloud -Atw -c INSERT INTO groups (gid) values('admin');
web#        INSERT INTO users (uid,password)
web#          values('owncloud','e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4');
web#        INSERT INTO group_user (gid,uid)
web#          values('admin','owncloud');
web# [   11.227043] sudo[976]: pam_unix(sudo:session): session opened for user postgres by (uid=0)
web# [   11.247347] postgresql-start[764]: ERROR:  relation "groups" does not exist at character 13
web# [   11.248355] postgresql-start[764]: STATEMENT:  INSERT INTO groups (gid) values('admin');
web# [   11.249197] postgresql-start[764]: 	       INSERT INTO users (uid,password)
web# [   11.249967] postgresql-start[764]: 	         values('owncloud','e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4');
web# [   11.250855] postgresql-start[764]: 	       INSERT INTO group_user (gid,uid)
web# [   11.252286] postgresql-start[764]: 	         values('admin','owncloud');
web# [   11.253953] httpd-pre-start[927]: ERROR:  relation "groups" does not exist
web# [   11.255216] httpd-pre-start[927]: LINE 1: INSERT INTO groups (gid) values('admin');
```

I'm not using this module and I don't have munch interest in debugging this further.

@matejc @aborsu could you help out?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

