### PR TITLE
Revert "ocamlPackages.csv: 1.5 -> 1.7"

### DIFF
--- a/pkgs/development/ocaml-modules/csv/default.nix
+++ b/pkgs/development/ocaml-modules/csv/default.nix
@@ -1,35 +1,19 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, ocaml_lwt }:
-
-let param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.2"
-  then {
-    version = "1.7";
-    url = https://math.umons.ac.be/anum/software/csv/csv-1.7.tar.gz;
-    sha256 = "1mmcjiiz0jppgipavpph5kn04xcpalw4scbjrw2z3drghvr3qqwf";
-    lwtSupport = true;
-  } else {
-    version = "1.5";
-    url = https://github.com/Chris00/ocaml-csv/releases/download/1.5/csv-1.5.tar.gz;
-    sha256 = "1ca7jgg58j24pccs5fshis726s06fdcjshnwza5kwxpjgdbvc63g";
-    lwtSupport = false;
-  };
-in
+{ stdenv, fetchzip, ocaml, findlib, ocamlbuild }:
 
 stdenv.mkDerivation {
 
-  name = "ocaml${ocaml.version}-csv-${param.version}";
+  name = "ocaml-csv-1.5";
 
   src = fetchzip {
-    inherit (param) url sha256;
+    url = https://github.com/Chris00/ocaml-csv/releases/download/1.5/csv-1.5.tar.gz;
+    sha256 = "1ca7jgg58j24pccs5fshis726s06fdcjshnwza5kwxpjgdbvc63g";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ]
-  ++ stdenv.lib.optional param.lwtSupport ocaml_lwt;
+  buildInputs = [ ocaml findlib ocamlbuild ];
 
   createFindlibDestdir = true;
 
-  configurePhase = "ocaml setup.ml -configure --prefix $out --enable-tests"
-  + stdenv.lib.optionalString param.lwtSupport " --enable-lwt";
+  configurePhase = "ocaml setup.ml -configure --prefix $out --enable-tests";
 
   buildPhase = "ocaml setup.ml -build";
 


### PR DESCRIPTION
This reverts commit 574f3c3bfef49c682490e065b8f93e93ed49038b.

###### Motivation for this change

The previous version fails to build due to unavailable source files:
```
building path(s) ‘/nix/store/2f7cdgac0x6sk7xbwfzayyvfvpg0h7qa-csv-1.7.tar.gz’
  2 2285k    2 51852    0     0  51852      0  0:00:45 --:--:--  0:00:45 66391
trying https://math.umons.ac.be/anum/software/csv/csv-1.7.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0remote: Counting objects: 2938, done.        
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
error: cannot download csv-1.7.tar.gz from any mirror
builder for ‘/nix/store/2ap6cx8bli5r8vfp675ys109lwxczc01-csv-1.7.tar.gz.drv’ failed with exit code 1
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

