### PR TITLE
selenium: 2.52.0 -> 3.6.0

### DIFF
--- a/pkgs/development/python-modules/selenium/default.nix
+++ b/pkgs/development/python-modules/selenium/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchurl
+, fetchFromGitHub
+, buildPythonPackage
+, geckodriver
+, xorg
+}:
+
+buildPythonPackage rec {
+  name = "selenium-3.6.0";
+  src = fetchurl {
+    url = "mirror://pypi/s/selenium/${name}.tar.gz";
+    sha256 = "15qpvz0bdwjvpcj11fm0rw6r5inr66sqw89ww50l025sbhf04qwm";
+  };
+
+  buildInputs = [xorg.libX11];
+
+  propagatedBuildInputs = [
+    geckodriver
+  ];
+
+  # Recompiling x_ignore_nofocus.so as the original one dlopen's libX11.so.6 by some
+  # absolute paths. Replaced by relative path so it is found when used in nix.
+  x_ignore_nofocus =
+    fetchFromGitHub {
+      owner = "SeleniumHQ";
+      repo = "selenium";
+      rev = "selenium-3.6.0";
+      sha256 = "13wf4hx4i7nhl4s8xkziwxl0km1j873syrj4amragj6mpip2wn8v";
+    };
+
+  patchPhase = ''
+    cp "${x_ignore_nofocus}/cpp/linux-specific/"* .
+    substituteInPlace x_ignore_nofocus.c --replace "/usr/lib/libX11.so.6" "${xorg.libX11.out}/lib/libX11.so.6"
+    gcc -c -fPIC x_ignore_nofocus.c -o x_ignore_nofocus.o
+    gcc -shared \
+      -Wl,${if stdenv.isDarwin then "-install_name" else "-soname"},x_ignore_nofocus.so \
+      -o x_ignore_nofocus.so \
+      x_ignore_nofocus.o
+    cp -v x_ignore_nofocus.so selenium/webdriver/firefox/${if stdenv.is64bit then "amd64" else "x86"}/
+  '';
+
+  meta = with lib; {
+    description = "The selenium package is used to automate web browser interaction from Python";
+    homepage = http://www.seleniumhq.org;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jraygauthier ];
+  };
+}

--- a/pkgs/development/tools/geckodriver/default.nix
+++ b/pkgs/development/tools/geckodriver/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, fetchurl
+, rustPlatform
+}:
+
+with rustPlatform; 
+
+buildRustPackage rec {
+  version = "0.19.1";
+  name = "geckodriver-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/mozilla/geckodriver/archive/v${version}.tar.gz";
+    sha256 = "04zpv4aiwbig466yj24hhazl5hrapkyvwlhvg0za5599ykzdv47m";
+  };
+
+  cargoSha256 = "1cny8caqcd9p98hra1k7y4d3lb8sxsyaplr0svbwam0d2qc1c257";
+
+  meta = with lib; {
+    description = "Proxy for using W3C WebDriver-compatible clients to interact with Gecko-based browsers";
+    homepage = https://github.com/mozilla/geckodriver;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ jraygauthier ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1074,6 +1074,8 @@ with pkgs;
 
   go-dependency-manager = callPackage ../development/tools/gdm { };
 
+  geckodriver = callPackage ../development/tools/geckodriver { };
+
   geekbench = callPackage ../tools/misc/geekbench { };
 
   gencfsm = callPackage ../tools/security/gencfsm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18615,36 +18615,7 @@ in {
 
   seaborn = callPackage ../development/python-modules/seaborn { };
 
-  selenium = buildPythonPackage rec {
-    name = "selenium-2.52.0";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/s/selenium/${name}.tar.gz";
-      sha256 = "0971rd9b8kb97xp9fvrwzvxr8vqfdjc020cs75n787ya82km01c2";
-    };
-
-    buildInputs = with self; [pkgs.xorg.libX11];
-
-    # Recompiling x_ignore_nofocus.so as the original one dlopen's libX11.so.6 by some
-    # absolute paths. Replaced by relative path so it is found when used in nix.
-    x_ignore_nofocus =
-      pkgs.fetchFromGitHub {
-        owner = "SeleniumHQ";
-        repo = "selenium";
-        rev = "selenium-2.52.0";
-        sha256 = "1n58akim9np2jy22jfgichq1ckvm8gglqi2hn3syphh0jjqq6cfx";
-      };
-
-    patchPhase = ''
-      cp "${x_ignore_nofocus}/cpp/linux-specific/"* .
-      substituteInPlace x_ignore_nofocus.c --replace "/usr/lib/libX11.so.6" "${pkgs.xorg.libX11.out}/lib/libX11.so.6"
-      gcc -c -fPIC x_ignore_nofocus.c -o x_ignore_nofocus.o
-      gcc -shared \
-        -Wl,${if stdenv.isDarwin then "-install_name" else "-soname"},x_ignore_nofocus.so \
-        -o x_ignore_nofocus.so \
-        x_ignore_nofocus.o
-      cp -v x_ignore_nofocus.so py/selenium/webdriver/firefox/${if pkgs.stdenv.is64bit then "amd64" else "x86"}/
-    '';
-  };
+  selenium = callPackage ../development/python-modules/selenium { };
 
   serpy = callPackage ../development/python-modules/serpy { };
 


### PR DESCRIPTION
Also brings into scope the `geckodriver` on which it depends.

###### Motivation for this change

Selenium was incompatible with latest firefox version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Related to #30186.

