### PR TITLE
curl-unix-socket: fix build

### DIFF
--- a/pkgs/tools/networking/curl-unix-socket/default.nix
+++ b/pkgs/tools/networking/curl-unix-socket/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ go ];
-  buildPhase = "go build";
-  installPhase = "install -D curl-unix-socket* $out/bin/curl-unix-socket";
+  buildPhase = "go build -o curl-unix-socket";
+  installPhase = "install -D curl-unix-socket $out/bin/curl-unix-socket";
 
   meta = with stdenv.lib; {
     description = "Run HTTP requests over UNIX socket";


### PR DESCRIPTION
###### Motivation for this change

[It doesn't build anymore](https://hydra.nixos.org/build/63379692).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

