### PR TITLE
netatalk: 3.1.7 -> 3.1.11

### DIFF
--- a/pkgs/tools/filesystems/netatalk/default.nix
+++ b/pkgs/tools/filesystems/netatalk/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, stdenv, pkgconfig, db, libgcrypt, avahi, libiconv, pam, openssl, acl, ed, glibc }:
 
 stdenv.mkDerivation rec{
-  name = "netatalk-3.1.7";
+  name = "netatalk-3.1.11";
 
   src = fetchurl {
     url = "mirror://sourceforge/netatalk/netatalk/${name}.tar.bz2";
-    sha256 = "0wf09fyqzza024qr1s26z5x7rsvh9zb4pv598gw7gm77wjcr6174";
+    sha256 = "3434472ba96d3bbe3b024274438daad83b784ced720f7662a4c1d0a1078799a6";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -46,3 +46,4 @@ stdenv.mkDerivation rec{
     maintainers = with stdenv.lib.maintainers; [ jcumming ];
   };
 }
+

--- a/pkgs/tools/filesystems/netatalk/default.nix
+++ b/pkgs/tools/filesystems/netatalk/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, db, libgcrypt, avahi, libiconv, pam, openssl, acl, ed, glibc }:
+{ fetchurl, stdenv, pkgconfig, db, libgcrypt, avahi, libiconv, pam, openssl, acl, ed, glibc, perl, python2 }:
 
 stdenv.mkDerivation rec{
   name = "netatalk-3.1.11";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec{
     sha256 = "3434472ba96d3bbe3b024274438daad83b784ced720f7662a4c1d0a1078799a6";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig perl python2 ];
   buildInputs = [ db libgcrypt avahi libiconv pam openssl acl ];
 
   patches = ./omitLocalstatedirCreation.patch;

--- a/pkgs/tools/filesystems/netatalk/default.nix
+++ b/pkgs/tools/filesystems/netatalk/default.nix
@@ -1,4 +1,7 @@
-{ fetchurl, stdenv, pkgconfig, db, libgcrypt, avahi, libiconv, pam, openssl, acl, ed, glibc, perl, python2 }:
+{ fetchurl, stdenv, autoreconfHook, pkgconfig, perl, python
+, db, libgcrypt, avahi, libiconv, pam, openssl, acl
+, ed, glibc
+}:
 
 stdenv.mkDerivation rec{
   name = "netatalk-3.1.11";
@@ -8,14 +11,18 @@ stdenv.mkDerivation rec{
     sha256 = "3434472ba96d3bbe3b024274438daad83b784ced720f7662a4c1d0a1078799a6";
   };
 
-  nativeBuildInputs = [ pkgconfig perl python2 ];
-  buildInputs = [ db libgcrypt avahi libiconv pam openssl acl ];
+  patches = [
+    ./no-suid.patch
+    ./omitLocalstatedirCreation.patch
+  ];
 
-  patches = ./omitLocalstatedirCreation.patch;
+  nativeBuildInputs = [ autoreconfHook pkgconfig perl python python.pkgs.wrapPython ];
+
+  buildInputs = [ db libgcrypt avahi libiconv pam openssl acl ];
 
   configureFlags = [
     "--with-bdb=${db}"
-    "--with-openssl=${openssl.dev}"
+    "--with-ssl-dir=${openssl.dev}"
     "--with-lockfile=/run/lock/netatalk"
     "--localstatedir=/var/lib"
   ];
@@ -36,6 +43,11 @@ stdenv.mkDerivation rec{
     EOF
   '';
 
+  postInstall = ''
+    buildPythonPath ${python.pkgs.dbus-python}
+    patchPythonScript $out/bin/afpstats
+  '';
+
   enableParallelBuilding = true;
 
   meta = {
@@ -46,4 +58,3 @@ stdenv.mkDerivation rec{
     maintainers = with stdenv.lib.maintainers; [ jcumming ];
   };
 }
-

--- a/pkgs/tools/filesystems/netatalk/no-suid.patch
+++ b/pkgs/tools/filesystems/netatalk/no-suid.patch
@@ -1,0 +1,11 @@
+diff --git a/bin/afppasswd/Makefile.am b/bin/afppasswd/Makefile.am
+index 578eac1..d17aa22 100644
+--- a/bin/afppasswd/Makefile.am
++++ b/bin/afppasswd/Makefile.am
+@@ -16,5 +16,5 @@ AM_CFLAGS = @SSL_CFLAGS@ -I$(top_srcdir)/sys \
+ 
+ install-exec-hook:
+ if HAVE_OPENSSL
+-	chmod u+s $(DESTDIR)$(bindir)/afppasswd
++#	chmod u+s $(DESTDIR)$(bindir)/afppasswd
+ endif

--- a/pkgs/tools/filesystems/netatalk/omitLocalstatedirCreation.patch
+++ b/pkgs/tools/filesystems/netatalk/omitLocalstatedirCreation.patch
@@ -1,35 +1,19 @@
-diff -ur netatalk-3.1.11-old/config/Makefile.in netatalk-3.1.11-new/config/Makefile.in
---- netatalk-3.1.11-old/config/Makefile.in	2017-11-07 17:16:50.000000000 -0500
-+++ netatalk-3.1.11-new/config/Makefile.in	2017-11-07 17:17:33.000000000 -0500
-@@ -735,7 +735,7 @@
- 
- info-am:
- 
--install-data-am: install-data-local install-dbusserviceDATA
-+install-data-am: install-dbusserviceDATA
- 
- install-dvi: install-dvi-recursive
- 
-@@ -788,7 +788,7 @@
- 	ctags-am distclean distclean-generic distclean-libtool \
- 	distclean-tags distdir dvi dvi-am html html-am info info-am \
- 	install install-am install-data install-data-am \
--	install-data-local install-dbusserviceDATA install-dvi \
-+	install-dbusserviceDATA install-dvi \
- 	install-dvi-am install-exec install-exec-am install-html \
- 	install-html-am install-info install-info-am install-man \
- 	install-pdf install-pdf-am install-ps install-ps-am \
-@@ -817,12 +817,6 @@
- # install configuration files
+diff --git a/config/Makefile.am b/config/Makefile.am
+index c98a2ab..58b7f0a 100644
+--- a/config/Makefile.am
++++ b/config/Makefile.am
+@@ -36,10 +36,10 @@ endif
  #
  
--install-data-local: install-config-files
+ install-data-local: install-config-files
 -	mkdir -pm 0755 $(DESTDIR)$(localstatedir)/netatalk/
 -	mkdir -pm 0755 $(DESTDIR)$(localstatedir)/netatalk/CNID/
 -	$(INSTALL_DATA) $(srcdir)/README $(DESTDIR)$(localstatedir)/netatalk/
 -	$(INSTALL_DATA) $(srcdir)/README $(DESTDIR)$(localstatedir)/netatalk/CNID/
--
++#	mkdir -pm 0755 $(DESTDIR)$(localstatedir)/netatalk/
++#	mkdir -pm 0755 $(DESTDIR)$(localstatedir)/netatalk/CNID/
++#	$(INSTALL_DATA) $(srcdir)/README $(DESTDIR)$(localstatedir)/netatalk/
++#	$(INSTALL_DATA) $(srcdir)/README $(DESTDIR)$(localstatedir)/netatalk/CNID/
+ 
  uninstall-local:
  	@for f in $(CONFFILES) $(GENFILES); do \
- 		echo rm -f $(DESTDIR)$(pkgconfdir)/$$f; \
-

--- a/pkgs/tools/filesystems/netatalk/omitLocalstatedirCreation.patch
+++ b/pkgs/tools/filesystems/netatalk/omitLocalstatedirCreation.patch
@@ -1,7 +1,7 @@
-diff -ur netatalk-3.1.7-old/config/Makefile.in netatalk-3.1.7-new/config/Makefile.in 
---- netatalk-3.1.7-old/config/Makefile.in	2014-08-29 03:33:35.000000000 -0700
-+++ netatalk-3.1.7-new/config/Makefile.in	2015-08-13 20:52:35.000000000 -0700
-@@ -699,7 +699,7 @@
+diff -ur netatalk-3.1.11-old/config/Makefile.in netatalk-3.1.11-new/config/Makefile.in
+--- netatalk-3.1.11-old/config/Makefile.in	2017-11-07 17:16:50.000000000 -0500
++++ netatalk-3.1.11-new/config/Makefile.in	2017-11-07 17:17:33.000000000 -0500
+@@ -735,7 +735,7 @@
  
  info-am:
  
@@ -10,16 +10,16 @@ diff -ur netatalk-3.1.7-old/config/Makefile.in netatalk-3.1.7-new/config/Makefil
  
  install-dvi: install-dvi-recursive
  
-@@ -754,7 +754,7 @@
- 	cscopelist cscopelist-recursive ctags ctags-recursive \
- 	distclean distclean-generic distclean-libtool distclean-tags \
- 	distdir dvi dvi-am html html-am info info-am install \
--	install-am install-data install-data-am install-data-local \
-+	install-am install-data install-data-am \
- 	install-dbusserviceDATA install-dvi install-dvi-am \
- 	install-exec install-exec-am install-html install-html-am \
- 	install-info install-info-am install-man install-pdf \
-@@ -782,12 +782,6 @@
+@@ -788,7 +788,7 @@
+ 	ctags-am distclean distclean-generic distclean-libtool \
+ 	distclean-tags distdir dvi dvi-am html html-am info info-am \
+ 	install install-am install-data install-data-am \
+-	install-data-local install-dbusserviceDATA install-dvi \
++	install-dbusserviceDATA install-dvi \
+ 	install-dvi-am install-exec install-exec-am install-html \
+ 	install-html-am install-info install-info-am install-man \
+ 	install-pdf install-pdf-am install-ps install-ps-am \
+@@ -817,12 +817,6 @@
  # install configuration files
  #
  


### PR DESCRIPTION
###### Motivation for this change

Netatalk 3.1.11 is the latest stable release.  There is also a nasty bug
with netatalk < 3.1.11 (https://sourceforge.net/p/netatalk/bugs/636/)
that prevents using netatalk shares for time machine backups.

I've tested all the executable files in result/bin, and there are script files there that depend on python and perl using /usr/bin/env.  I'm not sure if that's a problem or not, but it is the same situation as before this patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

