### PR TITLE
openmsx: init at git-2017-11-02

### DIFF
--- a/pkgs/misc/emulators/openmsx/custom-nixos.mk
+++ b/pkgs/misc/emulators/openmsx/custom-nixos.mk
@@ -1,0 +1,9 @@
+# This file substitutes $sourceRoot/build/custom.mk
+
+VERSION_EXEC:=false
+SYMLINK_FOR_BINARY:=false
+INSTALL_CONTRIB:=true
+INSTALL_BASE:=${out}
+INSTALL_DOC_DIR:=${INSTALL_BASE}/share/doc/openmsx
+INSTALL_SHARE_DIR:=${INSTALL_BASE}/share/openmsx
+INSTALL_BINARY_DIR:=${INSTALL_BASE}/bin

--- a/pkgs/misc/emulators/openmsx/default.nix
+++ b/pkgs/misc/emulators/openmsx/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, pkgconfig
+, python
+, alsaLib, glew, mesa_noglu, libpng
+, libogg, libtheora, libvorbis
+, SDL, SDL_image, SDL_ttf
+, freetype, tcl, zlib
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "openmsx-${version}";
+  version = "git-2017-11-02";
+
+  src = fetchFromGitHub {
+    owner = "openMSX";
+    repo = "openMSX";
+    rev = "eeb74206ae347a3b17e9b99f91f2b4682c5db22c";
+    sha256 = "170amj7k6wjhwx6psbplqljvckvhxxbv3aw72jrdxl1fb8zlnq3s";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkgconfig python ];
+
+  buildInputs = [ alsaLib glew mesa_noglu libpng
+    libogg libtheora libvorbis freetype
+    SDL SDL_image SDL_ttf tcl zlib ];
+
+  postPatch = ''
+    cp ${./custom-nixos.mk} build/custom.mk
+  '';
+
+  dontAddPrefix = true;
+
+  # Many thanks @mthuurne from OpenMSX project
+  # for providing support to Nixpkgs :)
+  TCL_CONFIG="${tcl}/lib/";
+
+  meta = with stdenv.lib; {
+    description = "A MSX emulator";
+    longDescription = ''
+      OpenMSX is an emulator for the MSX home computer system. Its goal is
+      to emulate all aspects of the MSX with 100% accuracy.
+    '';
+    homepage = https://openmsx.org;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19792,6 +19792,10 @@ with pkgs;
 
   snes9x-gtk = callPackage ../misc/emulators/snes9x-gtk { };
 
+  openmsx = callPackage ../misc/emulators/openmsx {
+    python = python27;
+  };
+
   higan = callPackage ../misc/emulators/higan {
     inherit (gnome2) gtksourceview;
   };


### PR DESCRIPTION
###### Motivation for this change

New package - openmsx

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

