### PR TITLE
htpdate: 1.1.3 -> 1.2.0

### DIFF
--- a/pkgs/tools/networking/htpdate/default.nix
+++ b/pkgs/tools/networking/htpdate/default.nix
@@ -1,24 +1,26 @@
-{ stdenv, fetchurl, coreutils, binutils }:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "1.1.3";
+  version = "1.2.0";
   name = "htpdate-${version}";
 
   src = fetchurl {
-    url = "http://twekkel.home.xs4all.nl/htp/htpdate-${version}.tar.gz";
-    sha256 = "0hfg4qrsmpqw03m9qwf3zgi4brbf65w6wd3w30nkamc7x8b4vn5i";
+    url = "http://www.vervest.org/htp/archive/c/${name}.tar.xz";
+    sha256 = "00xwppq3aj951m0srjvxmr17kiaaflyjmbfkvpnfs3jvqhzczci2";
   };
 
-  installFlags = [
-    "INSTALL=${coreutils}/bin/install"
-    "STRIP=${binutils}/bin/strip"
+  makeFlags = [
+    "INSTALL=install"
+    "STRIP=strip"
     "prefix=$(out)"
   ];
 
-  meta = {
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
     description = "Utility to fetch time and set the system clock over HTTP";
     homepage = http://www.vervest.org/htp/;
-    platforms = stdenv.lib.platforms.linux;
-    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = platforms.unix;
+    license = licenses.gpl2Plus;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Version bump
Contains fixes:
> Fix for port numbers that were not used in daemon mode
> Discard the use of local time, because it causes incorrect synchronisation when TZDATA isn't correct


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

