### PR TITLE
firefox-devedition-bin: 57.0b13 -> 58.0b1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,955 +1,965 @@
 {
-  version = "57.0b13";
+  version = "58.0b1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/ach/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ach/firefox-58.0b1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "cf01dfc2fa0995b24457e9aea6faafcafee48c900794845c08ae452fe920f75841db9e67302a7b23b6bf956baf0c79eb8bd2d63ea4a45b3f515a4745552756e3";
+      sha512 = "c76b0c8d0774eabdd49abdb211312da230ca467711ab3e4700bf683246986aef8bbae8eda45126bbb6c610db8bd5d12f8e35877956879fe02edb216f16449c58";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/af/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/af/firefox-58.0b1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "76be18af3bd07ce72f6ee1522d6b7e86f82d6449f178f07cc465c20afb9c453fb16b37aa6f301b4e83f9e7bc9affd8e76a52685be7a45db7fcedb50c99584630";
+      sha512 = "d72db113a55e6d70cf467c1aedf24df07d9f4f5d74f3c67f3474ba3c8f959a52164a345d19b6c43e5c7ddcceefd639a9153950f5f30c945f3ba87d15ea23a66b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/an/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/an/firefox-58.0b1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "3f544f11deed60cbf9cbd6bda27d68c7523ec087d71ff9eef74989b7185f5271d53e6ca7f6d463a64c11fda67692b609890dbfae73bacd164fb3cf7fbf327183";
+      sha512 = "ad347d9d9a8cac45a5f369a4fb8284893b60b7a94b2daf4d67273410b0ecacd53d0040f78aed43405b5a99e30cdff1eeb986b7c1ad13cbf3807dae915f4dfe9f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/ar/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ar/firefox-58.0b1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "48515a3ef14a0caf407fa69eb42e27915bf5a8ebec1de7e4f53d85fbcbc756fb763ab9e596e6580900fbf52854da1dadfa7f8920b43dc9d1a6e36b07b989fd82";
+      sha512 = "9eb1d698f2ad84a4e8046b511272fc88d66d5142c72dce817cfa00814f4bb5320c314bbcc36f74acd774bb9bec0ae57a09ab0c46def2fdf4e1f225d467c1987c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/as/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/as/firefox-58.0b1.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "376e899b9ccfa0bdb2a77977bc302c01504fd309226e9d63e79d1b799503284c7cc0ff8636e63afc17fe2e611594965ac14334e0c65058e80fc471f3057d3d3e";
+      sha512 = "d9315adfac80bbdd4af955f7f7f19d14d3209d7fdb1df538dace2264b39901a94b5d79f8944ed1509de15168058eab44a43de46d2c90c1707853ff2e4401a116";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/ast/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ast/firefox-58.0b1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "17fb3d94d037ab1be8912662c9cf79590ecdd2c17b227b38477f3aaf18b3fc6309c9a3dbdfeeaaec9134ed9d3de8a7810f905c68003db5efa6e733a8b22e8226";
+      sha512 = "3dc39b449c5eb3b877cfaff84534dc9d1acb3921d03ab2b520c5f02d1b8d2a09843976cb89954da1b99eab353e1960185580a70cb1d222dc42aed052361c4c28";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/az/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/az/firefox-58.0b1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "ef29f2265b91bee270c77afe9a0034c07138157c5be1cd3ad5a68ecb94cacf98a7c52de1985ba9dd51ae4e92df08a916249ebad24df4ba672d757d9cf95ee135";
+      sha512 = "6329d4265be5662d4e7286ee3147dd14896eae75738a6e29548fcd7daa86c1021a00e44508efa8ed686e58f1a927115f01e797472848b1782c90410031672227";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/be/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/be/firefox-58.0b1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "c002738e74b87b9423d8b6c8cc15fd6532adc4cb9558c0f059c2b0a1c821663c7cd8e741c5835d91daeadda8cba92938484bea5099e5b6d7c386590a69a513a1";
+      sha512 = "978062dcf2f6991c5e9f0a7b23ae65c1d3b79c526d27ac86be8f1190a866491857cc2f3d93f444a2c5654df327c53ebc05fc30e6c9e3ef2f766c55274202cc3c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/bg/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/bg/firefox-58.0b1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "b85df314c69649277e4a33e8374f21cb22565396685b742c6566b1c138daca254770c1d5e87f6af1f27ec65ac247b3eb888a14734cefd7a40755ff100b803531";
+      sha512 = "eda16736abc407eba700e6cc6eb865e97091c89772df9d23d8514b2c05d1197c014586cf03e3732a839dc6ff0e031f85008c12144736145f7ef94b89b7761e41";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/bn-BD/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/bn-BD/firefox-58.0b1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "54bd6f4fc5b2a2a24bafcf19f48c3e4d104449af06ab9d68a58f6d02e29edda65024f32363988034246f989578bd37d7c7d9bdb567d5869767f908072ce8bc00";
+      sha512 = "fd5980c7127464fcb4153d52096df9b4fc784fea4a3216265451394fa73800207c9df91a098860819bd4aad1acb0c04965dd196d41b0dcca70071b51a20e4437";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/bn-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/bn-IN/firefox-58.0b1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "c4acb6c52ba7bdc1e34f7020293daa2a8d230e92c19c700d34df6dc7052fde2928d2e79d252e9f2aa7b148d61328e839c218e5df78104617cf15a0bad8450b4a";
+      sha512 = "f82ddf7e43f17d836a7c8e9fa5a9eaf1c8956ee9b879ece444bdb0a4e98380c07c45cb168cdfdf8080d26ff330c0d71921d6fc65d1e59a7bd4e89fea6c2ba7d5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/br/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/br/firefox-58.0b1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "ceac213b63c36e6e3fc388cd725c52a77f223dd6864bf29a26c143d9b0631af62eb26d0a90efe737b08f2342096dbd32692fce7df281b6804dfed9798dc0a6d7";
+      sha512 = "6e98d54e5fcc89da576648c666a9788e1843c57879d3bcfe81e6f92c5a6386c7fb606e35a1d5b6d45a6c6208122f36f127754747b4b0a75b1b0ef9f8ebb1ec6d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/bs/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/bs/firefox-58.0b1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "179d662409f89bd47bbbee8903577048cbb114788ddc462b4fdb25c3a5ec1f7c5c52a218ec1b22039098761dc25f6021a14972d89522b798d9fa0104af7c5cad";
+      sha512 = "1d418dc9092188a40ec3ad5b168685840fe3da5444222a076324f38d71d332cfe9cba0b6497287e231252f7db4017ed31d3f004fff7425d801babd485ab13807";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/ca/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ca/firefox-58.0b1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "5b5b9558beb99619667c24a80341d74541f99a3cb9e3e958cbb53b7e7dc0e271071fd034fbcbcb909924a1712b6cb328c2de1c53f9d881a7f246fb2f92741f31";
+      sha512 = "8482b0b9552915cc839f560a6a884511e6470673684877fbff233e6af23067a9e5a04589a255f885f90efc1fa00ff826bd65e6b53d4993c4eba793b578d898cd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/cak/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/cak/firefox-58.0b1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "c5628b6333a0d4cf59994e70a1dddaa9143d498c929ed9237a6fccb87e5c19dd50c562cdcb4933d92f0b16acc7a881246c51baf1ebaf65b1ad897a208a20801d";
+      sha512 = "1f701c6a9946686f92439b354476c96254c8a57def972966a6b3f54136f259bc377f1f95801abd1e2e42785c2650f62dd449f01a305147ea2f788eaffb348b88";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/cs/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/cs/firefox-58.0b1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "e5262f2be60ca5ad641483e773aee80669f63383990ea217a9a35a26865e58102b962c94ad9d4a3526055fd5dc6d0963485d7614a7dd10c74fc28888adcb6a54";
+      sha512 = "11159a760106742340387a75637929eb1d7df32a811720ad509cdbd7c58cacb6b50621dba012bccf72f4960cb13fb19152512d9bcd83b2f17dcfffbf10d4976b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/cy/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/cy/firefox-58.0b1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "5e77baf6c754a44ca730345ccdbe0bac033d8c547f033306ecf4ffcf3015a3f1c28d0d4542899f873e687dd90a4d6dd60bc970cef4c884598a1e919873e4e25d";
+      sha512 = "387d647ed24ec9d7f77a6dc38796868a6324db960f7b8077e2b53387a1837edbccad0675eb9d4bf7a68d2ecb7bc60fc8840217d49865a05b1c4f5235479a8a65";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/da/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/da/firefox-58.0b1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "8903979b66612b7d8a856068a4ff1d4cd139ef96ca4fd1efe1abe1fa0af38a5965376b98522ef9ebefff28fee4ee6d3bc5d540e3db7f3047a6e0beda6b376f9e";
+      sha512 = "60e94f82dc68b5251b084e69be480e5fb281483d1355696328888d620f3b9e404abbb990c80d43a28acaf0df062948231fdd17ebf1dc9205cd1b74d962278bf0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/de/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/de/firefox-58.0b1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "dd2be7aa009dc3322a065ca242e35b73f35bb28f639146b189a3306689d018f4fa23f213cb075ff4306acaf07146e3b207bfe6a9ef8f8ba57e7a810e434da627";
+      sha512 = "a1699568157938780c4105888b528db7ef2277c8a5e1afc6a55382fe57b2009d7eb00351c2b993ebc3294df75bc452016a5c35e3428b4b548483a0fc4a1f2013";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/dsb/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/dsb/firefox-58.0b1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "15ab166ef554ce8d157cca1b11379f0542a2db0dc810f4520f56fe78b365f618fdac4d511e0fbae5f80ebbcfe18c03d9dcc3e02c49dd350cac7c01197573eced";
+      sha512 = "dea6a3e68356cfb47db8a6e7347437e88c9349113e73268964776ca8a1399671d648e426151cbec939b3b3b8691d8b2869536d853f0390d5ae4cfb982c2eef50";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/el/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/el/firefox-58.0b1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "4ec1569340e2490a445970f75992f21f48d13411199f65df788e9e43327de8fcbffc64d628dd589471b9f7b0b5873a54c3583b2d5171ab531c602a2b22dff95f";
+      sha512 = "b0eba65b07508dd2f96846bdf7b4a71b6668d8ae38cbddcd842b7e08fbd1769087b32f05cee00d8a471adac7c63845ba93b34d906092c9778776066610c788d6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/en-GB/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/en-GB/firefox-58.0b1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "1fa272fba658cea484b4f857c11daeb4abdd6e684040864d8eabf3d8671ed1019dc1dfc440d079e098fe7edae6258f39598b3d3da6301046d52460e31a409dad";
+      sha512 = "3fc478ed384adabde913525d2afcec4f3d029c85a102144b6ba7549543429530d3970edee5bf14ac069f122e2709dcac2462f572faa9c2ebffa322101929a914";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/en-US/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/en-US/firefox-58.0b1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "2106925dc8e912826332681de238dc5d72921bc9916488a242a0186a8550386e24a7eed6b67edd8126aadb42890b16c5572ff2ca6b1478720b00a5134267e27a";
+      sha512 = "5afe0a59430e9241a58af0926d5d73151355e9d64a8c8f562ca0369199824d10a1a4bc2de84102e96a8aa5921d83d9b630f49d9ed998ac4506dd481dc06264d2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/en-ZA/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/en-ZA/firefox-58.0b1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "7c33f60a0126c8058127499c178af6cc3398fc63ca0b1d2fec0ddb469da437349e063c61d1cd573fa157eb24f447099d82a189ef4026be865585883e9e6e41f9";
+      sha512 = "c84deb7d082259e29dd2ae7964c0ab585d3bee0d2be7c1042babc122356d067792166eabf2fed8a55c7f688c23ee7f6125d7c89a3b0948546091a54b4a136ae1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/eo/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/eo/firefox-58.0b1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "ef54f0c7c7fa9ae8aa760f4dd5c65734dbea6bc88f09dfdb814dbd16f86d1444f81f72584c3729d922c8f85bf4b9d0e2816d1ff4dc2325d92b8df1ff76221407";
+      sha512 = "76c714ce1840b4dcab54bd675d74bd93fd8f76a45f90e526b2e0c55a2fd8882e6b8c9c8e4f559ec575338eeeea2ec7f3ff75629a276eda0051e898256b0f2add";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/es-AR/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/es-AR/firefox-58.0b1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "f19457ed569da5316d167691b59d8ad134e0b10394716612843e4f56adfc027631e8d927324c8ce04188e0e952c115967e63782e6fea8d461dd716458835aa26";
+      sha512 = "b049c2e42a4868da6eacd1d5c0d945203acd6d3ed3803d2257b504df4ea7288765b6b6922d3b73397b0fd8b54a990b0340d4722a0ee3171a55e3a566c5a2bbce";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/es-CL/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/es-CL/firefox-58.0b1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "eed518d08ddfcd9be98d9905005b566821f1912816618c5ee1d3b76ee1972bc97e22e0fece4d35b64631db339916802d4c8e9c8416359fca0e77faea6127d53a";
+      sha512 = "48c2b419d67c26c6c6b5ce1e8b6d12dcd5bf8c084176d4c8afb3f45d17f50817a38a85e509fbc7cded4e00f659067c3e34080f58c22f74ba1e19e83cb58a415a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/es-ES/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/es-ES/firefox-58.0b1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "c26995c5de7f426baa55df935ad527b7a5c7490cdf2c3772ed680818e43ad102dec9aee510e17fc67fafa5c099216b3d23ffc7ac1f2021551e77047421ace60b";
+      sha512 = "2ae19907f1d812268b3c49247d902b061f9caced2fa87a19ef40c88de48cff7b68d26577b30ce7f1b8f94f0e1924f32205230bc503f226c4a85497da834ac740";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/es-MX/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/es-MX/firefox-58.0b1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "fb4df0e91cb7c1a7c6fceeab29cf90dfda6d977123367944ce59bde0ffca551c0c4853451735bace50f260ca5fafdfca5ee109ef0600efec5eceb20ff067a315";
+      sha512 = "e82f465b33114ad11628c06fbc0c0102e682d8e8277e3900888aa05481a3cbc4e707545ebf5b7fbd0eaef12e824135b437bd51676cc9299ddda1969c4d4bcf2d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/et/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/et/firefox-58.0b1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "e7784770c0f40e3ce90b2e3ed200e7aa1143d62e47069c681646d5f406b299e50c45a4986880a7ed789ae3f6228307a07cc17e1c66d27b4b7864447af16ef956";
+      sha512 = "6c7802262a3042a78d25ed5774db69079ebea48e540847a70c0f8bdaec7e87aee5ca4ea31110ea54db14058d4f7f7a0fd12a5100e2c66f9f4c1b591d17abbcf9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/eu/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/eu/firefox-58.0b1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "987b47288aec5c78ea75d8afc5d0c0850783034342de05c7ee6ebdc951ae73a6185dea25e5959d3932938915d539610c10d8943e2b1f094ee8f97c20d9add806";
+      sha512 = "ae43f9ed41f67610a1394cd27225585904f1efec63b2b8149a16515eceff0e2921cf8ee18c1555d69972af8b0fda71180a2e6872e9abae3cebd642693aa281be";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/fa/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/fa/firefox-58.0b1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "7ad730d4e8312d861cb0882b45dfcd4656cebccab5d89dd49e78533cf6de5c525b48dcfa3ec700cf14eea579be4ed2806e1673d73f7f32a6c078fa397cb9687a";
+      sha512 = "f5ca6891883c09f292a4939c0443bd5bda8b292e7f432d81c32d1fd5e5d4c15a7d649ea6d430a618b72522ffa53319c2b5a32c028ff2a619e0f68bfee7420dff";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/ff/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ff/firefox-58.0b1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "e1374f015fc8c5827ddc87d4d0c7c6ac7eecfef247c8f2e88c484c392160ef023695b11f8b02a526d266442cb54297769a647490257d54d7bc251cc6e03d7e03";
+      sha512 = "0a3e6d06e0e61c1bfba7ebca1a80fc7615210a148c48d89acc04f8b9ef2050a7ceb9aa7c92b9d888a376f668e4b6f1c0d40a752ba3de185548a3ac1630d9260d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/fi/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/fi/firefox-58.0b1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "f6cee8f460a52106d1b06f65b9ce17555aa18a9c5baa707bab16bf1cb458dbe6effa7278379d5d8e13394412f95a3472d793551ffd6788612a166216edc1c814";
+      sha512 = "5213bbbb4620cd718741f4c1f31e37addaa72bf3947a81255d556c6ebcfa2def8c830f4b9d73ef472acd28fd7efaff064fe96a67b1f276f6901353ed420bfe72";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/fr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/fr/firefox-58.0b1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "a1b252852b88523945962152a93cd0367ff5110642681bfddaf7d1659a232eed751f86378f29d4c01d08462e1d2369e23ce18f38b2580e39316741216b440f31";
+      sha512 = "6e4c02cecae55b7930521384482b9b5edc8480fcc103ac762960a8af4230e7eb52ca5d17d3fd71fa559b49c5b2d0eee2bdce150f486969f77f71a483d8cd04f6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/fy-NL/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/fy-NL/firefox-58.0b1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "dfe5bdbdb642e21094be85c05aac9aaf24af22917d7d5f294f304ce2c5e53328eeb4d850e927b199b8f96ff573af4b22700890361edd14339581b5f3aaa4e9de";
+      sha512 = "7263eb28bbeab70a833e28984108dc125868b1f1fc0cf3c1d37c3e1694b0512c028368363c28a1c0a48e87cadba366f7ce91509783805a6fe6f8ad7e298b27f1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/ga-IE/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ga-IE/firefox-58.0b1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "aaf0169774f0aa05b458d69bcb340796d6ee242f69dfd69dfeaaaf0647635e9e81a5658c3641c62623dd6a57dabbc42ffa3bbcb31b12c6efbf132c95c86043c2";
+      sha512 = "c64a0c0889e10d6463e02323e386142113afaabeff1b772d5411dfc747e09803911b161fe4332d36becbcd45bf0f1b5e000aba2e099c5bcbfc39b3e5d300e072";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/gd/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/gd/firefox-58.0b1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "161d0be36d2d590215eba19230bc660d19e6c6d2659d0fb14075bbb42b9033612cbbfd086f07ad237960fa732d1a3b2b8e9a759d24d808c8d250f2e282db234b";
+      sha512 = "70ee658038c2c2d8c9c12cd45993daa5226d35a8ef974cdd14649cf5cd3a6abc149f56eaadefef01d98daca0b5686a65b17300b5cfcea704c9942cf827e29aaf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/gl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/gl/firefox-58.0b1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "30bfcf0e3cef19fd751242eb523fd52c4ea96c829416348e36be3f3e48e9cc9d6be6e05c63461881a7289966b64f2abcae4ad004ab0ad32c91e99459bffc7df4";
+      sha512 = "73400f4ca91de506d18cefff5ac33847c1caf05770d0fac1481a58a3cd709eb96337f6f5f9a77635e18202f007f736e815fbe60ead23dd64a537ab6c67028c20";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/gn/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/gn/firefox-58.0b1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "8500db008a57146706f1f6617d12a58ec238382551e45c31e140c2da499ee890fa48245518b87d53457488850a4103a204bf97d9a3edd8c92b802402b885863c";
+      sha512 = "c5310f699ebe8f28f0ae3b07b5569c202aba5f2641ae6a365c4bc581780d12b736b8cbd2f7dab7b4b5ab4a8853af3cf004b3306ab47b71c50f428f2471c6d2c0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/gu-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/gu-IN/firefox-58.0b1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "0a1ff4f35272bbc744f7a33317fc517d78fbca08b63edb91a0859d7c0c5a0bb5944ac574ab4c347f60f7dda4e8ad881e1a41696161336379ab3a40f7dd62c59d";
+      sha512 = "34e9331c90ab69f43867ed77520d820386a3c9e5b116b6e0851b7a264d6a632fe69080d2885819afaf7c434ecca8324a2a67b2af4d3dfb0dd737a6f147d41077";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/he/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/he/firefox-58.0b1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "56eff40d5dd8affe55b8e920d0778489186824a0b056d8413c3196ec66d4d4bceecdd5ee0a3c72d7a99ca93e9fce85b0ee51e3f79aac1ed968790293f0fe6959";
+      sha512 = "b3e2155264ddc8ebeab870e3c865aba4c7c04325e526134c0132efd503b825d4bfaea4389e39412e047b18eea1abd6249754c4571c690c6a4276f8a7ad627840";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/hi-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/hi-IN/firefox-58.0b1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "f61d90b6aedd17f3afd25fd11bfb730320fd5e9eb0a7cbf24f3b0c6a5665c01b40cce8b88f753f7680c01548c1d71c4bb3a94ee16c4a87e22010269e4e03d7bf";
+      sha512 = "03ba58309941b1a209e2d162374abbd46c4fdfae505ec6b51a20a41e306d8c0d5070ebd7eb882ff63010f41aaa11be589e91c567b2efde702732051eb31e3104";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/hr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/hr/firefox-58.0b1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "d92b842aab0e1f4247842ca3fb9000f76ed2396b3e8bdb2f68de5b71956306bf30a58c20ed49a2c66b8551d89e65a21e9d50a69e78909aff4ac4ddab1af2c29e";
+      sha512 = "c41bab3259faddc4cda80d24f9b28bdb888078547c1fe63b7f7016748e930da158ce20707e78cd15342b6a38d37d0166094cfffbeef08f6266aee6ce80380783";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/hsb/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/hsb/firefox-58.0b1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "2be15782b4f478742ca0e2f00c6986a3efa10d63dd15f3f3ab249efa79aac8c0827c5f65ad38db55ec4789bb8e967cb9c397b8b5184d8ba91d5bb76b0e046648";
+      sha512 = "479436f7066df5ecda4e284a8b3b1d453385d9dda69b4b04cd1532f369dfc6ede9de9cae0218594b46dbf1feb0c44b8e5fdfe8084b9627524fd16ec3981fad68";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/hu/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/hu/firefox-58.0b1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "ffeafdf7b9792ce3d23f221d6b63671ac4a424f64e85996c7889f6257458d0902560b8b9133f133269191a1fc6b6d42fb0e2f1395aa1300e41c9096a6c8610c2";
+      sha512 = "4ded7381906f90f5660c81025d5ad1dd27e4c9bc49f464c84a05904d2c7a8c860f7576cc9f0f65e9666cc894084a539cece48f6242fad69d6f8f265f2b3f35b4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/hy-AM/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/hy-AM/firefox-58.0b1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "c6508a8049d2fd753c4ebca241db2a5a14a67843aa7203ae142144f7c1989aa28212224c3d09436710eb9049a8f6febb575bf6d7e301c1a7c568491e3d35b71a";
+      sha512 = "1e90907b9280b33faebaf770ee5e148f35a3d6d79f2c3d19b8d1834c84e09a6dabe965e3f9585dc357e145e0b8272225fc90c27ec507aad7dfda0aaf0c26db89";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/id/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/id/firefox-58.0b1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "f217a62dfb40b9956ac0cba5ba96598ca04765135626fc29d12f5e2d547cb74ceeb77f7b02d41f56c2db50f0cf2b5ef46b16ee0b8d6f03fa90f97fa30939c23e";
+      sha512 = "f2eb5f44cbe8c20e6716bd2db644f54768c6ccdbac15acbdc8268f95383545b3f9d9e74092dedf886bd3dc02b56fc9f0f468d1cd1205ddc5fedd361b557213ef";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/is/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/is/firefox-58.0b1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "4861ee96ad8136ac16b47c1721a6e08a13de3b4fa4fbc25dc093e61137cc4137ff598c4c76364cdbc79a922e340318cfc735c0abfc54bf28b6b76ad5f30a4155";
+      sha512 = "d1397242c59aeca21ff98f8b3e158fb496c6813de0a73ea5454602888caf71dbcf33d2847a99a224fece4fd60e24b6b4c0c7d1b68f9df0088eddd6011e64c9b8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/it/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/it/firefox-58.0b1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "7057172854e90d7b555b65ecc3c73cd254db1e5bbc679ebe84e840885017fc37af67fa1cc29960f7fc0b98fa6eea86e428662b3cf60df5f3c12149e36b368688";
+      sha512 = "468070735cbf093381640627ffe594efd0504e9a87ae2547fcb0d132e44d2ef3abb98861452f177d0d901ad8586b55c44189fff7b2dfb99d25a7d2055eb8410c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/ja/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ja/firefox-58.0b1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "ce05d81cec4ebe23214c7f8cfcaa0571a78631c31b489a2a256ad2d4b71be9247fb05b9a1bdb4069ead050ca0a2ebbd5423035e544f362de9a6590633b407e1d";
+      sha512 = "7cef74da3ff145b1b02a6b60f8f4b4933f427fd5268c4fac0cff31d0d09ec75f123a97ef08d3b5e8ce2d45bf44ac0d3fcdae0d0ab844608998fc51fb1805986f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/ka/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ka/firefox-58.0b1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "9fe9261290cfb4c39e6a6e2bca646232aa71c78b3953636a8c353da45bf8498250231809c5b2496a2bcbcc3aed82dac22b0dc41bd2195d259bc653c9126f16a9";
+      sha512 = "febbd32b794d70c4e1a41a793f69dafd230dddecaba329c65f34ff49cfe779d63e7bf53326a0a286206f51742199776190704c8e7c1f0fa0aa663a5cd2153f26";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/kab/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/kab/firefox-58.0b1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "6c4644299a5e45b50c9039daf6e6440917556a7c77bbdcbc63075b29e6b477df71fe5110de8cdeecfc160c9d13b1848541ecf777e3d5b3504da04ae2ee86083d";
+      sha512 = "caedabf8a7cc8cc54e46b6e9d7933fa7b04953dc4fd19311d097c350a8219938d3819ea34fde869f24a0f932677411114955670b179c7037b4c61ddf6b2674d3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/kk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/kk/firefox-58.0b1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "afe910f21c844f1af11e8655ffcbd00d009db44751884463322b17cb2aac576155be821fad093f2b1d6169f63af9a8674e4a1389e7502d2263343dc776c3c2e5";
+      sha512 = "44f92252326591941edccbe19f62a46728fb332bb9c83c5a5904f62e9f886ef55c792cefda9ff47136c2e90ca01059f71679417a559eb257464b2a1ee3fbd261";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/km/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/km/firefox-58.0b1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "4b090f71b3b8c37e6944de298736a03a046ee1705ce6a30a35d75a66caa51503093f6e6287110756ee380a1524c56516e905dcf65f9af3f2f16b7c32a177a8f8";
+      sha512 = "a3f09ec1af9c65a046ad84fc25a67cf4d5c81d16e7700ff3923d192e73846789b256ffce375436f10c563f0d31bbde6af690f8d36545412c6911329cd1315f46";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/kn/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/kn/firefox-58.0b1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "7776e3a75daaf0334f7a121fad252f8ec132ec35e32d8dd19e6c3880a802215ddfa2b147efdd21946817ef506f80c69e92dda3ba66f065776029ca39dbeaf64b";
+      sha512 = "c8192e86a04c82b02a8232cee724a870e70990d0a706177c1937897dd82e8b4d1b87f3723e8227ad266ab4bb75393bb1bd799d3d094c5d63a38bfd356f8ab0c6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/ko/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ko/firefox-58.0b1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "dffc3101063aa5c945b5eefd7bf487841676ba1d6021f22129f74520b5cda357c9134c7d99eb01886c70386a7bd8608fa2042c389a154b535dbd2dab471d0c47";
+      sha512 = "87b23fd57f68d60e55a01303a7ea7e4cc49cc017416eb582ecc6ced589f841504425c60e5b2b45f9d7bc17cfc0c5b8a6aae36b08314583d011bda59f96dc687d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/lij/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/lij/firefox-58.0b1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "4e80affa66e0cccadc62289a68ee6ea7a4484e86432af7eab481c26c278a23ceaa37adc97af571cabb0380611fbeaa4841b679454f13c35f39de7a6d1178e058";
+      sha512 = "a96df7d83aa66c52e73682fec0d06433a32c75a9d60ec225be4a29768ab245e3263f253c15f5001615ebd9cb2bce19a8c7ad9994c17801ca59a573986f4c3f97";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/lt/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/lt/firefox-58.0b1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "3701dfe9d3489e30f12546860ae0816d7b740345ff668b93e639f73da15ae362543c9bc6308d62b4b176836a348bea37147c7168c0e92c422b626419c079e06b";
+      sha512 = "ad89134d5104eee908b67faf1cf6770d9c40091de1da2382f67f224e16527e63a705d7a1ed0a5fcdfbff68813bb3d6de4a17d69e150cd702cc886d761ab2749f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/lv/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/lv/firefox-58.0b1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "bd32cceceb51dc5170c383c024b506eafc213b377bcd9d06ba38b4922fcf5360cf78b896af331dc04323f530b7ea4b39215bf57e41dae9510b928b40fd24c91c";
+      sha512 = "d28affbb7c92d56a3de7cdb06db345d73e0aa877b683b242ed88450471b7ca63e43e211e167041ddcfb10e408d6b7dacad09c102fa59465d337fd557ff8c6c1b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/mai/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/mai/firefox-58.0b1.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "5670c0b03d5e999c04ca1136e67d565b546a9b2750c18c639a79ed7c51afe6e2e1bf349fc2d512639194f352558c1af8db114d0b58f0370e3014907ce1d42eb7";
+      sha512 = "4296967ff83a31e5470bd0fb354208030a5bc3b2fd7d8358f0de6df22bb50a2636188ba54194ea534dd34244e1e036f1d525bb6a397633b2c1749e78160c5eea";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/mk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/mk/firefox-58.0b1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "c8cdc24f00b91db14231b3cc870ad13050907b44222fb4d84268252b572ca70c5a4818240e2c09f4e2a67517e2b3827f079fe06a075216c6017aab100841416a";
+      sha512 = "bb6c4a0320911ee062ad5fd2d10c2b121fbed1bff2de3f7014b8d0e4b5962814e52bd6d8e96ac4c88aef07bfc18964dbc24659c32b475a18a888723327ce6b8d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/ml/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ml/firefox-58.0b1.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "1dac139667d0c94413cd9b3262674bce3e0d72f9deaf9b9ae0c847b8073257ffe41cc1694fc6a12316811817b23c1b19747ee3031f397a1fe3d7a6f47f26642d";
+      sha512 = "c20dd470b07c46e105b4a3689797b25294a2f445825d7c3b9e55dca277fdb134003889f625fbf02807f56b04451223dc61b376337f0483f3b62e94e1b89d2382";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/mr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/mr/firefox-58.0b1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "fc37de2c1e80b25953dbabb745231efa8fe8ecca2c70f8ae8f1508c92cd8b087649513a2e6e0d19f3fefc627ff0eea863f2bf686cc79fbfe9cbe9419085c1508";
+      sha512 = "d1baed0c6dddec7f0f8bc731e8928eea02d5e6fda10adba7a329cdbe08cc3afb8527c47756b9db07ab812cb6bdbd2439680e001b2614ce1e8afa23b5091ff642";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/ms/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ms/firefox-58.0b1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "f610c6b7e44eb3ecdc5b28f181511f232e368c031e94ea63cd2ef34defb17f89b66397ef63e0c625cff4d67c04f208cf965bc41580b8f570b79d3e79e01f9a15";
+      sha512 = "c9162c9c22a07cbd8ac6a3aec1ee218925821e24c9f41965d11ce221b21cd99f77f8e91f0c7426d272c418de11d3d51ede0f89ac6710a9d05f50cd558e59f094";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/my/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/my/firefox-58.0b1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "ab3089727c9887b9867f0069c8eb9ef47e3f3d37b8381e5bfc32a1822ff34b3496cc1c81ff44de096717455059e1b5f7cd4f40c87f1b0168b4b9c14cabe3b4f9";
+      sha512 = "46b6758c2368780e6d0619a501d753ae51da65c55391aba72fb7eb2462c56afb5903afc04a274de68ee90afb98543f16536ab86cfc71219fecdcaf5b92fef41b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/nb-NO/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/nb-NO/firefox-58.0b1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "13faa2d26f5f20c0e571d6afc7f5e3f81f5dede9c3923ce96427f9256bfacefef886525bec56d6ea59d5f39f466f50f7718afd0850e3cbd1a0949f0beca585d2";
+      sha512 = "92f72a819c65e299e5f42bf08ddba7a87037da4bcf7f40f4a175c2813a4d16407e30fb767161a8bf33762848e5c1649293cfca40e77ac7f127d024593f9e936d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/nl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ne-NP/firefox-58.0b1.tar.bz2";
+      locale = "ne-NP";
+      arch = "linux-x86_64";
+      sha512 = "bd18c5c1c106cc37fc041722150131896665132427a5562acacf36772e6f77e34735a5c0799c8292feadd2ff5b91f5373937ac9f780b130c02707c63c9d10ace";
+    }
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/nl/firefox-58.0b1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "65c584e15f82c99417051a3ae14abd09b1a871a6371fbd6bf47300b4985ce34894a8dc34a9f50dbd106d7e0a3f196c870ff7fc28afab1ba4f5e7ccad3d281602";
+      sha512 = "f1b1ac149e1ee37cbf54e355364f6788c638f46f4ec82541728c6f641cfefc4c5369ec541723e91ed5c75abd8a86048780375370eca9aa6fd91beda1b153168e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/nn-NO/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/nn-NO/firefox-58.0b1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "8abe9743e39fabf29eab41c9c02001389852805a548c645acf53a4cf4bef1c1d4103b528a3efca0614e5ef858cf358d26deb4c61a72b29bf93827f133def2685";
+      sha512 = "7c2f8035101ac0b197095d5c7cf1117bbb82727ff328b7752b0cba8d707a519c385f37d987190226b1fcf8256dfc70e103bbd558814e62b8dcdab1f2477dfc64";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/or/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/or/firefox-58.0b1.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "8895fed23449529006c8f1c821fcd3d95de74fc368e8ade0a41abc39a16510ccdef3a45b9df87ea88598d3e46dbbf404fee545fd1c0f07498028ce55914b68c9";
+      sha512 = "1983452f6208949a0fd412712aae93f49f051d730b4f73ad95dc77086b745f39cc35e765f270f6d4c2094df10d99348c9aa745cf765e731a947ab99b48676921";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/pa-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/pa-IN/firefox-58.0b1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "c7367e682f0a37d99d5de03b5b7824596b74f8c79a2860e58b10cc1bce2e6f41e676cc39ec664817ea91a34c79aaf5a997cf7700d6484d5fb5271067e871943b";
+      sha512 = "1c86552ea21ae1c6a7d9745fa72e9e52754544b0f145e87cba1e5df6a719d524295331c6dd691ec5402cdc46fff14e68a7260da2ad7ebf56bdcdc8c9fc793fba";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/pl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/pl/firefox-58.0b1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "5b542121130b2df20c0d6789729254955d0192832c87a28d4e9d976313da09654ea9ab415f2bd9aacfc796b2aacba2321f13854cf68c3ddd9ff910939edb027e";
+      sha512 = "0b2df8461171913f2d6a3621c74ba497617e9512572e5fde0b5e0ae54f514e083b42134b38fc3e380be444196965a078fedd199ad3115070cb1d69f20f6540a5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/pt-BR/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/pt-BR/firefox-58.0b1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "dcd06cc70ff67138b5b9431c84e4b771449920e5973753db1f203f72f8636c69fb91c217b04ab95773efe4f324a7c63baf32a58978534bbce6fec47e967d25e4";
+      sha512 = "86e7c61df3bc0c1cc00bd4eab4ae9a9d307490c6c871792d8afd27208fa93c5ae4b39564caced53102d8ec5f2c7275889c23378f6bfaf4f44c1244b5c661dcc8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/pt-PT/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/pt-PT/firefox-58.0b1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "85caa2576bc8258cc3f5f5077b6a9ba816624d772b54c7c62a0f2c82e7e75bd0abd29677e36d709cb55eebecc9d28bdd673dc29d07329602b788c7d7d3a4a57e";
+      sha512 = "36e9e0fbddafbed694acdb37e46a2665b1bdead88fddf7b4859e33d48e6dffc904106a3c760619886981aa6cd642153dd203110269834d6183d0a09de6f7c6d6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/rm/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/rm/firefox-58.0b1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "82942a52ad073ccfc0f58e7b84b26b5394adb2bdf5f520ff946478a7299f2156e97e1ec5c8686dcd1d4b7e47ebd43eaefbb8fe2f68b0584f79ade7724981bfd2";
+      sha512 = "eb0e746a428912e1d15e20e2929fb6d3fd92b2954baa5e717e393fa0449d9c15e8396ae0c2aac50213b1320347869c923c5fe29153bce1182102971d69560946";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/ro/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ro/firefox-58.0b1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "b45fa5a738d92fb5cedd06b42c5ae4599008f6abc05149e8f47bedd024470421cf8c5d3a56a111b590894c0941d5cef96476aaf0457a1f3e2a5112143572a8e7";
+      sha512 = "a38120e5e5aa2202ce215a938619323565ca00021cee6f66eb8d5ebd25164e3ec4fd2e4bb13a0c2d95c9b215adfe2f663f62170fc61dcd156d49615d2c1a5329";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/ru/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ru/firefox-58.0b1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "0f7655a3f0f290a14027305916b7c4a73a2292e6140677cca137bbd9417473a9c286807f8279dc3e6d723af2c142bdd958f68c748a48fa42b8d0dcc5f88d9407";
+      sha512 = "acea191b728bf9be9c979be2b869dffb5d37649ebcc2511695c85daba41a8e7e3481fdbc474cd70017c75e08a054fa068a09ac52ba11cdc3803bdbfa4a94f548";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/si/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/si/firefox-58.0b1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "da2243a741a095132dda129af616e88fe4daca07e5a3d4ba65f18b9bd407636a3a312494a49cc1d48cf777650e44613dc69b49538d87616ca061264ba20e2447";
+      sha512 = "8f79244bea0d018ddedc32bbfd0fa057782d0bc88e99f82850f711dd753201f3903c588a1b065743750bdf09f6119e1af0720bccdb5f0e8e74c73e99ed267f6f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/sk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/sk/firefox-58.0b1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "3b09eb8284944e6bf490e071b64d3c373fc76f42d056635d4b3179068fba0064582ddd6deed1273fe429eacaeb3f786695824786f09d9ed1b35c4719f5dc97df";
+      sha512 = "6d54dffe631bd5cb1042daf577b6695d643d87f9fa332b24d7461b61c1871034195eb931726f2f35a76cfc5f3cffcbd44c34f9b5fff4ae9435b2518e8f6143c3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/sl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/sl/firefox-58.0b1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "47cb5682058b1240bf31f2358ee72598956227c3dc344c58d82ce61bae24ec68a6f5c06adf1f39e7f824ac365fffd52dd20e4cf93489b1f7de79fa88faa4d923";
+      sha512 = "85d6480d65f110bdb3bcc1c7187541d2c7a652629f57f42c5640c84f29632624fbbcd6ef70de804cdde9b903e1b6a81739297dbb7235b1cbc8877c77feab787f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/son/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/son/firefox-58.0b1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "738b5f57c0e7a36e5063ae7daf7dc51212098dcff77b26617a69e87392b26430414985a90ac81ed108f64d7b593e3a9e50d6dbd2eba79e4807309ef64ec351ab";
+      sha512 = "956ce25b91bc64e72a5160f185076d5afa51ed4a8a70ddbe20a0ad5ea372c9ded252ba5b29b355ecb7d7ffbf53f58da82f082f389dd178993059d911a3d8248c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/sq/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/sq/firefox-58.0b1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "7dfb54a4760e58880b2c0acef221c6822deb795f2dbf8e7d9e4d4949c750d1caea87ddbdf7ddce4d39388b318d470aa56d6bdfcbcb2a4f85f21ad0d2a6e76f82";
+      sha512 = "7b2429c1ad8ff0febea367d6f9b049fd9d29ee74be2418777dfee396949d54d05f976964d801b5a67a83bc34558e3a6940297fce135b76d0fa4df4bf220569fc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/sr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/sr/firefox-58.0b1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "7ff4cfcba96156775744f6332c8ecd931f4e33613ffb78b04ecef0f7cd26fc8131c8de34b5eee250b2860d8c5696899a9e87e1d6d1e34de1730845595d6062a7";
+      sha512 = "fa728c7049659aa6d2f0570ae037b20bc01eb15e8fa1315ff8766c7b4b93f2d7147ff8af5ed78a55ea73c57324b6c5882de77c905c984b55a3d1180e87444a8f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/sv-SE/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/sv-SE/firefox-58.0b1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "7deb0438f37aff6fe17426fec316b2392823d6d6fbe98309921f305479475e8f8262f0f9566e9fa5d03ac90df65bbc6bf85f7082ea84836de7df016a85f81519";
+      sha512 = "9b1cd04b974a0952a5525f33ba8fa1195b6cf874849fc84ef8c037acf4af1497e7041057b8ea0b362f5bf57df944002f2cfb06d2004eb7114a2491d7bae2cca6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/ta/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ta/firefox-58.0b1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "e30979bbaf5e66ba05800c23beb050c77658099aeb65819848fe282b00fd73b98e58cfb518f1db3e30132dd3ff5b3478c82db0177b7035952b6474157d9083df";
+      sha512 = "28578f38c1c6a38edaa5120dc772901ff7db0e752501ba5e949c6d64b2477e6c1edf59df1ead5356652f5f5f550c3520a75db65ab4c8ee430fa9c8fd62f76fb5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/te/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/te/firefox-58.0b1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "3bc7727c833709281e998b9201f2bf8e6e327d746ca080c73eb1f95239a30ca55c349040ff5789cadb03454e7ef836ebc3f1f1e47a86a19f3db1aa290a213a54";
+      sha512 = "3317b9857651cdad4dd3886a4a778889f62df6981d40c9c28e4ca09cfe879adaad2502108d7085048ed233be4328a7bdc24d264cf7a5e0955b573e271054a01f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/th/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/th/firefox-58.0b1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "3ef644ae9d627f2fb46e5d1870f6b9dd71d9c8fce6ec74e027c67b3dfeec0015bd5b59e10e3b255387c86c25d7cf55ac7379d30589ab70548040452921a7f52a";
+      sha512 = "171da97ebff3276da07ea3ed3b3e9fd3a09e1ff7b443e0bc6f9a31098515eb48c604a5491cae701a9ee9e8d23f788a5e2bc095cadc9060a014aab3b157dee825";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/tr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/tr/firefox-58.0b1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "6b67d6386251e7bbac5fee1f0df49d34ac03856b0a22f717e62c1d246c218594b164863edba9f387c4acc3a3e6fd41dad80fac6816fcde672635b8e3f84265ce";
+      sha512 = "d33e3b109238f1ec24cb4301e89c039bb2a7002bda379aafb1a46fd3621268d10bfb446ff9c81f3d96101c11ae946e74b359970f588a4d40af360057f6bc2537";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/uk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/uk/firefox-58.0b1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "89c5585413f09f5aab57532aa261d56f5df5b4f466608aea0957856036d5e1cf59763c7864e41bb9feb1313149ed5dff973193dd8c91b77e80ec3ccc9132cbd7";
+      sha512 = "b28fb0f609d33dcb5d7d9331a3a89979779fa284fe1a0ceac6badfb4549ea830d181d52f2f8d25c888b448b0e7400bc99bf829e185fdc06680bf81efd5f9b843";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/ur/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/ur/firefox-58.0b1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "e3cf517fb7f5894d14833a7febadc14caaabc05211deafc5c0e69604131fc5b566a2898f91117cd556c7d551392fbe0cf35ba4fee357ad53a40a756600371024";
+      sha512 = "1d15aa7b5ba212e0b2f7520f4a0c4c7f9d53be840a971852485ab3491b28c0d81f0425f32774cd90508eb74d42175f3ba76f3f20f21c182a276b21090062a9b8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/uz/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/uz/firefox-58.0b1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "d290e74c418d37cca154f56fbafa4ac9e07ec9e035d513f6b652567f72512c350212748aca15c3baff9b2137309261287cfc947f2cfdf81715e59b83fe6c2b5d";
+      sha512 = "bc750432a94d68897a2a39b425946aeb65e3a9980ce05dbca143615360b45d7f8afd0523ba9bfc4769d41a52ebe554e74d81981391a36b0a812a2938bb0df91d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/vi/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/vi/firefox-58.0b1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "d83f34b3d40faad14a8e9a91e07cb24f2ddfff65923788e258a9fe2455fa812b1b7d35dfc07c628f41b3bbd6b9ffc81dc0d313bacf33c36f5bb85106dc3fbc52";
+      sha512 = "71088078c930889f1747f087d6424743df809fcf62c833470c3222002c1037e5a91d6a2c81e08d39527c673e4d5e807e40c85ae63a7917796af8e9f1e0ea6b6a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/xh/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/xh/firefox-58.0b1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "326fdc7d0082257b970a3b38aa7d25e57e558a204da939f061eb6bd43cdeb17c2d65b9f6ff38524c14d5225e3703949a4e6f01dafd926336d404742eb289b156";
+      sha512 = "c64f34d50755e61487d9280ec60659dd8fc883effe88d61d73416ce740ed5205bff1e107844f04c658aa495bde5add5d10fd8d171312913e2dabf351ade7b481";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/zh-CN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/zh-CN/firefox-58.0b1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "04048407183c8607d6ca06b446e6da8b1cbe253b58561cb9635843479a1963474c26db589828c5586da8b76387b34696e3b256da9f978db51a96fbf3f1157bdf";
+      sha512 = "3e86e76898a2587d079384ebff6a511c6d8a212a1a4632c224de9a1259020358d0ccb2acd1383949f0f6610c284dcb2a942c6aa483ce61d82a8bdb22a6d95ee1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-x86_64/zh-TW/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-x86_64/zh-TW/firefox-58.0b1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "aa9ae37761cd9096029e5f83a81eddc0e21964fa637f3af41d4928675f02c2d4f0b7558dd79c374c6cfaaf74e464837e5d0bcb1c5eb55c68aab24d501b163ebf";
+      sha512 = "f560cfec6fb0999be49da6c27df85086a1dcb9f88d1467008c417ce47c596cc4616d5971eec40db5e112d1a57cb135ae12e9fafbc4d20b903c3e77dcf23eb826";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/ach/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ach/firefox-58.0b1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "83e9e88b26a4c5e84560e4248a2c465f0d73a0044c34b219ade4207702abda9355eba16222fee6c825118f70e36298d802cc8bb6e8806ff4fa099f8ac2d8173f";
+      sha512 = "d322b206a5c7e8873d9c161984a95730b91ed900d81b9ef53b0464192cfa52dda02a684a6bb615bbb109f1f6d93f50236dd36147acb681fbb3be8e08332e6d5c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/af/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/af/firefox-58.0b1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "d08c73098a6b95efc5ba120fe2d9e5c3ba1493333339e48e74346f82a4bd89bf65b1d3aa94f99f511d8716cc665cf5b4021da84aefc6ceb0a9b8fc5c21435447";
+      sha512 = "68b112350d8f8b4ca5499e04193ffb0a8871e8089bad80cec0e232f72aad4561ac9f44a33ef65b9014fce830a878cfa9975cc6408a70d7e62878453895e3e557";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/an/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/an/firefox-58.0b1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "c6b460a4b52586795c0d8a9ac51e7990b8a8b0245e91056b0b1ac8290643fae32116fb3769961981da81a7ceff4979b04c923d9bda01a49f93aa08172897a101";
+      sha512 = "69954435c30b30c77896cf195658e32465b93c7c2795f60ddcecf837b85aac4be27bf739250412bed286a9148754edaea29229593d0fd1f0dfdc02ac7918789f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/ar/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ar/firefox-58.0b1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "346fe20b1b98c2ea7be7852252a844ccd87b2bc4c6097818198c79af5efcaf905f25157b8249be116afced8955bae9912c08d9decb7eca31050720adfb7856a2";
+      sha512 = "962d6b22c1513c2d1e148e30b93aaff1a768e6f7aad5e2d2fa3403e47db1712daf14a32be51b5e2de74e789bc7db3cb3a7d82d24392f0af10c2d313f899a69c2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/as/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/as/firefox-58.0b1.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "d7f92e268a5ab4b3eb6f6d42f775a35237a529feb19656b895fb33398749024b029a66e639db30c342a753501dfb8c97868a9726cac33419c3d58865fdd24895";
+      sha512 = "8f1278ec528108c4b93c734aecac9a1cc28f5c459a76aabcbb2f03cb467299db858c89e167e8b576b74f58950979cc7c4d4c1fc563151abd1b1c50c4d89ba2e8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/ast/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ast/firefox-58.0b1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "a54e7fcf922ee97824d21fdaa2183fa45709f6989f41a96f913c664fc43d0d45be071c4458b026f8a22a10eb18f2b618778ca560b95dd52a43ff4897680e4eba";
+      sha512 = "bc79681e1256efbb3ffaf0faeb53f8336c6c3be90f94fd815670563298adfc6e4bcad5936fd7988aca49d4ad069abbb0e9769458455b5b8d338c3d0d36a93d0f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/az/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/az/firefox-58.0b1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "8299a0f1a33289485dc92a66600720289645e341eaf862678f6f0ea194c7f11b17a171ffb1f6d582a2810742f97085673bb8fbe58ce21b94e41b46bd1aa60e0f";
+      sha512 = "9a7360b36c18ef4668ded6eef44030e99e488e404e083bf63c1a47bda13ebe1b8674fdbbf39f2e4ceb3fba832c0e78ed3e280d036b6cbfae3b662a716dde8c23";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/be/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/be/firefox-58.0b1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "6ff4d7d353c4c4273a59d09d1c642bee5245c79e62c9e6a5818785f0c22d02ed03613e93353d59793e214bee1fe34de73271a1ec84d9f74853fd821582bd8ca5";
+      sha512 = "083df6a06d92174d1f9b0c8348d668e8834e03b4c1cac657f7cb4981167926f4d851f7f6b2071c077b99a1f5a2f717d16531092cf01b8c01320afcc69043d990";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/bg/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/bg/firefox-58.0b1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "b13a4e6ffbaae528136cfbdbe17f9ad8811cf2fd23d5764d583f63fb3ac2a76fc7ebfd51d8ec649e0f9e33fd618a5108b0cddd32fd25ac98bf83418086b9e364";
+      sha512 = "cc38cfa3f2f7bb99d4c4c25bc90d5756500ed3aadbd517e3bf6cb1e700cf8c5216cae2683e9ee801613375ba8442b75efff14fa17057c9e5cc0129a813a5260d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/bn-BD/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/bn-BD/firefox-58.0b1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "678021fce64a2725b8968d3090fe10caad1aac6a883a44c1a3fd7e2a5dcea9e9764f36249a299e9348bdaefe2bd9bdcfc3ae2d2bd864c5e66b022c8f61dc8947";
+      sha512 = "3137e5f268b52d400a67bcb9652a3d446879e5b68ce1ad5bfe0653e1f630dcab7294a9ac060c2a9238634df13274b948e95d3549065b471db6bc33e7ab03a8f6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/bn-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/bn-IN/firefox-58.0b1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "801fefcae2eb5d6959fac142d2ce77c6522b842b63f0a2493652ffe682b4d261a91278cea7777cd4d32575765206a4f7ce81e2fd73afe6466e418c40d99a7400";
+      sha512 = "40c279e62742135fa246f2f005677cfebe2e1530ffa832c435d3b7248edcb9ab28c9f82ff5a9118f05da98a0b93de02f5d66059cbac935243b6b7824dccd10cf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/br/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/br/firefox-58.0b1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "dd1e074400bf491b833e7ed1dc97d211371be17ff5ca1b3d8221965b5ed67e79594b94eef3a8a778f4fef679debdb106e5c18db4d75989d4e4e9e6c794f05631";
+      sha512 = "07fffb9c815a1a3299e3adf5016b2f9f4f405907f567124ba9e05dcfe7e098efffbf0cb4cc7b5ac3df171e9705331ea33cb02ce8c78d8c35766f13a328f52174";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/bs/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/bs/firefox-58.0b1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "444c9c97b8aaaadfa6b725709c6f49580f22e004f3d9de2c5b50f0f6c60e1496743c12ecce2b0482f3ff56408cbca14753e58b17337db016f7d217a5d62a3940";
+      sha512 = "f7f591e6783fdcd7de3a5e33dc43580937f88381458ab774b86688a7c76943afe717026b75ad003c041df426e22638fb085ebb640f459110f5f37f195fee73c1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/ca/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ca/firefox-58.0b1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "e59c7ff93df39d6e6365e751ed9fb42170bb17f05cf88d8fd96decef6e7bd69fa60d7efda8ae3100e169bc401f3cbc26c94b67137e960f6684c8f219b934acc1";
+      sha512 = "0ad04e6f72ad6df7cba03008ca5053f162c94d0e0109fe3d2d49e80546561f010f890bff3fb632ebf91edcd71bfac3f743614759ef3207eb19f1278ae2283561";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/cak/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/cak/firefox-58.0b1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "d0e0fcbc207ea7cd1d69d80add30bcd6f31e0931129328d17760c6681d12d6442c0c1006121ea8a7199756208868d892250be6405ee4d43ba23750fc9b3d7789";
+      sha512 = "1be5b051151eec3e46d9d8a5da1a44569bf56ce160a49041be51ad25c5081d019014a7c2a2861e654c39f8fc918c308450827ad68f409161a07e15de44f14b1d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/cs/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/cs/firefox-58.0b1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "9e7a35fdd318037a638eede7ae11c4c28b63e8c3893ccc38b50d25bcab229002a0f912e50719a358ebe6f30205f61187a3fe4ed3d93f04545542888bda18c279";
+      sha512 = "6362cbc640673f6c93c073f116fc98efaf5ec417a5f6754eaa28d750b4c239e12da5b89eadb7a1f163237daafea2b1fb3db211cf00d2062fc9272865472e4a04";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/cy/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/cy/firefox-58.0b1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "1a1edc73f902139e8696c2c6609c763664f61bc654b33d822b60a31140f7f52afafe3878516d705d90196f72aa38fca57e3a085d5d03651f1a8f344235e2f92f";
+      sha512 = "d72e0eeaa88a03af2f8d10b329d5d734841aa45f05f6c283e2774a7a80625c638b59bf579ab0609385557e911f319701a073e6982f5319df717f786e11475df0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/da/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/da/firefox-58.0b1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "6a5833ecde7edea045ab18325a55ffe19f55d0a18af879caaeeac3b00b7412e2f6b9330959068632f3d87b932f544a993c7d836a69f0ab0be310c07c46851b90";
+      sha512 = "7585f369e94b4f2f0ecc9f2ecfaa059c0295ee96e13cdd93f94a6558d99764bf20b248a47cb1ea97cd4f7f14c37bddebf4e1f1f396df5384795321656882d790";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/de/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/de/firefox-58.0b1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "c0e0954430d656565ce99d91c15ba7cc74da840034c4f70fb9ccb38ece341c86c500b27a3d1b57e8f5da4bb6484703dc98c6b8ad3d95972a9316a0c549de9814";
+      sha512 = "94610bb17c0164a9b39fecd5c108f08b44c98a7493f9db16305cfd1dce95eac8565d57dabf3335c674b92a45dd8590f95f4d0046bc132b724710cd1338d712de";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/dsb/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/dsb/firefox-58.0b1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "e5ddd864a5ff73edbf2152828b036095ef1197595cf5ab751cd8037d3fff11c9e119293d4adb427488c20e0bfa13c064c76d4720c709d4ce31eedd74395e8dd5";
+      sha512 = "1508bfb8bb5d2756ebe39a9e778b45baee849c6109022475e9106ab79a03ee49986421b809dab70d924fa0edc6613c877150de334738cb3f9a9c53ce3d524ce8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/el/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/el/firefox-58.0b1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "bde94744268cbceac403a4f166d7cd9d182c18cc8321af72d0197de00737b6f31f7d1a5513d1702d7f29df3d4eb7208d2a5086d6e0bb7a2d9b7fb33088f82f31";
+      sha512 = "660a1f30c682ae84aa75d7519e76cb9e2c30978a5195a9e194f734c7b37ed2b12fb216a50c44c0278aa11c51e426b7b85a81363d263dc49a41dd7935db4bc49a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/en-GB/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/en-GB/firefox-58.0b1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "48d4fb95963853cee8398c168f51da141ed7e5d18c224d15c35f184669997248078756e6da0f619ed287df034c7d9836f75188c5c8ad17b4af9d1dc022336eff";
+      sha512 = "3e52290ebcc54803162781fb2b87389819537b6e1ad671c8bd95185372ea8dbce11a7cd40ab6d71130effba71155c16be729d0cf74bb39e0aca3d1547cd096b9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/en-US/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/en-US/firefox-58.0b1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "22555ce1e9f574e5e2e9b1164071ebf2362bdba7c182b6989b8da5e7fb736c7c6444faa44d52d91041d1862c2ad8c0881868e63c424b84d88ef39136e087f87e";
+      sha512 = "f1aacb89284c8627c55c186fc50a5fbb2db42577e0c8db86889599332f711f484cbdf3f53c0ecafe4431da35fe51c3a8b7cb831710c19eeb7eab2ad475061684";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/en-ZA/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/en-ZA/firefox-58.0b1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "2589efe14b8762492d668def0b4149755ec9ace70f581a1fae669249cfdd44d5bfe60a718fbe300bb92a3ba631ec8b0515357587c8d095013916320f8f1a90b6";
+      sha512 = "f4eb9f4dd20a255bc054089a71d9fdea91c184919b8bbf75ced397bac4d4ee1fb5299d60203f59701ccd1673439653338071fa7c90c32ed0b94ad78cb510f3ff";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/eo/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/eo/firefox-58.0b1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "1a614091e1638edfcce4d755d4529594bbbc8785ad33af360b9003c76dc64dcd227f71a28e4fcc13b5b2a7afd2858bd9ff6287e7b97b48bee5025ef1de400870";
+      sha512 = "b310c3d01ed998222d922deefb641333239c57da410fff273f238c852e75909eaf1ea851afce1a93257527670b0f0d8861d9b47b68cdc80c5ba4c8bf1afe9775";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/es-AR/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/es-AR/firefox-58.0b1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "508812c53be4877f130dbcf0aa712c6410774370b54571210f3c52e1d92fa0477d43f2f24aa95198059c318e91ba7a8fcbfe476cad03a8256eb37eb88ca9f460";
+      sha512 = "95ce1ffd9d736b3ee78e22c3c8b6185d55fc3cfa501bef1779f30d345f4af642c92ed5a0248b2acee04136c7ab04bff604f6931d8e19fa86b9a0047c18d41569";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/es-CL/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/es-CL/firefox-58.0b1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "bd7c5493a92fb7d6ee5680895ab24bede3f8dbdbe176166599fa918a981d11fbd124f4fab4b2bcd5f88df5c1cdac48c85a2fcde0fb87ea361ca2baed2db9270c";
+      sha512 = "2be8b488b2c633513e9b8832a3be8263769fcd28721bf26085ffd62d855aa22eee94bd32bf57d19a8a226d6a5997c4595e4a1d4ff3df71948e66ef9d778975cc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/es-ES/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/es-ES/firefox-58.0b1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "cde05cd2e4127258cfa26c76c018f2dcf8214a75a8c4cfac5b4dfabb51ffc43f21828e9a89fcd326cda5cd0c6fbd09649259b81212e13e4d15e32d0c1b87c267";
+      sha512 = "e5b26bb9cb2a428bee971fb09694a47601304ed5bb49945ce83a84eab90d59e4b60358baea20015a54e4dd8dee1beaa9ce06f80faf9e1d6ef3572087eccee172";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/es-MX/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/es-MX/firefox-58.0b1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "75b8750f830a6353587a9eb555bb2e207b9d7e37894b6b2334be1dd27025d69adefdbd7ae1bff6c7fed823acf2684352e1bfeaae8a5ce5f0721838a82067a6be";
+      sha512 = "2069a6fe973341930bbb482a7983d49576475a6ab858089c64e388812002e698efc7efa328508cb52cb38f013edbe995b5b941779e03f4f44afabe0b013f2209";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/et/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/et/firefox-58.0b1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "f33bc9d8e107eb70ab039257540e9a3f96826e597771ad86ec416773a1755b1e5551f8a14664e8507e29eb08d0e3abc8e1eb9e00c4320ba82b32c9b7eae7a68d";
+      sha512 = "65c02f08263fb91e5eb5f4edc445f1590e96586890200298339496ec93c9b003eff729f96ce2a954b80bd8161e1ab066bce5df1d1ec501292f4080bd3414a9b1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/eu/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/eu/firefox-58.0b1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "94c844674a045f2ef4d2dab12b070e49f6a79e4d86856b29965962df420b4dd57db5f21dab66b7a54317dc908c9b29c9bb3ab74a0b4b8eaf806e2fc2bc45a821";
+      sha512 = "b45b71c7ce796bf6a9bdf1e07ed239b33655ef4b79db6d45be4ce5137039b3ee3e10054d90db19b3733b92e9c77e822c5c27b23f1fa5dfc0350129571e56e7c0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/fa/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/fa/firefox-58.0b1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "487d78630469eaa93bfc24b1b3a9d027b57b62c74904d9440e3cb173a86182e17758f98013b3089a173da0f671e2a44f334c61835f1e6f143d3d83704e36f3b8";
+      sha512 = "e64792f27a99925e49b10db7442963d8ac188f3d2d658fbb6a15e2ca462e2c609abd9f265a6577503b3bf62d9e64879c44917f541d84bd389b6f6ff4150cdf1e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/ff/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ff/firefox-58.0b1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "b6465926764e311aca0a74f6d6fb19396f0475bba5d2c43dd3af124e7d6dd1b0c018fd541d2c4f5916d8bf03db6a93344b558fcc392adf222893716bef95275d";
+      sha512 = "ecdf7ffe75352bccc1e5a642f48ed82ed7cef703193ccc97163177fc3c7a77b5bcf4bbef452ea1768ca490037ecad5d742800ec45d984e41dfcc30dcbc70b3a9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/fi/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/fi/firefox-58.0b1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "76f0748b9337bbd7232b0d1a056378f4149b1539bec8c43cc99b14d8036c8b737d71467b8d46fe51a4dbe0cc1fe3a061d749fe3937ad5df045da374ee72d4581";
+      sha512 = "063fbd923090c7452620db1a42358687e1d29975cf19049a5867c18eb0265790f4fca2644010196c09b639e63ada98ffb71bbe17191b31a0cc1b4fd468b4838c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/fr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/fr/firefox-58.0b1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "84ae5e6b2d6a89bfe20646064f97ecab399cc916ba1c9a17a4787c6e01cffe159fcd563a595f0362c20132dd4dcb143334145a05c7cd6e065678b73f6b5c0017";
+      sha512 = "889f628248f6c504198988697f18cd2f99be305090350aa5fb8d5afcdac572c14cb780ba07e9c3f98b6155f29e4d32fb5f140886b0dbcc55d9a71cf31d058fc9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/fy-NL/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/fy-NL/firefox-58.0b1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "e1e8a0d6f1e96b7e4f6e8c315b04130c36717f9cf5a47d3fff06dd1b69ab424674161862296b93fa294a980afe75cdf04ec115e06272cb67cfd74809747a2bb8";
+      sha512 = "8749fc2e704a9156bc944f89626e3fdb2ac51d325cc6c3f2c6646c0a60d6029caf5b51ad8cb6a269cbd4b6c0b23b719cfa1f7c4dd1febc3cea2febc6b4964f5d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/ga-IE/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ga-IE/firefox-58.0b1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "3cfa2704c00b21d15445489735753014a481ad5b8eaef25a2c6ca35122aab9313b5cc9885d685c3ff206ed895e14dfdb7518ae5476e86bb35e6b81f06e54aad6";
+      sha512 = "93628f55f76a44041a49ae2c2564814b277095d33b67fbe4d902234554a30461acd5eaaef74780722287874ac4080b8def72a2fece9ed72f5a9e6d2140cebae3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/gd/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/gd/firefox-58.0b1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "b7e4e20f35ffe7275f8009194bd8325c3c8f6c02e185e7a337c85d03232909a44f1d4a41b598d466f560339c0e64cc3babeea2ec2efee0ffed015a791fbe265f";
+      sha512 = "af3bdeeb07e2f63628d787f66d0838bc073b927900e6358768a083832a13e0b056ea1821a43623e3c385b6a77d6cef49cdeacf7678be3ba16263ea7c34144d4e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/gl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/gl/firefox-58.0b1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "9759d271de728720319dcd30507525a1693d00e6f443a5921eb221da1f0e2c122fe1da36c881b0e4032cd5ef074438da5933e8c10b42370f114dbe572204589e";
+      sha512 = "37082a0429ea2fa9d8009452fc9940b4d507f64a5285d67f3f9d77ae4846aac4d40b58f4ea5c6b6684c5c59057bff330f7ca21a7ce240b78037ca90589231990";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/gn/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/gn/firefox-58.0b1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "9d4ee42485ef63e7747538362a4b5baabb4ecfa706b4c8b0c3fd440c48a6d15c4f8a1cf5e2b8ec71672dc529b50c7a6645986a867491e4f14e0cda127db5bc13";
+      sha512 = "b2ec403ccb785f8eda9e1a03d5200c40827f20bf450a334f8ef0ad1a1b4fb38ba63b812405360efe77e0c6705730dc484541065a969e9b51406a47a8a13fa32f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/gu-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/gu-IN/firefox-58.0b1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "45c21939311dc0414716ab272fe72c063b8adad201f2dc7893347a66c5e9abe7f1b215a4d75bd3ed3801b823679fb27f5cfb5fb6691785126ae516f237133ac8";
+      sha512 = "2275c8bf1639108c77b304140ce32a69239fbc96a371c1d88464694f989deb9264ab41053c3a2d3e1afd6443ff3f0fb8e58b61d085dd2f6cde346867aa380c08";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/he/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/he/firefox-58.0b1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "f17386cf6652a794303dfb24dc439031630239a9e7b82afcab0bd49bc3e018c4ee4f499f3c1557c68d38f74c37b8775a49fc72318a08fdfc2ee8f593426540a9";
+      sha512 = "982b15fc9cef3fb813154f90e1ca6d0768237b04ed496d91c141c59e6b59ce0d02623644d12b885339e6677b01556d1724f3010ed06cce89c1d26a3cbaa9863d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/hi-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/hi-IN/firefox-58.0b1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "c7311b1a5d69439b93fc0865394895e3d1776fd940d21838d4681659dd2aa222cf1aa041821f5f385cdf904de13e8ee16e000a582495f9eac91c0542317eec1a";
+      sha512 = "40e6842ab3a8fd79bf9c06cbb2bf1aed9244e87470a7b39957db7c48f8eab2dcbd988c47b81d362bfdf19e7c9891c1ecbf0183cceaae9761c38583aff32e6706";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/hr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/hr/firefox-58.0b1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "70eff0fd9ec9c9c70ddc4afd3b95e427a945b35dad26dc29b166d784efacf9960738cbb0c62c700cfdcb48b38824d34ce46eef1ce0f55fdf63932beb1a69b04e";
+      sha512 = "9c798f2d7483a4b122fa579c0b40232a312a5ac7e19db9a940fd58aa7b54a52494822bf545a79a690c181d47dfbaa7e4e7b9c70d68a981e9bb46f3469b356855";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/hsb/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/hsb/firefox-58.0b1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "973817d6011a72c676b14f9f5b333ae53fd38af8a06c5434eff0debd88f3beea8d209331870620dc3457cf0bb0f24462d2f9fadb302416e0e9ce84928ddc4d23";
+      sha512 = "b00f4b0e377e413c196eadc2eed1c914b496e6b71742c51ef87ec502308fae0fb55c0d69172d47a9ba6271b137b50e1fa365781cef11d0d65ead0089d8c16ef0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/hu/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/hu/firefox-58.0b1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "836aec8829d07baced10aea1b461a4b503bd3887541c6e030cd802ee1a04d6533f7f899c268077a3f79e8ada8fe2606780c506a24f0388e3292e6935afc04048";
+      sha512 = "806ec30cfbfc22fa206dda8e3cb5b43aeba99866a19e8fdde212b95c852bd2f313f451b93409d153c0dc07ed5e1ac94a18b75f91a4ba9b4787a89b77491a5293";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/hy-AM/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/hy-AM/firefox-58.0b1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "9a411df379d0f900fcabe91515409934da6d51092a4a44df7f7e003f1761504b399e353fc93f69022b91d72c44198d35ad9d7e2cf9be30c549503043bcee9b12";
+      sha512 = "9e3a8e46d15d9b71d645d830f10e3ee2089c4dc5083dd2debbd3d9d05ef464b01405f920d9a2787d5155e533ec57c3fe3def34ad88137a4542a2cf5cf8a904fb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/id/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/id/firefox-58.0b1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "e91a619f10a6b9948bef49a5c21545f3881430d8f6c7b5f0eae112c9b8716519a88c635c37cd89586d8ff4669e31f4b549b4eed6cebf5a13a48df9ccd37e3988";
+      sha512 = "253958e0e6955a8768c5dc7645f6431135bacdfc9c1552305f7409c8044a3bff529a87bcdb2a0676b0eca3ec90de34fdff41a46a9ea63c5ab038b4119e231b4b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/is/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/is/firefox-58.0b1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "aacbee57162998c21c870d541bd453130292211a19aec1d2b3ed0695f143eafff132cd4700f9a381e405e46ee1ec5865017c447771fee7bcd9c0c8586601c1ba";
+      sha512 = "070ba6e602719e79d2a3ecbca1f5c3c412c02cad89c8aba624918179b436606f352c6fc0586597deb2ba7f703623e0484c17a11df78655b4ca0a1a6a826a1b9b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/it/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/it/firefox-58.0b1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "4388a33307067545cbc6c292a5aee825a53d7e38aba4847c347aa4ba3f30df2b2ac15430fd4a28a7fb490efc7c6a6d555d58d61fe753e0f8368d80a2a8034f25";
+      sha512 = "9f624b314b29b1ebaa6c92f2b8cf7b4a0b3c38851af4bfb123e140f49435e294a7aa2bf6e449ecb6b315b893d5d55beb487d30814cf6d72c4905eb7df91d0327";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/ja/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ja/firefox-58.0b1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "f37f851f573e9ae734ad819f5ba22ff97a9081c10f63950ebc52cfd97202b295e035129fb7f4afcccbfface1de188f1ec8dee7bee14bb3f0f779f9cbc00667df";
+      sha512 = "22a95b25a5e66280791fc18bd5050db7726265aa999ad959b07d45c7fa4720f067749a60e33cf8f548b93adbf440e15e47269f98a31d3643d157ed3d3c46b9d1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/ka/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ka/firefox-58.0b1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "f06b7589ad1e2d96273be1470032d29816295ee48f05f9da685e210e0ecf35187dfde82cd5a6596ee0a0ecc8143c169eb2e7423c4f9026e3b06851b6ced6e3c4";
+      sha512 = "3cec01bb5d98f192426cb39ccab91d823604b7c722831baefd8f1f6deeebcd5068a9ec8ad52cffeb02842ecccad891534598cb6a898adb40c0fda77a038b94b4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/kab/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/kab/firefox-58.0b1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "c4ca6d1a50378309bff211138924f7b3ce22705592186c14d5b17501f2c49f04a29b4edb23746efcbc2947e0de0db88d0349c85e5a3b7e993649eace1975965b";
+      sha512 = "9f43fea99f324955625889082fc8ca119d0aeef63d226532f87121c6659c0c5a9cb54a07faee30f8b1b10ba58ece7ca1419996269f05c705fa36c364c8fb609b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/kk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/kk/firefox-58.0b1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "78379ec69c88d1ec8c03feae66d4f4ea3b48de0c324084f8f68a331bba16cef5a66f388d5c0fad4cdeb3ec9b1ade21dcd67e4b5fb026319718daaa8a151d1e5a";
+      sha512 = "c3f10ae05036eff27646d613699c4be408891917fc9d523e202f58815d2ce76a976f3660a507e6f5e4db4dfa7172227c6ab874c8586997d530808ff409ef827a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/km/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/km/firefox-58.0b1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "ebcd7d6259f83f7ac9528e1eaabe7f75600ea96c49ab0f55c77688949096d7503973a262761ec0828f233654d0aa2271f338a756335f27b73a6174aee05e6f9b";
+      sha512 = "d25c83ccbbaec8e599c5ccbd5a21926020392bad5349d65e62a12f9ffcf7fe44bd46fb79974bec12fde2a79e43c6089b9906d5b6926cd17daa30ac3dc6e811ba";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/kn/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/kn/firefox-58.0b1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "dc9f84b8d3efb12710c1a245bdf26c54f421fb6b993ed4219f28bbece45c37aa5c118206cc9c4e2e2805a667d90b7993462e57778c0eaf8193c71dd3111285be";
+      sha512 = "d707cabbe662203520681556c9dce1c7dd0f97e002b795214d17e61f8ef6bcbdd7e16b77f2e5bfd1a0fa80cbba9cff49f4d416f1cffe04138460a49dc7baeded";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/ko/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ko/firefox-58.0b1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "377b555ea022b2a963fc2fa9bd44002485f575710925aa5d7056b2c343e476f599060e50e708322c535a8dda3cb50255519a833c031e2aecb5d4fb1f1c3ae65b";
+      sha512 = "c6ad38ff830a6a1af80422af252bcf9dcbdef4151deb59e72de10d048649f8e8ec7ff3013b50ee4e3851afdf609a019bb15e4bb92d93a848b8cd2d57a0bf5a3a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/lij/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/lij/firefox-58.0b1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "56985bc727c6c7baafab85cfbc8e3fd83f4770a446aa2e6a894983948af99a36f522898bc35a17c1e91edad7eb3a80eb736a9bc75a0cfbc1cda49f617d649edd";
+      sha512 = "98dea891a50e0176283eb7435aa36e038e2608ed32ac46b587d6212d3484fd42c5f4fa4dae98878fa2b79c69b46f186ce4487234cfe53474db2fce063bbebcc8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/lt/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/lt/firefox-58.0b1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "fb3644bf073c9c418ea3db482780d6a409e7761e31cb82641d6021dc90ae81f3f955cdfc3f773e4293a29dfc43e93db3d0feff8124f1dcee23a80e3006cb48ea";
+      sha512 = "5b0ed58b46552c756b47a83b6334c7a47184172db0babfe9b40e3b296088f8814ccd190854cc24c4e79f512f444ba447321848ed34d105c419ec6b1372d746e6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/lv/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/lv/firefox-58.0b1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "5a273bc8d85095663c6d66915e31c2cec48274db8445a3127b5fe23e1a6b59e0cf398a0631b23d7e8e29c2bdb40ea4b1f98d2d09c34f1f609e2b35f106263785";
+      sha512 = "34a6f8469d4fd7e4fd2c3c8f8f336be95160a076dd7a88b58d345ad540179d241d4a68b46c122380627b2177509ca04a565a53364a9f2190017e75dc0b26bd1f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/mai/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/mai/firefox-58.0b1.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "13503b7879ae1c10e151ae85ef0f657dca6bced41bdca7b2ddaf3445c56e712c2b5c084f5490d41c5459ec9c5167c62ed517ca9083dd86cb3523d00a84ced8d1";
+      sha512 = "a5bcf34dd945648f6ef88fb96d7b545936aa811f4d1863fb1b381df9e4190e74ee08eb38bab30a46bc5e6449c98a2b3db99d70a62fc46ab85a178bceab7981f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/mk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/mk/firefox-58.0b1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "8071102677b25f92dddfe1b5ad16aadd9bccf4a794b9df4655f75777d7d55fdb0c1a5e4ab292c222e61302f1cefc15b649ac17fe58680708bea2223e0c5f0a66";
+      sha512 = "974c9f4ef377be4b456dfc74d8510074f8bc0bceeaec90670a806fc583795bc06360b4aa21831fa23aff8ebd8d4b8ae6c9f88126a9374b4bc96577b6cd7a5b2e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/ml/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ml/firefox-58.0b1.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "962cabdb6a3baa3fe6e25885eb27c5f119c37ca27fe75547a704b3409375d7dc61fdc4a1e4e12f0f0e6405f7be08dd628fd53eccf8431645c549bdac6ff6e6cc";
+      sha512 = "a2ee22bc5caba643d7694652c2f6288aa6e709ba816023321997e070bfb84a356c6b5d5b92c4a973554aa44862e673690c388d92ac5699e4aec7290d24054565";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/mr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/mr/firefox-58.0b1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "0758144703046081bf3bf600de84c7a71275d73c3b6f9f27e2797937250b8ad288f41081fbf6f0c31e4d0bd61e1a8c449b546839e2a1da0ecda4097e7de6482b";
+      sha512 = "cd828c6366c5450fc3fc5e16268cbccfae4a14bc2cd8041f2965192a9175d642527194564d9891c57bc6f7f8d70ad56338908520ec1c24407f2bfcad1ec1070a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/ms/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ms/firefox-58.0b1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "015433073ad4703c7636eed2e41645d1505b9ead82a8ea5c6e1e639e28db87d0f5afb1aab0e7bb852b2c5b5be7182bfa6bf7bf62a2cfd29d4948b1243d29ff2b";
+      sha512 = "21abfe77496cfef3807c962d8f9328511ced673627dd7227c025733d5e229683590b4200e6654f6c20d1ad82657d31ee4dcb64b6d83f797d0c7fa7bc3f5372ce";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/my/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/my/firefox-58.0b1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "603b30c61668fdcb0ee54e0881fe4bddd6a6787062060d28fb0a5b632e178b8396c868c637bb08e0e1b03e51d53e878407505f484d864175e357c9aac790dd9c";
+      sha512 = "5d4dec8c8107401ba3e09a1137866b8f690093be14991a0890d941bc4530747d3f64d9cd68bc41dab92b95aa566a30ffbb4156e69f920f0aca7d1560dd9c19c6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/nb-NO/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/nb-NO/firefox-58.0b1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "6c761e7827f210386ccbf210246e2a68a200ed98c3c14b18a9a4b9ceb99383cf59ec2873c0c5fd749a8ccb71575691fbfd0ecff62f9a044b3e4d2c272232a15f";
+      sha512 = "10eb68ae015e2a686bea9340f4a26776b388d1a0394ff229a18fc0861a5bea9b3e726f9e3256f99463b2ef56b0035bd17beb8a06b6b3d57b14e22ebd396b135a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/nl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ne-NP/firefox-58.0b1.tar.bz2";
+      locale = "ne-NP";
+      arch = "linux-i686";
+      sha512 = "6eccbc0c1cd1307a3f37893b3e0bdc01d9de889fe5a203c034aee4ed7a615d8d049728e7fef4ee87776d9294223839d6cf15565e2a7ced72bda56faab5970a9b";
+    }
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/nl/firefox-58.0b1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "2847d4ceb5c572c090eb030a3c5ccc03a2a43f43002f4e308695905f7ed164bef73d1342800b7c0d0932d5b84246d68c8d5ef1b84b09690558d5b2b7453312cb";
+      sha512 = "f1e27b02d460af36dba3fea06c83446a1a12a5994fb3e8ad84dff769fe2307283e7d8eb4dd04211d1bbc12a8b058b4463b012ab01fd8996c12718072ac94311f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/nn-NO/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/nn-NO/firefox-58.0b1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "892eca2b59ae33326c1699afc273c0726b4fc26cea9adf7787310833bb50fac07bb2af18fbdf283f29ea1ac737e654a86bd844e97a0df408c7eb77c931ac4d85";
+      sha512 = "d3c6c97576c393f9a32375ddfe2b6f7055fda84e340af9fa2e4405c0d2e76f309da67a4885ffe58439e7394845c78815bc4ff39367626a3092bf96ae1ccdbb3f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/or/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/or/firefox-58.0b1.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "0c4e996d5d73b1b13ca6fef1ae79a7f4c180cca8c6b5d1666c7172f80767624f5f64f70c2b5597ca22496e161379b37fbfbd20cc94998488eb6ebdbc1c2a9b5b";
+      sha512 = "93c8b41c446b15144615ef7c58ac81f0e63dac3747e874e52a6503a953cacb9220274dcc31268440c95dae8b242416dfeef39b392e262bae5b741a323be5fbcb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/pa-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/pa-IN/firefox-58.0b1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "eb30dba1b3ee43ff2e6e86bb896b36e775ad6a803062aaa5c3ec68e3d579a0ce2ead6527b0dc1a5b4233f3be707c03af03063ef3495019eea04e331df544dae0";
+      sha512 = "b17ac7bc677fa78f45a2855cc12a35c70701e882a6839764a4d05ee3519f68e1347194895475e916d62d2a679c7bc60588253f6f201b41d82b3a7b85a356a6f7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/pl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/pl/firefox-58.0b1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "d951353704501d27d6fb93da04ecdf8d06a2a6664167976fe018f39f82cf70ec7e59554043e7b4fb7a4b423331bac829f07a9f4d05c3dbe7d66eba3db09284a9";
+      sha512 = "8b65402216f991dbc780099859821facbee757993d1b57cb9c4cdef792affdc14c01519dfc47731f195796322e5a4d3ee5db319c8d96b2565ee6fd639b42a026";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/pt-BR/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/pt-BR/firefox-58.0b1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "5e8cfd1c70bc72c58c7a7a06d30d9bb701c0c574de4bfffbffd96ac6009c712c0f8b14227c77dd109d16587f906b01c94f18c7d55f08a479cacb4bc479859db7";
+      sha512 = "925380239a6575be1e933f645dd26d922ab5368cd10c6822d9b14df8dcb4aed5a59f4c36181d6da79fdd94019800533bff33e6879070815d3ceb089f6ded8249";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/pt-PT/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/pt-PT/firefox-58.0b1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "1035994860329ab318146f1faade952abfc48a50c828efdf73b3a103e7ef331acc82aad1a589b591384f33de1e3f0976eb62b61accb2507069e4055fd7bd5441";
+      sha512 = "d87499d577afcf51f2d7dad05a2307567506612adb87eee14412bd996602c6c8eed554beb1450deaf8224192ee82f8aa6dd51066e7ec1f1cd052f2285402a969";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/rm/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/rm/firefox-58.0b1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "3430038ecd626b4056cb95815ca36ab1d9385e4783259cf973dd1ed7fcce12a3c0e1a18555a579d94f1021d1073089c3d9be40ccd003e00057c498e98ce7bcbb";
+      sha512 = "a99a69291f670e09abeb7bc336e089da68209fb6b7dcca3391e1716c1a0a2f679c0b2ac902f3ba7239d248159de0128ea5643b01478b66f92d139d2232cbdc10";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/ro/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ro/firefox-58.0b1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "488907bf47fdc4a02e2fdcf11c0c4517aacae0421eac41ca75b573c5401ea729e9dbbdce4a176dfca871ab919ca1a07a1db9e61a82f0516902fc80f6a070b9b2";
+      sha512 = "13d6d1421ccc54a249b89f172aafc1a4330df11fe68d8c49b74c8da8c4e34d7372be770e19d70f46ac57b6784a57848ecd006a35c93e50b05f89568365bd74c4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/ru/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ru/firefox-58.0b1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "4bf91ef098ced14a89efefb99a8162a328c583ad0e2276ff3539b9ace7540bf7fadbf057acd9cf604b3fed0359bc208186cc42d8801304bc9dde85c4a12f38af";
+      sha512 = "2af20c6a0e203fe79c285718bd286a2c8c282e4d1fc669a1586ff3682d704a07e593670c63f94be646e7e3324666ed1de10e445cf05849184ddb295b5bec71b4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/si/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/si/firefox-58.0b1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "e214d7fd32c669f0a5367aad50ea9ea9c0f642c4af862251c52f1f1c95cb17a895edaecc2f69b6899ce95cd023480978936007ff26493cba9971624af422a5fc";
+      sha512 = "b403cb79bfa008d094262c22071e4499101f15607ae43985bb1a550aac4cfc5fd361742dbaf3a1f655cd74aab41dfdbcfeebdb1606ce9cca77030cb1dcab83aa";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/sk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/sk/firefox-58.0b1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "17206bb3d59a74ec7acf2ea205e2d02db7257484257c8cf63341b99b7cbf9434968d3c16df7ba96438c44e970e53498883ac2744dfecb7993c21fc34dc4d9f2e";
+      sha512 = "a1a4b65c352ccc73a8d55f38de5aac5288b7f8b406f62d5cc6993f53b0e5a90dd71834a92be5078b0da5a95892070dd1ad51c9458b54f294c791c8307daa1219";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/sl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/sl/firefox-58.0b1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "d04a0b97ad4f3385e48e7a248d280ac5c46a1d63261ab2a4b3e6b7769d82c70bf523acbb040bc3d341669f6b51a724970fe8e358ccb3e88c9656182dff0d3317";
+      sha512 = "8b90668816fb2869f81e4c4ed1611817b63e0072fb58a46409337e4069167722aba206976b9550f72307d8366da5c1379de05cc0102ccfd5b1a01d97b1dfd365";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/son/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/son/firefox-58.0b1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "ae95b4d44e9a0287d6696745edd2d9e6b03eeb7bdaf1959334ec4dd28a84154ec075ab25bdd319f92f2173f8d806f95b875d2050ceda125acf8e98e81e6ba47c";
+      sha512 = "3b6792727ccfdae1ac318b93b82997f6aae8754607429c2f15e16c2ed1d8f1d04f6c95bd474abed2604f16969ca580e85945a7d8ced2a694734a236c43c10949";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/sq/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/sq/firefox-58.0b1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "713dd79c91fc01940c9b102ebbf83d5a9ffb62e77c42d971eeeddc9dcff1b2947268bab5c99285de5826fe3a5ffd55d9ccbd62c809bcbf2a266f019e35451cb3";
+      sha512 = "554397bd32fbfa5475227cbb5d926c03b5359460c02833b917bd4278ac1917e9fc4da8a75c8cba566a573c26e8f8e0f82f41fef9b57e6584e3da327c6a566b5d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/sr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/sr/firefox-58.0b1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "c7ba73cc0df99cb28f5f5bc6a8dd237a3c9d5b67d7c63444ff8b63ed34f0e0e390d233a3f886999d5531ceb9be5b2272b3b282008499c5f09278c9a9043636a3";
+      sha512 = "8e753463023f2428b15b58fe932ce9a33ff1dab4dcbd4321fb5055eba7768260769b1468d515c76590c61e2248d07fcffe2cc0c0d7035260d6b3694b90ce954e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/sv-SE/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/sv-SE/firefox-58.0b1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "58663250980e784ed5481a31c09b4ee9002004d4026d6743f89c739beceb9a135c587a61a391dd3cb68d53ac34427d0ff00cfb8b6a235eb29d6da4d026ea3504";
+      sha512 = "a86ddb45f3900e00906a938d35d5a463f12a7008f0c17c4775ac08216fb4207dc366ce4c23eefaaa7157af8a973cf2bc7a80e166f51c7388dc497ce9455c23fc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/ta/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ta/firefox-58.0b1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "89fc06a036be7359494eb098def2a7118e0e46449ad7545b148a4194fca4ee446aed7172567a7bc746a202e48aa67a5fd18321f93920c761851a103402dbb008";
+      sha512 = "65565bff074e4f5299c6aeafd81f21d8fd265ee060788d0c494371b0c862baa9fabd1a5182d14b49d1f6aa6a9f8c47894163292236421c42fd93b27f0d9da195";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/te/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/te/firefox-58.0b1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "1c74315d96536cb03e842823e70246bf9597489ea0586db6c474a5a905031e034034a62ea549b202dfd5464684a52d3364d1423f34a5e720b6449981fc8bbe53";
+      sha512 = "5b4f7656a5ef4dee75c958da7492d7d52e3636f0ee064e1ba93c7ad0360fb0a66825be76a4d26e316f67fb73616d223fc77ba95eaf4283f679c22da1dee79adb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/th/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/th/firefox-58.0b1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "4f23ed4c12757f6d472c358af4dcf1366992a8c391bbeaf1f86f735ad2fc1638d516b76b22b118179062ba260154048c179b88bc3178488cfa20be4bcadcafc7";
+      sha512 = "cee14df62eb7923ccf2d63953ddc4763ba76443c181cd9e1239db3b489216207b0a367eb9794cf4d52f3b7459df7515348383eb9a035f4252b0310045aa215b6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/tr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/tr/firefox-58.0b1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "3b45d8d29d6f7f8a08e4fac95ee28b12d482fcd2812ba357252d85bc2bf49dbf640190b3174fdc0e63b9b5d95e87ab3086efb1b1fb717323e971080e0bc5b570";
+      sha512 = "e385eaeb6fc0cd0902c3e48bf99fec484880ca4907c8feeabe2c0747e10fbc3d8198d5aee83bd0b21cff2550d144d20d7a9e9e68ef07169825ef8a512cb0af7c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/uk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/uk/firefox-58.0b1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "a17831cff53566f313f691ae35f6b7032cd7c11b5501b4e84b70b64323d0dd9988ff422d8b7bbf67436af8c8ec631f9c68e7338c8c6d3d470094034a5766f3ec";
+      sha512 = "962aef76a18a25890be145184aabe5149a5469d69ac46c8bafe3ea997613b31c214c96d9ddd565d65173fa639fb5f2cbf5de73b9c9b2aa6394fcbc84233fd38d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/ur/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/ur/firefox-58.0b1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "e0eeb311d9cb0789cd17979057c1f4baa2065dcfa30f33058b2a866b239bb44690263ac408cdcbff8d4f7fce312bcd51dab60b84479917f2c615689ed0e1714d";
+      sha512 = "68de26543d894104bf4349a6e7e13ae58cfafdb35bd14cb97604410b02196d0cdcc40750a04c64be301fbbcdd2c74e624c47cc2363d96d4e293edbfbe0a1f3e5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/uz/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/uz/firefox-58.0b1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "3d6399921209541e003e8fd83e3eebb39d30682090b0f306fbbae6705cacc7fd1db50426f00084bc1c6b239b57da5587479ffda6bf0b848cf4c458f821936a9f";
+      sha512 = "37afeaeced1488f94212ae76b58465c3ecffc5550db240afc9dee2c5dd1277027402f7264d35707bb132f467305b367d982eaefd83cac72e51601c7d65bef0a7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/vi/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/vi/firefox-58.0b1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "3a3d751644d605c92f973b680b4a093fdb8c476aa4eb4473e9350a03128668cfd9c96dc5a1f49dda2647342704e02326ecdda5c02e0b4bd80d73d03d4d5642de";
+      sha512 = "1d23a043e6f1ba27f13f89a88061b1f4f81c4ba70abcd6c15f563c76ff7b3bb95e66d968ead3df8bca51540b10042a8ed1f1792a42eb7f1e563eed0e92035f0d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/xh/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/xh/firefox-58.0b1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "8aca9406db4ec188f0c123a298f4bc89d8b5adf6a1471202dcac40e2abd7fb16c807458a52c2a5e9e31703a67dc792153d7c745219da9ab2c7144bb3f853a7c1";
+      sha512 = "247dc73aeb071d3f430e5f61447287d641d18951bb0c519a95146746906f4a25595f57a781c2f402ec7da2379d0b4fad657b5b097d00f774584f1d746fa783ed";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/zh-CN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/zh-CN/firefox-58.0b1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "ff87569273037e5de47a5c1ff61fc31933f8a4a9147ce8f54b8c9e16413e3546f7ffacf4ef8127363082ae173d4234783e54a7ece55a8afec1a51a57527d4e43";
+      sha512 = "10ad6c7fe8693d502b9d16630962f19f23b0457403430c8d24b34fe32de9b88513f82af3b09dc23bf252c2026efc6f45cad75e7244533aaebd824c7b0ab01926";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/57.0b13/linux-i686/zh-TW/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/58.0b1/linux-i686/zh-TW/firefox-58.0b1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "063d9e0f85a04655f41e3e8cf9c875d6ec19d936c9c9aa04eb151dbd3de34493f7bfac557ae5f4f4dcb42037aad787e7e98ee42bf7fdf89c7833a21e5f827404";
+      sha512 = "d69059c966b06a9b2c7bc10ce83d0b927f29b85d6aa2a78e62163f8718bde6478f7ee5f8040a70816a29719ae7336cc6d483b4ceefbb2b8153acd5040e0bedcc";
     }
     ];
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

