### PR TITLE
vboot_reference:  20130507 -> 20171023

### DIFF
--- a/pkgs/tools/system/vboot_reference/default.nix
+++ b/pkgs/tools/system/vboot_reference/default.nix
@@ -1,42 +1,35 @@
-{ stdenv, fetchgit, pkgconfig, libuuid, openssl }:
+{ stdenv, fetchgit, pkgconfig, libuuid, openssl, libyaml, lzma }:
 
 stdenv.mkDerivation rec {
-  version = "20130507";
-  checkout = "25/50225/2";
+  version = "20171023";
+  checkout = "8122e0b8b13794";
 
   name = "vboot_reference-${version}";
 
   src = fetchgit {
     url = https://chromium.googlesource.com/chromiumos/platform/vboot_reference;
-    rev = "refs/changes/${checkout}";
-    sha256 = "14d3a93ha5k4al4ib43nyn1ppx7kgb12xw6mkflhx8nxmx8827nc";
+    rev = "${checkout}";
+    sha256 = "0qxm3qlvm2fgjrn9b3n8rdccw2f5pdi7z542m2hdfddflx7jz1w7";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ openssl stdenv.cc.libc.static ]
-    ++ stdenv.lib.optional (libuuid != null)
-         (libuuid.overrideAttrs (attrs:
-           { configureFlags = attrs.configureFlags ++ [ "--enable-static" ]; }));
+  buildInputs = [ openssl libuuid libyaml lzma ];
 
-  arch = if stdenv.system == "x86_64-linux" then "x86_64"
-    else if stdenv.system == "i686-linux" then "x86"
-    else throw "vboot_reference for: ${stdenv.system} not supported!";
+  enableParallelBuilding = true;
 
   buildPhase = ''
-    make ARCH=${arch} `pwd`/build/cgpt/cgpt
-    make ARCH=${arch} `pwd`/build/utility/vbutil_kernel
-    make ARCH=${arch} `pwd`/build/utility/vbutil_key
-    make ARCH=${arch} `pwd`/build/utility/vbutil_keyblock
-    make ARCH=${arch} `pwd`/build/utility/vbutil_firmware
+    patchShebangs scripts
+    make -j''${NIX_BUILD_CORES:-1} \
+         `pwd`/build/cgpt/cgpt \
+         `pwd`/build/futility/futility
   '';
 
   installPhase = ''
     mkdir -p $out/bin
     cp build/cgpt/cgpt $out/bin
-    cp build/utility/vbutil_kernel $out/bin
-    cp build/utility/vbutil_key $out/bin
-    cp build/utility/vbutil_keyblock $out/bin
-    cp build/utility/vbutil_firmware $out/bin
+    cp build/futility/futility $out/bin
+    mkdir -p $out/share/vboot
+    cp -r tests/devkeys* $out/share/vboot/
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

In addition to updating to a more recent upstream version, this
installs the development signing keys to $out/share and removes the separate
vbutil_* tools in favour of the single futility tool. It also removes the restriction to only build on x86 systems — it works just fine on ARM!


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).