### PR TITLE
snes9x-gtk: fix build

### DIFF
--- a/pkgs/misc/emulators/snes9x-gtk/default.nix
+++ b/pkgs/misc/emulators/snes9x-gtk/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook intltool pkgconfig ];
 
-  sourceRoot = "snes9x-${version}-src";
   preAutoreconf = "cd gtk; intltoolize";  
     
   buildInputs = [ SDL zlib gtk2 libxml2 libXv ];


### PR DESCRIPTION
###### Motivation for this change

[It doesn't build anymore](https://hydra.nixos.org/build/63378362).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

