### PR TITLE
docs and glibc: explicit comments on glibc executables not being in the first output

### DIFF
--- a/doc/multiple-output.xml
+++ b/doc/multiple-output.xml
@@ -36,9 +36,15 @@
   <para>Here you find how to write a derivation that produces multiple outputs.</para>
   <para>In nixpkgs there is a framework supporting multiple-output derivations. It tries to cover most cases by default behavior.  You can find the source separated in &lt;<filename>nixpkgs/pkgs/build-support/setup-hooks/multiple-outputs.sh</filename>&gt;; it's relatively well-readable.  The whole machinery is triggered by defining the <varname>outputs</varname> attribute to contain the list of desired output names (strings).</para>
   <programlisting>outputs = [ "bin" "dev" "out" "doc" ];</programlisting>
-  <para>Often such a single line is enough.  For each output an equally named environment variable is passed to the builder and contains the path in nix store for that output.  By convention, the first output should contain the executable programs provided by the package as that output is used by Nix in string conversions, allowing references to binaries like <literal>${pkgs.perl}/bin/perl</literal> to always work. Typically you also want to have the main <varname>out</varname> output, as it catches any files that didn't get elsewhere.</para>
-
+  <para>Often such a single line is enough.  For each output an equally named environment variable is passed to the builder and contains the path in nix store for that output. Typically you also want to have the main <varname>out</varname> output, as it catches any files that didn't get elsewhere.</para>
   <note><para>There is a special handling of the <varname>debug</varname> output, described at <xref linkend="stdenv-separateDebugInfo" />.</para></note>
+
+  <section xml:id="multiple-output-file-binaries-first-convention">
+    <title><quote>Binaries first</quote></title>
+    <para>A commonly adopted convention in <literal>nixpkgs</literal> is that executables provided by the package are contained within its first output. This convention allows the dependent packages to reference the executables provided by packages in a uniform manner. For instance, provided with the knowledge that the <literal>perl</literal> package contains a <literal>perl</literal> executable it can be referenced as <literal>${pkgs.perl}/bin/perl</literal> within a Nix derivation that needs to execute a Perl script.</para>
+    <para>The <literal>glibc</literal> package is a deliberate single exception to the <quote>binaries first</quote> convention. The <literal>glibc</literal> has <literal>libs</literal> as its first output allowing the libraries provided by <literal>glibc</literal> to be referenced directly (e.g. <literal>${stdenv.glibc}/lib/ld-linux-x86-64.so.2</literal>). The executables provided by <literal>glibc</literal> can be accessed via its <literal>bin</literal> attribute (e.g. <literal>${stdenv.glibc.bin}/bin/ldd</literal>).</para>
+    <para>The reason for why <literal>glibc</literal> deviates from the convention is because referencing a library provided by <literal>glibc</literal> is a very common operation among Nix packages. For instance, third-party executables packaged by Nix are typically patched and relinked with the relevant version of <literal>glibc</literal> libraries from Nix packages (please see the documentation on <link xlink:href="https://nixos.org/patchelf.html">patchelf</link> for more details).</para>
+  </section>
 
   <section xml:id="multiple-output-file-type-groups">
     <title>File type groups</title>

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -1,5 +1,21 @@
 /* Build configuration used to build glibc, Info files, and locale
-   information.  */
+   information.
+
+   Note that this derivation has multiple outputs and does not respect the
+   standard convention of putting the executables into the first output. The
+   first output is `lib` so that the libraries provided by this derivation
+   can be accessed directly, e.g.
+
+     "${pkgs.glibc}/lib/ld-linux-x86_64.so.2"
+
+   The executables are put into `bin` output and need to be referenced via
+   the `bin` attribute of the main package, e.g.
+
+     "${pkgs.glibc.bin}/bin/ldd".
+
+  The executables provided by glibc typically include `ldd`, `locale`, `iconv`
+  but the exact set depends on the library version and the configuration.
+*/
 
 { stdenv, lib
 , buildPlatform, hostPlatform


### PR DESCRIPTION
###### Motivation for this change
The chapter on multiple outputs mentions the commonly adopted convention to put the binaries in the package's first output. The `glibc` package contradticts this convention and I have spent quite some time figuring out why I cannot find `ldd` in `glibc` as prescribed. 

This commit adds the brief description of this deliberate exception in `glibc` package and why it exists (#30984) to the nixpkgs guide 

###### Things done
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions

---

