### PR TITLE
build-pecl: honour nativeBuildInputs

### DIFF
--- a/pkgs/build-support/build-pecl.nix
+++ b/pkgs/build-support/build-pecl.nix
@@ -2,6 +2,7 @@
 
 { name
 , buildInputs ? []
+, nativeBuildInputs ? []
 , makeFlags ? []
 , src ? fetchurl {
     url = "http://pecl.php.net/get/${name}.tgz";
@@ -15,7 +16,7 @@ stdenv.mkDerivation (args // {
 
   inherit src;
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook ] ++ nativeBuildInputs;
   buildInputs = [ php ] ++ buildInputs;
 
   makeFlags = [ "EXTENSION_DIR=$(out)/lib/php/extensions" ] ++ makeFlags;


### PR DESCRIPTION
Otherwise certain extensions are unable to locate pkgconfig.

###### Motivation for this change

Following tree wide clean up of moving pkgconfig to nativeBuildInputs a number of PHP extensions are currently failing to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

