### PR TITLE
libtom{crypt,math}: update to 1.18.0 and 1.0.1 resp.

### DIFF
--- a/pkgs/development/libraries/libtomcrypt/default.nix
+++ b/pkgs/development/libraries/libtomcrypt/default.nix
@@ -1,27 +1,34 @@
-{stdenv, fetchurl, libtool}:
+{ stdenv, fetchurl, libtool }:
 
-stdenv.mkDerivation {
-  name = "libtomcrypt-1.17";
+stdenv.mkDerivation rec {
+  name = "libtomcrypt-${version}";
+  version = "1.18.0";
 
   src = fetchurl {
-    url = "https://github.com/libtom/libtomcrypt/releases/download/1.17/crypt-1.17.tar.bz2";
-    sha256 = "e33b47d77a495091c8703175a25c8228aff043140b2554c08a3c3cd71f79d116";
+    url = "https://github.com/libtom/libtomcrypt/releases/download/v${version}/crypt-${version}.tar.xz";
+    sha256 = "0ymqi0zf5gzn8pq4mnylwgg6pskml2v1p9rsjrqspyja65mgb7fs";
   };
 
-  buildInputs = [libtool];
+  nativeBuildInputs = [ libtool ];
+
+  postPatch = ''
+    substituteInPlace makefile.shared --replace "LT:=glibtool" "LT:=libtool"
+  '';
 
   preBuild = ''
-    makeFlagsArray=(LIBPATH=$out/lib INCPATH=$out/include \
-      DATAPATH=$out/share/doc/libtomcrypt/pdf \
+    makeFlagsArray=(PREFIX=$out \
       INSTALL_GROUP=$(id -g) \
       INSTALL_USER=$(id -u))
   '';
 
   makefile = "makefile.shared";
 
-  meta = {
-    homepage = http://libtom.org/?page=features&newsitems=5&whatfile=crypt;
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://www.libtom.net/LibTomCrypt/;
     description = "A fairly comprehensive, modular and portable cryptographic toolkit";
-    platforms = stdenv.lib.platforms.linux;
+    license = with licenses; [ publicDomain wtfpl ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libtommath/default.nix
+++ b/pkgs/development/libraries/libtommath/default.nix
@@ -1,27 +1,35 @@
-{stdenv, fetchurl, libtool}:
+{ stdenv, fetchurl, libtool }:
 
-stdenv.mkDerivation {
-  name = "libtommath-1.0";
-  
+stdenv.mkDerivation rec {
+  name = "libtommath-${version}";
+  version = "1.0.1";
+
   src = fetchurl {
-    url = https://github.com/libtom/libtommath/releases/download/v1.0/ltm-1.0.tar.xz;
-    sha256 = "0v5mpd8zqjfs2hr900w1mxifz23xylyjdqyx1i1wl7q9xvwpsflr";
+    url = "https://github.com/libtom/libtommath/releases/download/v${version}/ltm-${version}.tar.xz";
+    sha256 = "0sbccdwbkfc680id2fi0x067j23biqcjqilwkk7y9339knrjy0s7";
   };
 
-  buildInputs = [libtool];
+  nativeBuildInputs = [ libtool ];
+
+  postPatch = ''
+    substituteInPlace makefile.shared --replace "LT:=glibtool" "LT:=libtool"
+    substituteInPlace makefile_include.mk --replace "shell arch" "shell uname -m"
+  '';
 
   preBuild = ''
-    makeFlagsArray=(LIBPATH=$out/lib INCPATH=$out/include \
-      DATAPATH=$out/share/doc/libtommath/pdf \
+    makeFlagsArray=(PREFIX=$out \
       INSTALL_GROUP=$(id -g) \
       INSTALL_USER=$(id -u))
   '';
 
   makefile = "makefile.shared";
 
-  meta = {
-    homepage = http://math.libtomcrypt.com/;
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://www.libtom.net/LibTomMath/;
     description = "A library for integer-based number-theoretic applications";
-    platforms = stdenv.lib.platforms.unix;
+    license = with licenses; [ publicDomain wtfpl ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Version bump
And homepage refresh (see #30636)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

