### PR TITLE
ibus: 1.5.16 -> 1.5.17, fix

### DIFF
--- a/pkgs/desktops/gnome-3/core/gconf/default.nix
+++ b/pkgs/desktops/gnome-3/core/gconf/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, dbus_glib, gnome3 ? null, glib, libxml2
-, intltool, polkit, orbit, withGtk ? false }:
+, intltool, polkit, orbit, python, withGtk ? false }:
 
 assert withGtk -> (gnome3 != null);
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = "0k3q9nh53yhc9qxf1zaicz4sk8p3kzq4ndjdsgpaa2db0ccbj4hr";
   };
 
-  buildInputs = [ libxml2 polkit orbit ] ++ stdenv.lib.optional withGtk gnome3.gtk;
+  buildInputs = [ libxml2 polkit orbit python ] ++ stdenv.lib.optional withGtk gnome3.gtk;
   propagatedBuildInputs = [ glib dbus_glib  ];
   nativeBuildInputs = [ pkgconfig intltool ];
 

--- a/pkgs/development/libraries/gobject-introspection/setup-hook.sh
+++ b/pkgs/development/libraries/gobject-introspection/setup-hook.sh
@@ -1,5 +1,4 @@
 make_gobject_introspection_find_gir_files() {
-
     # required for .typelib files, eg mypaint git version
     if [ -d "$1/lib/girepository-1.0" ]; then
       addToSearchPath GI_TYPELIB_PATH $1/lib/girepository-1.0
@@ -13,9 +12,16 @@ make_gobject_introspection_find_gir_files() {
 
 envHooks+=(make_gobject_introspection_find_gir_files)
 
+giDiscoverSelf() {
+    if [ -d "$prefix/lib/girepository-1.0" ]; then
+      addToSearchPath GI_TYPELIB_PATH $prefix/lib/girepository-1.0
+    fi
+}
+
+preFixupHooks+=(giDiscoverSelf)
+
 _multioutMoveGlibGir() {
   moveToOutput share/gir-1.0 "${!outputDev}"
 }
 
 preFixupHooks+=(_multioutMoveGlibGir)
-

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -1,129 +1,138 @@
-{ stdenv, fetchurl, wrapGAppsHook
-, intltool, isocodes, pkgconfig
-, python3
-, gtk2, gtk3, atk, dconf, glib, json_glib
-, dbus, libnotify, gobjectIntrospection, wayland
-}:
+{ stdenv, fetchurl, fetchFromGitHub, autoreconfHook, gconf, intltool, makeWrapper, pkgconfig
+, vala, wrapGAppsHook, atk, dbus, dconf ? null, glib, gdk_pixbuf, gobjectIntrospection, gtk2
+, gtk3, gtk_doc, isocodes, python3, json_glib, libnotify ? null, enablePythonLibrary ? true
+, enableUI ? true, withWayland ? false, libxkbcommon ? null, wayland ? null }:
+
+assert withWayland -> wayland != null && libxkbcommon != null;
+
+with stdenv.lib;
 
 let
-  emojiData = let
-    srcs = {
-      data = fetchurl {
-        url = "http://unicode.org/Public/emoji/5.0/emoji-data.txt";
-        sha256 = "11jfz5rrvyc2ixliqfcjgmch4cn9mfy0x96qnpfcyz5fy1jvfyxf";
-      };
-      sequences = fetchurl {
-        url = "http://unicode.org/Public/emoji/5.0/emoji-sequences.txt";
-        sha256 = "09bii7f5mmladg0kl3n80fa9qaix6bv5ylm92x52j7wygzv0szb1";
-      };
-      variation-sequences = fetchurl {
-        url = "http://unicode.org/Public/emoji/5.0/emoji-variation-sequences.txt";
-        sha256 = "1wlg4gbq7spmpppjfy5zdl82sj0hc836p8gljgfrjmwsjgybq286";
-      };
-      zwj-sequences = fetchurl {
-        url = "http://unicode.org/Public/emoji/5.0/emoji-zwj-sequences.txt";
-        sha256 = "16gvzv76mjv9g81lm1m6cr3rpfqyn2k4hb9a62xd329252dhl25q";
-      };
-      test = fetchurl {
-        url = "http://unicode.org/Public/emoji/5.0/emoji-test.txt";
-        sha256 = "031qk2v8xdnba7hfinmgrmpglc9l8ll2hds6mw885p0hngdb3dgw";
-      };
+  emojiSrcs = {
+    data = fetchurl {
+      url = "http://unicode.org/Public/emoji/5.0/emoji-data.txt";
+      sha256 = "11jfz5rrvyc2ixliqfcjgmch4cn9mfy0x96qnpfcyz5fy1jvfyxf";
     };
-  in stdenv.mkDerivation {
+    sequences = fetchurl {
+      url = "http://unicode.org/Public/emoji/5.0/emoji-sequences.txt";
+      sha256 = "09bii7f5mmladg0kl3n80fa9qaix6bv5ylm92x52j7wygzv0szb1";
+    };
+    variation-sequences = fetchurl {
+      url = "http://unicode.org/Public/emoji/5.0/emoji-variation-sequences.txt";
+      sha256 = "1wlg4gbq7spmpppjfy5zdl82sj0hc836p8gljgfrjmwsjgybq286";
+    };
+    zwj-sequences = fetchurl {
+      url = "http://unicode.org/Public/emoji/5.0/emoji-zwj-sequences.txt";
+      sha256 = "16gvzv76mjv9g81lm1m6cr3rpfqyn2k4hb9a62xd329252dhl25q";
+    };
+    test = fetchurl {
+      url = "http://unicode.org/Public/emoji/5.0/emoji-test.txt";
+      sha256 = "031qk2v8xdnba7hfinmgrmpglc9l8ll2hds6mw885p0hngdb3dgw";
+    };
+  };
+  emojiData = stdenv.mkDerivation {
     name = "emoji-data-5.0";
     unpackPhase = ":";
-    dontBuild = true;
-    installPhase = with stdenv.lib; ''
+    installPhase = ''
       mkdir $out
-      ${builtins.toString (flip mapAttrsToList srcs (k: v: ''
-        cp ${v} $out/emoji-${k}.txt
-      ''))}
+      ${builtins.toString (flip mapAttrsToList emojiSrcs (k: v: "cp ${v} $out/emoji-${k}.txt;"))}
     '';
   };
   cldrEmojiAnnotation = stdenv.mkDerivation rec {
     name = "cldr-emoji-annotation-${version}";
-    version = "31.0.1_1";
-    src = fetchurl {
-      url = "https://github.com/fujiwarat/cldr-emoji-annotation/releases/download/${version}/${name}.tar.gz";
-      sha256 = "1a3qzsab7vzjqpdialp1g8ppr21x05v0ph8ngyq9pyjkx4vzcdi7";
+    version = "31.90.0_1";
+    src = fetchFromGitHub {
+      owner = "fujiwarat";
+      repo = "cldr-emoji-annotation";
+      rev = version;
+      sha256 = "1vsj32bg8ab4d80rz0fxy6sj2lv31inzyjnddjm079bnvlaf2kih";
     };
+    nativeBuildInputs = [ autoreconfHook ];
   };
-  pyEnv = python3.buildEnv.override {
-    extraLibs = [ python3.pkgs.pygobject3 ];
-
+  python3Runtime = python3.withPackages (ps: with ps; [ pygobject3 ]);
+  python3BuildEnv = python3.buildEnv.override {
     # ImportError: No module named site
     postBuild = ''
-      makeWrapper '${glib.dev}/bin/glib-genmarshal' "$out"/bin/glib-genmarshal \
-        --unset PYTHONPATH
+      makeWrapper ${glib.dev}/bin/gdbus-codegen $out/bin/gdbus-codegen --unset PYTHONPATH
+      makeWrapper ${glib.dev}/bin/glib-genmarshal $out/bin/glib-genmarshal --unset PYTHONPATH
+      makeWrapper ${glib.dev}/bin/glib-mkenums $out/bin/glib-mkenums --unset PYTHONPATH
     '';
   };
-in stdenv.mkDerivation rec {
-  name = "ibus-${version}";
-  version = "1.5.16";
+in
 
-  src = fetchurl {
-    url = "https://github.com/ibus/ibus/releases/download/${version}/${name}.tar.gz";
-    sha256 = "07py16jb81kd7vkqhcia9cb2avsbg5jswp2kzf0k4bprwkxppd9n";
+stdenv.mkDerivation rec {
+  name = "ibus-${version}";
+  version = "1.5.17";
+
+  src = fetchFromGitHub {
+    owner = "ibus";
+    repo = "ibus";
+    rev = version;
+    sha256 = "09mrj9d8qpl9cbylg1zx8c3ymc5gdy4jrf6zs125wjz0b574g5av";
   };
 
   postPatch = ''
-    # These paths will be set in the wrapper.
-    sed -e "/export IBUS_DATAROOTDIR/ s/^.*$//" \
-        -e "/export IBUS_LIBEXECDIR/ s/^.*$//" \
-        -e "/export IBUS_LOCALEDIR/ s/^.*$//" \
-        -e "/export IBUS_PREFIX/ s/^.*$//" \
-        -i "setup/ibus-setup.in"
+    substituteInPlace setup/ibus-setup.in --subst-var-by PYTHON ${python3Runtime.interpreter}
+    substituteInPlace data/dconf/Makefile.am --replace "dconf update" true
+    substituteInPlace configure.ac --replace '$python2dir/ibus' $out/${python3.sitePackages}/ibus
+    echo \#!${stdenv.shell} > data/dconf/make-dconf-override-db.sh
+    cp ${gtk_doc}/share/gtk-doc/data/gtk-doc.make .
   '';
+
+  preAutoreconf = "touch ChangeLog";
+  preConfigure = "intltoolize";
 
   configureFlags = [
     "--disable-gconf"
-    "--enable-dconf"
     "--disable-memconf"
-    "--enable-ui"
-    "--enable-python-library"
+    (enableFeature (dconf != null) "dconf")
+    (enableFeature (libnotify != null) "libnotify")
+    (enableFeature withWayland "wayland")
+    (enableFeature enablePythonLibrary "python-library")
+    (enableFeature enableUI "ui")
     "--with-unicode-emoji-dir=${emojiData}"
     "--with-emoji-annotation-dir=${cldrEmojiAnnotation}/share/unicode/cldr/common/annotations"
   ];
 
-  buildInputs = [
-    pyEnv
-    intltool isocodes pkgconfig
-    gtk2 gtk3 dconf
-    json_glib
-    dbus libnotify gobjectIntrospection wayland
+  nativeBuildInputs = [
+    autoreconfHook
+    gconf
+    gtk_doc
+    intltool
+    makeWrapper
+    pkgconfig
+    python3BuildEnv
+    vala
+    wrapGAppsHook
   ];
 
   propagatedBuildInputs = [ glib ];
 
-  nativeBuildInputs = [ wrapGAppsHook ];
-
-  outputs = [ "out" "dev" ];
+  buildInputs = [
+    dbus
+    dconf
+    gdk_pixbuf
+    gobjectIntrospection
+    gtk2
+    gtk3
+    isocodes
+    json_glib
+    libnotify
+  ] ++ optionals withWayland [
+    libxkbcommon
+    wayland
+  ];
 
   enableParallelBuilding = true;
-
-  preConfigure = ''
-    # Fix hard-coded installation paths, so make does not try to overwrite our
-    # Python installation.
-    sed -e "/py2overridesdir=/ s|=.*$|=$out/lib/${python3.libPrefix}|" \
-        -e "/pyoverridesdir=/ s|=.*$|=$out/lib/${python3.libPrefix}|" \
-        -e "/PYTHON2_LIBDIR/ s|=.*|=$out/lib/${python3.libPrefix}|" \
-        -i configure
-
-    # Don't try to generate a system-wide dconf database; it wouldn't work.
-    substituteInPlace data/dconf/Makefile.in --replace "dconf update" "echo"
-  '';
 
   doInstallCheck = true;
   installCheckPhase = "$out/bin/ibus version";
 
-  postInstall = ''
-    moveToOutput "bin/ibus-setup" "$dev"
-  '';
-
-  meta = with stdenv.lib; {
+  meta = {
     homepage = https://github.com/ibus/ibus;
-    description = "Intelligent Input Bus for Linux / Unix OS";
+    description = "Intelligent Input Bus, input method framework";
+    license = licenses.lgpl21Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.ttuegel ];
+    maintainers = with maintainers; [ ttuegel yegortimoshenko ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1542,7 +1542,7 @@ with pkgs;
   skk-dicts = callPackage ../tools/inputmethods/skk/skk-dicts { };
 
   ibus = callPackage ../tools/inputmethods/ibus {
-    inherit (gnome3) dconf glib;
+    inherit (gnome3) dconf gconf glib;
   };
 
   ibus-qt = callPackage ../tools/inputmethods/ibus/ibus-qt.nix { };


### PR DESCRIPTION
###### Motivation for this change


Fixes #30265, fixes #31454. `ibus-setup` is not broken anymore.

* Update cldrEmojiAnnotation: 31.0.1_1 -> 31.90.0_1
* Build from Git so that we don't have to patch `./configure` scripts when we could just generate them correctly
* Drop patch that removes IBUS_* environment variables from ibus-setup wrapper: they are actually set correctly, and we don't set them which breaks `ibus-setup`
* Add withWayland option (building with Wayland requires libxcbcommon package, previously wayland was included into buildInputs w/o libxcbcommon and respective configure flag)
* Add license (LGPLv2.1)

Relies on two other commits in this branch that add `GI_TYPELIB_PATH` discovery and fix `gconf` Python scripts (fixes #31083).

/cc @edolstra @globin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

