### PR TITLE
elixir: 1.5.1 -> 1.5.2

### DIFF
--- a/pkgs/development/interpreters/elixir/1.5.nix
+++ b/pkgs/development/interpreters/elixir/1.5.nix
@@ -1,7 +1,9 @@
 { mkDerivation }:
 
+# to generate sha256 use nix-prefetch-git git@github.com:elixir-lang/elixir.git --rev 05418eaa4bf4fa8473900741252d93d76ed3307b
+
 mkDerivation rec {
-  version = "1.5.1";
-  sha256 = "0q0zr3v9cyb7p9aab8v038hnjm84nf9b60kikffp6w9rfqqqf767";
+  version = "1.5.2";
+  sha256 = "0ng7z2gz1c8lkn07fric18b3awcw886s9xb864kmnn2iah5gc65j";
   minimumOTPVersion = "18";
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

