### PR TITLE
i3lock-color: limit to i686 and x86-64 platforms

### DIFF
--- a/pkgs/applications/window-managers/i3/lock-color.nix
+++ b/pkgs/applications/window-managers/i3/lock-color.nix
@@ -28,6 +28,9 @@ stdenv.mkDerivation rec {
     homepage = https://i3wm.org/i3lock/;
     maintainers = with maintainers; [ garbas malyn ];
     license = licenses.bsd3;
-    platforms = platforms.all;
+
+    # Needs the SSE2 instruction set. See upstream issue
+    # https://github.com/chrjguill/i3lock-color/issues/44
+    platforms = platforms.i686 ++ platforms.x86_64;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Compilation [fails](https://nix-cache.s3.amazonaws.com/log/r1vw8scwh5v5gg7sg9zjwfgb31f1s434-i3lock-color-2.9.1-c.drv) for other CPU architectures due to requiring the
SSE2 instruction set. See https://github.com/chrjguill/i3lock-color/issues/44 for upstream issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

