### PR TITLE
rdfind: 1.3.4 → 1.3.5

### DIFF
--- a/pkgs/tools/filesystems/rdfind/default.nix
+++ b/pkgs/tools/filesystems/rdfind/default.nix
@@ -2,20 +2,20 @@
 
 stdenv.mkDerivation rec {
   name = "rdfind-${version}";
-  version = "1.3.4";
+  version = "1.3.5";
 
   src = fetchurl {
-    url = "http://rdfind.pauldreik.se/${name}.tar.gz";
-    sha256 = "0zfc5whh6j5xfbxr6wvznk62qs1mkd3r7jcq72wjgnck43vv7w55";
+    url = "https://rdfind.pauldreik.se/${name}.tar.gz";
+    sha256 = "0i63f2lwwkiq5m8shi3wwi59i1s25r6dx6flsgqxs1jvlcg0lvn3";
   };
 
   buildInputs = [ nettle ];
 
-  meta = {
-    homepage = http://rdfind.pauldreik.se/;
+  meta = with stdenv.lib; {
+    homepage = https://rdfind.pauldreik.se/;
     description = "Removes or hardlinks duplicate files very swiftly";
     license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [ wmertens ];
-    platforms = with stdenv.lib.platforms; all;
+    maintainers = [ maintainers.wmertens ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION

###### Motivation for this change
Version bump
Contains bug fixes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

