### PR TITLE
musl: 1.1.17 -> 1.1.18

### DIFF
--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name    = "musl-${version}";
-  version = "1.1.17";
+  version = "1.1.18";
 
   src = fetchurl {
     url    = "http://www.musl-libc.org/releases/${name}.tar.gz";
-    sha256 = "0r0lyp2w6v2bvm8h1si7w3p2qx037szl14qnxm5p00568z3m3an8";
+    sha256 = "0651lnj5spckqjf83nz116s8qhhydgqdy3rkl4icbh5f05fyw5yh";
   };
 
   enableParallelBuilding = true;
@@ -24,8 +24,6 @@ stdenv.mkDerivation rec {
     "--enable-static"
     "CFLAGS=-fstack-protector-strong"
   ];
-
-  patches = [];
 
   dontDisableStatic = true;
 


### PR DESCRIPTION
Use this as an opportunity to remove empty patches array.


###### Motivation for this change

Minor update.
Includes fix particularly relevant for Nix users where large PATH entries overflowed the stack and badness resulted:
https://git.musl-libc.org/cgit/musl/commit/?id=004dc9549b8003288e635ba5aa91e3353e1974c4
The commit author is also super cool :innocent:.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Checked `nix-build pkgs/stdenv/linux/make-bootstrap-tools.nix -A test`