### PR TITLE
services.xserver: fix defaults of X11

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -90,6 +90,14 @@ following incompatible changes:</para>
       That means that old configuration is not overwritten by default when update to the znc options are made.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      The option <option>services.xserver.desktopManager.default</option> is now <literal>none</literal> by default.
+      An assertion failure is thrown if WM's and DM's default are <literal>none</literal>.
+      To explicitly run a plain X session without and DM or WM, the newly introduced option <option>services.xserver.plainX</option>
+      must be set to true.
+    </para>
+  </listitem>
 </itemizedlist>
 
 </section>

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -87,8 +87,8 @@ in
 
       default = mkOption {
         type = types.str;
-        default = "";
-        example = "none";
+        default = "none";
+        example = "plasma5";
         description = "Default desktop manager loaded if none have been chosen.";
         apply = defaultDM:
           if defaultDM == "" && cfg.session.list != [] then

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -91,7 +91,7 @@ in
         example = "plasma5";
         description = "Default desktop manager loaded if none have been chosen.";
         apply = defaultDM:
-          if defaultDM == "" && cfg.session.list != [] then
+          if defaultDM == "none" && cfg.session.list != [] then
             (head cfg.session.list).name
           else if any (w: w.name == defaultDM) cfg.session.list then
             defaultDM

--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -61,7 +61,9 @@ in
         example = "wmii";
         description = "Default window manager loaded if none have been chosen.";
         apply = defaultWM:
-          if any (w: w.name == defaultWM) cfg.session then
+          if defaultWM == "none" && cfg.session != []  then
+            (head cfg.session).name
+          else if any (w: w.name == defaultWM) cfg.session then
             defaultWM
           else
             throw "Default window manager (${defaultWM}) not found.";

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -562,7 +562,9 @@ in
                 + concatMapStringsSep ", " (x: x.output) primaryHeads;
       })
       { assertion = cfg.desktopManager.default == "none" && cfg.windowManager.default == "none" -> cfg.plainX;
-        message = "Either the desktop manager or the window manager shouldn't be `none`! To explicitly allow this, you can also set `services.xserver.plainX` to `true`.";
+        message = "Either the desktop manager or the window manager shouldn't be `none`! "
+                + "To explicitly allow this, you can also set `services.xserver.plainX` to `true`. "
+                + "The `default` value looks for enabled WMs/DMs and select the first one.";
       }
     ];
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -161,6 +161,15 @@ in
         '';
       };
 
+      plainX = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether the X11 session can be plain (without DM/WM) and
+          the Xsession script will be used as fallback or not.
+        '';
+      };
+
       autorun = mkOption {
         type = types.bool;
         default = true;
@@ -552,6 +561,9 @@ in
                 + "${toString (length primaryHeads)} heads set to primary: "
                 + concatMapStringsSep ", " (x: x.output) primaryHeads;
       })
+      { assertion = cfg.desktopManager.default == "none" && cfg.windowManager.default == "none" -> cfg.plainX;
+        message = "Either the desktop manager or the window manager shouldn't be `none`! To explicitly allow this, you can also set `services.xserver.plainX` to `true`.";
+      }
     ];
 
     environment.etc =


### PR DESCRIPTION
###### Motivation for this change

follow-up for #30517 (/cc @nbp @bendlas @NeQuissimus)

This ensures that if a WM/DM is enabled, no default needs to be set and re-adds my original change.

Please not that setting `services.xserver.enable = true;` without any further configuration works now
since `xterm` is enabled by default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

