### PR TITLE
wireguard: add support for default routing

### DIFF
--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -227,13 +227,16 @@ let
 
             (optionals (values.allowedIPsAsRoutes != false) (map (peer:
             (map (allowedIP:
-            "${ipCommand} route replace ${allowedIP} dev ${name} table ${values.table}"
+            if (allowedIP == "0.0.0.0/0") || (builtins.match "[0:]+/0" allowedIP != null)
+            then "${pkgs.wireguard}/bin/wg-default add ${name} ${allowedIP}"
+            else "${ipCommand} route replace ${allowedIP} dev ${name} table ${values.table}"
             ) peer.allowedIPs)
             ) values.peers))
 
             values.postSetup
           ]);
           ExecStop = flatten([
+            "${pkgs.wireguard}/bin/wg-default rm ${name}"
             "${ipCommand} link del dev ${name}"
             values.postShutdown
           ]);

--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libmnl, kernel ? null }:
+{ stdenv, fetchurl, libmnl, iproute, kernel ? null }:
 
 # module requires Linux >= 3.10 https://www.wireguard.io/install/#kernel-requirements
 assert kernel != null -> stdenv.lib.versionAtLeast kernel.version "3.10";
@@ -41,7 +41,7 @@ let
   };
 
   tools = stdenv.mkDerivation {
-    inherit src meta name;
+    inherit src meta name iproute;
 
     preConfigure = "cd src";
 
@@ -63,6 +63,8 @@ let
     postInstall = ''
       substituteInPlace $out/lib/systemd/system/wg-quick@.service \
         --replace /usr/bin $out/bin
+      substituteAll ${./wg-default.sh} "$out"/bin/wg-default
+      chmod a+x "$out"/bin/wg-default
     '';
   };
 

--- a/pkgs/os-specific/linux/wireguard/wg-default.sh
+++ b/pkgs/os-specific/linux/wireguard/wg-default.sh
@@ -1,0 +1,48 @@
+#! /usr/bin/env bash
+set -x
+WG="@out@/bin/wg"
+IP="@iproute@/bin/ip"
+
+if [[ $# -lt 2 ]] || [[ "$1" != "add" && "$1" != "rm" ]] || [[ "$1" == "add" && $# -ne 3 ]] || [[ "$1" == "rm" && $# -ne 2 ]]; then
+  echo "Usage: $0 [add|rm] interface [ipaddrToAdd]"
+  exit 1
+fi
+
+INTERFACE="$2"
+
+fwmark="$($WG show $INTERFACE fwmark)"
+DEFAULT_TABLE=0
+[[ $fwmark != off ]] && DEFAULT_TABLE=$(( fwmark ))
+
+if [[ "$1" == add ]]; then
+  # Add default route
+  if [[ $DEFAULT_TABLE -eq 0 ]]; then
+    DEFAULT_TABLE=51820
+    while [[ -n $($IP -4 route show table $DEFAULT_TABLE) || -n $($IP -6 route show table $DEFAULT_TABLE) ]]; do
+      ((DEFAULT_TABLE++))
+    done
+  fi
+  ipaddr="$3"
+  proto=-4
+  [[ "$ipaddr" == *:* ]] && proto=-6
+  $WG set "$INTERFACE" fwmark $DEFAULT_TABLE
+  $IP $proto route add "$ipaddr" dev "$INTERFACE" table $DEFAULT_TABLE
+  $IP $proto rule add not fwmark $DEFAULT_TABLE table $DEFAULT_TABLE
+  $IP $proto rule add table main suppress_prefixlength 0
+else
+  # Remove default routes
+  if [[ $DEFAULT_TABLE -ne 0 ]]; then
+    while [[ $($IP -4 rule show) == *"lookup $DEFAULT_TABLE"* ]]; do
+      $IP -4 rule delete table $DEFAULT_TABLE
+    done
+    while [[ $($IP -4 rule show) == *"from all lookup main suppress_prefixlength 0"* ]]; do
+      $IP -4 rule delete table main suppress_prefixlength 0
+    done
+    while [[ $($IP -6 rule show) == *"lookup $DEFAULT_TABLE"* ]]; do
+      $IP -6 rule delete table $DEFAULT_TABLE
+    done
+    while [[ $($IP -6 rule show) == *"from all lookup main suppress_prefixlength 0"* ]]; do
+      $IP -6 rule delete table main suppress_prefixlength 0
+    done
+  fi
+fi


### PR DESCRIPTION
###### Motivation for this change
Currently, when the allowedIP is set to 0.0.0.0/0 or ::/0, the default route is replaced to go through the wireguard wireguard. This is undesirable because the packets from the wireguard interface itself is looped back into the interface, making the interface unable to connect to its endpoint(s). This change replicates the bahaviour of the wg-quick script in this case, by routing all packets with a specific fwmark set by the wireguard interface to the default interface.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

