### PR TITLE
treewide: get rid of invalid `buildPhases` argument

### DIFF
--- a/nixos/modules/services/search/solr.nix
+++ b/nixos/modules/services/search/solr.nix
@@ -15,8 +15,6 @@ let
       sha256 = "01mzvh53wrs1p2ym765jwd00gl6kn8f9k3nhdrnhdqr8dhimfb2p";
     };
 
-    buildPhases = [ "unpackPhase" "installPhase" ];
-
     installPhase = ''
       mkdir -p $out/lib
       cp common/lib/*.jar $out/lib/

--- a/pkgs/misc/screensavers/i3lock-pixeled/default.nix
+++ b/pkgs/misc/screensavers/i3lock-pixeled/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
     playerctl
   ];
 
-  buildPhases = [ "unpackPhase" "patchPhase" "installPhase" ];
   makeFlags = [
     "PREFIX=$(out)/bin"
   ];

--- a/pkgs/servers/tt-rss/default.nix
+++ b/pkgs/servers/tt-rss/default.nix
@@ -10,8 +10,6 @@ stdenv.mkDerivation rec {
     sha256 = "07ng21n4pva56cxnxkzd6vzs381zn67psqpm51ym5wnl644jqh08";
   };
 
-  buildPhases = ["unpackPhase" "installPhase"];
-
   installPhase = ''
     mkdir $out
     cp -ra * $out/

--- a/pkgs/servers/web-apps/selfoss/default.nix
+++ b/pkgs/servers/web-apps/selfoss/default.nix
@@ -11,8 +11,6 @@ stdenv.mkDerivation rec {
     sha256 = "00vrpw7sb95x6lwpaxrlzxyj98k98xblqcrjr236ykv0ha97xv30";
   };
 
-  buildPhases = ["unpackPhase" "installPhase"];
-
   installPhase = ''
     mkdir $out
     cp -ra * $out/

--- a/pkgs/shells/lambda-mod-zsh-theme/default.nix
+++ b/pkgs/shells/lambda-mod-zsh-theme/default.nix
@@ -10,8 +10,6 @@ stdenv.mkDerivation {
     rev = "61c373c8aa5556d51522290b82ad44e7166bced1";
   };
 
-  buildPhases = [ "unpackPhase" "installPhase" ];
-
   installPhase = ''
     mkdir -p $out/share/themes
     cp lambda-mod.zsh-theme $out/share/themes

--- a/pkgs/shells/zsh-autosuggestions/default.nix
+++ b/pkgs/shells/zsh-autosuggestions/default.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zsh ];
 
-  buildPhases = [ "unpackPhase" "installPhase" ];
-
   installPhase = ''
     install -D zsh-autosuggestions.zsh \
       $out/share/zsh-autosuggestions/zsh-autosuggestions.zsh


### PR DESCRIPTION
###### Motivation for this change

I don't know where this comes from (I accidentally did that as well
once), but some derivations seem to use `buildPhases` rather than
`phases` in their derivations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

