### PR TITLE
Fix nix-shell command example in python docs

### DIFF
--- a/doc/languages-frameworks/python.md
+++ b/doc/languages-frameworks/python.md
@@ -165,7 +165,7 @@ run the script in the `python3` shell.
 
 ```py
 #! /usr/bin/env nix-shell
-#! nix-shell -i 'python3.withPackages(ps: [ps.numpy])'
+#! nix-shell -i python3 -p 'python3.withPackages(ps: [ps.numpy])'
 
 import numpy
 


### PR DESCRIPTION
The nix-shell command here is incorrect AFAICT.  `-i` is supposed to specify the interpreter and `-p` specifies the packages.

Fixes #31196

###### Motivation for this change
Incorrect example in documentation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

