### PR TITLE
Revert "redmine: mark as broken"

### DIFF
--- a/pkgs/applications/version-management/redmine/default.nix
+++ b/pkgs/applications/version-management/redmine/default.nix
@@ -67,8 +67,5 @@ in stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = [ maintainers.garbas ];
     license = licenses.gpl2;
-    # Marked as broken due to needing an update for security issues.
-    # See: https://github.com/NixOS/nixpkgs/issues/18856
-    broken = true;
   };
 }


### PR DESCRIPTION
This reverts commit f9c9c1dac85444be95e970bced3d7dbbf7c7086d.

###### Motivation for this change

The Issue why this was marked as broken was already closed and I was able to build the package.

###### Things done

- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (debian with nix installed)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

