### PR TITLE
armv7l-linux: add a beagleboard.org kernel + platform.

### DIFF
--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -480,6 +480,11 @@ rec {
     uboot = null;
   };
 
+  bb-org-beaglebone = beaglebone // {
+    name = "bb-org-beaglebone";
+    kernelBaseConfig = "bb.org_defconfig";
+  };
+
   armv7l-hf-multiplatform = {
     name = "armv7l-hf-multiplatform";
     kernelMajor = "2.6"; # Using "2.6" enables 2.6 kernel syscalls in glibc.

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -473,16 +473,11 @@ rec {
 
   beaglebone = armv7l-hf-multiplatform // {
     name = "beaglebone";
-    kernelBaseConfig = "omap2plus_defconfig";
+    kernelBaseConfig = "bb.org_defconfig";
     kernelAutoModules = false;
     kernelExtraConfig = ""; # TBD kernel config
     kernelTarget = "zImage";
     uboot = null;
-  };
-
-  bb-org-beaglebone = beaglebone // {
-    name = "bb-org-beaglebone";
-    kernelBaseConfig = "bb.org_defconfig";
   };
 
   armv7l-hf-multiplatform = {

--- a/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
+++ b/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
@@ -1,0 +1,26 @@
+{ stdenv, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
+
+let
+  modDirVersion = "4.9.59";
+  tag = "r73";
+in
+import ./generic.nix (args // rec {
+  version = "${modDirVersion}-ti-${tag}";
+  inherit modDirVersion;
+
+  src = fetchFromGitHub {
+    owner = "beagleboard";
+    repo = "linux";
+    rev = "${version}";
+    sha256 = "1kzbbaqmzgvfls1v9jir2ck9vcdd774mq474vhr5x6dqjnnb5kg9";
+  };
+
+  kernelPatches = args.kernelPatches;
+
+  features.iwlwifi = true;
+  features.efiBootStub = true;
+  features.needsCifsUtils = true;
+  features.netfilterRPFilter = true;
+
+  extraMeta.hydraPlatforms = [];
+} // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
+++ b/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
@@ -17,10 +17,9 @@ import ./generic.nix (args // rec {
 
   kernelPatches = args.kernelPatches;
 
-  features.iwlwifi = true;
-  features.efiBootStub = true;
-  features.needsCifsUtils = true;
-  features.netfilterRPFilter = true;
+  features = {
+    efiBootStub = false;
+  } // (args.features or {});
 
   extraMeta.hydraPlatforms = [];
 } // (args.argsOverride or {}))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12407,6 +12407,15 @@ with pkgs;
 
   klibcShrunk = lowPrio (callPackage ../os-specific/linux/klibc/shrunk.nix { });
 
+  linux_beagleboard = callPackage ../os-specific/linux/kernel/linux-beagleboard.nix {
+    kernelPatches =
+      [ kernelPatches.bridge_stp_helper
+        kernelPatches.p9_fixes
+        kernelPatches.cpu-cgroup-v2."4.9"
+        kernelPatches.modinst_arg_list_too_long
+      ];
+  };
+
   linux_hardened_copperhead = callPackage ../os-specific/linux/kernel/linux-hardened-copperhead.nix {
     kernelPatches = with kernelPatches; [
       kernelPatches.bridge_stp_helper
@@ -12673,6 +12682,7 @@ with pkgs;
   linux_latest = linuxPackages_latest.kernel;
 
   # Build the kernel modules for the some of the kernels.
+  linuxPackages_beagleboard = linuxPackagesFor pkgs.linux_beagleboard;
   linuxPackages_hardened_copperhead = linuxPackagesFor pkgs.linux_hardened_copperhead;
   linuxPackages_mptcp = linuxPackagesFor pkgs.linux_mptcp;
   linuxPackages_rpi = linuxPackagesFor pkgs.linux_rpi;


### PR DESCRIPTION
###### Motivation for this change

/cc @dezgeg 

beagleboard.org maintains a kernel fork for its armv7l-based BeagleBone platforms, maintained by @RobertCNelson. The fork adds support for BeagleBone-specific pinmuxes, DTSes, etc., and does a good job of tracking upstream.

I have been using kernels built from this kernel tree with NixOS on a BeagleBone Black for the past 5 months with great success. The device has maintained 100% uptime in an outdoor environment, running several services that read and write GPIO pins.

(Note: Robert maintains several kernel versions in this fork. I have only tested the 4.9 version, so that is the version used by this derivation.)

###### Things done

This patch adds a derivation for the beagleboard.org kernel; and a new variant of the existing `beaglebone` platform which uses the `bb.org_defconfig` defconfig from the kernel fork.

Alternatively, you could drop the new platform and simply modify the existing `beaglebone` platform to use this defconfig.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
