### PR TITLE
synergy: track upstream repository name change.

### DIFF
--- a/pkgs/applications/misc/synergy/default.nix
+++ b/pkgs/applications/misc/synergy/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "symless";
-    repo = "synergy";
+    repo = "synergy-core";
     rev = "v${version}-stable";
     sha256 = "0ksgr9hkf09h54572p7k7b9zkfhcdb2g2d5x7ixxn028y8i3jyp3";
   };


### PR DESCRIPTION
###### Motivation for this change
The name of the github repo for synergy changed, this changes the derivation to match.
