### PR TITLE
subsurface: 4.6.0 -> 4.7.2

### DIFF
--- a/pkgs/applications/misc/subsurface/default.nix
+++ b/pkgs/applications/misc/subsurface/default.nix
@@ -1,63 +1,22 @@
-{
-  stdenv,
-  cmake, doxygen, pkgconfig, autoreconfHook,
-  curl,
-  fetchgit,
-  grantlee,
-  libgit2,
-  libusb,
-  libssh2,
-  libxml2,
-  libxslt,
-  libzip,
-  qtbase, qtconnectivity, qtquickcontrols, qtscript, qtsvg, qttools, qtwebkit,
-  sqlite
+{ stdenv, fetchurl, fetchFromGitHub, autoreconfHook, cmake, makeWrapper, pkgconfig, qmake
+, curl, grantlee, libgit2, libusb, libssh2, libxml2, libxslt, libzip, zlib
+, qtbase, qtconnectivity, qtlocation, qtsvg, qttools, qtwebkit
 }:
 
 let
-  version = "4.6.0";
-
-  libmarble = stdenv.mkDerivation rec {
-    name = "libmarble-ssrf-${version}";
-
-    src = fetchgit {
-      url    = "git://git.subsurface-divelog.org/marble";
-      rev    = "refs/tags/v${version}";
-      sha256 = "1dm2hdk6y36ls7pxbzkqmyc46hdy2cd5f6pkxa6nfrbhvk5f31zd";
-    };
-
-    buildInputs = [ qtbase qtquickcontrols qtscript qtwebkit ];
-    nativeBuildInputs = [ doxygen pkgconfig cmake ];
-
-    enableParallelBuilding = true;
-
-    cmakeFlags = [
-      "-DQTONLY=TRUE"
-      "-DQT5BUILD=ON"
-      "-DBUILD_MARBLE_TESTS=NO"
-      "-DWITH_DESIGNER_PLUGIN=NO"
-      "-DBUILD_MARBLE_APPS=NO"
-    ];
-
-    meta = with stdenv.lib; {
-      description = "Qt library for a slippy map with patches from the Subsurface project";
-      homepage = http://subsurface-divelog.org;
-      license = licenses.lgpl21;
-      maintainers = with maintainers; [ mguentner ];
-      platforms = platforms.all;
-    };
-  };
+  version = "4.7.2";
 
   libdc = stdenv.mkDerivation rec {
     name = "libdivecomputer-ssrf-${version}";
 
-    src = fetchgit {
-      url    = "git://subsurface-divelog.org/libdc";
-      rev    = "refs/tags/v${version}";
-      sha256 = "0s82c8bvqph9c9chwzd76iwrw968w7lgjm3pj4hmad1jim67bs6n";
+    src = fetchurl {
+      url = "https://subsurface-divelog.org/downloads/libdivecomputer-subsurface-branch-${version}.tgz";
+      sha256 = "04wadhhva1bfnwk0kl359kcv0f83mgym2fzs441spw5llcl7k52r";
     };
 
     nativeBuildInputs = [ autoreconfHook ];
+
+    buildInputs = [ zlib ];
 
     enableParallelBuilding = true;
 
@@ -70,31 +29,73 @@ let
     };
   };
 
+  googlemaps = stdenv.mkDerivation rec {
+    name = "googlemaps-${version}";
+
+    version = "2017-09-17";
+
+    src = fetchFromGitHub {
+      owner = "vladest";
+      repo = "googlemaps";
+      rev = "1b857c02504dd52b1aa442418b8dcea78ced3f35";
+      sha256 = "14icmc925g4abwwdrldjc387aiyvcp3ia5z7mfh9qa09bv829a84";
+    };
+
+    nativeBuildInputs = [ qmake ];
+
+    buildInputs = [ qtbase qtlocation ];
+
+    pluginsSubdir = "lib/qt-${qtbase.qtCompatVersion}/plugins";
+
+    installPhase = ''
+      mkdir $out $(dirname ${pluginsSubdir})
+      mv plugins ${pluginsSubdir}
+      mv lib $out/
+    '';
+
+    enableParallelBuilding = true;
+
+    meta = with stdenv.lib; {
+      inherit (src.meta) homepage;
+      description = "QtLocation plugin for Google maps tile API";
+      maintainers = with maintainers; [ orivej ];
+      license = licenses.mit;
+      platforms = platforms.all;
+    };
+  };
+
 in stdenv.mkDerivation rec {
   name = "subsurface-${version}";
 
-  src = fetchgit {
-    url    = "git://git.subsurface-divelog.org/subsurface";
-    rev    = "refs/tags/v${version}";
-    sha256 = "1rk5n52p6cnyjrgi7ybhmvh7y31zxrjny0mqpnc1wql69f90h94c";
+  src = fetchurl {
+    url = "https://subsurface-divelog.org/downloads/Subsurface-${version}.tgz";
+    sha256 = "06f215xx1nc2q2qff2ihcl86fkrlnkvacl1swi3fw9iik6nq3bjp";
   };
 
   buildInputs = [
-    libdc libmarble
+    libdc googlemaps
     curl grantlee libgit2 libssh2 libusb libxml2 libxslt libzip
     qtbase qtconnectivity qtsvg qttools qtwebkit
   ];
-  nativeBuildInputs = [ cmake pkgconfig ];
 
-  enableParallelBuilding = false; # subsurfacewebservices.h dependency on ui_webservices.h
+  nativeBuildInputs = [ cmake makeWrapper pkgconfig ];
 
   cmakeFlags = [
-    "-DMARBLE_LIBRARIES=${libmarble}/lib/libssrfmarblewidget.so"
+    "-DLIBDC_FROM_PKGCONFIG=ON"
     "-DNO_PRINTING=OFF"
   ];
 
+  postInstall = ''
+    wrapProgram $out/bin/subsurface \
+      --prefix QT_PLUGIN_PATH : "${googlemaps}/${googlemaps.pluginsSubdir}"
+  '';
+
+  enableParallelBuilding = true;
+
+  passthru = { inherit version libdc googlemaps; };
+
   meta = with stdenv.lib; {
-    description = "Subsurface is an open source divelog program that runs on Windows, Mac and Linux";
+    description = "A divelog program";
     longDescription = ''
       Subsurface can track single- and multi-tank dives using air, Nitrox or TriMix.
       It allows tracking of dive locations including GPS coordinates (which can also


### PR DESCRIPTION
###### Motivation for this change

The previous version does not build:

```
/tmp/nix-build-subsurface-4.6.0.drv-0/subsurface/desktop-widgets/plugins/facebook/facebookconnectwidget.cpp:24:0:
/tmp/nix-build-subsurface-4.6.0.drv-0/subsurface/desktop-widgets/./mainwindow.h:16:27: fatal error: ui_mainwindow.h: No such file or directory
```

`libmarble` dependency was replaced by `googlemaps`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc maintainer @mguentner