### PR TITLE
zsh-syntax-highlighting: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/shells/zsh-syntax-highlighting/default.nix
+++ b/pkgs/shells/zsh-syntax-highlighting/default.nix
@@ -3,14 +3,14 @@
 # To make use of this derivation, use the `programs.zsh.enableSyntaxHighlighting` option
 
 stdenv.mkDerivation rec {
-  version = "0.5.0";
+  version = "0.6.0";
   name = "zsh-syntax-highlighting-${version}";
 
   src = fetchFromGitHub {
     owner = "zsh-users";
     repo = "zsh-syntax-highlighting";
     rev = version;
-    sha256 = "0k0m5aw67lhi4z143sdawx93y1892scvvdfdnjvljb4hf0vzs2ww";
+    sha256 = "0zmq66dzasmr5pwribyh4kbkk23jxbpdw4rjxx0i7dx8jjp2lzl4";
   };
 
   buildInputs = [ zsh ];


### PR DESCRIPTION
###### Motivation for this change

Update zsh-syntax-highlighting to the last version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

