### PR TITLE
openrct2: fix build

### DIFF
--- a/pkgs/games/openrct2/default.nix
+++ b/pkgs/games/openrct2/default.nix
@@ -24,8 +24,7 @@ in
 stdenv.mkDerivation rec {
   inherit name;
 
-  srcs = [ openrct2-src title-sequences-src ];
-  sourceRoot = ".";
+  src = openrct2-src;
 
   buildInputs = [
     SDL2
@@ -46,11 +45,7 @@ stdenv.mkDerivation rec {
   ];
 
   postUnpack = ''
-    cp -r ${openrct2-src}/* ${sourceRoot}
-    cp -r ${title-sequences-src} ${sourceRoot}/title
-
-    # creating temporary files in fixCmakeFiles fails otherwise
-    chmod -R u+w ${sourceRoot}
+    cp -r ${title-sequences-src} $sourceRoot/title
   '';
 
   cmakeFlags = [


### PR DESCRIPTION
###### Motivation for this change

It won't build following https://github.com/NixOS/nixpkgs/commit/c3255fe8ec326d2c8fe9462d49ed83aa64d3e68f.

/cc @geistesk 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

