### PR TITLE
cmake: add manpage

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, pkgconfig
 , bzip2, curl, expat, libarchive, xz, zlib, libuv, rhash
+, withDoc ? true, sphinx
 # darwin attributes
 , ps
 , isBootstrap ? false
@@ -41,7 +42,7 @@ stdenv.mkDerivation rec {
   patches = [ ./search-path-3.9.patch ]
     ++ optional stdenv.isCygwin ./3.2.2-cygwin.patch;
 
-  outputs = [ "out" ];
+  outputs = [ "out" "man" ];
   setOutputFlags = false;
 
   setupHook = ./setup-hook.sh;
@@ -49,6 +50,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ setupHook pkgconfig ]
     ++ optionals useSharedLibraries [ bzip2 curl expat libarchive xz zlib libuv rhash ]
+    ++ optional withDoc sphinx
     ++ optional useNcurses ncurses
     ++ optional useQt4 qt4
     ++ optional withQt5 qtbase;
@@ -67,6 +69,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [ "--docdir=share/doc/${name}" ]
+    ++ optional withDoc "--sphinx-man"
     ++ (if useSharedLibraries then [ "--no-system-jsoncpp" "--system-libs" ] else [ "--no-system-libs" ]) # FIXME: cleanup
     ++ optional (useQt4 || withQt5) "--qt-gui"
     ++ optionals (!useNcurses) [ "--" "-DBUILD_CursesDialog=OFF" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7046,6 +7046,7 @@ with pkgs;
 
   cmake = libsForQt5.callPackage ../development/tools/build-managers/cmake {
     inherit (darwin) ps;
+    inherit (python3Packages) sphinx;
   };
 
   cmakeCurses = cmake.override { useNcurses = true; };


### PR DESCRIPTION
###### Motivation for this change
Wanted cmake manpage:
https://github.com/NixOS/nixpkgs/issues/30561

I enabled it by default. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

