### PR TITLE
Upgrade OpenSSL for CVE-2017-3732, CVE-2017-3193

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -107,8 +107,8 @@ let
 in {
 
   openssl_1_0_2 = common {
-    version = "1.0.2l";
-    sha256 = "037kvpisc6qh5dkppcwbm5bg2q800xh2hma3vghz8xcycmdij1yf";
+    version = "1.0.2m";
+    sha256 = "03vvlfnxx4lhxc83ikfdl6jqph4h52y7lb7li03va6dkqrgg2vwc";
   };
 
   openssl_1_1_0 = common {

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -112,8 +112,8 @@ in {
   };
 
   openssl_1_1_0 = common {
-    version = "1.1.0f";
-    sha256 = "0r97n4n552ns571diz54qsgarihrxvbn7kvyv8wjyfs9ybrldxqj";
+    version = "1.1.0g";
+    sha256 = "1bvka2wf33w2vxv7yw578nnjqyhz2b3chvfb0l4k2ffscw950kfy";
   };
 
 }

--- a/pkgs/development/libraries/openssl/nix-ssl-cert-file.patch
+++ b/pkgs/development/libraries/openssl/nix-ssl-cert-file.patch
@@ -5,10 +5,10 @@ diff -ru -x '*~' openssl-1.0.2j-orig/crypto/x509/by_file.c openssl-1.0.2j/crypto
      switch (cmd) {
      case X509_L_FILE_LOAD:
          if (argl == X509_FILETYPE_DEFAULT) {
--            file = (char *)getenv(X509_get_default_cert_file_env());
-+            file = (char *)getenv("NIX_SSL_CERT_FILE");
+-            file = getenv(X509_get_default_cert_file_env());
++            file = getenv("NIX_SSL_CERT_FILE");
 +            if (!file)
-+                file = (char *)getenv(X509_get_default_cert_file_env());
++                file = getenv(X509_get_default_cert_file_env());
              if (file)
                  ok = (X509_load_cert_crl_file(ctx, file,
                                                X509_FILETYPE_PEM) != 0);


### PR DESCRIPTION
###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/31144

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

