### PR TITLE
Remove .net from mirror URL.

### DIFF
--- a/pkgs/tools/X11/xosview2/default.nix
+++ b/pkgs/tools/X11/xosview2/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2.2.2";
 
   src = fetchurl {
-    url = "mirror://sourceforge.net/xosview/${name}.tar.gz";
+    url = "mirror://sourceforge/xosview/${name}.tar.gz";
     sha256 = "3502e119a5305ff2396f559340132910807351c7d4e375f13b5c338404990406";
   };
 


### PR DESCRIPTION
###### Motivation for this change
Fix an uncorrected issue with the last PR.

@peterhoeg Do you see any issues other than the removed .net from the mirror? I had trouble building it locally, but I'm also on macOS and have somehow broken pretty much all of my nix packages. I will be reaching out to people on ##nix-darwin for help with that.