### PR TITLE
fetchgitPrivate: put our custom ssh on PATH

### DIFF
--- a/pkgs/build-support/fetchgit/private.nix
+++ b/pkgs/build-support/fetchgit/private.nix
@@ -1,19 +1,26 @@
-{ fetchgit, writeScript, openssh, stdenv }: args: derivation ((fetchgit args).drvAttrs // {
+{ fetchgit, runCommand, makeWrapper, openssh, stdenv }: args: derivation ((fetchgit args).drvAttrs // {
   SSH_AUTH_SOCK = if (builtins.tryEval <ssh-auth-sock>).success
     then builtins.toString <ssh-auth-sock>
     else null;
-  GIT_SSH = writeScript "fetchgit-ssh" ''
-    #! ${stdenv.shell}
-    exec -a ssh ${openssh}/bin/ssh -F ${let
-      sshConfigFile = if (builtins.tryEval <ssh-config-file>).success
-        then <ssh-config-file>
-        else builtins.trace ''
-          Please set your nix-path such that ssh-config-file points to a file that will allow ssh to access private repositories. The builder will not be able to see any running ssh agent sessions unless ssh-auth-sock is also set in the nix-path.
 
-          Note that the config file and any keys it points to must be readable by the build user, which depending on your nix configuration means making it readable by the build-users-group, the user of the running nix-daemon, or the user calling the nix command which started the build. Similarly, if using an ssh agent ssh-auth-sock must point to a socket the build user can access.
+  GIT_SSH = let
+    config = ''${let
+        sshConfigFile = if (builtins.tryEval <ssh-config-file>).success
+          then <ssh-config-file>
+          else builtins.trace ''
+            Please set your nix-path such that ssh-config-file points to a file that will allow ssh to access private repositories. The builder will not be able to see any running ssh agent sessions unless ssh-auth-sock is also set in the nix-path.
 
-          You may need StrictHostKeyChecking=no in the config file. Since ssh will refuse to use a group-readable private key, if using build-users you will likely want to use something like IdentityFile /some/directory/%u/key and have a directory for each build user accessible to that user.
-        '' "/var/lib/empty/config";
-    in builtins.toString sshConfigFile} "$@"
-  '';
+            Note that the config file and any keys it points to must be readable by the build user, which depending on your nix configuration means making it readable by the build-users-group, the user of the running nix-daemon, or the user calling the nix command which started the build. Similarly, if using an ssh agent ssh-auth-sock must point to a socket the build user can access.
+
+            You may need StrictHostKeyChecking=no in the config file. Since ssh will refuse to use a group-readable private key, if using build-users you will likely want to use something like IdentityFile /some/directory/%u/key and have a directory for each build user accessible to that user.
+          '' "/var/lib/empty/config";
+      in builtins.toString sshConfigFile}'';
+
+    ssh-wrapped = runCommand "fetchgit-ssh" {
+      buildInputs = [ makeWrapper ];
+    } ''
+      mkdir -p $out/bin
+      makeWrapper ${openssh}/bin/ssh $out/bin/ssh --prefix PATH : "$out/bin" --add-flags "-F ${config}" "$@"
+    '';
+  in "${ssh-wrapped}/bin/ssh";
 })


### PR DESCRIPTION
Currently we wrap ssh so it can find the config file passed in by
<ssh-config-file>. If one however uses ProxyCommand ssh, then ssh that
is on PATH is taken (which is also unavailable when using nix-shell
--pure), which is the plain ${openssh}/bin/ssh.

This commit makes sure our wrapped ssh is available on PATH.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

