### PR TITLE
pdns-recursor: 4.0.4 -> 4.0.6

### DIFF
--- a/pkgs/servers/dns/pdns-recursor/default.nix
+++ b/pkgs/servers/dns/pdns-recursor/default.nix
@@ -11,11 +11,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "pdns-recursor-${version}";
-  version = "4.0.4";
+  version = "4.0.6";
 
   src = fetchurl {
     url = "https://downloads.powerdns.com/releases/pdns-recursor-${version}.tar.bz2";
-    sha256 = "0k8y9zxj2lz4rq782vgzr28yd43q0hwlnvszwq0k9l6c967pff13";
+    sha256 = "03fnjiacvhdlkr3a2206mham0p6p24gkawashs5v12r68k32l67j";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/dns/pdns-recursor/default.nix
+++ b/pkgs/servers/dns/pdns-recursor/default.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
     "--with-systemd"
   ];
 
+  enableParallelBuilding = true;
+
   meta = {
     description = "A recursive DNS server";
     homepage = http://www.powerdns.com/;


### PR DESCRIPTION
###### Motivation for this change
New version available.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s)
- [x] Tested compilation of all pkgs that depend on this change (none)
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

