### PR TITLE
python: fastimport 0.9.4 -> 0.9.6

### DIFF
--- a/pkgs/development/python-modules/fastimport/default.nix
+++ b/pkgs/development/python-modules/fastimport/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, python, fetchurl }:
+
+buildPythonPackage rec {
+  name = "fastimport-${version}";
+  version = "0.9.6";
+
+  src = fetchurl {
+    url = "mirror://pypi/f/fastimport/${name}.tar.gz";
+    sha256 = "1aqjsin4rmqm7ln4j0p73fzxifws6c6ikgyhav7r137m2ixsxl43";
+  };
+
+  checkPhase = ''
+    ${python.interpreter} -m unittest discover
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://launchpad.net/python-fastimport;
+    description = "VCS fastimport/fastexport parser";
+    maintainers = with maintainers; [ koral ];
+    license = licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8645,30 +8645,8 @@ in {
     };
   };
 
-  fastimport = buildPythonPackage rec {
-    name = "fastimport-${version}";
-    version = "0.9.4";
-
-    # Judging from SyntaxError
-    disabled = isPy3k;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/f/fastimport/${name}.tar.gz";
-      sha256 = "0k8x7552ypx9rc14vbsvg2lc6z0r8pv9laah28pdwyynbq10825d";
-    };
-
-    checkPhase = ''
-      ${python.interpreter} -m unittest discover
-    '';
-
-    meta = {
-      homepage = https://launchpad.net/python-fastimport;
-      description = "VCS fastimport/fastexport parser";
-      maintainers = with maintainers; [ koral ];
-      license = licenses.gpl2Plus;
-    };
-  };
-
+  fastimport = callPackage ../development/python-modules/fastimport { };
+ 
   feedgen = callPackage ../development/python-modules/feedgen { };
 
   feedgenerator = callPackage ../development/python-modules/feedgenerator {


### PR DESCRIPTION
###### Motivation for this change
Update fastimport to v0.9.6. This version supports Python 3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I haven't been able to check this with nox-review as it needs a large rebuild. I've tried, but keep finding packages that don't build with or without the change.

I have read through [every line of code that's been edited](https://github.com/jelmer/python-fastimport/compare/fastimport-0.9.4...fastimport-0.9.6). One bug is fixed, a handful of lines are refactored without any change in meaning, and there are many changes for Python 3 compatibility - but no change in effect/in the API, and without breaking Python 2 compatibility. This upgrade seems fully backwards compatible.

---