### PR TITLE
cvs: fix CVE-2017-12836

### DIFF
--- a/pkgs/applications/version-management/cvs/CVE-2017-12836.patch
+++ b/pkgs/applications/version-management/cvs/CVE-2017-12836.patch
@@ -1,0 +1,29 @@
+--- a/src/rsh-client.c.orig	2005-10-02 17:17:21.000000000 +0200
++++ b/src/rsh-client.c	2017-11-07 16:56:06.957370469 +0100
+@@ -53,7 +53,7 @@
+     char *cvs_server = (root->cvs_server != NULL
+ 			? root->cvs_server : getenv ("CVS_SERVER"));
+     int i = 0;
+-    /* This needs to fit "rsh", "-b", "-l", "USER", "host",
++    /* This needs to fit "rsh", "-b", "-l", "USER", "--", "host",
+        "cmd (w/ args)", and NULL.  We leave some room to grow. */
+     char *rsh_argv[10];
+ 
+@@ -97,6 +97,9 @@
+ 	rsh_argv[i++] = root->username;
+     }
+ 
++    /* Only non-option arguments from here. (CVE-2017-12836) */
++    rsh_argv[i++] = "--";
++
+     rsh_argv[i++] = root->hostname;
+     rsh_argv[i++] = cvs_server;
+     rsh_argv[i++] = "server";
+@@ -171,6 +174,7 @@
+ 	    *p++ = root->username;
+ 	}
+ 
++	*p++ = "--";
+ 	*p++ = root->hostname;
+ 	*p++ = command;
+ 	*p++ = NULL;

--- a/pkgs/applications/version-management/cvs/default.nix
+++ b/pkgs/applications/version-management/cvs/default.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation {
   patches = [
     ./getcwd-chroot.patch
     ./CVE-2012-0804.patch
+    ./CVE-2017-12836.patch
   ];
 
   hardeningDisable = [ "fortify" "format" ];


### PR DESCRIPTION
This patch is based on the work of the patch from Thorsten Glaser (MirBSD) [1]

[1] http://www.mirbsd.org/cvs.cgi/src/gnu/usr.bin/cvs/src/rsh-client.c.diff?r1=1.6;r2=1.7

Please consider backporting to stable.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

