### PR TITLE
rust: 1.20.0 -> 1.21.0

### DIFF
--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -3,14 +3,14 @@
 let
   # Note: the version MUST be one version prior to the version we're
   # building
-  version = "1.19.0";
+  version = "1.20.0";
 
-  # fetch hashes by running `print-hashes.sh 1.19.0`
+  # fetch hashes by running `print-hashes.sh 1.20.0`
   hashes = {
-    i686-unknown-linux-gnu = "657b78f3c1a1b4412e12f7278e20cc318022fa276a58f0d38a0d15b515e39713";
-    x86_64-unknown-linux-gnu = "30ff67884464d32f6bbbde4387e7557db98868e87fb2afbb77c9b7716e3bff09";
-    i686-apple-darwin = "bdfd2189245dc5764c9f26bdba1429c2bf9d57477d8e6e3f0ba42ea0dc63edeb";
-    x86_64-apple-darwin = "5c668fb60a3ba3e97dc2cb8967fc4bb9422b629155284dcb89f94d116bb17820";
+    i686-unknown-linux-gnu = "abe592e06616cdc2fcca56ddbe482050dd49a1fada35e2af031c64fe6eb14668";
+    x86_64-unknown-linux-gnu = "ca1cf3aed73ff03d065a7d3e57ecca92228d35dc36d9274a6597441319f18eb8";
+    i686-apple-darwin = "b3c2470f8f132d285e6c989681e251592b67071bc9d93cac8a2e6b66f7bdfcb5";
+    x86_64-apple-darwin = "fa1fb8896d5e327cbe6deeb50e6e9a3346de629f2e6bcbd8c10f19f3e2ed67d5";
   };
 
   platform =

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -1,7 +1,11 @@
 { stdenv, fetchFromGitHub, file, curl, pkgconfig, python, openssl, cmake, zlib
 , makeWrapper, libiconv, cacert, rustPlatform, rustc, libgit2, darwin
 , version, srcSha, cargoSha256
-, patches ? []}:
+, patches ? [] }:
+
+let
+  inherit (darwin.apple_sdk.frameworks) CoreFoundation;
+in
 
 rustPlatform.buildRustPackage rec {
   name = "cargo-${version}";
@@ -21,12 +25,16 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ file curl python openssl cmake zlib makeWrapper libgit2 ]
-    # FIXME: Use impure version of CoreFoundation because of missing symbols.
-    # CFURLSetResourcePropertyForKey is defined in the headers but there's no
-    # corresponding implementation in the sources from opensource.apple.com.
-    ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.CoreFoundation libiconv ];
+    ++ stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation libiconv ];
 
   LIBGIT2_SYS_USE_PKG_CONFIG=1;
+
+  # FIXME: Use impure version of CoreFoundation because of missing symbols.
+  # CFURLSetResourcePropertyForKey is defined in the headers but there's no
+  # corresponding implementation in the sources from opensource.apple.com.
+  preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
+    export NIX_CFLAGS_COMPILE="-F${CoreFoundation}/Library/Frameworks $NIX_CFLAGS_COMPILE"
+  '';
 
   postInstall = ''
     # NOTE: We override the `http.cainfo` option usually specified in
@@ -36,8 +44,7 @@ rustPlatform.buildRustPackage rec {
     wrapProgram "$out/bin/cargo" \
       --suffix PATH : "${rustc}/bin" \
       --set CARGO_HTTP_CAINFO "${cacert}/etc/ssl/certs/ca-bundle.crt" \
-      --set SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt" \
-      ${stdenv.lib.optionalString stdenv.isDarwin ''--suffix DYLD_LIBRARY_PATH : "${rustc}/lib"''}
+      --set SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt"
   '';
 
   checkPhase = ''

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -6,7 +6,7 @@
 
 let
   rustPlatform = recurseIntoAttrs (makeRustPlatform (callPackage ./bootstrap.nix {}));
-  version = "1.20.0";
+  version = "1.21.0";
 in
 rec {
   rustc = callPackage ./rustc.nix {
@@ -18,7 +18,7 @@ rec {
 
     src = fetchurl {
       url = "https://static.rust-lang.org/dist/rustc-${version}-src.tar.gz";
-      sha256 = "0542y4rnzlsrricai130mqyxl8r6rd991frb4qsnwb27yigqg91a";
+      sha256 = "1yj8lnxybjrybp00fqhxw8fpr641dh8wcn9mk44xjnsb4i1c21qp";
     };
 
     patches = [


### PR DESCRIPTION
###### Motivation for this change

Rust 1.21.0 has been released

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

