### PR TITLE
gcc: 5.4.0 -> 5.5.0

### DIFF
--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -59,8 +59,8 @@ assert langGo -> langCC;
 with stdenv.lib;
 with builtins;
 
-let version = "5.4.0";
-    sha256 = "0fihlcy5hnksdxk0sn6bvgnyq8gfrgs8m794b1jxwd1dxinzg3b0";
+let version = "5.5.0";
+    sha256 = "11zd1hgzkli3b2v70qsm2hyqppngd4616qc96lmm9zl2kl9yl32k";
 
     # Whether building a cross-compiler for GNU/Hurd.
     crossGNU = targetPlatform != hostPlatform && targetPlatform.config == "i586-pc-gnu";
@@ -217,7 +217,7 @@ stdenv.mkDerivation ({
   builder = ../builder.sh;
 
   src = fetchurl {
-    url = "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.bz2";
+    url = "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.xz";
     inherit sha256;
   };
 


### PR DESCRIPTION
Use this as an opportunity to remove empty patches array.


###### Motivation for this change

Minor update.
Includes fix particularly relevant for Nix users where large PATH entries overflowed the stack and badness resulted:
https://git.musl-libc.org/cgit/musl/commit/?id=004dc9549b8003288e635ba5aa91e3353e1974c4
The commit author is also super cool :innocent:.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


---

Checked `nix-build pkgs/stdenv/linux/make-bootstrap-tools.nix -A test`