### PR TITLE
abiword: 3.0.1 -> 3.0.2

### DIFF
--- a/pkgs/applications/office/abiword/default.nix
+++ b/pkgs/applications/office/abiword/default.nix
@@ -5,14 +5,18 @@
 
 stdenv.mkDerivation rec {
   name = "abiword-${version}";
-  version = "3.0.1";
+  version = "3.0.2";
 
   src = fetchurl {
-    url = "http://www.abisource.org/downloads/abiword/${version}/source/${name}.tar.gz";
+    url = "http://www.abisource.com/downloads/abiword/${version}/source/${name}.tar.gz";
     sha256 = "1ik591rx15nn3n1297cwykl8wvrlgj78i528id9wbidgy3xzd570";
   };
 
   enableParallelBuilding = true;
+
+  patches = [
+  (fetchurl { url = https://gist.githubusercontent.com/ylwghst/f65fef2a751e81af57e2d64d40128247/raw/; sha256 = "1ni2sc7jhqafwkkjdwchdx56fv7rp91grxblravp2kymrf9j1add"; })
+  ];
 
   buildInputs =
     [ pkgconfig gtk3 libglade librsvg bzip2 libgnomecanvas fribidi libpng popt
@@ -29,6 +33,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.abisource.com/;
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ pSub ];
+    maintainers = with maintainers; [ pSub ylwghst ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

A bug both in 3.0.1 and 3.0.2 makes Abiword unusable.
Raising to 3.0.2 and appending fix patch.

Bug description: Document view is black
Bug report: https://bugzilla.abisource.com/show_bug.cgi?id=13815
Patch source: https://bugzilla.abisource.com/attachment.cgi?id=5837

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [+] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [+] Tested execution of all binary files (usually in `./result/bin/`)
- [+] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

