### PR TITLE
[WIP] xandikos: init at 0.0.6

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -308,7 +308,6 @@
       kanboard = 281;
       # pykms = 282; # DynamicUser = true
       kodi = 283;
-<<<<<<< HEAD
       restya-board = 284;
       mighttpd2 = 285;
       hass = 286;
@@ -642,9 +641,7 @@
       cockroachdb = 313;
       zoneminder = 314;
       paperless = 315;
-=======
-      xandikos = 284;
->>>>>>> Add xandikos service
+      xandikos = 316;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -308,6 +308,7 @@
       kanboard = 281;
       # pykms = 282; # DynamicUser = true
       kodi = 283;
+<<<<<<< HEAD
       restya-board = 284;
       mighttpd2 = 285;
       hass = 286;
@@ -340,6 +341,7 @@
       cockroachdb = 313;
       zoneminder = 314;
       paperless = 315;
+      xandikos = 316;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -640,6 +642,9 @@
       cockroachdb = 313;
       zoneminder = 314;
       paperless = 315;
+=======
+      xandikos = 284;
+>>>>>>> Add xandikos service
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -700,6 +700,7 @@
   ./services/networking/wicd.nix
   ./services/networking/wireguard.nix
   ./services/networking/wpa_supplicant.nix
+  ./services/networking/xandikos.nix
   ./services/networking/xinetd.nix
   ./services/networking/xl2tpd.nix
   ./services/networking/xrdp.nix

--- a/nixos/modules/services/networking/xandikos.nix
+++ b/nixos/modules/services/networking/xandikos.nix
@@ -1,0 +1,123 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.xandikos;
+
+in
+
+{
+
+  options = {
+    services.xandikos.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+          Enable xandikos CalDAV and CardDAV server.
+      '';
+    };
+
+    services.xandikos.directory = mkOption {
+      type = types.string;
+      default = "/var/lib/xandikos";
+      description = ''
+        Directory to serve from.
+      '';
+    };
+
+    services.xandikos.autocreate = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Automatically create necessary directories.
+      '';
+    };
+
+    services.xandikos.defaults = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Create initial calendar and address bool.
+        Implies <literal>autocreate</literal>.
+      '';
+    };
+
+    services.xandikos.port = mkOption {
+      type = types.int;
+      default = 8080;
+      description = ''
+        Port to listen on.
+      '';
+    };
+
+    services.xandikos.host = mkOption {
+      type = types.string;
+      default = "localhost";
+      description = ''
+        Binding IP address.
+      '';
+    };
+
+    services.xandikos.routeprefix = mkOption {
+      type = types.string;
+      default = "/";
+      description = ''
+        Path to Xandikos.
+        Useful when Xandikos is behind a reverse proxy.
+      '';
+    };
+
+    services.xandikos.package = mkOption {
+      type = types.package;
+      default = pkgs.xandikos;
+      description = ''
+        Xandikos package to use.
+      '';
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    users.extraUsers = singleton
+      { name = "xandikos";
+        uid = config.ids.uids.xandikos;
+        description = "xandikosuser";
+        home = "/var/lib/xandikos";
+        createHome = true;
+      };
+
+    users.extraGroups = singleton
+      { name = "xandikos";
+        gid = config.ids.gids.xandikos;
+      };
+
+    systemd.services.xandikos = {
+      description   = "A Simple Calendar and Contact Server";
+      after         = [ "network.target" ];
+      wantedBy      = [ "multi-user.target" ];
+      serviceConfig = {
+        User      = "xandikos";
+        Group     = "xandikos";
+        ExecStart =
+          concatStringsSep " "
+            ([
+              "${cfg.package}/bin/xandikos"
+              "--directory" cfg.directory
+              "--autocreate" cfg.autocreate
+            ]
+            ++ (if cfg.defaults then "--defaults" else "")
+            ++ [
+              "--port" cfg.port
+              "--listen_address" cfg.host
+              "--route-prefix" cfg.routeprefix
+            ]);
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ matthiasbeyer ];
+}

--- a/pkgs/servers/xandikos/default.nix
+++ b/pkgs/servers/xandikos/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  version = "0.0.11";
+  name = "xandikos-${version}";
+
+  src = fetchFromGitHub {
+    owner = "jelmer";
+    repo = "xandikos";
+    rev = "v${version}";
+    sha256 = "0qkgcsj702g6aniawv1lya3qddbq9x67c4577klfzw7jk9kybqyc";
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = with python3Packages; [
+    icalendar
+    dulwich
+    defusedxml
+    jinja2
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/jelmer/xandikos;
+    description = "Lightweight CalDAV/CardDAV server";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+}
+

--- a/pkgs/servers/xandikos/default.nix
+++ b/pkgs/servers/xandikos/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, python3Packages }:
 
 python3Packages.buildPythonApplication rec {
-  version = "0.0.11";
+  version = "0.1.0";
   name = "xandikos-${version}";
 
   src = fetchFromGitHub {
     owner = "jelmer";
     repo = "xandikos";
     rev = "v${version}";
-    sha256 = "0qkgcsj702g6aniawv1lya3qddbq9x67c4577klfzw7jk9kybqyc";
+    sha256 = "12r8fciid2qpqf054584ywwh49yddyhhpkpcm6jihzyr5y2r4kn1";
   };
 
   doCheck = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13734,6 +13734,8 @@ in
 
   x265 = callPackage ../development/libraries/x265 { };
 
+  xandikos = callPackage ../servers/xandikos { };
+
   inherit (callPackages ../development/libraries/xapian { })
     xapian_1_2_22 xapian_1_4;
   xapian = xapian_1_4;


### PR DESCRIPTION
###### Motivation for this change


OwnCloud **SUCKS** so much for syncing calendar & contact data, fucks up my data every other day, does not allow creating collections from clients (using vdirsyncer) ... so I need an alternative.

Radicale is **HELL** when trying to set it up,...it just won't work as I request.

So this is another caldav/carddav server which claims to be compatible with my android sync client and vdirsyncer... hopefully it is.

---

Still waiting to get this issue: https://github.com/jelmer/xandikos/issues/70 resolved, though

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

WIP!