### PR TITLE
nodejs: init at 9.0.0

### DIFF
--- a/pkgs/development/web/nodejs/v9.nix
+++ b/pkgs/development/web/nodejs/v9.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, openssl, python2, zlib, libuv, v8, utillinux, http-parser
+, pkgconfig, runCommand, which, libtool, fetchpatch
+, callPackage
+, darwin ? null
+, enableNpm ? true
+}@args:
+
+let
+  nodejs = import ./nodejs.nix args;
+  baseName = if enableNpm then "nodejs" else "nodejs-slim";
+in
+  stdenv.mkDerivation (nodejs // rec {
+    version = "9.0.0";
+    name = "${baseName}-${version}";
+    src = fetchurl {
+      url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
+      sha256 = "19az7mxcb3d1aj0f7gvhriyyghn1rwn0425924pa84d6j1mbsljv";
+    };
+
+    patches = stdenv.lib.optionals stdenv.isDarwin [ ./no-xcode-v7.patch ];
+  })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3057,6 +3057,15 @@ with pkgs;
     enableNpm = false;
   };
 
+  nodejs-9_x = callPackage ../development/web/nodejs/v9.nix {
+    libtool = darwin.cctools;
+  };
+
+  nodejs-slim-9_x = callPackage ../development/web/nodejs/v9.nix {
+    libtool = darwin.cctools;
+    enableNpm = false;
+  };
+
   nodePackages_6_x = callPackage ../development/node-packages/default-v6.nix {
     nodejs = pkgs.nodejs-6_x;
   };


### PR DESCRIPTION
###### Motivation for this change

This adds the new node.js 9.x release line starting at 9.0.0.

[Release Notes](https://nodejs.org/en/blog/release/v9.0.0/)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

