### PR TITLE
nixos/gdm,nvidia: fix assertion for gdm not using wayland on nvidia

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -42,7 +42,7 @@ in
   config = mkIf enabled {
     assertions = [
       {
-        assertion = config.services.xserver.displayManager.gdm.wayland;
+        assertion = !config.services.xserver.displayManager.gdm.wayland;
         message = "NVidia drivers don't support wayland";
       }
     ];

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -55,6 +55,8 @@ in
         Option "RandRRotation" "on"
       '';
 
+    services.xserver.displayManager.gdm.wayland = mkDefault false;
+
     environment.etc."nvidia/nvidia-application-profiles-rc" = mkIf nvidia_x11.useProfiles {
       source = "${nvidia_x11.bin}/share/nvidia/nvidia-application-profiles-rc";
     };


### PR DESCRIPTION
###### Motivation for this change
The assertion checking that wayland is disabled in GDM when using NVIDIA drivers works in the opposite way. When I set `services.xserver.displayManager.gdm.wayland = false`, the build fails on
```
Failed assertions:
- NVidia drivers don't support wayland
```
Fixing the assertion will make `nixos-rebuild` fail after upgrade so I have disabled wayland in GDM on NVIDIA by default. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

