### PR TITLE
nixos docs: add release manager section

### DIFF
--- a/nixos/doc/manual/development/releases.xml
+++ b/nixos/doc/manual/development/releases.xml
@@ -220,6 +220,30 @@
    </itemizedlist>
   </section>
  </section>
+ <section xml:id="release-managers">
+  <title>Release Management Team</title>
+  <para>
+   For each release there are two release managers. After each release the
+   release manager having managed two releases steps down and the release
+   management team of the last release appoints a new release manager.
+  </para>
+  <para>
+   This makes sure a release management team always consists of one release
+   manager who already has managed one release and one release manager being
+   introduced to their role, making it easier to pass on knowledge and
+   experience.
+  </para>
+  <para>
+   A release manager's role and responsibilities are:
+  </para>
+  <itemizedlist>
+   <listitem><para>manage the release process</para></listitem>
+   <listitem><para>start discussions about features and changes for a given release</para></listitem>
+   <listitem><para>create a roadmap</para></listitem>
+   <listitem><para>release in cooperation with Eelco Dolstra</para></listitem>
+   <listitem><para>decide which bug fixes, features, etc... get backported after a release</para></listitem>
+  </itemizedlist>
+ </section>
  <section xml:id="release-schedule">
   <title>Release schedule</title>
 


### PR DESCRIPTION
###### Motivation for this change
This documents the process of electing and roles and responsibilities of the release management team per https://github.com/NixOS/rfcs/blob/master/rfcs/0015-release-manager.md.
