### PR TITLE
breeze-plymouth: add optional nixos branding, enable for plasma5

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -195,7 +195,12 @@ in
 
       boot.plymouth = {
         theme = mkDefault "breeze";
-        themePackages = mkDefault [ pkgs.breeze-plymouth ];
+        themePackages = mkDefault [
+          (pkgs.breeze-plymouth.override {
+            nixosBranding = true;
+            nixosVersion = config.system.nixosRelease;
+          })
+        ];
       };
 
       security.pam.services.kde = { allowNullPassword = true; };

--- a/pkgs/desktops/plasma-5/breeze-plymouth/default.nix
+++ b/pkgs/desktops/plasma-5/breeze-plymouth/default.nix
@@ -1,15 +1,44 @@
 {
-  mkDerivation, lib, copyPathsToStore,
+  mkDerivation,
+  lib,
+  copyPathsToStore,
   extra-cmake-modules,
-  plymouth
+  plymouth,
+  nixos-icons,
+  imagemagick,
+  netpbm,
+  perl,
+  # these will typically need to be set via an override
+  # in a NixOS context
+  nixosBranding ? false,
+  nixosName ? "NixOS",
+  nixosVersion ? "",
+  topColor ? "black",
+  bottomColor ? "black"
 }:
 
+let
+  logoName = "nixos";
+in
 mkDerivation {
   name = "breeze-plymouth";
   nativeBuildInputs = [ extra-cmake-modules ];
-  buildInputs = [ plymouth ];
+  buildInputs = [ plymouth ] ++ lib.optionals nixosBranding [ imagemagick netpbm perl ];
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  cmakeFlags = lib.optionals nixosBranding [
+    "-DDISTRO_NAME=${nixosName}"
+    "-DDISTRO_VERSION=${nixosVersion}"
+    "-DDISTRO_LOGO=${logoName}"
+    "-DBACKGROUND_TOP_COLOR=${topColor}"
+    "-DBACKGROUND_BOTTOM_COLOR=${bottomColor}"
+  ];
   postPatch = ''
       substituteInPlace cmake/FindPlymouth.cmake --subst-var out
+  '' + lib.optionalString nixosBranding ''
+      cp ${nixos-icons}/share/icons/hicolor/128x128/apps/nix-snowflake.png breeze/images/${logoName}.logo.png
+
+      # conversion for 16bit taken from the breeze-plymouth readme
+      convert ${nixos-icons}/share/icons/hicolor/128x128/apps/nix-snowflake.png -alpha Background -background "#000000" -fill "#000000" -flatten tmp.png
+      pngtopnm tmp.png | pnmquant 16 | pnmtopng > breeze/images/16bit/${logoName}.logo.png
   '';
 }


### PR DESCRIPTION
###### Motivation for this change
I noticed that the breeze-plymouth theme has some options for customizing it for a distro. I thought it would be nice to do this for nixos.

I then enabled this for the version that's used by plasma5 by default.

Note that we need to set some of the arguments in an override directly in the nixos module, since we want to include the vesion.

The result is now quite a nice splash screen which includes the proper nixos version and logo. There are also some options to set a color gradient in the background, but the selection of colors is quite limited and I wasn't sure any of it looked better than just black, so I left it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

