### PR TITLE
icicles: 2014-11-06 -> 2017-10-28

### DIFF
--- a/pkgs/applications/editors/emacs-modes/icicles/default.nix
+++ b/pkgs/applications/editors/emacs-modes/icicles/default.nix
@@ -2,27 +2,28 @@
 
 let
   modules = [
-    { name = "icicles.el"; sha256 = "175g8w620vy73pp3zyasfjspgljk6g0lki71kdnvw5z88w3s9d1n"; }
-    { name = "icicles-chg.el"; sha256 = "1bx5xdhirvnrjqk4pk0sjp9bpj1syymsjnckklsw04gv6y0x8zik"; }
-    { name = "icicles-cmd1.el"; sha256 = "1ff0mndin9zxrswwwq3a7b1s879rr6gy8rzxanr7kxg1ppciafad"; }
-    { name = "icicles-cmd2.el"; sha256 = "1a44l86jacp9nsy4z260azz6y672drjw3w5a0jsc8w26fgsrnx1k"; }
-    { name = "icicles-doc1.el"; sha256 = "0s3r4z3y06hd1nxp18wd0b8b88z2a7ryy0j8sx5fzibbmp58ars1"; }
-    { name = "icicles-doc2.el"; sha256 = "0c10jg91qxyrg1zwiyi4m57dbw3yf43jdrpi4nnby3pkzh6i37ic"; }
-    { name = "icicles-face.el"; sha256 = "0n0vcbhwgd2lyj7anq1zpwja28xry018qxbm8sprxkh6y3vlw8d2"; }
-    { name = "icicles-fn.el"; sha256 = "1i10593a7hp465bxd86h7h7gwrdyqxx0d13in53z4jnab8icp3d4"; }
-    { name = "icicles-mac.el"; sha256 = "1piq0jk8nz0hz9wwci7dkxnfxscdpygjzpj5zg3310vs22l7rrsz"; }
-    { name = "icicles-mcmd.el"; sha256 = "0c4325yp84i46605nlxmjm6n0f4fh69shsihvd0wb9ryg0a8qa65"; }
-    { name = "icicles-mode.el"; sha256 = "069wx5clqpsq2c9aavgd9xihvlad3g00iwwrc3cpl47v64dvlipq"; }
-    { name = "icicles-opt.el"; sha256 = "16487l3361ca8l6il2c0z892843sc5l9v4gr7lx5fxbmrlsswvvn"; }
-    { name = "icicles-var.el"; sha256 = "1a9cwxpi10x44fngxa7qnrg8hqfvdjb8s8k47gnn1rbh63blkkry"; }
+    { name = "icicles.el"; sha256 = "10w1lghh9jqxxm5cszi2qyk24vnvazfywmyyz1v7zf6cyiwbndrz"; }
+    { name = "icicles-chg.el"; sha256 = "020yg4hv120mcy7qvn76j85q6hl7mfcfv66w55c6izc9lbrvvnv8"; }
+    { name = "icicles-cmd1.el"; sha256 = "1715x1vkiax93890gfjbzslxsn4swsv37spvyx7chy4s1mym9kfw"; }
+    { name = "icicles-cmd2.el"; sha256 = "187k0gmn34fn6w1dw9hjf4i788y01vk47z7ac11ar4bddwh97ddx"; }
+    { name = "icicles-doc1.el"; sha256 = "1bw5dkymn2xdrfrp80am0gqi0szs0xihny4qmgzgx6hfbng351qh"; }
+    { name = "icicles-doc2.el"; sha256 = "0zd94m1a8mwwbrbcrahxxx8q34w8cg5lna4yww4m1gliyklww86s"; }
+    { name = "icicles-face.el"; sha256 = "1mlz8dq7bgzp2cf5j37i25yw90ry657d2m8r93rdj67h7l4wyxhj"; }
+    { name = "icicles-fn.el"; sha256 = "1cdghvgsr0b7pdq4lmnfm6kwwcqbk4wqf168kf2sjajbpa24ix96"; }
+    { name = "icicles-mac.el"; sha256 = "1w5sgzbp8hyjzrmqd8bwivszaayzh8dkyqa0d751adiwjfs9sq9m"; }
+    { name = "icicles-mcmd.el"; sha256 = "1lf2galn3g52hfz61avlr4ifyn5b42dfbmyq78cpzlq7hzc928v2"; }
+    { name = "icicles-mode.el"; sha256 = "0gci04j6vx0vqsh4skarznklam1xibj7pjvy67kaip8b6a4zx9ip"; }
+    { name = "icicles-opt.el"; sha256 = "17g35ancml0mvywagzhjrgmlr4rhm1wgb5wg3fsqhhldib9qlz56"; }
+    { name = "icicles-var.el"; sha256 = "0ydixg41h09yncp8g2nv8zsyv8avg1hj2f3mgrmd2kf0n27bw2nv"; }
   ];
 
   forAll = f: map f modules;
 in
-stdenv.mkDerivation {
-  name = "icicles-2014-11-06";
+stdenv.mkDerivation rec {
+  version = "2017-10-28";
+  name = "icicles-${version}";
 
-  srcs = forAll ({name, sha256}: fetchurl { url = "http://www.emacswiki.org/emacs-en/download/${name}"; inherit sha256; });
+  srcs = forAll ({name, sha256}: fetchurl { url = "http://www.emacswiki.org/emacs/download/${name}"; inherit sha256; });
 
   buildInputs = [ emacs ];
 
@@ -30,11 +31,13 @@ stdenv.mkDerivation {
 
   buildPhase = "emacs --batch -L . -f batch-byte-compile *.el";
 
-  installPhase = "mkdir -p $out/share/emacs/site-lisp; cp *.el *.elc $out/share/emacs/site-lisp/";
+  installPhase = "mkdir -p $out/share/emacs/site-lisp/emacswiki/${name}/; cp *.el *.elc $out/share/emacs/site-lisp/emacswiki/${name}/";
 
   meta = {
     homepage = http://www.emacswiki.org/emacs/Icicles;
     description = "Enhance Emacs minibuffer input with cycling and powerful completion";
     license = stdenv.lib.licenses.gpl2Plus;
+    platforms   = emacs.meta.platforms;
+    maintainers = with stdenv.lib.maintainers; [ scolobb ];
   };
 }

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -268,6 +268,8 @@ let
     };
   };
 
+  icicles = callPackage ../applications/editors/emacs-modes/icicles { };
+
   rtags = melpaBuild rec {
     pname = "rtags";
     version = "2.12";


### PR DESCRIPTION
Also add icicles to the new Emacs infrastructure.

###### Motivation for this change
Update Icicles and make it usable with the new Emacs infrastructure (and thus in home-manager).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [-] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

