### PR TITLE
jython: 2.7.0 -> 2.7.1

### DIFF
--- a/pkgs/development/interpreters/jython/default.nix
+++ b/pkgs/development/interpreters/jython/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "jython-${version}";
 
-  version = "2.7.0";
+  version = "2.7.1";
 
   src = fetchurl {
     url = "http://search.maven.org/remotecontent?filepath=org/python/jython-standalone/${version}/jython-standalone-${version}.jar";
-    sha256 = "0sk4myh9v7ma7nmzb8khg41na77xfi2zck7876bs7kq18n8nc1nx";
+    sha256 = "0jwc4ly75cna78blnisv4q8nfcn5s0g4wk7jf4d16j0rfcd0shf4";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
addresses CVE-2016-4000 (tracked as jython bug 2454).

Additional Changelog:

```
Jython 2.7.1
  same as 2.7.1rc3

Jython 2.7.1rc3
  Bugs fixed
    - [ 2597 ] PySystemState.sysClosers requires cleanup to prevent memory leak
    - [ 2593 ] file.write(obj) raises NullPointerException on type error
    - [ 2592 ] Line breaks in exceptions are wrong (characters being backslash-escaped)

Jython 2.7.1rc2
  Bugs fixed
    - [ 2536 ] deadlocks in regrtests due to StackOverflowError in finally block (workaround, still open)
    - [ 2356 ] java.lang.IllegalArgumentException on startup on Windows if username not ASCII
    - [ 1839 ] sys.getfilesystemencoding() is None (now utf-8)
    - [ 2579 ] Pyc files are not loading for too large modules if path contains __pyclasspath__
    - [ 2570 ] Wrong shebang set for OS X installation of Jython
    - [ 2585 ] test_ssl failure due to Netty exception mapping
    - [ 2313 ] test_jython_initializer failure on Windows
    - [ 2399 ] test_sort failure on Java 8
    - [ 2309 ] test_classpathimporter fails on Windows.
    - [ 2318 ] test_zipimport_jy failure on Windows
    - [ 2571 ] Error handling in test_codecencodings_tw fails on Java 8
    - [ 2568 ] test_threading intermittent failure
    - [ 2559 ] test_marshal fails
    - [ 2564 ] test_socket_jy fails on Linux
    - [ 2524 ] datetime <-> time conversion incorrect in non UTC times
    - [ 2504 ] datetime.date.__tojava__ returns incorrect dates in non-UTC timezones with
               negative offset (Jython 2.7.0)
    - [ 2500 ] Loading default cacerts on client socket when specifying a default java truststore
               unnecessarily searches for more cacerts in the same dir
    - [ 2561 ] win32_ver raises exception (breaks test_platform on windows)
    - [ 2521 ] Windows installation (all) fails on Windows 10
    - [ 2557 ] ongoing pain with platform detection via os.name and sys.platform
    - [ 1996 ] Core slots array out of bounds with multiple inheritance
    - [ 2101 ] Diamond-style multiple inheritance fails when using __slots__ on the second branch

  New Features
    - Updated Netty to 4.1.11, ASM to 5.2, BouncyCastle to 1.57, Commons Compress to 1.14,
      Guava to 22.0, ICU4J to 59.1, JFFI to 1.2.15, JNR-JFFI to 2.1.5, JNR-POSIX to 3.0.41,
      JNR-Constants 0.9.9, JLine to 2.14.3, MySQL Connector to 5.1.42, PostgreSQL to 42.1.1
      Note:
      You might find it strange that Jython bundles guava-22.0-android.jar rather than guava-22.0.jar.
      This is the official way to support Java 7 with Guava > 20.0, also on non-Android platforms.
      See https://github.com/google/guava/wiki/Release22#guava-release-220-release-notes.
    - There is now support for non-ascii paths in all (home, installation, temporary)
      directories, which previously caused failures. sys.getplatformencoding() returns
      'utf-8' as the nominal file-system encoding, irrespective of localization. This may
      differ from what CPython reports on the same OS. In Jython a file path presented
      as bytes is the UTF-8 encoding of the unicode file path as Java sees it. (See issues
      #1839 and #2356.) This matter is unrelated to file.encoding or the console.

Jython 2.7.1rc1
  Bugs fixed
    - [ 2552 ] installing scandir via pip fails (breaks e.g. installing pathlib2 via pip)
    - [ 2534 ] os.getlogin() returns a wrong user or returns an exception
    - [ 2553 ] sys.getwindowsversion not implemented (breaks pathlib on Windows)
    - [ PR55 ] Replace deprecated use of ASCII constant with ascii()
    - [ 1777 ] Help getting SymPy working with Jython
    - [ 2475 ] Backported python 3 pathlib and pathlib2 do not work b/c of meta class issues
    - [ 2551 ] __slots__ in diamond-style causes lay-out conflict (breaks pathlib and sympy)
    - [ 2550 ] test_list_jy fails on Java 8
    - [ 2549 ] test_posix fails on Linux
    - [ 2548 ] Unicode u'\N{name}' frequently broken, because ucnhash.dat outdated
    - [ 2527 ] cStringIO throws IllegalArgumentException with non-ASCII values
    - [ 2511 ] Percent operator calls __getattr__('__getitem__')
    - [ PR28 ] zipimporter supports multi-byte characters in pathnames
    - [ 2228 ] Re-use "makeCompiledFilename" function where possible
    - [ 608632 ] __doc__foo should accept java String
    - [ 2523 ] defaultdict.__getitem__() does not propagate exceptions raised by calling
               default_factory
    - [ 2522 ] defaultdict.__getitem__(unhashable) raises KeyError instead of TypeError
    - [ 2515 ] typing module doesn't import
    - [ 2538 ] Test failures in test_unittest
    - [ 2293 ] "java.lang.IllegalArgumentException: java.lang.IllegalArgumentException:
               Cannot create PyString with non-byte value" triggered after adding
               unicode element with non-ASCII character to sys.path
    - [ 2535 ] Building jython standalone manually results in local filesystem paths
               showing up in Jython stacktraces
    - [ 2533 ] Opcode.java is outdated -> breaks PyBytecode.interpret
    - [ 2502 ] Missing OpenFlags enum entry makes Jython clash with JRuby dependency
    - [ 2446 ] Support SNI for SSL/TLS client sockets
    - [ PR50 ] Calling Java vararg methods with no arguments fails
    - [ 2455 ] Java classes in packages with __init__.py not found
    - [ 2481 ] Update urllib2.py from 2.7.11
    - [ 2514 ] Jython Class.__subclasses__() does not match Python output (not in load order)
    - [ 2413 ] ElementTree.write doesn't close files if used with invalid encoding
    - [ 2443 ] java.util.Map derived classes lack iterkeys, itervalues methods
    - [ 2516 ] _get_open_ssl_key_manager tries to validate that the private and
               public keys match, and is throwing an SSLError:
               "key values mismatch" when provided with multiple certs (Root/CA/Cert)
    - [ 2314 ] Failures in test_shutil on Windows
    - [ 2488 ] Subprocess should always join corresponding coupler threads
    - [ 2461 ] SSL Handshake fails for peers connected via IPV6
    - [ 2508 ] Jython non-blocking socket send() does not conform to Python's behavior.
    - [ 2462 ] SSL Handshake never happens even if do_handshake_on_connect=True for serv
    - [ 2487 ] PyType.fromClass deadlocks on slow systems (circleci for example)
    - [ 2480 ] Repeating from <javapackage> import <class> results in reload
    - [ 2472 ] Importing simplejson fails with: 'NoneType' object has no
               attribute 'encode_basestring_ascii'
    - [ 2471 ] Jython is using netty channel future incorrectly
    - [ 2470 ] Jython leaks sockets in select reactor
    - [ 2469 ] Embedded BouncyCastle provider does not validate properly
    - [ 2460 ] Wrong result when multiplying complex numbers involving infinity
    - [ 2454 ] Security Vulnerability in Jython
    - [ 2442 ] Overriding __len__, __iter__, and __getitem__ in a tuple subclass
               causes an infinite recursion
    - [ 2112 ] time.strptime() has different default year in Jython and CPython
    - [ 1767 ] Rich comparisons

  New Features
    - Recognize cpython_cmd property to automatically build CPython bytecode for oversized
      functions (e.g. jython -J-Dcpython_cmd=python). This is especially convenient when
      installing things like SymPy via pip; it would frequently prompt you to provide yet
      another pyc-file. Now just run: pip install --global-option="-J-Dcpython_cmd=python" sympy
    - SymPy is now workable. (However it runs somewhat slow; some profiling will be required.)
    - Updated ucnhash to support name lookup for Unicode 9.0 (like in u'\N{name}').
    - Jython doc-entries in Java-code (__doc__foo) now accept anything that implements
      java.lang.CharSequence (PyString implements CharSequence now as well).
      This allows Jython-friendly Java-code without PyString-induced dependency on Jython.
    - Provided a painless way to deal with long-standing Issue 527524 - "Cannot compile to use
      methods exceeding JVM size restrictions": If a CPython 2.7 bytecode-file (.pyc) exists,
      Jython automatically uses that bytecode to represent oversized functions and methods,
      while methods with proper size are still compiled to JVM bytecode.
      The crucial bytecode sections from the pyc-file are embedded seamlessly into the created
      class-file, so you wouldn't have to distribute the pyc-file at all.
      Current implementation of this feature is provisional and might change in future versions.
      Issue 527524 was still not listed as solved, because Jython cannot yet create the pyc-file
      by itself.
    - Support for CPython bytecode (.pyc-files) was updated to Python 2.7 bytecode (from 2.5).
    - Buffer API changes allow java.nio.ByteBuffer to provide the storage when a PyBuffer
      is exported. This is to support CPython extensions via JyNI, but has other uses too
      (including access to direct memory buffers from Python). There is no change at the
      Python level or for client code using PyBuffer via the "fully encapsulated" API. It
      risks breaking code that makes direct access to a byte array via PyBuffer, implements
      the PyBuffer interface, or extends implementation classes in org.python.core.buffer.
    - Updated Netty to 4.1.4
    - Fixed platform.mac_ver to provide actual info on Mac OS similar to CPython behavior.
    - Added uname function to posix module. The mostly Java-based implementation even
      works to some extend on non-posix systems (e.g. Windows).

Jython 2.7.1b3
  Bugs fixed
    - [ 550200 ] Jython does not work on ebcdic platforms
    - [ 2457 ] Synchronization bug in PySystemStateCloser causes complete deadlock
    - [ 2456 ] java.util.List.remove(index) does not dispatch to overloaded method for index remove
    - [ 2453 ] org.python.modules.sre.PatternObject should be named SRE_Pattern to look like CPython
    - [ 2452 ] Jython locking threads on Java proxy objects (multithreaded performance degradation)
    - [ 2451 ] array.array objects should not hash
    - [ 2441 ] sys.executable is None on standalone install, thus causing a setup()
               install/build to fail
    - [ 2439 ] 'SSLSocket' object has no attribute 'accept'
    - [ 2437 ] no common ciphers SSL handshake error
    - [ 2436 ] Missing socket.SOL_TCP (= socket.IPPROTO_TCP)
    - [ 2435 ] Remove unsupported socket options like socket.SO_EXCLUSIVEADDRUSE
    - [ 2434 ] zlib module has different flush behaviour than CPython and PyPy
    - [ 2431 ] tox not working because of zero width bug in Jython sre
    - [ 2428 ] socket.connect_ex does not properly report connection state sequence
    - [ 2426 ] Support socket shutdown with "how" of _socket.SHUT_RDWR (2)
    - [ 2423 ] jarray.array() method broken in 2.7
    - [ 2421 ] UnboundLocalError: local variable 'key_store' referenced before
               assignment in _sslverify.py
    - [ 2417 ] os.utime fails on UNC network paths
    - [ 2416 ] os.system does not use changes to os.environ in subprocesses
    - [ 2401 ] SSL race produces NPE
    - [ 2400 ] Installing pip as part of Jython installation fails
    - [ 2393 ] Clean running regression tests on windows
    - [ 2392 ] Intermittent errors from sre_compile.py - 
               ValueError('unsupported operand type', 'subpattern')
    - [ 2391 ] read-only attr wrongly reported
    - [ 2390 ] Support SSLContext
    - [ 2374 ] setsockopt call from pika fails with "Protocol not available"error
    - [ 2368 ] Problem with _io and BlockingIOError
    - [ 2360 ] Not installing pip on Jython
    - [ 2358 ] Using "read all" ops on /proc files on Linux produces empty strings
    - [ 2357 ] Infinite recursion with set subclass
    - [ 2338 ] readline.py startup hook
    - [ 2329 ] Cannot create virtualenv with jython2.7rc2 - breaks tox
    - [ 2321 ] Py.setSystemState() is a NOOP
    - [ 2279 ] PyIterator#__tojava__ should support coercion to java array
    - [ 2350 ] Installer errors on ensurepip
    - [ 2276 ] Ctrl-Z doesn't exit Jython console on Windows
    - [ 2223 ] __file__ not defined when running from ScriptEngine
    - [ 2154 ] When running multiple engines in different threads, the last registered
               writer is in use for all script executions.
    - [ 2124 ] xml.dom.minidom.writexml() changes value of TEXT_NODE
    - [ 1984 ] os.pipe() missing
    - [ 1953 ] lib2to3 missing
    - [ 1780 ] jarray not properly converted to list with java.util.Arrays.asList(T... a)
    - [ 1739 ] JSR223: ScriptEngine.FILENAME not honoured
    - [ 1738 ] JSR223: ScriptEngine.ARGV is not honoured

  New Features
    - Use latest upstream bundled wheels for ensurepip: pip (7.1.2), setuptools (18.4),
      replacing wheels patched specifically for Jython
    - Unified PyDictionary and PyStringMap under a common abstract base class.
    - Added Py.newJ method family for easier access to Python code from Java. Now you
      can coerce Python types under Java interfaces without needing to inherit from
      the Java-interface in Python code. Also see PyModule.newJ.

Jython 2.7.1b2
  Bugs fixed
   - [ 2396 ] test_threading and others fail under Cygwin (sys.executable).
   - [ 2397 ] test.test_os_jy fails on Windows due to non-byte PyString.
   - [ 2405 ] os.getpid() is missing (JNR JARs updated). 

Jython 2.7.1b1
  Bugs fixed
   - [ 1423 ] Circular imports no longer cause RuntimeError.
   - [ 2310 ] test_import runs on Windows (and passes with 4 skips).
   - [ 2347 ] failures in test_import_pep328 when run with -m
   - [ 2158, 2259 ] Fixed behaviour of relative from ... import *
   - [ 1879 ] -m command now executes scripts from inside a jar file 
   - [ 2058 ] ClasspathPyImporter implements PEP 302 get_data (and others)
   +
−- [ 2364 ] bytearray and str: isalpha(), isupper() etc. now match Python 2
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

