### PR TITLE
Mtail

### DIFF
--- a/pkgs/development/tools/gotools/default.nix
+++ b/pkgs/development/tools/gotools/default.nix
@@ -2,8 +2,8 @@
 
 buildGoPackage rec {
   name = "gotools-${version}";
-  version = "20160519-${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "9ae4729fba20b3533d829a9c6ba8195b068f2abc";
+  version = "20170807-${stdenv.lib.strings.substring 0 7 rev}";
+  rev = "5d2fd3ccab986d52112bf301d47a819783339d0e";
 
   goPackagePath = "golang.org/x/tools";
   goPackageAliases = [ "code.google.com/p/go.tools" ];
@@ -11,7 +11,7 @@ buildGoPackage rec {
   src = fetchgit {
     inherit rev;
     url = "https://go.googlesource.com/tools";
-    sha256 = "1j51aaskfqc953p5s9naqimr04hzfijm4yczdsiway1xnnvvpfr1";
+    sha256 = "0r3fp7na6pg0bc5xfycjvv951f0vma1qfnpw5zy6l75yxm5r47kn";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/servers/monitoring/mtail/default.nix
+++ b/pkgs/servers/monitoring/mtail/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchFromGitHub, gotools, buildGoPackage }:
+
+buildGoPackage rec {
+  name = "mtail-${version}";
+  version = "3.0.0-rc4";
+  goPackagePath = "github.com/google/mtail";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "mtail";
+    rev = "v${version}";
+    sha256 = "1n7pqvid48ayn15qfpgpbsx0iqg24x08wphzpc08mlfw47gq7jg3";
+  };
+
+  buildInputs = [ gotools ];
+  goDeps = ./deps.nix;
+  patches = [ ./fix-gopath.patch ];
+  preBuild = "go generate -x ./go/src/github.com/google/mtail/vm/";
+
+
+  meta = with lib; {
+    license = licenses.asl20;
+    homepage = "https://github.com/google/mtail";
+    description = "Tool for extracting metrics from application logs";
+  };
+}

--- a/pkgs/servers/monitoring/mtail/deps.nix
+++ b/pkgs/servers/monitoring/mtail/deps.nix
@@ -1,0 +1,56 @@
+[
+  rec {
+    goPackagePath = "github.com/golang/glog";
+    fetch = {
+      type = "git";
+      url = "https://${goPackagePath}.git";
+      rev = "23def4e6c14b4da8ac2ed8007337bc5eb5007998";
+      sha256 = "0jb2834rw5sykfr937fxi8hxi2zy80sj2bdn9b3jb4b26ksqng30";
+    };
+  }
+  rec {
+    goPackagePath = "github.com/spf13/afero";
+    fetch = {
+      type = "git";
+      url = "https://${goPackagePath}.git";
+      rev = "5660eeed305fe5f69c8fc6cf899132a459a97064";
+      sha256 = "0rpwvjp9xfmy2yvbmy810qamjhimr56zydvx7hb1gjn3b7jp4rhd";
+    };
+  }
+  rec {
+    goPackagePath = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://${goPackagePath}.git";
+      rev = "v1.4.2";
+      sha256 = "06wfg1mmzjj04z7d0q1x2fai9k6hm957brngsaf02fa9a3qqanv3";
+    };
+  }
+  rec {
+    goPackagePath = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://${goPackagePath}.git";
+      rev = "v0.8.0";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "95c6576299259db960f6c5b9b69ea52422860fce";
+      sha256 = "1fhq8bianb9a1iccpr92mi2hix9zvm10n0f7syx6vfbxdw32i316";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "3ba1a4dc141f5236b19ccbf2f67cb63d1a688d46";
+      sha256 = "07sbakmman41p5hmdbf4y2wak0gh7k1z88m0zb72acsypp4179h1";
+    };
+  }
+]

--- a/pkgs/servers/monitoring/mtail/fix-gopath.patch
+++ b/pkgs/servers/monitoring/mtail/fix-gopath.patch
@@ -1,0 +1,13 @@
+diff --git a/vm/compiler.go b/vm/compiler.go
+index c55266b..a46417c 100644
+--- a/vm/compiler.go
++++ b/vm/compiler.go
+@@ -2,7 +2,7 @@
+ // This file is available under the Apache license.
+ 
+ // Build the parser:
+-//go:generate $GOPATH/bin/goyacc -v y.output -o parser.go -p mtail parser.y
++//go:generate goyacc -v y.output -o parser.go -p mtail parser.y
+ 
+ package vm
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2971,6 +2971,8 @@ with pkgs;
 
   mkcast = callPackage ../applications/video/mkcast { };
 
+  mtail = callPackage ../servers/monitoring/mtail { };
+
   multitail = callPackage ../tools/misc/multitail { };
 
   mxt-app = callPackage ../misc/mxt-app { };


### PR DESCRIPTION
###### Motivation for this change

Add new package - mtail.

mtail is a tool for extracting metrics from application logs to be exported into a timeseries database or timeseries calculator for alerting and dashboarding.
https://github.com/google/mtail

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

