### PR TITLE
numix-gtk-theme: fix hash

### DIFF
--- a/pkgs/misc/themes/numix/default.nix
+++ b/pkgs/misc/themes/numix/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     repo = "numix-gtk-theme";
     owner = "numixproject";
     rev = version;
-    sha256 = "1fmlc6vi8prvwsq0nxxcd00lp04bwmapzjqf727wb1czqf2lf0dv";
+    sha256 = "12mw0kr0kkvg395qlbsvkvaqccr90cmxw5rrsl236zh43kj8grb7";
   };
 
   nativeBuildInputs = [ sass glib libxml2 gdk_pixbuf ];


### PR DESCRIPTION
###### Motivation for this change

Found this while doing a nox-review for another PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

