### PR TITLE
postage: replaced by pgmanage-10.0.2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -63,6 +63,15 @@ following incompatible changes:</para>
       pass literal dollar signs through Postfix, double them.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      The <literal>postage</literal> package (for web-based PostgreSQL
+      administration) has been renamed to <literal>pgmanage</literal>. The
+      corresponding module has also been renamed. To migrate please rename all
+      <option>services.postage</option> options to
+      <option>services.pgmanage</option>.
+    </para>
+  </listitem>
 </itemizedlist>
 
 </section>

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -185,7 +185,7 @@
   ./services/databases/neo4j.nix
   ./services/databases/openldap.nix
   ./services/databases/opentsdb.nix
-  ./services/databases/postage.nix
+  ./services/databases/pgmanage.nix
   ./services/databases/postgresql.nix
   ./services/databases/redis.nix
   ./services/databases/riak.nix

--- a/nixos/modules/services/databases/pgmanage.nix
+++ b/nixos/modules/services/databases/pgmanage.nix
@@ -3,16 +3,16 @@
 with lib;
 
 let
-  cfg = config.services.postage;
+  cfg = config.services.pgmanage;
 
   confFile = pkgs.writeTextFile {
-    name = "postage.conf";
+    name = "pgmanage.conf";
     text =  ''
-      connection_file = ${postageConnectionsFile}
+      connection_file = ${pgmanageConnectionsFile}
 
       allow_custom_connections = ${builtins.toJSON cfg.allowCustomConnections}
 
-      postage_port = ${toString cfg.port}
+      pgmanage_port = ${toString cfg.port}
 
       super_only = ${builtins.toJSON cfg.superOnly}
 
@@ -20,7 +20,7 @@ let
 
       login_timeout = ${toString cfg.loginTimeout}
 
-      web_root = ${cfg.package}/etc/postage/web_root
+      web_root = ${cfg.package}/etc/pgmanage/web_root
 
       data_root = ${cfg.dataRoot}
 
@@ -33,24 +33,23 @@ let
     '';
   };
 
