### PR TITLE
mitmproxy: 2.0.2 -> 2017-10-31

### DIFF
--- a/pkgs/development/python-modules/h2/default.nix
+++ b/pkgs/development/python-modules/h2/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, enum34, hpack, hyperframe }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "h2";
+  version = "3.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0r3f43r0v7sqgdjjg5ngw0dndk2v6cyd0jncpwya54m37y42z5mj";
+  };
+
+  propagatedBuildInputs = [ enum34 hpack hyperframe ];
+
+  meta = with stdenv.lib; {
+    description = "HTTP/2 State-Machine based protocol implementation";
+    homepage = "http://hyper.rtfd.org/";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/hyperframe/default.nix
+++ b/pkgs/development/python-modules/hyperframe/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "hyperframe";
+  version = "5.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "017vjbb1xjak1pxcvihhilzjnmpfvhapk7k88wp6lvdkkm9l8nd2";
+  };
+
+  meta = with stdenv.lib; {
+    description = "HTTP/2 framing layer for Python";
+    homepage = "http://hyper.rtfd.org/";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/kaitaistruct/default.nix
+++ b/pkgs/development/python-modules/kaitaistruct/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, kaitaistruct, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "kaitaistruct";
+  version = "0.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "19j3snmr0qbd48f7yd3cc21ffv13dahf8ys591dnalbhvnkar71i";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Kaitai Struct: runtime library for Python";
+    homepage = "https://github.com/kaitai-io/kaitai_struct_python_runtime";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/ldap3/default.nix
+++ b/pkgs/development/python-modules/ldap3/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchPypi, buildPythonPackage, gssapi, pyasn1 }:
+
+buildPythonPackage rec {
+  version = "2.3";
+  pname = "ldap3";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1b36lwil4iflk2ay8gi663abpnfm8id7qg4n3jkmmqbnc1sv6mn0";
+  };
+
+  buildInputs = [ gssapi ];
+
+  propagatedBuildInputs = [ pyasn1 ];
+
+  doCheck = false; # requires network
+
+  meta = with stdenv.lib; {
+    homepage = https://pypi.python.org/pypi/ldap3;
+    description = "A strictly RFC 4510 conforming LDAP V3 pure Python client library";
+    license = licenses.lgpl3;
+  };
+}

--- a/pkgs/development/python-modules/pyasn1-modules/default.nix
+++ b/pkgs/development/python-modules/pyasn1-modules/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, pyasn1, isPyPy }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "pyasn1-modules";
+  version = "0.1.5";
+  disabled = isPyPy;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1239h6h67vg0wazg2qgv6m3hdim2gs66pl89lbnayk55bbnkwc0x";
+  };
+
+  propagatedBuildInputs = [ pyasn1 ];
+
+  meta = with stdenv.lib; {
+    description = "A collection of ASN.1-based protocols modules";
+    homepage = https://pypi.python.org/pypi/pyasn1-modules;
+    license = licenses.bsd3;
+    platforms = platforms.unix;  # same as pyasn1
+  };
+}

--- a/pkgs/development/python-modules/pyasn1/default.nix
+++ b/pkgs/development/python-modules/pyasn1/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi, }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "pyasn1";
+  version = "0.3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06hhy38jhwh95gpn8f03cr439273fsfsh4vhd5024r86nh5gyiir";
+  };
+
+  meta = with stdenv.lib; {
+    description = "ASN.1 tools for Python";
+    homepage = http://pyasn1.sourceforge.net/;
+    license = "mBSD";
+    platforms = platforms.unix;  # arbitrary choice
+  };
+}

