### PR TITLE
phpPackages.apcu: 5.1.2 -> 5.1.8 and enable tests

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -18,9 +18,13 @@ let
   };
 
   apcu51 = assert isPhp7; buildPecl {
-    name = "apcu-5.1.2";
+    name = "apcu-5.1.8";
 
-    sha256 = "0r5pfbjbmdj46h20jm3iqmy969qd27ajyf0phjhgykv6j0cqjlgd";
+    sha256 = "01dfbf0245d8cc0f51ba16467a60b5fad08e30b28df7846e0dd213da1143ecce";
+
+    doCheck = true;
+    checkTarget = "test";
+    checkFlagsArray = ["REPORT_EXIT_STATUS=1" "NO_INTERACTION=1"];
   };
 
   ast = assert isPhp7; buildPecl {


### PR DESCRIPTION
###### Motivation for this change

Fixes #30734 - 5.1.2 segfaults

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm using a multi-user setup on Ubuntu Xenial at the moment, and getting this when I enable sandboxing (considering I just changed the version, I wouldn't expect this to be a result of my change):

```
/nix/store/dkrn0k8hxqcdk0bmap3dx41ln0y5cvrf-php-7.0.24-dev/bin/phpize: /nix/store/463g7ww3vdy5bkrl5ycvlqfnxfsz4q76-autoconf-2.69/bin/autoconf: /bin/sh: bad interpreter: No such file or directory
```

I'm also not sure how to get the alternate, shorter sha256 - I tried using the one from the source folder in /nix/store but it was much shorter.

