### PR TITLE
libzip: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/development/libraries/libzip/default.nix
+++ b/pkgs/development/libraries/libzip/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libzip-${version}";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchurl {
     url = "http://www.nih.at/libzip/${name}.tar.gz";
-    sha256 = "17vxj2ffsxwh8lkc6801ppmwj15jp8q58rin76znxfbx88789ybc";
+    sha256 = "1633dvjc08zwwhzqhnv62rjf1abx8y5njmm8y16ik9iwd07ka6d9";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Motivation for this change

Upstream update available, includes fix for CVE-2017-12858.

Some dependent packages fail to build:

- CNTK
- python3.6-CNTK
- python2.7-CNTK
- mlt
- kdenlive

but those are currently broken in master without this change (fix for mlt & kdenlive is in https://github.com/NixOS/nixpkgs/pull/31402)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

