### PR TITLE
iwona (font): init at 0_995

### DIFF
--- a/pkgs/data/fonts/iwona/default.nix
+++ b/pkgs/data/fonts/iwona/default.nix
@@ -5,13 +5,12 @@ stdenv.mkDerivation rec {
   version = "0_995";
 
   src = fetchzip {
-    url = "jmn.pl/pliki/Iwona-otf-${version}.zip";
+    url = "http://jmn.pl/pliki/Iwona-otf-${version}.zip";
     sha256 = "1wj5bxbxpz5a8p3rhw708cyjc0lgqji8g0iv6brmmbrrkpb3jq2s";
   };
 
   installPhase = ''
-    mkdir -p $out/share/fonts/opentype/
-    cp -v *.otf $out/share/fonts/opentype/
+    install -m 444 -D -t $out/share/fonts/opentype/ *.otf
   '';
 
   outputHashAlgo = "sha256";

--- a/pkgs/data/fonts/iwona/default.nix
+++ b/pkgs/data/fonts/iwona/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchzip }:
+
+stdenv.mkDerivation rec {
+  name = "iwona-${version}";
+  version = "0_995";
+
+  src = fetchzip {
+    url = "jmn.pl/pliki/Iwona-otf-${version}.zip";
+    sha256 = "1wj5bxbxpz5a8p3rhw708cyjc0lgqji8g0iv6brmmbrrkpb3jq2s";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype/
+    cp -v *.otf $out/share/fonts/opentype/
+  '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "1dcpn13bd31dw7ir0s722bv3nk136dy6qsab0kznjbzfqd7agswa";
+
+  meta = with stdenv.lib; {
+    description = "A two-element sans-serif typeface, created by Małgorzata Budyta";
+    homepage = http://jmn.pl/en/kurier-i-iwona/;
+    # "[...] GUST Font License (GFL), which is a free license, legally
+    # equivalent to the LaTeX Project Public # License (LPPL), version 1.3c or
+    # later." - GUST website
+    license = licenses.lppl13c;
+    maintainers = with maintainers; [ siddharthist ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13339,6 +13339,8 @@ with pkgs;
   ipafont = callPackage ../data/fonts/ipafont {};
   ipaexfont = callPackage ../data/fonts/ipaexfont {};
 
+  iwona = callPackage ../data/fonts/iwona { };
+
   junicode = callPackage ../data/fonts/junicode { };
 
   kawkab-mono-font = callPackage ../data/fonts/kawkab-mono {};


### PR DESCRIPTION
###### Motivation for this change
Another great sans-serif font!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

