### PR TITLE
signal-desktop: init at 1.0.35

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl, dpkg, gnome2, atk, cairo, gdk_pixbuf, glib, freetype,
+fontconfig, dbus, libX11, xlibs, libXi, libXcursor, libXdamage, libXrandr,
+libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss,
+nspr, alsaLib, cups, expat, udev }:
+
+stdenv.mkDerivation rec {
+  pname = "signal-desktop";
+  version = "1.0.35";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
+    sha256 = "0q0q9k253f20qmnvclry665hha3qjpzz076zxb4fy8a19zax9yfr";
+  };
+
+  phases = [ "unpackPhase" "installPhase" ];
+  buildInputs = [ dpkg ];
+  unpackPhase = "dpkg-deb -x $src .";
+
+  libPath = stdenv.lib.makeLibraryPath [
+    gnome2.gtk gnome2.pango atk cairo gdk_pixbuf glib freetype fontconfig dbus
+    libX11 xlibs.libxcb libXi libXcursor libXdamage libXrandr libXcomposite
+    libXext libXfixes libXrender libXtst libXScrnSaver gnome2.GConf nss nspr
+    alsaLib cups expat stdenv.cc.cc udev
+  ];
+
+  installPhase = ''
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+             --set-rpath "$out/opt/Signal:$libPath" opt/Signal/signal-desktop
+    mkdir -p $out/bin
+    cp -r opt $out
+    ln -s $out/opt/Signal/signal-desktop $out/bin
+    cp -r usr/share $out
+    substituteInPlace $out/share/applications/signal-desktop.desktop \
+      --replace Exec=\"/opt/Signal/signal-desktop\" Exec=signal-desktop
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Signal Private Messenger for the Desktop";
+    homepage = https://signal.org/;
+    downloadPage = "https://github.com/WhisperSystems/Signal-Desktop";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.nickhu ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Signal just released their standalone (electron) app


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---