### PR TITLE
awsebcli: fix build and update

### DIFF
--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -3,6 +3,16 @@ let
 
   localPython = python.override {
     packageOverrides = self: super: rec {
+      cement = super.cement.overridePythonAttrs (oldAttrs: rec {
+        version = "2.8.2";
+
+        src = super.fetchPypi {
+          inherit (oldAttrs) pname;
+          inherit version;
+          sha256 = "1li2whjzfhbpg6fjb6r1r92fb3967p1xv6hqs3j787865h2ysrc7";
+        };
+      });
+
       colorama = super.colorama.overridePythonAttrs (oldAttrs: rec {
         version = "0.3.7";
 

--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -77,11 +77,11 @@ let
 in with localPython.pkgs; buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "awsebcli";
-  version = "3.11.0";
+  version = "3.12.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "052388annhyirlzdr89hbgif8k7pw7win2zm1ybn4iiisr5l49zi";
+    sha256 = "0ljras4bgxpmk1l3plialmhi7jsm2cpzx0dcs9411ijykzkamdkd";
   };
 
   checkInputs = [

--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -1,4 +1,4 @@
- { stdenv, python }:
+{ stdenv, python }:
 let
 
   localPython = python.override {


### PR DESCRIPTION
###### Motivation for this change

`awsebcli` was broken after `cement` was updated, this PR fixes that and also updates it to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

