### PR TITLE
Add wrapper for idris exe for gcc/gmp runtime deps

### DIFF
--- a/pkgs/development/idris-modules/default.nix
+++ b/pkgs/development/idris-modules/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, idris, overrides ? (self: super: {}) }: let
+{ pkgs, idris-no-deps, overrides ? (self: super: {}) }: let
   inherit (pkgs.lib) callPackageWith fix' extends;
 
   /* Taken from haskell-modules/default.nix, should probably abstract this away */
@@ -33,7 +33,12 @@
 
     value = callPackage (./. + "/${name}.nix") {};
   }) files)) // {
-    inherit idris callPackage;
+    inherit idris-no-deps callPackage;
+    # See #10450 about why we have to wrap the executable
+    idris =
+        (pkgs.callPackage ./idris-wrapper.nix {})
+          idris-no-deps
+          { path = [ pkgs.gcc ]; lib = [pkgs.gmp]; };
 
     # A list of all of the libraries that come with idris
     builtins = pkgs.lib.mapAttrsToList (name: value: value) builtins_;

--- a/pkgs/development/idris-modules/idris-wrapper.nix
+++ b/pkgs/development/idris-modules/idris-wrapper.nix
@@ -1,0 +1,14 @@
+{ symlinkJoin, makeWrapper, stdenv }: idris: { path, lib }:
+
+symlinkJoin {
+  name = idris.name;
+  src = idris.src;
+  paths = [ idris ];
+  buildInputs = [ makeWrapper ];
+  postBuild = ''
+    wrapProgram $out/bin/idris \
+      --suffix PATH : ${ stdenv.lib.makeBinPath path } \
+      --suffix LIBRARY_PATH : ${stdenv.lib.makeLibraryPath lib}
+      '';
+  }
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5876,7 +5876,8 @@ with pkgs;
   icedtea_web = icedtea8_web;
 
   idrisPackages = callPackage ../development/idris-modules {
-    idris =
+
+    idris-no-deps =
       let
         inherit (self.haskell) lib;
         haskellPackages = self.haskellPackages.override {
@@ -5892,6 +5893,8 @@ with pkgs;
       in
         haskellPackages.idris;
   };
+
+  idris = idrisPackages.with-packages [ idrisPackages.base ] ;
 
   intercal = callPackage ../development/compilers/intercal { };
 


### PR DESCRIPTION
Fixes #10450

When compiling packages with -o the executable invokes gcc.
There is no compile time flag to control this path so for
now we create a wrapper which provides the dependency at runtime.

I also took the liberty of adding a top level `idris` attribute as there wasn't already one. 

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

