### PR TITLE
pythonPackages.pomegranate: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/development/python-modules/joblib/default.nix
+++ b/pkgs/development/python-modules/joblib/default.nix
@@ -6,6 +6,7 @@
 , numpydoc
 , isPy3k
 , stdenv
+, pytest
 }:
 
 
@@ -18,14 +19,10 @@ buildPythonPackage rec {
     sha256 = "7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085";
   };
 
-  checkInputs = [ nose sphinx numpydoc ];
+  checkInputs = [ sphinx numpydoc pytest ];
 
-  # Failing test on Python 3.x and Darwin
-  postPatch = '''' + lib.optionalString (isPy3k || stdenv.isDarwin) ''
-    sed -i -e '70,84d' joblib/test/test_format_stack.py
-    # test_nested_parallel_warnings: ValueError: Non-zero return code: -9.
-    # Not sure why but it's nix-specific. Try removing for new joblib releases.
-    rm joblib/test/test_parallel.py
+  checkPhase = ''
+    py.test -k 'not test_disk_used and not test_nested_parallel_warnings' joblib/test
   '';
 
   meta = {

--- a/pkgs/development/python-modules/pomegranate/default.nix
+++ b/pkgs/development/python-modules/pomegranate/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, fetchPypi, numpy, scipy, cython, networkx, joblib, nose }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, numpy, scipy, cython, networkx, joblib, nose }:
 
 buildPythonPackage rec {
   pname = "pomegranate";

--- a/pkgs/development/python-modules/pomegranate/default.nix
+++ b/pkgs/development/python-modules/pomegranate/default.nix
@@ -1,13 +1,15 @@
-{ stdenv, buildPythonPackage, fetchPypi, numpy, scipy, cython, networkx, joblib, nose }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, fetchPypi, numpy, scipy, cython, networkx, joblib, nose }:
 
 buildPythonPackage rec {
   pname = "pomegranate";
-  version = "0.8.0";
+  version = "0.8.1";
   name  = "${pname}-${version}";
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "6b03d05bffbe46c674800652cf273a8d338a2e40001b763cd6925aac0b578a43";
+  
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "jmschrei";
+    rev = "v${version}";
+    sha256 = "085nka5bh88bxbd5vl1azyv9cfpp6grz2ngclc85f9kgccac1djr";
   };
 
   propagatedBuildInputs = [ numpy scipy cython networkx joblib ];


### PR DESCRIPTION
Also now using GitHub instead of PiPy, because the PiPy version fails to build. Not sure why they aren't identical.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

