### PR TITLE
cloc: fix build

### DIFF
--- a/pkgs/tools/misc/cloc/default.nix
+++ b/pkgs/tools/misc/cloc/default.nix
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "1ihma4f6f92jp1mvzr4rjrgyh9m5wzrlxngaxfn7g0a8r2kyi65b";
   };
 
-  sourceRoot = "source/Unix";
+  setSourceRoot = ''
+    sourceRoot=$(echo */Unix)
+  '';
 
   buildInputs = [ makeWrapper perl AlgorithmDiff RegexpCommon ];
 


### PR DESCRIPTION
###### Motivation for this change

[It doesn't build anymore](https://hydra.nixos.org/build/63178748). Looks to be result of c3255fe8ec326d2c8fe9462d49ed83aa64d3e68f. Note that I'm not sure if this is the proper way to deal with the issue as I don't understand the offending commit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

