### PR TITLE
pony-stable: 0.0.1 -> 0.1.1

### DIFF
--- a/pkgs/development/compilers/ponyc/pony-stable.nix
+++ b/pkgs/development/compilers/ponyc/pony-stable.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "pony-stable-${version}";
-  version = "0.0.1";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = "pony-stable";
     rev = version;
-    sha256 = "0q05135mnzzdwam7cnmxq34clqhmc83yp2gi63sx20c74rcw3p6v";
+    sha256 = "0v4039iijjv93m89s3dsikcbp1y0hml6g1agj44s6w2g4m8kiiw3";
   };
 
   buildInputs = [ ponyc ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/ponylang/pony-stable/issues/46

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

