### PR TITLE
Remove manual rpath settings now that meson is fixed

### DIFF
--- a/pkgs/applications/audio/ncmpc/default.nix
+++ b/pkgs/applications/audio/ncmpc/default.nix
@@ -1,11 +1,7 @@
 { stdenv, fetchFromGitHub, meson, ninja, pkgconfig, glib, ncurses
 , mpd_clientlib, gettext }:
 
-let
-  rpath = stdenv.lib.makeLibraryPath [
-    glib ncurses mpd_clientlib
-  ];
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "ncmpc-${version}";
   version = "0.28";
 
@@ -18,12 +14,6 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ glib ncurses mpd_clientlib ];
   nativeBuildInputs = [ meson ninja pkgconfig gettext ];
-
-  postFixup = ''
-    for elf in "$out"/bin/*; do
-      patchelf --set-rpath '${rpath}':"$out/lib" "$elf"
-    done
-  '';
 
   meta = with stdenv.lib; {
     description = "Curses-based interface for MPD (music player daemon)";

--- a/pkgs/development/libraries/appstream-glib/default.nix
+++ b/pkgs/development/libraries/appstream-glib/default.nix
@@ -3,15 +3,7 @@
 , gobjectIntrospection, sqlite, libsoup, gcab, attr, acl, docbook_xsl
 , libuuid, json_glib, autoconf-archive, meson, gperf, ninja, gdk_pixbuf
 }:
-let rpath = stdenv.lib.makeLibraryPath
-      [ libuuid.out
-        glib
-        libsoup
-        gdk_pixbuf
-        libarchive.lib
-        gcab
-      ];
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "appstream-glib-0.7.2";
 
   src = fetchFromGitHub {
@@ -27,12 +19,6 @@ in stdenv.mkDerivation rec {
                   libarchive gobjectIntrospection gperf ];
   propagatedBuildInputs = [ gtk3 ];
   mesonFlags = [ "-Denable-rpm=false" "-Denable-stemmer=false" "-Denable-dep11=false" ];
-
-  postFixup = ''
-    for elf in "$out"/bin/* "$out"/lib/*.so; do
-      patchelf --set-rpath '${rpath}':"$out/lib" "$elf"
-    done
-  '';
 
   meta = with stdenv.lib; {
     description = "Objects and helper methods to read and write AppStream metadata";

--- a/pkgs/tools/filesystems/sshfs-fuse/default.nix
+++ b/pkgs/tools/filesystems/sshfs-fuse/default.nix
@@ -4,7 +4,6 @@
 
 let
   inherit (stdenv.lib) optional;
-  rpath = stdenv.lib.makeLibraryPath [ fuse3 glib ];
 in stdenv.mkDerivation rec {
   version = "3.3.1";
   name = "sshfs-fuse-${version}";
@@ -28,10 +27,6 @@ in stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/sbin
     ln -sf $out/bin/sshfs $out/sbin/mount.sshfs
-  '';
-
-  postFixup = ''
-       patchelf --set-rpath '${rpath}' "$out/bin/sshfs"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Similarly to 9e37df185c75a2ba7724ae4ce5ce3c356c1ce225, I cleaned up `ncmpc`, `appstream-glib` and `sshfs-fuse`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

