### PR TITLE
pip-tools: update tests for 1.9.0 -> 1.10.1

### DIFF
--- a/pkgs/development/python-modules/pip-tools/default.nix
+++ b/pkgs/development/python-modules/pip-tools/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, buildPythonPackage, pip, pytest, click, six, first
-, setuptools_scm, glibcLocales, mock }:
+, setuptools_scm, git, glibcLocales, mock }:
 
 buildPythonPackage rec {
   pname = "pip-tools";
@@ -12,12 +12,18 @@ buildPythonPackage rec {
   };
 
   LC_ALL = "en_US.UTF-8";
-  checkInputs = [ pytest glibcLocales mock ];
+  checkInputs = [ pytest git glibcLocales mock ];
   propagatedBuildInputs = [ pip click six first setuptools_scm ];
 
   checkPhase = ''
-    export HOME=$(mktemp -d)
-    py.test -k "not test_realistic_complex_sub_dependencies" # requires network
+    export HOME=$(mktemp -d) VIRTUAL_ENV=1
+    tests_without_network_access="
+      not test_realistic_complex_sub_dependencies \
+      and not test_editable_package_vcs \
+      and not test_generate_hashes_all_platforms \
+      and not test_generate_hashes_without_interfering_with_each_other \
+    "
+    py.test -k "$tests_without_network_access"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15114,6 +15114,7 @@ in {
   };
 
   pip-tools = callPackage ../development/python-modules/pip-tools {
+    git = pkgs.gitMinimal;
     glibcLocales = pkgs.glibcLocales;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Fix tests after 7ce848309e6d64820af1e96045c5386992e90a4a updated pip-tools from 1.9.0 to 1.10.1. The tests now require that `VIRTUAL_ENV` is set, but do not care about its value or if they run inside virtualenv. All four deselected tests pass without sandbox.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).