### PR TITLE
bundlerEnv: support unicode executables

### DIFF
--- a/pkgs/development/ruby-modules/bundled-common/gen-bin-stubs.rb
+++ b/pkgs/development/ruby-modules/bundled-common/gen-bin-stubs.rb
@@ -18,7 +18,8 @@ paths.each do |path|
   next unless File.directory?("#{path}/nix-support/gem-meta")
 
   name = File.read("#{path}/nix-support/gem-meta/name")
-  executables = File.read("#{path}/nix-support/gem-meta/executables").split
+  executables = File.read("#{path}/nix-support/gem-meta/executables")
+    .force_encoding('UTF-8').split
   executables.each do |exe|
     File.open("#{out}/bin/#{exe}", "w") do |f|
       f.write(<<-EOF)


### PR DESCRIPTION
###### Motivation for this change

This fixes https://github.com/manveru/bundix/issues/19

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

