### PR TITLE
gnome3.gnome-settings-daemon: use zone.tab from tzdata

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, pkgconfig, gnome3, intltool, glib, libnotify, lcms2, libXtst
 , libxkbfile, libpulseaudio, libcanberra_gtk3, upower, colord, libgweather, polkit
 , geoclue2, librsvg, xf86_input_wacom, udev, libgudev, libwacom, libxslt, libtool, networkmanager
-, docbook_xsl, docbook_xsl_ns, wrapGAppsHook, ibus, xkeyboard_config }:
+, docbook_xsl, docbook_xsl_ns, wrapGAppsHook, ibus, xkeyboard_config, tzdata }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
       libcanberra_gtk3 upower colord libgweather xkeyboard_config
       polkit geocode_glib geoclue2 librsvg xf86_input_wacom udev libgudev libwacom libxslt
       libtool docbook_xsl docbook_xsl_ns wrapGAppsHook gnome_themes_standard ];
+
+  postPatch = ''
+    substituteInPlace plugins/datetime/tz.h --replace /usr/share/zoneinfo/zone.tab ${tzdata}/share/zoneinfo/zone.tab
+  '';
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change
`gsd-datetime` segfaults when automatic time zone is turned on in date & time settings. This is caused by reading zone db from `/usr/share/zoneinfo/zone.tab` and not checking return value.
I have patched `gsd` to use `zone.tab` from `tzdata`.
https://github.com/NixOS/nixpkgs/issues/30022#issuecomment-340261272

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

