### PR TITLE
CODEOWNERS: fix path notation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,75 +8,75 @@
 # Mentioned users will get code review requests.
 
 # This file
-.github/CODEOWNERS @edolstra
+/.github/CODEOWNERS @edolstra
 
 # Boostraping and core infra
-pkgs/stdenv/    @edolstra
-pkgs/build-support/cc-wrapper/  @edolstra
+/pkgs/stdenv                    @edolstra
+/pkgs/build-support/cc-wrapper  @edolstra
 
 # Libraries
-lib/                       @edolstra @nbp
+/lib                        @edolstra @nbp
 
 # Nixpkgs Internals
-default.nix                @nbp
-pkgs/top-level/default.nix @nbp
-pkgs/top-level/impure.nix  @nbp
-pkgs/top-level/stage.nix   @nbp
+/default.nix                @nbp
+/pkgs/top-level/default.nix @nbp
+/pkgs/top-level/impure.nix  @nbp
+/pkgs/top-level/stage.nix   @nbp
 
 # NixOS Internals
-nixos/default.nix         @nbp
-nixos/lib/from-env.nix    @nbp
-nixos/lib/eval-config.nix @nbp
-nixos/doc/manual/configuration/abstractions.xml      @nbp
-nixos/doc/manual/configuration/config-file.xml       @nbp
-nixos/doc/manual/configuration/config-syntax.xml     @nbp
-nixos/doc/manual/configuration/modularity.xml        @nbp
-nixos/doc/manual/development/assertions.xml          @nbp
-nixos/doc/manual/development/meta-attributes.xml     @nbp
-nixos/doc/manual/development/option-declarations.xml @nbp
-nixos/doc/manual/development/option-def.xml          @nbp
-nixos/doc/manual/development/option-types.xml        @nbp
-nixos/doc/manual/development/replace-modules.xml     @nbp
-nixos/doc/manual/development/writing-modules.xml     @nbp
-nixos/doc/manual/man-nixos-option.xml                @nbp
-nixos/modules/installer/tools/nixos-option.sh        @nbp
+/nixos/default.nix          @nbp
+/nixos/lib/from-env.nix     @nbp
+/nixos/lib/eval-config.nix  @nbp
+/nixos/doc/manual/configuration/abstractions.xml      @nbp
+/nixos/doc/manual/configuration/config-file.xml       @nbp
+/nixos/doc/manual/configuration/config-syntax.xml     @nbp
+/nixos/doc/manual/configuration/modularity.xml        @nbp
+/nixos/doc/manual/development/assertions.xml          @nbp
+/nixos/doc/manual/development/meta-attributes.xml     @nbp
+/nixos/doc/manual/development/option-declarations.xml @nbp
+/nixos/doc/manual/development/option-def.xml          @nbp
+/nixos/doc/manual/development/option-types.xml        @nbp
+/nixos/doc/manual/development/replace-modules.xml     @nbp
+/nixos/doc/manual/development/writing-modules.xml     @nbp
+/nixos/doc/manual/man-nixos-option.xml                @nbp
+/nixos/modules/installer/tools/nixos-option.sh        @nbp
 
 # Python-related code and docs
-pkgs/top-level/python-packages.nix      @FRidh
-pkgs/development/interpreters/python/*  @FRidh
-pkgs/development/python-modules/*       @FRidh
-doc/languages-frameworks/python.md      @FRidh
+/pkgs/top-level/python-packages.nix     @FRidh
+/pkgs/development/interpreters/python   @FRidh
+/pkgs/development/python-modules        @FRidh
+/doc/languages-frameworks/python.md     @FRidh
 
 # Haskell
-pkgs/development/compilers/ghc                       @peti
-pkgs/development/haskell-modules                     @peti
-pkgs/development/haskell-modules/default.nix         @peti
-pkgs/development/haskell-modules/generic-builder.nix @peti
-pkgs/development/haskell-modules/hoogle.nix          @peti
+/pkgs/development/compilers/ghc                       @peti
+/pkgs/development/haskell-modules                     @peti
+/pkgs/development/haskell-modules/default.nix         @peti
+/pkgs/development/haskell-modules/generic-builder.nix @peti
+/pkgs/development/haskell-modules/hoogle.nix          @peti
 
 # R
-pkgs/applications/science/math/R @peti
-pkgs/development/r-modules       @peti
+/pkgs/applications/science/math/R   @peti
+/pkgs/development/r-modules         @peti
 
 # Ruby
-pkgs/development/interpreters/ruby/* @zimbatm
-pkgs/development/ruby-modules/*      @zimbatm
+/pkgs/development/interpreters/ruby @zimbatm
+/pkgs/development/ruby-modules      @zimbatm
 
 # Darwin-related
-/pkgs/stdenv/darwin/             @org/darwin-maintainers
-/pkgs/os-specific/darwin/        @org/darwin-maintainers
+/pkgs/stdenv/darwin         @NixOS/darwin-maintainers
+/pkgs/os-specific/darwin    @NixOS/darwin-maintainers
 
 # Beam-related (Erlang, Elixir, LFE, etc)
-pkgs/development/beam-modules/*	@gleber
-pkgs/development/interpreters/erlang/*	@gleber
-pkgs/development/interpreters/lfe/*	@gleber
-pkgs/development/interpreters/elixir/*	@gleber
-pkgs/development/tools/build-managers/rebar/*	@gleber
-pkgs/development/tools/build-managers/rebar3/*	@gleber
-pkgs/development/tools/erlang/*	@gleber
+/pkgs/development/beam-modules                  @gleber
+/pkgs/development/interpreters/erlang           @gleber
+/pkgs/development/interpreters/lfe              @gleber
+/pkgs/development/interpreters/elixir           @gleber
+/pkgs/development/tools/build-managers/rebar    @gleber
+/pkgs/development/tools/build-managers/rebar3   @gleber
+/pkgs/development/tools/erlang                  @gleber
 
 # Jetbrains
-pkgs/applications/editors/jetbrains @edwtjo
+/pkgs/applications/editors/jetbrains @edwtjo
 
 # Eclipse
-pkgs/applications/editors/eclipse @rycee
+/pkgs/applications/editors/eclipse @rycee


### PR DESCRIPTION
This format uses the path matching algorithm as the .gitignore format.

The paths need to be prefixed with a / to become absolute, otherwise it
will match all of these files.

The paths will also match any of the sub-paths by default so it's not
necessary to use the `*` like in bash globbing.

###### Motivation for this change

I noticed that @nbp was marked as a codeowner on one of my PRs because he's owning /default.nix. This is probably not what he wants.
