### PR TITLE
mpdas: init at 0.4.4

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -614,6 +614,7 @@
   sztupi = "Attila Sztupak <attila.sztupak@gmail.com>";
   taeer = "Taeer Bar-Yam <taeer@necsi.edu>";
   tailhook = "Paul Colomiets <paul@colomiets.name>";
+  taketwo = "Sergey Alexandrov <alexandrov88@gmail.com>";
   takikawa = "Asumu Takikawa <asumu@igalia.com>";
   taktoa = "Remy Goldschmidt <taktoa@gmail.com>";
   taku0 = "Takuo Yonezawa <mxxouy6x3m_github@tatapa.org>";

--- a/pkgs/tools/audio/mpdas/default.nix
+++ b/pkgs/tools/audio/mpdas/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ mpd_clientlib curl ];
 
-  makeFlags = [ "DESTDIR=" "PREFIX=$(out)" ];
+  makeFlags = [ "CONFIG=/etc" "DESTDIR=" "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "Music Player Daemon AudioScrobbler";

--- a/pkgs/tools/audio/mpdas/default.nix
+++ b/pkgs/tools/audio/mpdas/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, pkgconfig, mpd_clientlib, curl }:
+
+stdenv.mkDerivation rec {
+  name = "mpdas-${version}";
+  version = "0.4.4";
+
+  src = fetchFromGitHub {
+    owner = "hrkfdn";
+    repo = "mpdas";
+    rev = version;
+    sha256 = "1i6i36jd582y3nm5plcrswqljf528hd23whp8zw06hwqnsgca5b6";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ mpd_clientlib curl ];
+
+  makeFlags = [ "DESTDIR=" "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Music Player Daemon AudioScrobbler";
+    homepage = http://50hz.ws/mpdas/;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.taketwo ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1158,6 +1158,8 @@ with pkgs;
 
   mp3fs = callPackage ../tools/filesystems/mp3fs { };
 
+  mpdas = callPackage ../tools/audio/mpdas { };
+
   mpdcron = callPackage ../tools/audio/mpdcron { };
 
   mpdris2 = callPackage ../tools/audio/mpdris2 { };


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

