### PR TITLE
coqPackages.{ssreflect,mathcomp}: 1.6.1 -> 1.6.4

### DIFF
--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -2,9 +2,9 @@
 
 let param =
   {
-    version = "1.6.1";
-    url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.1.tar.gz;
-    sha256 = "1j9ylggjzrxz1i2hdl2yhsvmvy5z6l4rprwx7604401080p5sgjw";
+    version = "1.6.4";
+    url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.4.tar.gz;
+    sha256 = "0qmjjb6jsxmmf4gpw10r30rmrvwqgzirvvgyy41mz2vhgwis8wn6";
   }; in
 
 callPackage ./generic.nix {

--- a/pkgs/development/coq-modules/ssreflect/default.nix
+++ b/pkgs/development/coq-modules/ssreflect/default.nix
@@ -2,9 +2,9 @@
 
 let param =
   {
-    version = "1.6.1";
-    url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.1.tar.gz;
-    sha256 = "1j9ylggjzrxz1i2hdl2yhsvmvy5z6l4rprwx7604401080p5sgjw";
+    version = "1.6.4";
+    url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.4.tar.gz;
+    sha256 = "0qmjjb6jsxmmf4gpw10r30rmrvwqgzirvvgyy41mz2vhgwis8wn6";
   }; in
 
 callPackage ./generic.nix {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
