### PR TITLE
alembic: fix build

### DIFF
--- a/pkgs/development/libraries/alembic/default.nix
+++ b/pkgs/development/libraries/alembic/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec
 
   buildInputs = [ unzip cmake openexr hdf5 ];
 
-  sourceRoot = "${name}-src";
-
   enableParallelBuilding = true;
 
   buildPhase = ''


### PR DESCRIPTION
###### Motivation for this change

[It doesn't build anymore](https://hydra.nixos.org/build/63176911). Unsure why `sourceRoot` was necessary here; see also comment at https://github.com/NixOS/nixpkgs/pull/31106#issue-270439902

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

