### PR TITLE
ac - init at 0.1.1

### DIFF
--- a/pkgs/tools/system/ac/default.nix
+++ b/pkgs/tools/system/ac/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, fetchgit, ats }:
+
+stdenv.mkDerivation rec {
+  name = "ac-0.1.2";
+  src = fetchgit {
+    url = "https://github.com/vmchale/fastcat";
+    rev = "5031c47631ea5a31d4eb8a584c8226a698453125";
+    sha256 = "d2757a58a29c721f65a9677f803d5f51aa2b099fd0b2ab61f97a3a65dd01fce8";
+  };
+  outputs = [ "out" ];
+  installPhase = ''
+    PATH=$ats/bin:$PATH
+    atscc src/ac.dats -o $out -O3
+  '';
+  inherit ats;
+}

--- a/pkgs/tools/system/ac/default.nix
+++ b/pkgs/tools/system/ac/default.nix
@@ -1,16 +1,25 @@
-{ stdenv, fetchgit, ats }:
+{ stdenv, fetchFromGitHub, ats }:
 
 stdenv.mkDerivation rec {
   name = "ac-0.1.2";
-  src = fetchgit {
-    url = "https://github.com/vmchale/fastcat";
+
+  src = fetchFromGitHub {
+    owner = "vmchale";
+    repo = "fastcat";
     rev = "5031c47631ea5a31d4eb8a584c8226a698453125";
-    sha256 = "d2757a58a29c721f65a9677f803d5f51aa2b099fd0b2ab61f97a3a65dd01fce8";
+    sha256 = "1s7w07fnafksz5hspcnhkw4jpajibwyq0zv7m5jiywlwl9c7lxfj";
   };
-  outputs = [ "out" ];
+
+  buildInputs = [ ats ];
+
   installPhase = ''
-    PATH=$ats/bin:$PATH
-    atscc src/ac.dats -o $out -O3
+    mkdir -p $out/bin
+    atscc src/ac.dats -o $out/bin/ac -O3
   '';
-  inherit ats;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/vmchale/fastcat;
+    license = licenses.bsd3;
+    maintainers = [];
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -370,6 +370,8 @@ with pkgs;
 
   acbuild = callPackage ../applications/misc/acbuild { };
 
+  ac = callPackage ../tools/system/ac { };
+
   acct = callPackage ../tools/system/acct { };
 
   acoustidFingerprinter = callPackage ../tools/audio/acoustid-fingerprinter {


### PR DESCRIPTION
###### Motivation for this change

Add `ac` as a package.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
