### PR TITLE
fdm: 1.8 -> 1.9.0.20170124

### DIFF
--- a/pkgs/tools/networking/fdm/default.nix
+++ b/pkgs/tools/networking/fdm/default.nix
@@ -1,45 +1,31 @@
-{ stdenv, fetchurl
-  , openssl, tdb, zlib, flex, bison
-  }:
-let 
-  buildInputs = [ openssl tdb zlib flex bison ];
-  sourceInfo = rec {
-    baseName="fdm";
-    version = "1.8";
-    name="${baseName}-${version}";
-    url="mirror://sourceforge/${baseName}/${baseName}/${name}.tar.gz";
-    sha256 = "0hi39f31ipv8f9wxb41pajvl61w6vaapl39wq8v1kl9c7q6h0k2g";
-  };
+{ stdenv, fetchFromGitHub, autoreconfHook, openssl, tdb, zlib, flex, bison }:
+
+let
+
+  baseName = "fdm";
+  version = "1.9.0.20170124";
+
 in
-stdenv.mkDerivation {
-  src = fetchurl {
-    inherit (sourceInfo) url sha256;
+
+stdenv.mkDerivation rec {
+  name = "${baseName}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "nicm";
+    repo = baseName;
+    rev = "cae4ea37b6b296d1b2e48f62934ea3a7f6085e33";
+    sha256 = "048191wdv1yprwinipmx2152gvd2iq1ssv7xfb1bzh6zirh1ya3n";
   };
 
-  inherit (sourceInfo) name version;
-  inherit buildInputs;
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ openssl tdb zlib flex bison ];
 
-  preBuild = ''
-    export makeFlags="$makeFlags PREFIX=$out"
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Dbool=int"
 
-    sed -i */Makefile -i Makefile -e 's@ -g bin @ @'
-    sed -i */Makefile -i Makefile -e 's@ -o root @ @'
-    sed -i GNUmakefile -e 's@ -g $(BIN_OWNER) @ @'
-    sed -i GNUmakefile -e 's@ -o $(BIN_GROUP) @ @'
-    sed -i */Makefile -i Makefile -i GNUmakefile -e 's@-I-@@g'
-  '';
-      
-  meta = {
+  meta = with stdenv.lib; {
     description = "Mail fetching and delivery tool - should do the job of getmail and procmail";
-    maintainers = with stdenv.lib.maintainers;
-    [
-      raskin
-    ];
-    platforms = with stdenv.lib.platforms;
-      linux;
-    homepage = http://fdm.sourceforge.net/;
-    inherit (sourceInfo) version;
-    updateWalker = true;
+    maintainers = with maintainers; [ raskin ];
+    platforms = with platforms; linux;
+    homepage = https://github.com/nicm/fdm;
+    downloadPage = https://github.com/nicm/fdm/releases;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Version bump
_and_ sf.net repo does not exist anymore so this updates homepage and src (part of #30636 )
_and_ fetching a recent commit rather than plain v1.9 so we get these fixes :

- [Use-after-free](https://github.com/nicm/fdm/commit/71a3ff139deaa5bfb83d3f2dac49f91346ad1d14)
- [Disable insecure stuff that OpenSSL leaves enabled by default](https://github.com/nicm/fdm/commit/b9248206fa5f725753dc7fb721b9b6f977d50ec8)
- [No more SF mail address](https://github.com/nicm/fdm/commit/766fcf6a4d6ccb83ea607e26cdd72ae216c05703) (man pages refresh)

cc @7c6f434c as maintainer : can you check I'm not messing up your `update-walker` process here?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

