### PR TITLE
nixos/gitlab: Store secrets in files rather than the store

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -97,6 +97,16 @@
        start org.nixos.nix-daemon</command>.
       </para>
      </listitem>
+     <listitem>
+       <para>
+         Several options for <literal>services.gitlab<literal> have been changed
+         into paths instead of strings and are no longer imported into the
+         store to avoid secrets being made world readable. To start Gitlab,
+         ensure that <literal>services.gitlab.databasePassword</literal> and all
+         options in <literal>services.gitlab.secrets</literal> are set to the
+         paths of the files that contain the relevant secrets.
+       </para>
+     </listitem>
     </itemizedlist>
    </listitem>
    <listitem>

--- a/nixos/tests/gitlab.nix
+++ b/nixos/tests/gitlab.nix
@@ -22,14 +22,14 @@ import ./make-test.nix ({ pkgs, ...} : {
       systemd.services.gitlab.serviceConfig.TimeoutStartSec = "10min";
       services.gitlab = {
         enable = true;
-        databasePassword = "dbPassword";
+        databasePassword = pkgs.writeText "dbPasswordFile" "dbPassword";
         secrets = {
-          secret = "secret";
-          otp = "otpsecret";
-          db = "dbsecret";
+          secret = pkgs.writeText "secretKeyFile" "secret";
+          otp    = pkgs.writeText "otpKeyFile"    "otpsecret";
+          db     = pkgs.writeText "dbKeyFile"     "dbsecret";
 
           # nix-shell -p openssl --run "openssl genrsa 2048"
-          jws = ''
+          jws = pkgs.writeText "jwsKeyFile" ''
             -----BEGIN RSA PRIVATE KEY-----
             MIIEpAIBAAKCAQEA13/qEio76OWUtWO0WIz9lWnsTWOU8Esv4sQHDq9PCEFsLt21
             PAXrlWhLjjWcxGfsrDwnh7YErGHYL62BMSxMdFJolaknlQK/O/V8UETDe45VoHM+


### PR DESCRIPTION
###### Motivation for this change
The current gitlab module stores all secrets in the store, rendering them world readable. This PR converts databasePassword and secrets.* to `types.path` and ensures that preStart substitutes them into place. The NixOS test has also been altered to write dummy secrets to the store (but it still times out in qemu, which I've not been able to fix.)

There are some things I would like to improve:
- Better error on the change. Right now, I'm relying on `types.path` solely, which could conceivably fail.
- The database password is still emitted in the journal upon creation. This should be safe since normal users cannot read it, though
- The substitution feels brittle. I am not a sed wizard.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

