### PR TITLE
{lib-}mediainfo{-gui},libzen: 0.7.99 -> 17.10, 0.4.35 -> 0.4.37

### DIFF
--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -2,11 +2,11 @@
 , desktop_file_utils, libSM, imagemagick }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.99";
+  version = "17.10";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
     url = "https://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "127d6wsrq3wg3ibbb28m26wrm54qbkv8h8xycanvml6ys4zqsc6a";
+    sha256 = "1yvh4r19kk3bzzgnr4ikrjxqldr6860s35sh4bqr51c7l77k048c";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "./MediaInfo/Project/GNU/GUI/";
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     description = "Supplies technical and tag information about a video or audio file (GUI version)";
     longDescription = ''

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-libmediainfo=${libmediainfo}" ];
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     description = "Supplies technical and tag information about a video or audio file";
     longDescription = ''

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, libzen, libmediainfo, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.99";
+  version = "17.10";
   name = "mediainfo-${version}";
   src = fetchurl {
     url = "https://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "127d6wsrq3wg3ibbb28m26wrm54qbkv8h8xycanvml6ys4zqsc6a";
+    sha256 = "1yvh4r19kk3bzzgnr4ikrjxqldr6860s35sh4bqr51c7l77k048c";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--enable-shared" ];
 
+  enableParallelBuilding = true;
+
   postInstall = ''
     install -vD -m 644 libmediainfo.pc "$out/lib/pkgconfig/libmediainfo.pc"
   '';

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, libzen, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.99";
+  version = "17.10";
   name = "libmediainfo-${version}";
   src = fetchurl {
     url = "https://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.xz";
-    sha256 = "126nkxrzs6dxzm3hzx6smvw6xgrqr3zs6hdqvl2xmvqy10p8z6pc";
+    sha256 = "00m1b4m37c9lm16yhh63p5pidg2sr3qvsw36672lklmcv3y1ic30";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/development/libraries/libzen/default.nix
+++ b/pkgs/development/libraries/libzen/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
 
   preConfigure = "sh autogen.sh";
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     description = "Shared library for libmediainfo and mediainfo";
     homepage = https://mediaarea.net/;

--- a/pkgs/development/libraries/libzen/default.nix
+++ b/pkgs/development/libraries/libzen/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  version = "0.4.35";
+  version = "0.4.37";
   name = "libzen-${version}";
   src = fetchurl {
     url = "https://mediaarea.net/download/source/libzen/${version}/libzen_${version}.tar.bz2";
-    sha256 = "12a1icgcffgv503ii2k1453kxg5hfly09mf4zjcc80aq8a6rf8by";
+    sha256 = "1hcsrmn85b0xp0mp33aazk7g071q1v3f163nnhv8b0mv9c4bgsfn";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
Update to the latest version (note versioning change).

From the changelog for `mediainfo` (`libzen` changelog is unavailable):

Version 17.10, 2017-11-02
--------------
```
+ We need your support! Visit https://mediaarea.net/SupportUs
+ Version scheme is now YY.MM (year dot month, 2 digits each)
+ New MediaInfo XML output, with XSD, more suitable for automatic
parsing. Use Option("Inform", "OLDXML") for keeping previous behavior
+ New "Info_OutputFormats" option for listing supported output formats
+ Universal Ad ID: refactored display, better display of value and
registry, XML name slightly modified
+ MOV: support of HDR metadata (MasteringDisplayColorVolume, MaxCLL,
MaxFALL)
+ BWF: display of UMID and loudness info
+ AAC: show program_config_element in trace
+ MPEG Audio: frame rate info
+ PCM in WAV and Matroska: Support of ValidBitsPerSample
+ I197, EBUCore: 1.8 output uses now final version of XSD and final XSD
location
+ Matroska: tweaking frame rate empirical detection for some corner
cases
x I1070, LAME 3.100 info tag was incorrectly parsed
x B1068, MPEG Audio: Incoherent duration between General and Audio
parts, Audio part duration fixed
x Matroska: showing "A_MS/ACM" Matroska CodecID
x MXF: Fix crash with some buggy files
x MXF: was not well supporting MXF referencing only 1 file
x PCM in WAV: 8-bit content is unsigned and without endianess
x PCM in WAV and Matroska: More coherency between Wave info and
ExtensibleWave Info (bitdepth, sign)
x WAV: GUID display was with first 8 bytes in wrong order
x Several crash fixes
```

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

