### PR TITLE
vscode-extension-ms-python-python: Init at 0.8.0

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -1,7 +1,8 @@
 { stdenv, lib, fetchurl, callPackage, vscode-utils }:
 
 let
-  inherit (vscode-utils) buildVscodeExtension buildVscodeMarketplaceExtension;
+  inherit (vscode-utils) buildVscodeExtension buildVscodeMarketplaceExtension
+      extensionFromVscodeMarketplace;
 in
 #
 # Unless there is a good reason not to, we attemp to use the same name as the 
@@ -24,4 +25,6 @@ rec {
   };
 
   ms-vscode.cpptools = callPackage ./cpptools {};
+  
+  ms-python.python = callPackage ./python {};
 }

--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, lib, vscode-utils
+
+, pythonUseFixed ? false, python  # When `true`, the python default setting will be fixed to specified. 
+                                  # Use version from `PATH` for default setting otherwise.
+                                  # Defaults to `false` as we expect it to be project specific most of the time.
+, ctagsUseFixed ? true, ctags     # When `true`, the ctags default setting will be fixed to specified. 
+                                  # Use version from `PATH` for default setting otherwise.
+                                  # Defaults to `true` as usually not defined on a per projet basis.
+}:
+
+assert pythonUseFixed -> null != python;
+assert ctagsUseFixed -> null != ctags;
+
+let
+  pythonDefaultsTo = if pythonUseFixed then "${python}/bin/python" else "python";
+  ctagsDefaultsTo = if ctagsUseFixed then "${ctags}/bin/ctags" else "ctags";
+in
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "python";
+    publisher = "ms-python";
+    version = "0.8.0";
+    sha256 = "0i7s93l5g5lyi6vn77zh3ipj0p267y17fayv6vjrxc2igrs27ik6";
+  };
+
+  postPatch = ''
+    # Patch `packages.json` so that nix's *python* is used as default value for `python.pythonPath`.
+    substituteInPlace "./package.json" \
+      --replace "\"default\": \"python\"" "\"default\": \"${pythonDefaultsTo}\""
+
+    # Patch `packages.json` so that nix's *ctags* is used as default value for `python.workspaceSymbols.ctagsPath`.
+    substituteInPlace "./package.json" \
+      --replace "\"default\": \"ctags\"" "\"default\": \"${ctagsDefaultsTo}\""
+  '';
+
+    meta = with lib; {
+      license = licenses.mit;
+      maintainer = [ maintainers.jraygauthier ];
+    };
+}

--- a/pkgs/misc/vscode-extensions/vscode-utils.nix
+++ b/pkgs/misc/vscode-extensions/vscode-utils.nix
@@ -70,12 +70,14 @@ let
       mktplcRef = ext; 
     }); 
 
+  extensionFromVscodeMarketplace = mktplcExtRefToExtDrv;
   extensionsFromVscodeMarketplace = mktplcExtRefList:
-    builtins.map mktplcExtRefToExtDrv mktplcExtRefList;
+    builtins.map extensionFromVscodeMarketplace mktplcExtRefList;
 
 in
 
 {
   inherit fetchVsixFromVscodeMarketplace buildVscodeExtension 
-          buildVscodeMarketplaceExtension extensionsFromVscodeMarketplace;
+          buildVscodeMarketplaceExtension extensionFromVscodeMarketplace
+          extensionsFromVscodeMarketplace;
 }


### PR DESCRIPTION
###### Motivation for this change

Missing vscode extension.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

