### PR TITLE
snapraid: fix release checksum

### DIFF
--- a/pkgs/tools/filesystems/snapraid/default.nix
+++ b/pkgs/tools/filesystems/snapraid/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "amadvance";
     repo = "snapraid";
     rev = "v${version}";
-    sha256 = "13v0gz22ng09gs87f7900z2sk2hg5543njl32rfn4cxxp0jncs3r";
+    sha256 = "1vgyiagn6qvyyz4jkf8pzlg0w9apb6mzza97a9x03p82fav2afx0";
   };
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change

it seams that the release tarball has changed again. However looking at the release page on github it does not show a change (last update may 2017). I have mirrored the current release tarball to archive.org for reference if the checksum should change again

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

