### PR TITLE
[RFC] ns-3: init at 28.0

### DIFF
--- a/pkgs/development/libraries/science/networking/ns3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns3/default.nix
@@ -1,0 +1,98 @@
+{ stdenv
+, fetchFromGitHub, fetchurl
+, python
+
+# for binding generation
+, castxml ? null
+
+# can take a long time, generates > 30000 images/graphs
+, enableDoxygen ? false
+
+# e.g. "optimized" or "debug". If not set, use default one
+, build_profile ? null
+
+# --enable-examples
+, withExamples ? false
+
+# very long
+, withManual ? false, doxygen ? null, graphviz ? null, imagemagick ? null
+# for manual, tetex is used to get the eps2pdf binary
+# texlive to get latexmk. building manual still fails though
+, dia, tetex ? null, ghostscript ? null, texlive ? null
+
+# generates python bindings
+, generateBindings ? false, ncurses ? null
+
+# All modules can be enabled by choosing 'all_modules'.
+# we include here the DCE mandatory ones
+, modules ? [ "core" "network" "internet" "point-to-point" "fd-net-device" "netanim"]
+, gcc6
+, lib
+}:
+
+let
+  pythonEnv = python.withPackages(ps:
+    stdenv.lib.optional withManual ps.sphinx
+    ++ stdenv.lib.optionals generateBindings (with ps;[ pybindgen pygccxml ])
+  );
+in
+stdenv.mkDerivation rec {
+
+  name = "ns-3.${version}";
+  version = "28";
+
+  # the all in one https://www.nsnam.org/release/ns-allinone-3.27.tar.bz2;
+  # fetches everything (netanim, etc), this package focuses on ns3-core
+  src = fetchFromGitHub {
+    owner  = "nsnam";
+    repo   = "ns-3-dev-git";
+    rev    = name;
+    sha256 = "17kzfjpgw2mvyx1c9bxccnvw67jpk09fxmcnlkqx9xisk10qnhng";
+  };
+
+  # ncurses is a hidden dependency of waf when checking python
+  buildInputs = lib.optionals generateBindings [ castxml ncurses ]
+    ++ stdenv.lib.optional enableDoxygen [ doxygen graphviz imagemagick ]
+    ++ stdenv.lib.optional withManual [ dia tetex ghostscript texlive.combined.scheme-medium ];
+
+  propagatedBuildInputs = [ gcc6 pythonEnv ];
+
+  postPatch = ''
+    patchShebangs ./waf
+    patchShebangs doc/ns3_html_theme/get_version.sh
+  '';
+
+  configureScript = "${python.interpreter} ./waf configure";
+
+  configureFlags = with stdenv.lib; [
+      "--enable-modules=${stdenv.lib.concatStringsSep "," modules}"
+      "--with-python=${pythonEnv.interpreter}"
+  ]
+  ++ optional (build_profile != null) "--build-profile=${build_profile}"
+  ++ optional generateBindings [  ]
+  ++ optional withExamples " --enable-examples "
+  ++ optional doCheck " --enable-tests "
+  ;
+
+  postBuild = with stdenv.lib; let flags = concatStringsSep ";" (
+      optional enableDoxygen "./waf doxygen"
+      ++ optional withManual "./waf sphinx"
+    );
+    in "${flags}"
+  ;
+
+  doCheck = true;
+
+  # we need to specify the proper interpreter else ns3 can check against a
+  # different version even though we
+  checkPhase =  ''
+    ${pythonEnv.interpreter} ./test.py
+  '';
+
+  meta = {
+    homepage = http://www.nsnam.org;
+    license = stdenv.lib.licenses.gpl3;
+    description = "A discrete time event network simulator";
+    platforms = with stdenv.lib.platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20204,6 +20204,8 @@ with pkgs;
 
   megam = callPackage ../applications/science/misc/megam { };
 
+  ns-3 = callPackage ../development/libraries/science/networking/ns3 { };
+
   root = callPackage ../applications/science/misc/root {
     inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
   };


### PR DESCRIPTION
ns-3 is a discrete event C++ network simulator developed at www.nsnam.org popular in the networking research community.

Python bindings might not be functional yet, I could not test them as the required libraries are still in PR https://github.com/NixOS/nixpkgs/pull/30473 but I have yet to meet someone using the bindings.
The manual building doesn't complete yet but it's mostly useful for core developers upon release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

