### PR TITLE
rambox: build from source

### DIFF
--- a/pkgs/applications/networking/instant-messengers/rambox/bare.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/bare.nix
@@ -1,0 +1,61 @@
+{ stdenv, fetchFromGitHub, fetchNodeModules, nodejs-8_x, ruby, sencha }:
+
+stdenv.mkDerivation rec {
+  name = "rambox-bare-${version}";
+  version = "0.5.13";
+
+  src = fetchFromGitHub {
+    owner = "saenzramiro";
+    repo = "rambox";
+    rev = version;
+    sha256 = "0c770a9z017y6gcrpyri7s1gifm8zi5f29bq5nvh3zzg4wgqh326";
+  };
+
+  nativeBuildInputs = [ nodejs-8_x ruby sencha ];
+
+  node_modules = fetchNodeModules {
+    inherit src;
+
+    nodejs = nodejs-8_x;
+    sha256 = "1y3q8ggyvfywxqi5hn9mvr1sjfylspis43iyf4b7snyr1a1br3r4";
+  };
+
+  patches = [ ./hide-check-for-updates.patch ./isDev.patch ];
+
+  # These credentials are only for this derivation. If you want to get credentials
+  # for another distribution, go to https://auth0.com. If you want to reuse the same
+  # domain, drop a line at yegortimoshenko@gmail.com!
+  auth0ClientID = "0spuNKfIGeLAQ_Iki9t3fGxbfJl3k8SU";
+  auth0Domain = "nixpkgs.auth0.com";
+
+  configurePhase = ''
+    echo 'var auth0Cfg = { clientID: "${auth0ClientID}", domain: "${auth0Domain}" };' > env.js
+    ln -s ${node_modules} node_modules
+  '';
+
+  buildPhase = ''
+    mkdir ../rambox-build
+    npm run sencha:compile:build
+  '';
+
+  installPhase = ''
+    mv ../rambox-build/ $out
+
+    # https://github.com/saenzramiro/rambox/issues/1281
+    echo '{"name": "rambox", "version": "${version}", "main": "electron/main.js"}' > $out/package.json
+
+    # https://github.com/saenzramiro/rambox/issues/1282
+    cp --parents ext/packages/ext-locale/build/ext-locale-*.js $out
+
+    # Symbolic link causes `Uncaught Error: Cannot find module 'immutable'`
+    cp -r ${node_modules} $out/node_modules
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Messaging and emailing app that combines common web applications into one";
+    homepage = http://rambox.pro;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ gnidorah ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/rambox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/default.nix
@@ -1,64 +1,26 @@
-{ stdenv, fetchurl, dpkg, makeWrapper
-, xorg, gtk2, atk, glib, pango, gdk_pixbuf, cairo, freetype, fontconfig
-, gnome2, dbus, nss, nspr, alsaLib, cups, expat, udev, libnotify, xdg_utils }:
+{ stdenv, newScope, makeWrapper, electron, xdg_utils }:
 
 let
-  bits = if stdenv.system == "x86_64-linux" then "x64"
-         else "ia32";
-
-  version = "0.5.13";
-
-  runtimeDeps = [
-    udev libnotify
-  ];
-  deps = (with xorg; [
-    libXi libXcursor libXdamage libXrandr libXcomposite libXext libXfixes
-    libXrender libX11 libXtst libXScrnSaver libxcb
-  ]) ++ [
-    gtk2 atk glib pango gdk_pixbuf cairo freetype fontconfig dbus
-    gnome2.GConf nss nspr alsaLib cups expat stdenv.cc.cc
-  ] ++ runtimeDeps;
-in stdenv.mkDerivation rec {
-  name = "rambox-${version}";
-  src = fetchurl {
-    url = "https://github.com/saenzramiro/rambox/releases/download/${version}/Rambox_${version}-${bits}.deb";
-    sha256 = if bits == "x64" then
-      "0bn562fr1wsnn3xsd4q2rrxi6c56vckrkfmjl2dqb30hpmj2vn0d" else
-      "180ndvkil5mk5idwnn7spfygnhhll6pjc342pfzgmzk46a723qs4";
+  callPackage = newScope self;
+  self = {
+    fetchNodeModules = callPackage ./fetchNodeModules.nix {};
+    rambox-bare = callPackage ./bare.nix {};
+    sencha = callPackage ./sencha {};
   };
+in
 
-  # don't remove runtime deps
-  dontPatchELF = true;
+with self;
 
-  buildInputs = [ dpkg makeWrapper ];
+stdenv.mkDerivation {
+  name = "rambox-${rambox-bare.version}";
 
-  unpackPhase = "dpkg-deb -x $src .";
+  nativeBuildInputs = [ makeWrapper ];
+
+  unpackPhase = ":";
 
   installPhase = ''
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" opt/Rambox/rambox
-    patchelf --set-rpath "$out/opt/Rambox:${stdenv.lib.makeLibraryPath deps}" opt/Rambox/rambox
-
-    mkdir -p $out/bin
-    cp -r opt $out
-    ln -s $out/opt/Rambox/rambox $out/bin
-
-    # provide resources
-    cp -r usr/share $out
-    substituteInPlace $out/share/applications/rambox.desktop \
-      --replace Exec=\"/opt/Rambox/rambox\" Exec=rambox
+    makeWrapper ${electron}/bin/electron $out/bin/rambox \
+      --add-flags "${rambox-bare} --without-update" \
+      --prefix PATH : ${xdg_utils}/bin
   '';
-
-  postFixup = ''
-    paxmark m $out/opt/Rambox/rambox
-    wrapProgram $out/opt/Rambox/rambox --prefix PATH : ${xdg_utils}/bin
-  '';
-
-  meta = with stdenv.lib; {
-    description = "Free and Open Source messaging and emailing app that combines common web applications into one";
-    homepage = http://rambox.pro;
-    license = licenses.mit;
-    maintainers = [ maintainers.gnidorah ];
-    platforms = ["i686-linux" "x86_64-linux"];
-    hydraPlatforms = [];
-  };
 }

--- a/pkgs/applications/networking/instant-messengers/rambox/fetchNodeModules.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/fetchNodeModules.nix
@@ -1,0 +1,26 @@
+{ stdenv, jq }: { src, nodejs, sha256 }:
+
+# Only npm >= 5.4.2 is deterministic, see:
+# https://github.com/npm/npm/issues/17979#issuecomment-332701215
+assert stdenv.lib.versionAtLeast nodejs.version "8.9.0";
+
+stdenv.mkDerivation {
+  name = "node_modules";
+
+  outputHashAlgo = "sha256";
+  outputHash = sha256;
+  outputHashMode = "recursive";
+
+  nativeBuildInputs = [ jq nodejs ];
+
+  buildCommand = ''
+    cp -r ${src}/* .
+    HOME=. npm install --force --ignore-scripts --only=production
+    for f in $(find node_modules -name package.json); do
+      # https://github.com/npm/npm/issues/10393
+      jq -S 'delpaths(keys | map(select(startswith("_")) | [.]))' $f > $f.tmp
+      mv $f.tmp $f
+    done
+    mv node_modules $out
+  '';
+}

--- a/pkgs/applications/networking/instant-messengers/rambox/hide-check-for-updates.patch
+++ b/pkgs/applications/networking/instant-messengers/rambox/hide-check-for-updates.patch
@@ -1,0 +1,35 @@
+https://github.com/saenzramiro/rambox/issues/1283
+
+diff -urNZ a/electron/menu.js b/electron/menu.js
+--- a/electron/menu.js	2017-11-02 22:02:59.753119865 +0000
++++ b/electron/menu.js	2017-11-02 22:08:34.419698562 +0000
+@@ -220,14 +220,6 @@
+ 					}
+ 				},
+ 				{
+-					label: locale['menu.help[5]'],
+-					click(item, win) {
+-						const webContents = win.webContents;
+-						const send = webContents.send.bind(win.webContents);
+-						send('autoUpdater:check-update');
+-					}
+-				},
+-				{
+ 					label: locale['menu.help[6]'],
+ 					click() {
+ 						sendAction('showAbout')
+@@ -290,14 +282,6 @@
+ 			type: 'separator'
+ 		});
+ 		helpSubmenu.push({
+-			label: `&`+locale['menu.help[5]'],
+-			click(item, win) {
+-				const webContents = win.webContents;
+-				const send = webContents.send.bind(win.webContents);
+-				send('autoUpdater:check-update');
+-			}
+-		});
+-		helpSubmenu.push({
+ 			label: `&`+locale['menu.help[6]'],
+ 			click() {
+ 				sendAction('showAbout')

--- a/pkgs/applications/networking/instant-messengers/rambox/isDev.patch
+++ b/pkgs/applications/networking/instant-messengers/rambox/isDev.patch
@@ -1,0 +1,14 @@
+https://github.com/saenzramiro/rambox/issues/1280
+
+diff -urNZ a/electron/main.js b/electron/main.js
+--- a/electron/main.js	2017-11-02 14:58:06.085127616 +0000
++++ b/electron/main.js	2017-11-02 14:58:18.316887679 +0000
+@@ -8,7 +8,7 @@
+ // Configuration
+ const Config = require('electron-config');
+ // Development
+-const isDev = require('electron-is-dev');
++const isDev = false;
+ // Updater
+ const updater = require('./updater');
+ // File System

--- a/pkgs/applications/networking/instant-messengers/rambox/sencha/bare.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/sencha/bare.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, gzip, which, unzip, jdk }:
+
+let
+  version = "6.5.2";
+  srcs = {
+    i686-linux = fetchurl {
+      url = "https://cdn.sencha.com/cmd/${version}/no-jre/SenchaCmd-${version}-linux-i386.sh.zip";
+      sha256 = "18gcqw9434xab97skcb97iw4p4s2pgggvq7jaisblap0ja00kqjr";
+    };
+    x86_64-linux = fetchurl {
+      url = "https://cdn.sencha.com/cmd/${version}/no-jre/SenchaCmd-${version}-linux-amd64.sh.zip";
+      sha256 = "1b8jv99k37q1bi7b29f23lfzxc66v5fqdmr1rxsrqchwcrllc0z7";
+    };
+  };
+in
+
+stdenv.mkDerivation rec {
+  inherit version;
+
+  name = "sencha-bare-${version}";
+  src = srcs.${stdenv.system};
+
+  nativeBuildInputs = [ gzip which unzip ];
+  buildInputs = [ jdk ];
+
+  sourceRoot = ".";
+
+  configurePhase = ''
+    substituteAll ${./response.varfile} response.varfile
+  '';
+
+  installPhase = ''
+    ./SenchaCmd*.sh -q -dir $out -varfile response.varfile
+    rm $out/shell-wrapper.sh $out/Uninstaller
+  '';
+
+  meta = with stdenv.lib; {
+    license = licenses.unfree;
+    platforms = attrNames srcs;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/rambox/sencha/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/sencha/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, callPackage, makeWrapper }:
+
+let
+  sencha-bare = callPackage ./bare.nix {};
+in
+
+stdenv.mkDerivation {
+  name = "sencha-${sencha-bare.version}";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  unpackPhase = ":";
+
+  installPhase = ''
+    makeWrapper ${sencha-bare}/sencha $out/bin/sencha
+  '';
+}

--- a/pkgs/applications/networking/instant-messengers/rambox/sencha/response.varfile
+++ b/pkgs/applications/networking/instant-messengers/rambox/sencha/response.varfile
@@ -1,0 +1,13 @@
+addToPath$Integer=1
+parentDir=.
+sys.adminRights$Boolean=false
+sys.component.148$Boolean=true
+sys.component.157$Boolean=true
+sys.component.26$Boolean=true
+sys.component.30$Boolean=true
+sys.component.90$Boolean=true
+sys.component.91$Boolean=true
+sys.component.92$Boolean=true
+sys.component.94$Boolean=true
+sys.installationDir=@out@
+sys.languageId=en


### PR DESCRIPTION
###### Motivation for this change

This makes rambox build from source. It also includes Sencha Cmd derivation (build tool used by rambox) and `fetchNodeModules` fetcher both of which are currently not available at top-level (not good enough).

@gnidorah, please check this out and tell if it works for you, and if you see any errors in DevTools console in normal workflow.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

