### PR TITLE
[WIP] Python language server provider

### DIFF
--- a/pkgs/development/python-modules/autopep8/default.nix
+++ b/pkgs/development/python-modules/autopep8/default.nix
@@ -3,7 +3,6 @@
 buildPythonPackage rec {
   pname = "autopep8";
   version = "1.3.5";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/future/default.nix
+++ b/pkgs/development/python-modules/future/default.nix
@@ -9,7 +9,6 @@
 buildPythonPackage rec {
   pname = "future";
   version = "0.16.0";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/jedi/default.nix
+++ b/pkgs/development/python-modules/jedi/default.nix
@@ -2,12 +2,11 @@
 
 buildPythonPackage rec {
   pname = "jedi";
-  version = "0.11.1";
-  name = "${pname}-${version}";
+  version = "0.12.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d6e799d04d1ade9459ed0f20de47c32f2285438956a677d083d3c98def59fa97";
+    sha256 = "1bcr7csx4xil1iwmk03d79jis0bkmgi9k0kir3xa4rmwqsagcwhr";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/json-rpc/default.nix
+++ b/pkgs/development/python-modules/json-rpc/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, nose
+, mock
+}:
+buildPythonPackage rec {
+
+  pname = "json-rpc";
+  version = "1.10.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1dfk8v2bcl0fjjyzbbqr0bybkqzngqa1ra8f40dyrshjsfc4mw11";
+  };
+
+  checkInputs = [ nose mock ];
+
+  meta = with stdenv.lib; {
+    homepage = http://github.com/pavlov99/json-rpc;
+    description = "JSON-RPC2.0 and JSON-RPC1.0 transport specification implementation";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/parso/default.nix
+++ b/pkgs/development/python-modules/parso/default.nix
@@ -6,12 +6,11 @@
 
 buildPythonPackage rec {
   pname = "parso";
-  version = "0.1.1";
-  name = "${pname}-${version}";
+  version = "0.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5815f3fe254e5665f3c5d6f54f086c2502035cb631a91341591b5a564203cffb";
+    sha256 = "0lamywk6dm5xshlkdvxxf5j6fa2k2zpi7xagf0bwidaay3vnpgb2";
   };
 
   checkInputs = [ pytest ];

--- a/pkgs/development/python-modules/python-language-server/default.nix
+++ b/pkgs/development/python-modules/python-language-server/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, jedi, mccabe, future, futures, rope, tox
+, yapf, pycodestyle, pluggy, pyflakes
+, json-rpc, pydocstyle, pytest
+, fetchPypi
+, buildPythonPackage
+, pythonOlder
+, configparser ? null
+}:
+buildPythonPackage rec {
+
+  pname = "python-language-server";
+  version = "0.16.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1sp9wyna44izw0ygb4m73v5g04fhqbpypkvfc7lqzyb22dp54a2a";
+  };
+
+  postPatch = stdenv.lib.optionalString (!pythonOlder "3.0") ''
+    substituteInPlace setup.py --replace 'configparser'  ""
+  '';
+
+  propagatedBuildInputs = [
+    future
+    mccabe
+    jedi
+    json-rpc
+    yapf
+    pycodestyle
+    pydocstyle
+    pyflakes
+    pluggy
+    rope
+  ] ++ stdenv.lib.optionals (pythonOlder "3.0") [ configparser futures ];
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://github.com/palantir/python-language-server;
+    description = "Language Server for Python";
+    license = licenses.mit;
+  };
+}
+

--- a/pkgs/development/python-modules/python-language-server/default.nix
+++ b/pkgs/development/python-modules/python-language-server/default.nix
@@ -1,7 +1,8 @@
 { stdenv
 , jedi, mccabe, future, futures, rope, tox
 , yapf, pycodestyle, pluggy, pyflakes
-, json-rpc, pydocstyle, pytest
+, json-rpc
+, pydocstyle, pytest, mock, versioneer, autopep8
 , fetchPypi
 , buildPythonPackage
 , pythonOlder
@@ -10,11 +11,11 @@
 buildPythonPackage rec {
 
   pname = "python-language-server";
-  version = "0.16.0";
+  version = "0.18.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1sp9wyna44izw0ygb4m73v5g04fhqbpypkvfc7lqzyb22dp54a2a";
+    sha256 = "0n106b92xdkp9pqk6qrsgh5qm7gvzskyjhkbj4sjj55rkwadsmij";
   };
 
   postPatch = stdenv.lib.optionalString (!pythonOlder "3.0") ''
@@ -32,9 +33,11 @@ buildPythonPackage rec {
     pyflakes
     pluggy
     rope
-  ] ++ stdenv.lib.optionals (pythonOlder "3.0") [ configparser futures ];
+  ]
+  ++ stdenv.lib.optionals (pythonOlder "3.0") [ configparser ]
+  ++ stdenv.lib.optionals (pythonOlder "3.2") [ futures ];
 
-  checkInputs = [ pytest ];
+  checkInputs = [ autopep8 versioneer pytest mock ];
 
   checkPhase = ''
     py.test

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3267,6 +3267,8 @@ in {
     };
   };
 
+  json-rpc = callPackage ../development/python-modules/json-rpc {};
+
   jsonrpclib = buildPythonPackage rec {
     name = "jsonrpclib-${version}";
     version = "0.1.7";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -398,6 +398,8 @@ in {
 
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
 
+  python-language-server = callPackage ../development/python-modules/python-language-server { };
+
   python-sql = callPackage ../development/python-modules/python-sql { };
 
   python-stdnum = callPackage ../development/python-modules/python-stdnum { };


### PR DESCRIPTION
###### Motivation for this change
LSP (Language Service Protocol) is the current big thing in IDEs  https://langserver.org/ . 
You can try on vim with for instance https://github.com/autozimu/LanguageClient-neovim .

This should work (the pyls binary is made available) but needs some cleaning.
I have a few other PRs I would like to clean first so feel free to takeover. I opened the PR to prevent duplicate work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