-  postageConnectionsFile = pkgs.writeTextFile {
-    name = "postage-connections.conf";
+  pgmanageConnectionsFile = pkgs.writeTextFile {
+    name = "pgmanage-connections.conf";
     text = concatStringsSep "\n"
       (mapAttrsToList (name : conn : "${name}: ${conn}") cfg.connections);
   };
 
-  postage = "postage";
-in {
+  pgmanage = "pgmanage";
 
-  options.services.postage = {
+  pgmanageOptions = {
     enable = mkEnableOption "PostgreSQL Administration for the web";
 
     package = mkOption {
       type = types.package;
-      default = pkgs.postage;
-      defaultText = "pkgs.postage";
+      default = pkgs.pgmanage;
+      defaultText = "pkgs.pgmanage";
       description = ''
-        The postage package to use.
+        The pgmanage package to use.
       '';
     };
 
@@ -62,14 +61,14 @@ in {
         "mini-server" = "hostaddr=127.0.0.1 port=5432 dbname=postgres sslmode=require";
       };
       description = ''
-        Postage requires at least one PostgreSQL server be defined.
+        pgmanage requires at least one PostgreSQL server be defined.
         </para><para>
         Detailed information about PostgreSQL connection strings is available at:
         <link xlink:href="http://www.postgresql.org/docs/current/static/libpq-connect.html"/>
         </para><para>
         Note that you should not specify your user name or password. That
         information will be entered on the login screen. If you specify a
-        username or password, it will be removed by Postage before attempting to
+        username or password, it will be removed by pgmanage before attempting to
         connect to a database.
       '';
     };
@@ -78,7 +77,7 @@ in {
       type = types.bool;
       default = false;
       description = ''
-        This tells Postage whether or not to allow anyone to use a custom
+        This tells pgmanage whether or not to allow anyone to use a custom
         connection from the login screen.
       '';
     };
@@ -87,7 +86,7 @@ in {
       type = types.int;
       default = 8080;
       description = ''
-        This tells Postage what port to listen on for browser requests.
+        This tells pgmanage what port to listen on for browser requests.
       '';
     };
 
@@ -95,7 +94,7 @@ in {
       type = types.bool;
       default = true;
       description = ''
-        This tells Postage whether or not to set the listening socket to local
+        This tells pgmanage whether or not to set the listening socket to local
         addresses only.
       '';
     };
@@ -104,10 +103,10 @@ in {
       type = types.bool;
       default = true;
       description = ''
-        This tells Postage whether or not to only allow super users to
+        This tells pgmanage whether or not to only allow super users to
         login. The recommended value is true and will restrict users who are not
         super users from logging in to any PostgreSQL instance through
-        Postage. Note that a connection will be made to PostgreSQL in order to
+        pgmanage. Note that a connection will be made to PostgreSQL in order to
         test if the user is a superuser.
       '';
     };
@@ -116,8 +115,8 @@ in {
       type = types.nullOr types.str;
       default = null;
       description = ''
-        This tells Postage to only allow users in a certain PostgreSQL group to
-        login to Postage. Note that a connection will be made to PostgreSQL in
+        This tells pgmanage to only allow users in a certain PostgreSQL group to
+        login to pgmanage. Note that a connection will be made to PostgreSQL in
         order to test if the user is a member of the login group.
       '';
     };
@@ -133,10 +132,10 @@ in {
 
     dataRoot = mkOption {
       type = types.str;
-      default = "/var/lib/postage";
+      default = "/var/lib/pgmanage";
       description = ''
-        This tells Postage where to put the SQL file history. All tabs are saved
-        to this location so that if you get disconnected from Postage you
+        This tells pgmanage where to put the SQL file history. All tabs are saved
+        to this location so that if you get disconnected from pgmanage you
         don't lose your work.
       '';
     };
@@ -156,15 +155,15 @@ in {
       });
       default = null;
       description = ''
-        These options tell Postage where the TLS Certificate and Key files
+        These options tell pgmanage where the TLS Certificate and Key files
         reside. If you use these options then you'll only be able to access
-        Postage through a secure TLS connection. These options are only
-        necessary if you wish to connect directly to Postage using a secure TLS
-        connection. As an alternative, you can set up Postage in a reverse proxy
+        pgmanage through a secure TLS connection. These options are only
+        necessary if you wish to connect directly to pgmanage using a secure TLS
+        connection. As an alternative, you can set up pgmanage in a reverse proxy
         configuration. This allows your web server to terminate the secure
-        connection and pass on the request to Postage. You can find help to set
+        connection and pass on the request to pgmanage. You can find help to set
         up this configuration in:
-        <link xlink:href="https://github.com/workflowproducts/postage/blob/master/INSTALL_NGINX.md"/>
+        <link xlink:href="https://github.com/pgManage/pgManage/blob/master/INSTALL_NGINX.md"/>
       '';
     };
 
@@ -177,29 +176,47 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
-    systemd.services.postage = {
-      description = "postage - PostgreSQL Administration for the web";
-      wants    = [ "postgresql.service" ];
-      after    = [ "postgresql.service" ];
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        User         = postage;
-        Group        = postage;
-        ExecStart    = "${pkgs.postage}/sbin/postage -c ${confFile}" +
-                       optionalString cfg.localOnly " --local-only=true";
+
+in {
+
+  options.services.pgmanage = pgmanageOptions;
+
+  # This is deprecated and should be removed for NixOS-18.03.
+  options.services.postage = pgmanageOptions;
+
+  config = mkMerge [
+    { assertions = [
+        { assertion = !config.services.postage.enable;
+          message =
+            "services.postage is deprecated in favour of pgmanage. " +
+            "They have the same options so just substitute postage for pgmanage." ;
+        }
+      ];
+    }
+    (mkIf cfg.enable {
+      systemd.services.pgmanage = {
+        description = "pgmanage - PostgreSQL Administration for the web";
+        wants    = [ "postgresql.service" ];
+        after    = [ "postgresql.service" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          User         = pgmanage;
+          Group        = pgmanage;
+          ExecStart    = "${pkgs.pgmanage}/sbin/pgmanage -c ${confFile}" +
+                         optionalString cfg.localOnly " --local-only=true";
+        };
       };
-    };
-    users = {
-      users."${postage}" = {
-        name  = postage;
-        group = postage;
-        home  = cfg.dataRoot;
-        createHome = true;
+      users = {
+        users."${pgmanage}" = {
+          name  = pgmanage;
+          group = pgmanage;
+          home  = cfg.dataRoot;
+          createHome = true;
+        };
+        groups."${pgmanage}" = {
+          name = pgmanage;
+        };
       };
-      groups."${postage}" = {
-        name = postage;
-      };
-    };
-  };
+    })
+  ];
 }

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -306,6 +306,7 @@ in rec {
   #tests.panamax = hydraJob (import tests/panamax.nix { system = "x86_64-linux"; });
   tests.peerflix = callTest tests/peerflix.nix {};
   tests.postgresql = callSubTests tests/postgresql.nix {};
+  tests.pgmanage = callTest tests/pgmanage.nix {};
   tests.postgis = callTest tests/postgis.nix {};
   #tests.pgjwt = callTest tests/pgjwt.nix {};
   tests.printing = callTest tests/printing.nix {};

--- a/nixos/tests/pgmanage.nix
+++ b/nixos/tests/pgmanage.nix
@@ -1,0 +1,39 @@
+import ./make-test.nix ({ pkgs, ... } :
+let
+  role     = "test";
+  password = "secret";
+  conn     = "local";
+in
+{
+  name = "pgmanage";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ basvandijk ];
+  };
+  nodes = {
+    one = { config, pkgs, ... }: {
+      services = {
+        postgresql = {
+          enable = true;
+          initialScript = pkgs.writeText "pg-init-script" ''
+            CREATE ROLE ${role} SUPERUSER LOGIN PASSWORD '${password}';
+          '';
+        };
+        pgmanage = {
+          enable = true;
+          connections = {
+            "${conn}" = "hostaddr=127.0.0.1 port=${toString config.services.postgresql.port} dbname=postgres";
+          };
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    startAll;
+    $one->waitForUnit("default.target");
+    $one->requireActiveUnit("pgmanage.service");
+
+    # Test if we can log in.
+    $one->waitUntilSucceeds("curl 'http://localhost:8080/pgmanage/auth' --data 'action=login&connname=${conn}&username=${role}&password=${password}' --fail");
+  '';
+})

--- a/pkgs/applications/misc/pgmanage/default.nix
+++ b/pkgs/applications/misc/pgmanage/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, runCommand, postgresql, openssl } :
 
 stdenv.mkDerivation rec {
-  name = "postage-${version}";
-  version = "3.2.18";
+  name = "pgmanage-${version}";
+  version = "10.0.2";
 
   src = fetchFromGitHub {
-    owner  = "workflowproducts";
-    repo   = "postage";
-    rev    = "eV${version}";
-    sha256 = "1kdg8pw2vxwkxw3b6dim4s740s60j3iyrh96524wi3lqkkq98krn";
+    owner  = "pgManage";
+    repo   = "pgManage";
+    rev    = "v${version}";
+    sha256 = "0g9kvhs9b6kc1s7j90fqv71amiy9v0w5p906yfvl0j7pf3ayq35a";
   };
 
   buildInputs = [ postgresql openssl ];
@@ -20,8 +20,8 @@ stdenv.mkDerivation rec {
       the style of NGINX and Node.js. This heart makes Postage as fast as any
       PostgreSQL interface can hope to be.
     '';
-    homepage = http://www.workflowproducts.com/postage.html;
-    license = licenses.asl20;
+    homepage = https://github.com/pgManage/pgManage;
+    license = licenses.postgresql;
     maintainers = [ maintainers.basvandijk ];
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -116,6 +116,7 @@ mapAliases (rec {
   pgp-tools = signing-party; # added 2017-03-26
   pidgin-with-plugins = pidgin; # added 2016-06
   pidginlatexSF = pidginlatex; # added 2014-11-02
+  postage = pgmanage; # added 2017-11-03
   poppler_qt5 = libsForQt5.poppler;  # added 2015-12-19
   PPSSPP = ppsspp; # added 2017-10-01
   prometheus-statsd-bridge = prometheus-statsd-exporter;  # added 2017-08-27

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19309,7 +19309,7 @@ with pkgs;
 
   opkg-utils = callPackage ../tools/package-management/opkg-utils { };
 
-  postage = callPackage ../applications/misc/postage { };
+  pgmanage = callPackage ../applications/misc/pgmanage { };
 
   pgadmin = callPackage ../applications/misc/pgadmin { };
 


### PR DESCRIPTION
`postage` is no longer maintained and has been [replaced](https://github.com/workflowproducts/postage#postage-has-been-replaced-with-pgmanage) by the identical `pgmanage`.

I replaced `pkgs.postage` with `pkgs.pgmanage` and renamed the corrersponding NixOS module.

When a user enables the deprecated `services.postage.enable` option the following error will be raised:

    Failed assertions:
    - services.postage is deprecated in favor of pgmanage. They have the same options so just substitute postage for pgmanage.

A new test  `tests.pgmanage` has been added which builds successfully.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

