### PR TITLE
osx_private_sdk: reduce output size and remove it from runtime closures

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurity_filedb/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurity_filedb/default.nix
@@ -6,7 +6,7 @@ appleDerivation {
     libsecurity_cdsa_plugin
   ];
   patchPhase = ''
-    cp ${osx_private_sdk}/PrivateSDK10.9.sparse.sdk/usr/local/include/sandbox_private.h .
+    cp ${osx_private_sdk}/include/sandbox_private.h .
     substituteInPlace sandbox_private.h --replace '<sandbox.h>' '"${apple_sdk.sdk}/include/sandbox.h"'
     substituteInPlace lib/AtomicFile.cpp --replace '<sandbox.h>' '"sandbox_private.h"'
   '';

--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurity_generic/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurity_generic/default.nix
@@ -10,7 +10,7 @@ name: version: sha256: args: let
 
       patchPhase = ''
         # allows including <Security/some-private-header.h>
-        ln -s ${pkgs.darwin.osx_private_sdk}/PrivateSDK10.9.sparse.sdk/System/Library/Frameworks/Security.framework/Versions/A/PrivateHeaders Security
+        cp -R ${pkgs.darwin.osx_private_sdk}/include/SecurityPrivateHeaders Security
 
         grep -Rl MacErrors.h . | while read file; do
           substituteInPlace "''$file" --replace \

--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurity_keychain/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurity_keychain/default.nix
@@ -18,9 +18,9 @@ appleDerivation {
 
     substituteInPlace lib/SecCertificate.cpp --replace '#include <Security/SecCertificatePriv.h>' ""
 
-    cp ${osx_private_sdk}/PrivateSDK10.9.sparse.sdk/usr/include/xpc/private.h xpc
+    cp ${osx_private_sdk}/include/xpc/private.h xpc
     cp ${apple_sdk.sdk}/include/xpc/*.h xpc
-    cp ${osx_private_sdk}/PrivateSDK10.9.sparse.sdk/usr/local/include/sandbox_private.h lib/sandbox.h
+    cp ${osx_private_sdk}/include/sandbox_private.h lib/sandbox.h
 
     substituteInPlace lib/SecItemPriv.h \
       --replace "extern CFTypeRef kSecAttrAccessGroup" "extern const CFTypeRef kSecAttrAccessGroup" \

--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurity_utilities/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurity_utilities/default.nix
@@ -17,9 +17,8 @@ appleDerivation {
     substituteInPlace lib/powerwatch.h --replace \
       '<IOKit/pwr_mgt/IOPMLibPrivate.h>' \
       '"${IOKit}/Library/Frameworks/IOKit.framework/Headers/pwr_mgt/IOPMLibPrivate.h"'
-
-    cp ${osx_private_sdk}/PrivateSDK10.9.sparse.sdk/usr/include/security_utilities/utilities_dtrace.h lib
-    cp -R ${osx_private_sdk}/PrivateSDK10.9.sparse.sdk/usr/local/include/bsm lib
+    cp -R ${osx_private_sdk}/include/bsm lib
+    cp ${osx_private_sdk}/include/utilities_dtrace.h lib
   '' + stdenv.lib.optionalString (!stdenv.cc.nativeLibc) ''
     substituteInPlace lib/vproc++.cpp --replace /usr/local/include/vproc_priv.h ${stdenv.libc}/include/vproc_priv.h
   '';

--- a/pkgs/os-specific/darwin/cf-private/default.nix
+++ b/pkgs/os-specific/darwin/cf-private/default.nix
@@ -1,31 +1,18 @@
 { stdenv, osx_private_sdk, CF }:
 
-let
-  headers = [
-    "CFAvailability.h"
-    "CFAttributedString.h"
-    "CFFileDescriptor.h"
-    "CFFileSecurity.h"
-    "CFNotificationCenter.h"
-    "CFStringTokenizer.h"
-    "CFURLEnumerator.h"
-    "CFURL.h"
-    "CoreFoundation.h"
-  ];
-
-in stdenv.mkDerivation {
+stdenv.mkDerivation {
   name = "${CF.name}-private";
   phases = [ "installPhase" "fixupPhase" ];
   installPhase = ''
     dest=$out/Library/Frameworks/CoreFoundation.framework/Headers
     mkdir -p $dest
     pushd $dest
-    for file in ${CF}/Library/Frameworks/CoreFoundation.framework/Headers/*; do
-      ln -s $file
-    done
+      cp -Lv ${osx_private_sdk}/include/CoreFoundationPrivateHeaders/* $dest
+      for file in ${CF}/Library/Frameworks/CoreFoundation.framework/Headers/*; do
+        ln -sf $file 
+      done
     popd
 
-    install -m 0644 ${osx_private_sdk}/PrivateSDK10.10.sparse.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/{${stdenv.lib.concatStringsSep "," headers}} $dest
   '';
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/os-specific/darwin/osx-private-sdk/default.nix
+++ b/pkgs/os-specific/darwin/osx-private-sdk/default.nix
@@ -1,8 +1,27 @@
 { stdenv, fetchFromGitHub }:
 
-fetchFromGitHub {
-  owner = "samdmarshall";
-  repo = "OSXPrivateSDK";
-  rev = "f4d52b60e86b496abfaffa119a7d299562d99783";
-  sha256 = "0bv0884yxpvk2ishxj8gdy1w6wb0gwfq55q5qjp0s8z0z7f63zqh";
+stdenv.mkDerivation {
+  name = "OSXPrivateSDK";
+
+  src = fetchFromGitHub {
+    owner = "samdmarshall";
+    repo = "OSXPrivateSDK";
+    rev = "f4d52b60e86b496abfaffa119a7d299562d99783";
+    sha256 = "0bv0884yxpvk2ishxj8gdy1w6wb0gwfq55q5qjp0s8z0z7f63zqh";
+  };
+
+  # NOTE: we install only headers that are really needed to keep closure sie
+  # reasonable.
+  installPhase = ''
+    mkdir -p $out/include
+    sdk10=PrivateSDK10.10.sparse.sdk
+    sdk=PrivateSDK10.9.sparse.sdk
+    cp $sdk/usr/local/include/sandbox_private.h $out/include/sandbox_private.h
+    # this can be removed once we dtrace binary
+    cp $sdk/usr/local/include/security_utilities/utilities_dtrace.h $out/include/utilities_dtrace.h
+    cp -RL $sdk/usr/include/xpc $out/include/xpc
+    cp -RL $sdk/usr/local/include/bsm $out/include/bsm
+    cp -RL $sdk/System/Library/Frameworks/Security.framework/Versions/A/PrivateHeaders $out/include/SecurityPrivateHeaders
+    cp -RL $sdk10/System/Library/Frameworks/CoreFoundation.framework/Headers $out/include/CoreFoundationPrivateHeaders
+  '';
 }

--- a/pkgs/os-specific/darwin/security-tool/default.nix
+++ b/pkgs/os-specific/darwin/security-tool/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     # copied from libsecurity_generic
-    ln -s ${osx_private_sdk}/PrivateSDK10.9.sparse.sdk/System/Library/Frameworks/Security.framework/Versions/A/PrivateHeaders Security
+    cp -R ${osx_private_sdk}/include/SecurityPrivateHeaders Security
 
     substituteInPlace cmsutil.c --replace \
       '<CoreServices/../Frameworks/CarbonCore.framework/Headers/MacErrors.h>' \


### PR DESCRIPTION
- reduces `osx_private_sdk` output size from 350MB to 0.5MB
- gets rid of it completely in runtime