### PR TITLE
keybase service: Turn off debug logging

### DIFF
--- a/nixos/modules/services/networking/keybase.nix
+++ b/nixos/modules/services/networking/keybase.nix
@@ -28,7 +28,7 @@ in {
       description = "Keybase service";
       serviceConfig = {
         ExecStart = ''
-          ${pkgs.keybase}/bin/keybase -d service --auto-forked
+          ${pkgs.keybase}/bin/keybase service --auto-forked
         '';
         Restart = "on-failure";
         PrivateTmp = true;


### PR DESCRIPTION
###### Motivation for this change

Keybase is _extremely_ verbose with its debug output when run with `-d` (i.e. `--debug`).