### PR TITLE
pythonPakages.meliae fix version

### DIFF
--- a/pkgs/development/python-modules/meliae/default.nix
+++ b/pkgs/development/python-modules/meliae/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "meliae";
-  version = "0.4.0.final.0";
+  version = "0.4.0";
   name = "${pname}-${version}";
 
   src = fetchPypi {


### PR DESCRIPTION
###### Motivation for this change
The tarball in Pypi for this package has been renamed from `meliae-0.4.0.final.0.tar.gz` to `meliae-0.4.0.tar.gz`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

