### PR TITLE
nixpkgs manual : clearer meta.platforms description

### DIFF
--- a/doc/meta.xml
+++ b/doc/meta.xml
@@ -200,11 +200,9 @@ meta-attributes</title>
 meta.platforms = stdenv.lib.platforms.linux;
 </programlisting>
 
-    Attribute Set <varname>stdenv.lib.platforms</varname> in
-    <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/lib/platforms.nix">
-    <filename>nixpkgs/lib/platforms.nix</filename></link> defines various common
-    lists of platforms types.
-    </para></listitem>
+    Attribute Set <varname>stdenv.lib.platforms</varname> defines
+    <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/lib/systems/doubles.nix">
+    various common lists</link> of platforms types.</para></listitem>
   </varlistentry>
 
   <varlistentry>


### PR DESCRIPTION
###### Motivation for this change
Follow-up to #31217
Refer to `doubles.nix` for a list of common platforms types usually seen in package definitions

@BlessJah @grahamc 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

