### PR TITLE
Restore and update RedNotebook

### DIFF
--- a/pkgs/applications/editors/rednotebook/default.nix
+++ b/pkgs/applications/editors/rednotebook/default.nix
@@ -1,22 +1,37 @@
-{ lib, buildPythonPackage, fetchurl, pygtk, pywebkitgtk, pyyaml, chardet }:
+{ lib, buildPythonApplication, fetchFromGitHub
+, gdk_pixbuf, glib, gtk3, pango, webkitgtk
+, pygobject3, pyyaml
+}:
 
-buildPythonPackage rec {
-  name = "rednotebook-1.8.1";
+buildPythonApplication rec {
+  name = "rednotebook-${version}";
+  version = "2.3";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/rednotebook/${name}.tar.gz";
-    sha256 = "00b7s4xpqpxsbzjvjx9qsx5d84m9pvn383c5di1nsfh35pig0rzn";
+  src = fetchFromGitHub {
+    owner = "jendrikseipp";
+    repo = "rednotebook";
+    rev = "v${version}";
+    sha256 = "0zkfid104hcsf20r6829v11wxdghqkd3j1zbgyvd1s7q4nxjn5lj";
   };
 
-  # no tests available
+  # We have not packaged tests.
   doCheck = false;
 
-  propagatedBuildInputs = [ pygtk pywebkitgtk pyyaml chardet ];
+  propagatedBuildInputs = [
+    gdk_pixbuf glib gtk3 pango webkitgtk
+    pygobject3 pyyaml
+  ];
+
+  makeWrapperArgs = [
+    "--set GI_TYPELIB_PATH $GI_TYPELIB_PATH"
+    "--prefix XDG_DATA_DIRS : $out/share"
+    "--suffix XDG_DATA_DIRS : $XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
+  ];
 
   meta = with lib; {
-    homepage = http://rednotebook.sourceforge.net/index.html;
+    homepage = http://rednotebook.sourceforge.net/;
     description = "A modern journal that includes a calendar navigation, customizable templates, export functionality and word clouds";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ tstrobel ];
+    maintainers = with maintainers; [ orivej tstrobel ];
   };
 }

--- a/pkgs/applications/editors/rednotebook/default.nix
+++ b/pkgs/applications/editors/rednotebook/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchurl, pygtk, pywebkitgtk, pyyaml, chardet }:
+
+buildPythonPackage rec {
+  name = "rednotebook-1.8.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/rednotebook/${name}.tar.gz";
+    sha256 = "00b7s4xpqpxsbzjvjx9qsx5d84m9pvn383c5di1nsfh35pig0rzn";
+  };
+
+  # no tests available
+  doCheck = false;
+
+  propagatedBuildInputs = [ pygtk pywebkitgtk pyyaml chardet ];
+
+  meta = with lib; {
+    homepage = http://rednotebook.sourceforge.net/index.html;
+    description = "A modern journal that includes a calendar navigation, customizable templates, export functionality and word clouds";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ tstrobel ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16361,6 +16361,8 @@ with pkgs;
 
   recode = callPackage ../tools/text/recode { };
 
+  rednotebook = python3Packages.callPackage ../applications/editors/rednotebook { };
+
   remotebox = callPackage ../applications/virtualization/remotebox { };
 
   retroshare = libsForQt5.callPackage ../applications/networking/p2p/retroshare { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22735,28 +22735,7 @@ EOF
     };
   };
 
-
-  redNotebook = buildPythonPackage rec {
-    name = "rednotebook-1.8.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://sourceforge/rednotebook/${name}.tar.gz";
-      sha256 = "00b7s4xpqpxsbzjvjx9qsx5d84m9pvn383c5di1nsfh35pig0rzn";
-    };
-
-    # no tests available
-    doCheck = false;
-
-    propagatedBuildInputs = with self; [ pygtk pywebkitgtk pyyaml chardet ];
-
-    meta = {
-      homepage = http://rednotebook.sourceforge.net/index.html;
-      description = "A modern journal that includes a calendar navigation, customizable templates, export functionality and word clouds";
-      license = licenses.gpl2;
-      maintainers = with maintainers; [ tstrobel ];
-    };
-  };
-
+  redNotebook = callPackage ../applications/editors/rednotebook { };
 
   uncertainties = callPackage ../development/python-modules/uncertainties { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22735,6 +22735,29 @@ EOF
     };
   };
 
+
+  redNotebook = buildPythonPackage rec {
+    name = "rednotebook-1.8.1";
+
+    src = pkgs.fetchurl {
+      url = "mirror://sourceforge/rednotebook/${name}.tar.gz";
+      sha256 = "00b7s4xpqpxsbzjvjx9qsx5d84m9pvn383c5di1nsfh35pig0rzn";
+    };
+
+    # no tests available
+    doCheck = false;
+
+    propagatedBuildInputs = with self; [ pygtk pywebkitgtk pyyaml chardet ];
+
+    meta = {
+      homepage = http://rednotebook.sourceforge.net/index.html;
+      description = "A modern journal that includes a calendar navigation, customizable templates, export functionality and word clouds";
+      license = licenses.gpl2;
+      maintainers = with maintainers; [ tstrobel ];
+    };
+  };
+
+
   uncertainties = callPackage ../development/python-modules/uncertainties { };
 
   funcy = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22735,7 +22735,7 @@ EOF
     };
   };
 
-  redNotebook = callPackage ../applications/editors/rednotebook { };
+  redNotebook = pkgs.rednotebook; # Backwards compatibility alias.
 
   uncertainties = callPackage ../development/python-modules/uncertainties { };
 


### PR DESCRIPTION
###### Motivation for this change

This restores RedNotebook that was removed at #30919 and updates it. The new version has no noticeable changes except that it has switched from GTK 2 to GTK 3, uses a newer webkit that is not marked insecure to render its markdown, and crashes in the font selection dialog with the same error as https://github.com/jamiemcg/Remarkable/issues/200 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
