### PR TITLE
kafkacat: fix sandboxed build

### DIFF
--- a/pkgs/development/tools/kafkacat/default.nix
+++ b/pkgs/development/tools/kafkacat/default.nix
@@ -16,6 +16,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib rdkafka yajl ];
 
+  preConfigure = ''
+    patchShebangs ./configure
+  '';
+
   meta = with stdenv.lib; {
     description = "A generic non-JVM producer and consumer for Apache Kafka";
     homepage = https://github.com/edenhill/kafkacat;


### PR DESCRIPTION
###### Motivation for this change

[It won't build with sandboxing enabled](https://hydra.nixos.org/build/63309583).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

