### PR TITLE
Revert "coqPackages.{ssreflect,mathcomp}: 1.6.1 -> 1.6.4"

### DIFF
--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -2,9 +2,9 @@
 
 let param =
   {
-    version = "1.6.4";
-    url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.4.tar.gz;
-    sha256 = "0qmjjb6jsxmmf4gpw10r30rmrvwqgzirvvgyy41mz2vhgwis8wn6";
+    version = "1.6.1";
+    url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.1.tar.gz;
+    sha256 = "1j9ylggjzrxz1i2hdl2yhsvmvy5z6l4rprwx7604401080p5sgjw";
   }; in
 
 callPackage ./generic.nix {

--- a/pkgs/development/coq-modules/ssreflect/default.nix
+++ b/pkgs/development/coq-modules/ssreflect/default.nix
@@ -2,9 +2,9 @@
 
 let param =
   {
-    version = "1.6.4";
-    url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.4.tar.gz;
-    sha256 = "0qmjjb6jsxmmf4gpw10r30rmrvwqgzirvvgyy41mz2vhgwis8wn6";
+    version = "1.6.1";
+    url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.1.tar.gz;
+    sha256 = "1j9ylggjzrxz1i2hdl2yhsvmvy5z6l4rprwx7604401080p5sgjw";
   }; in
 
 callPackage ./generic.nix {


### PR DESCRIPTION
Reverts NixOS/nixpkgs#31354 because older Coqs do not work with the updates