### PR TITLE
freetds: add openssl support

### DIFF
--- a/pkgs/development/libraries/freetds/default.nix
+++ b/pkgs/development/libraries/freetds/default.nix
@@ -1,7 +1,10 @@
 { stdenv, fetchurl
-, odbcSupport ? false, unixODBC ? null }:
+, odbcSupport ? false, unixODBC ? null
+, sslSupport ? true, openssl ? null
+}:
 
 assert odbcSupport -> unixODBC != null;
+assert sslSupport -> openssl != null;
 
 stdenv.mkDerivation rec {
   name = "freetds-0.91";
@@ -13,9 +16,14 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  buildInputs = stdenv.lib.optional odbcSupport [ unixODBC ];
+  buildInputs =
+    stdenv.lib.optional odbcSupport [ unixODBC ] ++
+    stdenv.lib.optional sslSupport [ openssl.dev ];
 
-  configureFlags = stdenv.lib.optionalString odbcSupport "--with-odbc=${unixODBC}";
+  configureFlags = stdenv.lib.concatStringsSep " " (
+    stdenv.lib.optional odbcSupport "--with-odbc=${unixODBC}" ++
+    stdenv.lib.optional sslSupport "--with-openssl=${openssl.dev}"
+  );
 
   doDist = true;
 


### PR DESCRIPTION
###### Motivation for this change

This is necessary for freetds to be able to use encrypted database connections

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

