### PR TITLE
vboot_reference: build all the tools

### DIFF
--- a/pkgs/tools/system/vboot_reference/default.nix
+++ b/pkgs/tools/system/vboot_reference/default.nix
@@ -17,17 +17,17 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildPhase = ''
+  patches = [ ./dont_static_link.patch ];
+
+  preBuild = ''
     patchShebangs scripts
-    make -j''${NIX_BUILD_CORES:-1} \
-         `pwd`/build/cgpt/cgpt \
-         `pwd`/build/futility/futility
   '';
 
-  installPhase = ''
-    mkdir -p $out/bin
-    cp build/cgpt/cgpt $out/bin
-    cp build/futility/futility $out/bin
+  makeFlags = [
+    "DESTDIR=$(out)"
+  ];
+
+  postInstall = ''
     mkdir -p $out/share/vboot
     cp -r tests/devkeys* $out/share/vboot/
   '';

--- a/pkgs/tools/system/vboot_reference/dont_static_link.patch
+++ b/pkgs/tools/system/vboot_reference/dont_static_link.patch
@@ -1,0 +1,30 @@
+---
+--- a/Makefile
++++ b/Makefile
+@@ -964,7 +964,7 @@ ${UTILLIB21}: ${UTILLIB21_OBJS} ${FWLIB2
+ # Link tests for external repos
+ ${BUILD}/host/linktest/extern: ${HOSTLIB}
+ ${BUILD}/host/linktest/extern: LIBS = ${HOSTLIB}
+-${BUILD}/host/linktest/extern: LDLIBS += -static
++#${BUILD}/host/linktest/extern: LDLIBS += -static
+ TEST_OBJS += ${BUILD}/host/linktest/extern.o
+ 
+ .PHONY: hostlib
+@@ -1056,7 +1056,7 @@ ${UTIL_BINS} ${UTIL_BINS_STATIC}: ${UTIL
+ ${UTIL_BINS} ${UTIL_BINS_STATIC}: LIBS = ${UTILLIB}
+ 
+ # Utilities for auto-update toolkits must be statically linked.
+-${UTIL_BINS_STATIC}: LDFLAGS += -static
++${UTIL_BINS_STATIC}:
+ 
+ 
+ .PHONY: utils
+@@ -1089,7 +1089,7 @@ futil: ${FUTIL_STATIC_BIN} ${FUTIL_BIN}
+ 
+ ${FUTIL_STATIC_BIN}: ${FUTIL_STATIC_OBJS} ${UTILLIB}
+ 	@${PRINTF} "    LD            $(subst ${BUILD}/,,$@)\n"
+-	${Q}${LD} -o $@ ${CFLAGS} ${LDFLAGS} -static $^ ${LDLIBS}
++	${Q}${LD} -o $@ ${CFLAGS} ${LDFLAGS} $^ ${LDLIBS}
+ 
+ ${FUTIL_BIN}: LDLIBS += ${CRYPTO_LIBS}
+ ${FUTIL_BIN}: ${FUTIL_OBJS} ${UTILLIB}


### PR DESCRIPTION
###### Motivation for this change

This expands the package to include more things that are useful on chromebooks, like `crossystem`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---