### PR TITLE
utox: 0.13.1 -> 0.16.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/utox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/utox/default.nix
@@ -16,11 +16,11 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libtoxcore dbus libvpx libX11 openal freetype
     libv4l libXrender fontconfig libXext libXft filter-audio
-    libsodium libopus check
+    libsodium libopus
   ];
 
   nativeBuildInputs = [
-    cmake git pkgconfig
+    cmake git pkgconfig check
   ];
 
   cmakeFlags = [
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = false;
+
+  checkTarget = "test";
 
   meta = with stdenv.lib; {
     description = "Lightweight Tox client";

--- a/pkgs/applications/networking/instant-messengers/utox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/utox/default.nix
@@ -1,22 +1,22 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, libtoxcore, filter-audio, dbus, libvpx, libX11, openal, freetype, libv4l
-, libXrender, fontconfig, libXext, libXft, utillinux, git, libsodium }:
+, libXrender, fontconfig, libXext, libXft, utillinux, git, libsodium, libopus, check }:
 
 stdenv.mkDerivation rec {
   name = "utox-${version}";
-  # >= 0.14 should have unit tests and dbus support
-  version = "0.13.1";
+
+  version = "0.16.1";
 
   src = fetchFromGitHub {
     owner  = "uTox";
     repo   = "uTox";
     rev    = "v${version}";
-    sha256 = "07aa92isknxf7531jr9kgk89wl5rvv34jrvir043fs9xvim5zq99";
+    sha256 = "0ak10925v67yaga2pw9yzp0xkb5j1181srfjdyqpd29v8mi9j828";
   };
 
   buildInputs = [
     libtoxcore dbus libvpx libX11 openal freetype
     libv4l libXrender fontconfig libXext libXft filter-audio
-    libsodium
+    libsodium libopus check
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Updated to latest upstream version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

