### PR TITLE
signal-desktop: init at 1.0.35

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,0 +1,95 @@
+{ stdenv, lib, fetchurl, dpkg, electron, gnome2, atk, cairo, gdk_pixbuf
+, glib, zulu, zulu8, freetype, fontconfig, fontconfig_210, dbus_daemon
+, xlibs, gnome3, glib-tested, nss, nspr, alsaLib, cups, expat, nodejs
+, libudev
+}:
+let
+  rpath = lib.makeLibraryPath [
+    alsaLib
+    atk
+    cairo
+    cups.lib
+    dbus_daemon.lib
+    electron
+    expat
+    fontconfig
+    fontconfig_210
+    freetype
+    gdk_pixbuf
+    glib
+    glib-tested
+    gnome2.GConf
+    gnome2.gtk
+    gnome2.pango
+    gnome3.gconf
+    libudev
+    nodejs
+    nspr
+    nss
+    stdenv.cc.cc
+    xlibs.libX11
+    xlibs.libX11
+    xlibs.libXScrnSaver
+    xlibs.libXcomposite
+    xlibs.libXcursor
+    xlibs.libXdamage
+    xlibs.libXext
+    xlibs.libXfixes
+    xlibs.libXi
+    xlibs.libXrandr
+    xlibs.libXrender
+    xlibs.libXtst
+    xlibs.libxcb
+    zulu
+    zulu8
+  ] + ":${stdenv.cc.cc.lib}/lib64";
+
+in
+  stdenv.mkDerivation rec {
+    name = "signal-desktop-${version}";
+
+    version = "1.0.35";
+
+    src =
+      if stdenv.system == "x86_64-linux" then
+        fetchurl {
+          url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
+          sha256 = "d9f9d4d54f4121efc8eadf1cf0ff957828088b313e53b66dc540b851c44c1860";
+        }
+      else
+        throw "Signal for Desktop is not currently supported on ${stdenv.system}";
+
+    nativeBuildInputs = [ dpkg ];
+    unpackPhase = "true";
+    buildCommand = ''
+      mkdir -p $out
+      dpkg -x $src $out
+
+      mv $out/usr/share $out/share
+      mv $out/opt/Signal $out/libexec
+      rmdir $out/usr $out/opt
+
+      chmod -R g-w $out
+
+      # Patch signal
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/libexec/signal-desktop
+      patchelf --set-rpath ${rpath}:$out/libexec $out/libexec/signal-desktop
+
+      # Symlink to bin
+      mkdir -p $out/bin
+      ln -s $out/libexec/signal-desktop $out/bin/signal-desktop
+
+      # Fix the desktop link
+      substituteInPlace $out/share/applications/signal-desktop.desktop \
+        --replace /opt/Signal/signal-desktop $out/bin/signal-desktop
+    '';
+
+    meta = {
+      description = "Signal messenger for the desktop.";
+      homepage = https://signal.org/;
+      license = lib.licenses.gpl3;
+      platforms = [
+        "x86_64-linux"
+      ];
+    };
+  }

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,48 +1,40 @@
-{ stdenv, lib, fetchurl, dpkg, electron, gnome2, atk, cairo, gdk_pixbuf
-, glib, zulu, zulu8, freetype, fontconfig, fontconfig_210, dbus_daemon
-, xlibs, gnome3, glib-tested, nss, nspr, alsaLib, cups, expat, nodejs
-, libudev
+{ stdenv, lib, fetchurl, dpkg, gnome2, atk, cairo, gdk_pixbuf, glib, freetype,
+fontconfig, dbus, libX11, xlibs, libXi, libXcursor, libXdamage, libXrandr,
+libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss,
+nspr, alsaLib, cups, expat, udev
 }:
 let
   rpath = lib.makeLibraryPath [
     alsaLib
     atk
     cairo
-    cups.lib
-    dbus_daemon.lib
-    electron
+    cups
+    dbus
     expat
     fontconfig
-    fontconfig_210
     freetype
     gdk_pixbuf
     glib
-    glib-tested
     gnome2.GConf
     gnome2.gtk
     gnome2.pango
-    gnome3.gconf
-    libudev
-    nodejs
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
     nspr
     nss
     stdenv.cc.cc
-    xlibs.libX11
-    xlibs.libX11
-    xlibs.libXScrnSaver
-    xlibs.libXcomposite
-    xlibs.libXcursor
-    xlibs.libXdamage
-    xlibs.libXext
-    xlibs.libXfixes
-    xlibs.libXi
-    xlibs.libXrandr
-    xlibs.libXrender
-    xlibs.libXtst
+    udev
     xlibs.libxcb
-    zulu
-    zulu8
-  ] + ":${stdenv.cc.cc.lib}/lib64";
+  ];
 
 in
   stdenv.mkDerivation rec {
@@ -59,21 +51,22 @@ in
       else
         throw "Signal for Desktop is not currently supported on ${stdenv.system}";
 
+    phases = [ "unpackPhase" "installPhase" ];
     nativeBuildInputs = [ dpkg ];
-    unpackPhase = "true";
-    buildCommand = ''
+    unpackPhase = "dpkg-deb -x $src .";
+    installPhase = ''
       mkdir -p $out
-      dpkg -x $src $out
+      cp -R opt $out
 
-      mv $out/usr/share $out/share
+      mv ./usr/share $out/share
       mv $out/opt/Signal $out/libexec
-      rmdir $out/usr $out/opt
+      rmdir $out/opt
 
       chmod -R g-w $out
 
       # Patch signal
-      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/libexec/signal-desktop
-      patchelf --set-rpath ${rpath}:$out/libexec $out/libexec/signal-desktop
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+               --set-rpath ${rpath}:$out/libexec $out/libexec/signal-desktop
 
       # Symlink to bin
       mkdir -p $out/bin
@@ -85,7 +78,7 @@ in
     '';
 
     meta = {
-      description = "Signal messenger for the desktop.";
+      description = "Signal Private Messenger for the Desktop.";
       homepage = https://signal.org/;
       license = lib.licenses.gpl3;
       platforms = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4379,6 +4379,8 @@ with pkgs;
 
   sigil = libsForQt56.callPackage ../applications/editors/sigil { };
 
+  signal-desktop = callPackage ../applications/networking/instant-messengers/signal-desktop { };
+
   # aka., pgp-tools
   signing-party = callPackage ../tools/security/signing-party { };
 


### PR DESCRIPTION
###### Motivation for this change
The Signal Desktop application was recently released and the community has no derivation for it.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

