### PR TITLE
gnuplot: 5.2.0 -> 5.2.1

### DIFF
--- a/pkgs/tools/graphics/gnuplot/default.nix
+++ b/pkgs/tools/graphics/gnuplot/default.nix
@@ -21,11 +21,11 @@ let
   withX = libX11 != null && !aquaterm && !stdenv.isDarwin;
 in
 stdenv.mkDerivation rec {
-  name = "gnuplot-5.2.0";
+  name = "gnuplot-5.2.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/gnuplot/${name}.tar.gz";
-    sha256 = "0hqyajcnlk822fk7hyl07sqk6a75n93awbdl3ydk9fd6l4jn9zkx";
+    sha256 = "123yh0ysahn71nlibsz5qkq18rlf18qqfhrlkvl925ijdgxv1ikx";
   };
 
   buildInputs =


### PR DESCRIPTION
###### Motivation for this change

Minor update, anecdotally tested by regenerating my figures worked and actually were bit-identical.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

