### PR TITLE
glibc 2.26 fixes

### DIFF
--- a/pkgs/development/libraries/mlt/default.nix
+++ b/pkgs/development/libraries/mlt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeWrapper
+{ stdenv, fetchFromGitHub, fetchurl, makeWrapper
 , SDL, ffmpeg, frei0r, libjack2, libdv, libsamplerate
 , libvorbis, libxml2, movit, pkgconfig, sox
 , gtk2
@@ -14,6 +14,19 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0k9vj21n6qxdjd0vvj22cwi35igajjzh5fbjza766izdbijv2i2w";
   };
+
+  patches = [
+    # fix for glibc-2.26
+    (fetchurl {
+      url = "https://github.com/mltframework/mlt/commit/2125e3955a0d0be61571cf43b674f74b4b93c6f8.patch";
+      sha256 = "1bgs5a3dblsmdmb7hwval9nmq1as4r4f48b3amsc23v69nsl2g0a";
+    })
+    # fix for glibc-2.26
+    (fetchurl {
+      url = "https://github.com/mltframework/mlt/commit/fbf6a5187776f2f392cf258935ff49e4c0e87024.patch";
+      sha256 = "045vchpcznzsz47j67kxwdbg133kar66ssna3parnzrxdfqi72pv";
+    })
+  ];
 
   buildInputs = [
     SDL ffmpeg frei0r libjack2 libdv libsamplerate libvorbis libxml2

--- a/pkgs/development/libraries/mlt/qt-5.nix
+++ b/pkgs/development/libraries/mlt/qt-5.nix
@@ -11,6 +11,18 @@ stdenv.mkDerivation rec {
     url = "https://github.com/mltframework/mlt/archive/v${version}.tar.gz";
     sha256 = "10m3ry0b2pvqx3bk34qh5dq337nn8pkc2gzfyhsj4nv9abskln47";
   };
+  patches = [
+    # fix for glibc-2.26
+    (fetchurl {
+      url = "https://github.com/mltframework/mlt/commit/2125e3955a0d0be61571cf43b674f74b4b93c6f8.patch";
+      sha256 = "1bgs5a3dblsmdmb7hwval9nmq1as4r4f48b3amsc23v69nsl2g0a";
+    })
+    # fix for glibc-2.26
+    (fetchurl {
+      url = "https://github.com/mltframework/mlt/commit/fbf6a5187776f2f392cf258935ff49e4c0e87024.patch";
+      sha256 = "045vchpcznzsz47j67kxwdbg133kar66ssna3parnzrxdfqi72pv";
+    })
+  ];
 
   buildInputs = [
     SDL ffmpeg frei0r libjack2 libdv libsamplerate libvorbis libxml2

--- a/pkgs/os-specific/linux/ffado/default.nix
+++ b/pkgs/os-specific/linux/ffado/default.nix
@@ -41,7 +41,10 @@ stdenv.mkDerivation rec {
     optXdg_utils libxmlxx glibmm
   ];
 
-  patches = [ ./gcc6.patch ];
+  patches = [
+    ./gcc6.patch
+    ./glibc226.patch
+  ];
 
   postPatch = ''
     # SConstruct checks cpuinfo and an objdump of /bin/mount to determine the appropriate arch

--- a/pkgs/os-specific/linux/ffado/glibc226.patch
+++ b/pkgs/os-specific/linux/ffado/glibc226.patch
@@ -1,0 +1,10 @@
+--- libffado/src/libutil/PosixMessageQueue.cpp  (revision 2705)
++++ libffado/src/libutil/PosixMessageQueue.cpp  (revision 2706)
+@@ -30,6 +30,7 @@
+ #include <errno.h>
+ #include <string.h>
+ #include <poll.h>
++#include <signal.h>
+
+ #define MQ_INVALID_ID ((mqd_t) -1)
+ // one second


### PR DESCRIPTION
###### Motivation for this change

At the moment these packages fail to build with glibc 2.26.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

