### PR TITLE
ACME: default to Let's Encrypt's staging CA.

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -150,7 +150,8 @@ in
           See
           <literal>https://letsencrypt.org/docs/staging-environment</literal>
           for more detail.
-      ''; };
+        '';
+      };
 
       certs = mkOption {
         default = { };

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -141,16 +141,15 @@ in
 
       production = mkOption {
         type = types.bool;
-        default = false;
+        default = true;
         description = ''
           If set to true, use Let's Encrypt's production environment
           instead of the staging environment. The main benefit of the
           staging environment is to get much higher rate limits.
 
-          See https://letsencrypt.org/docs/staging-environment for
-          more detail.
-        '';
-      };
+          See
+          <literal>https://letsencrypt.org/docs/staging-environment</literal>
+          for more detail.  ''; };
 
       certs = mkOption {
         default = { };

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -149,7 +149,8 @@ in
 
           See
           <literal>https://letsencrypt.org/docs/staging-environment</literal>
-          for more detail.  ''; };
+          for more detail.
+      ''; };
 
       certs = mkOption {
         default = { };


### PR DESCRIPTION
###### Motivation for this change

The goal is to avoid hitting rate limits too soon by default, which is
pretty bad when it hits you (for instance when NixOps forced you to
reinstall your instance more than five times in a week)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

