### PR TITLE
erlang: 20.0 -> 20.1

### DIFF
--- a/pkgs/development/interpreters/erlang/R20.nix
+++ b/pkgs/development/interpreters/erlang/R20.nix
@@ -1,8 +1,8 @@
 { mkDerivation, fetchurl }:
 
 mkDerivation rec {
-  version = "20.0";
-  sha256 = "12dbay254ivnakwknjn5h55wndb0a0wqx55p156h8hwjhykj2kn0";
+  version = "20.1";
+  sha256 = "13f53lzgq2himg9kax41f66rzv5pjfrb1ln8b54yv9spkqx2hqqi";
 
   prePatch = ''
     substituteInPlace configure.in --replace '`sw_vers -productVersion`' '10.10'


### PR DESCRIPTION
Add building of erlangR20 with odbc and javac support.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

