### PR TITLE
doas: init at 6.0

### DIFF
--- a/pkgs/tools/security/doas/default.nix
+++ b/pkgs/tools/security/doas/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub, bison, pam }:
+
+stdenv.mkDerivation rec {
+  name = "doas-${version}";
+
+  version = "6.0";
+
+  src = fetchFromGitHub {
+    owner = "Duncaen";
+    repo = "OpenDoas";
+    rev = "v${version}";
+    sha256 = "1j50l3jvbgvg8vmp1nx6vrjxkbj5bvfh3m01bymzfn25lkwwhz1x";
+  };
+
+  # otherwise confuses ./configure
+  dontDisableStatic = true;
+
+  postPatch = ''
+    sed -i '/\(chown\|chmod\)/d' bsd.prog.mk
+  '';
+
+  buildInputs = [ bison pam ];
+
+  meta = with lib; {
+    description = "Executes the given command as another user";
+    homepage = "https://github.com/Duncaen/OpenDoas";
+    license = licenses.isc;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ cstrahan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1753,6 +1753,8 @@ with pkgs;
     inherit (perlPackages) PerlMagick;
   };
 
+  doas = callPackage ../tools/security/doas { };
+
   docbook2x = callPackage ../tools/typesetting/docbook2x {
     inherit (perlPackages) XMLSAX XMLParser XMLNamespaceSupport;
   };


### PR DESCRIPTION

Portable version of the OpenBSD `doas` command.

###### Motivation for this change

I want this package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

