### PR TITLE
COPYING: there are no more bootstrap binaries in Nixpkgs tree

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -23,9 +23,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Note: the license above does not apply to the packages built by the
 Nix Packages collection, merely to the package descriptions (i.e., Nix
-expressions, build scripts, etc.).  Also, the license does not apply
-to some of the binaries used for bootstrapping Nixpkgs (e.g.,
-pkgs/stdenv/linux/tools/bash).  It also might not apply to patches
+expressions, build scripts, etc.).  It also might not apply to patches
 included in Nixpkgs, which may be derivative works of the packages to
 which they apply.  The aforementioned artifacts are all covered by the
 licenses of the respective packages.


### PR DESCRIPTION
###### Motivation for this change

`COPYING` has path to bash listed as an example that doesn't exist anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

