### PR TITLE
nixos/cc-wrapper: Fix bug if dynamicLinker not found

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -297,7 +297,6 @@ stdenv.mkDerivation {
         fi
 
         local ldflagsBefore=(-dynamic-linker "$dynamicLinker")
-
     '') + ''
       fi
 

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -296,9 +296,8 @@ stdenv.mkDerivation {
           echo ${libc_lib}/lib/32/ld-linux.so.2 > $out/nix-support/dynamic-linker-m32
         fi
 
-     if [ -n "''${dynamicLinker:-}" ]; then
-             local ldflagsBefore=(-dynamic-linker "$dynamicLinker")
-     fi
+        local ldflagsBefore=(-dynamic-linker "$dynamicLinker")
+
     '') + ''
       fi
 

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -286,7 +286,7 @@ stdenv.mkDerivation {
         *) echo "Multiple dynamic linkers found for platform '${targetPlatform.config}'." >&2;;
       esac
 
-      if [ -n "$dynamicLinker" ]; then
+      if [ -n "''${dynamicLinker:-}" ]; then
         echo $dynamicLinker > $out/nix-support/dynamic-linker
 
     '' + (if targetPlatform.isDarwin then ''
@@ -296,7 +296,9 @@ stdenv.mkDerivation {
           echo ${libc_lib}/lib/32/ld-linux.so.2 > $out/nix-support/dynamic-linker-m32
         fi
 
-        local ldflagsBefore=(-dynamic-linker "$dynamicLinker")
+     if [ -n "''${dynamicLinker:-}" ]; then
+             local ldflagsBefore=(-dynamic-linker "$dynamicLinker")
+     fi
     '') + ''
       fi
 


### PR DESCRIPTION
If a dynamic linker for target is not found the generated script fails
due to unbound variable error (in turn due to "set -u"). Correct by specifying
default value with dynamicLinker:- and not generating ldflagsBefore if
no linker is found.

This problem was found when cross compiling to mingw32 targets

###### Motivation for this change

Cross-compiling for mingw32 targets was currently broken with "variable unbound" errors. This change allows the compilation to proceed further.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

