### PR TITLE
pythonPackages.sybase: move to python-modules

### DIFF
--- a/pkgs/development/python-modules/sybase/default.nix
+++ b/pkgs/development/python-modules/sybase/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, buildPythonPackage
+, fetchurl
+, isPy3k
+, freetds
+}:
+
+buildPythonPackage rec {
+  name = "python-sybase-${version}";
+  version = "0.40pre2";
+  disabled = isPy3k;
+
+  src = fetchurl {
+    url = "https://sourceforge.net/projects/python-sybase/files/python-sybase/${name}/${name}.tar.gz";
+    sha256 = "0pm88hyn18dy7ljam4mdx9qqgmgraf2zy2wl02g5vsjl4ncvq90j";
+  };
+
+  propagatedBuildInputs = [ freetds ];
+
+  SYBASE = freetds;
+  setupPyBuildFlags = [ "-DHAVE_FREETDS" "-UWANT_BULKCOPY" ];
+
+  meta = with stdenv.lib; {
+    description = "The Sybase module provides a Python interface to the Sybase relational database system";
+    homepage    = http://python-sybase.sourceforge.net;
+    license     = licenses.bsd3;
+    maintainers = with maintainers; [ veprbl ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -356,30 +356,7 @@ in {
 
   python-uinput = callPackage ../development/python-modules/python-uinput {};
 
-  python-sybase = buildPythonPackage rec {
-    name = "python-sybase-${version}";
-    version = "0.40pre2";
-    disabled = isPy3k;
-
-    src = pkgs.fetchurl {
-      url = "https://sourceforge.net/projects/python-sybase/files/python-sybase/${name}/${name}.tar.gz";
-      sha256 = "0pm88hyn18dy7ljam4mdx9qqgmgraf2zy2wl02g5vsjl4ncvq90j";
-    };
-
-    propagatedBuildInputs = [ pkgs.freetds ];
-
-    SYBASE = pkgs.freetds;
-    setupPyBuildFlags = [ "-DHAVE_FREETDS" "-UWANT_BULKCOPY" ];
-
-    meta = {
-      description = "The Sybase module provides a Python interface to the Sybase relational database system";
-      homepage    = http://python-sybase.sourceforge.net;
-      license     = licenses.bsd3;
-      maintainers = with maintainers; [ veprbl ];
-      platforms   = platforms.unix;
-    };
-  };
-
+  python-sybase = callPackage ../development/python-modules/sybase {};
 
   alot = buildPythonPackage rec {
     rev = "0.5.1";


### PR DESCRIPTION
###### Motivation for this change
To move pythonPackages.sybase from python-packages.nix to python-modules.
#30929 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@veprbl 