### PR TITLE
lame: prevent build failure from using outdated symbol list

### DIFF
--- a/pkgs/development/libraries/lame/default.nix
+++ b/pkgs/development/libraries/lame/default.nix
@@ -55,6 +55,12 @@ stdenv.mkDerivation rec {
     (if debugSupport then "--enable-debug=alot" else "")
   ];
 
+  preConfigure = ''
+    # Prevent a build failure for 3.100 due to using outdated symbol list
+    # https://hydrogenaud.io/index.php/topic,114777.msg946373.html#msg946373
+    sed -i '/lame_init_old/d' include/libmp3lame.sym
+  '';
+
   meta = {
     description = "A high quality MPEG Audio Layer III (MP3) encoder";
     homepage    = http://lame.sourceforge.net;


### PR DESCRIPTION
Before this change, trying to build LAME on Darwin would throw an error:

Undefined symbols for architecture x86_64:
  "_lame_init_old", referenced from:
     -exported_symbol[s_list] command line option
ld: symbol(s) not found for architecture x86_64
clang-4.0: error: linker command failed with exit code 1 (use -v to see invocation)

Other platforms may have been affected too.

###### Motivation for this change

Just want to rebuild `mpv`, which depends on `ffmpeg`, which depends on this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

