### PR TITLE
mawk: 1.3.4-20161120 -> 1.3.4-20171017

### DIFF
--- a/pkgs/tools/text/mawk/default.nix
+++ b/pkgs/tools/text/mawk/default.nix
@@ -1,11 +1,14 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "mawk-1.3.4-20161120";
+  name = "mawk-1.3.4-20171017";
 
   src = fetchurl {
-    url = "ftp://invisible-island.net/mawk/${name}.tgz";
-    sha256 = "07hc33g2ip7463dravsiz0zwfc8vy4y4jxqvp7rz3hb896xw27in";
+    urls = [
+      "https://invisible-mirror.net/archives/mawk/${name}.tgz"
+      "ftp://invisible-island.net/mawk/${name}.tgz"
+    ];
+    sha256 = "0nwyxhipn4jx7j695lih1xggxm6cp4fjk4wbgihd33ni3rfi25yv";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Update mawk to the last version
 
> 20171017
>         + add Debian compile/link flags to test-package.
>         + cleanup spurious warnings from latest gcc.
>         + changes for Original-Mawk #48:
>           + add checks for stack overflow and underflow
>           + increase stack limit to 1024
>         + updated configure macros
>         + update config.guess and config.sub

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

