### PR TITLE
nixpkgs manual: add rstudio shell.nix example

### DIFF
--- a/pkgs/development/r-modules/README.md
+++ b/pkgs/development/r-modules/README.md
@@ -79,6 +79,23 @@ environment, see `rstudioWrapper`, which functions similarly to
 Then like above, `nix-env -f "<nixpkgs>" -iA rstudioEnv` will install
 this into your user profile.
 
+Alternatively, you can create a self-contained `shell.nix` without the need to
+modify any configuration files:
+
+```nix
+{ pkgs ? import <nixpkgs> {}
+}:
+
+pkgs.rstudioWrapper.override {
+  packages = with pkgs.rPackages; [ dplyr ggplot2 reshape2 ];
+}
+
+```
+
+Executing `nix-shell` will then drop you into an environment equivalent to the
+one above. If you need additional packages just add them to the list and
+re-enter the shell.
+
 ## Updating the package set
 
 ```bash


### PR DESCRIPTION
Provide an example of a self-contained shell.nix to setup an environment with custom R packages and RStudio.

###### Motivation for this change

This could help people new to nix to quickly get started with a working RStudio setup without looking for the right configuration files to modify or people who like to keep all the configuration within each project like myself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

