### PR TITLE
linux.kernel: enable build of stk1160 modules

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -573,6 +573,11 @@ with stdenv.lib;
   ''}
   MEDIA_USB_SUPPORT y
   MEDIA_PCI_SUPPORT y
+  MEDIA_ANALOG_TV_SUPPORT y
+  VIDEO_STK1160_COMMON m
+  ${optionalString (versionOlder version "4.11") ''
+    VIDEO_STK1160_AC97 y
+  ''}
 
   # Our initrd init uses shebang scripts, so can't be modular.
   BINFMT_SCRIPT y


### PR DESCRIPTION
###### Motivation for this change

Right now, for each new kernel or stdenv update i will have to build my own kernel with the stk1160 modules enabled (see http://cgit.euer.krebsco.de/stockholm/tree/makefu/2configs/hw/stk1160.nix ). This PR introduces the stk1160 module into the kernel configuration

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

