### PR TITLE
textadept: fix build

### DIFF
--- a/pkgs/applications/editors/textadept/default.nix
+++ b/pkgs/applications/editors/textadept/default.nix
@@ -32,7 +32,7 @@ let
       build_dir=$PWD
       cd $TMPDIR
 
-      local_path=$(basename ${store_path} .zip | sed -e 's/^[a-z0-9]*-//')
+      local_path=$(basename ${url} .zip)
 
       cp -r ${store_path} $local_path
       chmod u+rwX -R $local_path


### PR DESCRIPTION
###### Motivation for this change

It won't build following https://github.com/NixOS/nixpkgs/commit/c3255fe8ec326d2c8fe9462d49ed83aa64d3e68f
While this change works perhaps it might be better to explicitly feed a `name` to `fetchzip`.

/cc @7c6f434c @mirrexagon 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

