### PR TITLE
lmms: 1.1.90 -> 1.2.0-rc4, Qt5, optional lame, libsoundio, portaudio

### DIFF
--- a/pkgs/applications/audio/lmms/default.nix
+++ b/pkgs/applications/audio/lmms/default.nix
@@ -1,31 +1,47 @@
-{ stdenv, fetchFromGitHub, SDL, alsaLib, cmake, fftwSinglePrec, fluidsynth
-, fltk13, libjack2, libvorbis , libsamplerate, libsndfile, pkgconfig
-, libpulseaudio, qt4, freetype, libgig
-}:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, alsaLib ? null, fftwFloat, fltk13
+, fluidsynth ? null, lame ? null, libgig ? null, libjack2 ? null, libpulseaudio ? null
+, libsamplerate, libsoundio ? null, libsndfile, libvorbis ? null, portaudio ? null
+, qtbase, qttools, SDL ? null }:
 
 stdenv.mkDerivation rec {
   name = "lmms-${version}";
-  version = "1.1.90";
+  version = "1.2.0-rc4";
 
   src = fetchFromGitHub {
     owner = "LMMS";
     repo = "lmms";
     rev = "v${version}";
-    sha256 = "0njiarndwqamqiinr1wbwkzjn87yzr1z5k9cfwk0jdkbalgakkq3";
+    sha256 = "1n3py18zqbvfnkdiz4wc6z60xaajpkd3kn1wxmby5dmc4vccvjj5";
   };
 
+  nativeBuildInputs = [ cmake qttools pkgconfig ];
+
   buildInputs = [
-    SDL alsaLib cmake fftwSinglePrec fltk13 fluidsynth libjack2 libgig
-    libsamplerate libsndfile libvorbis pkgconfig libpulseaudio qt4
+    alsaLib
+    fftwFloat
+    fltk13
+    fluidsynth
+    lame
+    libgig
+    libjack2
+    libpulseaudio
+    libsamplerate
+    libsndfile
+    libsoundio
+    libvorbis
+    portaudio
+    qtbase
+    SDL # TODO: switch to SDL2 in the next version
   ];
 
+  cmakeFlags = [ "-DWANT_QT5=ON" ];
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    description = "Linux MultiMedia Studio";
+    description = "DAW similar to FL Studio (music production software)";
     homepage = https://lmms.io;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = with maintainers; [ goibhniu yegortimoshenko ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15475,8 +15475,10 @@ with pkgs;
 
   llpp = ocaml-ng.ocamlPackages.callPackage ../applications/misc/llpp { };
 
-  lmms = callPackage ../applications/audio/lmms {
-    stdenv = overrideCC stdenv gcc5;
+  lmms = libsForQt5.callPackage ../applications/audio/lmms {
+    lame = null;
+    libsoundio = null;
+    portaudio = null;
   };
 
   loxodo = callPackage ../applications/misc/loxodo { };


### PR DESCRIPTION
###### Motivation for this change

Qt 4 is old. Might also solve #21668.

I've also tried to compile it with Wine for plugin support, but haven't succeeded yet, requires 32-bit glibc.

By the way: `v1.1.90` is also known as `v1.2.0-rc1`: https://github.com/LMMS/lmms/releases/tag/v1.1.90

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

