### PR TITLE
rlwrap: 0.42 -> 0.43

### DIFF
--- a/pkgs/tools/misc/rlwrap/default.nix
+++ b/pkgs/tools/misc/rlwrap/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, readline }:
 
 stdenv.mkDerivation rec {
-  name = "rlwrap-0.42";
+  name = "rlwrap-${version}";
+  version = "0.43";
 
   src = fetchurl {
-    url = "http://utopia.knoware.nl/~hlub/uck/rlwrap/${name}.tar.gz";
-    sha256 = "0i3yz303wscrysyzpdq04h4nrl9ajz9dbwi80risdl5rkm3dhw2s";
+    url = "https://github.com/hanslub42/rlwrap/releases/download/v${version}/${name}.tar.gz";
+    sha256 = "0bzb7ylk2770iv59v2d0gypb21y2xn87m299s9rqm6rdi2vx11lf";
   };
 
   buildInputs = [ readline ];
@@ -17,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Readline wrapper for console programs";
-    homepage = http://utopia.knoware.nl/~hlub/uck/rlwrap/;
+    homepage = https://github.com/hanslub42/rlwrap;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];


### PR DESCRIPTION
###### Motivation for this change

Update rlwrap to the last version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

