### PR TITLE
firefox-beta-bin: 57.0b11 -> 57.0b13

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,955 +1,955 @@
 {
-  version = "57.0b11";
+  version = "57.0b13";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ach/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ach/firefox-57.0b13.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "298e523e55916ea7c6fb31ad383aaa6eeb582440aca98519d6abc3e44201b60f3e382be7947dd434b47e13f7e2d2c88b62009bbb4298a7085d0512307d37b4ea";
+      sha512 = "051daa6d23e8d9559135f89a871372ae69ebb46c143265f72d85a55c5edbdc927fd2be25869815cce3ecb4bc5a4245f6bd3cfec2317e727c632437f377552793";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/af/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/af/firefox-57.0b13.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "00e31d736101e3cd5c8f1b999f9b4342369bce56c061271e952022459e80ea8b77ca356cdf28ff0255bf09984caa059ee0e62a2dc0f2cb31f1156224e7eaa4ff";
+      sha512 = "b9b936333fc86f3ebf34dfc05d5277a6a2552b427fa26a1e29c9fed93fbcd76c533c3543b3356ac61da808eb5154d83d40888c19a37003dce88c4da64fdec7f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/an/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/an/firefox-57.0b13.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "7dec20660dbd4bf0a88742b58f4282d10b8f8778aa8b8b2b7847485039fe266b2ae4dcdc76ff1a37a516d2f0c16a2db2c2fbbab1e79d6eb8a79c63561da2539c";
+      sha512 = "ed028a38d5360890f57617f8e0d9e02c578f7e786e78de8f2b8a3b96d0915d3369dc398da71d387761f56f6371d3047c63f0d39131e7dc7cdaa9cd6c8dd22abc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ar/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ar/firefox-57.0b13.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "05e8c1271f5e3f297e927bd08ef3308d57067d18116b98010c3cb2025e7b0a9ca608d046cd592a4afa3949b9a3244127a44ad90e89ce4b651397e95f5bd4a29e";
+      sha512 = "ede95e488ee234430c3694a14c75ab116a29b91d9a1ec4b0676f687ce5a175122758815dbec69e2aaab0ab8ac91181fd4e0fdac545dddc0b1e3b4e7c81ccb648";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/as/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/as/firefox-57.0b13.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "fc2986315e7514e51be8ab082be42be9b7f7f878c0c1d7cbdf36f3d7b5dccf59a39ea44329c3aa9afdd7118a29706308118c89937dfdd3d8f6109f8722c5646d";
+      sha512 = "9e27132b8b1d0665cc88951ff24b316142bede88677dfbf6bd43ab147db8dd2b7ec44e830d152a2af48805e2a2de1b8858f4ceb0e8ff96d65c7cb769c0463d92";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ast/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ast/firefox-57.0b13.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "8dc4d3aa8935b61f90b21a059a97a6ffbaa90f13aeeb204b7eb28dd0ea33b899934ab162b7ba8ea00cd3c341d0f61de30ae2b3af052cd420246a891a2d902563";
+      sha512 = "4e458e8dc02a226e40314bbce9771330a378536c7176e5f2e9ccfd0f0998d61ce33b234228226156abcd87aac88c01c740ccd7b0590863f6f1da44bea3b43af6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/az/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/az/firefox-57.0b13.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "9fb126c09f39b6c943fcc30636b19e3b566cb5fd78b1ce68ae78b1c94d68198bfd391bdab6474ce7d616ddb114b5ff7bf54caabed94e2e3dc4557c95832e1c8f";
+      sha512 = "90a283a92da98ebc422f78deb01793888f9df97bdbb17f5e0f9045ac5f61eb2e4ae9ae706026f043535c2399fa476509af9d358093a92cdc344883e40bc4ed03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/be/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/be/firefox-57.0b13.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "ba5250a70bf92c555f87fe2376c6c415678e5d065ae7c0fdcfe613a53119173a7231f5c711dc1451cb6fdd77a94c5077c98019f0441f0f0ecb97ec16aed8bffc";
+      sha512 = "b16136b9d37ab3a563b9c90be7520430a89c204bab6d9e616939ce88f4d56c395a7670911361f746b9ac62e802e4b791b60ea1e77335c56fe80a0bd27c00fb14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/bg/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/bg/firefox-57.0b13.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "aa38dca42bb1ed7472e10db04e4346918c7d495c24d484a9182c8b1651d1ae2f68188d12f133581a6b1a7463f559320283ab0877b2c51a1b93edb195706a1ed0";
+      sha512 = "7ad46009c3101e05b0285862f61067e68c50a202c4889efd138438721487ad21ae68228b9fa82162730fe41be297206831d5b4f8587c3243397427192f4351ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/bn-BD/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/bn-BD/firefox-57.0b13.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "11ba74486259041c06dc0c806c6b21332fbddfc525eaadd9a6eb37b1a8498bf25bd34b42155f642c8daa840040dbaeebb0721b541239656df4fe518d1cba3aab";
+      sha512 = "24650ce5b04485512f7af58b0c0428f9aa442d28d614a2dfc2e427e33b35e442d0310ce3212a0750bbc0e5ab79aab848218c140edc49b7be456fc2f7f33b01a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/bn-IN/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/bn-IN/firefox-57.0b13.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "25ae74c773a9d525497c9d0c7d3e14cafe490fc8dbcd363f7daa102bbddafe06c4999f84847545da5c8dd974528613a5c6e1468b323f60eb0e3ba79e360b88a2";
+      sha512 = "9c48ad3e4081edf3c1b973f161fb9741f2f37a125ba5e63599698100c26f529c727fcb828696ac3b1f54fa299502cb4c537f15be6c696eaf51452c1cd0eac61f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/br/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/br/firefox-57.0b13.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "4f3dc389261f384238fc622d5ab1059cca0a5a4eb02daad0233bac7addd118bfc2c4c95a5bf5b7cf66053b049bc3150358593eafeb5026be47d676db212aeece";
+      sha512 = "022d5dc1a4e4906375ca2b425d86636ba6cb91b5bc60459938e9e77341c886c4aa7285f4b52e7be221149519bd3bf72d1b4540a7c62cc347e2beac9de3d6c953";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/bs/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/bs/firefox-57.0b13.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "91b13a19dacd457db11f78955bad518c2e590433ee1951e2951566f6609293da7195940de7daf97004021ae5229e887bc3c52832be21ae514c6a4afff3a365ef";
+      sha512 = "9e4e388f43404eb98e68349ae95bf40631fbf33670d4a9200f60d9ab25f8dc2501d4fe1aaf6f95d9ade80d790b1ba53b78ead54f2cac45d7a2c2d85e505a1455";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ca/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ca/firefox-57.0b13.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "037eb9153e9f05a0c9cb2d80f39ae08ad8d425f349753ae2113e6a98a96950c6ddf3784fe2859383a5ed8a7450de02e6c2d344e20b851923c91576ad0d2de9b2";
+      sha512 = "3c7e6f9c11ddf88900af2eccf8a22524f6cf74e5ac27464f8b4ad19849ac30220bc6eac03d79e22c349eba9e170ec379071b258d6bc80e9178dd1ddfe0aec965";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/cak/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/cak/firefox-57.0b13.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "990d5f8637d4386e698cfa070118ef1e39d77065a54ff8293460caecf319707402e1f043c3ae9a46a7a58e2ddeabc312708cde361709835453a22d7826a46d1c";
+      sha512 = "e5f9e7bf7145f2b33a0c59de6c576f82bb857ebe85335f218cd03ba005816c3e8e8fff03d5b6534885d796ea523696423c70035e62bb6a32bae4e4b7c1d79c71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/cs/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/cs/firefox-57.0b13.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "50422d5a16c205e10c1657eacad657403836ebeb5c1de656e12c4ad7b65776f0377faf55c6ea5b586be8f8694ee5952c289257d119aa3fae1860d5565f89643f";
+      sha512 = "7e527e7bd04cd6107ec92d27f0705ebcf8da8117c84e61e13c2026dadd2ac3a888c9e3bb86f51026f19b10d06365bb41d48bc4fcbb08d09a88b3bb01e9637967";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/cy/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/cy/firefox-57.0b13.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "a78d86f637729089f5cf86778032c8093f07b03974a32444b1866f25a286b7e903630f3e836ef12a4c9df6025037885b0140a39680ffa6e6473f023fa3153155";
+      sha512 = "287df6655c9793da325681baa13fc4c0b9a5975f0b13be38d8875838a762b2f435839ef5893c6b6a3439c225994fc64060f69edf349d2a9d4fd2d225e95fd1c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/da/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/da/firefox-57.0b13.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "50eaa3e29c322af80df70c3a52df53698c984187b8f8db86cf922fb38d61bea65dda2ecb6d6889a2f1a07c5f8b0d6026590d37c71df74068df0403f91998a584";
+      sha512 = "8d03dae91a9cfe20091a2222eeb0bd41f3b3541c5ef6520a17a32187974daf8584e1d69017cfb99d2d18224ffb287f586bdf1ed678981a6b6a3d16ba9ba4a2e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/de/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/de/firefox-57.0b13.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "213227706f35dca646f3938044387aa42097d131cb6a2f361ec5d114f2c78b37b2298d9de3b289cd504c6559f37758324cdd7e59e5535caf3f8b8c8d71e701f4";
+      sha512 = "ef084c0d0efcb77cdef1ffc0cb994ae6c6a9484c36282c7d9914b2d3e8599c8f2e9623cfef1e890a7d4c4feb6fba1c091937877ae8ea1d654a9bc824b5c8bf12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/dsb/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/dsb/firefox-57.0b13.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "67406fe340fdd8107a36755bc75b05560540421cb1000b47d89a6492c38c0904dda5ba17686ec01e1f77a0f8b6a52878042a9f0d999766847eed54fcea0ee470";
+      sha512 = "e08b193db4230efae96862a6a9b62200c42b03667c3d5a905938375391d99eca37716cbea561341ae76547be0b5ee94475f9ca9faec64fc178be92236a4ac91b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/el/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/el/firefox-57.0b13.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "60a67bb618aba13377c10e3d798fc370e633070c30d50e7180244667449308ceea4571e7a997c80af80ad027e27074f6b3fc670e5253f6159ed10653f8abd798";
+      sha512 = "db49f80f7c08322307dc5cd225d2dc10a3179ce4ce25723264679c1c78454fe1c701ebf218a34704946a1e7d042349d0fedfae5b70b1c68b5100ad7cd4ae4900";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/en-GB/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/en-GB/firefox-57.0b13.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "4bed5620eb52e080379044e3785a318e131387181748414367b02a5b6dd2a4dcf43b55a794d9add241b5a438a79ecf1cfc15eeeb82d6c188baf18914d722542f";
+      sha512 = "b2cc8bc706e89390b500e6e8e3bd548417af1b0500aec7ed1c0ad79245941e20343cbcce80b03a2c885c7134c069e9f3d459739e6ea2a62c217a9f4ddb8851a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/en-US/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/en-US/firefox-57.0b13.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "85d751cfc31fbc330292aebc1fe8e7563d726a91242708b85104dde6a8043726e647628ee084b71c3f922eb0d40cbd7e1381a9a1b47aaf641edbd7401f3ec24a";
+      sha512 = "621828144f0421ac2a3d5af1cf62a337d23409d26032d4c2518e99b0d04caebe1efc67c50f2b692612facfd5927cb0b51d9acceeecf9fc4c2129e6a899c9ddb9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/en-ZA/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/en-ZA/firefox-57.0b13.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "ebf2cc4e016e3623e2cda742d468fb0ebf0b6ff05c90d32e9eb5bad131fbbe12c46e667a21d1f446eca897ee65a8ec7ebd59b56951cf12e5ee44ce89e7bc147e";
+      sha512 = "4dc4822fbc6d3027b9ba0b93b126e5223675c69c9e36c22e85681ca02c97fcfb9f9ef7dfa281dabec32b93ef8cb619ccb74ca18a3ebaf55f64c5547f5cb97c08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/eo/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/eo/firefox-57.0b13.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "e3719652420eb97abe0097aed9736370dd55c572e7745f862d4b031fc84e84611f0c08bf8a2b7fc830a6759ff73183b02269dd7cd1b9eee5076e7d26155c77f3";
+      sha512 = "8eafe225337ad597afdb9a90caef3a252f9f467b6d0988f63d92ea35f5d284431c1ad1a29350d9cdd83f5108649d4cf05de50706025f8b2e2db55955bbc8f964";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/es-AR/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/es-AR/firefox-57.0b13.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "4cc08c7b8b242d671ec85dc46761f546479d2e207628d68de4186ac48b619013ba39005ce3b67ea08eee6df8ac46effececc83c8fe5cb2f184d9d56d36f98f41";
+      sha512 = "f9837bc84534f1d35aac94c0775fee981b9c7e5031bdd2c78b5609406a73cefa5797282aaf122e2eb772fae7baa0dc0714413c1b6d7255145fef540c31b89183";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/es-CL/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/es-CL/firefox-57.0b13.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "5c6f753e119198ef1633a1a7039199f00c891d43ee5b49b95a4a1e8d5d20ada55ae03ef30e380fa50de4b777d4ad9dd5aa8bde9d0186265a6af9d7c277858ebf";
+      sha512 = "e7fd613944dfdeafeee8877b77cb78844b1bfd1d5469dcfdbd90b6a0ea08c98f4fd9423dd18ae1333b90b5717f800a446f8d237de34a8131cf89db602b72a846";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/es-ES/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/es-ES/firefox-57.0b13.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "702ec0d89777a6a9c4a54a9542a0d2e89b352643eb5854db83600a7a93ca41b5d811de21d1de1f33c976b9ce5b19492d2fed12be1f570aa66dd09d21aebdcc5f";
+      sha512 = "b571a99b0e11c8b4fc202cc720f2f0850b54978bb98ca9a6fff2cfdb6c853c74ccb8f9b49cb14649cefeca5768ee408e6ab8028bf005be0def9c519ca8d14108";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/es-MX/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/es-MX/firefox-57.0b13.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "2066be080187a297a2156d9953de0b9c38ff4c18e509f56884f596e37ef21e4a832bd0644f4e2df872d22a6fe3925b72b0548187d64e88974cfd50f9f1c18c54";
+      sha512 = "fa46b9751f8548ea3724867a2d41cf9aa62a7416fa06ab63a4f59e24c45a5bddb84f982049d1cdb4d0ef3318aef46fb25f494cfc3be203165ba125234c9619ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/et/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/et/firefox-57.0b13.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "0ec67c6a1186fb686f67075dbe1f07b34f2a0f45d3631b7f6b3a144b7d6ac89bc7d34bf98088826cbd908aa05a38a410fbe32135203595e604483f465d4f8af1";
+      sha512 = "21b6cb415d45f53f8c5bd63a463be60ed05f55604d55dcfd0587fe023653d4736f1945f1f5d96bd97718b8ef492fb2901fe883ed522db4d9edc805af0c118013";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/eu/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/eu/firefox-57.0b13.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "2da25d33b6fff7bb463b65a866ec5bc89a39886e66022dc9b0ce7752d962cf3852158f1ef79bf4df0d7587729e295637b9c27c99840e3f2dc0ebaf6cbdc7a3c0";
+      sha512 = "9e341110f6c2d52182faa95f032090b2904d734efb7f4472f87ba77b6604287ebe21c7b1502f71e107e285578cb6c0da6dd95b45fd27bc28a16c14735725d22b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/fa/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/fa/firefox-57.0b13.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "d3e17c82f7020af45b50215f39d78826a5072dd94be5bf3cdd61ed7f67a45593765efd7f65b071ec3b00be86f90ed65f15bd6a5bc2a4906c2eed9b0cac23ee6c";
+      sha512 = "15085dcd3803767b4161fb6b3e55af4c29dfc573ff2ed24dad02eaf001e657e3ec8466e827df472cbb89a442e33641ad422f11b7d663f1944a0f5d2fb94bb305";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ff/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ff/firefox-57.0b13.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "2a17680f7a595a35aff6f2a6a25eb9aeb8497ed7ab2cd2cf95e1894ea29cf99fd3c222144e3a0feee660cf0fc31d21c54d572483544267c8bc5312f0b31b9c3f";
+      sha512 = "ccb9d489fb9211c9cabe344c65ba165f0aaa4e1217e4c60860c96e7d938532d1602a4c6d885ab5c934c744957a060cdcfa4203c8d93bdefb4f25bf938a4cc1a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/fi/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/fi/firefox-57.0b13.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "a54e8c300ff17a0b2f1124b5c637fc2b07f47761b5df71e219a8bb77b21f67542b19ab6051bca5c542cd30bd3517817fb5f44250990d683a997a6f9d925f6b93";
+      sha512 = "306668c5cd48f4c0c81e2a160a6703c43ab93d79cec7c9b754425faac9441edd5cddc1bd67d743e577a5c7aa2db39dfb2b5a290e983713c8de780e6596a720d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/fr/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/fr/firefox-57.0b13.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "50a58b205bd0d7ecddeeb4011ac9c499b35b32659f567cf27954561dac91b6bbc2a79e37e19b1fec07aa7459dc114d4cb8641847118fe50efd7d6c98e66a6203";
+      sha512 = "099fcd14b1cc7429c7cc4330aa7a397c32acd28006732d272a89c2a6f5c7b1a0a0529734e24fad308c26fdef6418aac2d1b386d7e7dec8ea19a12490cfe53e50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/fy-NL/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/fy-NL/firefox-57.0b13.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "22025a263c986be90ab5dc05138c2a8b58108bd39de83fe8266969cc1742358c2cd0730315904a1a35adcab94bd499e8d688d65920c346c28f76b650395838d4";
+      sha512 = "688f6d9ccb1a130181e154ed75ffa71069348f82bc20ac649e5aabf69b31a65ba022b3a28d2149a63941bb6287dc8e14946e2f7d9d5ce8f89432c2a32f5095a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ga-IE/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ga-IE/firefox-57.0b13.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "a1fd88907a14be9eda4e392762dcdcb009701baeac908a4cce664c8dce3c6957cc889add929b26fb48e592001c2e6e1f34ced9bbe137b0ceb7d230dbbc102f3f";
+      sha512 = "fdebffe1190222cd5b3955e54aa49286166366d910f1b4471ee36372abb7d515b22a48fbf2799abed4943b2a3203c983d0906cac6b5652f507c58778e8d98ff4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/gd/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/gd/firefox-57.0b13.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "eb8331550bb43251a5d66c5f108568de1fed964a8360cccb9426b6d163f47764d34c79224026c058aefb2a526475c6b406fc1717a588a61c65d73098f217df8b";
+      sha512 = "5a957ebc86c7e305afb0e0f9e91f2c73b52b7ed2b65ca8c372cbc0666a86e809494e7deaf5ac4caaedd60400e8a82dd9e3773ec3aee04daebffc7c91a2586b08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/gl/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/gl/firefox-57.0b13.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "e7326fbe2c6b9e10a3fae76d27ec0de8856f9aef95a31db1ae5481ea43d895ccb220337b68deaf8a76fd110d6d1f74209dd27e8726ced57a635befb8e27c0e7b";
+      sha512 = "024ae0ddc5fe5590ef8ed4153e298b5a05dba17fd5a4d6ec78777969841cbd284908d7c19c36f6290efbc5ce1248c3f24c0cf4418f524166c1407199a6b5de90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/gn/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/gn/firefox-57.0b13.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "cb81a34ee5f87636b5519c9804f65d714c5ea4406a05c465c5ee2bc29381e8235a1788111dacc78066e420f2583f004b3dc4841df9aeef848dc7a48accb3c9c5";
+      sha512 = "e6b36e68cb07c4563b350e4af1fe511ddd69ec05fe027809f5561a788b2fcd95c88bc8eb8d67618bb1769f10d11a75898374a433185de49e09554eb948b2aab3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/gu-IN/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/gu-IN/firefox-57.0b13.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "e26a80e9aa0e72892d79d0cbbee8473208342d3bd966cb034fbabfa6c3e844490184089ead6dddcd2f655c1577b66da239a24a636a651a8ad7951478e3dced9f";
+      sha512 = "c8e3f732c6e91893f07821a2cd9d18e3c5effe7551434cc311455366faa5891afdd25b6d83b5e4c314f3d4f5c01e499c5d4823b332a120bc07c979dae8f171fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/he/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/he/firefox-57.0b13.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "13814b3b670a92013c08dbc8e37169fe758e378db0ac464f9b1d061ef5ba48063a1bc9284686317f4fb5b791a133b773bfda4db2ca25a154da258b81e2ba7bc7";
+      sha512 = "a7192f190a83f5d3d1f300a072eea4396397fe02623daf9bfcd6a73ad2b8e89884723d9596f0be2d3da655fd937469f08d65e39037e3b7168edd28c8c23c10d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/hi-IN/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/hi-IN/firefox-57.0b13.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "51f0fd4d50751559e0590340da3f3561f3526792965aa9cd86ba2b83866ac3342b5b4b225da2f2a2724b937c7ea00ea16881f27c8bee3deacebaeabdcc446c3d";
+      sha512 = "30a355f58c9419472ede2713101721509a8c86c6c363693c256553cd64800572cf0eb000c8b2bcdfa788ea8876cbf6b7e8a86282ae1726eff4bde93dc8b33a1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/hr/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/hr/firefox-57.0b13.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "fe9febf45bb0b79c131868a16a4139a7e885923eadd8ec07f0aa5262e66c06c5c188d4e6b8b4d6164bb32195f27330abc199b79a8d2a524fe4699f9c02ed66be";
+      sha512 = "fff70e068a744e89e28ede72398d60b83decbc908c6776b23d8e532b4630a9526411a62572882a596241a7b6b6550766f3ccf99a5d044d7fc14afa52772ee270";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/hsb/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/hsb/firefox-57.0b13.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "fbfaa755ed9ea1f86f1f27216fa6925957b3fc48ae847534ad289361722e8c70e28beb83b9b30a447c0acc06703fd2642c652a88ec8ddd215dc3538ea0baa819";
+      sha512 = "aec6950ed6cd9b357bdb63e5edbcab7b42e76a72e44ec370380d2b5717db585da8060620eba7290880020b1e6325f134f001163f2ce7719c50b83e6a5a2fbc91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/hu/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/hu/firefox-57.0b13.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "b51b7ef5f2b0ed15796abffc299bf633af897393b17d12b2cd6dce5bcd6fb9165c2ee001b44eb89b91e68e616b2265b1fa307d90e68e35c34f425254a0135dab";
+      sha512 = "912b23344f96d37bdf66775ad933ac769e19818ccd178a6ad97b815228670c053111dd623fb98de382e2c2d414414fd9fc276f4aee5a00a439dfe235452fb16a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/hy-AM/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/hy-AM/firefox-57.0b13.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "b2f781a77542c754185bd4f3aa040eb0d0aabbd773f27a422db87c8cb0cb60d1173c5e32e02886f608e03f2ef8ff84dc8a3cab7d55305fc36d9b11b96ec11485";
+      sha512 = "04b2e8ae9de10cdc2aff751c5954f190ec749fea27ab265343b73d762e6e9ef6d96a7136cd9354988ac791ba7bf32661b5658fb490f1d80907505923bd7a70d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/id/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/id/firefox-57.0b13.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "6e251aa02c0ec21272cf8bc4bbccc9e8d3b1d512a0a1bc90ea90e4d3844fd90c03989b102d9129348ced8734a40576b2dd294e8a85422e215b01b025e48180d7";
+      sha512 = "834087d98921683d0ae7216b6264c7dd7b77568b59e4739a7464f065328d3efa8256f03e9343177673ef5257db142466e3803936ec30a8f6902999a71c0ad163";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/is/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/is/firefox-57.0b13.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "5fe16a677f6413b0229c67b46e7831fadc0a9ef04395ea7c928d1149fc262cb9f28bf3c40b7d57eec09fd821a37286177a19f1a608a062b84ab9d82897560994";
+      sha512 = "2a8f3b35f7c1f8adc40504c3460139ae7959ca9657f899fab9e73eaeff5d983996a33d284d058599406d4d46ca941cd9969a7e6152650f6ecf6165329bf2f350";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/it/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/it/firefox-57.0b13.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "f0ed83b63ea8df081f9110b5e8a5f848e9b4e89ff5ad7ee685f9792fa4438cdceae34b0e1bf265454f966f6a6f9d00bf47d665e6553c3c786bf48f4fbceefe4f";
+      sha512 = "6b04fbe6ad821a68d7bb968836d047fa08308a571fef1d5ef82d4719841a7b517362f706f4251d4d60fb084c06af9ebc671a8c131e5a403a21ad9190d84c5789";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ja/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ja/firefox-57.0b13.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "8e9d0e446bd4b46b267001f1d24563ff5eb064bcb72be2ff30f42834d91658664e96683d680ec03fb62b8ae3f5e6d68b4a18800d6f4fe1b93692b1e4ab7258e0";
+      sha512 = "9dfae62887b03ab6a963547c1f4c4332bbc4469bce62318fbdc439130c65677e9e0328942b49b37d251aee45b56f474aa5e1ef487244ec61561217f1e7f2bcc4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ka/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ka/firefox-57.0b13.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "b557a2da452b41685e4ef61dbacd8a4563c4016b16946e197eeb60f39523dce87942f38659047a284ba2f8dc78ebd4ce5d377a86d54366e0f0c49176e29b3255";
+      sha512 = "8f1ae26d22d02bd3a1aa21cbcd750e6003f13fdd1aadc85114485cccf59f300b962a729016c3dd1611b8f32333422318ca806b7dac1a790c11749c909908840e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/kab/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/kab/firefox-57.0b13.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "cab2e7df696e67a290aadeba8553e65880156f33b4cc57feedc971517496e8a8beb2ada6f8dcf4fd963a034cae4bcdc03bd970c6a9b27af720f64ce1aa9bf8b8";
+      sha512 = "28a00d36928bb60a2c65eb9e3866b8ec1fbe76973fcdcad78a6f00aa601e4990c1ea96c37984171577400dd511937011957e51e4996fa64db0600c0c3cadb810";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/kk/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/kk/firefox-57.0b13.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "ea92799a2896013796459e8b8e3f5cbb8e2da528eda74091d22c93fad5791d8669d8f092842090ed5ccfb9ee39e7c09b44502c752d29a956b5e9cbc793ff74d2";
+      sha512 = "76361b378b4b2bd2a1e31caa344491868188155caa57317f46c9f89b9a77df5ea65f2d4f8ddd2e8cc574e602fc163c4d671de932938ffbb64a1e68a7fb51bd51";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/km/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/km/firefox-57.0b13.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "76f3d509693148cc94949a786697a6bd3bdda894bc4692715e33397e24aba446d94f9e364e159c4504bc0317adba5388ccdf3698f1226cb0bfa6bee2f00fb4e0";
+      sha512 = "abd176c702ab4f1e829e23a4fc4bedba45724ad119d84cd18a6d7d2c8487aed690702709312f5806f2fbe82076215e55e3e4de3cc8cb56b33079d4ab7e2921c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/kn/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/kn/firefox-57.0b13.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "3de7da4fa42a74b0187dec9b28cea76e3ca1bf80827f374bdf895461477a67478761c2059572da14c1e5660586a07239ed22d066e548c5271ab563713a3e0ef4";
+      sha512 = "62056efe59a3acb2fdd04eaa343372b7b2e1f974485ca7f122d6cd9d7d67159f2a4361aa01c68cd11a93cc56d807068842b735b74e596b5d218c952f5e318658";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ko/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ko/firefox-57.0b13.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "fbe8b5a9a196a08f56408f57eaab71e3bb7ffec53bc05c4db0bfde4478267975aac5b876923c915a0a182d54fc1bc99f6361117fe659cc9e998e98f3a9aa122e";
+      sha512 = "d1772efaaa2e2f42bb01d5ac39187accf59a235327d5d159866c5b80d7d54a867aa496d63fbf23737d52b976f0be8c35bf5f6045f0d69eb5d5af5e67b6202eef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/lij/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/lij/firefox-57.0b13.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "031ec2684ac7aee9a02e7aba789707b8aa6937fea27e191612b7cac6b0aa7bdf996c3f3cac1379d7ccce0a53701238f4379d691f29e2d4ad4c5b27a518d1d2b7";
+      sha512 = "a45f3f8181906382f3df68abfba8682fb43db58fd7b6846eb3b64eb67e6d57971cb83ed6c74785e19807be06dbfcb7b003c67b800292cffcbb1b42c812bb034e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/lt/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/lt/firefox-57.0b13.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "ab056e37c0159b7b62e4d20e6fac5de190c3e7b53919bfc29cadad90c664c800e233abae58d1e7c1b8ded76af6da7603ea187da6510bac904bc2d32f9f37feda";
+      sha512 = "101d43ee97cb635073ea9bea836ac0aaec514fb5b4eb9b821df0f48d527b89745907f557a96339c19ebd152639d9a4bd745396bcc97c94e69579b177f9c1d7ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/lv/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/lv/firefox-57.0b13.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "c4a498bd7832c9ee93d0d98730c962176775b347e95241e0e307a97e8d53fc21dd943143e880f994d81d4fe15a7d24a480a07ed41efc10d1f816549c5b37ebac";
+      sha512 = "74afad1dea785fefa379c7eee2efd0f38673a632b9232102a02e8fa7591f89b0c58447362205b23638b54fbdfce90a813c111344ab4569f57b21bf3e3894b4c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/mai/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/mai/firefox-57.0b13.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "81f85952c2966471f4c74fe7092b7b614f33130ca19c74842084aecc6b53f8dc975d05ff0d9e7a8d692096e1f9cf2a49576bb9d4625904ae1074c5e0476e4bf1";
+      sha512 = "4b87cc59533c6b9d3f131ba533314f5c622efba35084a8ca6b67c4c63b55833a8a3ad9a72ac1371dea86e39691a6670a3d38952120ef8e3af712a72fbf69caa4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/mk/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/mk/firefox-57.0b13.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "c9ddf832f7da91e15ce16fa46777e2458ade47c68dbc0c5a368e5e2b8a26682487449e51ee46057724c422ced2715754a4b5f459f6598e342ac0d553f2fba267";
+      sha512 = "dd85e3305ef45f319211492163215f2f4140091d33422cf9bd01540493b13c9fb923a0c64aacb2639682a79cf6163fbb6e559aa29fd6dbe28f22c7cc0a1398ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ml/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ml/firefox-57.0b13.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "55b8c4e2152fadd17d21ae060532ad078dc83f92c383058d1ea979dfaafbea58f9c7c7d5852688f619c6332a8ffaa37e2bbea47517f4bee71af5696a21593611";
+      sha512 = "19487b16d24a71463b1227a450648ad0f7a0dc08b6a0ba69b99d87387bb2c011f7139031eb09127bcef5c5e28be90b8bed4de449af4b2180e900cef4c7e26218";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/mr/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/mr/firefox-57.0b13.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "713455cb6defd82c93ef80d92803923bc5049014b2409f1903056e0c04c2316a5606c9fcd13e96c9aed79224e24ee491e24ab31366a22c5ea74b55c556cca2a0";
+      sha512 = "7a71d953b192d2453698318f7fcfec7e4a1a08f893094891b446add05a0a570df3db76a1054c296d723855e4190dc2b2cf84c953fa97486a8bcdeeaaed707bf9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ms/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ms/firefox-57.0b13.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "53402320cf458dd250bcbd967381df5d5901fd62fb34943b18f86137f338e96d5b7175698d57ed3169ba138fe303c21365baaa56cd40dbe05717a82bb14d4c26";
+      sha512 = "8970064b77ede1f1b52a974bfc7bf543a203943a3aad2f42952669e48e1ddb092ac47d41704364802129501a5e0106e5158d6650a4ae7a84ff07916ff61af07c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/my/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/my/firefox-57.0b13.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "92b06c4aff57149610269474dcf242e58e0a9676a04a01e843bdb71cffbd24f222d0f65bc73751cc0807c6efd84149e7d241687c66413f76f75031edadce60d2";
+      sha512 = "3681f7a89ff3f099c5a387c9bc32880e3935a68edaf004d97ce492a271491e40b06d28e9afe732163f94d0f882a777ce8655ec0d9aa61b5a3be53792661857dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/nb-NO/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/nb-NO/firefox-57.0b13.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "52d82c8194062ec95b06f8956b52f7ef47df60436c40f3ae00358cec47034ebbc61fb2f0cb27a93dc96afd3aea5e3c7e8ebb92268f7fab01ae21d78d45f15994";
+      sha512 = "10d807437bb0f40095486c6495be4460bd9f10747243576503faa78b3212b71a893b4dcc1bdbeac2cef0ffceda288687033d05db9e76576e6ed049ebcd0a547c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/nl/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/nl/firefox-57.0b13.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "75689e5e642b82e97f734b3997984d805794b9ee07a44314a6cdbfa36f7caef3840f02daa13cd1338ed8bb435aea59c14b634e269211cba3b31babbf594f8f27";
+      sha512 = "31fb0e57141696f5ee310fff881e811e23c9c1d182c898cb8be142db54ac268dcfcb8a0e865ff5759984ced5e0cc9b87f64b6b27f5ae82c04b3011c7460694a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/nn-NO/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/nn-NO/firefox-57.0b13.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "5000b5497707614d74210aa372697c38db2997fa1fdced45e885de3838abdddde402e4282f32517e2b75f25b8d21d03149ec9621affe2e84f3dc34aac5ade534";
+      sha512 = "386d209088359eddfe3d68eb2466b491139e9f372a424e8509e531ebed8901fc098eaedfb11a2d606f22a940a2520b2da7ae9c6ad8a1e6dc24e5b4efce39b63c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/or/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/or/firefox-57.0b13.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "123b0de9d2fea6509566df36fd2c2d0e540fada2b226e824c914cfd02ad964b37c34c3d1846aae0fe13e8bed1b01b267cb396a25f9bab1db9a6b0db420addf11";
+      sha512 = "8bc59e0d4ac62b1409616512ba15ff15bce172e27f161407bfd11668399692a53d362e0198b6c0b137d979609b6b534ed63e1875747111af0faed895133f4b4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/pa-IN/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/pa-IN/firefox-57.0b13.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "38618f7df36e1044bbcc32d50e6158e47a0e98cb171d03082a1874b990722d535f2dc4c8df5177475ae8c33bad9407ad480925158e6f74077a977c5abeb4b4ea";
+      sha512 = "b25496c3795ec349989b6fac8cbf055974dbee73287e9550b9266ef475a979f7589c8b318a9c05f4c324e69333b943382f2ebfedd0cc8c8b6d77f823537cef0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/pl/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/pl/firefox-57.0b13.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "54b384c63c0c017898ab5df66ccf5176c6d69c1a55c3470d3f16fb2e654854da802d4c15206f7419e26572871b09c700e6caa8cb1d85ecfccc364796d8595824";
+      sha512 = "762e795c44733f161b2849a7057afd2b47021312324565c39d51a3b06634761518284eac7d34927c7e650c1e43179cb88b80396ca91592603ce737988c197533";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/pt-BR/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/pt-BR/firefox-57.0b13.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "11c908bd35ded6e5dbf4df7c518534fe321cddcc1de9ae55db4ec1557ed9df5228e085c5947117ecb50fffd7af3365455e8ba6c98dfb587c8edfb53fa7a330a1";
+      sha512 = "a278133a771f43cf8fd48ca4fc06e324ef3d9187518ba1405c371004b94e608c3cff839dbda184b6c23c6818f8cc55b192bc9118f19e8fbafd6af0b2f0d6b611";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/pt-PT/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/pt-PT/firefox-57.0b13.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "54d9dcdcda3cc5cbacdb4bf6d5e697a0f1ed257ac8650573655485342db89fdb7ec6b98675d7255b600f76284a510b11e53c6bc9a2896d2f3656f2420f252ebc";
+      sha512 = "f56e9591b8eb311484d814723a9d7eeb66914cae8d9b74cbe12f8824eba898f5fdf072e3cf0384deef3087826225bddc31c9a92e11906a05f6505524a6e9c7e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/rm/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/rm/firefox-57.0b13.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "9f5565b6692fdb5fc7c9004261f4b1bf2b6b51e75fd6397018f2c5eb8699cfe93eed15e9564ab89ea3f643898ea55c98245ff8da713e479477356de645c87da7";
+      sha512 = "b0021b2b2c26aff1ef7bc043b64ba39e4152ed3ecb981cb8876d4c15af9e157b30cf9cf92481f76a4071f9407312a8a02a20cfe7223a4f20ad9cea46ffad3343";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ro/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ro/firefox-57.0b13.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "402afbb1552668d7efe27faa3895ef8f2edac40a389d5694de04a0b74f01087659503e46cc9c49c57c35dee3f8079943efc2d655b3f8eb3fff3281d4ea6972aa";
+      sha512 = "dca26a56abe6f6000e755a5df7d62245bea47964ef47bd0c5ad0283eb6b04c235e225e66bb54c979460188ef9a1c870d9d53b2c185e6dee2a37a36880cfca6e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ru/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ru/firefox-57.0b13.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "fea3a0c0192a5c74cc47c8355f7b78500cf20a0c1deccb2adc3e3639404f07cbd9edfce9960a1e84a41887e1175e2643af6d2c6027f3aabcc840226f2940c153";
+      sha512 = "26eb37a11bd7b484617d29432c67eb62c84f4a7aa1575234d284e39a23edf1f679532f818f7f4c64273d70bb400e52f327498ccc8226304e0e859fc7daa38dec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/si/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/si/firefox-57.0b13.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "b57c8c5327d6393b841f0d4b1b327a5816560a7ad2744182bf99cab8a333b3fb833c14cc0587d1111529876e89b9de24005084967b327c3376543e0284223ebd";
+      sha512 = "a7eba6aa32b73a64b7b21447d7ebbfc25ac21c9cc353d06fa9eb1e6b5e43f2673f125abdc662e8296a8254c96e97e8684a8408d712bb201eb1b9ee494aebcc23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/sk/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/sk/firefox-57.0b13.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "221ee97c377002033a46564d8707308ab9c730eccb9dea3c93fa03d9f952cccab745298a8cc6ca4eba11fd171c92ffc159ce8fc004e9cb4710ff3553781635d6";
+      sha512 = "da4a7e40f4063f11434616a1130640b663d1c73aeac6a8638a281174df890f0dec105fd8e5e0200dadf8898bce7adccfca5b059f35773abf4c642ea1d25ffbf6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/sl/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/sl/firefox-57.0b13.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "c9264bccf0c5c9c02c674349e641330e3a2a55807fd44d964c1bb50622597958278ce22c64e10ba5bdb3623d14d283ce91d61385bf0e58bd784e46f5e81b10ea";
+      sha512 = "6d00fcd3f71520a5924772f0b04f091a3abaea2b481bc2f2eca793330a8a9600a7eab38c7b1a9bc575cfa40c74fad56c6f3847ec8edbfed3364a8b7522e23c1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/son/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/son/firefox-57.0b13.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "e0c93706e7ebf5e054beee0827fedf620b10b3c41140bb999e722cd5dbf8c9227d478ee689fdc88d77bf85b9e41414dbdf33017ac26b3d026ffea3d3cfe94415";
+      sha512 = "0484c6de79a605e94192369aad55850b6897ecdc44912204fac58a23ecbedb8991ea3f670c3794d1cb1f311578db41ec518ae030e16e5266b2d802120bf151b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/sq/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/sq/firefox-57.0b13.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "faad9344981f9b9a4f978a53156825bc49c88084ebeb0cf14a950a11f7d0468e3fa00a3306f48d58c18c8ae0622299b3abd428390863101678cc4ad146094451";
+      sha512 = "c5704bbea312df025d1e439563b358ae5115c0e91b82755c8a895194a04a5ca349da96aac99db11627912c5440a9e675c8bcc14456fb14bd4461c373781c2151";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/sr/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/sr/firefox-57.0b13.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "cb8926a04f9c5563821ede2bca7e409ebe14c4f00c90c0edc5afa6668f9eac9e2225412cd8ec8cdbc530bc0c4988e5ab82d6a659cc19c127fb5db70d1fa898fa";
+      sha512 = "27a3bff0a5ddbcd0905fc9ba69ea733d6a6c14da78d1bac0448b6804b8cfa8668890f2a1e617b17e1a642b59795c11b82d1ac4192863f23dc82adbafe2078714";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/sv-SE/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/sv-SE/firefox-57.0b13.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "e20c6b93249abb71c3550623603c2a20e1ef4eff5530c1b3971f1190f00ac60539a54d17cbe8964fa91d7edc377e16c54970901077526f3964521c3aff0dea68";
+      sha512 = "e762be3b52075b4050719634f9e68ae86faf55295803535c046b2abf05ad6f695a0695311705b2293f79c1c8ce69d69b39609f27be6d0af9b625c0d9368449a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ta/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ta/firefox-57.0b13.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "1cd968168f9b496046c0a10fc75bb0265deb964644098afe118f0d56f8bdc5dd038f23f78e94fe8f5585ab27f2bfbf85beb9771ca93ab9049e8d7947dd99d83d";
+      sha512 = "cc0570a17d2325faadc7b1ae313241935588dcb1de8d6a1224a583fec6511a34d2a7ac786bce894f1a4b8b0b92d2d4392d8b4f7d0a0db9d31378191cf1ac8dc2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/te/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/te/firefox-57.0b13.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "b7270f188b747ef0a833c29e9155bc58d1bbf38b9e97bc8a073df70b026751bf303b424ceb295746b3529775b8eaf0d9e3112970b5fad9673adbe435af9cf16a";
+      sha512 = "3f6c7e8612cd483e209c95ff594ebcb0fcab2b03d3687c6a2cd8832bf512b85257e0ee5af2aa1426c6b3471c6d00910447cee91d5b45d5a5aefed0beeaad781b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/th/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/th/firefox-57.0b13.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "9dd0b419c71e6f8229973ce0738bd69247488786c1be9818930d24ba9506f40eef6fb9e4ab56b38136149755b217e8353eb07d3bbf11a673d34c485d4672b967";
+      sha512 = "2576defc0da691c1a3a58387cef996e031683de1d0a1a0f928692b5982b61e53cf01953d473539e8afb5173d674d9e1ce82fa785307525a65e9af062924ff0c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/tr/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/tr/firefox-57.0b13.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "de7b9bd2cc817662a7975ff95bc34773f940d2b2a491b85df4bc3d19dc02dee75cb6305e9fc2441e3dd3d9ab746ae2de6d8984187f7276f988354a447a6096be";
+      sha512 = "bf5b69d5d47c21bcf32ed5e9277d59d09cbdefc73f750b957feaf0f8aceb184425ea6d87e731aeee01bdd74ac42243eab0d781261d63db26bb57ffc3f530bb8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/uk/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/uk/firefox-57.0b13.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "13ee663e62cd68b92083b001b2a3753e4c5a6c15aa5e1187c01e6cad8692a6f53b6e25cbb0d294a62a3986421bcfdafc8bb82dc167118c213e9f4939bc991ad7";
+      sha512 = "eeae9bc7f51c8827c07bc140883c672455088aa9cbb5c4473399f612847ded8e95f61b6c0a295c598c2a943e641812fa75173f26cb46922fd0d962af7ebf9d53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/ur/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ur/firefox-57.0b13.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "d913ddbf3e10f048226f3fdb5e8524e2599b236379e6def3786789b767e9359ef2d47e2ea025a508467d7c47101b922150866984d91dfc41d525876b72ed4549";
+      sha512 = "36d2c5bcad4aadb2aa381e2a8f0d69256268d337088639a031af86fe4958529e0f32cf11c5703c39999dd247023134ea80201c351963639160875547e4728b00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/uz/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/uz/firefox-57.0b13.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "107db43aa14f63c0b7ff4fa4bfd43b0343b657c3791fe29b07812af2c810bbc5343eeb90cd43028259c40dc79b0a763cd770b1f4954bdbadffa598bf0885ce83";
+      sha512 = "a245b8eeb1cf93dd51e85425c129e0a88c3b9d312bbd502a5125f603259f3ee97eef76489a5f9939f09d3bf1b134deb3391689a54d607bca125138761378602a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/vi/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/vi/firefox-57.0b13.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "851f0e5fd8d057a3d55807ad8cd215dc378dcbe71b4c416bd8b88d0f0cfdd9d4febd7e93dd562affa0890d6aef9818970773f95ed76fa136c034459eecd977d4";
+      sha512 = "b1e2fde3c1d08870153a83e921231aa2fb34238b450aa6ce7b79b180b5902ae7bbb2a2dc689a119cd0d8b3d9f9907223c08894634810c48b629d74c2521683e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/xh/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/xh/firefox-57.0b13.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "195e35390839059a49e6c4ae03c1d6d4f085f7cff5b1c7963455bf73904303946c0926158a0bff4024c03be96b9570eb0e18c19ffb42081609f5812cbcc2e941";
+      sha512 = "36345b203efe934147e96548c25ac4cfa21b7eb4cd0a849c7e35ed8e99d36687ac3ac5657a42fad30113192b364b6577dbcf47b854244f02659cb89ac4553519";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/zh-CN/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/zh-CN/firefox-57.0b13.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "2ceb83e0e1182c756ccf30ca95f252ed8e81d293f2c33cc2d325bc091fccae183bf3e75dec67bf6f497b257d4037d8715b12b540bac95427289ea0baa2bdabcb";
+      sha512 = "b5a8464db5ffe2eba9e33de952e4a44077f0af332ceefe562805a5f285a42c5bdeedf4ccb3bb4598b9eca7875ed1f2144a2b54b652250c8a5dd98b0a76535243";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-x86_64/zh-TW/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/zh-TW/firefox-57.0b13.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "44597eb5fa3eb073a04a5fa36d92055ae9bff41049e4c8c3762ce2166d8af5974bb232ae244830d32d51a56e132cee3afee55f23704d389be78bc48063aef1b4";
+      sha512 = "5967f8d5d89ea780dc7475ed50709a7b269f08eaae74c200df97e2b914e01466af1e3cf58fda4eb44f417e384dea03906d7855d612df3dcca7aeec58040ad30a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ach/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ach/firefox-57.0b13.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "9809327388821a5aaea4e8c4d85b61608f677c2af3842108b27d3786dacfb36ea82eb29458a7acf9337eea51f6f850c4ac0398dc67fb503d5fcc3cbbbfecfef3";
+      sha512 = "d32fbe4ed3824f2ece3987ceec2ab408032eb5d352a035b2db3c279a5c368a125ec234e3ab24728d4251838a2b60c13d3db3028cf48e3d2b2ed4c5b54ea47238";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/af/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/af/firefox-57.0b13.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "7bbb60c0bc784c4e58b2537b47e7b4b7ebcbf0a4fd63ab6db8ee0ddc1948ba9117c08baed37e5743ea90d28395dbf4df0bc512aa8bafcd810ac4e2b11ea220c1";
+      sha512 = "fc5222c5df35584fbb18099913f8389f2c8b2f25b41f0e753d3e5f5ec78b5294fe5c88da0ac477e0363f31d7af96ec121b89325a0765cacec0e7ae3e03762d09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/an/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/an/firefox-57.0b13.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "d2dcadaee4456e112edaaca783c91e9c78246aa742835a3d4cd074c612bbe1b85b28ecac222550eb920f09a96249e36bcb49a274c28352a6896d8beebbcbfbd4";
+      sha512 = "e97bd96f4d22d6893d4f89bb9e2b53eac8a68d30b46352cf296ff36ee02d60d3982c02c84c97c803b0216f86d3c7998101f91745b109e29d8c7d0c61e324a8a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ar/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ar/firefox-57.0b13.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "c993eda8d34a3b5f656a7d4cf616f820bb2230a734df6c2f0b4270d5403e8d6d23bd4bf003ae9b115acd1f7925d46b89c3cccc9345ddc7f9d73a269e3c243431";
+      sha512 = "55741f17e8698e02731b431c8b20a2d702255e37171f027ed779243056aaca35fd863a80109679c5fb920d0a2026bdc3db6759f1b3fdfaacf237e4b20bc7e9cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/as/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/as/firefox-57.0b13.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "5112aa43ee870c3fd8f13378a4159977cf4dae3b1792ef983325a0d1f0134f377e6e4c473b27406f2722c138309a1af175f4bc9ff4e37f08696abf4b8f001fc2";
+      sha512 = "0e14c33b6f328cf931a7f9c42d5fe1d7fbcb8736381232c69920a45111410da3d09c1f5667e7206628d70a7caf1404c304bf9f4ec8a5ccc3342103b3ebcf3757";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ast/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ast/firefox-57.0b13.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "cb7fa643c742ac1062f34acb1498a7e903dde4c8b685ba48b997cf0247aa70157ce2317b5e25660748294757f0d0fde7d08dddd6581726c8f33db1cef3767878";
+      sha512 = "a2d51ee57a7cef66d862c593bb1e52311593a21ae0a25d2b9c14a64065906de26770c61665dbb0d55930241302940d697c982e050750fc04a5c89ae1ca1b419e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/az/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/az/firefox-57.0b13.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "267fe9b5398ec432e684efed10624819eee7a1729c8480a4acd616cf4dc988295c069a62f6e3f2936a9e822f45fc459d8aee2d94549fc77d3f2fdc6a23aa9ec6";
+      sha512 = "b9fa717fe7d861152d2117f1d69a7ae264f18c7e1bcd4e71df7404277db6376a93021e070edf73fffe1b00b3f7031d8c555df645efe63571d8831922d0212d05";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/be/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/be/firefox-57.0b13.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "35977b89eed0a7e7401bad75eb20e7acd07ea52ac252ffb73a464f7d7c7f44fdb9dd6bfd1418324cf8834165825ebde256704e7822734077a68c0a3ceecb8b56";
+      sha512 = "670dc2d6d9d35947d181dfa1c11bb84cc65aebd268cdea059997fef685619757d3d7c6025a12d00fc5364f258a64fe1b08a69357a2d31fff7bfbd0ca07cdbd4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/bg/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/bg/firefox-57.0b13.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "dabb67aad05867acd8fc5226f1adc91168f70d68926a7d9e8407feb8795a9fa56121234c639b03cf10cd2ad44f638b6f96003e48977ecd07b8f267c9da10b943";
+      sha512 = "99deb263d7111123582ef53bbb1919497a6ce6c73cc160b4e26f5adc22f46e383208ae25acb5b4bf6dbac4d9a4f801ce70e170b0e6e5c9a03593eb2db8edb601";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/bn-BD/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/bn-BD/firefox-57.0b13.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "f6185c2eceae26618c3ddbb09f87cf120f300d8c3642d36b257fc8c6c0fbe7a0d0f0e409b53bf3fceb2158497be91b9dd70e3605a5177d858a115cb4cb065683";
+      sha512 = "34132da469314d9fe9295b835ec2b8b79816611eda646c04f7e064bbee5cfb2cc42f92e14a2eac60239c44205be4f3239eefbd1cad6700520ca3fd4bcc1d127a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/bn-IN/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/bn-IN/firefox-57.0b13.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "50730081c97abb504f76f2e4c5bfc42258473b5b1cd4393a09be927156e626ede088f7ee6242ecaf9b641345cb4f28fb9f0a5276bd781882aa047adb4d1281c2";
+      sha512 = "9cd206c11d28b866004174532a253ad49c06f2c6cf9b2004b15bb14bf597e776cadfebec4b3935a323b98dcfd3590bf5a3b289a9f7952a8a438a7e90884cc0af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/br/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/br/firefox-57.0b13.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "6a1cbf642c85abe216854a45d371dd8463c37a3d30a9cc0e7b88aef19baf4695def56c9ff61110868c1359c7b6b082ea9862ab4026fda70ddef05c304f805fe9";
+      sha512 = "f30fe67e71b5c3c0e3f352653395094a31cbc52574a9dfbf5d5ccafcca528ca0a5b164cc75d5dc7d248eab74f0470cf8547fced782c979fb1e9ba4e177ca2b6b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/bs/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/bs/firefox-57.0b13.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "f62dfafbccb28abda10bdda208ff161e5db06eaf4bb3291c4a2149c990ac28a80ff4eaa28bd300c296e349c762c1baade01f5881b8e079e0e690a9c3fdc302b8";
+      sha512 = "b2a546259e46cb58d44a61fa78e53632fdf0708921d80f329924180eb1a01dbcafe1372c8818280c0b40aafc7d4e6fa59d3f34b7e6a514f2adb1796d4274c093";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ca/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ca/firefox-57.0b13.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "990e3c75c387050c728bb6fb2dff2040e53b0ecdd73fba6ed27c6c66206597fd2ac099d561ba8a9cae1875ff38628a562143dd5802c7ab67221e2837de4ee0e9";
+      sha512 = "0f256326b5338228098ec31b8182e2d5d85418c9ace5fae1ef5cde37704d2f333172e4db7497f36157fa530148585dc70c0bc1b677b9888ebf0ae850b4aba2af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/cak/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/cak/firefox-57.0b13.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "698fac4d2a06a5057cb81a57608eea45752e6ab787ce8264e5d3e0a1c11469d1e0b2c97a5ae34ccdce7e6221f6367dc4682154c6b013105750c854c1340252f7";
+      sha512 = "effb3d74d649b7adacdfbbd568b561f55ef277a9b7ffebbc27cad5ea0533a73918effa9997b9565d33635d8bb39658900f251cd071799fb15adffbd8022b4515";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/cs/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/cs/firefox-57.0b13.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "ae2e138b886fc3c2350437a57fff8f29a5018b78dc2b31a45dc981ffdf233d6ad11be5df8602cd7de4ff9df6868701b296ee42d1e41922da1db7aa5f1c1dfabb";
+      sha512 = "494dc250f77d7933006121720aa6526534c7b90c17dcbdee6bad4e0a6f5224de661d3744862d5ce519a9ae4f36095af76d9b86d873d4db97991b1d27ff5ded8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/cy/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/cy/firefox-57.0b13.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "fff159c8d07c544a8cb66b4cb52ffed3f8975d362c0b69ee83a26490eda68bebdfce45ff71147198a2ee94841deb9115a6a2ced6ff7a583d09c6dad8edc87d99";
+      sha512 = "910254333d2f47f4d2162cab76f84f2b9f1808d559d1eab0d1ac0c1673406869b3092eabe7f4107758dede9394b383ae98ccacfba768772d550630f34efe5c62";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/da/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/da/firefox-57.0b13.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "32d5bfb5293e1d5346d189638b1e0269fc0d6aa2ebf3e7ca2f018533744d96868eed09797e8222102a6afe66d0b7e2f6ffcae5e72fcd2f249fc66f8af30e5bbe";
+      sha512 = "f9fff4a380c84543212c610aed98fb0fdc4a0d2693bd87c3dc3188d7eda73615d028c7ff7c15db12425855105a1b5230a7f62d2eae84a893f07a4b8cdd47538c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/de/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/de/firefox-57.0b13.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "63b9b1ef0c83c91406c165034f0429c9c2ecac617d4f69dce40b9d12fd5f0583fb88148f6d14858e21a71ec0f59cc22c18abc296d0c561624d584fe6e6967b18";
+      sha512 = "2e772ae4b2f5246c96e30811a322bceac788325c40463470152b495492e60e3084e0ce55473aab56c9be584992b6761e364902352616e70050b4b0e9467b1a79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/dsb/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/dsb/firefox-57.0b13.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "c902b5bfbefeeeccd7b49dfdcff94f3219ab42398ff2e73aa166846b7265b896838754719f1e84d0662660bd03ec14737183e60e653721840cc53b4bbd6d6658";
+      sha512 = "8c6b05440d039b4ea3666b718f8cb59f91804ac2899e9d2e0a32a7622f800126e3b3bf9360a8e830cb70408cd7e4bc18f4eeb639dab403718ca6226576d262db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/el/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/el/firefox-57.0b13.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "85b2c08615e034ed9f1aba837bd73564e877f3385e3c3989ce864b1848f79f72e30a5bf06d6b32358a7f296137207a785fb343874fcf551f6f0b98515a52fb14";
+      sha512 = "9589eb08e3d128e1c22b639945790aea4ce2524eb3c16d581c615f18b3f1247240085fb3b6d9cf3b283029060a86c0747def43c3d89a1548d907edd50d0867e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/en-GB/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/en-GB/firefox-57.0b13.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "d14d1d17020b8a79dc580f7f526403e17cf0337fdd567b464097bb3796e752a669208b2a94a0fa4d1834816153230be67ce815bf440e1acb9220c951fe84cfa2";
+      sha512 = "b1848e886919f8698fb8ab7272e49fad3ae1f5d98ce92b3b82c6117f79df56a8ee6bc2ea2cdc8987701b9a0fb4c2b1e1a58a9faceddb0366372a40139a1c7664";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/en-US/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/en-US/firefox-57.0b13.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "fdaef350da4b8eda52c70c613f8c5e6a5c80522d5afc8f6bdd9590c91bfce43d2d2034ea095b377b47f8da65d950fe4c203c2cdfa9bd880d3f6253fcd0b252a4";
+      sha512 = "327081605198481bb18bcc45a88c4388ec9091c6c10bc6a27ae58e133470651d50edb106f95499de4e38d7ce78eff68bf38f430371e4c490962e2cdd3ea55635";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/en-ZA/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/en-ZA/firefox-57.0b13.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "c4ce10a2ad4d8ac8cff1e87a408caba7c1736f84ad2e228b45b7f9d0f87e5c9f6a4adb0a0ade89fa88c54c38a68189f7e203370890eaf69b6bd033b90afda8c7";
+      sha512 = "bb1432ab9e9f2e11fc2270501f25e3181aed4a782fb0337ea676e75c4db487a48bb1e3e44f0ea703c84c4dbe8d5c4e9a102c8cd1d45ff673bef7a5b884dfe707";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/eo/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/eo/firefox-57.0b13.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "37f75ab35b3ecb080dfd7c3b5edb65df950d260edb0156bb09887e8f30f1ef1d66016f6b07eaed0288be1c5c92dcd5c18b88fb0a9e742ced375ecf661a3ff5b1";
+      sha512 = "8ff8c209c3aeacff538d2f265f8a6eb7621d27df237c33b9265d9246674d61f7905369fb2b7636920cdacaeb3d44be11dfc136de940658309f3285e62179f8ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/es-AR/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/es-AR/firefox-57.0b13.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "8f2603e1d4942e6c6d4f7bb5823473a0e44f820805301aa2b0faefca6540f4a8078d43b6b9427e581d9720f6ee47ce4af82113c113753fa7131d6971ec10441e";
+      sha512 = "4eea00d279524be9a682ae46cf602572e0e1469d1dc10e37b1b0a58868386930ddecfe0dc43f0d185ed9bedb29fb85eefaf87d83ffd00ce51db04d37e5fa78ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/es-CL/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/es-CL/firefox-57.0b13.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "9a6845eeecb831cbc3d804377ef11ccebe513307a72f4b542968d1851e54679ce202e5c6e5b1b2efc767451a0202737837f564f146862791c53d9880e42a2565";
+      sha512 = "c130ca1390f9859ec6d276f77889cd804a38e32551c898a17158b1b7b629f7f72a39afafbde38029438c465e3a0ca82cc80dd73905d84c0aabad8ebb35f2512c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/es-ES/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/es-ES/firefox-57.0b13.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "4d94719060001c3e4fdabb0a08e977079a3ac05d5a5f006d724dc0d6a7bd31646f5603be8236b6cb0ceba10eef64697044cc104bcb10b4308b28fe4883e89167";
+      sha512 = "6b515f16a2555f56c1cd8d4487efe2d4ba8107f3122b0dd81df9168768808d08314565a0a7bcfbbf4451d2a4e84559e84fcc730caa1641e801c6daae0ad517ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/es-MX/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/es-MX/firefox-57.0b13.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "38d46eaf7b40f753b9fd6fdffda3b21c5f4ea9a554488277cf55f97e230911606c98fb4e5b6b188621db24c552236aa67b1ebc880630c74f6c57777c6c0aabc1";
+      sha512 = "a3fa5b35773656152eb16efb6486d8e33ca29e0094de24e389e94a6e7fea761569c3ad48984f8bad255c8ee97f54bb5521444993f0a8ba7a3c922da66c1295f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/et/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/et/firefox-57.0b13.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "3babcc9f0bf78b491d11d96be70a62b409729180e3ebb0fc97ea0eecfa3caaa2db1f6956f8becd97066d8b7216101804d2fccd249ccea335b92bbbfe12b99d89";
+      sha512 = "7a0a165105f5b1ff3f997fd400bc8d5a1bf976c1f4910d4c91be9827a5094dcbc03e8426e644766b4b255dacf861e88cb3c2b75131a9fbd89e2c0eca69718b36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/eu/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/eu/firefox-57.0b13.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "f2b1b2befbafdfcd2467822b7834c5a03ec380c2876d6641addffc5852453232c350273d310e734e7071d2dbe35c94779eea858ecda49411b6a8520629394c62";
+      sha512 = "7cd08c560ae83926226cc69a10691918b7c89cc10282cedcc57955b362546554e76b36af217a3187b11abe8472838f4cfb1a32095bb537b43f33920b37b5965a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/fa/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/fa/firefox-57.0b13.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "05d1bc4004261475c6b806fd2327d2d1f0a1246769cf9de0755ac0cffad99c270064699b5d05cbc9353c5ce77be9810546f59b0d47a0f88c96d6296d4e51a358";
+      sha512 = "02b19d0f74413a92c998be3540f5f8d25ae2857e1eb9b4171083bdf392e5dc5ab0c6b58de54e75f221f731806fb8a6df070146564a3b294acaef76fcc8e633b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ff/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ff/firefox-57.0b13.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "448fc135f815bf79fbb62e2b4ca799bfae3891f9d1197ec8febb441f2a13dee8405add2c54a12d2eb11fad6eb291d7cacbdc31fd5af1978a253a5672444fd30e";
+      sha512 = "df7485cad8f46fd93ac6a013e5f362a19b1b603240ce50044169ffa4a4267102910c1d6bbce9a5d3675911acaf64dcf0ee3638090c0236ab664e9af5b4b567a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/fi/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/fi/firefox-57.0b13.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "06f995e53b88f32fadbed3d0b3b22c11117515b2e926b6ce7e9763ec6fa29bea6a05292ad8325368badd4a0a6b3f5ec8c49a147a7f864c238c814c4f53d99082";
+      sha512 = "26971b0778b87e3b0a617197356626bc3120b2214b406e01f5fe865430abfeb6dff471496548883e3e2355d32b1630fc85f501eb9934a9b6fd23270d47df5984";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/fr/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/fr/firefox-57.0b13.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "dfd06c21d7dd83309f9d6d11fea295bfb1f942e9bfd19a5a1c45b63466eada5ed75b88fab5d4730b13db0522b3a977eb85164cb0c4121242a975462dd9518acf";
+      sha512 = "324c4cb614a8c50d9d7eabe6e2e3aa420398db7074a7d043c4a44c5785a640988c9d531aab92f51adfaebcbcb1e274f825024b09e302334241a16c622ed97f7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/fy-NL/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/fy-NL/firefox-57.0b13.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "ab381fb599161dd7df10db3a1c93f1e71d96ef1364a59518e1413c17f7a26b524c02ce54a33f8ea54a02829e519f8e8c475b9579b69bea62f44c76e909079e3d";
+      sha512 = "e5d8d67c5c549240264b7a02ff6c5f54295f04a26553a5a19d3b58f94bd3531c04d5402084fd6f40d63f9aebe2df7d8b50415d8575774f71df5a180e50d39728";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ga-IE/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ga-IE/firefox-57.0b13.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "9054ad0c2184063e6c42ac23004c9c63438368c03fdd7bf9bc0610d1a2d4a47b9bc4cf4762a0cafc633ae397c38ff64e050409c5d6fa0ca1ac869d918dae547d";
+      sha512 = "01c0998e8a32e6da0127680d17e71c173c21eaab66603ee6fee0ddf8698a16501d290b1ef9d375d4cf678606cb4a73c679434e22b309a592523d11ebcdfd9fab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/gd/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/gd/firefox-57.0b13.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "3844132a9433fbcb107f380200d9b57756820a9a3495c805622b7f3952c59feb8b3599c774d844f57bd38aabe01eeb45cc35d8e06073350f884ddd0a0a18d3fe";
+      sha512 = "88eb2f45c0242400d62310e0efd492b27b6439750d01f0f567dcfa48398c0b2572c842c6155e370b0400b40c2dd88b7f2696daa4e42d0dd5440b4175a409517c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/gl/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/gl/firefox-57.0b13.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "2d864cda23c59108866f6e8f473bf98d8c328f24202130d9168ca0588f43a9cc49c8df1ee4872601608cd27422d7243666b5a1dd006ae5ba101773b7334cdc15";
+      sha512 = "d8c9f478d1859240b411ba6a819153d6d260216aa3bd4acdd043b0bd6e65630f02fe4b7f8dd549aef81190ac8358620487d5f2fb796797d220df70b3a597cbbb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/gn/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/gn/firefox-57.0b13.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "fb23767c66deed8f0ef97fa5b8044654740b8952bd7b76da9d6074e22c91301fffd3006c5f9c09ee7e7b3ee3001e70b31a6c09a096e3dc73fcb867f15251a553";
+      sha512 = "572a00d95247c758bc81b0cb61c2fa659ee5412ee3ee948640549d6e737fd0ef622ac4e16715fcb269980461bea32ccbd2249448ae8b340ef26c322f5c504090";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/gu-IN/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/gu-IN/firefox-57.0b13.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "7e146f4b6c3eb1c96be1d95ce8502aa62b1483befbd7aaf9fb945fdee4e8b8f62088841057bb81d9d5f8d2163b25bf17797d5af5eb6d6f32ee77b0b7b84aecd8";
+      sha512 = "34a4760f8748b6e6cd1856f5e99f04e320dbcd1cc3021e185abcd23c12e881e2eba31ef9253bda6677c767d5e7fe5aa0dc22f1145852dc58a7e24278a0c6dda2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/he/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/he/firefox-57.0b13.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "3ecc278918acc5f65c0552f9108bd167a9ed3f55b39b4f3ec41175bf9a1cb1d84e32b57ab208e6c6816cfd66b33b5d2846d5a776a79510c7186e0d5ce6bd25bc";
+      sha512 = "57a0b28a0f68d88298d25c62efa70898aa911c11f0733798739f40e546288856306e062033d24abb80964345c0f0224e2c5f3a15b01d89c4ed3584b1e931d91f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/hi-IN/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/hi-IN/firefox-57.0b13.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "7aac53bb08c527b1c199bfffc5edc25e8d49082dc7df453439775afc07722bb126f95955aec799909818cfdc949efd5a9f987942a4655440c0ac26691a0bfd9b";
+      sha512 = "dc1db5ed5ca72c48729ef8d2a25cf608072fa7112e02b001943242ec027157e197828e85697561febc15740f52f9ecc6d666d5c83201ec8101a24ff66e8eb4dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/hr/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/hr/firefox-57.0b13.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "ea03e4f1370fcf59c9022c7f4019484ebaea8e295e2c3ff3ad8f44aad9336ba809cda22fc0f98df2f5ed7ec536ed9ba349d5ee57bea3c4626ba5fcf41fe83be0";
+      sha512 = "5488074d04fb6f592abde28e1ddd8e2d949a8744849f51192fbe0441a551b358ef8cf1cb78f69b5340c07b266d11783e2e722ad5574f255186c6bdf9762aed7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/hsb/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/hsb/firefox-57.0b13.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "71ee5338b776daa0e9b33834079c94e3e9582b50d7b0e92f64e25546167838852ab606c2c2f9abb1f3480755a653b091e60c97babee00e66d4140600ae4d2612";
+      sha512 = "4bffd78e28363aca1d2b63e56ed44703bbbcb701b4d6e1c353f36939b86c3d7045b5104d7f3da920a8a6cd3b69d021b5d19f9727c5fddb8a86c594d15fae80e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/hu/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/hu/firefox-57.0b13.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "defae5f9c7164bb5150af1fdd6c0b262fc88c63b9c7ed09753af5a361815ffce9ed43d0d79bad65bdf2e0de775d17660ff0c31a39134f9ebd2b6f60ca4a02d23";
+      sha512 = "6a5ee323244358ed68c96de80f9ce1741217cb002e33a8c93e8386773ab27f11b7bb58747daa4138e5b91b2bb4543e1dbfd14b90731cf5bf357376f4dbdd3a44";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/hy-AM/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/hy-AM/firefox-57.0b13.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "924efdc4e8584d89b60d98117a229c4c9a619b42f0a713b0fbf9fab2ed63b5761a9b5051e7cfa825459cb3d499eb4679363b13a76dee2973ef6b843c7ee9fd9b";
+      sha512 = "28e0cfb93884fd78cc2f126f8c08714545c2550ae40de29e0dc1f3186fdc437592c6365eaa92135dcd1983009be7a5021001d2a7e703bfe6bc81f695ae662619";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/id/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/id/firefox-57.0b13.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "508c42fff4f6ba5e39cf757a1a306c7404e3c133308d6bf4d734f4d2c53fe79998724f861843d2ad76af2dc5482f108ddfa11026b8351a8786d814eacbbf839a";
+      sha512 = "00136a82e957274eb9316778ff0f9aae66df21d6ecc64f67757816104aaf5cd6d83c0d9c0224214cd2d1c5a68c7bab75d439cb049035ed2a071255a415b337b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/is/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/is/firefox-57.0b13.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "9930f784440abd54b53fbe94f7eeb0e26ff2b1e2b16ba30fe1a7d298195db58fc32a25624444df89176072a9344088cbff188b73b9d7fa8e8b571b4390a481b3";
+      sha512 = "6f22f0efac6858498c755fdcb848553a0e40bb80bc8dd6717d986e84ee5bb8cf7c608592eaeb6653f6454147cf73bfe57b5e62b581c2217b8546fd27fa9e5c79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/it/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/it/firefox-57.0b13.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "4bd98c6c17a3cc3f883e7c2cf8a76a5423aeba67c6c22a50befaa8d4efe0e8dab495598e17789dbe078c75aec7e612ce959ef8f82254ccfab460b273456ca50c";
+      sha512 = "6321ade81a09236ab3b3ddd024b3e5ad6404fd712ff6f23f72901018157f9a845c492ecccd1148cedc1911365c70c286a7d947cfc4afa534b274080e7bc6909a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ja/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ja/firefox-57.0b13.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "f034c703ab191fb39fd61859df9ec14040764a8e22502277d11447add96ab3b060931efc4f7dc1277519c47315c40793a7a7b8da161892b13fd433aae4f723dd";
+      sha512 = "b652eb0aa3dfd71dd4d72e45fbf2713fed947b866f1fdf172a473d80cf3005706558a32d7a04b38766517f6ff571166ac5fdc1c8a5b89cacdeb91f9ebe98674f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ka/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ka/firefox-57.0b13.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "8ed142d84d31914f638daec87ad64cf1aab76e110bc7bc147630df019f1a6cfec8cfffdafa139cdde91a06b65966741aefaeaf3d16c63aeb94c4f2945e04ba8d";
+      sha512 = "38ca6189c55363040db09d55d6b6d525eb91aa4858a660fed3b400ebe5e4cbe723efd9735b77705a1caf811ad0f0a9a117701ce8414ef6109157357193c1a655";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/kab/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/kab/firefox-57.0b13.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "435e8dedbc0014ac19a37d0450537d7b9c2d4e7de993644991c58640edbfeeba17c6a59ab5eedaf1318bb8c71cefb5d30adf01528bcbd8e043e0eefa63296be3";
+      sha512 = "bf581810fd19d073fb80dd3ea93b6b856614e4821d095800faacc3c17d63c53d7d65aed4b168a3cdcc29a155073af78d26f5967f29102ec4b1e29325c3686b67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/kk/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/kk/firefox-57.0b13.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "3b059e976cc10eb97b10ac4bd9e4dd2b8cbc24b805e23ec125d42ab731c5cc6f97bed8ecf222b1ed3e2c84a422a677cb938239110a38d6e34efa2a9f2472bbfe";
+      sha512 = "aabff3d68e37a9b41f9345d8968608082c24e50e859a693d4642a52e534c5b8b7a5233469a1930fc54ecaf7b15aca486ad66b8cf3100fa62e474b4ff261b37cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/km/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/km/firefox-57.0b13.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "aacd4ce2f5a8152916b2a9b8f532cdd09c382e0e365de297082e5bc16f6c19136430504bd74e51422db530c66a13af45721c01b5cce3a7b4fa31e08beb852539";
+      sha512 = "e5bb4825d777bc6001d7d95140d03ac6c44c96eb602141be48c36ac82863dfd5bcfb25b529d61f80b8a939e692bf833886fbbc48c45ecc7e024952ddc5dee570";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/kn/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/kn/firefox-57.0b13.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "10993f98c96e83b8010957af8467c4434070ed5b3c52311aa67596621f415d6ef5d7946a6fa5112ad7fdbaea00675bb07f6845c6553774e1a9666716505778ef";
+      sha512 = "1f5f4d4fe4b729ae2f08432a5d074354121c876c4cb0e7344e37b8d02e2aad38a0b16547d2987418acb98ecda10805dfd012448332c8f8e5d1f772cbf21554eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ko/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ko/firefox-57.0b13.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "c31ea13732f5b2d14f7089d71923287be8fc99bc60db396757f1a8a2936d9ca5aa5f1e2c447cfde0f90683038868dae95eabd55ca16df17742b2f7bbbc89e7be";
+      sha512 = "19ef2c157469a3225c7ffb875e66f41a9d2828635b26f6dfa0062cb92c0841c53f2eecf77ba9b043e3e2f448b8a08de55c7f74fc6fdd3f7b4554d13ecfa746bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/lij/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/lij/firefox-57.0b13.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "b7febb474eb13034eaf9ec555202153562b8dc34cebd0c03d680757c19b2b8fc5f7060e66b115d0080cd3510a56033597409222eb56024ba136d9ab50cfb246e";
+      sha512 = "4e5e6103793dd20efb49bb85dac4dbd208c0d164e69c5856bf9fba96350c3682d894af857d239e23f3c3e802f7300b5b915486421414fb6f9b8af86ee50e247e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/lt/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/lt/firefox-57.0b13.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "d07c56a82054d1238a8a5678b65efbb88b7807aaefb327eaeaa393218ae280ef4e134d4a3ac28694458470611610e3bde2be68f3df325a496d9f922d985681fd";
+      sha512 = "d01f311ee9f36aec032a5c4eca34a86ebcb54960fd29b03af00f2b289c2b4a38e232242d1e48847e2385e7ccabcc1c928ecb1e57f9001d181c350762d59ecc72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/lv/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/lv/firefox-57.0b13.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "fd8adc196bded44b80d6875a0cfc270cd8672a19b8911753a7b62545823262c34381c3e1d72d21af695c273242093b4df45188bf6b07f83ba5a73aa7a8e5e528";
+      sha512 = "d23ce47ecf7c790f38a9bd605150f403776b4e469be590a57b9de624fc10bfac2a3572470ff496899c2bd6ebd1799e9f4687b4e77e4714ab8228c26998760b21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/mai/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/mai/firefox-57.0b13.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "c31e747aa29393f12b4d32131b4a9134f57fcc88235258dabcec99583494832cf61079b8980171be2ea952121f3c5568c42e006e2bb9b1c0e6f6fd05d2204dc9";
+      sha512 = "7d8baaa2d79f6e50afe9b915d461a4ca25ba777dbb0497d2fe0b1ed92eb30061061b3a29514351841f86366b91da0979b5bf270e290c477397f3201f1b517398";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/mk/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/mk/firefox-57.0b13.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "3e304e2a82640adfb7d15705ccf740de623995385618a351651005da3bc23edaed3707209594bc2b70a244f0ba86accb80c319ef4f55ba156f5487e694fe37ee";
+      sha512 = "b1f35402ed051ba91294dbacb52aa451efd48300fe982d638d206c75c3b0f7871fede1d7467ac8d6ea4308c4967b0334873d72c4c731c69f343b92d56fa7bbd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ml/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ml/firefox-57.0b13.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "d229529966b0890b78d53e221d2e809d003248e2e42dce182f3f761434da72362181edaa0db9ae255878d01118ccb38921af715a412408e60373a0a76f02b104";
+      sha512 = "32ea1f66ab87b299de4256cc25c6a67c0754e9fc8569f9c9693aee850c034bce1e77cfa6f8115015f085f74bddee99a7cf487cff09277f011dc51f9deb07b97c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/mr/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/mr/firefox-57.0b13.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "d8e81fd44be727b8b72cfd5c4852df33f812b6c3fbf09c07a461c00b53bb41fa63a1e2cf9c17dc90ebbd630ef18541d4aea4d9cddf471fc52d9ba10952ec5ad5";
+      sha512 = "3cf3fc88a84de5dce220f89928f05b8f8b1d8ecef2f83d01a880f07d5a935886fc30341eafd941f31213301773f463fb4f4681cfb5e8311665f61c8f28a5c0d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ms/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ms/firefox-57.0b13.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "e025f2b6a8724eabe4128d9e3567f0817c833a6fb2855b541e6a12208992c2586970b5adc422156bc00fc403714bfdaab762505308931584ed9ab8f9352e1183";
+      sha512 = "a3b9dca6a332f939e6ac7b51956f34e893e1ab5e62e9c8e3afceeb6233d7d378b44fdd9f6dc46eecd73aa738df46534956545293604faccefc34591a7ee6e12c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/my/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/my/firefox-57.0b13.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "6518b67cc4ffe848a0e79fce56af5f9ba60f3338bad5dc65644d6064b51e1730182f4d6038c4deb64be852fac673229b75cf1fd0d1d7c37db62c830d018824fb";
+      sha512 = "9daa4560c3c4424bfbce4f23bc414979dcc96359af3cb7c29f2a9c262aac81d96493cbf9f938b8b25ed0720801d0f87a11a7e5cfa83ba78e86e2fa0d2495fc45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/nb-NO/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/nb-NO/firefox-57.0b13.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "177f3638d429bc4b5d97796de91c39c3a5712ca3fe5f93d5e1801937d16b80faab94cdd75dd99ec7c6451f55a5a9282195a0deef8f5500833b83dc3ab46ab20c";
+      sha512 = "d5ab3676fbc7c3d3bea1af43bff89c3290af5846eefb7bc51d6f946c8c2c7968332de918d5fb11c475e873e7e1a032213e75a00407092e51baa5f0d0a64fcf9e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/nl/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/nl/firefox-57.0b13.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "192f7cdededf9424631e96bd88d15fe66b7654cbf09701f361e0083b38106636df68f183aaf3b9a4894e432cf828f429ab5a62ee0b521956eed14e470c909aa1";
+      sha512 = "6f1e8bb355f6ca1e8ced4b9b69de26d8cec4adcf2957a7422b98421fba4c3d7c3fe91596fc9ea06e15137f8bdff27153b9d068b7707c7f56b5357a7aa2ec6ffd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/nn-NO/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/nn-NO/firefox-57.0b13.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "e1d9ad0238f5fbbbb95d08e01f95a9ba71ec35ed47d0609a49a9f76e9f9008f21932a12b9a342b9ad02fde563dcbe7779d43b9bfbfcfbe7f17c4f59d324808e4";
+      sha512 = "b9c27a5c824efc48e85fba2823d9288990fcec545fac3b1ef6c4617a624ad685b01d96d23ad8bd5eb1e7787849afc630560e08cb7fc617cf2e25c9cb9f2c1ffc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/or/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/or/firefox-57.0b13.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "12012e659184136db31cad4448226eb4e70760b9234632c9fa1b71a54b0ca06608de7ffc62ecd018671fcb9ee7c3357ff18b7b5459b395a39eda59d1a44bbaf7";
+      sha512 = "50c0e9956bb17f6df5d342e0f43a4439510e80d4001f504d566d2856e885aeef2b54b57761943771f8a4ba6648209080290fbd6d556934e14565bee023c257ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/pa-IN/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/pa-IN/firefox-57.0b13.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "cc154c9b0d53ccfd515dacfcde3a55a75c16f542080770927533b9efba8bedb7f46adf0a54772f60ff8395c1e83d0ff602687d7b04998e9d9e0f6c3da2e95142";
+      sha512 = "e01f2c4a9cb3f7e6adfcc3e58a5fb5485ab41ae01e302c93404e7b5a7bb1b30f351e364846853a2c6ac0ecddacc03806fea945338c050928c6e8eb6dd0a80600";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/pl/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/pl/firefox-57.0b13.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "ffa0cd7b26d4fd48cbbb9b56b60937190dc271cc6f002fd4da11929945d064d4aa59788a756ea4226b15e1856434094e151fb92a96f3ca9d14141fc1bf98d037";
+      sha512 = "1bfbc1b9a401e0d9b912f5c91f1eb22b0b968d8bc75ddafa28390071431d17c4251b2624673aa068f59a451b7a9bab165690b5c87ba1dc952242287980c63dc8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/pt-BR/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/pt-BR/firefox-57.0b13.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "6e227b96787f07b9e04632d54ad33ffe17931e787d1e0212a3419bace1cf8fb062178adf6a2ae8d11a851d3de2eae983b086850e8df775c0a33d518dc0306b51";
+      sha512 = "75b83b22962b42160d5956db90e55f23c2f12335569f908b1ad1acce48704e9012b4d2c8b3575854e7a36ba9dee49f4b96391a4b6958fe80545501dd91609084";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/pt-PT/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/pt-PT/firefox-57.0b13.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "fad503b60076143c5941ea7c280212570896aebe39e594e4af4b2c258b387a5489a63be17730e4c31628b96661d8deef7aad6ebd31eafd3bb52f841e4a344a39";
+      sha512 = "4d9eca88e092531b87d8ddabda513f9a42a762f7af2511dbec25eb88fe791fa94bac3b08c7521227ddec2b049a4a55cd7d862144696702073bc13906b1f39f83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/rm/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/rm/firefox-57.0b13.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "737c4cd8234d87f96b1970f1ddead34eb4b109e201f794942bf2ae0603cafefce7b38f2900bea2d08d058766e8d1851d96052ed5f23fa46e351179c9ddae1c91";
+      sha512 = "44b3eaa4cde855738c221e7c1a3acc80d862f5159c13d946d67e47b382dfb4a5a6d360be961a03f605aae3e1c89e2a8a0d16f586646cdd1a3dec13f777b32577";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ro/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ro/firefox-57.0b13.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "506c842023cd3fd3bc0a6a57abf7b2b822253b0ef4bf2d3f511bb3ce5407d310cc976803f6959b8678899b38ffcda582da21a887d8608fe8d42c46ac70cbf133";
+      sha512 = "a9dc8a1b4f0b236f2660be71df78c41e055b0547d8ce9bc258798fd4483fe888040d2c04a0ab0bab4c95a712d22370d957513b5ed08f1e332803d7067bc37aee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ru/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ru/firefox-57.0b13.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "94213fe894d4d6222b321aa6d9d37f3cf32f257c0e021f8d6f122c4e8c458f9845ab5abbfcab1b043b4d8aa72f83307081685a63ce7569194fc15e2ea655cd27";
+      sha512 = "d2c42dee48f21e847de67efe353088ee949fc0af99ef510f5b76128933fd5432b2e0cced59ce0a0157e396b92beb645d78d758823582cc5dbb63718bf85d9b20";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/si/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/si/firefox-57.0b13.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "2174dc7cc1a8e8cf96550199d70e279c85a91671fe1b1a71161aa73acffc8a0c818dee6d0f2c3490384eff4de5175eb6c04cbe04ae92c60da72f5bb987bf60fd";
+      sha512 = "57be5923936b02cce924fa05994a6a887906104175e305043ea5a51e90cd35cc48c190ddbe2d060d64965b32c65296967dfc53a1e700d7defa078d02907069ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/sk/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/sk/firefox-57.0b13.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "f9a30f631ea892c1362eb17652213cdb603eddbb0a687f4ccaffe70949b8692e637a35c4d90e27f5f823da59ba01de45f810bce1ac33a0243a5c96f470f13ffd";
+      sha512 = "12a74e9df967e6a058fbf53baa842bf199190dcc3e5c81eb49da29267760034ea41abdd5b1610f4e06cb30e462cde4c74430d58ab7efe7ed755d19919550827c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/sl/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/sl/firefox-57.0b13.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "abb5746927a53331da0604e4259a97b8d836c489a3c777ebcefb9d3c724503772474a2551c7347c8466e007fd248ca4b96c8e334272c958089abedd60f810a50";
+      sha512 = "9053a6dd752ee19f8dc49a2bc41c1d91b6a0f77bca71cbdbbe46b645388320a12be4db14714c62c2306b1bab78059826a8fecdf0897ec52ce0fa8e743e25b83c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/son/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/son/firefox-57.0b13.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "a88ec432a39c197d4b312b8eade6b5b1c27e2909dcf27c309844fddf6a21255a1bfe7f666f3287c6662a0985c75810eaf67bbac20a0b871bdb583da30beebf96";
+      sha512 = "b8f6bbe404306f17ae982238d573302165c366beff14917e64dda7c07b6a2f4e1f9b2042a97b3cbfab02f5e7fb860287cbaa30536494506ded1ee51818d3093a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/sq/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/sq/firefox-57.0b13.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "32054a108dd8beef5dc9dedfdcddc4b37ec854ce32f65f6f69e1a4506e45931909391182ea61a9eefc4e3bd354027fd6cfda0d71d996906397d833a27b07cc55";
+      sha512 = "6dd4c84f38d7c1d0ebff77737fec3ec669532fa9be785414a9f125cbf184c88185bfd4541818d696b93237d4acb0654d7c6f38e9a0ab7ea35a10369ccde1bcb8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/sr/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/sr/firefox-57.0b13.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "adc284dba815ef84d2b99b90730d15ebb2a8974601cddbf38053356c8e7464f13d0e1fd764c8dc34e0cba0ca1bae427c2e1ec31bf0553f834d0213426295917b";
+      sha512 = "984be4970c5224077e6e97c3137df1d62ccebb7fe78e3506ce4ae78e17d7961653feb276712735293d2ebf22a8ce8b0b91b28edc80b2413fea24dbf059eb1ad6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/sv-SE/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/sv-SE/firefox-57.0b13.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "51f3a397e95f39fc2da2349b25d625114d02bb0444e56fa09c8246d57a93575ba9cb83479681c73ae1b257269ad9100949829aced4c1567b167dfb5ea680bee4";
+      sha512 = "d0fd4b307598fd42d76414f4f097d0ea3e2243ab8de536870be23687eb6ea64f226a54b3fee176451bcd9e1305c6aa4c60daeb72b3341102f670d4905f4efe27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ta/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ta/firefox-57.0b13.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "a1a5a458d540be0a5359c15f2a70770b39bf983d1f19a469c8caf1f7c2d61688a2650bfcdfd2d41321788b63d5a900ca1cc36fac4a62b67087182d9c1c3fa84c";
+      sha512 = "6b59fe4cde16c02c5b4867d48e6af4814794bf4a4f3b41e24cfb6e85d1e81f31446193c831b2ce50f30114260fda5e0a20ebe15fa23e1b962f07d66394f5d654";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/te/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/te/firefox-57.0b13.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "a948071e0f1ad4e29483a87765a307a1cc4d2af629125025e71439875144535bf0d6d69be5100a8ec6f5be6b8b9a7c7d10e851486ae41ea5c8517dea932c54e2";
+      sha512 = "a65e6b4d28f91764aadde1dd954d1e888a5bb24f356deba73c68fcc98d8be669a8f5147233af89881dbf20e40ba987326d15d5fcb857598e6718fdac4c5a59ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/th/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/th/firefox-57.0b13.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "1340d951f126571e3d3fbdfb91e478ae914aeba9251da35b253a67f62b4148f0e5b9452495a7bf23e918c9fb3ab88db37f4f0fd11f28330957dc23bc65cbfe5b";
+      sha512 = "bc6d32c9054072fe931b703aec3c2a6a60d25dccd6e853eca5e716903a4694618e4cae79c9aafa52a2bd34133b6314b5eeecb92e56082c84dc10c47dd46be085";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/tr/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/tr/firefox-57.0b13.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "37e37e3679ffb5ebf93e3e7410c5bc9e1f85fe8bbecc83a7a33dd5b1c7d7f7150ffff3d91fc200f4c378a253627d5dd8ec90f46692b01f72cbf9f48bea84742d";
+      sha512 = "31e923c48adbb9e2b87ab6d5bf9ceb951426ad8c523b8def49900875d2a66220c2800ca25ddd4fc0f8a007ca4c95f7a69311228b34c5a8429bb26ce9b0f43871";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/uk/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/uk/firefox-57.0b13.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "067353b9d466bcff799f6c1ae46a91ffe9150a6c429a117464cf1289433fa2fed6a0f0a6e773f8b27d3618ffae233c7ebd56841f97d3c82b97ed24f038c7e4ea";
+      sha512 = "5036b3bf40bbfb13eb99aec17d90e9a7a60bb39eab1bcd21fa62b1d12b47f4b9eca7980c762f67ff5406ddcb20777a6553fcb02e611b276f1cdd483c8b67c162";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/ur/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ur/firefox-57.0b13.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "a868433b2b18ca92bd6a6b765ec0fe072a44043a12f75ec4bbc16f4dac29577698b1fd7618e5c0876ff14742656263c0bffc2ae5ba0826a55df70c139275f9f0";
+      sha512 = "3605b5370f7158ffa54f5c5def6806885cc609b385b363e5a5c6442ff9262fd666e35b3f2256ad68b8f03a9e95282f3792ab83f49f0efb1e422b6dde56a85713";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/uz/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/uz/firefox-57.0b13.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "33603cb219121d06a97cc5c62865bdb9ad4f9acd0de6c14ef86acc16d818faf3e21b24f9f497dafd20639b81edbe7affa1fedd7a2aaf99a1a9d137b02e2b77d9";
+      sha512 = "a15e00c34a831eb8b251f60a9e17f7cdb65ed097fe0182a576c5809ecd208938d38c99a711750f0fb7835565adfefb15acbabe3b66c2f03eff36bf05527b47d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/vi/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/vi/firefox-57.0b13.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "a841c65cade257e6b5708b3de3c6109004f54a295e6b6fea97e6b3959cb70620844f8a4029dcf908d6fbba1ae71d038cd2adc0724180e22959edadc549bf8d12";
+      sha512 = "fa4e9de86197c3a95cd0d048e16de89bafd9d4733d3f2c96d221aa5c3839b980ab92efde0d18347251edf718f8d37a3fb8c5afcbaf254f697e320420cb91cc96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/xh/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/xh/firefox-57.0b13.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "9d8338b04f2d8f43a096049b11b8d359a1a09a22a2074bb0fb4364e8a551976810cef148405fb45800a4d751d2321e4d9492a79549d076a8dad3db33d22dafb1";
+      sha512 = "19b4a96abda10b29ab9aada2d9ba70e259ba0a3082796def317e1869f27b6326fe03f9d909f6753f494caef08f0f24e41f5b8be16c5c84ccaf06cf354b926cf5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/zh-CN/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/zh-CN/firefox-57.0b13.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "d3f4dab15e4293cff13be4da142169c18b2d672c9af141287c388a31fd1aec4305ce178af1dad6a21fbeef571445cc15ee15c38464bccefb4eae80dbb03177b1";
+      sha512 = "dd7e4c7bf1af9975f043bcc2be140b6c667f6dd74c2acc5d31963f6963fa5e0d7dc672fcfaca7ebfe99fd14cbd78725d24dc9c490c9ed1e211bd9e154e51c311";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b11/linux-i686/zh-TW/firefox-57.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/zh-TW/firefox-57.0b13.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "4b82c8291dda948e1f63dcce2c8803c1ed1db862e585612c0c2de96e14c7442c2a845cf896c5fb9492cb4424c05f14ca5a546b30c6491f557c511f936153cac2";
+      sha512 = "82b442aeb21b5b0fa7d48519ef5a1d3a6b57f2e013cc4e7a18b050cdd6632ec69e8383e58d0608515397a460a2bf339e03f3e11f780698d5b8e3cd4f3aa8f5fc";
     }
     ];
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

