### PR TITLE
qt5: fix cmake cleanup on darwin

### DIFF
--- a/pkgs/development/libraries/qt-5/qtbase-setup-hook-darwin.sh
+++ b/pkgs/development/libraries/qt-5/qtbase-setup-hook-darwin.sh
@@ -3,7 +3,7 @@ qtQmlPrefix=@qtQmlPrefix@
 qtDocPrefix=@qtDocPrefix@
 
 _qtRmCMakeLink() {
-    find "${!outputLib}" -name "*.cmake" -type l | xargs rm
+    find "${!outputLib}" -name "*.cmake" -type l -delete
 }
 
 postInstallHooks+=(_qtRmCMakeLink)


### PR DESCRIPTION
This fixes the case where the `find` command does not return any
files.

###### Motivation for this change
This was breaking the end of the `installPhase` of the `pcl` package on `darwin`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

