### PR TITLE
webkitgtk[release-17.09]: 2.16.6 -> 2.18.2

### DIFF
--- a/pkgs/development/libraries/webkitgtk/2.18.nix
+++ b/pkgs/development/libraries/webkitgtk/2.18.nix
@@ -12,7 +12,7 @@ assert enableGeoLocation -> geoclue2 != null;
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "webkitgtk-${version}";
-  version = "2.18.1";
+  version = "2.18.2";
 
   meta = {
     description = "Web content rendering engine, GTK+ port";
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://webkitgtk.org/releases/${name}.tar.xz";
-    sha256 = "15fp7szmkpannx7avsynf0nv3y343qwq0fvq3rz2m2mw5wq7pnww";
+    sha256 = "1ry8zvv6k01g9p7agg326n0ziqpqjxd49h5w1b2is6rjnpqv6k5i";
   };
 
   # see if we can clean this up....


### PR DESCRIPTION
###### Motivation for this change

We need to keep stable secure.

###### Things done

Backported commits touching webkitgtk, including the update to 2.18.2, that I recently pushed to staging: https://github.com/NixOS/nixpkgs/commit/ee0c6293250c95ba1434c50d03632c6a424b3e63

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @fpletz 