### PR TITLE
mkPythonDerivation: let name default to ${pname}-${version}

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -8,7 +8,7 @@
 , ensureNewerSourcesHook
 }:
 
-{ name
+{ name ? "${attrs.pname}-${attrs.version}"
 
 # by default prefix `name` e.g. "python3.3-${name}"
 , namePrefix ? python.libPrefix + "-"


### PR DESCRIPTION
###### Motivation for this change

Python packages that use `fetchPypi` typically refer only to their `pname` and `version` instead of `name`, but have to define `name = "${pname}-${version}";` to conform to the interface of `mkDerivation`. @FRidh has [proposed](https://github.com/NixOS/nixpkgs/commit/7ce848309e6d64820af1e96045c5386992e90a4a#commitcomment-25365743) to get rid of this.

This commit rebuilds nothing. I've tested it by deleting the name from a python derivation. If we migrate `python-packages.nix` into `python-modules/` automatically, we could delete unneeded names in the process.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).