### PR TITLE
gcc: Refactor treatment of configure flags

### DIFF
--- a/pkgs/development/compilers/gcc/4.5/default.nix
+++ b/pkgs/development/compilers/gcc/4.5/default.nix
@@ -74,8 +74,8 @@ let version = "4.5.4";
       optional (gccCpu != null) "--with-cpu=${gccCpu}" ++
       optional (gccAbi != null) "--with-abi=${gccAbi}" ++
       # Ensure that -print-prog-name is able to find the correct programs.
-      [ " --with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
-        " --with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
+      [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
+        "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
       (if crossMingw && crossStageStatic then [
         "--with-headers=${libcCross}/include"
         "--with-gcc"
@@ -88,19 +88,21 @@ let version = "4.5.4";
         "--enable-sjlj-exceptions"
         "--enable-threads=win32"
         "--disable-win32-registry"
-        ] else if crossStageStatic then [
-        "--disable-libssp --disable-nls"
+      ] else if crossStageStatic then [
+        "--disable-libssp"
+        "--disable-nls"
         "--without-headers"
         "--disable-threads"
         "--disable-libmudflap"
-        "--disable-libgomp "
+        "--disable-libgomp"
         "--disable-shared"
         "--disable-decimal-float" # libdecnumber requires libc
-        ] else [
+      ] else [
         "--with-headers=${libcCross}/include"
         "--enable-__cxa_atexit"
         "--enable-long-long"
-        ] ++ (if crossMingw then [
+      ] ++
+        (if crossMingw then [
           "--enable-threads=win32"
           "--enable-sjlj-exceptions"
           "--enable-hash-synchronization"
@@ -108,12 +110,11 @@ let version = "4.5.4";
           "--disable-libssp"
           "--disable-nls"
           "--with-dwarf2"
-          ] else [
+        ] else [
           "--enable-threads=posix"
           "--enable-nls"
-          "--disable-decimal-float"
-        ]) # No final libdecnumber (it may work only in 386)
-      );
+          "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+        ]));
     stageNameAddon = if crossStageStatic then "-stage-static" else
       "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
@@ -274,11 +275,12 @@ stdenv.mkDerivation ({
 
     # Java options
     optionals langJava [
-      "--with-ecj-jar=${javaEcj} "
+      "--with-ecj-jar=${javaEcj}"
 
       # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
       # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
-      "--enable-java-home --with-java-home=\${prefix}/lib/jvm/jre "
+      "--enable-java-home"
+      "--with-java-home=\${prefix}/lib/jvm/jre"
     ] ++
     optional javaAwtGtk "--enable-java-awt=gtk" ++
     optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}" ++

--- a/pkgs/development/compilers/gcc/4.5/default.nix
+++ b/pkgs/development/compilers/gcc/4.5/default.nix
@@ -67,55 +67,53 @@ let version = "4.5.4";
     gccArch = stdenv.lib.attrByPath [ "gcc" "arch" ] null targetPlatform;
     gccCpu = stdenv.lib.attrByPath [ "gcc" "cpu" ] null targetPlatform;
     gccAbi = stdenv.lib.attrByPath [ "gcc" "abi" ] null targetPlatform;
-    withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
-    withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
-    withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
     crossMingw = (targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt");
 
     crossConfigureFlags =
-      withArch +
-      withCpu +
-      withAbi +
+      optional (gccArch != null) "--with-arch=${gccArch}" ++
+      optional (gccCpu != null) "--with-cpu=${gccCpu}" ++
+      optional (gccAbi != null) "--with-abi=${gccAbi}" ++
       # Ensure that -print-prog-name is able to find the correct programs.
-      " --with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as" +
-      " --with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" +
-      (if crossMingw && crossStageStatic then
-        " --with-headers=${libcCross}/include" +
-        " --with-gcc" +
-        " --with-gnu-as" +
-        " --with-gnu-ld" +
-        " --with-gnu-ld" +
-        " --disable-shared" +
-        " --disable-nls" +
-        " --disable-debug" +
-        " --enable-sjlj-exceptions" +
-        " --enable-threads=win32" +
-        " --disable-win32-registry"
-        else if crossStageStatic then
-        " --disable-libssp --disable-nls" +
-        " --without-headers" +
-        " --disable-threads " +
-        " --disable-libmudflap " +
-        " --disable-libgomp " +
-        " --disable-shared" +
-        " --disable-decimal-float" # libdecnumber requires libc
-        else
-        " --with-headers=${libcCross}/include" +
-        " --enable-__cxa_atexit" +
-        " --enable-long-long" +
-        (if crossMingw then
-          " --enable-threads=win32" +
-          " --enable-sjlj-exceptions" +
-          " --enable-hash-synchronization" +
-          " --enable-version-specific-runtime-libs" +
-          " --disable-libssp" +
-          " --disable-nls" +
-          " --with-dwarf2"
-          else
-          " --enable-threads=posix" +
-          " --enable-nls" +
-          " --disable-decimal-float") # No final libdecnumber (it may work only in 386)
-        );
+      [ " --with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
+        " --with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
+      (if crossMingw && crossStageStatic then [
+        "--with-headers=${libcCross}/include"
+        "--with-gcc"
+        "--with-gnu-as"
+        "--with-gnu-ld"
+        "--with-gnu-ld"
+        "--disable-shared"
+        "--disable-nls"
+        "--disable-debug"
+        "--enable-sjlj-exceptions"
+        "--enable-threads=win32"
+        "--disable-win32-registry"
+        ] else if crossStageStatic then [
+        "--disable-libssp --disable-nls"
+        "--without-headers"
+        "--disable-threads"
+        "--disable-libmudflap"
+        "--disable-libgomp "
+        "--disable-shared"
+        "--disable-decimal-float" # libdecnumber requires libc
+        ] else [
+        "--with-headers=${libcCross}/include"
+        "--enable-__cxa_atexit"
+        "--enable-long-long"
+        ] ++ (if crossMingw then [
+          "--enable-threads=win32"
+          "--enable-sjlj-exceptions"
+          "--enable-hash-synchronization"
+          "--enable-version-specific-runtime-libs"
+          "--disable-libssp"
+          "--disable-nls"
+          "--with-dwarf2"
+          ] else [
+          "--enable-threads=posix"
+          "--enable-nls"
+          "--disable-decimal-float"
+        ]) # No final libdecnumber (it may work only in 386)
+      );
     stageNameAddon = if crossStageStatic then "-stage-static" else
       "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
@@ -241,44 +239,61 @@ stdenv.mkDerivation ({
     then []
     else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
-  configureFlags = "
-    ${if enableMultilib then "" else "--disable-multilib"}
-    ${if enableShared then "" else "--disable-shared"}
-    ${if ppl != null then "--with-ppl=${ppl}" else ""}
-    ${if cloogppl != null then "--with-cloog=${cloogppl}" else ""}
-    ${if langJava then
-      "--with-ecj-jar=${javaEcj} " +
+  configureFlags =
+    # Basic dependencies
+    [
+      "--with-gmp=${gmp.dev}"
+      "--with-mpfr=${mpfr.dev}"
+      "--with-mpc=${libmpc}"
+    ] ++
+    optional (libelf != null) "--with-libelf=${libelf}" ++
+
+    # Basic configuration
+    [
+      "--disable-libstdcxx-pch"
+      "--without-included-gettext"
+      "--with-system-zlib"
+      "--enable-languages=${
+        concatStrings (intersperse ","
+          (  optional langC        "c"
+          ++ optional langCC       "c++"
+          ++ optional langFortran  "fortran"
+          ++ optional langJava     "java"
+          ++ optional langAda      "ada"
+          ++ optional langVhdl     "vhdl"
+          )
+        )
+      }"
+    ] ++
+    optional (!enableMultilib) "--disable-multilib" ++
+    optional (!enableShared) "--disable-shared" ++
+
+    # Optional features
+    optional (cloogppl != null) "--with-cloog=${cloogppl}" ++
+    optional (ppl != null) "--with-ppl=${ppl}" ++
+
+    # Java options
+    optionals langJava [
+      "--with-ecj-jar=${javaEcj} "
 
       # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
       # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
       "--enable-java-home --with-java-home=\${prefix}/lib/jvm/jre "
-      else ""}
-    ${if javaAwtGtk then "--enable-java-awt=gtk" else ""}
-    ${if langJava && javaAntlr != null then "--with-antlr-jar=${javaAntlr}" else ""}
-    --with-gmp=${gmp.dev}
-    --with-mpfr=${mpfr.dev}
-    --with-mpc=${libmpc}
-    ${if libelf != null then "--with-libelf=${libelf}" else ""}
-    --disable-libstdcxx-pch
-    --without-included-gettext
-    --with-system-zlib
-    --enable-languages=${
-      concatStrings (intersperse ","
-        (  optional langC        "c"
-        ++ optional langCC       "c++"
-        ++ optional langFortran  "fortran"
-        ++ optional langJava     "java"
-        ++ optional langAda      "ada"
-        ++ optional langVhdl     "vhdl"
-        )
-      )
-    }
-    ${ # Trick that should be taken out once we have a mips64el-linux not loongson2f
-      if targetPlatform == hostPlatform && stdenv.system == "mips64el-linux" then "--with-arch=loongson2f" else ""}
-    ${if langAda then " --enable-libada" else ""}
-    ${if targetPlatform == hostPlatform && targetPlatform.isi686 then "--with-arch=i686" else ""}
-    ${if targetPlatform != hostPlatform then crossConfigureFlags else ""}
-  ";
+    ] ++
+    optional javaAwtGtk "--enable-java-awt=gtk" ++
+    optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}" ++
+
+    # Ada
+    optional langAda "--enable-libada" ++
+
+    # Cross-compilation
+    optional (targetPlatform != hostPlatform) crossConfigureFlags ++
+
+    # Platform-specific flags
+    optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++
+    # Trick that should be taken out once we have a mips64el-linux not loongson2f
+    optional (targetPlatform == hostPlatform && stdenv.system == "mips64el-linux") "--with-arch=loongson2f"
+  ;
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
 
@@ -295,37 +310,41 @@ stdenv.mkDerivation ({
     # If we are making a cross compiler, cross != null
     NIX_CC_CROSS = optionalString (targetPlatform == hostPlatform) builtins.toString stdenv.cc;
     dontStrip = true;
-    configureFlags = ''
-      ${if enableMultilib then "" else "--disable-multilib"}
-      ${if enableShared then "" else "--disable-shared"}
-      ${if ppl != null then "--with-ppl=${ppl.crossDrv}" else ""}
-      ${if cloogppl != null then "--with-cloog=${cloogppl.crossDrv}" else ""}
-      ${if langJava then "--with-ecj-jar=${javaEcj.crossDrv}" else ""}
-      ${if javaAwtGtk then "--enable-java-awt=gtk" else ""}
-      ${if langJava && javaAntlr != null then "--with-antlr-jar=${javaAntlr.crossDrv}" else ""}
-      --with-gmp=${gmp.crossDrv}
-      --with-mpfr=${mpfr.crossDrv}
-      --with-mpc=${libmpc.crossDrv}
-      --disable-libstdcxx-pch
-      --without-included-gettext
-      --with-system-zlib
-      --enable-languages=${
-        concatStrings (intersperse ","
-          (  optional langC        "c"
-          ++ optional langCC       "c++"
-          ++ optional langFortran  "fortran"
-          ++ optional langJava     "java"
-          ++ optional langAda      "ada"
-          ++ optional langVhdl     "vhdl"
+    configureFlags =
+      optional (!enableMultilib) "--disable-multilib" ++
+      optional (!enableShared) "--disable-shared" ++
+      optional langJava "--with-ecj-jar=${javaEcj.crossDrv}" ++
+      optional javaAwtGtk "--enable-java-awt=gtk" ++
+      optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr.crossDrv}" ++
+      optional (ppl != null) "--with-ppl=${ppl.crossDrv}" ++
+      optional (cloogppl != null) "--with-cloog=${cloogppl.crossDrv}" ++
+
+      [
+        "--with-gmp=${gmp.crossDrv}"
+        "--with-mpfr=${mpfr.crossDrv}"
+        "--with-mpc=${libmpc.crossDrv}"
+        "--disable-libstdcxx-pch"
+        "--without-included-gettext"
+        "--with-system-zlib"
+        "--enable-languages=${
+          concatStrings (intersperse ","
+            (  optional langC        "c"
+            ++ optional langCC       "c++"
+            ++ optional langFortran  "fortran"
+            ++ optional langJava     "java"
+            ++ optional langAda      "ada"
+            ++ optional langVhdl     "vhdl"
+            ++ optional langGo       "go"
+            )
           )
-        )
-      }
-      ${if langAda then " --enable-libada" else ""}
-      ${if targetplatform == hostPlatform && targetPlatform.isi686 then "--with-arch=i686" else ""}
-      ${if targetPlatform != hostPlatform then crossConfigureFlags else ""}
-    '';
+        }"
+      ] ++
+      optional langAda "--enable-libada" ++
+      optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++
+      optional (targetPlatform != hostPlatform) crossConfigureFlags
+    ;
   };
- 
+
 
   # Needed for the cross compilation to work
   AR = "ar";

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -108,102 +108,83 @@ let version = "4.8.5";
     javaAwtGtk = langJava && x11Support;
 
     /* Platform flags */
-    platformFlags = let
-        gccArch = stdenv.platform.gcc.arch or null;
-        gccCpu = stdenv.platform.gcc.cpu or null;
-        gccAbi = stdenv.platform.gcc.abi or null;
-        gccFpu = stdenv.platform.gcc.fpu or null;
-        gccFloat = stdenv.platform.gcc.float or null;
-        gccMode = stdenv.platform.gcc.mode or null;
-        withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
-        withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
-        withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
-        withFpu = if gccFpu != null then " --with-fpu=${gccFpu}" else "";
-        withFloat = if gccFloat != null then " --with-float=${gccFloat}" else "";
-        withMode = if gccMode != null then " --with-mode=${gccMode}" else "";
-      in
-        withArch +
-        withCpu +
-        withAbi +
-        withFpu +
-        withFloat +
-        withMode;
+    mkPlatformFlags = platform: let
+        gccArch = platform.gcc.arch or null;
+        gccCpu = platform.gcc.cpu or null;
+        gccAbi = platform.gcc.abi or null;
+        gccFpu = platform.gcc.fpu or null;
+        gccFloat = platform.gcc.float or null;
+        gccMode = platform.gcc.mode or null;
+     in
+        optional (gccArch != null) "--with-arch=${gccArch}" ++
+        optional (gccCpu != null) "--with-cpu=${gccCpu}" ++
+        optional (gccAbi != null) "--with-abi=${gccAbi}" ++
+        optional (gccFpu != null) "--with-fpu=${gccFpu}" ++
+        optional (gccFloat != null) "--with-float=${gccFloat}" ++
+        optional (gccMode != null) "--with-mode=${gccMode}";
 
-    /* Cross-gcc settings */
+    /* Cross-gcc settings (build == host != target) */
+    /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
     crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
-    crossConfigureFlags = let
-        gccArch = targetPlatform.gcc.arch or null;
-        gccCpu = targetPlatform.gcc.cpu or null;
-        gccAbi = targetPlatform.gcc.abi or null;
-        gccFpu = targetPlatform.gcc.fpu or null;
-        gccFloat = targetPlatform.gcc.float or null;
-        gccMode = targetPlatform.gcc.mode or null;
-        withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
-        withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
-        withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
-        withFpu = if gccFpu != null then " --with-fpu=${gccFpu}" else "";
-        withFloat = if gccFloat != null then " --with-float=${gccFloat}" else "";
-        withMode = if gccMode != null then " --with-mode=${gccMode}" else "";
-      in
-        withArch +
-        withCpu +
-        withAbi +
-        withFpu +
-        withFloat +
-        withMode +
+    crossConfigureFlags =
+        mkPlatformFlags targetPlatform ++
+
         # Ensure that -print-prog-name is able to find the correct programs.
-        " --with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as" +
-        " --with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" +
+        [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
+          "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
         (if crossMingw && crossStageStatic then
-          " --with-headers=${libcCross}/include" +
-          " --with-gcc" +
-          " --with-gnu-as" +
-          " --with-gnu-ld" +
-          " --with-gnu-ld" +
-          " --disable-shared" +
-          " --disable-nls" +
-          " --disable-debug" +
-          " --enable-sjlj-exceptions" +
-          " --enable-threads=win32" +
-          " --disable-win32-registry"
-          else if crossStageStatic then
-          " --disable-libssp --disable-nls" +
-          " --without-headers" +
-          " --disable-threads " +
-          " --disable-libmudflap " +
-          " --disable-libgomp " +
-          " --disable-libquadmath" +
-          " --disable-shared" +
-          " --disable-libatomic " +  # libatomic requires libc
-          " --disable-decimal-float" # libdecnumber requires libc
-          else
-          (if crossDarwin then " --with-sysroot=${libcCross.out}/share/sysroot"
-           else                " --with-headers=${libcCross.dev}/include") +
-          # Ensure that -print-prog-name is able to find the correct programs.
-          " --enable-__cxa_atexit" +
-          " --enable-long-long" +
-          (if crossMingw then
-            " --enable-threads=win32" +
-            " --enable-sjlj-exceptions" +
-            " --enable-hash-synchronization" +
-            " --disable-libssp" +
-            " --disable-nls" +
-            " --with-dwarf2" +
+          [ "--with-headers=${libcCross}/include"
+            "--with-gcc"
+            "--with-gnu-as"
+            "--with-gnu-ld"
+            "--with-gnu-ld"
+            "--disable-shared"
+            "--disable-nls"
+            "--disable-debug"
+            "--enable-sjlj-exceptions"
+            "--enable-threads=win32"
+            "--disable-win32-registry"
+          ] else if crossStageStatic then
+          [ "--disable-libssp --disable-nls"
+            "--without-headers"
+            "--disable-threads "
+            "--disable-libgomp "
+            "--disable-libquadmath"
+            "--disable-shared"
+            "--disable-libatomic "  # libatomic requires libc
+            "--disable-decimal-float" # libdecnumber requires libc
+          ] else
+            (if crossDarwin then ["--with-sysroot=${getLib libcCross}/share/sysroot"]
+             else                ["--with-headers=${getDev libcCross}/include"]) ++
+          [ "--enable-__cxa_atexit"
+            "--enable-long-long"
+          ] ++
+          (if crossMingw then [
+            "--enable-threads=win32"
+            "--enable-sjlj-exceptions"
+            "--enable-hash-synchronization"
+            "--disable-libssp"
+            "--disable-nls"
+            "--with-dwarf2"
             # I think noone uses shared gcc libs in mingw, so we better do the same.
             # In any case, mingw32 g++ linking is broken by default with shared libs,
             # unless adding "-lsupc++" to any linking command. I don't know why.
-            " --disable-shared" +
+            "--disable-shared"
             # To keep ABI compatibility with upstream mingw-w64
-            " --enable-fully-dynamic-string"
-            else (if targetPlatform.libc == "uclibc" then
+            "--enable-fully-dynamic-string"
+          ] else
+            optionals (targetPlatform.libc == "uclibc") [
               # In uclibc cases, libgomp needs an additional '-ldl'
               # and as I don't know how to pass it, I disable libgomp.
-              " --disable-libgomp" else "") +
-            " --enable-threads=posix" +
-            " --enable-nls" +
-            " --disable-decimal-float") # No final libdecnumber (it may work only in 386)
-          );
+              "--disable-libgomp"
+            ] ++
+            [ "--enable-threads=posix"
+              "--enable-nls"
+              "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+            ]
+          )
+        );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
@@ -329,63 +310,87 @@ stdenv.mkDerivation ({
     then []
     else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
-  configureFlags = "
-    ${if hostPlatform.isSunOS then
-      " --enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit " +
-      # On Illumos/Solaris GNU as is preferred
-      " --with-gnu-as --without-gnu-ld "
-      else ""}
-    --enable-lto
-    ${if enableMultilib then "--disable-libquadmath" else "--disable-multilib"}
-    ${if enableShared then "" else "--disable-shared"}
-    ${if enablePlugin then "--enable-plugin" else "--disable-plugin"}
-    ${optionalString (isl != null) "--with-isl=${isl}"}
-    ${optionalString (cloog != null) "--with-cloog=${cloog} --disable-cloog-version-check --enable-cloog-backend=isl"}
-    ${if langJava then
-      "--with-ecj-jar=${javaEcj} " +
+  configureFlags =
+    # Basic dependencies
+    [
+      "--with-gmp-include=${gmp.dev}/include"
+      "--with-gmp-lib=${gmp.out}/lib"
+      "--with-mpfr-include=${mpfr.dev}/include"
+      "--with-mpfr-lib=${mpfr.out}/lib"
+      "--with-mpc=${libmpc}"
+    ] ++
+    optional (libelf != null) "--with-libelf=${libelf}" ++
+
+    # Basic configuration
+    [
+      "--enable-lto"
+      "--disable-libstdcxx-pch"
+      "--without-included-gettext"
+      "--with-system-zlib"
+      "--enable-static"
+      "--enable-languages=${
+        concatStrings (intersperse ","
+          (  optional langC        "c"
+          ++ optional langCC       "c++"
+          ++ optional langFortran  "fortran"
+          ++ optional langJava     "java"
+          ++ optional langAda      "ada"
+          ++ optional langVhdl     "vhdl"
+          ++ optional langGo       "go"
+          ++ optional langObjC     "objc"
+          ++ optional langObjCpp   "obj-c++"
+          ++ optionals crossDarwin [ "objc" "obj-c++" ]
+          )
+        )
+      }"
+    ] ++
+
+    # Optional features
+    optional (isl != null) "--with-isl=${isl}" ++
+    optional (cloog != null) "--with-cloog=${cloog} --disable-cloog-version-check --enable-cloog-backend=isl" ++
+
+    (if enableMultilib
+      then ["--enable-multilib" "--disable-libquadmath"]
+      else ["--disable-multilib"]) ++
+    optional (!enableShared) "--disable-shared" ++
+    (if enablePlugin
+      then ["--enable-plugin"]
+      else ["--disable-plugin"]) ++
+
+    # Java options
+    optionals langJava [
+      "--with-ecj-jar=${javaEcj} "
 
       # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
       # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
       "--enable-java-home --with-java-home=\${prefix}/lib/jvm/jre "
-      else ""}
-    ${if javaAwtGtk then "--enable-java-awt=gtk" else ""}
-    ${if langJava && javaAntlr != null then "--with-antlr-jar=${javaAntlr}" else ""}
-    --with-gmp-include=${gmp.dev}/include
-    --with-gmp-lib=${gmp.out}/lib
-    --with-mpfr-include=${mpfr.dev}/include
-    --with-mpfr-lib=${mpfr.out}/lib
-    --with-mpc=${libmpc}
-    ${if libelf != null then "--with-libelf=${libelf}" else ""}
-    --disable-libstdcxx-pch
-    --without-included-gettext
-    --with-system-zlib
-    --enable-static
-    --enable-languages=${
-      concatStrings (intersperse ","
-        (  optional langC        "c"
-        ++ optional langCC       "c++"
-        ++ optional langFortran  "fortran"
-        ++ optional langJava     "java"
-        ++ optional langAda      "ada"
-        ++ optional langVhdl     "vhdl"
-        ++ optional langGo       "go"
-        ++ optional langObjC     "objc"
-        ++ optional langObjCpp   "obj-c++"
-        ++ optionals crossDarwin [ "objc" "obj-c++" ]
-        )
-      )
-    }
-    ${if targetPlatform == hostPlatform
-      then if hostPlatform.isDarwin
-        then " --with-native-system-header-dir=${darwin.usr-include}"
-        else " --with-native-system-header-dir=${getDev stdenv.cc.libc}/include"
-      else ""}
-    ${if langAda then " --enable-libada" else ""}
-    ${if targetPlatform == hostPlatform && targetPlatform.isi686 then "--with-arch=i686" else ""}
-    ${if targetPlatform != hostPlatform then crossConfigureFlags else ""}
-    ${if !bootstrap then "--disable-bootstrap" else ""}
-    ${if targetPlatform == hostPlatform then platformFlags else ""}
-  ";
+    ] ++
+    optional javaAwtGtk "--enable-java-awt=gtk" ++
+    optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}" ++
+
+    # Ada
+    optional langAda "--enable-libada" ++
+
+    # Cross-compilation
+    optional (targetPlatform == hostPlatform) (
+      let incDir = if hostPlatform.isDarwin
+                     then "${darwin.usr-include}"
+                     else "${getDev stdenv.cc.libc}/include";
+      in "--with-native-system-header-dir=${incDir}"
+    ) ++
+
+    optional (targetPlatform == hostPlatform) (mkPlatformFlags stdenv.platform) ++
+    optional (targetPlatform != hostPlatform) crossConfigureFlags ++
+    optional (!bootstrap) "--disable-bootstrap" ++
+
+    # Platform-specific flags
+    optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++
+    optionals hostPlatform.isSunOS [
+      "--enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit"
+      # On Illumos/Solaris GNU as is preferred
+      "--with-gnu-as --without-gnu-ld"
+    ]
+  ;
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
 
@@ -404,11 +409,6 @@ stdenv.mkDerivation ({
     xgccAbi = targetPlatform.gcc.abi or null;
     xgccFpu = targetPlatform.gcc.fpu or null;
     xgccFloat = targetPlatform.gcc.float or null;
-    xwithArch = if xgccArch != null then " --with-arch=${xgccArch}" else "";
-    xwithCpu = if xgccCpu != null then " --with-cpu=${xgccCpu}" else "";
-    xwithAbi = if xgccAbi != null then " --with-abi=${xgccAbi}" else "";
-    xwithFpu = if xgccFpu != null then " --with-fpu=${xgccFpu}" else "";
-    xwithFloat = if xgccFloat != null then " --with-float=${xgccFloat}" else "";
   in {
     AR = "${targetPlatform.config}-ar";
     LD = "${targetPlatform.config}-ld";
@@ -422,38 +422,40 @@ stdenv.mkDerivation ({
     # If we are making a cross compiler, cross != null
     NIX_CC_CROSS = optionalString (targetPlatform == hostPlatform) builtins.toString stdenv.cc;
     dontStrip = true;
-    configureFlags = ''
-      ${if enableMultilib then "" else "--disable-multilib"}
-      ${if enableShared then "" else "--disable-shared"}
-      ${if cloog != null then "--with-cloog=${cloog.crossDrv} --enable-cloog-backend=isl" else ""}
-      ${if langJava then "--with-ecj-jar=${javaEcj.crossDrv}" else ""}
-      ${if javaAwtGtk then "--enable-java-awt=gtk" else ""}
-      ${if langJava && javaAntlr != null then "--with-antlr-jar=${javaAntlr.crossDrv}" else ""}
-      --with-gmp=${gmp.crossDrv}
-      --with-mpfr=${mpfr.crossDrv}
-      --with-mpc=${libmpc.crossDrv}
-      --disable-libstdcxx-pch
-      --without-included-gettext
-      --with-system-zlib
-      --enable-languages=${
-        concatStrings (intersperse ","
-          (  optional langC        "c"
-          ++ optional langCC       "c++"
-          ++ optional langFortran  "fortran"
-          ++ optional langJava     "java"
-          ++ optional langAda      "ada"
-          ++ optional langVhdl     "vhdl"
-          ++ optional langGo       "go"
+    configureFlags =
+      optional (!enableMultilib) "--disable-multilib" ++
+      optional (!enableShared) "--disable-shared" ++
+      optional langJava "--with-ecj-jar=${javaEcj.crossDrv}" ++
+      optional javaAwtGtk "--enable-java-awt=gtk" ++
+      optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr.crossDrv}" ++
+      optional (cloog != null) "--with-cloog=${cloog.crossDrv} --enable-cloog-backend=isl" ++
+      [
+        "--with-gmp=${gmp.crossDrv}"
+        "--with-mpfr=${mpfr.crossDrv}"
+        "--with-mpc=${libmpc.crossDrv}"
+        "--disable-libstdcxx-pch"
+        "--without-included-gettext"
+        "--with-system-zlib"
+        "--enable-languages=${
+          concatStrings (intersperse ","
+            (  optional langC        "c"
+            ++ optional langCC       "c++"
+            ++ optional langFortran  "fortran"
+            ++ optional langJava     "java"
+            ++ optional langAda      "ada"
+            ++ optional langVhdl     "vhdl"
+            ++ optional langGo       "go"
+            )
           )
-        )
-      }
-      ${if langAda then " --enable-libada" else ""}
-      ${xwithArch}
-      ${xwithCpu}
-      ${xwithAbi}
-      ${xwithFpu}
-      ${xwithFloat}
-    '';
+        }"
+      ] ++
+      optional langAda "--enable-libada" ++
+      optional (xgccArch != null) "--with-arch=${xgccArch}" ++
+      optional (xgccCpu != null) "--with-cpu=${xgccCpu}" ++
+      optional (xgccAbi != null) "--with-abi=${xgccAbi}" ++
+      optional (xgccFpu != null) "--with-fpu=${xgccFpu}" ++
+      optional (xgccFloat != null) "--with-float=${xgccFloat}"
+    ;
     buildFlags = "";
   };
 

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -99,107 +99,90 @@ let version = "4.9.4";
     javaAwtGtk = langJava && x11Support;
 
     /* Platform flags */
-    platformFlags = let
-        gccArch = stdenv.platform.gcc.arch or null;
-        gccCpu = stdenv.platform.gcc.cpu or null;
-        gccAbi = stdenv.platform.gcc.abi or null;
-        gccFpu = stdenv.platform.gcc.fpu or null;
-        gccFloat = stdenv.platform.gcc.float or null;
-        gccMode = stdenv.platform.gcc.mode or null;
-        withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
-        withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
-        withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
-        withFpu = if gccFpu != null then " --with-fpu=${gccFpu}" else "";
-        withFloat = if gccFloat != null then " --with-float=${gccFloat}" else "";
-        withMode = if gccMode != null then " --with-mode=${gccMode}" else "";
-      in
-        withArch +
-        withCpu +
-        withAbi +
-        withFpu +
-        withFloat +
-        withMode;
+    mkPlatformFlags = platform: let
+        gccArch = platform.gcc.arch or null;
+        gccCpu = platform.gcc.cpu or null;
+        gccAbi = platform.gcc.abi or null;
+        gccFpu = platform.gcc.fpu or null;
+        gccFloat = platform.gcc.float or null;
+        gccMode = platform.gcc.mode or null;
+     in
+        optional (gccArch != null) "--with-arch=${gccArch}" ++
+        optional (gccCpu != null) "--with-cpu=${gccCpu}" ++
+        optional (gccAbi != null) "--with-abi=${gccAbi}" ++
+        optional (gccFpu != null) "--with-fpu=${gccFpu}" ++
+        optional (gccFloat != null) "--with-float=${gccFloat}" ++
+        optional (gccMode != null) "--with-mode=${gccMode}";
 
-    /* Cross-gcc settings */
+    /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
     crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
-    crossConfigureFlags = let
-        gccArch = targetPlatform.gcc.arch or null;
-        gccCpu = targetPlatform.gcc.cpu or null;
-        gccAbi = targetPlatform.gcc.abi or null;
-        gccFpu = targetPlatform.gcc.fpu or null;
-        gccFloat = targetPlatform.gcc.float or null;
-        gccMode = targetPlatform.gcc.mode or null;
-        withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
-        withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
-        withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
-        withFpu = if gccFpu != null then " --with-fpu=${gccFpu}" else "";
-        withFloat = if gccFloat != null then " --with-float=${gccFloat}" else "";
-        withMode = if gccMode != null then " --with-mode=${gccMode}" else "";
-      in
-        withArch +
-        withCpu +
-        withAbi +
-        withFpu +
-        withFloat +
-        withMode +
+    crossConfigureFlags =
+        mkPlatformFlags targetPlatform ++
+
         # Ensure that -print-prog-name is able to find the correct programs.
-        " --with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as" +
-        " --with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" +
+        [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
+          "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
         (if crossMingw && crossStageStatic then
-          " --with-headers=${libcCross}/include" +
-          " --with-gcc" +
-          " --with-gnu-as" +
-          " --with-gnu-ld" +
-          " --with-gnu-ld" +
-          " --disable-shared" +
-          " --disable-nls" +
-          " --disable-debug" +
-          " --enable-sjlj-exceptions" +
-          " --enable-threads=win32" +
-          " --disable-win32-registry"
-          else if crossStageStatic then
-          " --disable-libssp --disable-nls" +
-          " --without-headers" +
-          " --disable-threads " +
-          " --disable-libgomp " +
-          " --disable-libquadmath" +
-          " --disable-shared" +
-          " --disable-libatomic " +  # libatomic requires libc
-          " --disable-decimal-float" # libdecnumber requires libc
-          else
-          (if crossDarwin then " --with-sysroot=${libcCross.out}/share/sysroot"
-           else                " --with-headers=${libcCross.dev}/include") +
-          " --enable-__cxa_atexit" +
-          " --enable-long-long" +
-          (if crossMingw then
-            " --enable-threads=win32" +
-            " --enable-sjlj-exceptions" +
-            " --enable-hash-synchronization" +
-            " --disable-libssp" +
-            " --disable-nls" +
-            " --with-dwarf2" +
+          [ "--with-headers=${libcCross}/include"
+            "--with-gcc"
+            "--with-gnu-as"
+            "--with-gnu-ld"
+            "--with-gnu-ld"
+            "--disable-shared"
+            "--disable-nls"
+            "--disable-debug"
+            "--enable-sjlj-exceptions"
+            "--enable-threads=win32"
+            "--disable-win32-registry"
+          ] else if crossStageStatic then
+          [ "--disable-libssp"
+            "--disable-nls"
+            "--without-headers"
+            "--disable-threads "
+            "--disable-libgomp "
+            "--disable-libquadmath"
+            "--disable-shared"
+            "--disable-libatomic "  # libatomic requires libc
+            "--disable-decimal-float" # libdecnumber requires libc
+          ] else
+            (if crossDarwin then ["--with-sysroot=${getLib libcCross}/share/sysroot"]
+             else                ["--with-headers=${getDev libcCross}/include"]) ++
+          [ "--enable-__cxa_atexit"
+            "--enable-long-long"
+          ] ++
+
+          (if crossMingw then [
+            "--enable-threads=win32"
+            "--enable-sjlj-exceptions"
+            "--enable-hash-synchronization"
+            "--disable-libssp"
+            "--disable-nls"
+            "--with-dwarf2"
             # I think noone uses shared gcc libs in mingw, so we better do the same.
             # In any case, mingw32 g++ linking is broken by default with shared libs,
             # unless adding "-lsupc++" to any linking command. I don't know why.
-            " --disable-shared" +
+            "--disable-shared"
             # To keep ABI compatibility with upstream mingw-w64
-            " --enable-fully-dynamic-string"
-            else (if targetPlatform.libc == "uclibc" then
+            "--enable-fully-dynamic-string"
+          ] else
+            optionals (targetPlatform.libc == "uclibc") [
               # libsanitizer requires netrom/netrom.h which is not
               # available in uclibc.
-              " --disable-libsanitizer" +
+              "--disable-libsanitizer"
               # In uclibc cases, libgomp needs an additional '-ldl'
               # and as I don't know how to pass it, I disable libgomp.
-              " --disable-libgomp" else "") +
-            " --enable-threads=posix" +
-            " --enable-nls" +
-            " --disable-decimal-float") # No final libdecnumber (it may work only in 386)
+              "--disable-libgomp"
+            ] ++
+            [ "--enable-threads=posix"
+              "--enable-nls"
+              "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+            ])
           );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
-  bootstrap = targetPlatform == hostPlatform;
+    bootstrap = targetPlatform == hostPlatform;
 
 in
 
@@ -326,61 +309,86 @@ stdenv.mkDerivation ({
     then []
     else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
-  configureFlags = "
-    ${if hostPlatform.isSunOS then
-      " --enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit " +
-      # On Illumos/Solaris GNU as is preferred
-      " --with-gnu-as --without-gnu-ld "
-      else ""}
-    --enable-lto
-    ${if enableMultilib then "--enable-multilib --disable-libquadmath" else "--disable-multilib"}
-    ${if enableShared then "" else "--disable-shared"}
-    ${if enablePlugin then "--enable-plugin" else "--disable-plugin"}
-    ${optionalString (isl != null) "--with-isl=${isl}"}
-    ${optionalString (cloog != null) "--with-cloog=${cloog} --disable-cloog-version-check --enable-cloog-backend=isl"}
-    ${if langJava then
-      "--with-ecj-jar=${javaEcj} " +
+  configureFlags =
+    # Basic dependencies
+    [
+      "--with-gmp-include=${gmp.dev}/include"
+      "--with-gmp-lib=${gmp.out}/lib"
+      "--with-mpfr=${mpfr.dev}"
+      "--with-mpc=${libmpc}"
+    ] ++
+    optional (libelf != null) "--with-libelf=${libelf}" ++
+
+    # Basic configuration
+    [
+      "--enable-lto"
+      "--disable-libstdcxx-pch"
+      "--without-included-gettext"
+      "--with-system-zlib"
+      "--enable-static"
+      "--enable-languages=${
+        concatStrings (intersperse ","
+          (  optional langC        "c"
+          ++ optional langCC       "c++"
+          ++ optional langFortran  "fortran"
+          ++ optional langJava     "java"
+          ++ optional langAda      "ada"
+          ++ optional langVhdl     "vhdl"
+          ++ optional langGo       "go"
+          ++ optional langObjC     "objc"
+          ++ optional langObjCpp   "obj-c++"
+          ++ optionals crossDarwin [ "objc" "obj-c++" ]
+          )
+        )
+      }"
+    ] ++
+
+    (if enableMultilib
+      then ["--enable-multilib" "--disable-libquadmath"]
+      else ["--disable-multilib"]) ++
+    optional (!enableShared) "--disable-shared" ++
+    (if enablePlugin
+      then ["--enable-plugin"]
+      else ["--disable-plugin"]) ++
+
+    # Optional features
+    optional (isl != null) "--with-isl=${isl}" ++
+    optional (cloog != null) "--with-cloog=${cloog} --disable-cloog-version-check --enable-cloog-backend=isl" ++
+
+    # Java options
+    optionals langJava [
+      "--with-ecj-jar=${javaEcj} "
 
       # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
       # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
       "--enable-java-home --with-java-home=\${prefix}/lib/jvm/jre "
-      else ""}
-    ${if javaAwtGtk then "--enable-java-awt=gtk" else ""}
-    ${if langJava && javaAntlr != null then "--with-antlr-jar=${javaAntlr}" else ""}
-    --with-gmp=${gmp.dev}
-    --with-mpfr=${mpfr.dev}
-    --with-mpc=${libmpc}
-    ${if libelf != null then "--with-libelf=${libelf}" else ""}
-    --disable-libstdcxx-pch
-    --without-included-gettext
-    --with-system-zlib
-    --enable-static
-    --enable-languages=${
-      concatStrings (intersperse ","
-        (  optional langC        "c"
-        ++ optional langCC       "c++"
-        ++ optional langFortran  "fortran"
-        ++ optional langJava     "java"
-        ++ optional langAda      "ada"
-        ++ optional langVhdl     "vhdl"
-        ++ optional langGo       "go"
-        ++ optional langObjC     "objc"
-        ++ optional langObjCpp   "obj-c++"
-        ++ optionals crossDarwin [ "objc" "obj-c++" ]
-        )
-      )
-    }
-    ${if targetPlatform == hostPlatform
-      then if hostPlatform.isDarwin
-        then " --with-native-system-header-dir=${darwin.usr-include}"
-        else " --with-native-system-header-dir=${getDev stdenv.cc.libc}/include"
-      else ""}
-    ${if langAda then " --enable-libada" else ""}
-    ${if targetPlatform == hostPlatform && targetPlatform.isi686 then "--with-arch=i686" else ""}
-    ${if targetPlatform != hostPlatform then crossConfigureFlags else ""}
-    ${if !bootstrap then "--disable-bootstrap" else ""}
-    ${if targetPlatform == hostPlatform then platformFlags else ""}
-  ";
+    ] ++
+    optional javaAwtGtk "--enable-java-awt=gtk" ++
+    optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}" ++
+
+    # Ada
+    optional langAda "--enable-libada" ++
+
+    # Cross-compilation
+    optional (targetPlatform == hostPlatform) (
+      let incDir = if hostPlatform.isDarwin
+                     then "${darwin.usr-include}"
+                     else "${getDev stdenv.cc.libc}/include";
+      in "--with-native-system-header-dir=${incDir}"
+    ) ++
+
+    optional (targetPlatform == hostPlatform) (mkPlatformFlags stdenv.platform) ++
+    optional (targetPlatform != hostPlatform) crossConfigureFlags ++
+    optional (!bootstrap) "--disable-bootstrap" ++
+
+    # Platform-specific flags
+    optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++
+    optionals hostPlatform.isSunOS [
+      "--enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit"
+      # On Illumos/Solaris GNU as is preferred
+      "--with-gnu-as --without-gnu-ld"
+    ]
+  ;
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
 
@@ -393,17 +401,13 @@ stdenv.mkDerivation ({
     then "install-strip"
     else "install";
 
+  /* For cross-built gcc (build != host == target) */
   crossAttrs = let
     xgccArch = targetPlatform.gcc.arch or null;
     xgccCpu = targetPlatform.gcc.cpu or null;
     xgccAbi = targetPlatform.gcc.abi or null;
     xgccFpu = targetPlatform.gcc.fpu or null;
     xgccFloat = targetPlatform.gcc.float or null;
-    xwithArch = if xgccArch != null then " --with-arch=${xgccArch}" else "";
-    xwithCpu = if xgccCpu != null then " --with-cpu=${xgccCpu}" else "";
-    xwithAbi = if xgccAbi != null then " --with-abi=${xgccAbi}" else "";
-    xwithFpu = if xgccFpu != null then " --with-fpu=${xgccFpu}" else "";
-    xwithFloat = if xgccFloat != null then " --with-float=${xgccFloat}" else "";
   in {
     AR = "${targetPlatform.config}-ar";
     LD = "${targetPlatform.config}-ld";
@@ -417,38 +421,40 @@ stdenv.mkDerivation ({
     # If we are making a cross compiler, cross != null
     NIX_CC_CROSS = optionalString (targetPlatform == hostPlatform) builtins.toString stdenv.cc;
     dontStrip = true;
-    configureFlags = ''
-      ${if enableMultilib then "" else "--disable-multilib"}
-      ${if enableShared then "" else "--disable-shared"}
-      ${if cloog != null then "--with-cloog=${cloog.crossDrv} --enable-cloog-backend=isl" else ""}
-      ${if langJava then "--with-ecj-jar=${javaEcj.crossDrv}" else ""}
-      ${if javaAwtGtk then "--enable-java-awt=gtk" else ""}
-      ${if langJava && javaAntlr != null then "--with-antlr-jar=${javaAntlr.crossDrv}" else ""}
-      --with-gmp=${gmp.crossDrv}
-      --with-mpfr=${mpfr.crossDrv}
-      --with-mpc=${libmpc.crossDrv}
-      --disable-libstdcxx-pch
-      --without-included-gettext
-      --with-system-zlib
-      --enable-languages=${
-        concatStrings (intersperse ","
-          (  optional langC        "c"
-          ++ optional langCC       "c++"
-          ++ optional langFortran  "fortran"
-          ++ optional langJava     "java"
-          ++ optional langAda      "ada"
-          ++ optional langVhdl     "vhdl"
-          ++ optional langGo       "go"
+    configureFlags =
+      optional (!enableMultilib) "--disable-multilib" ++
+      optional (!enableShared) "--disable-shared" ++
+      optional langJava "--with-ecj-jar=${javaEcj.crossDrv}" ++
+      optional javaAwtGtk "--enable-java-awt=gtk" ++
+      optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr.crossDrv}" ++
+      optional (cloog != null) "--with-cloog=${cloog.crossDrv} --enable-cloog-backend=isl" ++
+      [
+        "--with-gmp=${gmp.crossDrv}"
+        "--with-mpfr=${mpfr.crossDrv}"
+        "--with-mpc=${libmpc.crossDrv}"
+        "--disable-libstdcxx-pch"
+        "--without-included-gettext"
+        "--with-system-zlib"
+        "--enable-languages=${
+          concatStrings (intersperse ","
+            (  optional langC        "c"
+            ++ optional langCC       "c++"
+            ++ optional langFortran  "fortran"
+            ++ optional langJava     "java"
+            ++ optional langAda      "ada"
+            ++ optional langVhdl     "vhdl"
+            ++ optional langGo       "go"
+            )
           )
-        )
-      }
-      ${if langAda then " --enable-libada" else ""}
-      ${xwithArch}
-      ${xwithCpu}
-      ${xwithAbi}
-      ${xwithFpu}
-      ${xwithFloat}
-    '';
+        }"
+      ] ++
+      optional langAda "--enable-libada" ++
+      optional (xgccArch != null) "--with-arch=${xgccArch}" ++
+      optional (xgccCpu != null) "--with-cpu=${xgccCpu}" ++
+      optional (xgccAbi != null) "--with-abi=${xgccAbi}" ++
+      optional (xgccFpu != null) "--with-fpu=${xgccFpu}" ++
+      optional (xgccFloat != null) "--with-float=${xgccFloat}"
+    ;
     buildFlags = "";
   };
 

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -118,67 +118,65 @@ let version = "4.9.4";
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
     crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
     crossConfigureFlags =
-        mkPlatformFlags targetPlatform ++
+      mkPlatformFlags targetPlatform ++
 
-        # Ensure that -print-prog-name is able to find the correct programs.
-        [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
-          "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-        (if crossMingw && crossStageStatic then
-          [ "--with-headers=${libcCross}/include"
-            "--with-gcc"
-            "--with-gnu-as"
-            "--with-gnu-ld"
-            "--with-gnu-ld"
-            "--disable-shared"
-            "--disable-nls"
-            "--disable-debug"
-            "--enable-sjlj-exceptions"
-            "--enable-threads=win32"
-            "--disable-win32-registry"
-          ] else if crossStageStatic then
-          [ "--disable-libssp"
-            "--disable-nls"
-            "--without-headers"
-            "--disable-threads "
-            "--disable-libgomp "
-            "--disable-libquadmath"
-            "--disable-shared"
-            "--disable-libatomic "  # libatomic requires libc
-            "--disable-decimal-float" # libdecnumber requires libc
-          ] else
-            (if crossDarwin then ["--with-sysroot=${getLib libcCross}/share/sysroot"]
-             else                ["--with-headers=${getDev libcCross}/include"]) ++
-          [ "--enable-__cxa_atexit"
-            "--enable-long-long"
-          ] ++
-
-          (if crossMingw then [
-            "--enable-threads=win32"
-            "--enable-sjlj-exceptions"
-            "--enable-hash-synchronization"
-            "--disable-libssp"
-            "--disable-nls"
-            "--with-dwarf2"
-            # I think noone uses shared gcc libs in mingw, so we better do the same.
-            # In any case, mingw32 g++ linking is broken by default with shared libs,
-            # unless adding "-lsupc++" to any linking command. I don't know why.
-            "--disable-shared"
-            # To keep ABI compatibility with upstream mingw-w64
-            "--enable-fully-dynamic-string"
-          ] else
-            optionals (targetPlatform.libc == "uclibc") [
-              # libsanitizer requires netrom/netrom.h which is not
-              # available in uclibc.
-              "--disable-libsanitizer"
-              # In uclibc cases, libgomp needs an additional '-ldl'
-              # and as I don't know how to pass it, I disable libgomp.
-              "--disable-libgomp"
-            ] ++
-            [ "--enable-threads=posix"
-              "--enable-nls"
-              "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-            ])
-          );
+      # Ensure that -print-prog-name is able to find the correct programs.
+      [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
+        "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
+      (if crossMingw && crossStageStatic then [
+        "--with-headers=${libcCross}/include"
+        "--with-gcc"
+        "--with-gnu-as"
+        "--with-gnu-ld"
+        "--with-gnu-ld"
+        "--disable-shared"
+        "--disable-nls"
+        "--disable-debug"
+        "--enable-sjlj-exceptions"
+        "--enable-threads=win32"
+        "--disable-win32-registry"
+      ] else if crossStageStatic then [
+        "--disable-libssp"
+        "--disable-nls"
+        "--without-headers"
+        "--disable-threads"
+        "--disable-libgomp"
+        "--disable-libquadmath"
+        "--disable-shared"
+        "--disable-libatomic"  # libatomic requires libc
+        "--disable-decimal-float" # libdecnumber requires libc
+      ] else [
+        (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
+         else                "--with-headers=${getDev libcCross}/include")
+        "--enable-__cxa_atexit"
+        "--enable-long-long"
+      ] ++
+        (if crossMingw then [
+          "--enable-threads=win32"
+          "--enable-sjlj-exceptions"
+          "--enable-hash-synchronization"
+          "--disable-libssp"
+          "--disable-nls"
+          "--with-dwarf2"
+          # I think noone uses shared gcc libs in mingw, so we better do the same.
+          # In any case, mingw32 g++ linking is broken by default with shared libs,
+          # unless adding "-lsupc++" to any linking command. I don't know why.
+          "--disable-shared"
+          # To keep ABI compatibility with upstream mingw-w64
+          "--enable-fully-dynamic-string"
+        ] else
+          optionals (targetPlatform.libc == "uclibc") [
+            # libsanitizer requires netrom/netrom.h which is not
+            # available in uclibc.
+            "--disable-libsanitizer"
+            # In uclibc cases, libgomp needs an additional '-ldl'
+            # and as I don't know how to pass it, I disable libgomp.
+            "--disable-libgomp"
+          ] ++ [
+          "--enable-threads=posix"
+          "--enable-nls"
+          "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+        ]));
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
@@ -353,15 +351,20 @@ stdenv.mkDerivation ({
 
     # Optional features
     optional (isl != null) "--with-isl=${isl}" ++
-    optional (cloog != null) "--with-cloog=${cloog} --disable-cloog-version-check --enable-cloog-backend=isl" ++
+    optionals (cloog != null) [
+      "--with-cloog=${cloog}"
+      "--disable-cloog-version-check"
+      "--enable-cloog-backend=isl"
+    ] ++
 
     # Java options
     optionals langJava [
-      "--with-ecj-jar=${javaEcj} "
+      "--with-ecj-jar=${javaEcj}"
 
       # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
       # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
-      "--enable-java-home --with-java-home=\${prefix}/lib/jvm/jre "
+      "--enable-java-home"
+      "--with-java-home=\${prefix}/lib/jvm/jre"
     ] ++
     optional javaAwtGtk "--enable-java-awt=gtk" ++
     optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}" ++
@@ -384,9 +387,9 @@ stdenv.mkDerivation ({
     # Platform-specific flags
     optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++
     optionals hostPlatform.isSunOS [
-      "--enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit"
+      "--enable-long-long" "--enable-libssp" "--enable-threads=posix" "--disable-nls" "--enable-__cxa_atexit"
       # On Illumos/Solaris GNU as is preferred
-      "--with-gnu-as --without-gnu-ld"
+      "--with-gnu-as" "--without-gnu-ld"
     ]
   ;
 
@@ -427,7 +430,7 @@ stdenv.mkDerivation ({
       optional langJava "--with-ecj-jar=${javaEcj.crossDrv}" ++
       optional javaAwtGtk "--enable-java-awt=gtk" ++
       optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr.crossDrv}" ++
-      optional (cloog != null) "--with-cloog=${cloog.crossDrv} --enable-cloog-backend=isl" ++
+      optional (cloog != null) "--with-cloog=${cloog.crossDrv}" "--enable-cloog-backend=isl" ++
       [
         "--with-gmp=${gmp.crossDrv}"
         "--with-mpfr=${mpfr.crossDrv}"

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -103,107 +103,89 @@ let version = "5.5.0";
     javaAwtGtk = langJava && x11Support;
 
     /* Platform flags */
-    platformFlags = let
-        gccArch = stdenv.platform.gcc.arch or null;
-        gccCpu = stdenv.platform.gcc.cpu or null;
-        gccAbi = stdenv.platform.gcc.abi or null;
-        gccFpu = stdenv.platform.gcc.fpu or null;
-        gccFloat = stdenv.platform.gcc.float or null;
-        gccMode = stdenv.platform.gcc.mode or null;
-        withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
-        withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
-        withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
-        withFpu = if gccFpu != null then " --with-fpu=${gccFpu}" else "";
-        withFloat = if gccFloat != null then " --with-float=${gccFloat}" else "";
-        withMode = if gccMode != null then " --with-mode=${gccMode}" else "";
-      in
-        withArch +
-        withCpu +
-        withAbi +
-        withFpu +
-        withFloat +
-        withMode;
+    mkPlatformFlags = platform: let
+        gccArch = platform.gcc.arch or null;
+        gccCpu = platform.gcc.cpu or null;
+        gccAbi = platform.gcc.abi or null;
+        gccFpu = platform.gcc.fpu or null;
+        gccFloat = platform.gcc.float or null;
+        gccMode = platform.gcc.mode or null;
+     in
+        optional (gccArch != null) "--with-arch=${gccArch}" ++
+        optional (gccCpu != null) "--with-cpu=${gccCpu}" ++
+        optional (gccAbi != null) "--with-abi=${gccAbi}" ++
+        optional (gccFpu != null) "--with-fpu=${gccFpu}" ++
+        optional (gccFloat != null) "--with-float=${gccFloat}" ++
+        optional (gccMode != null) "--with-mode=${gccMode}";
 
-    /* Cross-gcc settings */
+    /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
     crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
-    crossConfigureFlags = let
-        gccArch = targetPlatform.gcc.arch or null;
-        gccCpu = targetPlatform.gcc.cpu or null;
-        gccAbi = targetPlatform.gcc.abi or null;
-        gccFpu = targetPlatform.gcc.fpu or null;
-        gccFloat = targetPlatform.gcc.float or null;
-        gccMode = targetPlatform.gcc.mode or null;
-        withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
-        withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
-        withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
-        withFpu = if gccFpu != null then " --with-fpu=${gccFpu}" else "";
-        withFloat = if gccFloat != null then " --with-float=${gccFloat}" else "";
-        withMode = if gccMode != null then " --with-mode=${gccMode}" else "";
-      in
-        withArch +
-        withCpu +
-        withAbi +
-        withFpu +
-        withFloat +
-        withMode +
+    crossConfigureFlags =
+        mkPlatformFlags targetPlatform ++
+
         # Ensure that -print-prog-name is able to find the correct programs.
-        " --with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as" +
-        " --with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" +
+        [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
+          "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
         (if crossMingw && crossStageStatic then
-          " --with-headers=${libcCross}/include" +
-          " --with-gcc" +
-          " --with-gnu-as" +
-          " --with-gnu-ld" +
-          " --with-gnu-ld" +
-          " --disable-shared" +
-          " --disable-nls" +
-          " --disable-debug" +
-          " --enable-sjlj-exceptions" +
-          " --enable-threads=win32" +
-          " --disable-win32-registry"
-          else if crossStageStatic then
-          " --disable-libssp --disable-nls" +
-          " --without-headers" +
-          " --disable-threads " +
-          " --disable-libgomp " +
-          " --disable-libquadmath" +
-          " --disable-shared" +
-          " --disable-libatomic " +  # libatomic requires libc
-          " --disable-decimal-float" # libdecnumber requires libc
-          else
-          (if crossDarwin then " --with-sysroot=${getLib libcCross}/share/sysroot"
-           else                " --with-headers=${getDev libcCross}/include") +
-          " --enable-__cxa_atexit" +
-          " --enable-long-long" +
-          (if crossMingw then
-            " --enable-threads=win32" +
-            " --enable-sjlj-exceptions" +
-            " --enable-hash-synchronization" +
-            " --disable-libssp" +
-            " --disable-nls" +
-            " --with-dwarf2" +
+          [ "--with-headers=${libcCross}/include"
+            "--with-gcc"
+            "--with-gnu-as"
+            "--with-gnu-ld"
+            "--with-gnu-ld"
+            "--disable-shared"
+            "--disable-nls"
+            "--disable-debug"
+            "--enable-sjlj-exceptions"
+            "--enable-threads=win32"
+            "--disable-win32-registry"
+          ] else if crossStageStatic then
+          [ "--disable-libssp --disable-nls"
+            "--without-headers"
+            "--disable-threads "
+            "--disable-libgomp "
+            "--disable-libquadmath"
+            "--disable-shared"
+            "--disable-libatomic "  # libatomic requires libc
+            "--disable-decimal-float" # libdecnumber requires libc
+          ] else
+            (if crossDarwin then ["--with-sysroot=${getLib libcCross}/share/sysroot"]
+             else                ["--with-headers=${getDev libcCross}/include"]) ++
+          [ "--enable-__cxa_atexit"
+            "--enable-long-long"
+          ] ++
+          (if crossMingw then [
+            "--enable-threads=win32"
+            "--enable-sjlj-exceptions"
+            "--enable-hash-synchronization"
+            "--disable-libssp"
+            "--disable-nls"
+            "--with-dwarf2"
             # I think noone uses shared gcc libs in mingw, so we better do the same.
             # In any case, mingw32 g++ linking is broken by default with shared libs,
             # unless adding "-lsupc++" to any linking command. I don't know why.
-            " --disable-shared" +
+            "--disable-shared"
             # To keep ABI compatibility with upstream mingw-w64
-            " --enable-fully-dynamic-string"
-            else (if targetPlatform.libc == "uclibc" then
+            "--enable-fully-dynamic-string"
+          ] else
+            optionals (targetPlatform.libc == "uclibc") [
               # libsanitizer requires netrom/netrom.h which is not
               # available in uclibc.
-              " --disable-libsanitizer" +
+              "--disable-libsanitizer"
               # In uclibc cases, libgomp needs an additional '-ldl'
               # and as I don't know how to pass it, I disable libgomp.
-              " --disable-libgomp" else "") +
-            " --enable-threads=posix" +
-            " --enable-nls" +
-            " --disable-decimal-float") # No final libdecnumber (it may work only in 386)
-          );
+              "--disable-libgomp"
+            ] ++
+            [ "--enable-threads=posix"
+              "--enable-nls"
+              "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+            ]
+          )
+        );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
-  bootstrap = targetPlatform == hostPlatform;
+    bootstrap = targetPlatform == hostPlatform;
 
 in
 
@@ -340,62 +322,86 @@ stdenv.mkDerivation ({
     then []
     else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
-  configureFlags = "
-    ${if hostPlatform.isSunOS then
-      " --enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit " +
-      # On Illumos/Solaris GNU as is preferred
-      " --with-gnu-as --without-gnu-ld "
-      else ""}
-    --enable-lto
-    ${if enableMultilib then "--enable-multilib --disable-libquadmath" else "--disable-multilib"}
-    ${if enableShared then "" else "--disable-shared"}
-    ${if enablePlugin then "--enable-plugin" else "--disable-plugin"}
-    ${optionalString (isl != null) "--with-isl=${isl}"}
-    ${if langJava then
-      "--with-ecj-jar=${javaEcj} " +
+  configureFlags =
+    # Basic dependencies
+    [
+      "--with-gmp-include=${gmp.dev}/include"
+      "--with-gmp-lib=${gmp.out}/lib"
+      "--with-mpfr-include=${mpfr.dev}/include"
+      "--with-mpfr-lib=${mpfr.out}/lib"
+      "--with-mpc=${libmpc}"
+    ] ++
+    optional (libelf != null) "--with-libelf=${libelf}" ++
+
+    # Basic configuration
+    [
+      "--enable-lto"
+      "--disable-libstdcxx-pch"
+      "--without-included-gettext"
+      "--with-system-zlib"
+      "--enable-static"
+      "--enable-languages=${
+        concatStrings (intersperse ","
+          (  optional langC        "c"
+          ++ optional langCC       "c++"
+          ++ optional langFortran  "fortran"
+          ++ optional langJava     "java"
+          ++ optional langAda      "ada"
+          ++ optional langVhdl     "vhdl"
+          ++ optional langGo       "go"
+          ++ optional langObjC     "objc"
+          ++ optional langObjCpp   "obj-c++"
+          ++ optionals crossDarwin [ "objc" "obj-c++" ]
+          )
+        )
+      }"
+    ] ++
+
+    # Optional features
+    optional (isl != null) "--with-isl=${isl}" ++
+
+    (if enableMultilib
+      then ["--enable-multilib" "--disable-libquadmath"]
+      else ["--disable-multilib"]) ++
+    optional (!enableShared) "--disable-shared" ++
+    (if enablePlugin
+      then ["--enable-plugin"]
+      else ["--disable-plugin"]) ++
+
+    # Java options
+    optionals langJava [
+      "--with-ecj-jar=${javaEcj} "
 
       # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
       # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
       "--enable-java-home --with-java-home=\${prefix}/lib/jvm/jre "
-      else ""}
-    ${if javaAwtGtk then "--enable-java-awt=gtk" else ""}
-    ${if langJava && javaAntlr != null then "--with-antlr-jar=${javaAntlr}" else ""}
-    --with-gmp-include=${gmp.dev}/include
-    --with-gmp-lib=${gmp.out}/lib
-    --with-mpfr-include=${mpfr.dev}/include
-    --with-mpfr-lib=${mpfr.out}/lib
-    --with-mpc=${libmpc}
-    ${if libelf != null then "--with-libelf=${libelf}" else ""}
-    --disable-libstdcxx-pch
-    --without-included-gettext
-    --with-system-zlib
-    --enable-static
-    --enable-languages=${
-      concatStrings (intersperse ","
-        (  optional langC        "c"
-        ++ optional langCC       "c++"
-        ++ optional langFortran  "fortran"
-        ++ optional langJava     "java"
-        ++ optional langAda      "ada"
-        ++ optional langVhdl     "vhdl"
-        ++ optional langGo       "go"
-        ++ optional langObjC     "objc"
-        ++ optional langObjCpp   "obj-c++"
-        ++ optionals crossDarwin [ "objc" "obj-c++" ]
-        )
-      )
-    }
-    ${if targetPlatform == hostPlatform
-      then if hostPlatform.isDarwin
-        then " --with-native-system-header-dir=${darwin.usr-include}"
-        else " --with-native-system-header-dir=${getDev stdenv.cc.libc}/include"
-      else ""}
-    ${if langAda then " --enable-libada" else ""}
-    ${if targetPlatform == hostPlatform && targetPlatform.isi686 then "--with-arch=i686" else ""}
-    ${if targetPlatform != hostPlatform then crossConfigureFlags else ""}
-    ${if !bootstrap then "--disable-bootstrap" else ""}
-    ${if targetPlatform == hostPlatform then platformFlags else ""}
-  ";
+    ] ++
+    optional javaAwtGtk "--enable-java-awt=gtk" ++
+    optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}" ++
+
+    # Ada
+    optional langAda "--enable-libada" ++
+
+    # Cross-compilation
+    optional (targetPlatform == hostPlatform) (
+      let incDir = if hostPlatform.isDarwin
+                     then "${darwin.usr-include}"
+                     else "${getDev stdenv.cc.libc}/include";
+      in "--with-native-system-header-dir=${incDir}"
+    ) ++
+
+    optional (targetPlatform == hostPlatform) (mkPlatformFlags stdenv.platform) ++
+    optional (targetPlatform != hostPlatform) crossConfigureFlags ++
+    optional (!bootstrap) "--disable-bootstrap" ++
+
+    # Platform-specific flags
+    optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++
+    optionals hostPlatform.isSunOS [
+      "--enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit"
+      # On Illumos/Solaris GNU as is preferred
+      "--with-gnu-as --without-gnu-ld"
+    ]
+  ;
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
 
@@ -408,17 +414,13 @@ stdenv.mkDerivation ({
     then "install-strip"
     else "install";
 
+  /* For cross-built gcc (build != host == target) */
   crossAttrs = let
     xgccArch = targetPlatform.gcc.arch or null;
     xgccCpu = targetPlatform.gcc.cpu or null;
     xgccAbi = targetPlatform.gcc.abi or null;
     xgccFpu = targetPlatform.gcc.fpu or null;
     xgccFloat = targetPlatform.gcc.float or null;
-    xwithArch = if xgccArch != null then " --with-arch=${xgccArch}" else "";
-    xwithCpu = if xgccCpu != null then " --with-cpu=${xgccCpu}" else "";
-    xwithAbi = if xgccAbi != null then " --with-abi=${xgccAbi}" else "";
-    xwithFpu = if xgccFpu != null then " --with-fpu=${xgccFpu}" else "";
-    xwithFloat = if xgccFloat != null then " --with-float=${xgccFloat}" else "";
   in {
     AR = "${targetPlatform.config}-ar";
     LD = "${targetPlatform.config}-ld";
@@ -432,37 +434,39 @@ stdenv.mkDerivation ({
     # If we are making a cross compiler, cross != null
     NIX_CC_CROSS = optionalString (targetPlatform == hostPlatform) builtins.toString stdenv.cc;
     dontStrip = true;
-    configureFlags = ''
-      ${if enableMultilib then "" else "--disable-multilib"}
-      ${if enableShared then "" else "--disable-shared"}
-      ${if langJava then "--with-ecj-jar=${javaEcj.crossDrv}" else ""}
-      ${if javaAwtGtk then "--enable-java-awt=gtk" else ""}
-      ${if langJava && javaAntlr != null then "--with-antlr-jar=${javaAntlr.crossDrv}" else ""}
-      --with-gmp=${gmp.crossDrv}
-      --with-mpfr=${mpfr.crossDrv}
-      --with-mpc=${libmpc.crossDrv}
-      --disable-libstdcxx-pch
-      --without-included-gettext
-      --with-system-zlib
-      --enable-languages=${
-        concatStrings (intersperse ","
-          (  optional langC        "c"
-          ++ optional langCC       "c++"
-          ++ optional langFortran  "fortran"
-          ++ optional langJava     "java"
-          ++ optional langAda      "ada"
-          ++ optional langVhdl     "vhdl"
-          ++ optional langGo       "go"
+    configureFlags =
+      optional (!enableMultilib) "--disable-multilib" ++
+      optional (!enableShared) "--disable-shared" ++
+      optional langJava "--with-ecj-jar=${javaEcj.crossDrv}" ++
+      optional javaAwtGtk "--enable-java-awt=gtk" ++
+      optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr.crossDrv}" ++
+      [
+        "--with-gmp=${gmp.crossDrv}"
+        "--with-mpfr=${mpfr.crossDrv}"
+        "--with-mpc=${libmpc.crossDrv}"
+        "--disable-libstdcxx-pch"
+        "--without-included-gettext"
+        "--with-system-zlib"
+        "--enable-languages=${
+          concatStrings (intersperse ","
+            (  optional langC        "c"
+            ++ optional langCC       "c++"
+            ++ optional langFortran  "fortran"
+            ++ optional langJava     "java"
+            ++ optional langAda      "ada"
+            ++ optional langVhdl     "vhdl"
+            ++ optional langGo       "go"
+            )
           )
-        )
-      }
-      ${if langAda then " --enable-libada" else ""}
-      ${xwithArch}
-      ${xwithCpu}
-      ${xwithAbi}
-      ${xwithFpu}
-      ${xwithFloat}
-    '';
+        }"
+      ] ++
+      optional langAda "--enable-libada" ++
+      optional (xgccArch != null) "--with-arch=${xgccArch}" ++
+      optional (xgccCpu != null) "--with-cpu=${xgccCpu}" ++
+      optional (xgccAbi != null) "--with-abi=${xgccAbi}" ++
+      optional (xgccFpu != null) "--with-fpu=${xgccFpu}" ++
+      optional (xgccFloat != null) "--with-float=${xgccFloat}"
+    ;
     buildFlags = "";
   };
 

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -122,66 +122,65 @@ let version = "5.5.0";
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
     crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
     crossConfigureFlags =
-        mkPlatformFlags targetPlatform ++
+      mkPlatformFlags targetPlatform ++
 
-        # Ensure that -print-prog-name is able to find the correct programs.
-        [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
-          "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-        (if crossMingw && crossStageStatic then
-          [ "--with-headers=${libcCross}/include"
-            "--with-gcc"
-            "--with-gnu-as"
-            "--with-gnu-ld"
-            "--with-gnu-ld"
-            "--disable-shared"
-            "--disable-nls"
-            "--disable-debug"
-            "--enable-sjlj-exceptions"
-            "--enable-threads=win32"
-            "--disable-win32-registry"
-          ] else if crossStageStatic then
-          [ "--disable-libssp --disable-nls"
-            "--without-headers"
-            "--disable-threads "
-            "--disable-libgomp "
-            "--disable-libquadmath"
-            "--disable-shared"
-            "--disable-libatomic "  # libatomic requires libc
-            "--disable-decimal-float" # libdecnumber requires libc
-          ] else
-            (if crossDarwin then ["--with-sysroot=${getLib libcCross}/share/sysroot"]
-             else                ["--with-headers=${getDev libcCross}/include"]) ++
-          [ "--enable-__cxa_atexit"
-            "--enable-long-long"
-          ] ++
-          (if crossMingw then [
-            "--enable-threads=win32"
-            "--enable-sjlj-exceptions"
-            "--enable-hash-synchronization"
-            "--disable-libssp"
-            "--disable-nls"
-            "--with-dwarf2"
-            # I think noone uses shared gcc libs in mingw, so we better do the same.
-            # In any case, mingw32 g++ linking is broken by default with shared libs,
-            # unless adding "-lsupc++" to any linking command. I don't know why.
-            "--disable-shared"
-            # To keep ABI compatibility with upstream mingw-w64
-            "--enable-fully-dynamic-string"
-          ] else
-            optionals (targetPlatform.libc == "uclibc") [
-              # libsanitizer requires netrom/netrom.h which is not
-              # available in uclibc.
-              "--disable-libsanitizer"
-              # In uclibc cases, libgomp needs an additional '-ldl'
-              # and as I don't know how to pass it, I disable libgomp.
-              "--disable-libgomp"
-            ] ++
-            [ "--enable-threads=posix"
-              "--enable-nls"
-              "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-            ]
-          )
-        );
+      # Ensure that -print-prog-name is able to find the correct programs.
+      [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
+        "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
+      (if crossMingw && crossStageStatic then [
+        "--with-headers=${libcCross}/include"
+        "--with-gcc"
+        "--with-gnu-as"
+        "--with-gnu-ld"
+        "--with-gnu-ld"
+        "--disable-shared"
+        "--disable-nls"
+        "--disable-debug"
+        "--enable-sjlj-exceptions"
+        "--enable-threads=win32"
+        "--disable-win32-registry"
+      ] else if crossStageStatic then [
+        "--disable-libssp"
+        "--disable-nls"
+        "--without-headers"
+        "--disable-threads"
+        "--disable-libgomp"
+        "--disable-libquadmath"
+        "--disable-shared"
+        "--disable-libatomic"  # libatomic requires libc
+        "--disable-decimal-float" # libdecnumber requires libc
+      ] else [
+        (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
+         else                "--with-headers=${getDev libcCross}/include")
+        "--enable-__cxa_atexit"
+        "--enable-long-long"
+      ] ++
+        (if crossMingw then [
+          "--enable-threads=win32"
+          "--enable-sjlj-exceptions"
+          "--enable-hash-synchronization"
+          "--disable-libssp"
+          "--disable-nls"
+          "--with-dwarf2"
+          # I think noone uses shared gcc libs in mingw, so we better do the same.
+          # In any case, mingw32 g++ linking is broken by default with shared libs,
+          # unless adding "-lsupc++" to any linking command. I don't know why.
+          "--disable-shared"
+          # To keep ABI compatibility with upstream mingw-w64
+          "--enable-fully-dynamic-string"
+        ] else
+          optionals (targetPlatform.libc == "uclibc") [
+            # libsanitizer requires netrom/netrom.h which is not
+            # available in uclibc.
+            "--disable-libsanitizer"
+            # In uclibc cases, libgomp needs an additional '-ldl'
+            # and as I don't know how to pass it, I disable libgomp.
+            "--disable-libgomp"
+          ] ++ [
+          "--enable-threads=posix"
+          "--enable-nls"
+          "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+        ]));
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
@@ -370,11 +369,12 @@ stdenv.mkDerivation ({
 
     # Java options
     optionals langJava [
-      "--with-ecj-jar=${javaEcj} "
+      "--with-ecj-jar=${javaEcj}"
 
       # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
       # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
-      "--enable-java-home --with-java-home=\${prefix}/lib/jvm/jre "
+      "--enable-java-home"
+      "--with-java-home=\${prefix}/lib/jvm/jre"
     ] ++
     optional javaAwtGtk "--enable-java-awt=gtk" ++
     optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}" ++
@@ -397,9 +397,9 @@ stdenv.mkDerivation ({
     # Platform-specific flags
     optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++
     optionals hostPlatform.isSunOS [
-      "--enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit"
+      "--enable-long-long" "--enable-libssp" "--enable-threads=posix" "--disable-nls" "--enable-__cxa_atexit"
       # On Illumos/Solaris GNU as is preferred
-      "--with-gnu-as --without-gnu-ld"
+      "--with-gnu-as" "--without-gnu-ld"
     ]
   ;
 

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -119,67 +119,65 @@ let version = "6.4.0";
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
     crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
     crossConfigureFlags =
-        mkPlatformFlags targetPlatform ++
+      mkPlatformFlags targetPlatform ++
 
-        # Ensure that -print-prog-name is able to find the correct programs.
-        [ " --with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
-          " --with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-        (if crossMingw && crossStageStatic then
-          [ "--with-headers=${libcCross}/include"
-            "--with-gcc"
-            "--with-gnu-as"
-            "--with-gnu-ld"
-            "--with-gnu-ld"
-            "--disable-shared"
-            "--disable-nls"
-            "--disable-debug"
-            "--enable-sjlj-exceptions"
-            "--enable-threads=win32"
-            "--disable-win32-registry"
-        ] else if crossStageStatic then [
-            "--disable-libssp"
-            "--disable-nls"
-            "--without-headers"
-            "--disable-threads"
-            "--disable-libgomp"
-            "--disable-libquadmath"
-            "--disable-shared"
-            "--disable-libatomic"  # libatomic requires libc
-            "--disable-decimal-float" # libdecnumber requires libc
+      # Ensure that -print-prog-name is able to find the correct programs.
+      [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
+        "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
+      (if crossMingw && crossStageStatic then [
+        "--with-headers=${libcCross}/include"
+        "--with-gcc"
+        "--with-gnu-as"
+        "--with-gnu-ld"
+        "--with-gnu-ld"
+        "--disable-shared"
+        "--disable-nls"
+        "--disable-debug"
+        "--enable-sjlj-exceptions"
+        "--enable-threads=win32"
+        "--disable-win32-registry"
+      ] else if crossStageStatic then [
+        "--disable-libssp"
+        "--disable-nls"
+        "--without-headers"
+        "--disable-threads"
+        "--disable-libgomp"
+        "--disable-libquadmath"
+        "--disable-shared"
+        "--disable-libatomic"  # libatomic requires libc
+        "--disable-decimal-float" # libdecnumber requires libc
+      ] else [
+        (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
+         else                "--with-headers=${getDev libcCross}/include")
+        "--enable-__cxa_atexit"
+        "--enable-long-long"
+      ] ++
+        (if crossMingw then [
+          "--enable-threads=win32"
+          "--enable-sjlj-exceptions"
+          "--enable-hash-synchronization"
+          "--disable-libssp"
+          "--disable-nls"
+          "--with-dwarf2"
+          # I think noone uses shared gcc libs in mingw, so we better do the same.
+          # In any case, mingw32 g++ linking is broken by default with shared libs,
+          # unless adding "-lsupc++" to any linking command. I don't know why.
+          "--disable-shared"
+          # To keep ABI compatibility with upstream mingw-w64
+          "--enable-fully-dynamic-string"
         ] else
-          (if crossDarwin then ["--with-sysroot=${getLib libcCross}/share/sysroot"]
-           else                ["--with-headers=${getDev libcCross}/include"]) ++
-
-          [ "--enable-__cxa_atexit"
-            "--enable-long-long"
-          ] ++
-
-          (if crossMingw then [
-            "--enable-threads=win32"
-            "--enable-sjlj-exceptions"
-            "--enable-hash-synchronization"
-            "--disable-libssp"
-            "--disable-nls"
-            "--with-dwarf2"
-            # I think noone uses shared gcc libs in mingw, so we better do the same.
-            # In any case, mingw32 g++ linking is broken by default with shared libs,
-            # unless adding "-lsupc++" to any linking command. I don't know why.
-            "--disable-shared"
-            # To keep ABI compatibility with upstream mingw-w64
-            "--enable-fully-dynamic-string"
-            ] else
-              optionals (targetPlatform.libc == "uclibc") [
-                # libsanitizer requires netrom/netrom.h which is not
-                # available in uclibc.
-                "--disable-libsanitizer"
-                # In uclibc cases, libgomp needs an additional '-ldl'
-                # and as I don't know how to pass it, I disable libgomp.
-                "--disable-libgomp" ] ++
-              [ "--enable-threads=posix"
-                "--enable-nls"
-                "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-              ])
-        );
+          optionals (targetPlatform.libc == "uclibc") [
+            # libsanitizer requires netrom/netrom.h which is not
+            # available in uclibc.
+            "--disable-libsanitizer"
+            # In uclibc cases, libgomp needs an additional '-ldl'
+            # and as I don't know how to pass it, I disable libgomp.
+            "--disable-libgomp"
+          ] ++ [
+          "--enable-threads=posix"
+          "--enable-nls"
+          "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+        ]));
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
@@ -372,7 +370,7 @@ stdenv.mkDerivation ({
 
     # Java options
     optionals langJava [
-      "--with-ecj-jar=${javaEcj} "
+      "--with-ecj-jar=${javaEcj}"
 
       # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
       # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
@@ -399,9 +397,9 @@ stdenv.mkDerivation ({
     # Platform-specific flags
     optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++
     optionals (hostPlatform.isSunOS) [
-      " --enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit"
+      "--enable-long-long" "--enable-libssp" "--enable-threads=posix" "--disable-nls" "--enable-__cxa_atexit"
       # On Illumos/Solaris GNU as is preferred
-      " --with-gnu-as --without-gnu-ld"
+      "--with-gnu-as" "--without-gnu-ld"
     ]
   ;
 

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -100,103 +100,86 @@ let version = "6.4.0";
     javaAwtGtk = langJava && x11Support;
 
     /* Platform flags */
-    platformFlags = let
-        gccArch = stdenv.platform.gcc.arch or null;
-        gccCpu = stdenv.platform.gcc.cpu or null;
-        gccAbi = stdenv.platform.gcc.abi or null;
-        gccFpu = stdenv.platform.gcc.fpu or null;
-        gccFloat = stdenv.platform.gcc.float or null;
-        gccMode = stdenv.platform.gcc.mode or null;
-        withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
-        withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
-        withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
-        withFpu = if gccFpu != null then " --with-fpu=${gccFpu}" else "";
-        withFloat = if gccFloat != null then " --with-float=${gccFloat}" else "";
-        withMode = if gccMode != null then " --with-mode=${gccMode}" else "";
+    mkPlatformFlags = platform: let
+        gccArch = platform.gcc.arch or null;
+        gccCpu = platform.gcc.cpu or null;
+        gccAbi = platform.gcc.abi or null;
+        gccFpu = platform.gcc.fpu or null;
+        gccFloat = platform.gcc.float or null;
+        gccMode = platform.gcc.mode or null;
       in
-        withArch +
-        withCpu +
-        withAbi +
-        withFpu +
-        withFloat +
-        withMode;
+        optional (gccArch != null) "--with-arch=${gccArch}" ++
+        optional (gccCpu != null) "--with-cpu=${gccCpu}" ++
+        optional (gccAbi != null) "--with-abi=${gccAbi}" ++
+        optional (gccFpu != null) "--with-fpu=${gccFpu}" ++
+        optional (gccFloat != null) "--with-float=${gccFloat}" ++
+        optional (gccMode != null) "--with-mode=${gccMode}";
 
-    /* Cross-gcc settings */
+    /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
     crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
-    crossConfigureFlags = let
-        gccArch = targetPlatform.gcc.arch or null;
-        gccCpu = targetPlatform.gcc.cpu or null;
-        gccAbi = targetPlatform.gcc.abi or null;
-        gccFpu = targetPlatform.gcc.fpu or null;
-        gccFloat = targetPlatform.gcc.float or null;
-        gccMode = targetPlatform.gcc.mode or null;
-        withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
-        withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
-        withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
-        withFpu = if gccFpu != null then " --with-fpu=${gccFpu}" else "";
-        withFloat = if gccFloat != null then " --with-float=${gccFloat}" else "";
-        withMode = if gccMode != null then " --with-mode=${gccMode}" else "";
-      in
-        withArch +
-        withCpu +
-        withAbi +
-        withFpu +
-        withFloat +
-        withMode +
+    crossConfigureFlags =
+        mkPlatformFlags targetPlatform ++
+
         # Ensure that -print-prog-name is able to find the correct programs.
-        " --with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as" +
-        " --with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" +
+        [ " --with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
+          " --with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
         (if crossMingw && crossStageStatic then
-          " --with-headers=${libcCross}/include" +
-          " --with-gcc" +
-          " --with-gnu-as" +
-          " --with-gnu-ld" +
-          " --with-gnu-ld" +
-          " --disable-shared" +
-          " --disable-nls" +
-          " --disable-debug" +
-          " --enable-sjlj-exceptions" +
-          " --enable-threads=win32" +
-          " --disable-win32-registry"
-          else if crossStageStatic then
-          " --disable-libssp --disable-nls" +
-          " --without-headers" +
-          " --disable-threads " +
-          " --disable-libgomp " +
-          " --disable-libquadmath" +
-          " --disable-shared" +
-          " --disable-libatomic " +  # libatomic requires libc
-          " --disable-decimal-float" # libdecnumber requires libc
-          else
-          (if crossDarwin then " --with-sysroot=${getLib libcCross}/share/sysroot"
-           else                " --with-headers=${getDev libcCross}/include") +
-          " --enable-__cxa_atexit" +
-          " --enable-long-long" +
-          (if crossMingw then
-            " --enable-threads=win32" +
-            " --enable-sjlj-exceptions" +
-            " --enable-hash-synchronization" +
-            " --disable-libssp" +
-            " --disable-nls" +
-            " --with-dwarf2" +
+          [ "--with-headers=${libcCross}/include"
+            "--with-gcc"
+            "--with-gnu-as"
+            "--with-gnu-ld"
+            "--with-gnu-ld"
+            "--disable-shared"
+            "--disable-nls"
+            "--disable-debug"
+            "--enable-sjlj-exceptions"
+            "--enable-threads=win32"
+            "--disable-win32-registry"
+        ] else if crossStageStatic then [
+            "--disable-libssp"
+            "--disable-nls"
+            "--without-headers"
+            "--disable-threads"
+            "--disable-libgomp"
+            "--disable-libquadmath"
+            "--disable-shared"
+            "--disable-libatomic"  # libatomic requires libc
+            "--disable-decimal-float" # libdecnumber requires libc
+        ] else
+          (if crossDarwin then ["--with-sysroot=${getLib libcCross}/share/sysroot"]
+           else                ["--with-headers=${getDev libcCross}/include"]) ++
+
+          [ "--enable-__cxa_atexit"
+            "--enable-long-long"
+          ] ++
+
+          (if crossMingw then [
+            "--enable-threads=win32"
+            "--enable-sjlj-exceptions"
+            "--enable-hash-synchronization"
+            "--disable-libssp"
+            "--disable-nls"
+            "--with-dwarf2"
             # I think noone uses shared gcc libs in mingw, so we better do the same.
             # In any case, mingw32 g++ linking is broken by default with shared libs,
             # unless adding "-lsupc++" to any linking command. I don't know why.
-            " --disable-shared" +
+            "--disable-shared"
             # To keep ABI compatibility with upstream mingw-w64
-            " --enable-fully-dynamic-string"
-            else (if targetPlatform.libc == "uclibc" then
-              # libsanitizer requires netrom/netrom.h which is not
-              # available in uclibc.
-              " --disable-libsanitizer" +
-              # In uclibc cases, libgomp needs an additional '-ldl'
-              # and as I don't know how to pass it, I disable libgomp.
-              " --disable-libgomp" else "") +
-            " --enable-threads=posix" +
-            " --enable-nls" +
-            " --disable-decimal-float") # No final libdecnumber (it may work only in 386)
-          );
+            "--enable-fully-dynamic-string"
+            ] else
+              optionals (targetPlatform.libc == "uclibc") [
+                # libsanitizer requires netrom/netrom.h which is not
+                # available in uclibc.
+                "--disable-libsanitizer"
+                # In uclibc cases, libgomp needs an additional '-ldl'
+                # and as I don't know how to pass it, I disable libgomp.
+                "--disable-libgomp" ] ++
+              [ "--enable-threads=posix"
+                "--enable-nls"
+                "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+              ])
+        );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
@@ -341,85 +324,104 @@ stdenv.mkDerivation ({
     then []
     else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
-  configureFlags = "
-    ${if hostPlatform.isSunOS then
-      " --enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit " +
-      # On Illumos/Solaris GNU as is preferred
-      " --with-gnu-as --without-gnu-ld "
-      else ""}
-    --enable-lto
-    ${if enableMultilib then "--enable-multilib --disable-libquadmath" else "--disable-multilib"}
-    ${if enableShared then "" else "--disable-shared"}
-    ${if enablePlugin then "--enable-plugin" else "--disable-plugin"}
-    ${optionalString (isl != null) "--with-isl=${isl}"}
-    ${if langJava then
-      "--with-ecj-jar=${javaEcj} " +
+  configureFlags =
+    # Basic dependencies
+    [
+      "--with-gmp-include=${gmp.dev}/include"
+      "--with-gmp-lib=${gmp.out}/lib"
+      "--with-mpfr-include=${mpfr.dev}/include"
+      "--with-mpfr-lib=${mpfr.out}/lib"
+      "--with-mpc=${libmpc}"
+    ] ++
+    optional (libelf != null) "--with-libelf=${libelf}" ++
+
+    # Basic configuration
+    [
+      "--enable-lto"
+      "--disable-libstdcxx-pch"
+      "--without-included-gettext"
+      "--with-system-zlib"
+      "--enable-static"
+      "--enable-languages=${
+        concatStrings (intersperse ","
+          (  optional langC        "c"
+          ++ optional langCC       "c++"
+          ++ optional langFortran  "fortran"
+          ++ optional langJava     "java"
+          ++ optional langAda      "ada"
+          ++ optional langVhdl     "vhdl"
+          ++ optional langGo       "go"
+          ++ optional langObjC     "objc"
+          ++ optional langObjCpp   "obj-c++"
+          ++ optionals crossDarwin [ "objc" "obj-c++" ]
+          )
+        )
+      }"
+    ] ++
+
+    (if enableMultilib
+      then ["--enable-multilib" "--disable-libquadmath"]
+      else ["--disable-multilib"]) ++
+    optional (!enableShared) "--disable-shared" ++
+    (if enablePlugin
+      then ["--enable-plugin"]
+      else ["--disable-plugin"]) ++
+
+    # Optional features
+    optional (isl != null) "--with-isl=${isl}" ++
+
+    # Java options
+    optionals langJava [
+      "--with-ecj-jar=${javaEcj} "
 
       # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
       # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
-      "--enable-java-home --with-java-home=\${prefix}/lib/jvm/jre "
-      else ""}
-    ${if javaAwtGtk then "--enable-java-awt=gtk" else ""}
-    ${if langJava && javaAntlr != null then "--with-antlr-jar=${javaAntlr}" else ""}
-    --with-gmp-include=${gmp.dev}/include
-    --with-gmp-lib=${gmp.out}/lib
-    --with-mpfr-include=${mpfr.dev}/include
-    --with-mpfr-lib=${mpfr.out}/lib
-    --with-mpc=${libmpc}
-    ${if libelf != null then "--with-libelf=${libelf}" else ""}
-    --disable-libstdcxx-pch
-    --without-included-gettext
-    --with-system-zlib
-    --enable-static
-    --enable-languages=${
-      concatStrings (intersperse ","
-        (  optional langC        "c"
-        ++ optional langCC       "c++"
-        ++ optional langFortran  "fortran"
-        ++ optional langJava     "java"
-        ++ optional langAda      "ada"
-        ++ optional langVhdl     "vhdl"
-        ++ optional langGo       "go"
-        ++ optional langObjC     "objc"
-        ++ optional langObjCpp   "obj-c++"
-        ++ optionals crossDarwin [ "objc" "obj-c++" ]
-        )
-      )
-    }
-    ${if targetPlatform == hostPlatform
-      then if hostPlatform.isDarwin
-        then " --with-native-system-header-dir=${darwin.usr-include}"
-        else " --with-native-system-header-dir=${getDev stdenv.cc.libc}/include"
-      else ""}
-    ${if langAda then " --enable-libada" else ""}
-    ${if targetPlatform == hostPlatform && targetPlatform.isi686 then "--with-arch=i686" else ""}
-    ${if targetPlatform != hostPlatform then crossConfigureFlags else ""}
-    ${if !bootstrap then "--disable-bootstrap" else ""}
-    ${if targetPlatform == hostPlatform then platformFlags else ""}
-  ";
+      "--enable-java-home"
+      "--with-java-home=\${prefix}/lib/jvm/jre"
+    ] ++
+    optional javaAwtGtk "--enable-java-awt=gtk" ++
+    optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}" ++
+
+    # Ada
+    optional langAda "--enable-libada" ++
+
+    # Cross compilation
+    optional (targetPlatform == hostPlatform) (
+      let incDir = if hostPlatform.isDarwin
+                     then "${darwin.usr-include}"
+                     else "${getDev stdenv.cc.libc}/include";
+      in "--with-native-system-header-dir=${incDir}"
+    ) ++
+
+    optional (targetPlatform != hostPlatform) crossConfigureFlags ++
+    optional (!bootstrap) "--disable-bootstrap" ++
+
+    # Platform-specific flags
+    optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++
+    optionals (hostPlatform.isSunOS) [
+      " --enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit"
+      # On Illumos/Solaris GNU as is preferred
+      " --with-gnu-as --without-gnu-ld"
+    ]
+  ;
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
 
-  buildFlags = if bootstrap then
-    (if profiledCompiler then "profiledbootstrap" else "bootstrap")
-    else "";
+  buildFlags =
+    optional bootstrap (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   installTargets =
     if stripped
     then "install-strip"
     else "install";
 
+  /* For cross-built gcc (build != host == target) */
   crossAttrs = let
     xgccArch = targetPlatform.gcc.arch or null;
     xgccCpu = targetPlatform.gcc.cpu or null;
     xgccAbi = targetPlatform.gcc.abi or null;
     xgccFpu = targetPlatform.gcc.fpu or null;
     xgccFloat = targetPlatform.gcc.float or null;
-    xwithArch = if xgccArch != null then " --with-arch=${xgccArch}" else "";
-    xwithCpu = if xgccCpu != null then " --with-cpu=${xgccCpu}" else "";
-    xwithAbi = if xgccAbi != null then " --with-abi=${xgccAbi}" else "";
-    xwithFpu = if xgccFpu != null then " --with-fpu=${xgccFpu}" else "";
-    xwithFloat = if xgccFloat != null then " --with-float=${xgccFloat}" else "";
   in {
     AR = "${targetPlatform.config}-ar";
     LD = "${targetPlatform.config}-ld";
@@ -433,37 +435,39 @@ stdenv.mkDerivation ({
     # If we are making a cross compiler, cross != null
     NIX_CC_CROSS = optionalString (targetPlatform == hostPlatform) builtins.toString stdenv.cc;
     dontStrip = true;
-    configureFlags = ''
-      ${if enableMultilib then "" else "--disable-multilib"}
-      ${if enableShared then "" else "--disable-shared"}
-      ${if langJava then "--with-ecj-jar=${javaEcj.crossDrv}" else ""}
-      ${if javaAwtGtk then "--enable-java-awt=gtk" else ""}
-      ${if langJava && javaAntlr != null then "--with-antlr-jar=${javaAntlr.crossDrv}" else ""}
-      --with-gmp=${gmp.crossDrv}
-      --with-mpfr=${mpfr.crossDrv}
-      --with-mpc=${libmpc.crossDrv}
-      --disable-libstdcxx-pch
-      --without-included-gettext
-      --with-system-zlib
-      --enable-languages=${
-        concatStrings (intersperse ","
-          (  optional langC        "c"
-          ++ optional langCC       "c++"
-          ++ optional langFortran  "fortran"
-          ++ optional langJava     "java"
-          ++ optional langAda      "ada"
-          ++ optional langVhdl     "vhdl"
-          ++ optional langGo       "go"
+    configureFlags =
+      optional (!enableMultilib) "--disable-multilib" ++
+      optional (!enableShared) "--disable-shared" ++
+      optional langJava "--with-ecj-jar=${javaEcj.crossDrv}" ++
+      optional javaAwtGtk "--enable-java-awt=gtk" ++
+      optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr.crossDrv}" ++
+      [
+        "--with-gmp=${gmp.crossDrv}"
+        "--with-mpfr=${mpfr.crossDrv}"
+        "--with-mpc=${libmpc.crossDrv}"
+        "--disable-libstdcxx-pch"
+        "--without-included-gettext"
+        "--with-system-zlib"
+        "--enable-languages=${
+          concatStrings (intersperse ","
+            (  optional langC        "c"
+            ++ optional langCC       "c++"
+            ++ optional langFortran  "fortran"
+            ++ optional langJava     "java"
+            ++ optional langAda      "ada"
+            ++ optional langVhdl     "vhdl"
+            ++ optional langGo       "go"
+            )
           )
-        )
-      }
-      ${if langAda then " --enable-libada" else ""}
-      ${xwithArch}
-      ${xwithCpu}
-      ${xwithAbi}
-      ${xwithFpu}
-      ${xwithFloat}
-    '';
+        }"
+      ] ++
+      optional langAda "--enable-libada" ++
+      optional (xgccArch != null) "--with-arch=${xgccArch}" ++
+      optional (xgccCpu != null) "--with-cpu=${xgccCpu}" ++
+      optional (xgccAbi != null) "--with-abi=${xgccAbi}" ++
+      optional (xgccFpu != null) "--with-fpu=${xgccFpu}" ++
+      optional (xgccFloat != null) "--with-float=${xgccFloat}"
+    ;
     buildFlags = "";
   };
 

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -98,108 +98,90 @@ let version = "7.2.0";
     javaAwtGtk = langJava && x11Support;
 
     /* Platform flags */
-    platformFlags = let
-        gccArch = stdenv.platform.gcc.arch or null;
-        gccCpu = stdenv.platform.gcc.cpu or null;
-        gccAbi = stdenv.platform.gcc.abi or null;
-        gccFpu = stdenv.platform.gcc.fpu or null;
-        gccFloat = stdenv.platform.gcc.float or null;
-        gccMode = stdenv.platform.gcc.mode or null;
-        withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
-        withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
-        withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
-        withFpu = if gccFpu != null then " --with-fpu=${gccFpu}" else "";
-        withFloat = if gccFloat != null then " --with-float=${gccFloat}" else "";
-        withMode = if gccMode != null then " --with-mode=${gccMode}" else "";
-      in
-        withArch +
-        withCpu +
-        withAbi +
-        withFpu +
-        withFloat +
-        withMode;
+    mkPlatformFlags = platform: let
+        gccArch = platform.gcc.arch or null;
+        gccCpu = platform.gcc.cpu or null;
+        gccAbi = platform.gcc.abi or null;
+        gccFpu = platform.gcc.fpu or null;
+        gccFloat = platform.gcc.float or null;
+        gccMode = platform.gcc.mode or null;
+     in
+        optional (gccArch != null) "--with-arch=${gccArch}" ++
+        optional (gccCpu != null) "--with-cpu=${gccCpu}" ++
+        optional (gccAbi != null) "--with-abi=${gccAbi}" ++
+        optional (gccFpu != null) "--with-fpu=${gccFpu}" ++
+        optional (gccFloat != null) "--with-float=${gccFloat}" ++
+        optional (gccMode != null) "--with-mode=${gccMode}";
 
-    /* Cross-gcc settings */
+    /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
     crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
-    crossConfigureFlags = let
-        gccArch = targetPlatform.gcc.arch or null;
-        gccCpu = targetPlatform.gcc.cpu or null;
-        gccAbi = targetPlatform.gcc.abi or null;
-        gccFpu = targetPlatform.gcc.fpu or null;
-        gccFloat = targetPlatform.gcc.float or null;
-        gccMode = targetPlatform.gcc.mode or null;
-        withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
-        withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
-        withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
-        withFpu = if gccFpu != null then " --with-fpu=${gccFpu}" else "";
-        withFloat = if gccFloat != null then " --with-float=${gccFloat}" else "";
-        withMode = if gccMode != null then " --with-mode=${gccMode}" else "";
-      in
-        withArch +
-        withCpu +
-        withAbi +
-        withFpu +
-        withFloat +
-        withMode +
+    crossConfigureFlags =
+        mkPlatformFlags targetPlatform ++
+
         # Ensure that -print-prog-name is able to find the correct programs.
-        " --with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as" +
-        " --with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" +
+        [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
+          "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
         (if crossMingw && crossStageStatic then
-          " --with-headers=${libcCross}/include" +
-          " --with-gcc" +
-          " --with-gnu-as" +
-          " --with-gnu-ld" +
-          " --with-gnu-ld" +
-          " --disable-shared" +
-          " --disable-nls" +
-          " --disable-debug" +
-          " --enable-sjlj-exceptions" +
-          " --enable-threads=win32" +
-          " --disable-win32-registry"
-          else if crossStageStatic then
-          " --disable-libssp --disable-nls" +
-          " --without-headers" +
-          " --disable-threads " +
-          " --disable-libgomp " +
-          " --disable-libquadmath" +
-          " --disable-shared" +
-          " --disable-libatomic " +  # libatomic requires libc
-          " --disable-decimal-float" # libdecnumber requires libc
-          else
-          (if crossDarwin then " --with-sysroot=${getLib libcCross}/share/sysroot"
-           else                " --with-headers=${getDev libcCross}/include") +
-          # Ensure that -print-prog-name is able to find the correct programs.
-          " --enable-__cxa_atexit" +
-          " --enable-long-long" +
-          (if crossMingw then
-            " --enable-threads=win32" +
-            " --enable-sjlj-exceptions" +
-            " --enable-hash-synchronization" +
-            " --disable-libssp" +
-            " --disable-nls" +
-            " --with-dwarf2" +
+          [ "--with-headers=${libcCross}/include"
+            "--with-gcc"
+            "--with-gnu-as"
+            "--with-gnu-ld"
+            "--with-gnu-ld"
+            "--disable-shared"
+            "--disable-nls"
+            "--disable-debug"
+            "--enable-sjlj-exceptions"
+            "--enable-threads=win32"
+            "--disable-win32-registry"
+          ] else if crossStageStatic then
+          [ "--disable-libssp"
+            "--disable-nls"
+            "--without-headers"
+            "--disable-threads "
+            "--disable-libgomp "
+            "--disable-libquadmath"
+            "--disable-shared"
+            "--disable-libatomic "  # libatomic requires libc
+            "--disable-decimal-float" # libdecnumber requires libc
+          ] else
+            (if crossDarwin then ["--with-sysroot=${getLib libcCross}/share/sysroot"]
+             else                ["--with-headers=${getDev libcCross}/include"]) ++
+          [ "--enable-__cxa_atexit"
+            "--enable-long-long"
+          ] ++
+
+          (if crossMingw then [
+            "--enable-threads=win32"
+            "--enable-sjlj-exceptions"
+            "--enable-hash-synchronization"
+            "--disable-libssp"
+            "--disable-nls"
+            "--with-dwarf2"
             # I think noone uses shared gcc libs in mingw, so we better do the same.
             # In any case, mingw32 g++ linking is broken by default with shared libs,
             # unless adding "-lsupc++" to any linking command. I don't know why.
-            " --disable-shared" +
+            "--disable-shared"
             # To keep ABI compatibility with upstream mingw-w64
-            " --enable-fully-dynamic-string"
-            else (if targetPlatform.libc == "uclibc" then
+            "--enable-fully-dynamic-string"
+          ] else
+            optionals (targetPlatform.libc == "uclibc") [
               # libsanitizer requires netrom/netrom.h which is not
               # available in uclibc.
-              " --disable-libsanitizer" +
+              "--disable-libsanitizer"
               # In uclibc cases, libgomp needs an additional '-ldl'
               # and as I don't know how to pass it, I disable libgomp.
-              " --disable-libgomp" else "") +
-            " --enable-threads=posix" +
-            " --enable-nls" +
-            " --disable-decimal-float") # No final libdecnumber (it may work only in 386)
+              "--disable-libgomp"
+            ] ++
+            [ "--enable-threads=posix"
+              "--enable-nls"
+              "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+            ])
           );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
-  bootstrap = targetPlatform == hostPlatform;
+    bootstrap = targetPlatform == hostPlatform;
 
 in
 
@@ -335,62 +317,86 @@ stdenv.mkDerivation ({
     then []
     else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
-  configureFlags = "
-    ${if hostPlatform.isSunOS then
-      " --enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit " +
-      # On Illumos/Solaris GNU as is preferred
-      " --with-gnu-as --without-gnu-ld "
-      else ""}
-    --enable-lto
-    ${if enableMultilib then "--enable-multilib --disable-libquadmath" else "--disable-multilib"}
-    ${if enableShared then "" else "--disable-shared"}
-    ${if enablePlugin then "--enable-plugin" else "--disable-plugin"}
-    ${optionalString (isl != null) "--with-isl=${isl}"}
-    ${if langJava then
-      "--with-ecj-jar=${javaEcj} " +
+  configureFlags =
+    # Basic dependencies
+    [
+      "--with-gmp-include=${gmp.dev}/include"
+      "--with-gmp-lib=${gmp.out}/lib"
+      "--with-mpfr-include=${mpfr.dev}/include"
+      "--with-mpfr-lib=${mpfr.out}/lib"
+      "--with-mpc=${libmpc}"
+    ] ++
+    optional (libelf != null) "--with-libelf=${libelf}" ++
+
+    # Basic configuration
+    [
+      "--enable-lto"
+      "--disable-libstdcxx-pch"
+      "--without-included-gettext"
+      "--with-system-zlib"
+      "--enable-static"
+      "--enable-languages=${
+        concatStrings (intersperse ","
+          (  optional langC        "c"
+          ++ optional langCC       "c++"
+          ++ optional langFortran  "fortran"
+          ++ optional langJava     "java"
+          ++ optional langAda      "ada"
+          ++ optional langVhdl     "vhdl"
+          ++ optional langGo       "go"
+          ++ optional langObjC     "objc"
+          ++ optional langObjCpp   "obj-c++"
+          ++ optionals crossDarwin [ "objc" "obj-c++" ]
+          )
+        )
+      }"
+    ] ++
+
+    (if enableMultilib
+      then ["--enable-multilib" "--disable-libquadmath"]
+      else ["--disable-multilib"]) ++
+    optional (!enableShared) "--disable-shared" ++
+    (if enablePlugin
+      then ["--enable-plugin"]
+      else ["--disable-plugin"]) ++
+
+    # Optional features
+    optional (isl != null) "--with-isl=${isl}" ++
+
+    # Java options
+    optionals langJava [
+      "--with-ecj-jar=${javaEcj} "
 
       # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
       # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
       "--enable-java-home --with-java-home=\${prefix}/lib/jvm/jre "
-      else ""}
-    ${if javaAwtGtk then "--enable-java-awt=gtk" else ""}
-    ${if langJava && javaAntlr != null then "--with-antlr-jar=${javaAntlr}" else ""}
-    --with-gmp-include=${gmp.dev}/include
-    --with-gmp-lib=${gmp.out}/lib
-    --with-mpfr-include=${mpfr.dev}/include
-    --with-mpfr-lib=${mpfr.out}/lib
-    --with-mpc=${libmpc}
-    ${if libelf != null then "--with-libelf=${libelf}" else ""}
-    --disable-libstdcxx-pch
-    --without-included-gettext
-    --with-system-zlib
-    --enable-static
-    --enable-languages=${
-      concatStrings (intersperse ","
-        (  optional langC        "c"
-        ++ optional langCC       "c++"
-        ++ optional langFortran  "fortran"
-        ++ optional langJava     "java"
-        ++ optional langAda      "ada"
-        ++ optional langVhdl     "vhdl"
-        ++ optional langGo       "go"
-        ++ optional langObjC     "objc"
-        ++ optional langObjCpp   "obj-c++"
-        ++ optionals crossDarwin [ "objc" "obj-c++" ]
-        )
-      )
-    }
-    ${if targetPlatform == hostPlatform
-      then if hostPlatform.isDarwin
-        then " --with-native-system-header-dir=${darwin.usr-include}"
-        else " --with-native-system-header-dir=${getDev stdenv.cc.libc}/include"
-      else ""}
-    ${if langAda then " --enable-libada" else ""}
-    ${if targetPlatform == hostPlatform && targetPlatform.isi686 then "--with-arch=i686" else ""}
-    ${if targetPlatform != hostPlatform then crossConfigureFlags else ""}
-    ${if !bootstrap then "--disable-bootstrap" else ""}
-    ${if targetPlatform == hostPlatform then platformFlags else ""}
-  ";
+    ] ++
+    optional javaAwtGtk "--enable-java-awt=gtk" ++
+    optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}" ++
+
+    # Ada
+    optional langAda "--enable-libada" ++
+
+    # Cross-compilation
+    optional (targetPlatform == hostPlatform) (
+      let incDir = if hostPlatform.isDarwin
+                     then "${darwin.usr-include}"
+                     else "${getDev stdenv.cc.libc}/include";
+      in "--with-native-system-header-dir=${incDir}"
+    ) ++
+
+    optional (targetPlatform == hostPlatform) (mkPlatformFlags stdenv.platform) ++
+    optional (targetPlatform != hostPlatform) crossConfigureFlags ++
+    optional (!bootstrap) "--disable-bootstrap" ++
+
+    # Platform-specific flags
+    optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++
+    optionals hostPlatform.isSunOS [
+      "--enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit"
+      # On Illumos/Solaris GNU as is preferred
+      "--with-gnu-as --without-gnu-ld"
+    ]
+  ;
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
 
@@ -403,17 +409,13 @@ stdenv.mkDerivation ({
     then "install-strip"
     else "install";
 
+  /* For cross-built gcc (build != host == target) */
   crossAttrs = let
     xgccArch = targetPlatform.gcc.arch or null;
     xgccCpu = targetPlatform.gcc.cpu or null;
     xgccAbi = targetPlatform.gcc.abi or null;
     xgccFpu = targetPlatform.gcc.fpu or null;
     xgccFloat = targetPlatform.gcc.float or null;
-    xwithArch = if xgccArch != null then " --with-arch=${xgccArch}" else "";
-    xwithCpu = if xgccCpu != null then " --with-cpu=${xgccCpu}" else "";
-    xwithAbi = if xgccAbi != null then " --with-abi=${xgccAbi}" else "";
-    xwithFpu = if xgccFpu != null then " --with-fpu=${xgccFpu}" else "";
-    xwithFloat = if xgccFloat != null then " --with-float=${xgccFloat}" else "";
   in {
     AR = "${targetPlatform.config}-ar";
     LD = "${targetPlatform.config}-ld";
@@ -427,37 +429,39 @@ stdenv.mkDerivation ({
     # If we are making a cross compiler, targetPlatform != hostPlatform
     NIX_CC_CROSS = if targetPlatform == hostPlatform then "${stdenv.ccCross}" else "";
     dontStrip = true;
-    configureFlags = ''
-      ${if enableMultilib then "" else "--disable-multilib"}
-      ${if enableShared then "" else "--disable-shared"}
-      ${if langJava then "--with-ecj-jar=${javaEcj.crossDrv}" else ""}
-      ${if javaAwtGtk then "--enable-java-awt=gtk" else ""}
-      ${if langJava && javaAntlr != null then "--with-antlr-jar=${javaAntlr.crossDrv}" else ""}
-      --with-gmp=${gmp.crossDrv}
-      --with-mpfr=${mpfr.crossDrv}
-      --with-mpc=${libmpc.crossDrv}
-      --disable-libstdcxx-pch
-      --without-included-gettext
-      --with-system-zlib
-      --enable-languages=${
-        concatStrings (intersperse ","
-          (  optional langC        "c"
-          ++ optional langCC       "c++"
-          ++ optional langFortran  "fortran"
-          ++ optional langJava     "java"
-          ++ optional langAda      "ada"
-          ++ optional langVhdl     "vhdl"
-          ++ optional langGo       "go"
+    configureFlags =
+      optional (!enableMultilib) "--disable-multilib" ++
+      optional (!enableShared) "--disable-shared" ++
+      optional langJava "--with-ecj-jar=${javaEcj.crossDrv}" ++
+      optional javaAwtGtk "--enable-java-awt=gtk" ++
+      optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr.crossDrv}" ++
+      [
+        "--with-gmp=${gmp.crossDrv}"
+        "--with-mpfr=${mpfr.crossDrv}"
+        "--with-mpc=${libmpc.crossDrv}"
+        "--disable-libstdcxx-pch"
+        "--without-included-gettext"
+        "--with-system-zlib"
+        "--enable-languages=${
+          concatStrings (intersperse ","
+            (  optional langC        "c"
+            ++ optional langCC       "c++"
+            ++ optional langFortran  "fortran"
+            ++ optional langJava     "java"
+            ++ optional langAda      "ada"
+            ++ optional langVhdl     "vhdl"
+            ++ optional langGo       "go"
+            )
           )
-        )
-      }
-      ${if langAda then " --enable-libada" else ""}
-      ${xwithArch}
-      ${xwithCpu}
-      ${xwithAbi}
-      ${xwithFpu}
-      ${xwithFloat}
-    '';
+        }"
+      ] ++
+      optional langAda "--enable-libada" ++
+      optional (xgccArch != null) "--with-arch=${xgccArch}" ++
+      optional (xgccCpu != null) "--with-cpu=${xgccCpu}" ++
+      optional (xgccAbi != null) "--with-abi=${xgccAbi}" ++
+      optional (xgccFpu != null) "--with-fpu=${xgccFpu}" ++
+      optional (xgccFloat != null) "--with-float=${xgccFloat}"
+    ;
     buildFlags = "";
   };
 

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -117,67 +117,65 @@ let version = "7.2.0";
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
     crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
     crossConfigureFlags =
-        mkPlatformFlags targetPlatform ++
+      mkPlatformFlags targetPlatform ++
 
-        # Ensure that -print-prog-name is able to find the correct programs.
-        [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
-          "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-        (if crossMingw && crossStageStatic then
-          [ "--with-headers=${libcCross}/include"
-            "--with-gcc"
-            "--with-gnu-as"
-            "--with-gnu-ld"
-            "--with-gnu-ld"
-            "--disable-shared"
-            "--disable-nls"
-            "--disable-debug"
-            "--enable-sjlj-exceptions"
-            "--enable-threads=win32"
-            "--disable-win32-registry"
-          ] else if crossStageStatic then
-          [ "--disable-libssp"
-            "--disable-nls"
-            "--without-headers"
-            "--disable-threads "
-            "--disable-libgomp "
-            "--disable-libquadmath"
-            "--disable-shared"
-            "--disable-libatomic "  # libatomic requires libc
-            "--disable-decimal-float" # libdecnumber requires libc
-          ] else
-            (if crossDarwin then ["--with-sysroot=${getLib libcCross}/share/sysroot"]
-             else                ["--with-headers=${getDev libcCross}/include"]) ++
-          [ "--enable-__cxa_atexit"
-            "--enable-long-long"
-          ] ++
-
-          (if crossMingw then [
-            "--enable-threads=win32"
-            "--enable-sjlj-exceptions"
-            "--enable-hash-synchronization"
-            "--disable-libssp"
-            "--disable-nls"
-            "--with-dwarf2"
-            # I think noone uses shared gcc libs in mingw, so we better do the same.
-            # In any case, mingw32 g++ linking is broken by default with shared libs,
-            # unless adding "-lsupc++" to any linking command. I don't know why.
-            "--disable-shared"
-            # To keep ABI compatibility with upstream mingw-w64
-            "--enable-fully-dynamic-string"
-          ] else
-            optionals (targetPlatform.libc == "uclibc") [
-              # libsanitizer requires netrom/netrom.h which is not
-              # available in uclibc.
-              "--disable-libsanitizer"
-              # In uclibc cases, libgomp needs an additional '-ldl'
-              # and as I don't know how to pass it, I disable libgomp.
-              "--disable-libgomp"
-            ] ++
-            [ "--enable-threads=posix"
-              "--enable-nls"
-              "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-            ])
-          );
+      # Ensure that -print-prog-name is able to find the correct programs.
+      [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
+        "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
+      (if crossMingw && crossStageStatic then [
+        "--with-headers=${libcCross}/include"
+        "--with-gcc"
+        "--with-gnu-as"
+        "--with-gnu-ld"
+        "--with-gnu-ld"
+        "--disable-shared"
+        "--disable-nls"
+        "--disable-debug"
+        "--enable-sjlj-exceptions"
+        "--enable-threads=win32"
+        "--disable-win32-registry"
+      ] else if crossStageStatic then [
+        "--disable-libssp"
+        "--disable-nls"
+        "--without-headers"
+        "--disable-threads"
+        "--disable-libgomp"
+        "--disable-libquadmath"
+        "--disable-shared"
+        "--disable-libatomic"  # libatomic requires libc
+        "--disable-decimal-float" # libdecnumber requires libc
+      ] else [
+        (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
+         else                "--with-headers=${getDev libcCross}/include")
+        "--enable-__cxa_atexit"
+        "--enable-long-long"
+      ] ++
+        (if crossMingw then [
+          "--enable-threads=win32"
+          "--enable-sjlj-exceptions"
+          "--enable-hash-synchronization"
+          "--disable-libssp"
+          "--disable-nls"
+          "--with-dwarf2"
+          # I think noone uses shared gcc libs in mingw, so we better do the same.
+          # In any case, mingw32 g++ linking is broken by default with shared libs,
+          # unless adding "-lsupc++" to any linking command. I don't know why.
+          "--disable-shared"
+          # To keep ABI compatibility with upstream mingw-w64
+          "--enable-fully-dynamic-string"
+        ] else
+          optionals (targetPlatform.libc == "uclibc") [
+            # libsanitizer requires netrom/netrom.h which is not
+            # available in uclibc.
+            "--disable-libsanitizer"
+            # In uclibc cases, libgomp needs an additional '-ldl'
+            # and as I don't know how to pass it, I disable libgomp.
+            "--disable-libgomp"
+          ] ++ [
+          "--enable-threads=posix"
+          "--enable-nls"
+          "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+        ]));
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
@@ -365,11 +363,12 @@ stdenv.mkDerivation ({
 
     # Java options
     optionals langJava [
-      "--with-ecj-jar=${javaEcj} "
+      "--with-ecj-jar=${javaEcj}"
 
       # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
       # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
-      "--enable-java-home --with-java-home=\${prefix}/lib/jvm/jre "
+      "--enable-java-home"
+      "--with-java-home=\${prefix}/lib/jvm/jre"
     ] ++
     optional javaAwtGtk "--enable-java-awt=gtk" ++
     optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}" ++
@@ -392,9 +391,9 @@ stdenv.mkDerivation ({
     # Platform-specific flags
     optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++
     optionals hostPlatform.isSunOS [
-      "--enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit"
+      "--enable-long-long" "--enable-libssp" "--enable-threads=posix" "--disable-nls" "--enable-__cxa_atexit"
       # On Illumos/Solaris GNU as is preferred
-      "--with-gnu-as --without-gnu-ld"
+      "--with-gnu-as" "--without-gnu-ld"
     ]
   ;
 

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -98,108 +98,90 @@ let version = "7-20170409";
     javaAwtGtk = langJava && x11Support;
 
     /* Platform flags */
-    platformFlags = let
-        gccArch = stdenv.platform.gcc.arch or null;
-        gccCpu = stdenv.platform.gcc.cpu or null;
-        gccAbi = stdenv.platform.gcc.abi or null;
-        gccFpu = stdenv.platform.gcc.fpu or null;
-        gccFloat = stdenv.platform.gcc.float or null;
-        gccMode = stdenv.platform.gcc.mode or null;
-        withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
-        withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
-        withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
-        withFpu = if gccFpu != null then " --with-fpu=${gccFpu}" else "";
-        withFloat = if gccFloat != null then " --with-float=${gccFloat}" else "";
-        withMode = if gccMode != null then " --with-mode=${gccMode}" else "";
-      in
-        withArch +
-        withCpu +
-        withAbi +
-        withFpu +
-        withFloat +
-        withMode;
+    mkPlatformFlags = platform: let
+        gccArch = platform.gcc.arch or null;
+        gccCpu = platform.gcc.cpu or null;
+        gccAbi = platform.gcc.abi or null;
+        gccFpu = platform.gcc.fpu or null;
+        gccFloat = platform.gcc.float or null;
+        gccMode = platform.gcc.mode or null;
+     in
+        optional (gccArch != null) "--with-arch=${gccArch}" ++
+        optional (gccCpu != null) "--with-cpu=${gccCpu}" ++
+        optional (gccAbi != null) "--with-abi=${gccAbi}" ++
+        optional (gccFpu != null) "--with-fpu=${gccFpu}" ++
+        optional (gccFloat != null) "--with-float=${gccFloat}" ++
+        optional (gccMode != null) "--with-mode=${gccMode}";
 
-    /* Cross-gcc settings */
+    /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
     crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
-    crossConfigureFlags = let
-        gccArch = targetPlatform.gcc.arch or null;
-        gccCpu = targetPlatform.gcc.cpu or null;
-        gccAbi = targetPlatform.gcc.abi or null;
-        gccFpu = targetPlatform.gcc.fpu or null;
-        gccFloat = targetPlatform.gcc.float or null;
-        gccMode = targetPlatform.gcc.mode or null;
-        withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
-        withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
-        withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";
-        withFpu = if gccFpu != null then " --with-fpu=${gccFpu}" else "";
-        withFloat = if gccFloat != null then " --with-float=${gccFloat}" else "";
-        withMode = if gccMode != null then " --with-mode=${gccMode}" else "";
-      in
-        withArch +
-        withCpu +
-        withAbi +
-        withFpu +
-        withFloat +
-        withMode +
+    crossConfigureFlags =
+        mkPlatformFlags targetPlatform ++
+
         # Ensure that -print-prog-name is able to find the correct programs.
-        " --with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as" +
-        " --with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" +
+        [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
+          "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
         (if crossMingw && crossStageStatic then
-          " --with-headers=${libcCross}/include" +
-          " --with-gcc" +
-          " --with-gnu-as" +
-          " --with-gnu-ld" +
-          " --with-gnu-ld" +
-          " --disable-shared" +
-          " --disable-nls" +
-          " --disable-debug" +
-          " --enable-sjlj-exceptions" +
-          " --enable-threads=win32" +
-          " --disable-win32-registry"
-          else if crossStageStatic then
-          " --disable-libssp --disable-nls" +
-          " --without-headers" +
-          " --disable-threads " +
-          " --disable-libgomp " +
-          " --disable-libquadmath" +
-          " --disable-shared" +
-          " --disable-libatomic " +  # libatomic requires libc
-          " --disable-decimal-float" # libdecnumber requires libc
-          else
-          (if crossDarwin then " --with-sysroot=${getLib libcCross}/share/sysroot"
-           else                " --with-headers=${getDev libcCross}/include") +
-          # Ensure that -print-prog-name is able to find the correct programs.
-          " --enable-__cxa_atexit" +
-          " --enable-long-long" +
-          (if crossMingw then
-            " --enable-threads=win32" +
-            " --enable-sjlj-exceptions" +
-            " --enable-hash-synchronization" +
-            " --disable-libssp" +
-            " --disable-nls" +
-            " --with-dwarf2" +
+          [ "--with-headers=${libcCross}/include"
+            "--with-gcc"
+            "--with-gnu-as"
+            "--with-gnu-ld"
+            "--with-gnu-ld"
+            "--disable-shared"
+            "--disable-nls"
+            "--disable-debug"
+            "--enable-sjlj-exceptions"
+            "--enable-threads=win32"
+            "--disable-win32-registry"
+          ] else if crossStageStatic then
+          [ "--disable-libssp"
+            "--disable-nls"
+            "--without-headers"
+            "--disable-threads "
+            "--disable-libgomp "
+            "--disable-libquadmath"
+            "--disable-shared"
+            "--disable-libatomic "  # libatomic requires libc
+            "--disable-decimal-float" # libdecnumber requires libc
+          ] else
+            (if crossDarwin then ["--with-sysroot=${getLib libcCross}/share/sysroot"]
+             else                ["--with-headers=${getDev libcCross}/include"]) ++
+          [ "--enable-__cxa_atexit"
+            "--enable-long-long"
+          ] ++
+
+          (if crossMingw then [
+            "--enable-threads=win32"
+            "--enable-sjlj-exceptions"
+            "--enable-hash-synchronization"
+            "--disable-libssp"
+            "--disable-nls"
+            "--with-dwarf2"
             # I think noone uses shared gcc libs in mingw, so we better do the same.
             # In any case, mingw32 g++ linking is broken by default with shared libs,
             # unless adding "-lsupc++" to any linking command. I don't know why.
-            " --disable-shared" +
+            "--disable-shared"
             # To keep ABI compatibility with upstream mingw-w64
-            " --enable-fully-dynamic-string"
-            else (if targetPlatform.libc == "uclibc" then
+            "--enable-fully-dynamic-string"
+          ] else
+            optionals (targetPlatform.libc == "uclibc") [
               # libsanitizer requires netrom/netrom.h which is not
               # available in uclibc.
-              " --disable-libsanitizer" +
+              "--disable-libsanitizer"
               # In uclibc cases, libgomp needs an additional '-ldl'
               # and as I don't know how to pass it, I disable libgomp.
-              " --disable-libgomp" else "") +
-            " --enable-threads=posix" +
-            " --enable-nls" +
-            " --disable-decimal-float") # No final libdecnumber (it may work only in 386)
+              "--disable-libgomp"
+            ] ++
+            [ "--enable-threads=posix"
+              "--enable-nls"
+              "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+            ])
           );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
-  bootstrap = targetPlatform == hostPlatform;
+    bootstrap = targetPlatform == hostPlatform;
 
 in
 
@@ -322,62 +304,86 @@ stdenv.mkDerivation ({
     then []
     else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
-  configureFlags = "
-    ${if hostPlatform.isSunOS then
-      " --enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit " +
-      # On Illumos/Solaris GNU as is preferred
-      " --with-gnu-as --without-gnu-ld "
-      else ""}
-    --enable-lto
-    ${if enableMultilib then "--enable-multilib --disable-libquadmath" else "--disable-multilib"}
-    ${if enableShared then "" else "--disable-shared"}
-    ${if enablePlugin then "--enable-plugin" else "--disable-plugin"}
-    ${optionalString (isl != null) "--with-isl=${isl}"}
-    ${if langJava then
-      "--with-ecj-jar=${javaEcj} " +
+  configureFlags =
+    # Basic dependencies
+    [
+      "--with-gmp-include=${gmp.dev}/include"
+      "--with-gmp-lib=${gmp.out}/lib"
+      "--with-mpfr-include=${mpfr.dev}/include"
+      "--with-mpfr-lib=${mpfr.out}/lib"
+      "--with-mpc=${libmpc}"
+    ] ++
+    optional (libelf != null) "--with-libelf=${libelf}" ++
+
+    # Basic configuration
+    [
+      "--enable-lto"
+      "--disable-libstdcxx-pch"
+      "--without-included-gettext"
+      "--with-system-zlib"
+      "--enable-static"
+      "--enable-languages=${
+        concatStrings (intersperse ","
+          (  optional langC        "c"
+          ++ optional langCC       "c++"
+          ++ optional langFortran  "fortran"
+          ++ optional langJava     "java"
+          ++ optional langAda      "ada"
+          ++ optional langVhdl     "vhdl"
+          ++ optional langGo       "go"
+          ++ optional langObjC     "objc"
+          ++ optional langObjCpp   "obj-c++"
+          ++ optionals crossDarwin [ "objc" "obj-c++" ]
+          )
+        )
+      }"
+    ] ++
+
+    (if enableMultilib
+      then ["--enable-multilib" "--disable-libquadmath"]
+      else ["--disable-multilib"]) ++
+    optional (!enableShared) "--disable-shared" ++
+    (if enablePlugin
+      then ["--enable-plugin"]
+      else ["--disable-plugin"]) ++
+
+    # Optional features
+    optional (isl != null) "--with-isl=${isl}" ++
+
+    # Java options
+    optionals langJava [
+      "--with-ecj-jar=${javaEcj} "
 
       # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
       # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
       "--enable-java-home --with-java-home=\${prefix}/lib/jvm/jre "
-      else ""}
-    ${if javaAwtGtk then "--enable-java-awt=gtk" else ""}
-    ${if langJava && javaAntlr != null then "--with-antlr-jar=${javaAntlr}" else ""}
-    --with-gmp-include=${gmp.dev}/include
-    --with-gmp-lib=${gmp.out}/lib
-    --with-mpfr-include=${mpfr.dev}/include
-    --with-mpfr-lib=${mpfr.out}/lib
-    --with-mpc=${libmpc}
-    ${if libelf != null then "--with-libelf=${libelf}" else ""}
-    --disable-libstdcxx-pch
-    --without-included-gettext
-    --with-system-zlib
-    --enable-static
-    --enable-languages=${
-      concatStrings (intersperse ","
-        (  optional langC        "c"
-        ++ optional langCC       "c++"
-        ++ optional langFortran  "fortran"
-        ++ optional langJava     "java"
-        ++ optional langAda      "ada"
-        ++ optional langVhdl     "vhdl"
-        ++ optional langGo       "go"
-        ++ optional langObjC     "objc"
-        ++ optional langObjCpp   "obj-c++"
-        ++ optionals crossDarwin [ "objc" "obj-c++" ]
-        )
-      )
-    }
-    ${if targetPlatform == hostPlatform
-      then if hostPlatform.isDarwin
-        then " --with-native-system-header-dir=${darwin.usr-include}"
-        else " --with-native-system-header-dir=${getDev stdenv.cc.libc}/include"
-      else ""}
-    ${if langAda then " --enable-libada" else ""}
-    ${if targetPlatform == hostPlatform && targetPlatform.isi686 then "--with-arch=i686" else ""}
-    ${if targetPlatform != hostPlatform then crossConfigureFlags else ""}
-    ${if !bootstrap then "--disable-bootstrap" else ""}
-    ${if targetPlatform == hostPlatform then platformFlags else ""}
-  ";
+    ] ++
+    optional javaAwtGtk "--enable-java-awt=gtk" ++
+    optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}" ++
+
+    # Ada
+    optional langAda "--enable-libada" ++
+
+    # Cross-compilation
+    optional (targetPlatform == hostPlatform) (
+      let incDir = if hostPlatform.isDarwin
+                     then "${darwin.usr-include}"
+                     else "${getDev stdenv.cc.libc}/include";
+      in "--with-native-system-header-dir=${incDir}"
+    ) ++
+
+    optional (targetPlatform == hostPlatform) (mkPlatformFlags stdenv.platform) ++
+    optional (targetPlatform != hostPlatform) crossConfigureFlags ++
+    optional (!bootstrap) "--disable-bootstrap" ++
+
+    # Platform-specific flags
+    optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++
+    optionals hostPlatform.isSunOS [
+      "--enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit"
+      # On Illumos/Solaris GNU as is preferred
+      "--with-gnu-as --without-gnu-ld"
+    ]
+  ;
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
 
@@ -390,17 +396,13 @@ stdenv.mkDerivation ({
     then "install-strip"
     else "install";
 
+  /* For cross-built gcc (build != host == target) */
   crossAttrs = let
     xgccArch = targetPlatform.gcc.arch or null;
     xgccCpu = targetPlatform.gcc.cpu or null;
     xgccAbi = targetPlatform.gcc.abi or null;
     xgccFpu = targetPlatform.gcc.fpu or null;
     xgccFloat = targetPlatform.gcc.float or null;
-    xwithArch = if xgccArch != null then " --with-arch=${xgccArch}" else "";
-    xwithCpu = if xgccCpu != null then " --with-cpu=${xgccCpu}" else "";
-    xwithAbi = if xgccAbi != null then " --with-abi=${xgccAbi}" else "";
-    xwithFpu = if xgccFpu != null then " --with-fpu=${xgccFpu}" else "";
-    xwithFloat = if xgccFloat != null then " --with-float=${xgccFloat}" else "";
   in {
     AR = "${targetPlatform.config}-ar";
     LD = "${targetPlatform.config}-ld";
@@ -414,37 +416,39 @@ stdenv.mkDerivation ({
     # If we are making a cross compiler, cross != null
     NIX_CC_CROSS = optionalString (targetPlatform == hostPlatform) builtins.toString stdenv.cc;
     dontStrip = true;
-    configureFlags = ''
-      ${if enableMultilib then "" else "--disable-multilib"}
-      ${if enableShared then "" else "--disable-shared"}
-      ${if langJava then "--with-ecj-jar=${javaEcj.crossDrv}" else ""}
-      ${if javaAwtGtk then "--enable-java-awt=gtk" else ""}
-      ${if langJava && javaAntlr != null then "--with-antlr-jar=${javaAntlr.crossDrv}" else ""}
-      --with-gmp=${gmp.crossDrv}
-      --with-mpfr=${mpfr.crossDrv}
-      --with-mpc=${libmpc.crossDrv}
-      --disable-libstdcxx-pch
-      --without-included-gettext
-      --with-system-zlib
-      --enable-languages=${
-        concatStrings (intersperse ","
-          (  optional langC        "c"
-          ++ optional langCC       "c++"
-          ++ optional langFortran  "fortran"
-          ++ optional langJava     "java"
-          ++ optional langAda      "ada"
-          ++ optional langVhdl     "vhdl"
-          ++ optional langGo       "go"
+    configureFlags =
+      optional (!enableMultilib) "--disable-multilib" ++
+      optional (!enableShared) "--disable-shared" ++
+      optional langJava "--with-ecj-jar=${javaEcj.crossDrv}" ++
+      optional javaAwtGtk "--enable-java-awt=gtk" ++
+      optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr.crossDrv}" ++
+      [
+        "--with-gmp=${gmp.crossDrv}"
+        "--with-mpfr=${mpfr.crossDrv}"
+        "--with-mpc=${libmpc.crossDrv}"
+        "--disable-libstdcxx-pch"
+        "--without-included-gettext"
+        "--with-system-zlib"
+        "--enable-languages=${
+          concatStrings (intersperse ","
+            (  optional langC        "c"
+            ++ optional langCC       "c++"
+            ++ optional langFortran  "fortran"
+            ++ optional langJava     "java"
+            ++ optional langAda      "ada"
+            ++ optional langVhdl     "vhdl"
+            ++ optional langGo       "go"
+            )
           )
-        )
-      }
-      ${if langAda then " --enable-libada" else ""}
-      ${xwithArch}
-      ${xwithCpu}
-      ${xwithAbi}
-      ${xwithFpu}
-      ${xwithFloat}
-    '';
+        }"
+      ] ++
+      optional langAda "--enable-libada" ++
+      optional (xgccArch != null) "--with-arch=${xgccArch}" ++
+      optional (xgccCpu != null) "--with-cpu=${xgccCpu}" ++
+      optional (xgccAbi != null) "--with-abi=${xgccAbi}" ++
+      optional (xgccFpu != null) "--with-fpu=${xgccFpu}" ++
+      optional (xgccFloat != null) "--with-float=${xgccFloat}"
+    ;
     buildFlags = "";
   };
 

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -117,67 +117,65 @@ let version = "7-20170409";
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
     crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
     crossConfigureFlags =
-        mkPlatformFlags targetPlatform ++
+      mkPlatformFlags targetPlatform ++
 
-        # Ensure that -print-prog-name is able to find the correct programs.
-        [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
-          "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-        (if crossMingw && crossStageStatic then
-          [ "--with-headers=${libcCross}/include"
-            "--with-gcc"
-            "--with-gnu-as"
-            "--with-gnu-ld"
-            "--with-gnu-ld"
-            "--disable-shared"
-            "--disable-nls"
-            "--disable-debug"
-            "--enable-sjlj-exceptions"
-            "--enable-threads=win32"
-            "--disable-win32-registry"
-          ] else if crossStageStatic then
-          [ "--disable-libssp"
-            "--disable-nls"
-            "--without-headers"
-            "--disable-threads "
-            "--disable-libgomp "
-            "--disable-libquadmath"
-            "--disable-shared"
-            "--disable-libatomic "  # libatomic requires libc
-            "--disable-decimal-float" # libdecnumber requires libc
-          ] else
-            (if crossDarwin then ["--with-sysroot=${getLib libcCross}/share/sysroot"]
-             else                ["--with-headers=${getDev libcCross}/include"]) ++
-          [ "--enable-__cxa_atexit"
-            "--enable-long-long"
-          ] ++
-
-          (if crossMingw then [
-            "--enable-threads=win32"
-            "--enable-sjlj-exceptions"
-            "--enable-hash-synchronization"
-            "--disable-libssp"
-            "--disable-nls"
-            "--with-dwarf2"
-            # I think noone uses shared gcc libs in mingw, so we better do the same.
-            # In any case, mingw32 g++ linking is broken by default with shared libs,
-            # unless adding "-lsupc++" to any linking command. I don't know why.
-            "--disable-shared"
-            # To keep ABI compatibility with upstream mingw-w64
-            "--enable-fully-dynamic-string"
-          ] else
-            optionals (targetPlatform.libc == "uclibc") [
-              # libsanitizer requires netrom/netrom.h which is not
-              # available in uclibc.
-              "--disable-libsanitizer"
-              # In uclibc cases, libgomp needs an additional '-ldl'
-              # and as I don't know how to pass it, I disable libgomp.
-              "--disable-libgomp"
-            ] ++
-            [ "--enable-threads=posix"
-              "--enable-nls"
-              "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-            ])
-          );
+      # Ensure that -print-prog-name is able to find the correct programs.
+      [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
+        "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
+      (if crossMingw && crossStageStatic then [
+        "--with-headers=${libcCross}/include"
+        "--with-gcc"
+        "--with-gnu-as"
+        "--with-gnu-ld"
+        "--with-gnu-ld"
+        "--disable-shared"
+        "--disable-nls"
+        "--disable-debug"
+        "--enable-sjlj-exceptions"
+        "--enable-threads=win32"
+        "--disable-win32-registry"
+      ] else if crossStageStatic then [
+        "--disable-libssp"
+        "--disable-nls"
+        "--without-headers"
+        "--disable-threads"
+        "--disable-libgomp"
+        "--disable-libquadmath"
+        "--disable-shared"
+        "--disable-libatomic"  # libatomic requires libc
+        "--disable-decimal-float" # libdecnumber requires libc
+      ] else [
+        (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
+         else                "--with-headers=${getDev libcCross}/include")
+        "--enable-__cxa_atexit"
+        "--enable-long-long"
+      ] ++
+        (if crossMingw then [
+          "--enable-threads=win32"
+          "--enable-sjlj-exceptions"
+          "--enable-hash-synchronization"
+          "--disable-libssp"
+          "--disable-nls"
+          "--with-dwarf2"
+          # I think noone uses shared gcc libs in mingw, so we better do the same.
+          # In any case, mingw32 g++ linking is broken by default with shared libs,
+          # unless adding "-lsupc++" to any linking command. I don't know why.
+          "--disable-shared"
+          # To keep ABI compatibility with upstream mingw-w64
+          "--enable-fully-dynamic-string"
+        ] else
+          optionals (targetPlatform.libc == "uclibc") [
+            # libsanitizer requires netrom/netrom.h which is not
+            # available in uclibc.
+            "--disable-libsanitizer"
+            # In uclibc cases, libgomp needs an additional '-ldl'
+            # and as I don't know how to pass it, I disable libgomp.
+            "--disable-libgomp"
+          ] ++ [
+          "--enable-threads=posix"
+          "--enable-nls"
+          "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+        ]));
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
@@ -352,11 +350,12 @@ stdenv.mkDerivation ({
 
     # Java options
     optionals langJava [
-      "--with-ecj-jar=${javaEcj} "
+      "--with-ecj-jar=${javaEcj}"
 
       # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
       # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
-      "--enable-java-home --with-java-home=\${prefix}/lib/jvm/jre "
+      "--enable-java-home"
+      "--with-java-home=\${prefix}/lib/jvm/jre"
     ] ++
     optional javaAwtGtk "--enable-java-awt=gtk" ++
     optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}" ++
@@ -379,9 +378,9 @@ stdenv.mkDerivation ({
     # Platform-specific flags
     optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++
     optionals hostPlatform.isSunOS [
-      "--enable-long-long --enable-libssp --enable-threads=posix --disable-nls --enable-__cxa_atexit"
+      "--enable-long-long" "--enable-libssp" "--enable-threads=posix" "--disable-nls" "--enable-__cxa_atexit"
       # On Illumos/Solaris GNU as is preferred
-      "--with-gnu-as --without-gnu-ld"
+      "--with-gnu-as" "--without-gnu-ld"
     ]
   ;
 


### PR DESCRIPTION
Previously configureFlags was defined as one giant interpolated string. Here we
refactor this definition to instead use the usual stdenv string
combinators. This seems more in-line with the average nixpkgs expression
and it seems a bit more natural to things of these as lists of flags
rather than monolithic strings.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

