### PR TITLE
nox: add license information: MIT

### DIFF
--- a/pkgs/tools/package-management/nox/default.nix
+++ b/pkgs/tools/package-management/nox/default.nix
@@ -23,6 +23,7 @@ pythonPackages.buildPythonPackage rec {
     homepage = https://github.com/madjar/nox;
     description = "Tools to make nix nicer to use";
     maintainers = [ lib.maintainers.madjar ];
+    license = lib.licenses.mit;
     platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

nox was licensed under MIT License since at least 0.0.2 (see https://github.com/madjar/nox/commit/b7e084a7c507aff4c56afb4d719eefb142393d1a), but this wasn't reflected in the derivation/package meta information.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

