### PR TITLE
flexget: fix build with updated dependencies

### DIFF
--- a/pkgs/applications/networking/flexget/default.nix
+++ b/pkgs/applications/networking/flexget/default.nix
@@ -24,9 +24,6 @@ buildPythonApplication rec {
   # unicode-capable filesystem (and setting LC_ALL doesn't work).
   # setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
   postPatch = ''
-    sed -i '/def test_non_ascii/i\    import pytest\
-        @pytest.mark.skip' flexget/tests/test_filesystem.py
-
     substituteInPlace requirements.txt \
       --replace "chardet==3.0.3" "chardet" \
       --replace "rebulk==0.8.2" "rebulk" \
@@ -35,7 +32,13 @@ buildPythonApplication rec {
       --replace "sqlalchemy==1.1.10" "sqlalchemy" \
       --replace "zxcvbn-python==4.4.15" "zxcvbn-python" \
       --replace "flask-cors==3.0.2" "flask-cors" \
-      --replace "certifi==2017.4.17" "certifi"
+      --replace "certifi==2017.4.17" "certifi" \
+      --replace "apscheduler==3.3.1" "apscheduler" \
+      --replace "path.py==10.3.1" "path.py" \
+      --replace "tempora==1.8" "tempora" \
+      --replace "cheroot==5.5.0" "cheroot" \
+      --replace "six==1.10.0" "six" \
+      --replace "aniso8601==1.2.1" "aniso8601"
   '';
 
   checkPhase = ''
@@ -47,7 +50,8 @@ buildPythonApplication rec {
                                           and not test_double_episodes \
                                           and not test_inject_force \
                                           and not test_double_prefered \
-                                          and not test_double"
+                                          and not test_double \
+                                          and not test_non_ascii"
   '';
 
   buildInputs = [ pytest mock vcrpy pytest-catchlog boto3 ];


### PR DESCRIPTION
###### Motivation for this change

Recent updates to several dependencies broke the build ([Hydra](https://hydra.nixos.org/build/62988291)); unpin those dependencies to work with the updated versions.

Fixes #31269.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

