### PR TITLE
reaverwps-t6x: fix build

### DIFF
--- a/pkgs/tools/networking/reaver-wps-t6x/default.nix
+++ b/pkgs/tools/networking/reaver-wps-t6x/default.nix
@@ -15,7 +15,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ libpcap sqlite pixiewps ];
 
-  sourceRoot = "reaver-wps-fork-t6x-v${version}-src/src";
+  setSourceRoot = ''
+    sourceRoot=$(echo */src)
+  '';
 
   configureFlags = "--sysconfdir=${confdir}";
 


### PR DESCRIPTION
###### Motivation for this change

[It doesn't build anymore](https://hydra.nixos.org/build/63180053).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

