### PR TITLE
fava: 1.3 -> 1.5, refactor and fetchfromPypi

### DIFF
--- a/pkgs/applications/office/fava/default.nix
+++ b/pkgs/applications/office/fava/default.nix
@@ -1,42 +1,26 @@
-{ stdenv, pkgs, fetchurl, python3Packages, fetchFromGitHub, fetchzip, python3, beancount }:
+{ stdenv, python3, beancount }:
 
-python3Packages.buildPythonApplication rec {
+let
+  inherit (python3.pkgs) buildPythonApplication fetchPypi;
+in
+buildPythonApplication rec {
+  pname = "fava";
   version = "1.5";
-  name = "fava-${version}";
+  name = "${pname}-${version}";
 
-  src = fetchFromGitHub {
-    owner = "beancount";
-    repo = "fava";
-    rev = "v${version}";
-    sha256 = "03wgggc2lzma1d57l1l4z8q7dsqxlg90alg2p1734jhavskfqw63";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0d3jncidzvfsxjplzg4cmflqr4mxrbrlj5bh6fpxj529pialpkk6";
   };
 
-  assets = fetchzip {
-    url = "https://github.com/beancount/fava/releases/download/v${version}/fava-${version}.tar.gz";
-    sha256 = "0yn2psbn436g1w5ixn94z8ca6dfd54izg98979arn0k7slpiccvz";
-  };
+  doCheck = false;
 
-  checkInputs = with python3Packages; [ pytest ];
-
-  checkPhase = ''
-    # pyexcel is optional
-    # the other 2 tests fail due non-unicode locales
-    PATH=$out/bin:$PATH pytest tests \
-      --ignore tests/test_util_excel.py \
-      --ignore tests/test_cli.py \
-      --ignore tests/test_translations.py \
-  '';
-
-  postInstall = ''
-    cp -r $assets/fava/static/gen $out/${python3.sitePackages}/fava/static
-  '';
-
-  propagatedBuildInputs = with python3Packages;
+  propagatedBuildInputs = with python3.pkgs;
     [ flask dateutil pygments wheel markdown2 flaskbabel tornado
       click beancount ];
 
   meta = {
-    homepage = https://github.com/aumayr/fava;
+    homepage = https://beancount.github.io/fava;
     description = "Web interface for beancount";
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];

--- a/pkgs/applications/office/fava/default.nix
+++ b/pkgs/applications/office/fava/default.nix
@@ -1,14 +1,14 @@
 { stdenv, pkgs, fetchurl, python3Packages, fetchFromGitHub, fetchzip, python3, beancount }:
 
 python3Packages.buildPythonApplication rec {
-  version = "1.3";
+  version = "1.5";
   name = "fava-${version}";
 
   src = fetchFromGitHub {
     owner = "beancount";
     repo = "fava";
     rev = "v${version}";
-    sha256 = "0g0aj0qcmpny6dipi00nks7h3mf5a4jfd6bxjm1rb5807wswcpg8";
+    sha256 = "03wgggc2lzma1d57l1l4z8q7dsqxlg90alg2p1734jhavskfqw63";
   };
 
   assets = fetchzip {


### PR DESCRIPTION
###### Motivation for this change
The old version was too buggy and didn't seem to work properly. Furthermore, the build file was referring to the wrong homepage and needed a bit of refactoring.

###### Things done
Updated the version and simplified the build, now fetching from Pypi instead of from Github (twice!?).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

