### PR TITLE
vapoursynth: R38 -> R39

### DIFF
--- a/pkgs/development/libraries/vapoursynth/default.nix
+++ b/pkgs/development/libraries/vapoursynth/default.nix
@@ -1,7 +1,8 @@
-{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook,
-  zimg, libass, yasm, python3, libiconv, ApplicationServices,
-  ocrSupport ?  false, tesseract,
-  imwriSupport? true,  imagemagick7
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook
+, zimg, libass, python3, libiconv
+, ApplicationServices, nasm
+, ocrSupport ?  false, tesseract
+, imwriSupport? true,  imagemagick7
 }:
 
 assert ocrSupport   -> tesseract != null;
@@ -11,18 +12,18 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "vapoursynth-${version}";
-  version = "R38";
+  version = "R39";
 
   src = fetchFromGitHub {
     owner  = "vapoursynth";
     repo   = "vapoursynth";
     rev    = version;
-    sha256 = "0nabl6949s7awy7rnr4ck52v50xr0hwr280fyzsqixgp8w369jn0";
+    sha256 = "0cw7w8xiwhxhwykydy13m44wm9vn9hrsi30z6017ngga9d84fhqy";
   };
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook nasm ];
   buildInputs = [
-    zimg libass tesseract yasm
+    zimg libass
     (python3.withPackages (ps: with ps; [ sphinx cython ]))
   ] ++ optionals stdenv.isDarwin [ libiconv ApplicationServices ]
     ++ optional ocrSupport   tesseract


### PR DESCRIPTION
###### Motivation for this change
New release available.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

