### PR TITLE
zimg: 2.4 -> 2.6.1

### DIFF
--- a/pkgs/development/libraries/zimg/default.nix
+++ b/pkgs/development/libraries/zimg/default.nix
@@ -2,17 +2,16 @@
 
 stdenv.mkDerivation rec{
   name = "zimg-${version}";
-  version = "2.4";
+  version = "2.6.1";
 
   src = fetchFromGitHub {
     owner  = "sekrit-twc";
     repo   = "zimg";
-    rev    = "v${version}";
-    sha256 = "11pk8a5manr751jhy0xrql57jzab57lwqjxbpd8kvm9m8b51icwq";
+    rev    = "release-${version}";
+    sha256 = "08hynzcxz95a4i67k5cn6isafdb6xjgd0x0miyhlnp2xc220zfqj";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ ];
 
   meta = with stdenv.lib; {
     description = "Scaling, colorspace conversion and dithering library";


### PR DESCRIPTION
###### Motivation for this change
New version available.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s)
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files (none, library)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

