### PR TITLE
docs: add note about makeFlags quoting

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -698,8 +698,14 @@ nothing.</para>
     <listitem><para>A list of strings passed as additional flags to
     <command>make</command>.  These flags are also used by the default
     install and check phase.  For setting make flags specific to the
-    build phase, use <varname>buildFlags</varname> (see
-    below).</para></listitem>
+    build phase, use <varname>buildFlags</varname> (see below).
+
+<programlisting>
+makeFlags = [ "PREFIX=$(out)" ];
+</programlisting>
+
+    <note><para>The flags are quoted in bash, but environment variables can
+    be specified by using the make syntax.</para></note></para></listitem>
   </varlistentry>
 
   <varlistentry>


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

