### PR TITLE
openra: Add python to bin PATH, fixing launcher

### DIFF
--- a/pkgs/games/openra/default.nix
+++ b/pkgs/games/openra/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, mono, makeWrapper, lua
 , SDL2, freetype, openal, systemd, pkgconfig,
-  dotnetPackages, gnome3, curl, unzip, which
+  dotnetPackages, gnome3, curl, unzip, which, python
 }:
 
 stdenv.mkDerivation rec {
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
 
   postInstall = with stdenv.lib; let
     runtime = makeLibraryPath [ SDL2 freetype openal systemd lua ];
-    binaries= makeBinPath [ which mono gnome3.zenity ];
+    binaries= makeBinPath [ which mono gnome3.zenity python ];
   in ''
     wrapProgram $out/lib/openra/launch-game.sh \
       --prefix PATH : "${binaries}" \


### PR DESCRIPTION
###### Motivation for this change
Fixes #31282

###### Things done
nix-env -iA nixpkgs.openra && openra
Load screen actually opens.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

