### PR TITLE
runescape-launcher: init at 2.2.4, fixes #30582

### DIFF
--- a/pkgs/games/runescape-launcher/default.nix
+++ b/pkgs/games/runescape-launcher/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, newScope }:
+
+let
+  callPackage = newScope self;
+  self = {
+    runescape-launcher-runtime = callPackage ./runtime.nix {};
+    runescape-launcher-wrapper = callPackage ./wrapper.nix {};
+  };
+in
+
+with self;
+
+stdenv.mkDerivation rec {
+  name = "runescape-launcher-${version}";
+  version = runescape-launcher-runtime.version;
+
+  buildInputs = [
+    runescape-launcher-runtime
+    runescape-launcher-wrapper
+  ];
+
+  unpackPhase = ":";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    ln -s ${runescape-launcher-wrapper}/bin/${runescape-launcher-wrapper.name} $out/bin/runescape-launcher
+    ln -s ${runescape-launcher-runtime}/share $out/share
+  '';
+}

--- a/pkgs/games/runescape-launcher/runtime.nix
+++ b/pkgs/games/runescape-launcher/runtime.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, dpkg }:
+
+stdenv.mkDerivation rec {
+  name = "runescape-launcher-runtime-${version}";
+  version = "2.2.4";
+
+  src = fetchurl {
+    url = "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/runescape-launcher/runescape-launcher_${version}_amd64.deb";
+    sha256 = "0yab34widf3j4s6lhn6w1q76kihrbyphmr4ifkkawg10csd0n17l";
+  };
+
+  dontPatchELF = true;
+  dontStrip = true;
+
+  nativeBuildInputs = [ dpkg ];
+  unpackCmd = "dpkg -x $curSrc .";
+
+  installPhase = ''
+    cp -r . $out
+    substituteInPlace $out/bin/runescape-launcher --replace /usr/share $out/share
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Runescape NXT client";
+    homepage = https://www.runescape.com;
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ yegortimoshenko ];
+  };
+}

--- a/pkgs/games/runescape-launcher/wrapper.nix
+++ b/pkgs/games/runescape-launcher/wrapper.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildFHSUserEnv, runescape-launcher-runtime }:
+
+buildFHSUserEnv rec {
+  name = "runescape-launcher-wrapper-${runescape-launcher-runtime.version}";
+
+  runScript = "${runescape-launcher-runtime}/bin/runescape-launcher";
+
+  targetPkgs = pkgs: with pkgs // pkgs.xorg; [
+    libSM
+    libX11
+    libXxf86vm
+    libpng12
+    glib
+    glib_networking
+    pango
+    cairo
+    gdk_pixbuf
+    curl
+    gtk2
+    expat
+    SDL2
+    zlib
+    glew110
+    mesa
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17965,6 +17965,8 @@ with pkgs;
 
   rocksndiamonds = callPackage ../games/rocksndiamonds { };
 
+  runescape-launcher = callPackage ../games/runescape-launcher { };
+
   saga = callPackage ../applications/gis/saga { };
 
   samplv1 = callPackage ../applications/audio/samplv1 { };


### PR DESCRIPTION
###### Motivation for this change

Fixes #30582.

Runescape client only runs in FHS environment, otherwise it freezes at "Loading application resources".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

