### PR TITLE
firefox-beta-bin: 57.0b13 -> 57.0b14

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,955 +1,955 @@
 {
-  version = "57.0b13";
+  version = "57.0b14";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ach/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/ach/firefox-57.0b14.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "051daa6d23e8d9559135f89a871372ae69ebb46c143265f72d85a55c5edbdc927fd2be25869815cce3ecb4bc5a4245f6bd3cfec2317e727c632437f377552793";
+      sha512 = "07c3398805092ba5d252adcdb690a144f8143a8827e70e3be3cb71175735c9c37c9d0edb93936f8cd1af16ad7a6f988b8e8fe9eaed7e36bbb85abab0137893b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/af/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/af/firefox-57.0b14.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "b9b936333fc86f3ebf34dfc05d5277a6a2552b427fa26a1e29c9fed93fbcd76c533c3543b3356ac61da808eb5154d83d40888c19a37003dce88c4da64fdec7f6";
+      sha512 = "fd954a1ddae090d6bd2c76922d4ec53ef249749c27996fbeb1276d2d82284540a000ad4fe6efbd690bb5e73b6923016d5c9c98d34ac5748c29791187417dd8c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/an/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/an/firefox-57.0b14.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "ed028a38d5360890f57617f8e0d9e02c578f7e786e78de8f2b8a3b96d0915d3369dc398da71d387761f56f6371d3047c63f0d39131e7dc7cdaa9cd6c8dd22abc";
+      sha512 = "c57c10028a99df1694897966f54aa6f8b85a6b2d0ed23699542a7a2bbe458e26d622e2de398bf7559bc33e7e4172d23d5aff8402048174a39804247dd8516e0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ar/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/ar/firefox-57.0b14.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "ede95e488ee234430c3694a14c75ab116a29b91d9a1ec4b0676f687ce5a175122758815dbec69e2aaab0ab8ac91181fd4e0fdac545dddc0b1e3b4e7c81ccb648";
+      sha512 = "a4417b95c1bec25f148c57c42895e84024153065536a303f8eef7a0d9a7d39d4de8bf287f3af815e8ccb7ec7ec797f098416f78775acc8d778c91975d6268014";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/as/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/as/firefox-57.0b14.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "9e27132b8b1d0665cc88951ff24b316142bede88677dfbf6bd43ab147db8dd2b7ec44e830d152a2af48805e2a2de1b8858f4ceb0e8ff96d65c7cb769c0463d92";
+      sha512 = "5b624b9d0a4ee345d5c7b79913a8cdb48acebae32f088479c0745acee925d58c826b5125186ffa7c017ff3524983bfa06fe5061ee9423c37fb6f0e7323cac85c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ast/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/ast/firefox-57.0b14.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "4e458e8dc02a226e40314bbce9771330a378536c7176e5f2e9ccfd0f0998d61ce33b234228226156abcd87aac88c01c740ccd7b0590863f6f1da44bea3b43af6";
+      sha512 = "efb5ac3daa79a88425401f2bf5df6c0fba90fefd21840723cedc8ebae149816198b727dae67c3f74406c47e01dd2365d1eeb92c39a549f1acba4ba65dab704b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/az/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/az/firefox-57.0b14.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "90a283a92da98ebc422f78deb01793888f9df97bdbb17f5e0f9045ac5f61eb2e4ae9ae706026f043535c2399fa476509af9d358093a92cdc344883e40bc4ed03";
+      sha512 = "703332727a0db4a51a39859209ce76120cbdde5a00d32a931e118e478dbb5f4a4e8f3d06abfa9bc97bf66a411f533c23b7375599fc0a7f0c13c9d7f518cb8990";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/be/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/be/firefox-57.0b14.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "b16136b9d37ab3a563b9c90be7520430a89c204bab6d9e616939ce88f4d56c395a7670911361f746b9ac62e802e4b791b60ea1e77335c56fe80a0bd27c00fb14";
+      sha512 = "d8ad4ba538e2e3f86ad8564e2418cbd34f33d4e89233fa6638acf10a3e10eafc0b81d6c20b585b872c5c00bb6fa2af1ea4097c19de01446a6811e4843c99fbf2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/bg/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/bg/firefox-57.0b14.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "7ad46009c3101e05b0285862f61067e68c50a202c4889efd138438721487ad21ae68228b9fa82162730fe41be297206831d5b4f8587c3243397427192f4351ca";
+      sha512 = "cb6af38306ab8bcd9229cf1dbcfaaf310108c31e28dbae6b9fc21a4cbdd82baf9fa785a9a94bdacb779c8679721903bc721a0e7ca2a1a09995fa97f1486a8232";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/bn-BD/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/bn-BD/firefox-57.0b14.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "24650ce5b04485512f7af58b0c0428f9aa442d28d614a2dfc2e427e33b35e442d0310ce3212a0750bbc0e5ab79aab848218c140edc49b7be456fc2f7f33b01a3";
+      sha512 = "1739ab1c4c1a7387dab56fb89762b26d8cf279c14a7bbfb1f7f888e9c2c714eaec84aba12f1384defc7974e207b506e206f980a8a68be7f274cccf7232f30e32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/bn-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/bn-IN/firefox-57.0b14.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "9c48ad3e4081edf3c1b973f161fb9741f2f37a125ba5e63599698100c26f529c727fcb828696ac3b1f54fa299502cb4c537f15be6c696eaf51452c1cd0eac61f";
+      sha512 = "358f8e3c1e9774fabd6bd8faff4cd2903c0e0cae6e5e6ee6f2ceb228ce7d489ed9112eb729a4f7d0ea25c377a2a54772279ea1343cec449b949688dfe19a69a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/br/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/br/firefox-57.0b14.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "022d5dc1a4e4906375ca2b425d86636ba6cb91b5bc60459938e9e77341c886c4aa7285f4b52e7be221149519bd3bf72d1b4540a7c62cc347e2beac9de3d6c953";
+      sha512 = "df0c34c951d81d500a0720c2a9cfda76831564dc45d2e34d37b677702414b2f53710fe4eb7f63257658fd058ffa648a904aaad4d864a325a1b1e1ddfee2faf32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/bs/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/bs/firefox-57.0b14.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "9e4e388f43404eb98e68349ae95bf40631fbf33670d4a9200f60d9ab25f8dc2501d4fe1aaf6f95d9ade80d790b1ba53b78ead54f2cac45d7a2c2d85e505a1455";
+      sha512 = "091cffc15f609bfab74061f13c526d4c13946e7b79d3a190ced0ffe2fb9aed457e1e1780d9c152699f4b42aa920d9bc77701eb944d9f9671b70da3278fabde8d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ca/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/ca/firefox-57.0b14.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "3c7e6f9c11ddf88900af2eccf8a22524f6cf74e5ac27464f8b4ad19849ac30220bc6eac03d79e22c349eba9e170ec379071b258d6bc80e9178dd1ddfe0aec965";
+      sha512 = "cd485d1202daeee2e24ca812350ce348ba93a0bf389741b13ad6aa6a81ae4c57007ea0b312e401fed8c268c8a86b5ccbf62ee25d2c1d8d787f16e92467f3c136";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/cak/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/cak/firefox-57.0b14.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "e5f9e7bf7145f2b33a0c59de6c576f82bb857ebe85335f218cd03ba005816c3e8e8fff03d5b6534885d796ea523696423c70035e62bb6a32bae4e4b7c1d79c71";
+      sha512 = "c5573576cc70d776f3d40a2451295ad8a6230b0de280b0a2a3dae7ecc2c1fcc2eee5fd5e4df91a2b1c9a63411263a4a55f0bfa605a0688cbfb10c341dfe4eaa0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/cs/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/cs/firefox-57.0b14.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "7e527e7bd04cd6107ec92d27f0705ebcf8da8117c84e61e13c2026dadd2ac3a888c9e3bb86f51026f19b10d06365bb41d48bc4fcbb08d09a88b3bb01e9637967";
+      sha512 = "771141fa3d846651448b158d8ad583a45dd2fc05ca5e3ff2ca19687431a140744707260b3ad9e304bb2062757ef333815f69e10a48e72308a802f9088e24b22b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/cy/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/cy/firefox-57.0b14.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "287df6655c9793da325681baa13fc4c0b9a5975f0b13be38d8875838a762b2f435839ef5893c6b6a3439c225994fc64060f69edf349d2a9d4fd2d225e95fd1c7";
+      sha512 = "7fd6f5eb9473b3ee68a7a2a98128c205df6654bab21e4c19f6ecc1e427dcdca3b93e9ff22239ebb652a545a3cb8892782e34cb876ada78d604bc48816960f897";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/da/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/da/firefox-57.0b14.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "8d03dae91a9cfe20091a2222eeb0bd41f3b3541c5ef6520a17a32187974daf8584e1d69017cfb99d2d18224ffb287f586bdf1ed678981a6b6a3d16ba9ba4a2e2";
+      sha512 = "30df907a7e99f41f9291d2e677e124363a8c2f702e90db870e2ccc1bbabec2266f0c64fa3daac66c5da1543056d1e3e1e8458dd4627cecfc0a9090ab0aee13ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/de/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/de/firefox-57.0b14.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "ef084c0d0efcb77cdef1ffc0cb994ae6c6a9484c36282c7d9914b2d3e8599c8f2e9623cfef1e890a7d4c4feb6fba1c091937877ae8ea1d654a9bc824b5c8bf12";
+      sha512 = "bce375636ad043e2a9e331ecf84154f5e329217b6c1697ddcf17301115f39c6f35b88083cbec132f92fc30d93b414a8a913ddf02ff0c406295047d5d11a7a3e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/dsb/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/dsb/firefox-57.0b14.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "e08b193db4230efae96862a6a9b62200c42b03667c3d5a905938375391d99eca37716cbea561341ae76547be0b5ee94475f9ca9faec64fc178be92236a4ac91b";
+      sha512 = "0b75a555b9b02759b4315d3f77d78e71f2106db1b2901457b54e7a487b9f35a0aed3b6f47e7363257b2bbcd42104783fe14bc4171d658515b72fb61bdf9b0fd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/el/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/el/firefox-57.0b14.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "db49f80f7c08322307dc5cd225d2dc10a3179ce4ce25723264679c1c78454fe1c701ebf218a34704946a1e7d042349d0fedfae5b70b1c68b5100ad7cd4ae4900";
+      sha512 = "f4592a580dd7fa207943d071c92816c1f6583f579e8a8fb6564da6e95c0edff1c7dac24c581e25f874b354b55aabdb8fba17a2f4d9677b653e957a66360fabc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/en-GB/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/en-GB/firefox-57.0b14.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "b2cc8bc706e89390b500e6e8e3bd548417af1b0500aec7ed1c0ad79245941e20343cbcce80b03a2c885c7134c069e9f3d459739e6ea2a62c217a9f4ddb8851a7";
+      sha512 = "56731ee2e83a591201471bd6236a247a3a5713607344ae8a5c03efcad4f69eeec010dd89c1fdd6329325768a4b9a83ecbc278fc503a8d61244523748d0a8fd06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/en-US/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/en-US/firefox-57.0b14.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "621828144f0421ac2a3d5af1cf62a337d23409d26032d4c2518e99b0d04caebe1efc67c50f2b692612facfd5927cb0b51d9acceeecf9fc4c2129e6a899c9ddb9";
+      sha512 = "cbe3a6ae2dc8d89ebd935d2c58d3f735ce08f45418c31f1faa9f75d75255a07fa87d9b7d53f571bfd876701b566e27cb8bd761cd167749e2019b1f3bc1fb569f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/en-ZA/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/en-ZA/firefox-57.0b14.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "4dc4822fbc6d3027b9ba0b93b126e5223675c69c9e36c22e85681ca02c97fcfb9f9ef7dfa281dabec32b93ef8cb619ccb74ca18a3ebaf55f64c5547f5cb97c08";
+      sha512 = "f5c32cbea6753f4325c7cfdc99bacc4565b58b0ffb7cdc8db6d559922b8402493b502e7a05fda4e08746d48dfa50ca7b70ac27e152ceed3fadb9d2af2ac0f639";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/eo/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/eo/firefox-57.0b14.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "8eafe225337ad597afdb9a90caef3a252f9f467b6d0988f63d92ea35f5d284431c1ad1a29350d9cdd83f5108649d4cf05de50706025f8b2e2db55955bbc8f964";
+      sha512 = "89d278965fb4c7899abdf17f2fd1dbde201c959b623c46ba4db51628a3a09c5e054a614b8657f7f190ca5e9cdecced24f126978425bb38d14c84770958466bb0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/es-AR/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/es-AR/firefox-57.0b14.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "f9837bc84534f1d35aac94c0775fee981b9c7e5031bdd2c78b5609406a73cefa5797282aaf122e2eb772fae7baa0dc0714413c1b6d7255145fef540c31b89183";
+      sha512 = "d21ed37e2d6461f31519d08040b271e9a6d476e7132f5db406fa3eb3fdce67384af376a89d740426fba12a5602c20a4d315c0e337f0707ed7b91d739b648ad63";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/es-CL/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/es-CL/firefox-57.0b14.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "e7fd613944dfdeafeee8877b77cb78844b1bfd1d5469dcfdbd90b6a0ea08c98f4fd9423dd18ae1333b90b5717f800a446f8d237de34a8131cf89db602b72a846";
+      sha512 = "bd0dd077e732c996de27e5fabd22933aa1c1ff448425bc757be909ccfdf7a8a2f32944721a248e4998bf9d455fcce13c22a89dbb780c3a61d8fb06745075b122";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/es-ES/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/es-ES/firefox-57.0b14.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "b571a99b0e11c8b4fc202cc720f2f0850b54978bb98ca9a6fff2cfdb6c853c74ccb8f9b49cb14649cefeca5768ee408e6ab8028bf005be0def9c519ca8d14108";
+      sha512 = "7abe774d7c2baa9e055c382fbe4612244e9ce5c778185e86c1b4e8422ab8af4f99a949bc8560109e6995d8101f8563e6251643a5c6e4ff1ca9675b064e1da580";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/es-MX/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/es-MX/firefox-57.0b14.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "fa46b9751f8548ea3724867a2d41cf9aa62a7416fa06ab63a4f59e24c45a5bddb84f982049d1cdb4d0ef3318aef46fb25f494cfc3be203165ba125234c9619ec";
+      sha512 = "4f4c6a5cb3fb25a030a44f3b7c60d6a1af77b083ca4cd04711ed4663e276f03ac92f4b8be697554af7a4721641fc7588b005e27f2ed2c5c1efb947a64cfae8a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/et/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/et/firefox-57.0b14.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "21b6cb415d45f53f8c5bd63a463be60ed05f55604d55dcfd0587fe023653d4736f1945f1f5d96bd97718b8ef492fb2901fe883ed522db4d9edc805af0c118013";
+      sha512 = "f23d6cdaac6a412c28c633fcd304833bb341c159090575b8f8cd7bed6068a3ca3497cae072d831b1ac40ebc98853fec978a09009d3eaa5c1f6aa6bd4f8c3b956";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/eu/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/eu/firefox-57.0b14.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "9e341110f6c2d52182faa95f032090b2904d734efb7f4472f87ba77b6604287ebe21c7b1502f71e107e285578cb6c0da6dd95b45fd27bc28a16c14735725d22b";
+      sha512 = "1f7f209e1faafd254e607c7bfceb5b1913c59361d55bfde394d2af4f745e0be54b7d119cf71a88c577dc76f0ca9a96fa52cdb38b27ed5dd6d270eef5efca2501";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/fa/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/fa/firefox-57.0b14.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "15085dcd3803767b4161fb6b3e55af4c29dfc573ff2ed24dad02eaf001e657e3ec8466e827df472cbb89a442e33641ad422f11b7d663f1944a0f5d2fb94bb305";
+      sha512 = "e175dfa91bda0daac8854d999cf3770332d61dc11ba338ba8a9c42718e7d470e07dab656a3a13ff25f4295df648196549b4a3f4b273061c278f03e0a76815213";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ff/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/ff/firefox-57.0b14.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "ccb9d489fb9211c9cabe344c65ba165f0aaa4e1217e4c60860c96e7d938532d1602a4c6d885ab5c934c744957a060cdcfa4203c8d93bdefb4f25bf938a4cc1a6";
+      sha512 = "243c09586248988625ae347ad10b691cb5f93ad78562c3223a244403a5ad41b138289a992edfce91a8744f45ff8a2feb008ef3dfeca608fa2cf44e39746bf794";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/fi/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/fi/firefox-57.0b14.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "306668c5cd48f4c0c81e2a160a6703c43ab93d79cec7c9b754425faac9441edd5cddc1bd67d743e577a5c7aa2db39dfb2b5a290e983713c8de780e6596a720d1";
+      sha512 = "66ac96ceef9d36ab4c16a288da714c9bb9dd72b12cd814dcdb3740135ce6d19f18ee564c31050b619a1af207d086674ea4f60ee01de3a18eb854f35af5d3fb8c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/fr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/fr/firefox-57.0b14.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "099fcd14b1cc7429c7cc4330aa7a397c32acd28006732d272a89c2a6f5c7b1a0a0529734e24fad308c26fdef6418aac2d1b386d7e7dec8ea19a12490cfe53e50";
+      sha512 = "7a9398f8753c0b3d6777a5dab4c28fbacc493883e5326fcac0cb0a0f62509169768355a5c5db377afa6a1ec79676b8de53ccabc49666ac9830d588ad2c8bd8eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/fy-NL/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/fy-NL/firefox-57.0b14.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "688f6d9ccb1a130181e154ed75ffa71069348f82bc20ac649e5aabf69b31a65ba022b3a28d2149a63941bb6287dc8e14946e2f7d9d5ce8f89432c2a32f5095a9";
+      sha512 = "b309d91af97a94246c9450eea61f81cd8f6e8564bd089caab7e1238df4855aea54568ae8d40c3c59e09729779623f1f488e2b18f05094ad79d7d773a82196eee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ga-IE/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/ga-IE/firefox-57.0b14.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "fdebffe1190222cd5b3955e54aa49286166366d910f1b4471ee36372abb7d515b22a48fbf2799abed4943b2a3203c983d0906cac6b5652f507c58778e8d98ff4";
+      sha512 = "f3b699c8cddca58a8610aade833b470e006a804606ecf13f166239f32ec7fdf0ae57e6f91d3a104efd08fa9cb34c7d78026753d0cc235cabad8aed8ae85ccb22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/gd/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/gd/firefox-57.0b14.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "5a957ebc86c7e305afb0e0f9e91f2c73b52b7ed2b65ca8c372cbc0666a86e809494e7deaf5ac4caaedd60400e8a82dd9e3773ec3aee04daebffc7c91a2586b08";
+      sha512 = "261b14e52513485a14d4c92f580a9deb228dd730f77911dde25785b8eb7974a1fc6d39b6d377a3dabf3f488f9d29892aed86c38a115aa4c9660b27a229a512f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/gl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/gl/firefox-57.0b14.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "024ae0ddc5fe5590ef8ed4153e298b5a05dba17fd5a4d6ec78777969841cbd284908d7c19c36f6290efbc5ce1248c3f24c0cf4418f524166c1407199a6b5de90";
+      sha512 = "6028afc50364a4bc0e21fcf82181b3d6ab44a985d7ed55fc090544d25c0bd65ba8737e1b653e9cf860f201c6c3aded33693c2ee7cb7229b899007e9a607a39fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/gn/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/gn/firefox-57.0b14.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "e6b36e68cb07c4563b350e4af1fe511ddd69ec05fe027809f5561a788b2fcd95c88bc8eb8d67618bb1769f10d11a75898374a433185de49e09554eb948b2aab3";
+      sha512 = "a189db0e527b1a69d1f42b23b5898224313f73b269ece12bcafdaa9204cecc2424660ff3543098cd6036ca17c724436fc6cce9fa7f38376dbd35c943f56cb559";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/gu-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/gu-IN/firefox-57.0b14.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "c8e3f732c6e91893f07821a2cd9d18e3c5effe7551434cc311455366faa5891afdd25b6d83b5e4c314f3d4f5c01e499c5d4823b332a120bc07c979dae8f171fb";
+      sha512 = "59c9e99ce0da07aefa433b76a961cf8b9294b30c4c3198ac7c8cee5d430c89a10058f614f0955ef768d1e0c12e583fb98612caad4cd48389454b9878bbb08667";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/he/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/he/firefox-57.0b14.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "a7192f190a83f5d3d1f300a072eea4396397fe02623daf9bfcd6a73ad2b8e89884723d9596f0be2d3da655fd937469f08d65e39037e3b7168edd28c8c23c10d6";
+      sha512 = "101f7135364f544517674f8c0bae2d16aa600798ec7755f4e02d0827df6920a60c19fb0d2ab3dc20febe1e9dfecd192a64fddfb2697b825ac940de530383ad7c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/hi-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/hi-IN/firefox-57.0b14.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "30a355f58c9419472ede2713101721509a8c86c6c363693c256553cd64800572cf0eb000c8b2bcdfa788ea8876cbf6b7e8a86282ae1726eff4bde93dc8b33a1f";
+      sha512 = "dfabec31fc6170e3390a313a6f201ee51930c1e1c884a5e1b0b2107a2a3c1d19753c91404146dbbad9dc572f9828e3196e6fc1002a9b318b3648b1dffe2a9cf8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/hr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/hr/firefox-57.0b14.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "fff70e068a744e89e28ede72398d60b83decbc908c6776b23d8e532b4630a9526411a62572882a596241a7b6b6550766f3ccf99a5d044d7fc14afa52772ee270";
+      sha512 = "2dec6c07adeda8008e3d85b6552f29f882b1bb9b89a5e03422126067ebf9eda03e0272f31464c42f8b9deaea174c26b1571c1c416f1fab63a7e67cc0bfc2c136";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/hsb/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/hsb/firefox-57.0b14.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "aec6950ed6cd9b357bdb63e5edbcab7b42e76a72e44ec370380d2b5717db585da8060620eba7290880020b1e6325f134f001163f2ce7719c50b83e6a5a2fbc91";
+      sha512 = "b5dce6117e1c964a612708263adc5533d8a063ad6586030fda1a214c6df887995f7ae7782039f063786bb332732857781392c16c646c29d9ffc53fc3c8cac8fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/hu/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/hu/firefox-57.0b14.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "912b23344f96d37bdf66775ad933ac769e19818ccd178a6ad97b815228670c053111dd623fb98de382e2c2d414414fd9fc276f4aee5a00a439dfe235452fb16a";
+      sha512 = "fe5654e089d50c099aa3cc9279c0a4a3e975a3e10d15b9b832249d082f95d461cbaa51f5851c3f4a680419e293fc9137b1ddf275ad376e073090db37ed92d888";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/hy-AM/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/hy-AM/firefox-57.0b14.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "04b2e8ae9de10cdc2aff751c5954f190ec749fea27ab265343b73d762e6e9ef6d96a7136cd9354988ac791ba7bf32661b5658fb490f1d80907505923bd7a70d2";
+      sha512 = "9678679c8bdd32131fb7397a88098028a955624a68d59746d073671298a3ecbd8d2933675ba564fed0650f44add7fc1135f441a3edf2ea932cfe6fe5b2ef5d13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/id/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/id/firefox-57.0b14.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "834087d98921683d0ae7216b6264c7dd7b77568b59e4739a7464f065328d3efa8256f03e9343177673ef5257db142466e3803936ec30a8f6902999a71c0ad163";
+      sha512 = "c863c503ecbd71f17c311f99d94a86af12a57bc1ce0beed6fd0d0ccc5c814c25e5636de9127610b768fb947a0ee48ea585e1a205e1646ab20d2f6c2044b67618";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/is/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/is/firefox-57.0b14.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "2a8f3b35f7c1f8adc40504c3460139ae7959ca9657f899fab9e73eaeff5d983996a33d284d058599406d4d46ca941cd9969a7e6152650f6ecf6165329bf2f350";
+      sha512 = "7fe2398dfc0da2bd215867414d765729e2b30620930ee1f50b98a348f6e6fc098c952d0c5ee200dbb51a84ec82f4ee2fe8b01c4a6fc879d2ebebd95f39f825ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/it/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/it/firefox-57.0b14.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "6b04fbe6ad821a68d7bb968836d047fa08308a571fef1d5ef82d4719841a7b517362f706f4251d4d60fb084c06af9ebc671a8c131e5a403a21ad9190d84c5789";
+      sha512 = "043b409173d097ce49eda0e16144b3f50ba7f7a83ed679f8fd09c26d18914681e15b68308ec6c65aa09f26afd195b6f8e5afb4e2276a5717b716280450dc403b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ja/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/ja/firefox-57.0b14.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "9dfae62887b03ab6a963547c1f4c4332bbc4469bce62318fbdc439130c65677e9e0328942b49b37d251aee45b56f474aa5e1ef487244ec61561217f1e7f2bcc4";
+      sha512 = "9c4391e27831ae034624f22e8643922324b7940f2b6c739d1c6b5c47449b83f2c8756b11efca47a42820a867248efc023876e1218327f1c8e80cda0c960734a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ka/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/ka/firefox-57.0b14.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "8f1ae26d22d02bd3a1aa21cbcd750e6003f13fdd1aadc85114485cccf59f300b962a729016c3dd1611b8f32333422318ca806b7dac1a790c11749c909908840e";
+      sha512 = "490c43518d3cf1320d9a3e8f28c70908b31a5f9ed01b211f4e53aef67baa279eaf129f06ec6c21efe2fd4a89364f55ccda95847f058cb2f83fd1f92c466263dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/kab/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/kab/firefox-57.0b14.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "28a00d36928bb60a2c65eb9e3866b8ec1fbe76973fcdcad78a6f00aa601e4990c1ea96c37984171577400dd511937011957e51e4996fa64db0600c0c3cadb810";
+      sha512 = "bffa144bd5c6c0d3fcf9c8d44c679f22af1127734ac8934a5cad4d5e6726978133cc99c61dde870143fcfa0b07c146c4d7a84117178e01083a0c37d9b4810184";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/kk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/kk/firefox-57.0b14.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "76361b378b4b2bd2a1e31caa344491868188155caa57317f46c9f89b9a77df5ea65f2d4f8ddd2e8cc574e602fc163c4d671de932938ffbb64a1e68a7fb51bd51";
+      sha512 = "5b49760338013954ffcc3ae2c9c79b0d9ebd92f1a148188249559723bf23338a7b606b26f5326b48e2acb15e7ce023f4dd2a536c0cbf5b7af8eacfc33f3be670";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/km/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/km/firefox-57.0b14.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "abd176c702ab4f1e829e23a4fc4bedba45724ad119d84cd18a6d7d2c8487aed690702709312f5806f2fbe82076215e55e3e4de3cc8cb56b33079d4ab7e2921c1";
+      sha512 = "7ea92ede74eda15d9a77b6b22a02a634364b60bff135da5356991644f474a47c16283670d24f2cc28d112c97f3b49fcfacb1c618f9caa16fb013c3c650b50feb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/kn/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/kn/firefox-57.0b14.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "62056efe59a3acb2fdd04eaa343372b7b2e1f974485ca7f122d6cd9d7d67159f2a4361aa01c68cd11a93cc56d807068842b735b74e596b5d218c952f5e318658";
+      sha512 = "e3d3ad10a374421603068c420e2c5c28ee8a9f9b822df556a1237eccc54a778ca572e09795aa9022cfa373652cf2913c621c2fab82484f7eba77f56305ed6aab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ko/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/ko/firefox-57.0b14.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "d1772efaaa2e2f42bb01d5ac39187accf59a235327d5d159866c5b80d7d54a867aa496d63fbf23737d52b976f0be8c35bf5f6045f0d69eb5d5af5e67b6202eef";
+      sha512 = "a681d5e49952f1e671e0c86854102979e052b84140002b968f791f4a325858985751a3872446ae2495802ea0c1df884291c8559a573cdb236cadb7cd706ce718";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/lij/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/lij/firefox-57.0b14.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "a45f3f8181906382f3df68abfba8682fb43db58fd7b6846eb3b64eb67e6d57971cb83ed6c74785e19807be06dbfcb7b003c67b800292cffcbb1b42c812bb034e";
+      sha512 = "b33522bc78b07958a3b5b80bc0833673b1516652de2a165f5bc7ef54575a21af20a922e207be02c4531f64503e97279dca4ad4833d2eb86a6c04f3fd1fdae7f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/lt/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/lt/firefox-57.0b14.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "101d43ee97cb635073ea9bea836ac0aaec514fb5b4eb9b821df0f48d527b89745907f557a96339c19ebd152639d9a4bd745396bcc97c94e69579b177f9c1d7ce";
+      sha512 = "ec27a8aabc0736b410509a9fb9706627e06316b34a241639ae27108ba3c4945b4ae675fd85da390ae053603a0a13a124c0638c11c0750c665c8226446435bfec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/lv/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/lv/firefox-57.0b14.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "74afad1dea785fefa379c7eee2efd0f38673a632b9232102a02e8fa7591f89b0c58447362205b23638b54fbdfce90a813c111344ab4569f57b21bf3e3894b4c8";
+      sha512 = "bc4b125320ba7033946a290e0d974cd4a4f517ae9c9e2a24d86d28307476fbcb4372ec0cfc567d984e90d105cf692a08100bcec81e4ab615fff19ec0ced0096f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/mai/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/mai/firefox-57.0b14.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "4b87cc59533c6b9d3f131ba533314f5c622efba35084a8ca6b67c4c63b55833a8a3ad9a72ac1371dea86e39691a6670a3d38952120ef8e3af712a72fbf69caa4";
+      sha512 = "2aca4d6ce673fcb71a8c6228e243157e597573d152d05bebdf8b9df3bdb479dcce1708cdaf2462902c5ed0b7eac83a9dca523bc55a6bf6b2a9fd1d4582a3d68b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/mk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/mk/firefox-57.0b14.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "dd85e3305ef45f319211492163215f2f4140091d33422cf9bd01540493b13c9fb923a0c64aacb2639682a79cf6163fbb6e559aa29fd6dbe28f22c7cc0a1398ca";
+      sha512 = "22fd8e59aad75508702ea3fd37af4261f864a76e943cf6d07789d4f1d094d7e0d5e76e5d4c92b6dc642e0f30047d4515d8520bab667c05c16aa4ffb60f0fa168";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ml/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/ml/firefox-57.0b14.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "19487b16d24a71463b1227a450648ad0f7a0dc08b6a0ba69b99d87387bb2c011f7139031eb09127bcef5c5e28be90b8bed4de449af4b2180e900cef4c7e26218";
+      sha512 = "f96568186cf49bde7ceaf36805277c0cf4d75da2d5930227e625e2abddd5b740df4207ce53abac24c77dc755f52132204b945fcd7706de4e3075505635eae9fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/mr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/mr/firefox-57.0b14.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "7a71d953b192d2453698318f7fcfec7e4a1a08f893094891b446add05a0a570df3db76a1054c296d723855e4190dc2b2cf84c953fa97486a8bcdeeaaed707bf9";
+      sha512 = "82fbe7593e52299dbebe38fb97126b91f57e48968c7235d8adba93776ea6c6883dd8eb5df3345cae55d156a7bde2004f1f446339e46de90c85f1525eb1334147";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ms/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/ms/firefox-57.0b14.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "8970064b77ede1f1b52a974bfc7bf543a203943a3aad2f42952669e48e1ddb092ac47d41704364802129501a5e0106e5158d6650a4ae7a84ff07916ff61af07c";
+      sha512 = "3ece240f01f8322a86d1b8861be25e895fdbfc9a024406727400e0d6cee8efe88a11cbd6799e4b7d0d8396cad80a6a7438d4f0e3b641f94396a7d2e80be06e02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/my/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/my/firefox-57.0b14.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "3681f7a89ff3f099c5a387c9bc32880e3935a68edaf004d97ce492a271491e40b06d28e9afe732163f94d0f882a777ce8655ec0d9aa61b5a3be53792661857dc";
+      sha512 = "9e670ecd9628c8822f634031dc7b6ea2610687df8967591ff44a3fc2922fc11bf84575811e9e0f51997764d67c357de5020619e3f637e31c3421e64b533930dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/nb-NO/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/nb-NO/firefox-57.0b14.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "10d807437bb0f40095486c6495be4460bd9f10747243576503faa78b3212b71a893b4dcc1bdbeac2cef0ffceda288687033d05db9e76576e6ed049ebcd0a547c";
+      sha512 = "298d7d24c92a5f56f00d7d615ffcaa1b483882f5845f3de4bc8be2811ec6b5808a2bb813ee9d9b8aaac84a6c6f7bc600b45b7c22480e6c4c111fbe815d46e70f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/nl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/nl/firefox-57.0b14.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "31fb0e57141696f5ee310fff881e811e23c9c1d182c898cb8be142db54ac268dcfcb8a0e865ff5759984ced5e0cc9b87f64b6b27f5ae82c04b3011c7460694a0";
+      sha512 = "c59787d50bb14ecee498e9c454e3ab79571656160761e95a53b41ae8196093f6dec3f435d9a69f064b9c4aff0bef332e2d5334153d98c8984041e26c82ef04a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/nn-NO/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/nn-NO/firefox-57.0b14.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "386d209088359eddfe3d68eb2466b491139e9f372a424e8509e531ebed8901fc098eaedfb11a2d606f22a940a2520b2da7ae9c6ad8a1e6dc24e5b4efce39b63c";
+      sha512 = "c7c9965a5810bcaac0f1b0d08ab6a9d660a00e40368369998101c2cf043837459e6e65078906c0278564412655a76987f30b671bd90edb25820362c3a846b1eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/or/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/or/firefox-57.0b14.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "8bc59e0d4ac62b1409616512ba15ff15bce172e27f161407bfd11668399692a53d362e0198b6c0b137d979609b6b534ed63e1875747111af0faed895133f4b4e";
+      sha512 = "bbdad4aa7743a1af3c31eb81003612d0729ceeea5a0303f129f24e352219007b55f40a931a0140fe1b1b4cff694572d1141779238881376e77f30a3f3675512f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/pa-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/pa-IN/firefox-57.0b14.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "b25496c3795ec349989b6fac8cbf055974dbee73287e9550b9266ef475a979f7589c8b318a9c05f4c324e69333b943382f2ebfedd0cc8c8b6d77f823537cef0c";
+      sha512 = "99f5ba6937e08c2cb0f05be9b8f2e87e1f27d5ad610540b3011cc2fcd11c2a7a84a1cdaea9b6133d1c9a38311eaa13221ba57bdb444c9aa343c446abc41c986b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/pl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/pl/firefox-57.0b14.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "762e795c44733f161b2849a7057afd2b47021312324565c39d51a3b06634761518284eac7d34927c7e650c1e43179cb88b80396ca91592603ce737988c197533";
+      sha512 = "956648b1f331356f8ee31158758fa0ca7cc7685aa7b20c1833d87828f5f4d695fb3fdbebc55f4862c0f76afe72ea6035261c9ebaaec2561d728d61a4bf53ca9c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/pt-BR/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/pt-BR/firefox-57.0b14.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "a278133a771f43cf8fd48ca4fc06e324ef3d9187518ba1405c371004b94e608c3cff839dbda184b6c23c6818f8cc55b192bc9118f19e8fbafd6af0b2f0d6b611";
+      sha512 = "528a30c7ec5c7485d0a64b6787e0c14c66f832b2289884ff234799631f4e9c6d620c3312ca3d1872e28c80c7a192b8e0e4d0b9d88dbad610268e9d3fb37b3a05";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/pt-PT/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/pt-PT/firefox-57.0b14.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "f56e9591b8eb311484d814723a9d7eeb66914cae8d9b74cbe12f8824eba898f5fdf072e3cf0384deef3087826225bddc31c9a92e11906a05f6505524a6e9c7e4";
+      sha512 = "c70eb4dd653d035fbcb7de8bcc78cc1855f7d6dde8296a825d733a26e9c44e38c8e77ad54c63f806f12b90c601508bd6376aa620a1e0948c0b265dde3c2443ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/rm/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/rm/firefox-57.0b14.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "b0021b2b2c26aff1ef7bc043b64ba39e4152ed3ecb981cb8876d4c15af9e157b30cf9cf92481f76a4071f9407312a8a02a20cfe7223a4f20ad9cea46ffad3343";
+      sha512 = "c9b9f0e3ea90fe7e2d5c2907d82e7ea5abd5f30212f1fc5e726dfe72adbe3835107cc836e310ee4bcbbcb6ed6a08bc8bea06d3bda08d1fe7a08ae20b6a22bbdf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ro/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/ro/firefox-57.0b14.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "dca26a56abe6f6000e755a5df7d62245bea47964ef47bd0c5ad0283eb6b04c235e225e66bb54c979460188ef9a1c870d9d53b2c185e6dee2a37a36880cfca6e2";
+      sha512 = "6246be75562143b57f27de69e39f9c82c7aea3e60d515cbab0ed5e32228f5b33abd61cb2fa7f3c4e73c65a6dab5ed446a0eaaa94767e0196d5b337e6b5a410a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ru/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/ru/firefox-57.0b14.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "26eb37a11bd7b484617d29432c67eb62c84f4a7aa1575234d284e39a23edf1f679532f818f7f4c64273d70bb400e52f327498ccc8226304e0e859fc7daa38dec";
+      sha512 = "467a4adb72e27ea95d324f52007e18c3ea307b7ff158a4e58bba69859f5369fca8e7243329e2bacf590f35315402af10d8071c34886a7fdc3cfd6e0548653aba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/si/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/si/firefox-57.0b14.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "a7eba6aa32b73a64b7b21447d7ebbfc25ac21c9cc353d06fa9eb1e6b5e43f2673f125abdc662e8296a8254c96e97e8684a8408d712bb201eb1b9ee494aebcc23";
+      sha512 = "47b11ccc3bdc373f3591ee73b84edcb9afe915f1bdf5b7abe65eb2ea675da44316a4ee5087c0c4e69a90dc337d43e201ac15b98d04a0ad970f8017d737e4f738";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/sk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/sk/firefox-57.0b14.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "da4a7e40f4063f11434616a1130640b663d1c73aeac6a8638a281174df890f0dec105fd8e5e0200dadf8898bce7adccfca5b059f35773abf4c642ea1d25ffbf6";
+      sha512 = "c7696394b76668733814f1b2cc1c41cbfd962d4d58e424c041fd419b3da2559b1f4057a8aee328e0698ec8b350e7909ce5da3770f287ba485dfbcbeb3d1de9ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/sl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/sl/firefox-57.0b14.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "6d00fcd3f71520a5924772f0b04f091a3abaea2b481bc2f2eca793330a8a9600a7eab38c7b1a9bc575cfa40c74fad56c6f3847ec8edbfed3364a8b7522e23c1c";
+      sha512 = "aea6c90fe73f9aa1340de0ba8207089deebdfea21d5fbd5d5c0ada6df26a4acb4349eee4a7ce09f9088439cf059fb7fcd6169cb1c34c83a33c909bdb3ed7af43";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/son/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/son/firefox-57.0b14.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "0484c6de79a605e94192369aad55850b6897ecdc44912204fac58a23ecbedb8991ea3f670c3794d1cb1f311578db41ec518ae030e16e5266b2d802120bf151b1";
+      sha512 = "6d3a9b05ea14ad1281c51d99757475b6642a5411b7b409f2acba695c3c0a5719f4feaecd0c56713899475501fad3413fe46f4a3efd482111aae2395df22b1e25";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/sq/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/sq/firefox-57.0b14.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "c5704bbea312df025d1e439563b358ae5115c0e91b82755c8a895194a04a5ca349da96aac99db11627912c5440a9e675c8bcc14456fb14bd4461c373781c2151";
+      sha512 = "9e7639f9fce27b4c3b3fa265e0662b31360313569f1fad798c89ad1eca1944827c3aae23c283f4e153d3f81a73d235b5fac56598cc02dfe2dcb38aca806203a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/sr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/sr/firefox-57.0b14.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "27a3bff0a5ddbcd0905fc9ba69ea733d6a6c14da78d1bac0448b6804b8cfa8668890f2a1e617b17e1a642b59795c11b82d1ac4192863f23dc82adbafe2078714";
+      sha512 = "d84980d2b454f33a33fdd9b44ea7e2c41a73a351492fa7bd951a8e4ec288a7aa4d12ae362443a664abfb554693e8a8f5428843b28ed48429de3d32575f94ea74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/sv-SE/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/sv-SE/firefox-57.0b14.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "e762be3b52075b4050719634f9e68ae86faf55295803535c046b2abf05ad6f695a0695311705b2293f79c1c8ce69d69b39609f27be6d0af9b625c0d9368449a0";
+      sha512 = "b26deb242735a3fa662687efbb8a293e76561821540ad701091a8b7033c9c1047459fac955815790ed026e4f69a51d2b0396a21102a79623b72f5ef8cbbd06e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ta/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/ta/firefox-57.0b14.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "cc0570a17d2325faadc7b1ae313241935588dcb1de8d6a1224a583fec6511a34d2a7ac786bce894f1a4b8b0b92d2d4392d8b4f7d0a0db9d31378191cf1ac8dc2";
+      sha512 = "1e98d86b9df418542dd15a204ed70732dc8111d8fdf34edbfee8217460e04467a822b66804e9876e28f15e9167ec5a6dc1551c4159c136006392feb7ca218009";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/te/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/te/firefox-57.0b14.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "3f6c7e8612cd483e209c95ff594ebcb0fcab2b03d3687c6a2cd8832bf512b85257e0ee5af2aa1426c6b3471c6d00910447cee91d5b45d5a5aefed0beeaad781b";
+      sha512 = "d22b7c8b45d37631434007b196c63044a860912826cb301a218b0aebab5ae8283370924a703cebb16a98a589336e024b31ad580b6fb57ccf3ed53f238e361704";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/th/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/th/firefox-57.0b14.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "2576defc0da691c1a3a58387cef996e031683de1d0a1a0f928692b5982b61e53cf01953d473539e8afb5173d674d9e1ce82fa785307525a65e9af062924ff0c0";
+      sha512 = "8a806b68e3e5d4ba884bb9f72bf07c2bcdcf33a8111236fe837a41738e997116d092ffe73e4028dd7429c4bb0f097270fec7a20ff3b5bb316fde0a90af92d22e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/tr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/tr/firefox-57.0b14.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "bf5b69d5d47c21bcf32ed5e9277d59d09cbdefc73f750b957feaf0f8aceb184425ea6d87e731aeee01bdd74ac42243eab0d781261d63db26bb57ffc3f530bb8b";
+      sha512 = "9b1e73d28f5f1fc352f830aa59612170b72dffd7ae060a8f2422ce14ec46f9e646fe625ce36dc4d380fb58ba0300c68a83f2d8aa8282100f6ff33a43ca79d807";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/uk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/uk/firefox-57.0b14.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "eeae9bc7f51c8827c07bc140883c672455088aa9cbb5c4473399f612847ded8e95f61b6c0a295c598c2a943e641812fa75173f26cb46922fd0d962af7ebf9d53";
+      sha512 = "96d471b413e980ced87be210faccd8cb6b796c17b871cf785c34f10ebc04c4c76ce4756bec0dbe121b689bab2f777e54eef6ea43750e31c1c83524d0825d0fc7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/ur/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/ur/firefox-57.0b14.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "36d2c5bcad4aadb2aa381e2a8f0d69256268d337088639a031af86fe4958529e0f32cf11c5703c39999dd247023134ea80201c351963639160875547e4728b00";
+      sha512 = "0724b881cd4aa040b249882d41cf55260d6aca1f4876c89a42f717f00cecf40b32fa60451685b7a182d2ebb11dd08af7e0327bb5c9fe94b2a6f03ba8c9b4d02c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/uz/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/uz/firefox-57.0b14.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "a245b8eeb1cf93dd51e85425c129e0a88c3b9d312bbd502a5125f603259f3ee97eef76489a5f9939f09d3bf1b134deb3391689a54d607bca125138761378602a";
+      sha512 = "bedf1751786c828779fb719edfaec466a299ec706e40dda5f886bffe911d425b82e9f9a3cbf5a0deadff7ee77fd63c73f38ce3462aa7203316fc0569a4423927";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/vi/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/vi/firefox-57.0b14.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "b1e2fde3c1d08870153a83e921231aa2fb34238b450aa6ce7b79b180b5902ae7bbb2a2dc689a119cd0d8b3d9f9907223c08894634810c48b629d74c2521683e4";
+      sha512 = "3ed1b4f71d75d0e863da048edf60ee3cbcc5239d4a8ebaf69fa6d3a8e8be20e556dc838155d7b99ab2776ffed60e578ce253c8e6f57491dc84ef3b68049cf929";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/xh/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/xh/firefox-57.0b14.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "36345b203efe934147e96548c25ac4cfa21b7eb4cd0a849c7e35ed8e99d36687ac3ac5657a42fad30113192b364b6577dbcf47b854244f02659cb89ac4553519";
+      sha512 = "23db4e5df5432094b7f31a688b84d23304c7890d0ef99cd9c992d7a108a08199b6f6f94bf3574668b9b0a915ac49d2c0e8c6b0c37ecb145da3f5e2a5660d6d9f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/zh-CN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/zh-CN/firefox-57.0b14.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "b5a8464db5ffe2eba9e33de952e4a44077f0af332ceefe562805a5f285a42c5bdeedf4ccb3bb4598b9eca7875ed1f2144a2b54b652250c8a5dd98b0a76535243";
+      sha512 = "bf08e65cf257f789dee34891818f94368fe89bb500138ffc72855da7acc62cc08a4eec3f4d32a637f59fd0eaf072994ba4d5691da300d75738e3274e4db3ff45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-x86_64/zh-TW/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-x86_64/zh-TW/firefox-57.0b14.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "5967f8d5d89ea780dc7475ed50709a7b269f08eaae74c200df97e2b914e01466af1e3cf58fda4eb44f417e384dea03906d7855d612df3dcca7aeec58040ad30a";
+      sha512 = "6b924c8ad6b86cf07b6b2f01a6138636391acc519c469b7c1dd96ee5c707e1b81c656fe87df31519413ad60e56e06da46c0f762b26249426428dafa0420a5b97";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ach/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/ach/firefox-57.0b14.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "d32fbe4ed3824f2ece3987ceec2ab408032eb5d352a035b2db3c279a5c368a125ec234e3ab24728d4251838a2b60c13d3db3028cf48e3d2b2ed4c5b54ea47238";
+      sha512 = "56d847a9417a134af10f53ac5630f7b4a7108b177444327df97511494e2a28a279990ad37d48fe1fc482f34b45db66f1c8d458162f253faef3ea2e66e42e7166";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/af/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/af/firefox-57.0b14.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "fc5222c5df35584fbb18099913f8389f2c8b2f25b41f0e753d3e5f5ec78b5294fe5c88da0ac477e0363f31d7af96ec121b89325a0765cacec0e7ae3e03762d09";
+      sha512 = "98d55bc29423eaa62b1c5f179887ac95e8aa228ded6e077cc645660a048ee3e42da7966adb9dad5f168477262638456bd9509aeaabfb2a754f0435b60e9b3a46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/an/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/an/firefox-57.0b14.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "e97bd96f4d22d6893d4f89bb9e2b53eac8a68d30b46352cf296ff36ee02d60d3982c02c84c97c803b0216f86d3c7998101f91745b109e29d8c7d0c61e324a8a6";
+      sha512 = "0478d738826d3d9b0898ab93e25527b4dae789652a65a7b16ec5796b8e48e575387fa3b7474d7092ad851e107c03f9c58d8dbe738277371f2e881c56c9f727f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ar/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/ar/firefox-57.0b14.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "55741f17e8698e02731b431c8b20a2d702255e37171f027ed779243056aaca35fd863a80109679c5fb920d0a2026bdc3db6759f1b3fdfaacf237e4b20bc7e9cc";
+      sha512 = "4c884b86e8ef6b554d85151f1eb780edbee0bee6b60f2ae3b30ff9be74591c4f4df07e5834d0ca5cad456c574abac712a8e856e07892df652f7db510618d231a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/as/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/as/firefox-57.0b14.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "0e14c33b6f328cf931a7f9c42d5fe1d7fbcb8736381232c69920a45111410da3d09c1f5667e7206628d70a7caf1404c304bf9f4ec8a5ccc3342103b3ebcf3757";
+      sha512 = "a58c8f47fea197a5b9a397f8e58f73e381ffae3426c83872407481f079b62a585230d2f389245d5eca6308e8832fc95d8dbb7da97d25551faa44c20f6e032bfc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ast/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/ast/firefox-57.0b14.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "a2d51ee57a7cef66d862c593bb1e52311593a21ae0a25d2b9c14a64065906de26770c61665dbb0d55930241302940d697c982e050750fc04a5c89ae1ca1b419e";
+      sha512 = "fa4f10093602f03b759502d76ed1d7636ca2fb0f83174869e3cdaec3503fae625e6d49a07c011dfdf6964aca7e8ba81861677cb387ab8c638a5a671864451dd9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/az/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/az/firefox-57.0b14.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "b9fa717fe7d861152d2117f1d69a7ae264f18c7e1bcd4e71df7404277db6376a93021e070edf73fffe1b00b3f7031d8c555df645efe63571d8831922d0212d05";
+      sha512 = "8560bb32c0c3aec695d86d1c0ab6491ba0c2dfd0a936e7cddfb8d3cd35890db31ea233afc74d19974fa693614bfe7728e69b8d1ee47a34331b07674b0b57f118";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/be/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/be/firefox-57.0b14.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "670dc2d6d9d35947d181dfa1c11bb84cc65aebd268cdea059997fef685619757d3d7c6025a12d00fc5364f258a64fe1b08a69357a2d31fff7bfbd0ca07cdbd4f";
+      sha512 = "026e1ecbddc4972cbf1a2a930fa1488b4e649ca7c811ad243a3c068f8cd6b57e5a73d193a3feb4cb49f012dfe3b5af9002f30609cd1551abc1ccc5e89476440f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/bg/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/bg/firefox-57.0b14.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "99deb263d7111123582ef53bbb1919497a6ce6c73cc160b4e26f5adc22f46e383208ae25acb5b4bf6dbac4d9a4f801ce70e170b0e6e5c9a03593eb2db8edb601";
+      sha512 = "9d145f71f46e12f071e8e181f6511d20a6ca5f1f1950cb076ca25b929893da7546b950450f7fcb41021c4591238738f9b8797395a86c599a907f0df687cf0282";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/bn-BD/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/bn-BD/firefox-57.0b14.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "34132da469314d9fe9295b835ec2b8b79816611eda646c04f7e064bbee5cfb2cc42f92e14a2eac60239c44205be4f3239eefbd1cad6700520ca3fd4bcc1d127a";
+      sha512 = "846001c844e9ee3d9305eb5be18438af65d5920363f19935a60b503d4a31c0fecf1d7e6fd286cb7ee4b7e26455496b1d27fbf6ccdf2d2a432ec2e2472ebc9c75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/bn-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/bn-IN/firefox-57.0b14.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "9cd206c11d28b866004174532a253ad49c06f2c6cf9b2004b15bb14bf597e776cadfebec4b3935a323b98dcfd3590bf5a3b289a9f7952a8a438a7e90884cc0af";
+      sha512 = "712ae023c09681b1ee9f41240d12a1641df5c4fd7eeff15d157c379e5b5779c65b93719b238fb121fdb9e5ce10809b21125a6eae23a77e1806daa0b2b13e4372";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/br/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/br/firefox-57.0b14.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "f30fe67e71b5c3c0e3f352653395094a31cbc52574a9dfbf5d5ccafcca528ca0a5b164cc75d5dc7d248eab74f0470cf8547fced782c979fb1e9ba4e177ca2b6b";
+      sha512 = "b99c48b8971dfdd0e642cf76cf890706402079122311b1b6af77d658b03acf87feb67918cb83e5435cbf0746e2c2a7c49bf7283969685d0b4bd616d4ec3066b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/bs/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/bs/firefox-57.0b14.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "b2a546259e46cb58d44a61fa78e53632fdf0708921d80f329924180eb1a01dbcafe1372c8818280c0b40aafc7d4e6fa59d3f34b7e6a514f2adb1796d4274c093";
+      sha512 = "2203e66bcf453f22848df010cade83d6982178c8ccc023e05ff8fa60aa3f7e583f9d8e33a313fb70a696e149773d567be8228084708ca8d01b3cabc431a7576d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ca/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/ca/firefox-57.0b14.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "0f256326b5338228098ec31b8182e2d5d85418c9ace5fae1ef5cde37704d2f333172e4db7497f36157fa530148585dc70c0bc1b677b9888ebf0ae850b4aba2af";
+      sha512 = "75ce6cb2bd7c1d79b4260dfc19237a1344fbefdff9775a7e557f9a31dd9fc6235f58ca8bb8430b80bf0f25c14be5dc2509e86b41b7ff7814e2fc1baa63f187a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/cak/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/cak/firefox-57.0b14.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "effb3d74d649b7adacdfbbd568b561f55ef277a9b7ffebbc27cad5ea0533a73918effa9997b9565d33635d8bb39658900f251cd071799fb15adffbd8022b4515";
+      sha512 = "b4f0a11030bad0cd177db357bc49b6f745cd429d3a8dd9bb09e99db1dffd32ce8c21a94c0b98b6db703fdbe16750b4574b3378dfd40a358bc0c7957fd2cbbe2a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/cs/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/cs/firefox-57.0b14.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "494dc250f77d7933006121720aa6526534c7b90c17dcbdee6bad4e0a6f5224de661d3744862d5ce519a9ae4f36095af76d9b86d873d4db97991b1d27ff5ded8b";
+      sha512 = "5ee1dbd826801dc5b029c8eadcfe8d040f000527a6ff7f2a40713a137c59a144456adbb35cb202d7883d831486a0ad56079d07f681ce294a5e97825b7effd69c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/cy/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/cy/firefox-57.0b14.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "910254333d2f47f4d2162cab76f84f2b9f1808d559d1eab0d1ac0c1673406869b3092eabe7f4107758dede9394b383ae98ccacfba768772d550630f34efe5c62";
+      sha512 = "7116bf1dbec5603d22546b1927a6038812c2abe1e9e7e1ae556919e62f04af422950efd808e28eb7f8b349a9d79bf01b9280d6a6aab94bda8c0f6e2a8968b841";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/da/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/da/firefox-57.0b14.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "f9fff4a380c84543212c610aed98fb0fdc4a0d2693bd87c3dc3188d7eda73615d028c7ff7c15db12425855105a1b5230a7f62d2eae84a893f07a4b8cdd47538c";
+      sha512 = "538ddf539a6d9dd22bc2dbf9f712773c1d7896ce2a49632d4acc2e5716dda95dc9d10393bacdf2fb7d24342c8a93c39eee139f32edfb429b0bbf7053b7bb3240";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/de/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/de/firefox-57.0b14.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "2e772ae4b2f5246c96e30811a322bceac788325c40463470152b495492e60e3084e0ce55473aab56c9be584992b6761e364902352616e70050b4b0e9467b1a79";
+      sha512 = "ff33af1ffb0549951baa32e423eac3828b15bbce18ee03cfcdffb57504fb0e592db2721f7008e84562e5c1ad297311a1b3d4fd5ab41e3d8346a2d1ca50e54c35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/dsb/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/dsb/firefox-57.0b14.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "8c6b05440d039b4ea3666b718f8cb59f91804ac2899e9d2e0a32a7622f800126e3b3bf9360a8e830cb70408cd7e4bc18f4eeb639dab403718ca6226576d262db";
+      sha512 = "6dce022b035bf9c5d76c45492e29617668e0000f5f3981e3f132ca1595bb54b504cffa92d220e118fbefe8088f3749f4d077c591a12657ce9266b88aab8019c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/el/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/el/firefox-57.0b14.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "9589eb08e3d128e1c22b639945790aea4ce2524eb3c16d581c615f18b3f1247240085fb3b6d9cf3b283029060a86c0747def43c3d89a1548d907edd50d0867e3";
+      sha512 = "b917927c48189bd26289fabe3a51f59965c8a421aa941732a50aa9aa3769ce085ee69bb04202c21699f5ebd6ec2cff75ea2446246d89916127be9418bb00f47b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/en-GB/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/en-GB/firefox-57.0b14.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "b1848e886919f8698fb8ab7272e49fad3ae1f5d98ce92b3b82c6117f79df56a8ee6bc2ea2cdc8987701b9a0fb4c2b1e1a58a9faceddb0366372a40139a1c7664";
+      sha512 = "17257657f8366c5efab1a0c47aeb6129e624c883222a6bc3bbb097bb49b531894cdbfd39898d0d83981a1609fd3ea5dd101419819a1f156668fd3cdb3758b8d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/en-US/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/en-US/firefox-57.0b14.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "327081605198481bb18bcc45a88c4388ec9091c6c10bc6a27ae58e133470651d50edb106f95499de4e38d7ce78eff68bf38f430371e4c490962e2cdd3ea55635";
+      sha512 = "c86cce7893fbaaf4d3b00b961b07a2f2d680ec07451b735449a501b2d9fcfb2fcbc0cb29150866805ad38f6a4aa1b6c4cd87f5872b8c735791953f3646600703";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/en-ZA/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/en-ZA/firefox-57.0b14.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "bb1432ab9e9f2e11fc2270501f25e3181aed4a782fb0337ea676e75c4db487a48bb1e3e44f0ea703c84c4dbe8d5c4e9a102c8cd1d45ff673bef7a5b884dfe707";
+      sha512 = "0b278c62b2185a4a6cafb7015062693a0dad610ada1123d07e162456e4d942f02a0566ce525e68b639fd152c420b925ee3e934fd3c42ba25524b18cdeeb9af5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/eo/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/eo/firefox-57.0b14.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "8ff8c209c3aeacff538d2f265f8a6eb7621d27df237c33b9265d9246674d61f7905369fb2b7636920cdacaeb3d44be11dfc136de940658309f3285e62179f8ee";
+      sha512 = "a681db144a631e6584340febc3de05803921b757f7c1d39ad5b8ff3d119ed8b71a4d70a43ac1e3a121e04102770d2796103aa127886753b2bbea723e22df7000";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/es-AR/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/es-AR/firefox-57.0b14.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "4eea00d279524be9a682ae46cf602572e0e1469d1dc10e37b1b0a58868386930ddecfe0dc43f0d185ed9bedb29fb85eefaf87d83ffd00ce51db04d37e5fa78ce";
+      sha512 = "40f5a7d9ba055f7eef155601f8a57e566c0829f32c92df48ea2ecebf6e10dd80885881a98d18a693643e2c00f8734218a7ef8908652eba1c4d4288f95a34cde3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/es-CL/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/es-CL/firefox-57.0b14.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "c130ca1390f9859ec6d276f77889cd804a38e32551c898a17158b1b7b629f7f72a39afafbde38029438c465e3a0ca82cc80dd73905d84c0aabad8ebb35f2512c";
+      sha512 = "be1e5b8c6e184519d0b10fe67736d7635b6fe8ad71ab78014e53ce9a1f1342a83aa1b18f535ecde2406e8be7a8633ea58af9adb355ad2b19ce0879c62f70bd40";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/es-ES/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/es-ES/firefox-57.0b14.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "6b515f16a2555f56c1cd8d4487efe2d4ba8107f3122b0dd81df9168768808d08314565a0a7bcfbbf4451d2a4e84559e84fcc730caa1641e801c6daae0ad517ef";
+      sha512 = "be0d2b2cb5f82fbaf10be63aa76a5ff9b9111b4caf0ef5222b3ad7d67d39f25dafc125352c00bd91bb1eef50a6f57e996f6a10618d50c5d1340604883bffecd0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/es-MX/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/es-MX/firefox-57.0b14.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "a3fa5b35773656152eb16efb6486d8e33ca29e0094de24e389e94a6e7fea761569c3ad48984f8bad255c8ee97f54bb5521444993f0a8ba7a3c922da66c1295f9";
+      sha512 = "439f679ddd8169d51e1c1f9ad32185fc9b33df0a1301af7bdf8982dbfc5410cf82edb4dfce3dedc214ab258d714da91661882e45b8220895aafcca171fa9bb02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/et/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/et/firefox-57.0b14.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "7a0a165105f5b1ff3f997fd400bc8d5a1bf976c1f4910d4c91be9827a5094dcbc03e8426e644766b4b255dacf861e88cb3c2b75131a9fbd89e2c0eca69718b36";
+      sha512 = "2b80629eba503ca034fc4e9d873707aaa7668b2d4563792e3500acf89b35153fbd7f6406d12497b1ff1423e7ddc3bb4e0f3f63cc759758e544145f31aaea5a03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/eu/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/eu/firefox-57.0b14.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "7cd08c560ae83926226cc69a10691918b7c89cc10282cedcc57955b362546554e76b36af217a3187b11abe8472838f4cfb1a32095bb537b43f33920b37b5965a";
+      sha512 = "03047624365bb4fc5bae68a5bec91a396da7d404731cbe09d89baf3079be0c4a9a2c7ff73d231f39e98689d5c4dc7290d2401fe14cb564ea53d063f79d7c151c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/fa/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/fa/firefox-57.0b14.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "02b19d0f74413a92c998be3540f5f8d25ae2857e1eb9b4171083bdf392e5dc5ab0c6b58de54e75f221f731806fb8a6df070146564a3b294acaef76fcc8e633b5";
+      sha512 = "8758735d6bce447b8492f9a395da6f58c63537fcc946b17b8173554b6eaf32a41137011bbd44842b16e8053d55642feb880e9cd52dbe75fbd55dc592724a98a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ff/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/ff/firefox-57.0b14.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "df7485cad8f46fd93ac6a013e5f362a19b1b603240ce50044169ffa4a4267102910c1d6bbce9a5d3675911acaf64dcf0ee3638090c0236ab664e9af5b4b567a8";
+      sha512 = "5d6a1b45f69135dce282fc411237db713538830b00f6361f86a95da199d56f2bb351de9e59fb1d61a4b617c79e8a80adce3c3e57ba837187d4c368b79e414dad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/fi/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/fi/firefox-57.0b14.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "26971b0778b87e3b0a617197356626bc3120b2214b406e01f5fe865430abfeb6dff471496548883e3e2355d32b1630fc85f501eb9934a9b6fd23270d47df5984";
+      sha512 = "f35de96ff1b8542206fb8e9942333397050a6e88bd0e6bca3c1e56fc4dc754dfac0b554b74188d316e6c820881ded2812efd9221b2c3d6497826ff29b89382ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/fr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/fr/firefox-57.0b14.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "324c4cb614a8c50d9d7eabe6e2e3aa420398db7074a7d043c4a44c5785a640988c9d531aab92f51adfaebcbcb1e274f825024b09e302334241a16c622ed97f7f";
+      sha512 = "118d6ae69eb686ed1d791463bb2ba025749068017de94a9d002d22b195ccb9e0cf0d042e613ca88c310e685070612a070308971e12eeb318b26b2335b13a6a33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/fy-NL/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/fy-NL/firefox-57.0b14.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "e5d8d67c5c549240264b7a02ff6c5f54295f04a26553a5a19d3b58f94bd3531c04d5402084fd6f40d63f9aebe2df7d8b50415d8575774f71df5a180e50d39728";
+      sha512 = "79a22424fddf0add63c3a3528a63ea4c0c9d39f3bf9e35e18fc9ad4a57be7e7f675087f1a491698868d5ce57cdd149aabddc224b7b3078ad3a81e6ee6dc35b2b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ga-IE/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/ga-IE/firefox-57.0b14.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "01c0998e8a32e6da0127680d17e71c173c21eaab66603ee6fee0ddf8698a16501d290b1ef9d375d4cf678606cb4a73c679434e22b309a592523d11ebcdfd9fab";
+      sha512 = "04b87f564be35d19135973a0e17c2db1670aa804ad8c76b40c8f3ccd670e0c64456d84cfec276dfc55dfa29db5fc0bc70826752bba756cdb597c7fc12da1d30e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/gd/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/gd/firefox-57.0b14.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "88eb2f45c0242400d62310e0efd492b27b6439750d01f0f567dcfa48398c0b2572c842c6155e370b0400b40c2dd88b7f2696daa4e42d0dd5440b4175a409517c";
+      sha512 = "f2a66ee64ef80dfaf2c16af952be22ba9c11b3a2859b6a861e04ccc2e7863ed5bb1421338c1ce30ad9ca4506d6223190ab5feb194ee445e9fb09a11aa99a465f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/gl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/gl/firefox-57.0b14.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "d8c9f478d1859240b411ba6a819153d6d260216aa3bd4acdd043b0bd6e65630f02fe4b7f8dd549aef81190ac8358620487d5f2fb796797d220df70b3a597cbbb";
+      sha512 = "f59b462819ee53e8727863b3e4cc240b83ec5828860e3a0428b012eb4047ac837760157a7db60bd85486cfb9945185a2b8f637581e489d90bf140bef873dd9f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/gn/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/gn/firefox-57.0b14.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "572a00d95247c758bc81b0cb61c2fa659ee5412ee3ee948640549d6e737fd0ef622ac4e16715fcb269980461bea32ccbd2249448ae8b340ef26c322f5c504090";
+      sha512 = "17499a923e6f7d0e63e4ff0ebee17f02c99f614da02d0ff8a737a37ecdcf69ba1798139c1b824d187b67b443e54701b1046b59fc6bac3757f86fd6303a778c57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/gu-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/gu-IN/firefox-57.0b14.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "34a4760f8748b6e6cd1856f5e99f04e320dbcd1cc3021e185abcd23c12e881e2eba31ef9253bda6677c767d5e7fe5aa0dc22f1145852dc58a7e24278a0c6dda2";
+      sha512 = "605ef03bab50ab1438be938bd8aadd917c742a5ac0bebd14dc8388a6e5cd844b52e0ef23670537dc50c2f3b4ca20814a9e559e667f3baaf292ce3fa16ded26a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/he/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/he/firefox-57.0b14.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "57a0b28a0f68d88298d25c62efa70898aa911c11f0733798739f40e546288856306e062033d24abb80964345c0f0224e2c5f3a15b01d89c4ed3584b1e931d91f";
+      sha512 = "51bb0b64426ed0d46bb2265b18138dd0d5fdc58c2782d3bff4dd8ae13bbfb354648b346e07bfe2795a4fc31cff2df54d94ceb42ba0342a59218eb5444e9fc12f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/hi-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/hi-IN/firefox-57.0b14.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "dc1db5ed5ca72c48729ef8d2a25cf608072fa7112e02b001943242ec027157e197828e85697561febc15740f52f9ecc6d666d5c83201ec8101a24ff66e8eb4dd";
+      sha512 = "74c921e0bcefd0c81616b8685ac3a0fc85129a950a917ec37c724fbd92df8099e79726639cf18235379ebd345f78de754e4b4e87d859e696aec6e780c607839d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/hr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/hr/firefox-57.0b14.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "5488074d04fb6f592abde28e1ddd8e2d949a8744849f51192fbe0441a551b358ef8cf1cb78f69b5340c07b266d11783e2e722ad5574f255186c6bdf9762aed7f";
+      sha512 = "8c4b634cbacfe34a2031c1edf196201fbbf13f7bf22be2910f27788e56b0647598d805953b888869644f4ec3547a0813377d517676e732770684b057e5f76028";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/hsb/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/hsb/firefox-57.0b14.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "4bffd78e28363aca1d2b63e56ed44703bbbcb701b4d6e1c353f36939b86c3d7045b5104d7f3da920a8a6cd3b69d021b5d19f9727c5fddb8a86c594d15fae80e4";
+      sha512 = "59ed77d9722413d8d75c8474de28660fe59d8990deb3c1743fca4fb1c18529173e0e7bb171cdd98df961792ca6368b91db26d6ebeb461543473ee5ce8eb7da82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/hu/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/hu/firefox-57.0b14.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "6a5ee323244358ed68c96de80f9ce1741217cb002e33a8c93e8386773ab27f11b7bb58747daa4138e5b91b2bb4543e1dbfd14b90731cf5bf357376f4dbdd3a44";
+      sha512 = "de8d917b533941220763d011fc9b38f0c0f8f32f09d999fdbe985017a002c3375b592865420e58fdc4a3d56f73206ddbbac568fb506ccd2e3cf4d2507e8ed315";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/hy-AM/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/hy-AM/firefox-57.0b14.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "28e0cfb93884fd78cc2f126f8c08714545c2550ae40de29e0dc1f3186fdc437592c6365eaa92135dcd1983009be7a5021001d2a7e703bfe6bc81f695ae662619";
+      sha512 = "ea76bd2eff30277dd06d606b0568dedb0f01c6330118da99fd6952f9bd5c8060a621687c66853b46554560b56f1ad2401e87e66bd44d1a85831805caf7ccebe2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/id/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/id/firefox-57.0b14.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "00136a82e957274eb9316778ff0f9aae66df21d6ecc64f67757816104aaf5cd6d83c0d9c0224214cd2d1c5a68c7bab75d439cb049035ed2a071255a415b337b3";
+      sha512 = "024ba211754ca36470ff316d626f46cfc2763b94dbfe027fec9dd628a0c617fbc9050ce7af336d22c962bcbb9190f1980b1381c5d3509485b4f7bb5780c6d15b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/is/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/is/firefox-57.0b14.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "6f22f0efac6858498c755fdcb848553a0e40bb80bc8dd6717d986e84ee5bb8cf7c608592eaeb6653f6454147cf73bfe57b5e62b581c2217b8546fd27fa9e5c79";
+      sha512 = "d53d4d7545bca63ce99dc691481b890846c33f5efb802734514ba493e1b31e3b4ee9632a4389dc388c77692ceefa9eab4e9f85de1298d0337a6756ceb27d55a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/it/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/it/firefox-57.0b14.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "6321ade81a09236ab3b3ddd024b3e5ad6404fd712ff6f23f72901018157f9a845c492ecccd1148cedc1911365c70c286a7d947cfc4afa534b274080e7bc6909a";
+      sha512 = "960bdeabd29fd9bfe72f9e2b5dcefc1c9577490636e9cacee964b8646ee29ce2cc4c9cb87a93f057e2a6371cb734920928bbab90e6c6738a19098e9e5a4dab75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ja/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/ja/firefox-57.0b14.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "b652eb0aa3dfd71dd4d72e45fbf2713fed947b866f1fdf172a473d80cf3005706558a32d7a04b38766517f6ff571166ac5fdc1c8a5b89cacdeb91f9ebe98674f";
+      sha512 = "f9d889ff8a25259bcc28b1178ca511ad7cb0ad9d0882c8b3f6a04e98d5f4b63ad9b190cc66c184f93fc96e0f869bdb10cdabaeb7b9807d49c3f72b7c62efe3c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ka/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/ka/firefox-57.0b14.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "38ca6189c55363040db09d55d6b6d525eb91aa4858a660fed3b400ebe5e4cbe723efd9735b77705a1caf811ad0f0a9a117701ce8414ef6109157357193c1a655";
+      sha512 = "1ece76f8237065e712b9835d0ea15f2b7318f420f8e4d6f73496bd1dd9cc5fbbb4125a04b4b4cc5c36bedaac39fb844a101653efbb5d0555bd13c3a4ea3e9d28";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/kab/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/kab/firefox-57.0b14.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "bf581810fd19d073fb80dd3ea93b6b856614e4821d095800faacc3c17d63c53d7d65aed4b168a3cdcc29a155073af78d26f5967f29102ec4b1e29325c3686b67";
+      sha512 = "67d22ff37a79716869d7b59e95806c4a9b89bb2e256e0f1549fe5d3bc9fb3909f7d1c23111e8bb84a9cdfb4e029414908a79a8512c49847fb1d4b20263ccb43c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/kk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/kk/firefox-57.0b14.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "aabff3d68e37a9b41f9345d8968608082c24e50e859a693d4642a52e534c5b8b7a5233469a1930fc54ecaf7b15aca486ad66b8cf3100fa62e474b4ff261b37cb";
+      sha512 = "b9cc2b1c31ea4bfbf17c2c7b0452bebb830cd3b8cedfcf2739360dba562119e0eede3b660a403420f367287e94e0bb34f072ea13b1cd1b58681302267f299464";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/km/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/km/firefox-57.0b14.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "e5bb4825d777bc6001d7d95140d03ac6c44c96eb602141be48c36ac82863dfd5bcfb25b529d61f80b8a939e692bf833886fbbc48c45ecc7e024952ddc5dee570";
+      sha512 = "afb6985ad592ad2d634c3f84b1d573bb87c59bad892f066ddc1bafb5cce7109c59403f3c1394b2f65da0fcd29ec897a3144ce1ed410f623354410c27e386ce06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/kn/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/kn/firefox-57.0b14.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "1f5f4d4fe4b729ae2f08432a5d074354121c876c4cb0e7344e37b8d02e2aad38a0b16547d2987418acb98ecda10805dfd012448332c8f8e5d1f772cbf21554eb";
+      sha512 = "cc85e9d276e4833fc962554e44a54ba8f5d56c387c37ea78f2f8deb1b845eae8ecaba1761726e209275d24c4192bd61e409c9d87320c1315665c095fb5231a9f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ko/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/ko/firefox-57.0b14.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "19ef2c157469a3225c7ffb875e66f41a9d2828635b26f6dfa0062cb92c0841c53f2eecf77ba9b043e3e2f448b8a08de55c7f74fc6fdd3f7b4554d13ecfa746bb";
+      sha512 = "3934a012853c70b77fb02689141efcba7679e87d115d80d1c7f5945027f082986e679f146a6acbc97ff5b5be6b0d057e3b3f8dc292c4e66a37d5c3972fe865c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/lij/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/lij/firefox-57.0b14.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "4e5e6103793dd20efb49bb85dac4dbd208c0d164e69c5856bf9fba96350c3682d894af857d239e23f3c3e802f7300b5b915486421414fb6f9b8af86ee50e247e";
+      sha512 = "571334620261a36127ae1e7a03c6142ed22fe49a95e28534030882c47a7325ba8200b8350904fa0e501cbe0801c2bb1968b456e9982bef165d3db0e82ad34b89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/lt/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/lt/firefox-57.0b14.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "d01f311ee9f36aec032a5c4eca34a86ebcb54960fd29b03af00f2b289c2b4a38e232242d1e48847e2385e7ccabcc1c928ecb1e57f9001d181c350762d59ecc72";
+      sha512 = "3a7a0f09b52991a4d8cc6009c2fb91f3f908989d8178b4b9909bfd90f29db6ba11f29ffb35f3f1e578f96d6be10eb0fb337d28188dc792e6d024e42a5a16af8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/lv/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/lv/firefox-57.0b14.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "d23ce47ecf7c790f38a9bd605150f403776b4e469be590a57b9de624fc10bfac2a3572470ff496899c2bd6ebd1799e9f4687b4e77e4714ab8228c26998760b21";
+      sha512 = "7e5153caca960317e039f8ad44f6eee4ac8f582ff2b957f70c9eb3d6967d62fb94e4b13611006d746bcb4611ec1b0a003bbf610d412f9e41f86a8ea19096b70c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/mai/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/mai/firefox-57.0b14.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "7d8baaa2d79f6e50afe9b915d461a4ca25ba777dbb0497d2fe0b1ed92eb30061061b3a29514351841f86366b91da0979b5bf270e290c477397f3201f1b517398";
+      sha512 = "07cbb84ad4537482ae8b1ddb00a86197552d3a80f6432779952bc9b1577c920de07e60f78272b1ee3889b031fff1c5a34e1c1a69d3fa0621fc53413242f80242";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/mk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/mk/firefox-57.0b14.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "b1f35402ed051ba91294dbacb52aa451efd48300fe982d638d206c75c3b0f7871fede1d7467ac8d6ea4308c4967b0334873d72c4c731c69f343b92d56fa7bbd1";
+      sha512 = "230ba5c56d60d1ec08092e9f6ae396fa836df56dff1aaed933a706014318fb13328db5d6b0bc3dcc030daab5f906d7760bb3a6af3c03422f724d627ab8b9d48d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ml/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/ml/firefox-57.0b14.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "32ea1f66ab87b299de4256cc25c6a67c0754e9fc8569f9c9693aee850c034bce1e77cfa6f8115015f085f74bddee99a7cf487cff09277f011dc51f9deb07b97c";
+      sha512 = "e4aff215ab6b3bbdbe08f7cc698f11b12bfdab232ddcf995681ef62dd9808789541e8ac7b9b71c003775b78451c06f79ebc45d5a85562385a2e449679db346f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/mr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/mr/firefox-57.0b14.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "3cf3fc88a84de5dce220f89928f05b8f8b1d8ecef2f83d01a880f07d5a935886fc30341eafd941f31213301773f463fb4f4681cfb5e8311665f61c8f28a5c0d7";
+      sha512 = "b2b44d4a205e39d82b453a35569da1a3f428610551d322a1c57e64da42d96ca2f199e8e01769a24628506cbf3b621cd734923f9760305de8e480d51f360f79e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ms/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/ms/firefox-57.0b14.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "a3b9dca6a332f939e6ac7b51956f34e893e1ab5e62e9c8e3afceeb6233d7d378b44fdd9f6dc46eecd73aa738df46534956545293604faccefc34591a7ee6e12c";
+      sha512 = "3646303c3858e4c2a7dbb555495f5f06b1867a04a37cb8ce95bdfd998e7bc96d8afb8c83b1df7d945bdc8327cc8d7be3f3bd7199efbe23e58cc3e38608ff8313";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/my/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/my/firefox-57.0b14.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "9daa4560c3c4424bfbce4f23bc414979dcc96359af3cb7c29f2a9c262aac81d96493cbf9f938b8b25ed0720801d0f87a11a7e5cfa83ba78e86e2fa0d2495fc45";
+      sha512 = "afbcd9f8dce81267614855d4d59da02f87d369c2c0af78e28ebf25de18ea4eaa1412999fcf3d414ebd030f9448d71e48500a4e90aae03b3905ba69f2670b17d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/nb-NO/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/nb-NO/firefox-57.0b14.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "d5ab3676fbc7c3d3bea1af43bff89c3290af5846eefb7bc51d6f946c8c2c7968332de918d5fb11c475e873e7e1a032213e75a00407092e51baa5f0d0a64fcf9e";
+      sha512 = "747dbaa1919c1cec14d4e085f8c8f284fc49508ce82cdf9a97538a85aeb9b901eb9e160e03346a769ef760bdb2108b33a25a967a527dfd3758f25cf11bad2e31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/nl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/nl/firefox-57.0b14.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "6f1e8bb355f6ca1e8ced4b9b69de26d8cec4adcf2957a7422b98421fba4c3d7c3fe91596fc9ea06e15137f8bdff27153b9d068b7707c7f56b5357a7aa2ec6ffd";
+      sha512 = "d882e7c1a49ba670535f17fc9ea99e7be4505d6dbd5d90855e4614cef319c38718da445afc411f1951ec3fc5d9a3b8799c64459a7adb588a29a126d1cd16d8fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/nn-NO/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/nn-NO/firefox-57.0b14.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "b9c27a5c824efc48e85fba2823d9288990fcec545fac3b1ef6c4617a624ad685b01d96d23ad8bd5eb1e7787849afc630560e08cb7fc617cf2e25c9cb9f2c1ffc";
+      sha512 = "8bc137f953b13a447dfd419b9ee0e4005134437892f214e49e18f98e080d5413d1dc655bf0bf417cd7c8a09811d3e7850967662b9d0be0d3b72cbc92db7e2307";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/or/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/or/firefox-57.0b14.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "50c0e9956bb17f6df5d342e0f43a4439510e80d4001f504d566d2856e885aeef2b54b57761943771f8a4ba6648209080290fbd6d556934e14565bee023c257ea";
+      sha512 = "34bbba4bf288f62654f88afc461155a27cc0316a920d7b8e42198054d5800360401c933624140cd569bb9864f9eeaa5616fe2530888e4717c964506ce66cce0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/pa-IN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/pa-IN/firefox-57.0b14.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "e01f2c4a9cb3f7e6adfcc3e58a5fb5485ab41ae01e302c93404e7b5a7bb1b30f351e364846853a2c6ac0ecddacc03806fea945338c050928c6e8eb6dd0a80600";
+      sha512 = "1403e23fb95cf8449a149ecd698e768897a3733718dc1f6eb4590685263e2a1b54aaa3e557a968cfe71c5172bbdf7d24f3eb9fcdbeb431e31a1a26c0b9738e9e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/pl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/pl/firefox-57.0b14.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "1bfbc1b9a401e0d9b912f5c91f1eb22b0b968d8bc75ddafa28390071431d17c4251b2624673aa068f59a451b7a9bab165690b5c87ba1dc952242287980c63dc8";
+      sha512 = "a2d99c00bdb839e4ce89d1bd6a0334bee4b6c6d426c3054257824c46abb1eb3c1f283aa0a4a030f1865fea350a7032cfcba86e231d11ce06ec3066f5ac4d47fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/pt-BR/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/pt-BR/firefox-57.0b14.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "75b83b22962b42160d5956db90e55f23c2f12335569f908b1ad1acce48704e9012b4d2c8b3575854e7a36ba9dee49f4b96391a4b6958fe80545501dd91609084";
+      sha512 = "5768a805aa0b7780b55fecbd9bd349c6cd78efcbb3595acc7cab18d3356835e53e63e58e352c30c79b349e0b0c80be59509fa684be21f541cc67aa320e654f44";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/pt-PT/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/pt-PT/firefox-57.0b14.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "4d9eca88e092531b87d8ddabda513f9a42a762f7af2511dbec25eb88fe791fa94bac3b08c7521227ddec2b049a4a55cd7d862144696702073bc13906b1f39f83";
+      sha512 = "ca4dc2c76af2db4d9a44f8ce9f29adf7188a799d00d2e8cb1bac807dc90930b06cc5329097ef771e4f070969cf42c3cfd65b32dfd3112f59efdb0071bc6292e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/rm/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/rm/firefox-57.0b14.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "44b3eaa4cde855738c221e7c1a3acc80d862f5159c13d946d67e47b382dfb4a5a6d360be961a03f605aae3e1c89e2a8a0d16f586646cdd1a3dec13f777b32577";
+      sha512 = "86af2317c04244c63f8182f46eb95abb1a113223c6d503c6b85c2fa9b596f44959e86323da0ad3a708f6c94aea4180246bb562f26c64a8c9b27d9a490d65a291";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ro/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/ro/firefox-57.0b14.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "a9dc8a1b4f0b236f2660be71df78c41e055b0547d8ce9bc258798fd4483fe888040d2c04a0ab0bab4c95a712d22370d957513b5ed08f1e332803d7067bc37aee";
+      sha512 = "2120d05bdf2dd8a702726e232fb3f94838befaedeedcb7c651d8d07047759b885904220173bfaaaa6d55b71e52085ce23156ad030992e8ae3981d47b41de046e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ru/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/ru/firefox-57.0b14.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "d2c42dee48f21e847de67efe353088ee949fc0af99ef510f5b76128933fd5432b2e0cced59ce0a0157e396b92beb645d78d758823582cc5dbb63718bf85d9b20";
+      sha512 = "221b4170254ed9acd7edb256ae560060f640c7e6c02236e1925e38489e387f839c14b5cdfa2a0e4a0173e8b98a2ab57b7733a6fa361172166097fc84b260bba3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/si/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/si/firefox-57.0b14.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "57be5923936b02cce924fa05994a6a887906104175e305043ea5a51e90cd35cc48c190ddbe2d060d64965b32c65296967dfc53a1e700d7defa078d02907069ef";
+      sha512 = "ea216290852677ae93bdbfee42b65473f9e00797175b7e36f4766a251fb302fd69009888f36efca7d04ef29fb0d66e75bbfddbf25f7f59dbe1d6767ffeb0c543";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/sk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/sk/firefox-57.0b14.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "12a74e9df967e6a058fbf53baa842bf199190dcc3e5c81eb49da29267760034ea41abdd5b1610f4e06cb30e462cde4c74430d58ab7efe7ed755d19919550827c";
+      sha512 = "92071604add2392aa144caf61ad747d98be52c3fbb82c86f903772d470928f71748d8def2f367a8b6bfe04ac6769fc57f8de29210ae50bc45b75b94f5005b564";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/sl/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/sl/firefox-57.0b14.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "9053a6dd752ee19f8dc49a2bc41c1d91b6a0f77bca71cbdbbe46b645388320a12be4db14714c62c2306b1bab78059826a8fecdf0897ec52ce0fa8e743e25b83c";
+      sha512 = "94341abe0210c9632ebabc47325c55577e9e6a5f54b4cfb0ba9d19298dea1b3d6f70a68c3f82f6a4c371f8ddd6e088b18ea56282faeda0c824040e6c4cee0db1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/son/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/son/firefox-57.0b14.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "b8f6bbe404306f17ae982238d573302165c366beff14917e64dda7c07b6a2f4e1f9b2042a97b3cbfab02f5e7fb860287cbaa30536494506ded1ee51818d3093a";
+      sha512 = "537a57fb00d61b0566d9fd344919b65486f7c767c93d0aec9595467cf9a081d63c8ee7d3c7c3a3409ddb08d57f36ae078e3defc79826779954641c895079c1da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/sq/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/sq/firefox-57.0b14.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "6dd4c84f38d7c1d0ebff77737fec3ec669532fa9be785414a9f125cbf184c88185bfd4541818d696b93237d4acb0654d7c6f38e9a0ab7ea35a10369ccde1bcb8";
+      sha512 = "a4ad413f8bf4ea8333b3c182a5c02283886e395e58b6ac5a53a298afba0938ec38648b67af3009a44468ab6fa89b6684d86b4d83525f0dcbb470f078584b6dea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/sr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/sr/firefox-57.0b14.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "984be4970c5224077e6e97c3137df1d62ccebb7fe78e3506ce4ae78e17d7961653feb276712735293d2ebf22a8ce8b0b91b28edc80b2413fea24dbf059eb1ad6";
+      sha512 = "15990e14d69bc0f043f7bcba54c5c27b7562c8fa68c5c14e7df695382303ee6ad40eb6b22319e8f9110b59f51209e0c8a6357e257862a50d8d515ea7f414ae74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/sv-SE/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/sv-SE/firefox-57.0b14.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "d0fd4b307598fd42d76414f4f097d0ea3e2243ab8de536870be23687eb6ea64f226a54b3fee176451bcd9e1305c6aa4c60daeb72b3341102f670d4905f4efe27";
+      sha512 = "690e94fc46c94710e488b1a8cd096927756026d0d6ea49f983883092e32f9dc0d2fdbaf6efe4c236cf750873b7907807fcec6826d2ce8b2473d0c4ef5461a1e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ta/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/ta/firefox-57.0b14.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "6b59fe4cde16c02c5b4867d48e6af4814794bf4a4f3b41e24cfb6e85d1e81f31446193c831b2ce50f30114260fda5e0a20ebe15fa23e1b962f07d66394f5d654";
+      sha512 = "839ac81dd6cde69b05e934a4bfb943fa5c65f86d4c7d64c58eb86e7911f81d93a85abc3ad732ae0baa9c7df76a906826a109ea15cb4ee85e802248b99b9ef1fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/te/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/te/firefox-57.0b14.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "a65e6b4d28f91764aadde1dd954d1e888a5bb24f356deba73c68fcc98d8be669a8f5147233af89881dbf20e40ba987326d15d5fcb857598e6718fdac4c5a59ce";
+      sha512 = "58b1225e50a0d3aef4b1d2da5d494b41e5ee41f53e2878a4945daf308d452348deed4cf87641aa51e9c061393c239109d02523596efb8ef7c675c885d80298aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/th/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/th/firefox-57.0b14.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "bc6d32c9054072fe931b703aec3c2a6a60d25dccd6e853eca5e716903a4694618e4cae79c9aafa52a2bd34133b6314b5eeecb92e56082c84dc10c47dd46be085";
+      sha512 = "6d0cd2b6cd315ca50445f3f87d1d2d2977bc34246481a58239f06a90253bbb810c0de488d064e80d3d2bcc475d34481c1f59ef0499ff59057b77c0cd67e71c7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/tr/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/tr/firefox-57.0b14.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "31e923c48adbb9e2b87ab6d5bf9ceb951426ad8c523b8def49900875d2a66220c2800ca25ddd4fc0f8a007ca4c95f7a69311228b34c5a8429bb26ce9b0f43871";
+      sha512 = "291f0c8f1241120a4fe4c2754ac82f443ef6f0d354f8b71b25b2020948a4de5b7ddbc87bbe2fc08b09ab1ec491a34fbbc69e6d472dc0114e369a99f967bf27c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/uk/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/uk/firefox-57.0b14.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "5036b3bf40bbfb13eb99aec17d90e9a7a60bb39eab1bcd21fa62b1d12b47f4b9eca7980c762f67ff5406ddcb20777a6553fcb02e611b276f1cdd483c8b67c162";
+      sha512 = "a6db7a4daa79d614b2d7c94372aacc50b4068ad437b38aab72cce99aba668fb230d5b81691678e09efb645282118dedf25e0c94e9d9cd9ef6a692c43a288e119";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/ur/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/ur/firefox-57.0b14.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "3605b5370f7158ffa54f5c5def6806885cc609b385b363e5a5c6442ff9262fd666e35b3f2256ad68b8f03a9e95282f3792ab83f49f0efb1e422b6dde56a85713";
+      sha512 = "cb69cf2aab416490b866e9b15b3706dfb81b003887456ad83907047424285f46d1a4b727766b78a633b33c6418c3f24dd9b53a90b151a1752709191328c0e227";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/uz/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/uz/firefox-57.0b14.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "a15e00c34a831eb8b251f60a9e17f7cdb65ed097fe0182a576c5809ecd208938d38c99a711750f0fb7835565adfefb15acbabe3b66c2f03eff36bf05527b47d4";
+      sha512 = "bb29f30171804b14aed28e5953bdda7bc94e2e1d23eb9af54c36937f90ff7bfd068abe4c065690aeab2ea61df08a59a5ed808e1f41e7d055b81235f8662d35ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/vi/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/vi/firefox-57.0b14.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "fa4e9de86197c3a95cd0d048e16de89bafd9d4733d3f2c96d221aa5c3839b980ab92efde0d18347251edf718f8d37a3fb8c5afcbaf254f697e320420cb91cc96";
+      sha512 = "b91dade05c291572c257be0a33d685fb48079c4c1dceb95d6b51601430717c5bdd4f962b9047c2f2a22dad38578a041025ad59b424efd1260ddf6f9d9e4d92b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/xh/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/xh/firefox-57.0b14.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "19b4a96abda10b29ab9aada2d9ba70e259ba0a3082796def317e1869f27b6326fe03f9d909f6753f494caef08f0f24e41f5b8be16c5c84ccaf06cf354b926cf5";
+      sha512 = "771335861bfdb99f17ae6c8607e784e3901f637d8e4a06385bd2bab4797589377e8c1b875600e9d8434d6ce5a7003ba4ca154dced98228b85c6f70272c0b8616";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/zh-CN/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/zh-CN/firefox-57.0b14.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "dd7e4c7bf1af9975f043bcc2be140b6c667f6dd74c2acc5d31963f6963fa5e0d7dc672fcfaca7ebfe99fd14cbd78725d24dc9c490c9ed1e211bd9e154e51c311";
+      sha512 = "d48c546975b92cc5c130e50b9fb3c84116235aaaed6ae8e04e975d8ed3605540b9ad640bc995fed23e42d271b9b2b598613b14822358c7487852030c5802dca6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b13/linux-i686/zh-TW/firefox-57.0b13.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0b14/linux-i686/zh-TW/firefox-57.0b14.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "82b442aeb21b5b0fa7d48519ef5a1d3a6b57f2e013cc4e7a18b050cdd6632ec69e8383e58d0608515397a460a2bf339e03f3e11f780698d5b8e3cd4f3aa8f5fc";
+      sha512 = "9e731700c738f0db2390478ba293f78a98496c374cd871a0ae483c3911685f0cca1b89531c06177f739fda77ee94fba03f2d93ad4669ce219d215cac8429819a";
     }
     ];
 }


### PR DESCRIPTION
###### Motivation for this change



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

