### PR TITLE
make sure which and curl are available in the PATH for sbt-extras

### DIFF
--- a/pkgs/development/tools/build-managers/sbt-extras/default.nix
+++ b/pkgs/development/tools/build-managers/sbt-extras/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, which, curl, makeWrapper }:
 
 let
   rev = "77686b3dfa20a34270cc52377c8e37c3a461e484";
@@ -17,9 +17,13 @@ stdenv.mkDerivation {
 
   dontBuild = true;
 
+  buildInputs = [ makeWrapper ];
+
   installPhase = ''
     mkdir -p $out/bin
     install bin/sbt $out/bin
+
+    wrapProgram $out/bin/sbt --prefix PATH : ${stdenv.lib.makeBinPath [ which curl]}
   '';
 
   meta = {


### PR DESCRIPTION
sbt-extras uses `which` and `curl` to download the sbt launcher. We should make them available on the PATH to make the package easier to use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

