### PR TITLE
fetchurl: add passthru

### DIFF
--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -84,6 +84,9 @@ in
 
 , # Meta information, if any.
   meta ? {}
+
+  # Passthru information, if any.
+, passthru ? {}
 }:
 
 assert builtins.isList urls;
@@ -139,4 +142,5 @@ else stdenv.mkDerivation {
   '';
 
   inherit meta;
+  inherit passthru;
 }


### PR DESCRIPTION
so that we could add e.g. the `version` attribute.

###### Motivation for this change

There have been discussions in the past about adding a `version` parameter to `stdenv.mkDerivation`. In my opinion, `version` is an attribute of the source, and therefore I propose having the possibility to add it to the source, using `passthru`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