--- a/pkgs/development/python-modules/urwid/default.nix
+++ b/pkgs/development/python-modules/urwid/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi }:
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch }:
 
 buildPythonPackage (rec {
   pname = "urwid";
@@ -9,6 +9,19 @@ buildPythonPackage (rec {
     inherit pname version;
     sha256 = "18cnd1wdjcas08x5qwa5ayw6jsfcn33w4d9f7q3s29fy6qzc1kng";
   };
+
+  patches = [
+   # fix tests
+   (fetchpatch {
+     url = "https://github.com/mwhudson/urwid/commit/4b0ed8b6030450e6d99909a7c683e9642e546387.patch";
+     sha256 = "0azpn0ylbg8mfpr0y27n4lnq0ph75a4d4m9wdv3napnhf1vh9ahx";
+   })
+   # fix tests
+   (fetchpatch {
+     url = "https://github.com/floppym/urwid/commit/f68f2cf089cfd5ec45863baf59a91d5aeb0cf5c3.patch";
+     sha256 = "1b3vz7mrwz2bqvdwvbyv2j835f9lzapgw0j2km4sam76bxmgfpgq";
+   })
+  ];
 
   meta = with stdenv.lib; {
     description = "A full-featured console (xterm et al.) user interface library";

--- a/pkgs/tools/networking/mitmproxy/default.nix
+++ b/pkgs/tools/networking/mitmproxy/default.nix
@@ -1,82 +1,32 @@
 { stdenv, fetchpatch, fetchFromGitHub, fetchurl, python3, glibcLocales }:
 
-let
-  p = python3.override {
-    packageOverrides = self: super: {
-      cryptography = super.cryptography.overridePythonAttrs (oldAttrs: rec {
-        version = "1.8.2";
-        name = "${oldAttrs.pname}-${version}";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "8e88ebac371a388024dab3ccf393bf3c1790d21bc3c299d5a6f9f83fb823beda";
-        };
-      });
-      cryptography_vectors = super.cryptography_vectors.overridePythonAttrs (oldAttrs: rec {
-        version = self.cryptography.version;
-        name = "${oldAttrs.pname}-${version}";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "00daa04c9870345f56605d91d7d4897bc1b16f6fff7c74cb602b08ef16c0fb43";
-        };
-      });
-      pyopenssl = super.pyopenssl.overridePythonAttrs (oldAttrs: rec {
-        version = "17.0.0";
-        name = "${oldAttrs.pname}-${version}";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "1pdg1gpmkzj8yasg6cmkhcivxcdp4c12nif88y4qvsxq5ffzxas8";
-        };
-        patches = fetchpatch {
-          url = "https://github.com/pyca/pyopenssl/commit/"
-              + "a40898b5f1d472f9449a344f703fa7f90cddc21d.patch";
-          sha256 = "0bdfrhfvdfxhfknn46s4db23i3hww6ami2r1l5rfrri0pn8b8mh7";
-        };
-      });
-    };
-  };
-in p.pkgs.buildPythonPackage rec {
+python3.pkgs.buildPythonPackage rec {
   baseName = "mitmproxy";
-  name = "${baseName}-${version}";
-  version = "2.0.2";
+  name = "${baseName}-unstable-2017-10-31";
 
   src = fetchFromGitHub {
     owner = baseName;
     repo = baseName;
-    rev = "v${version}";
-    sha256 = "1x1a28al5clpfd69rjcpw26gjjnpsm1vfl4scrwpdd1jhkw044h9";
+    rev = "80a8eaa708ea31dd9c5e7e1ab6b02c69079039c0";
+    sha256 = "0rvwm11yryzlp3c1i42rk2iv1m38yn6r83k41jb51hwg6wzbwzvw";
   };
-
-  patches = [
-    # fix tests
-    (fetchpatch {
-      url = "https://github.com/mitmproxy/mitmproxy/commit/b3525570929ba47c10d9d08696876c39487f7000.patch";
-      sha256 = "111fld5gqdii7rs1jhqaqrxgbyhfn6qd0y7l15k4npamsnvdnv20";
-    })
-    # bump pyOpenSSL
-    (fetchpatch {
-      url = https://github.com/mitmproxy/mitmproxy/commit/6af72160bf98b58682b8f9fc5aabf51928d2b1d3.patch;
-      sha256 = "1q4ml81pq9c8j9iscq8janbxf4s37w3bqskbs6r30yqzy63v54f2";
-    })
-    # https://github.com/mitmproxy/mitmproxy/commit/3d7cde058b7e6242d93b9bc9d3e17520ffb578a5
-    ./tornado-4.6.patch
-  ];
 
   checkPhase = ''
     export HOME=$(mktemp -d)
     # test_echo resolves hostnames
-    LC_CTYPE=en_US.UTF-8 pytest -k 'not test_echo'
+    LC_CTYPE=en_US.UTF-8 pytest -k 'not test_echo and not test_find_unclaimed_URLs '
   '';
 
-  propagatedBuildInputs = with p.pkgs; [
-    blinker click certifi construct cryptography
-    cssutils editorconfig h2 html2text hyperframe
-    jsbeautifier kaitaistruct passlib pyasn1 pyopenssl
+  propagatedBuildInputs = with python3.pkgs; [
+    blinker click certifi cryptography
+    h2 hyperframe
+    kaitaistruct passlib pyasn1 pyopenssl
     pyparsing pyperclip requests ruamel_yaml tornado
-    urwid watchdog brotlipy sortedcontainers
+    urwid brotlipy sortedcontainers ldap3
   ];
 
-  buildInputs = with p.pkgs; [
-    beautifulsoup4 flask pytz pytest pytestrunner protobuf glibcLocales
+  buildInputs = with python3.pkgs; [
+    beautifulsoup4 flask pytest pytestrunner glibcLocales
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15526,25 +15526,7 @@ in {
 
   pyasn1 = callPackage ../development/python-modules/pyasn1 { };
 
-  pyasn1-modules = buildPythonPackage rec {
-    name = "pyasn1-modules-${version}";
-    version = "0.0.8";
-    disabled = isPyPy;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pyasn1-modules/${name}.tar.gz";
-      sha256 = "0drqgw81xd3fxdlg89kgd79zzrabvfncvkbybi2wr6w2y4s1jmhh";
-    };
-
-    propagatedBuildInputs = with self; [ pyasn1 ];
-
-    meta = {
-      description = "A collection of ASN.1-based protocols modules";
-      homepage = https://pypi.python.org/pypi/pyasn1-modules;
-      license = licenses.bsd3;
-      platforms = platforms.unix;  # same as pyasn1
-    };
-  };
+  pyasn1-modules = callPackage ../development/python-modules/pyasn1-modules { };
 
   pyaudio = buildPythonPackage rec {
     name = "python-pyaudio-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13812,21 +13812,7 @@ in {
 
   pecan = callPackage ../development/python-modules/pecan { };
 
-  kaitaistruct = buildPythonPackage rec {
-    name = "kaitaistruct-${version}";
-    version = "0.6";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/k/kaitaistruct/${name}.tar.gz";
-      sha256 = "0rwcrlz7f2bwmypqa38pag492bp71wp1bhz51hsaynjjyr9knr12";
-    };
-
-    meta = with stdenv.lib; {
-      description = "Kaitai Struct: runtime library for Python";
-      homepage = "https://github.com/kaitai-io/kaitai_struct_python_runtime";
-      license = licenses.mit;
-    };
-  };
+  kaitaistruct = callPackage ../development/python-modules/kaitaistruct { };
 
   Kajiki = buildPythonPackage rec {
     name = "Kajiki-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15524,21 +15524,7 @@ in {
   };
 
 
-  pyasn1 = buildPythonPackage rec {
-    name = "pyasn1-0.1.9";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pyasn1/${name}.tar.gz";
-      sha256 = "0zraxni14bqi20kr4bi6nwsh32aibz0fq0xaczfisw0zdpcsqg45";
-    };
-
-    meta = {
-      description = "ASN.1 tools for Python";
-      homepage = http://pyasn1.sourceforge.net/;
-      license = "mBSD";
-      platforms = platforms.unix;  # arbitrary choice
-    };
-  };
+  pyasn1 = callPackage ../development/python-modules/pyasn1 { };
 
   pyasn1-modules = buildPythonPackage rec {
     name = "pyasn1-modules-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11604,21 +11604,7 @@ in {
     };
   };
 
-  hyperframe = buildPythonPackage rec {
-    name = "hyperframe-${version}";
-    version = "4.0.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/h/hyperframe/${name}.tar.gz";
-      sha256 = "0hsfq0jigwa0i58z7vbnp62l7za49gmlg75vnygq2ijhkidkcmwa";
-    };
-
-    meta = {
-      description = "HTTP/2 framing layer for Python";
-      homepage = "http://hyper.rtfd.org/";
-      license = licenses.mit;
-    };
-  };
+  hyperframe = callPackage ../development/python-modules/hyperframe { };
 
   h2 = buildPythonPackage rec {
     name = "h2-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11606,23 +11606,7 @@ in {
 
   hyperframe = callPackage ../development/python-modules/hyperframe { };
 
-  h2 = buildPythonPackage rec {
-    name = "h2-${version}";
-    version = "2.5.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/h/h2/${name}.tar.gz";
-      sha256 = "0xhzm5vcfhdq3mihynwh4ljwi0r06lvzk3ypr0gmmbcp1x43ffb7";
-    };
-
-    propagatedBuildInputs = with self; [ enum34 hpack hyperframe ];
-
-    meta = {
-      description = "HTTP/2 State-Machine based protocol implementation";
-      homepage = "http://hyper.rtfd.org/";
-      license = licenses.mit;
-    };
-  };
+  h2 = callPackage ../development/python-modules/h2 { };
 
   editorconfig = buildPythonPackage rec {
     name = "EditorConfig-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16856,25 +16856,7 @@ in {
     inherit (pkgs) openldap cyrus_sasl openssl;
   };
 
-  ldap3 = buildPythonPackage rec {
-    version = "1.0.4";
-    name = "ldap3-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/l/ldap3/${name}.tar.gz";
-      sha256 = "0j4qqj9vq022hy7wfqn8s0j4vm2g6paabbzas1vbyspawvcfai98";
-    };
-
-    buildInputs = with self; [ gssapi ];
-
-    propagatedBuildInputs = with self; [ pyasn1 ];
-
-    meta = {
-      homepage = https://pypi.python.org/pypi/ldap3;
-      description = "A strictly RFC 4510 conforming LDAP V3 pure Python client library";
-      license = licenses.lgpl3;
-    };
-  };
+  ldap3 = callPackage ../development/python-modules/ldap3 {};
 
   ptest = buildPythonPackage rec {
     name = pname + "-" + version;


### PR DESCRIPTION
###### Motivation for this change

requires master for up-to-dated libraries.
nox-review over the other libraries updated has not yet been done.
cc @makefu 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

