### PR TITLE
nsjail: 2.1 -> 2.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -94,6 +94,7 @@
   bramd = "Bram Duvigneau <bram@bramd.nl>";
   bstrik = "Berno Strik <dutchman55@gmx.com>";
   bzizou = "Bruno Bzeznik <Bruno@bzizou.net>";
+  c0bw3b = "Renaud <c0bw3b@gmail.com>";
   c0dehero = "CodeHero <codehero@nerdpol.ch>";
   calbrecht = "Christian Albrecht <christian.albrecht@mayflower.de>";
   calrama = "Moritz Maxeiner <moritz@ucworks.org>";

--- a/pkgs/tools/security/nsjail/default.nix
+++ b/pkgs/tools/security/nsjail/default.nix
@@ -3,29 +3,31 @@
 
 stdenv.mkDerivation rec {
   name = "nsjail-${version}";
-  version = "2.1";
+  version = "2.2";
 
   src = fetchFromGitHub {
     owner           = "google";
     repo            = "nsjail";
     rev             = version;
     fetchSubmodules = true;
-    sha256          = "1wkhy86d0vgzngdvv593yhcghjh63chb8s67v891zll6bwgwg5h2";
+    sha256          = "11323j5wd02nm8ibvzbzq7dla70bmcldc71lv5bpk4x7h64ai14v";
   };
 
   nativeBuildInputs = [ autoconf libtool pkgconfig ];
   buildInputs = [ bison flex libnl protobuf protobufc ];
+  enableParallelBuilding = true;
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp nsjail $out/bin
+    mkdir -p $out/bin $out/share/man/man1
+    install nsjail $out/bin/
+    install nsjail.1 $out/share/man/man1/
   '';
 
   meta = with stdenv.lib; {
     description = "A light-weight process isolation tool, making use of Linux namespaces and seccomp-bpf syscall filters";
     homepage    = http://nsjail.com/;
-    license     = licenses.apsl20;
-    maintainers = [ maintainers.bosu ];
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ bosu c0bw3b ];
     platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Fixed the meta.license information
Version bump contains:

>     Works correctly with some archs which need aligned stack for clone (e.g. aarch64)
>     Enable CLONE_NEWCGROUP by default (can be disabled)
>     Added CTRL+\ (SIGQUIT) handler to show all connections
>     Create new dirs in /run/user/ first (instead of /tmp)
>     Unblock all signals prior to execve
>     Don't start new ns-init if CLONE_NEWPID is not requested
>     Support cgroup net_cls subsystem
>     Mount: better statvfs -> mount flags mapping


BTW, NixOS is the one distro providing a recent version of this tool  😹 
https://repology.org/metapackage/nsjail/versions


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

