### PR TITLE
slack: 2.8.0 -> 2.8.2 (potential electron security update)

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -4,7 +4,7 @@
 
 let
 
-  version = "2.8.0";
+  version = "2.8.2";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
@@ -46,7 +46,7 @@ let
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "https://downloads.slack-edge.com/linux_releases/slack-desktop-${version}-amd64.deb";
-        sha256 = "02khqi0qf8ryj6bkfla95mr3scvb99zrhihwdprdjqpgvy06wqhm";
+        sha256 = "019gzij6m1y9bv561nhbhgf2njp2svjqi5hs907pdjf7xwciwrkm";
       }
     else
       throw "Slack is not supported on ${stdenv.system}";


### PR DESCRIPTION
fixes japanese input & some obscure security issues:
`An important Electron update improving security. A precautionary measure, but it’s always good to be up to date.` and
`A small release containing nothing but another Electron update, this one better than the last.`

Release notes at: https://slack.com/intl/en-en/release-notes/linux

One might consider backporting this to stable due to the potential security fix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

