### PR TITLE
emacsPackages.font-lock-plus: init at 20170222.1755

### DIFF
--- a/pkgs/applications/editors/emacs-modes/font-lock-plus/default.nix
+++ b/pkgs/applications/editors/emacs-modes/font-lock-plus/default.nix
@@ -1,0 +1,23 @@
+{ fetchurl, stdenv, melpaBuild }:
+
+melpaBuild {
+  pname = "font-lock-plus";
+  version = "20170222.1755";
+
+  src = fetchurl {
+    url = "https://www.emacswiki.org/emacs/download/font-lock+.el";
+    sha256 = "0iajkgh0n3pbrwwxx9rmrrwz8dw2m7jsp4mggnhq7zsb20ighs30";
+    name = "font-lock+.el";
+  };
+
+  recipeFile = fetchurl {
+    url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/font-lock+";
+    sha256 = "1wn99cb53ykds87lg9mrlfpalrmjj177nwskrnp9wglyqs65lk4g";
+    name = "font-lock-plus";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://melpa.org/#/font-lock+";
+    license = lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -226,6 +226,8 @@ let
     };
   };
 
+  font-lock-plus = callPackage ../applications/editors/emacs-modes/font-lock-plus { };
+
   ghc-mod = melpaBuild rec {
     pname = "ghc";
     version = external.ghc-mod.version;


### PR DESCRIPTION
###### Motivation for this change
A while ago a lot of packages disappeared from `melpa-generated.nix` because they are hosted on emacswiki.
`font-lock-plus` was one of them, which broke `all-the-icons` and hence a whole bunch of themes.

This reinstates that package and fixes a bunch of emacs themes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

