### PR TITLE
adapta-gtk-theme: 3.91.2.147 -> 3.92.1.72

### DIFF
--- a/pkgs/misc/themes/adapta/default.nix
+++ b/pkgs/misc/themes/adapta/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "adapta-gtk-theme-${version}";
-  version = "3.91.2.147";
+  version = "3.92.1.72";
 
   src = fetchFromGitHub {
-    owner = "tista500";
-    repo = "Adapta";
+    owner = "adapta-project";
+    repo = "adapta-gtk-theme";
     rev = version;
-    sha256 = "1sv4s8rcc40v4lanapdqanlqf1l60rbc5wd7h73l5cigbqxxgda9";
+    sha256 = "19kav8m6aj4h7qg0z92k09lppzdgy6h9lxxv3qqqrl3hmg7bn0sx";
   };
 
   preferLocalBuild = true;
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "An adaptive Gtk+ theme based on Material Design";
-    homepage = https://github.com/tista500/Adapta;
+    homepage = https://github.com/adapta-project/adapta-gtk-theme;
     license = with licenses; [ gpl2 cc-by-sa-30 ];
     platforms = platforms.linux;
     maintainers = [ maintainers.romildo ];


### PR DESCRIPTION
###### Motivation for this change

I can't build the version currently in nixpkgs since it can no longer fetch the source from github (I get a 404 error). The repository owner changed from "tista500" to "adapta-project". This PR updates the package to the latest version in the new repo.

CC @romildo 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

