### PR TITLE
terminal-notifier: 1.5.0 -> 2.0.0

### DIFF
--- a/pkgs/applications/misc/terminal-notifier/default.nix
+++ b/pkgs/applications/misc/terminal-notifier/default.nix
@@ -3,11 +3,12 @@
 stdenv.mkDerivation rec {
   name = "terminal-notifier-${version}";
 
-  version = "1.5.0";
+  version = "2.0.0";
 
   src = fetchzip {
     url = "https://github.com/alloy/terminal-notifier/releases/download/${version}/terminal-notifier-${version}.zip";
-    sha256 = "09x7vl0kddivqq3pyrk6sg1f0sv5l7nj0bmblq222zk3b09bgg8p";
+    sha256 = "0gi54v92hi1fkryxlz3k5s5d8h0s66cc57ds0vbm1m1qk3z4xhb0";
+    stripRoot = false;
   };
 
   dontBuild = true;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

