### PR TITLE
Stdenv setup: Process dependencies before dependents

### DIFF
--- a/pkgs/applications/misc/xautoclick/default.nix
+++ b/pkgs/applications/misc/xautoclick/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   preConfigure = stdenv.lib.optional qtSupport ''
     mkdir .bin
     ln -s ${qt4}/bin/moc .bin/moc-qt4
-    addToSearchPath PATH .bin
+    appendToSearchPath PATH .bin
   '';
 
   meta = {

--- a/pkgs/applications/science/logic/coq/8.4.nix
+++ b/pkgs/applications/science/logic/coq/8.4.nix
@@ -55,12 +55,10 @@ stdenv.mkDerivation {
 
   setupHook = writeText "setupHook.sh" ''
     addCoqPath () {
-      if test -d "''$1/lib/coq/${coq-version}/user-contrib"; then
-        export COQPATH="''${COQPATH}''${COQPATH:+:}''$1/lib/coq/${coq-version}/user-contrib/"
-      fi
+        prependToSearchPath COQPATH "''$1/lib/coq/${coq-version}/user-contrib"
     }
 
-    envHooks=(''${envHooks[@]} addCoqPath)
+    envHooks+=(addCoqPath)
   '';
 
   passthru = {

--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -104,12 +104,10 @@ self = stdenv.mkDerivation {
 
   setupHook = writeText "setupHook.sh" ''
     addCoqPath () {
-      if test -d "''$1/lib/coq/${coq-version}/user-contrib"; then
-        export COQPATH="''${COQPATH}''${COQPATH:+:}''$1/lib/coq/${coq-version}/user-contrib/"
-      fi
+        prependToSearchPath COQPATH "$1/lib/coq/${coq-version}/user-contrib/"
     }
 
-    envHooks=(''${envHooks[@]} addCoqPath)
+    envHooks+=(addCoqPath)
   '';
 
   preConfigure = ''

--- a/pkgs/applications/science/math/R/setup-hook.sh
+++ b/pkgs/applications/science/math/R/setup-hook.sh
@@ -1,5 +1,5 @@
 addRLibPath () {
-    addToSearchPath R_LIBS_SITE $1/library
+    appendToSearchPath R_LIBS_SITE $1/library
 }
 
 envHooks+=(addRLibPath)

--- a/pkgs/applications/science/math/R/setup-hook.sh
+++ b/pkgs/applications/science/math/R/setup-hook.sh
@@ -1,5 +1,5 @@
 addRLibPath () {
-    appendToSearchPath R_LIBS_SITE $1/library
+    prependToSearchPath R_LIBS_SITE $1/library
 }
 
 envHooks+=(addRLibPath)

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation {
 
   preferLocalBuild = true;
 
-  inherit bintools_bin libc_bin libc_dev libc_lib coreutils_bin;
+  inherit libc_dev libc_lib coreutils_bin;
   shell = getBin shell + shell.shellPath or "";
   gnugrep_bin = if nativeTools then "" else gnugrep;
 
@@ -128,7 +128,7 @@ stdenv.mkDerivation {
 
       ldPath="${nativePrefix}/bin"
     '' else ''
-      echo $bintools_bin > $out/nix-support/orig-bintools
+      echo ${bintools_bin} > $out/nix-support/orig-bintools
 
       ldPath="${bintools_bin}/bin"
     ''
@@ -164,7 +164,7 @@ stdenv.mkDerivation {
       set +u
     '';
 
-  propagatedBuildInputs = extraPackages;
+  propagatedBuildInputs = [ bintools_bin libc_bin coreutils_bin ] ++ extraPackages;
 
   setupHook = ./setup-hook.sh;
 

--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -32,21 +32,6 @@ fi
 
 envHooks+=(bintoolsWrapper_addLDVars)
 
-# shellcheck disable=SC2157
-if [ -n "@bintools_bin@" ]; then
-    appendToSearchPath _PATH @bintools_bin@/bin
-fi
-
-# shellcheck disable=SC2157
-if [ -n "@libc_bin@" ]; then
-    appendToSearchPath _PATH @libc_bin@/bin
-fi
-
-# shellcheck disable=SC2157
-if [ -n "@coreutils_bin@" ]; then
-    appendToSearchPath _PATH @coreutils_bin@/bin
-fi
-
 # Export tool environment variables so various build systems use the right ones.
 
 export NIX_${role_pre}BINTOOLS=@out@

--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -34,17 +34,17 @@ envHooks+=(bintoolsWrapper_addLDVars)
 
 # shellcheck disable=SC2157
 if [ -n "@bintools_bin@" ]; then
-    addToSearchPath _PATH @bintools_bin@/bin
+    appendToSearchPath _PATH @bintools_bin@/bin
 fi
 
 # shellcheck disable=SC2157
 if [ -n "@libc_bin@" ]; then
-    addToSearchPath _PATH @libc_bin@/bin
+    appendToSearchPath _PATH @libc_bin@/bin
 fi
 
 # shellcheck disable=SC2157
 if [ -n "@coreutils_bin@" ]; then
-    addToSearchPath _PATH @coreutils_bin@/bin
+    appendToSearchPath _PATH @coreutils_bin@/bin
 fi
 
 # Export tool environment variables so various build systems use the right ones.

--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -11,12 +11,14 @@ bintoolsWrapper_addLDVars () {
             return 1 ;;
     esac
 
-    if [[ -d "$1/lib64" && ! -L "$1/lib64" ]]; then
-        export NIX_${role}LDFLAGS+=" -L$1/lib64"
+    if [[ -d "$1/lib" ]]; then
+        local var="NIX_${role}LDFLAGS"
+        export ${var}="-L$1/lib ${!var}"
     fi
 
-    if [[ -d "$1/lib" ]]; then
-        export NIX_${role}LDFLAGS+=" -L$1/lib"
+    if [[ -d "$1/lib64" && ! -L "$1/lib64" ]]; then
+        local var="NIX_${role}LDFLAGS"
+        export ${var}="-L$1/lib64 ${!var}"
     fi
 }
 

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -37,7 +37,6 @@ let
   ccVersion = (builtins.parseDrvName cc.name).version;
   ccName = (builtins.parseDrvName cc.name).name;
 
-  libc_bin = if libc == null then null else getBin libc;
   libc_dev = if libc == null then null else getDev libc;
   libc_lib = if libc == null then null else getLib libc;
   cc_solib = getLib cc;
@@ -64,7 +63,6 @@ let
 in
 
 # Ensure bintools matches
-assert libc_bin == bintools.libc_bin;
 assert libc_dev == bintools.libc_dev;
 assert libc_lib == bintools.libc_lib;
 assert nativeTools == bintools.nativeTools;
@@ -78,8 +76,8 @@ stdenv.mkDerivation {
 
   preferLocalBuild = true;
 
-  inherit cc libc_bin libc_dev libc_lib bintools coreutils_bin;
-  shell = getBin shell + stdenv.lib.optionalString (stdenv ? shellPath) stdenv.shellPath;
+  inherit cc libc_dev libc_lib bintools coreutils_bin;
+  shell = getBin shell + shell.shellPath or "";
   gnugrep_bin = if nativeTools then "" else gnugrep;
 
   inherit targetPrefix infixSalt;
@@ -201,7 +199,7 @@ stdenv.mkDerivation {
       ln -s $ccPath/${targetPrefix}ghdl $out/bin/${targetPrefix}ghdl
     '';
 
-  propagatedBuildInputs = [ bintools ] ++ extraPackages;
+  propagatedBuildInputs = [ cc coreutils_bin bintools ] ++ extraPackages;
 
   setupHook = ./setup-hook.sh;
 

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -71,11 +71,13 @@ ccWrapper_addCVars () {
     esac
 
     if [[ -d "$1/include" ]]; then
-        export NIX_${role}CFLAGS_COMPILE+=" ${ccIncludeFlag:--isystem} $1/include"
+        local var="NIX_${role}CFLAGS_COMPILE"
+        export ${var}="${ccIncludeFlag:--isystem} $1/include ${!var}"
     fi
 
     if [[ -d "$1/Library/Frameworks" ]]; then
-        export NIX_${role}CFLAGS_COMPILE+=" -F$1/Library/Frameworks"
+        local var="NIX_${role}CFLAGS_COMPILE"
+        export ${var}="-F$1/Library/Frameworks ${!var}"
     fi
 }
 

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -102,24 +102,6 @@ fi
 # dependencies.
 envHooks+=(ccWrapper_addCVars)
 
-# Note 1: these come *after* $out in the PATH (see setup.sh).
-# Note 2: phase separation makes this look useless to shellcheck.
-
-# shellcheck disable=SC2157
-if [ -n "@cc@" ]; then
-    appendToSearchPath _PATH @cc@/bin
-fi
-
-# shellcheck disable=SC2157
-if [ -n "@libc_bin@" ]; then
-    appendToSearchPath _PATH @libc_bin@/bin
-fi
-
-# shellcheck disable=SC2157
-if [ -n "@coreutils_bin@" ]; then
-    appendToSearchPath _PATH @coreutils_bin@/bin
-fi
-
 # Export tool environment variables so various build systems use the right ones.
 
 export NIX_${role_pre}CC=@out@

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -107,17 +107,17 @@ envHooks+=(ccWrapper_addCVars)
 
 # shellcheck disable=SC2157
 if [ -n "@cc@" ]; then
-    addToSearchPath _PATH @cc@/bin
+    appendToSearchPath _PATH @cc@/bin
 fi
 
 # shellcheck disable=SC2157
 if [ -n "@libc_bin@" ]; then
-    addToSearchPath _PATH @libc_bin@/bin
+    appendToSearchPath _PATH @libc_bin@/bin
 fi
 
 # shellcheck disable=SC2157
 if [ -n "@coreutils_bin@" ]; then
-    addToSearchPath _PATH @coreutils_bin@/bin
+    appendToSearchPath _PATH @coreutils_bin@/bin
 fi
 
 # Export tool environment variables so various build systems use the right ones.

--- a/pkgs/build-support/emacs/setup-hook.sh
+++ b/pkgs/build-support/emacs/setup-hook.sh
@@ -1,7 +1,5 @@
 addEmacsVars () {
-  if test -d $1/share/emacs/site-lisp; then
-      export EMACSLOADPATH="$1/share/emacs/site-lisp:$EMACSLOADPATH"
-  fi
+    prependToSearchPath EMACSLOADPATH "$1/share/emacs/site-lisp"
 }
 
 envHooks+=(addEmacsVars)

--- a/pkgs/build-support/gcc-wrapper-old/setup-hook.sh
+++ b/pkgs/build-support/gcc-wrapper-old/setup-hook.sh
@@ -17,17 +17,17 @@ envHooks=(${envHooks[@]} addCVars)
 # Note: these come *after* $out in the PATH (see setup.sh).
 
 if test -n "@gcc@"; then
-    addToSearchPath PATH @gcc@/bin
+    appendToSearchPath PATH @gcc@/bin
 fi
 
 if test -n "@binutils@"; then
-    addToSearchPath PATH @binutils@/bin
+    appendToSearchPath PATH @binutils@/bin
 fi
 
 if test -n "@libc@"; then
-    addToSearchPath PATH @libc_bin@/bin
+    appendToSearchPath PATH @libc_bin@/bin
 fi
 
 if test -n "@coreutils@"; then
-    addToSearchPath PATH @coreutils@/bin
+    appendToSearchPath PATH @coreutils@/bin
 fi

--- a/pkgs/build-support/gcc-wrapper-old/setup-hook.sh
+++ b/pkgs/build-support/gcc-wrapper-old/setup-hook.sh
@@ -1,18 +1,18 @@
 addCVars () {
     if test -d $1/include; then
-        export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem $1/include"
-    fi
-
-    if test -d $1/lib64; then
-        export NIX_LDFLAGS="$NIX_LDFLAGS -L$1/lib64"
+        export NIX_CFLAGS_COMPILE="-isystem $1/include $NIX_CFLAGS_COMPILE"
     fi
 
     if test -d $1/lib; then
-        export NIX_LDFLAGS="$NIX_LDFLAGS -L$1/lib"
+        export NIX_LDFLAGS="-L$1/lib $NIX_LDFLAGS"
+    fi
+
+    if test -d $1/lib64; then
+        export NIX_LDFLAGS="-L$1/lib64 $NIX_LDFLAGS"
     fi
 }
 
-envHooks=(${envHooks[@]} addCVars)
+envHooks+=(addCVars)
 
 # Note: these come *after* $out in the PATH (see setup.sh).
 

--- a/pkgs/build-support/setup-hooks/find-xml-catalogs.sh
+++ b/pkgs/build-support/setup-hooks/find-xml-catalogs.sh
@@ -2,10 +2,10 @@ addXMLCatalogs () {
     local d i
     # ‘xml/dtd’ and ‘xml/xsl’ are deprecated. Catalogs should be
     # installed underneath ‘share/xml’.
-    for d in $1/share/xml $1/xml/dtd $1/xml/xsl; do
+    for d in $1/xml/dtd $1/xml/xsl $1/share/xml; do
         if [ -d $d ]; then
             for i in $(find $d -name catalog.xml); do
-                XML_CATALOG_FILES+=" $i"
+                XML_CATALOG_FILES="$i $XML_CATALOG_FILES"
             done
         fi
     done

--- a/pkgs/build-support/setup-hooks/set-java-classpath.sh
+++ b/pkgs/build-support/setup-hooks/set-java-classpath.sh
@@ -6,7 +6,7 @@ export CLASSPATH
 addPkgToClassPath () {
     local jar
     for jar in $1/share/java/*.jar; do
-        export CLASSPATH=''${CLASSPATH}''${CLASSPATH:+:}''${jar}
+        export CLASSPATH="${jar}${CLASSPATH:+:}${CLASSPATH}"
     done
 }
 

--- a/pkgs/build-support/setup-hooks/setup-debug-info-dirs.sh
+++ b/pkgs/build-support/setup-hooks/setup-debug-info-dirs.sh
@@ -1,5 +1,5 @@
 setupDebugInfoDirs () {
-    appendToSearchPath NIX_DEBUG_INFO_DIRS $1/lib/debug
+    prependToSearchPath NIX_DEBUG_INFO_DIRS $1/lib/debug
 }
 
 envHooks+=(setupDebugInfoDirs)

--- a/pkgs/build-support/setup-hooks/setup-debug-info-dirs.sh
+++ b/pkgs/build-support/setup-hooks/setup-debug-info-dirs.sh
@@ -1,5 +1,5 @@
 setupDebugInfoDirs () {
-    addToSearchPath NIX_DEBUG_INFO_DIRS $1/lib/debug
+    appendToSearchPath NIX_DEBUG_INFO_DIRS $1/lib/debug
 }
 
 envHooks+=(setupDebugInfoDirs)

--- a/pkgs/build-support/setup-hooks/win-dll-link.sh
+++ b/pkgs/build-support/setup-hooks/win-dll-link.sh
@@ -16,7 +16,7 @@ _linkDLLs() {
     local DLLPATH=""
     local outName
     for outName in $outputs; do
-        appendToSearchPath DLLPATH "${!outName}/bin"
+        prependToSearchPath DLLPATH "${!outName}/bin"
     done
     DLLPATH="$DLLPATH:$PATH"
 

--- a/pkgs/build-support/setup-hooks/win-dll-link.sh
+++ b/pkgs/build-support/setup-hooks/win-dll-link.sh
@@ -16,7 +16,7 @@ _linkDLLs() {
     local DLLPATH=""
     local outName
     for outName in $outputs; do
-        addToSearchPath DLLPATH "${!outName}/bin"
+        appendToSearchPath DLLPATH "${!outName}/bin"
     done
     DLLPATH="$DLLPATH:$PATH"
 

--- a/pkgs/data/icons/hicolor-icon-theme/setup-hook.sh
+++ b/pkgs/data/icons/hicolor-icon-theme/setup-hook.sh
@@ -3,7 +3,7 @@ hicolorIconThemeHook() {
 
     # where to find icon themes
     if [ -d "$1/share/icons" ]; then
-      appendToSearchPath XDG_ICON_DIRS $1/share
+      prependToSearchPath XDG_ICON_DIRS $1/share
     fi
 	
 }

--- a/pkgs/data/icons/hicolor-icon-theme/setup-hook.sh
+++ b/pkgs/data/icons/hicolor-icon-theme/setup-hook.sh
@@ -1,11 +1,9 @@
 # Populate XDG_ICON_DIRS
 hicolorIconThemeHook() {
-
     # where to find icon themes
     if [ -d "$1/share/icons" ]; then
-      prependToSearchPath XDG_ICON_DIRS $1/share
+        prependToSearchPath XDG_ICON_DIRS $1/share
     fi
-	
 }
 
 envHooks+=(hicolorIconThemeHook)

--- a/pkgs/data/icons/hicolor-icon-theme/setup-hook.sh
+++ b/pkgs/data/icons/hicolor-icon-theme/setup-hook.sh
@@ -3,7 +3,7 @@ hicolorIconThemeHook() {
 
     # where to find icon themes
     if [ -d "$1/share/icons" ]; then
-      addToSearchPath XDG_ICON_DIRS $1/share
+      appendToSearchPath XDG_ICON_DIRS $1/share
     fi
 	
 }

--- a/pkgs/desktops/gnome-3/core/grilo/setup-hook.sh
+++ b/pkgs/desktops/gnome-3/core/grilo/setup-hook.sh
@@ -1,6 +1,6 @@
 make_grilo_find_plugins() {
     if [ -d "$1"/lib/grilo-0.3 ]; then
-        addToSearchPath GRL_PLUGIN_PATH "$1/lib/grilo-0.3"
+        appendToSearchPath GRL_PLUGIN_PATH "$1/lib/grilo-0.3"
     fi
 }
 

--- a/pkgs/desktops/gnome-3/core/grilo/setup-hook.sh
+++ b/pkgs/desktops/gnome-3/core/grilo/setup-hook.sh
@@ -1,6 +1,6 @@
 make_grilo_find_plugins() {
     if [ -d "$1"/lib/grilo-0.3 ]; then
-        appendToSearchPath GRL_PLUGIN_PATH "$1/lib/grilo-0.3"
+        prependToSearchPath GRL_PLUGIN_PATH "$1/lib/grilo-0.3"
     fi
 }
 

--- a/pkgs/desktops/gnustep/make/builder.sh
+++ b/pkgs/desktops/gnustep/make/builder.sh
@@ -30,27 +30,27 @@ postInstall() {
     # add the current package to the paths
     local tmp="$out/lib/GNUstep/Applications"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_APPS" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_APPS "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_APPS "$tmp"
     fi
     tmp="$out/lib/GNUstep/Applications"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_ADMIN_APPS" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_ADMIN_APPS "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_ADMIN_APPS "$tmp"
     fi
     tmp="$out/lib/GNUstep/WebApplications"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_WEB_APPS" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_WEB_APPS "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_WEB_APPS "$tmp"
     fi
     tmp="$out/bin"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_TOOLS" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_TOOLS "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_TOOLS "$tmp"
     fi
     tmp="$out/sbin"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_ADMIN_TOOLS" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_ADMIN_TOOLS "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_ADMIN_TOOLS "$tmp"
     fi
     tmp="$out/lib/GNUstep"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_LIBRARY" in *"${tmp}"*) false;; *) true;; esac; then
-    	addToSearchPath NIX_GNUSTEP_SYSTEM_LIBRARY "$tmp"
+    	appendToSearchPath NIX_GNUSTEP_SYSTEM_LIBRARY "$tmp"
     fi
     tmp="$out/include"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_HEADERS" in *"${tmp}"*) false;; *) true;; esac; then
@@ -62,19 +62,19 @@ postInstall() {
     fi
     tmp="$out/lib"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_LIBRARIES" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_LIBRARIES "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_LIBRARIES "$tmp"
     fi
     tmp="$out/share/GNUstep/Documentation"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_DOC" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_DOC "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_DOC "$tmp"
     fi
     tmp="$out/share/man"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_DOC_MAN" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_DOC_MAN "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_DOC_MAN "$tmp"
     fi
     tmp="$out/share/info"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_DOC_INFO" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_DOC_INFO "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_DOC_INFO "$tmp"
     fi
     
     # write the config file

--- a/pkgs/desktops/gnustep/make/setup-hook.sh
+++ b/pkgs/desktops/gnustep/make/setup-hook.sh
@@ -27,27 +27,27 @@ addEnvVars() {
 
     local tmp="$1/lib/GNUstep/Applications"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_APPS" in *"${tmp}"*) false;; *) true;; esac; then
-	appendToSearchPath NIX_GNUSTEP_SYSTEM_APPS "$tmp"
+	prependToSearchPath NIX_GNUSTEP_SYSTEM_APPS "$tmp"
     fi
     tmp="$1/lib/GNUstep/Applications"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_ADMIN_APPS" in *"${tmp}"*) false;; *) true;; esac; then
-	appendToSearchPath NIX_GNUSTEP_SYSTEM_ADMIN_APPS "$tmp"
+	prependToSearchPath NIX_GNUSTEP_SYSTEM_ADMIN_APPS "$tmp"
     fi
     tmp="$1/lib/GNUstep/WebApplications"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_WEB_APPS" in *"${tmp}"*) false;; *) true;; esac; then
-	appendToSearchPath NIX_GNUSTEP_SYSTEM_WEB_APPS "$tmp"
+	prependToSearchPath NIX_GNUSTEP_SYSTEM_WEB_APPS "$tmp"
     fi
     tmp="$1/bin"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_TOOLS" in *"${tmp}"*) false;; *) true;; esac; then
-	appendToSearchPath NIX_GNUSTEP_SYSTEM_TOOLS "$tmp"
+	prependToSearchPath NIX_GNUSTEP_SYSTEM_TOOLS "$tmp"
     fi
     tmp="$1/sbin"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_ADMIN_TOOLS" in *"${tmp}"*) false;; *) true;; esac; then
-	appendToSearchPath NIX_GNUSTEP_SYSTEM_ADMIN_TOOLS "$tmp"
+	prependToSearchPath NIX_GNUSTEP_SYSTEM_ADMIN_TOOLS "$tmp"
     fi
     tmp="$1/lib/GNUstep"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_LIBRARY" in *"${tmp}"*) false;; *) true;; esac; then
-    	appendToSearchPath NIX_GNUSTEP_SYSTEM_LIBRARY "$tmp"
+    	prependToSearchPath NIX_GNUSTEP_SYSTEM_LIBRARY "$tmp"
     fi
     tmp="$1/include"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_HEADERS" in *"${tmp}"*) false;; *) true;; esac; then
@@ -59,19 +59,19 @@ addEnvVars() {
     fi
     tmp="$1/lib"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_LIBRARIES" in *"${tmp}"*) false;; *) true;; esac; then
-	appendToSearchPath NIX_GNUSTEP_SYSTEM_LIBRARIES "$tmp"
+	prependToSearchPath NIX_GNUSTEP_SYSTEM_LIBRARIES "$tmp"
     fi
     tmp="$1/share/GNUstep/Documentation"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_DOC" in *"${tmp}"*) false;; *) true;; esac; then
-	appendToSearchPath NIX_GNUSTEP_SYSTEM_DOC "$tmp"
+	prependToSearchPath NIX_GNUSTEP_SYSTEM_DOC "$tmp"
     fi
     tmp="$1/share/man"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_DOC_MAN" in *"${tmp}"*) false;; *) true;; esac; then
-	appendToSearchPath NIX_GNUSTEP_SYSTEM_DOC_MAN "$tmp"
+	prependToSearchPath NIX_GNUSTEP_SYSTEM_DOC_MAN "$tmp"
     fi
     tmp="$1/share/info"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_DOC_INFO" in *"${tmp}"*) false;; *) true;; esac; then
-	appendToSearchPath NIX_GNUSTEP_SYSTEM_DOC_INFO "$tmp"
+	prependToSearchPath NIX_GNUSTEP_SYSTEM_DOC_INFO "$tmp"
     fi
 }
 envHooks=(${envHooks[@]} addEnvVars)

--- a/pkgs/desktops/gnustep/make/setup-hook.sh
+++ b/pkgs/desktops/gnustep/make/setup-hook.sh
@@ -74,4 +74,4 @@ addEnvVars() {
 	prependToSearchPath NIX_GNUSTEP_SYSTEM_DOC_INFO "$tmp"
     fi
 }
-envHooks=(${envHooks[@]} addEnvVars)
+envHooks+=(addEnvVars)

--- a/pkgs/desktops/gnustep/make/setup-hook.sh
+++ b/pkgs/desktops/gnustep/make/setup-hook.sh
@@ -27,27 +27,27 @@ addEnvVars() {
 
     local tmp="$1/lib/GNUstep/Applications"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_APPS" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_APPS "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_APPS "$tmp"
     fi
     tmp="$1/lib/GNUstep/Applications"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_ADMIN_APPS" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_ADMIN_APPS "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_ADMIN_APPS "$tmp"
     fi
     tmp="$1/lib/GNUstep/WebApplications"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_WEB_APPS" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_WEB_APPS "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_WEB_APPS "$tmp"
     fi
     tmp="$1/bin"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_TOOLS" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_TOOLS "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_TOOLS "$tmp"
     fi
     tmp="$1/sbin"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_ADMIN_TOOLS" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_ADMIN_TOOLS "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_ADMIN_TOOLS "$tmp"
     fi
     tmp="$1/lib/GNUstep"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_LIBRARY" in *"${tmp}"*) false;; *) true;; esac; then
-    	addToSearchPath NIX_GNUSTEP_SYSTEM_LIBRARY "$tmp"
+    	appendToSearchPath NIX_GNUSTEP_SYSTEM_LIBRARY "$tmp"
     fi
     tmp="$1/include"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_HEADERS" in *"${tmp}"*) false;; *) true;; esac; then
@@ -59,19 +59,19 @@ addEnvVars() {
     fi
     tmp="$1/lib"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_LIBRARIES" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_LIBRARIES "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_LIBRARIES "$tmp"
     fi
     tmp="$1/share/GNUstep/Documentation"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_DOC" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_DOC "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_DOC "$tmp"
     fi
     tmp="$1/share/man"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_DOC_MAN" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_DOC_MAN "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_DOC_MAN "$tmp"
     fi
     tmp="$1/share/info"
     if [ -d "$tmp" ] && case "$NIX_GNUSTEP_SYSTEM_DOC_INFO" in *"${tmp}"*) false;; *) true;; esac; then
-	addToSearchPath NIX_GNUSTEP_SYSTEM_DOC_INFO "$tmp"
+	appendToSearchPath NIX_GNUSTEP_SYSTEM_DOC_INFO "$tmp"
     fi
 }
 envHooks=(${envHooks[@]} addEnvVars)

--- a/pkgs/development/beam-modules/build-erlang-mk.nix
+++ b/pkgs/development/beam-modules/build-erlang-mk.nix
@@ -35,7 +35,7 @@ let
 
     setupHook = if setupHook == null
     then writeText "setupHook.sh" ''
-       addToSearchPath ERL_LIBS "$1/lib/erlang/lib"
+       appendToSearchPath ERL_LIBS "$1/lib/erlang/lib"
     ''
     else setupHook;
 

--- a/pkgs/development/beam-modules/build-erlang-mk.nix
+++ b/pkgs/development/beam-modules/build-erlang-mk.nix
@@ -35,7 +35,7 @@ let
 
     setupHook = if setupHook == null
     then writeText "setupHook.sh" ''
-       appendToSearchPath ERL_LIBS "$1/lib/erlang/lib"
+       prependToSearchPath ERL_LIBS "$1/lib/erlang/lib"
     ''
     else setupHook;
 

--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -38,7 +38,7 @@ let
 
     setupHook = if setupHook == null
     then writeText "setupHook.sh" ''
-       addToSearchPath ERL_LIBS "$1/lib/erlang/lib"
+       appendToSearchPath ERL_LIBS "$1/lib/erlang/lib"
     ''
     else setupHook;
 

--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -38,7 +38,7 @@ let
 
     setupHook = if setupHook == null
     then writeText "setupHook.sh" ''
-       appendToSearchPath ERL_LIBS "$1/lib/erlang/lib"
+       prependToSearchPath ERL_LIBS "$1/lib/erlang/lib"
     ''
     else setupHook;
 

--- a/pkgs/development/beam-modules/build-rebar3.nix
+++ b/pkgs/development/beam-modules/build-rebar3.nix
@@ -46,7 +46,7 @@ let
     inherit src;
 
     setupHook = writeText "setupHook.sh" ''
-       addToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
+       appendToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
     '';
 
     postPatch = ''

--- a/pkgs/development/beam-modules/build-rebar3.nix
+++ b/pkgs/development/beam-modules/build-rebar3.nix
@@ -46,7 +46,7 @@ let
     inherit src;
 
     setupHook = writeText "setupHook.sh" ''
-       appendToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
+       prependToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
     '';
 
     postPatch = ''

--- a/pkgs/development/beam-modules/hex/default.nix
+++ b/pkgs/development/beam-modules/hex/default.nix
@@ -18,7 +18,7 @@ let
     };
 
     setupHook = writeText "setupHook.sh" ''
-       appendToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
+       prependToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
     '';
 
     dontStrip = true;

--- a/pkgs/development/beam-modules/hex/default.nix
+++ b/pkgs/development/beam-modules/hex/default.nix
@@ -18,7 +18,7 @@ let
     };
 
     setupHook = writeText "setupHook.sh" ''
-       addToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
+       appendToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
     '';
 
     dontStrip = true;

--- a/pkgs/development/beam-modules/webdriver/default.nix
+++ b/pkgs/development/beam-modules/webdriver/default.nix
@@ -18,7 +18,7 @@ let
     };
 
     setupHook = writeText "setupHook.sh" ''
-       addToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
+       appendToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
     '';
 
     buildInputs = [ erlang ];

--- a/pkgs/development/beam-modules/webdriver/default.nix
+++ b/pkgs/development/beam-modules/webdriver/default.nix
@@ -18,7 +18,7 @@ let
     };
 
     setupHook = writeText "setupHook.sh" ''
-       appendToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
+       prependToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
     '';
 
     buildInputs = [ erlang ];

--- a/pkgs/development/compilers/chicken/setup-hook.sh
+++ b/pkgs/development/compilers/chicken/setup-hook.sh
@@ -1,7 +1,6 @@
 addChickenRepositoryPath() {
-    prependToSearchPathWithCustomDelimiter : CHICKEN_REPOSITORY_EXTRA "$1/lib/chicken/8/"
-    # prependToSearchPathWithCustomDelimiter \; CHICKEN_INCLUDE_PATH "$1/share/"
-    export CHICKEN_INCLUDE_PATH="$1/share;$CHICKEN_INCLUDE_PATH"
+    prependToSearchPathWithCustomDelimiter ':' CHICKEN_REPOSITORY_EXTRA "$1/lib/chicken/8/"
+    prependToSearchPathWithCustomDelimiter ';' CHICKEN_INCLUDE_PATH "$1/share/"
 }
 
-envHooks=(${envHooks[@]} addChickenRepositoryPath)
+envHooks+=(addChickenRepositoryPath)

--- a/pkgs/development/compilers/chicken/setup-hook.sh
+++ b/pkgs/development/compilers/chicken/setup-hook.sh
@@ -1,6 +1,6 @@
 addChickenRepositoryPath() {
-    addToSearchPathWithCustomDelimiter : CHICKEN_REPOSITORY_EXTRA "$1/lib/chicken/8/"
-    # addToSearchPathWithCustomDelimiter \; CHICKEN_INCLUDE_PATH "$1/share/"
+    appendToSearchPathWithCustomDelimiter : CHICKEN_REPOSITORY_EXTRA "$1/lib/chicken/8/"
+    # appendToSearchPathWithCustomDelimiter \; CHICKEN_INCLUDE_PATH "$1/share/"
     export CHICKEN_INCLUDE_PATH="$1/share;$CHICKEN_INCLUDE_PATH"
 }
 

--- a/pkgs/development/compilers/chicken/setup-hook.sh
+++ b/pkgs/development/compilers/chicken/setup-hook.sh
@@ -1,6 +1,6 @@
 addChickenRepositoryPath() {
-    appendToSearchPathWithCustomDelimiter : CHICKEN_REPOSITORY_EXTRA "$1/lib/chicken/8/"
-    # appendToSearchPathWithCustomDelimiter \; CHICKEN_INCLUDE_PATH "$1/share/"
+    prependToSearchPathWithCustomDelimiter : CHICKEN_REPOSITORY_EXTRA "$1/lib/chicken/8/"
+    # prependToSearchPathWithCustomDelimiter \; CHICKEN_INCLUDE_PATH "$1/share/"
     export CHICKEN_INCLUDE_PATH="$1/share;$CHICKEN_INCLUDE_PATH"
 }
 

--- a/pkgs/development/compilers/go/setup-hook.sh
+++ b/pkgs/development/compilers/go/setup-hook.sh
@@ -1,5 +1,5 @@
 addToGoPath() {
-    appendToSearchPath GOPATH $1/share/go
+    prependToSearchPath GOPATH $1/share/go
 }
 
 envHooks=(${envHooks[@]} addToGoPath)

--- a/pkgs/development/compilers/go/setup-hook.sh
+++ b/pkgs/development/compilers/go/setup-hook.sh
@@ -1,5 +1,5 @@
 addToGoPath() {
-    prependToSearchPath GOPATH $1/share/go
+    prependToSearchPath GOPATH "$1/share/go"
 }
 
-envHooks=(${envHooks[@]} addToGoPath)
+envHooks+=(addToGoPath)

--- a/pkgs/development/compilers/go/setup-hook.sh
+++ b/pkgs/development/compilers/go/setup-hook.sh
@@ -1,5 +1,5 @@
 addToGoPath() {
-    addToSearchPath GOPATH $1/share/go
+    appendToSearchPath GOPATH $1/share/go
 }
 
 envHooks=(${envHooks[@]} addToGoPath)

--- a/pkgs/development/compilers/haxe/setup-hook.sh
+++ b/pkgs/development/compilers/haxe/setup-hook.sh
@@ -1,6 +1,6 @@
 addHaxeLibPath() {
   if [ ! -d "$1/lib/haxe/std" ]; then
-    addToSearchPath HAXELIB_PATH "$1/lib/haxe"
+    appendToSearchPath HAXELIB_PATH "$1/lib/haxe"
   fi
 }
 

--- a/pkgs/development/compilers/haxe/setup-hook.sh
+++ b/pkgs/development/compilers/haxe/setup-hook.sh
@@ -1,6 +1,6 @@
 addHaxeLibPath() {
   if [ ! -d "$1/lib/haxe/std" ]; then
-    appendToSearchPath HAXELIB_PATH "$1/lib/haxe"
+    prependToSearchPath HAXELIB_PATH "$1/lib/haxe"
   fi
 }
 

--- a/pkgs/development/interpreters/elixir/setup-hook.sh
+++ b/pkgs/development/interpreters/elixir/setup-hook.sh
@@ -1,5 +1,5 @@
 addErlLibPath() {
-    addToSearchPath ERL_LIBS $1/lib/elixir/lib
+    appendToSearchPath ERL_LIBS $1/lib/elixir/lib
 }
 
 envHooks+=(addErlLibPath)

--- a/pkgs/development/interpreters/elixir/setup-hook.sh
+++ b/pkgs/development/interpreters/elixir/setup-hook.sh
@@ -1,5 +1,5 @@
 addErlLibPath() {
-    appendToSearchPath ERL_LIBS $1/lib/elixir/lib
+    prependToSearchPath ERL_LIBS $1/lib/elixir/lib
 }
 
 envHooks+=(addErlLibPath)

--- a/pkgs/development/interpreters/erlang/setup-hook.sh
+++ b/pkgs/development/interpreters/erlang/setup-hook.sh
@@ -1,5 +1,5 @@
 addErlangLibPath() {
-    appendToSearchPath ERL_LIBS $1/lib/erlang/lib
+    prependToSearchPath ERL_LIBS $1/lib/erlang/lib
 }
 
 envHooks+=(addErlangLibPath)

--- a/pkgs/development/interpreters/erlang/setup-hook.sh
+++ b/pkgs/development/interpreters/erlang/setup-hook.sh
@@ -1,5 +1,5 @@
 addErlangLibPath() {
-    addToSearchPath ERL_LIBS $1/lib/erlang/lib
+    appendToSearchPath ERL_LIBS $1/lib/erlang/lib
 }
 
 envHooks+=(addErlangLibPath)

--- a/pkgs/development/interpreters/guile/setup-hook-2.0.sh
+++ b/pkgs/development/interpreters/guile/setup-hook-2.0.sh
@@ -1,12 +1,12 @@
 addGuileLibPath () {
     if test -d "$1/share/guile/site/2.0"
     then
-        export GUILE_LOAD_PATH="${GUILE_LOAD_PATH}${GUILE_LOAD_PATH:+:}$1/share/guile/site/2.0"
-        export GUILE_LOAD_COMPILED_PATH="${GUILE_LOAD_COMPILED_PATH}${GUILE_LOAD_COMPILED_PATH:+:}$1/share/guile/site/2.0"
+        export GUILE_LOAD_PATH="$1/share/guile/site/2.0${GUILE_LOAD_PATH:+:}${GUILE_LOAD_PATH}"
+        export GUILE_LOAD_COMPILED_PATH="$1/share/guile/site/2.0${GUILE_LOAD_COMPILED_PATH:+:}${GUILE_LOAD_COMPILED_PATH}"
     elif test -d "$1/share/guile/site"
     then
-        export GUILE_LOAD_PATH="${GUILE_LOAD_PATH}${GUILE_LOAD_PATH:+:}$1/share/guile/site"
-        export GUILE_LOAD_COMPILED_PATH="${GUILE_LOAD_COMPILED_PATH}${GUILE_LOAD_COMPILED_PATH:+:}$1/share/guile/site"
+        export GUILE_LOAD_PATH="$1/share/guile/site${GUILE_LOAD_PATH:+:}${GUILE_LOAD_PATH}"
+        export GUILE_LOAD_COMPILED_PATH="$1/share/guile/site${GUILE_LOAD_COMPILED_PATH:+:}${GUILE_LOAD_COMPILED_PATH}"
     fi
 }
 

--- a/pkgs/development/interpreters/guile/setup-hook-2.2.sh
+++ b/pkgs/development/interpreters/guile/setup-hook-2.2.sh
@@ -1,12 +1,12 @@
 addGuileLibPath () {
     if test -d "$1/share/guile/site/2.2"
     then
-        export GUILE_LOAD_PATH="${GUILE_LOAD_PATH}${GUILE_LOAD_PATH:+:}$1/share/guile/site/2.2"
-        export GUILE_LOAD_COMPILED_PATH="${GUILE_LOAD_COMPILED_PATH}${GUILE_LOAD_COMPILED_PATH:+:}$1/share/guile/site/2.2"
+        export GUILE_LOAD_PATH="$1/share/guile/site/2.2${GUILE_LOAD_PATH:+:}${GUILE_LOAD_PATH}"
+        export GUILE_LOAD_COMPILED_PATH="$1/share/guile/site/2.2${GUILE_LOAD_COMPILED_PATH:+:}${GUILE_LOAD_COMPILED_PATH}"
     elif test -d "$1/share/guile/site"
     then
-        export GUILE_LOAD_PATH="${GUILE_LOAD_PATH}${GUILE_LOAD_PATH:+:}$1/share/guile/site"
-        export GUILE_LOAD_COMPILED_PATH="${GUILE_LOAD_COMPILED_PATH}${GUILE_LOAD_COMPILED_PATH:+:}$1/share/guile/site"
+        export GUILE_LOAD_PATH="$1/share/guile/site${GUILE_LOAD_PATH:+:}${GUILE_LOAD_PATH}"
+        export GUILE_LOAD_COMPILED_PATH="$1/share/guile/site${GUILE_LOAD_COMPILED_PATH:+:}${GUILE_LOAD_COMPILED_PATH}"
     fi
 }
 

--- a/pkgs/development/interpreters/guile/setup-hook.sh
+++ b/pkgs/development/interpreters/guile/setup-hook.sh
@@ -1,7 +1,7 @@
 addGuileLibPath () {
     if test -d "$1/share/guile/site"
     then
-        export GUILE_LOAD_PATH="${GUILE_LOAD_PATH}${GUILE_LOAD_PATH:+:}$1/share/guile/site"
+        export GUILE_LOAD_PATH="$1/share/guile/site${GUILE_LOAD_PATH:+:}${GUILE_LOAD_PATH}"
     fi
 }
 

--- a/pkgs/development/interpreters/jruby/default.nix
+++ b/pkgs/development/interpreters/jruby/default.nix
@@ -33,7 +33,7 @@ jruby = stdenv.mkDerivation rec {
      mkdir -p $out/nix-support
      cat > $out/nix-support/setup-hook <<EOF
        addGemPath() {
-         appendToSearchPath GEM_PATH \$1/${passthru.gemPath}
+         prependToSearchPath GEM_PATH \$1/${passthru.gemPath}
        }
 
        envHooks+=(addGemPath)

--- a/pkgs/development/interpreters/jruby/default.nix
+++ b/pkgs/development/interpreters/jruby/default.nix
@@ -33,7 +33,7 @@ jruby = stdenv.mkDerivation rec {
      mkdir -p $out/nix-support
      cat > $out/nix-support/setup-hook <<EOF
        addGemPath() {
-         addToSearchPath GEM_PATH \$1/${passthru.gemPath}
+         appendToSearchPath GEM_PATH \$1/${passthru.gemPath}
        }
 
        envHooks+=(addGemPath)

--- a/pkgs/development/interpreters/perl/setup-hook.sh
+++ b/pkgs/development/interpreters/perl/setup-hook.sh
@@ -1,5 +1,5 @@
 addPerlLibPath () {
-    appendToSearchPath PERL5LIB $1/lib/perl5/site_perl
+    prependToSearchPath PERL5LIB $1/lib/perl5/site_perl
 }
 
 envHooks+=(addPerlLibPath)

--- a/pkgs/development/interpreters/perl/setup-hook.sh
+++ b/pkgs/development/interpreters/perl/setup-hook.sh
@@ -1,5 +1,5 @@
 addPerlLibPath () {
-    addToSearchPath PERL5LIB $1/lib/perl5/site_perl
+    appendToSearchPath PERL5LIB $1/lib/perl5/site_perl
 }
 
 envHooks+=(addPerlLibPath)

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -279,7 +279,7 @@ let
             --replace '@PHP_LDFLAGS@' ""
         done
 
-        #[[ -z "$libxml2" ]] || addToSearchPath PATH $libxml2/bin
+        #[[ -z "$libxml2" ]] || appendToSearchPath PATH $libxml2/bin
 
         export EXTENSION_DIR=$out/lib/php/extensions
 

--- a/pkgs/development/interpreters/python/setup-hook.sh
+++ b/pkgs/development/interpreters/python/setup-hook.sh
@@ -1,5 +1,5 @@
 addPythonPath() {
-    addToSearchPathWithCustomDelimiter : PYTHONPATH $1/@sitePackages@
+    appendToSearchPathWithCustomDelimiter : PYTHONPATH $1/@sitePackages@
 }
 
 toPythonPath() {

--- a/pkgs/development/interpreters/python/setup-hook.sh
+++ b/pkgs/development/interpreters/python/setup-hook.sh
@@ -1,5 +1,5 @@
 addPythonPath() {
-    appendToSearchPathWithCustomDelimiter : PYTHONPATH $1/@sitePackages@
+    prependToSearchPathWithCustomDelimiter : PYTHONPATH $1/@sitePackages@
 }
 
 toPythonPath() {

--- a/pkgs/development/interpreters/python/setup-hook.sh
+++ b/pkgs/development/interpreters/python/setup-hook.sh
@@ -6,8 +6,8 @@ toPythonPath() {
     local paths="$1"
     local result=
     for i in $paths; do
-        p="$i/@sitePackages@"
-        result="${result}${result:+:}$p"
+        p="$i/@sitePackages@":
+        result="${p}${result:+:}${result}"
     done
     echo $result
 }

--- a/pkgs/development/interpreters/python/wrap.sh
+++ b/pkgs/development/interpreters/python/wrap.sh
@@ -17,7 +17,7 @@ buildPythonPath() {
     program_PYTHONPATH=
     program_PATH=
     pythonPathsSeen["@python@"]=1
-    addToSearchPath program_PATH @python@/bin
+    appendToSearchPath program_PATH @python@/bin
     for path in $pythonPath; do
         _addToPythonPath $path
     done
@@ -90,10 +90,10 @@ _addToPythonPath() {
     # Stop if we've already visited here.
     if [ -n "${pythonPathsSeen[$dir]}" ]; then return; fi
     pythonPathsSeen[$dir]=1
-    # addToSearchPath is defined in stdenv/generic/setup.sh. It will have
+    # appendToSearchPath is defined in stdenv/generic/setup.sh. It will have
     # the effect of calling `export program_X=$dir/...:$program_X`.
-    addToSearchPath program_PYTHONPATH $dir/lib/@libPrefix@/site-packages
-    addToSearchPath program_PATH $dir/bin
+    appendToSearchPath program_PYTHONPATH $dir/lib/@libPrefix@/site-packages
+    appendToSearchPath program_PATH $dir/bin
 
     # Inspect the propagated inputs (if they exist) and recur on them.
     local prop="$dir/nix-support/propagated-build-inputs"

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -139,7 +139,7 @@ let
           mkdir -p $out/nix-support
           cat > $out/nix-support/setup-hook <<EOF
           addGemPath() {
-            appendToSearchPath GEM_PATH \$1/${passthru.gemPath}
+            prependToSearchPath GEM_PATH \$1/${passthru.gemPath}
           }
 
           envHooks+=(addGemPath)

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -139,7 +139,7 @@ let
           mkdir -p $out/nix-support
           cat > $out/nix-support/setup-hook <<EOF
           addGemPath() {
-            addToSearchPath GEM_PATH \$1/${passthru.gemPath}
+            appendToSearchPath GEM_PATH \$1/${passthru.gemPath}
           }
 
           envHooks+=(addGemPath)

--- a/pkgs/development/libraries/SDL/setup-hook.sh
+++ b/pkgs/development/libraries/SDL/setup-hook.sh
@@ -1,11 +1,9 @@
 addSDLPath () {
-  if [ -e "$1/include/SDL" ]; then
-    export SDL_PATH="$SDL_PATH $1/include/SDL"
-  fi
+    prependToSearchPath SDL_PATH "1/include/SDL"
 }
 
 if test -n "$crossConfig"; then
-  crossEnvHooks+=(addSDLPath)
+    crossEnvHooks+=(addSDLPath)
 else
-  envHooks+=(addSDLPath)
+    envHooks+=(addSDLPath)
 fi

--- a/pkgs/development/libraries/SDL2/setup-hook.sh
+++ b/pkgs/development/libraries/SDL2/setup-hook.sh
@@ -1,7 +1,5 @@
 addSDL2Path () {
-  if [ -e "$1/include/SDL2" ]; then
-    export SDL2_PATH="$SDL2_PATH $1/include/SDL2"
-  fi
+  prependToSearchPath SDL2_PATH "$1/include/SDL2"
 }
 
 if test -n "$crossConfig"; then

--- a/pkgs/development/libraries/glib/setup-hook.sh
+++ b/pkgs/development/libraries/glib/setup-hook.sh
@@ -2,7 +2,7 @@
 make_glib_find_gsettings_schemas() {
     # For packages that need gschemas of other packages (e.g. empathy)
     if [ -d "$1"/share/gsettings-schemas/*/glib-2.0/schemas ]; then
-        appendToSearchPath GSETTINGS_SCHEMAS_PATH "$1/share/gsettings-schemas/"*
+        prependToSearchPath GSETTINGS_SCHEMAS_PATH "$1/share/gsettings-schemas/"*
     fi
 }
 envHooks+=(make_glib_find_gsettings_schemas)

--- a/pkgs/development/libraries/glib/setup-hook.sh
+++ b/pkgs/development/libraries/glib/setup-hook.sh
@@ -2,7 +2,7 @@
 make_glib_find_gsettings_schemas() {
     # For packages that need gschemas of other packages (e.g. empathy)
     if [ -d "$1"/share/gsettings-schemas/*/glib-2.0/schemas ]; then
-        addToSearchPath GSETTINGS_SCHEMAS_PATH "$1/share/gsettings-schemas/"*
+        appendToSearchPath GSETTINGS_SCHEMAS_PATH "$1/share/gsettings-schemas/"*
     fi
 }
 envHooks+=(make_glib_find_gsettings_schemas)
@@ -20,7 +20,7 @@ glibPreFixupPhase() {
         mv "${!outputLib}/share/glib-2.0/schemas" "${!outputLib}/share/gsettings-schemas/$name/glib-2.0/"
     fi
 
-    addToSearchPath GSETTINGS_SCHEMAS_PATH "${!outputLib}/share/gsettings-schemas/$name"
+    appendToSearchPath GSETTINGS_SCHEMAS_PATH "${!outputLib}/share/gsettings-schemas/$name"
 }
 preFixupPhases+=(glibPreFixupPhase)
 

--- a/pkgs/development/libraries/gobject-introspection/setup-hook.sh
+++ b/pkgs/development/libraries/gobject-introspection/setup-hook.sh
@@ -2,12 +2,12 @@ make_gobject_introspection_find_gir_files() {
 
     # required for .typelib files, eg mypaint git version
     if [ -d "$1/lib/girepository-1.0" ]; then
-      addToSearchPath GI_TYPELIB_PATH $1/lib/girepository-1.0
+      appendToSearchPath GI_TYPELIB_PATH $1/lib/girepository-1.0
     fi
 
     # XDG_DATA_DIRS: required for .gir files?
     if [ -d "$1/share" ]; then
-      addToSearchPath XDG_DATA_DIRS $1/share
+      appendToSearchPath XDG_DATA_DIRS $1/share
     fi
 }
 

--- a/pkgs/development/libraries/gobject-introspection/setup-hook.sh
+++ b/pkgs/development/libraries/gobject-introspection/setup-hook.sh
@@ -2,12 +2,12 @@ make_gobject_introspection_find_gir_files() {
 
     # required for .typelib files, eg mypaint git version
     if [ -d "$1/lib/girepository-1.0" ]; then
-      appendToSearchPath GI_TYPELIB_PATH $1/lib/girepository-1.0
+      prependToSearchPath GI_TYPELIB_PATH $1/lib/girepository-1.0
     fi
 
     # XDG_DATA_DIRS: required for .gir files?
     if [ -d "$1/share" ]; then
-      appendToSearchPath XDG_DATA_DIRS $1/share
+      prependToSearchPath XDG_DATA_DIRS $1/share
     fi
 }
 

--- a/pkgs/development/libraries/grantlee/5/setup-hook.sh
+++ b/pkgs/development/libraries/grantlee/5/setup-hook.sh
@@ -6,8 +6,8 @@ providesGrantleeRuntime() {
 
 _grantleeEnvHook() {
     if providesGrantleeRuntime "$1"; then
-        propagatedBuildInputs+=" $1"
-        propagatedUserEnvPkgs+=" $1"
+        propagatedBuildInputs="$1 $propagatedBuildInputs"
+        propagatedUserEnvPkgs="$1 $propagatedUserEnvPkgs"
     fi
 }
 if [ "$crossEnv" ]; then

--- a/pkgs/development/libraries/gstreamer/core/setup-hook.sh
+++ b/pkgs/development/libraries/gstreamer/core/setup-hook.sh
@@ -1,8 +1,5 @@
 addGstreamer1LibPath () {
-    if test -d "$1/lib/gstreamer-1.0"
-    then
-        export GST_PLUGIN_SYSTEM_PATH_1_0="${GST_PLUGIN_SYSTEM_PATH_1_0}${GST_PLUGIN_SYSTEM_PATH_1_0:+:}$1/lib/gstreamer-1.0"
-    fi
+    prependToSearchPathWithCustomDelimiter ' ' GST_PLUGIN_SYSTEM_PATH_1_0 "$1/lib/gstreamer-1.0"
 }
 
 envHooks+=(addGstreamer1LibPath)

--- a/pkgs/development/libraries/gstreamer/legacy/gstreamer/setup-hook.sh
+++ b/pkgs/development/libraries/gstreamer/legacy/gstreamer/setup-hook.sh
@@ -1,8 +1,5 @@
 addGstreamerLibPath () {
-    if test -d "$1/lib/gstreamer-0.10"
-    then
-        export GST_PLUGIN_SYSTEM_PATH="${GST_PLUGIN_SYSTEM_PATH}${GST_PLUGIN_SYSTEM_PATH:+:}$1/lib/gstreamer-0.10"
-    fi
+    prependToSearchPathWithCustomDelimiter GST_PLUGIN_SYSTEM_PATH "$1/lib/gstreamer-0.10"
 }
 
 envHooks+=(addGstreamerLibPath)

--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/setup-hook.sh
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/setup-hook.sh
@@ -1,6 +1,6 @@
 _ecmEnvHook() {
-    appendToSearchPath XDG_DATA_DIRS "$1/share"
-    appendToSearchPath XDG_CONFIG_DIRS "$1/etc/xdg"
+    prependToSearchPath XDG_DATA_DIRS "$1/share"
+    prependToSearchPath XDG_CONFIG_DIRS "$1/etc/xdg"
 }
 envHooks+=(_ecmEnvHook)
 

--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/setup-hook.sh
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/setup-hook.sh
@@ -1,6 +1,6 @@
 _ecmEnvHook() {
-    addToSearchPath XDG_DATA_DIRS "$1/share"
-    addToSearchPath XDG_CONFIG_DIRS "$1/etc/xdg"
+    appendToSearchPath XDG_DATA_DIRS "$1/share"
+    appendToSearchPath XDG_CONFIG_DIRS "$1/etc/xdg"
 }
 envHooks+=(_ecmEnvHook)
 

--- a/pkgs/development/libraries/kde-frameworks/kdoctools/setup-hook.sh
+++ b/pkgs/development/libraries/kde-frameworks/kdoctools/setup-hook.sh
@@ -1,5 +1,5 @@
 addXdgData() {
-    appendToSearchPath XDG_DATA_DIRS "$1/share"
+    prependToSearchPath XDG_DATA_DIRS "$1/share"
 }
 
 envHooks+=(addXdgData)

--- a/pkgs/development/libraries/kde-frameworks/kdoctools/setup-hook.sh
+++ b/pkgs/development/libraries/kde-frameworks/kdoctools/setup-hook.sh
@@ -1,5 +1,5 @@
 addXdgData() {
-    addToSearchPath XDG_DATA_DIRS "$1/share"
+    appendToSearchPath XDG_DATA_DIRS "$1/share"
 }
 
 envHooks+=(addXdgData)

--- a/pkgs/development/libraries/librep/setup-hook.sh
+++ b/pkgs/development/libraries/librep/setup-hook.sh
@@ -1,5 +1,5 @@
 addRepDLLoadPath () {
-    appendToSearchPath REP_DL_LOAD_PATH $1/lib/rep
+    prependToSearchPath REP_DL_LOAD_PATH $1/lib/rep
 }
 
 envHooks+=(addRepDLLoadPath)

--- a/pkgs/development/libraries/librep/setup-hook.sh
+++ b/pkgs/development/libraries/librep/setup-hook.sh
@@ -1,5 +1,5 @@
 addRepDLLoadPath () {
-    addToSearchPath REP_DL_LOAD_PATH $1/lib/rep
+    appendToSearchPath REP_DL_LOAD_PATH $1/lib/rep
 }
 
 envHooks+=(addRepDLLoadPath)

--- a/pkgs/development/libraries/physics/lhapdf/pdfset-hook.sh
+++ b/pkgs/development/libraries/physics/lhapdf/pdfset-hook.sh
@@ -1,5 +1,5 @@
 @name@ () {
-  addToSearchPath LHAPDF_DATA_PATH "@out@"
+  appendToSearchPath LHAPDF_DATA_PATH "@out@"
 }
 
 postHooks+=(@name@)

--- a/pkgs/development/libraries/physics/lhapdf/pdfset-hook.sh
+++ b/pkgs/development/libraries/physics/lhapdf/pdfset-hook.sh
@@ -1,5 +1,5 @@
 @name@ () {
-  appendToSearchPath LHAPDF_DATA_PATH "@out@"
+  prependToSearchPath LHAPDF_DATA_PATH "@out@"
 }
 
 postHooks+=(@name@)

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -22,8 +22,8 @@ export QMAKEMODULES
 
 addToQMAKEPATH() {
     if [ -d "$1/mkspecs" ]; then
-        QMAKEMODULES="${QMAKEMODULES}${QMAKEMODULES:+:}/mkspecs"
-        QMAKEPATH="${QMAKEPATH}${QMAKEPATH:+:}$1"
+        QMAKEMODULES="/mkspecs${QMAKEMODULES:+:}${QMAKEMODULES}"
+        QMAKEPATH="${1}${QMAKEPATH:+:}${QMAKEPATH}"
     fi
 }
 
@@ -37,9 +37,9 @@ qtEnvHook() {
     addToQMAKEPATH "$1"
     if providesQtRuntime "$1"; then
         if [ "z${!outputBin}" != "z${!outputDev}" ]; then
-            propagatedBuildInputs+=" $1"
+            propagatedBuildInputs="$1 $propagatedBuildInputs"
         fi
-        propagatedUserEnvPkgs+=" $1"
+        propagatedUserEnvPkgs="$1 $propagatedUserEnvPkgs"
     fi
 }
 if [ "$crossConfig" ]; then

--- a/pkgs/development/libraries/rep-gtk/setup-hook.sh
+++ b/pkgs/development/libraries/rep-gtk/setup-hook.sh
@@ -1,5 +1,5 @@
 addRepDLLoadPath () {
-    appendToSearchPath REP_DL_LOAD_PATH $1/lib/rep
+    prependToSearchPath REP_DL_LOAD_PATH $1/lib/rep
 }
 
 envHooks+=(addRepDLLoadPath)

--- a/pkgs/development/libraries/rep-gtk/setup-hook.sh
+++ b/pkgs/development/libraries/rep-gtk/setup-hook.sh
@@ -1,5 +1,5 @@
 addRepDLLoadPath () {
-    addToSearchPath REP_DL_LOAD_PATH $1/lib/rep
+    appendToSearchPath REP_DL_LOAD_PATH $1/lib/rep
 }
 
 envHooks+=(addRepDLLoadPath)

--- a/pkgs/development/libraries/slib/setup-hook.sh
+++ b/pkgs/development/libraries/slib/setup-hook.sh
@@ -1,12 +1,12 @@
 addSlibPath () {
     if test -f "$1/lib/slib/slibcat"
     then
-	export SCHEME_LIBRARY_PATH="$1/lib/slib/"
-	echo "SLIB found in \`$1'; setting \$SCHEME_LIBRARY_PATH to \`$SCHEME_LIBRARY_PATH'"
+	    export SCHEME_LIBRARY_PATH="$1/lib/slib/"
+	    echo "SLIB found in \`$1'; setting \$SCHEME_LIBRARY_PATH to \`$SCHEME_LIBRARY_PATH'"
 
-	# This is needed so that `(load-from-path "slib/guile.init")' works.
-	export GUILE_LOAD_PATH="$1/lib:$GUILE_LOAD_PATH"
-	echo "SLIB: setting \$GUILE_LOAD_PATH to \`$GUILE_LOAD_PATH'"
+	    # This is needed so that `(load-from-path "slib/guile.init")' works.
+	    export GUILE_LOAD_PATH="$1/lib${GUILE_LOAD_PATH:+:}${GUILE_LOAD_PATH}"
+	    echo "SLIB: prending \$GUILE_LOAD_PATH with \`$GUILE_LOAD_PATH'"
     fi
 }
 

--- a/pkgs/development/lisp-modules/clwrapper/setup-hook.sh
+++ b/pkgs/development/lisp-modules/clwrapper/setup-hook.sh
@@ -1,6 +1,6 @@
 NIX_LISP_ASDF="@out@"
 
-CL_SOURCE_REGISTRY="${CL_SOURCE_REGISTRY:+$CL_SOURCE_REGISTRY:}@out@/lib/common-lisp/asdf/"
+CL_SOURCE_REGISTRY="@out@/lib/common-lisp/asdf/${CL_SOURCE_REGISTRY:+:}${CL_SOURCE_REGISTRY}"
 
 addASDFPaths () {
     for j in "$1"/lib/common-lisp-settings/*-path-config.sh; do
@@ -25,7 +25,7 @@ setLisp () {
 
 collectNixLispLDLP () {
      if echo "$1/lib"/lib*.so* | grep . > /dev/null; then
-	 export NIX_LISP_LD_LIBRARY_PATH="$NIX_LISP_LD_LIBRARY_PATH${NIX_LISP_LD_LIBRARY_PATH:+:}$1/lib"
+	 export NIX_LISP_LD_LIBRARY_PATH="$1/lib${NIX_LISP_LD_LIBRARY_PATH:+:}${NIX_LISP_LD_LIBRARY_PATH}"
      fi
 }
 

--- a/pkgs/development/ocaml-modules/eliom/setup-hook.sh
+++ b/pkgs/development/ocaml-modules/eliom/setup-hook.sh
@@ -1,5 +1,5 @@
 addOcsigenDistilleryTemplate() {
-    addToSearchPathWithCustomDelimiter : ELIOM_DISTILLERY_PATH $1/eliom-distillery-templates
+    appendToSearchPathWithCustomDelimiter : ELIOM_DISTILLERY_PATH $1/eliom-distillery-templates
 }
 
 envHooks+=(addOcsigenDistilleryTemplate)

--- a/pkgs/development/ocaml-modules/eliom/setup-hook.sh
+++ b/pkgs/development/ocaml-modules/eliom/setup-hook.sh
@@ -1,5 +1,5 @@
 addOcsigenDistilleryTemplate() {
-    appendToSearchPathWithCustomDelimiter : ELIOM_DISTILLERY_PATH $1/eliom-distillery-templates
+    prependToSearchPathWithCustomDelimiter : ELIOM_DISTILLERY_PATH $1/eliom-distillery-templates
 }
 
 envHooks+=(addOcsigenDistilleryTemplate)

--- a/pkgs/development/pure-modules/generic-setup-hook.sh
+++ b/pkgs/development/pure-modules/generic-setup-hook.sh
@@ -1,2 +1,2 @@
-addToSearchPath PURE_INCLUDE $1/lib/pure
-addToSearchPath PURE_LIBRARY $1/lib/pure
+appendToSearchPath PURE_INCLUDE $1/lib/pure
+appendToSearchPath PURE_LIBRARY $1/lib/pure

--- a/pkgs/development/pure-modules/generic-setup-hook.sh
+++ b/pkgs/development/pure-modules/generic-setup-hook.sh
@@ -1,2 +1,2 @@
-appendToSearchPath PURE_INCLUDE $1/lib/pure
-appendToSearchPath PURE_LIBRARY $1/lib/pure
+prependToSearchPath PURE_INCLUDE $1/lib/pure
+prependToSearchPath PURE_LIBRARY $1/lib/pure

--- a/pkgs/development/ruby-modules/gem/gem-post-build.rb
+++ b/pkgs/development/ruby-modules/gem/gem-post-build.rb
@@ -45,9 +45,9 @@ end
 
 # add this gem to the GEM_PATH for dependencies
 File.open("#{out}/nix-support/setup-hook", "a") do |f|
-  f.puts("addToSearchPath GEM_PATH #{gem_home}")
+  f.puts("appendToSearchPath GEM_PATH #{gem_home}")
   spec.require_paths.each do |dir|
-    f.puts("addToSearchPath RUBYLIB #{install_path}/#{dir}")
+    f.puts("appendToSearchPath RUBYLIB #{install_path}/#{dir}")
   end
 end
 

--- a/pkgs/development/ruby-modules/gem/gem-post-build.rb
+++ b/pkgs/development/ruby-modules/gem/gem-post-build.rb
@@ -45,9 +45,9 @@ end
 
 # add this gem to the GEM_PATH for dependencies
 File.open("#{out}/nix-support/setup-hook", "a") do |f|
-  f.puts("appendToSearchPath GEM_PATH #{gem_home}")
+  f.puts("prependToSearchPath GEM_PATH #{gem_home}")
   spec.require_paths.each do |dir|
-    f.puts("appendToSearchPath RUBYLIB #{install_path}/#{dir}")
+    f.puts("prependToSearchPath RUBYLIB #{install_path}/#{dir}")
   end
 end
 

--- a/pkgs/development/ruby-modules/gem/nix-bundle-install.rb
+++ b/pkgs/development/ruby-modules/gem/nix-bundle-install.rb
@@ -152,6 +152,6 @@ end
 # make the lib available during bundler/git installs
 File.open("#{out}/nix-support/setup-hook", "a") do |f|
   spec.require_paths.each do |dir|
-    f.puts("addToSearchPath RUBYLIB #{source.install_path}/#{dir}")
+    f.puts("appendToSearchPath RUBYLIB #{source.install_path}/#{dir}")
   end
 end

--- a/pkgs/development/ruby-modules/gem/nix-bundle-install.rb
+++ b/pkgs/development/ruby-modules/gem/nix-bundle-install.rb
@@ -152,6 +152,6 @@ end
 # make the lib available during bundler/git installs
 File.open("#{out}/nix-support/setup-hook", "a") do |f|
   spec.require_paths.each do |dir|
-    f.puts("appendToSearchPath RUBYLIB #{source.install_path}/#{dir}")
+    f.puts("prependToSearchPath RUBYLIB #{source.install_path}/#{dir}")
   end
 end

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -1,5 +1,5 @@
 addCMakeParams() {
-    addToSearchPath CMAKE_PREFIX_PATH $1
+    appendToSearchPath CMAKE_PREFIX_PATH $1
 }
 
 fixCmakeFiles() {

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -1,5 +1,5 @@
 addCMakeParams() {
-    appendToSearchPath CMAKE_PREFIX_PATH $1
+    prependToSearchPath CMAKE_PREFIX_PATH $1
 }
 
 fixCmakeFiles() {

--- a/pkgs/development/tools/erlang/cuter/default.nix
+++ b/pkgs/development/tools/erlang/cuter/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   setupHook = writeText "setupHook.sh" ''
-    appendToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
+    prependToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
   '';
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/development/tools/erlang/cuter/default.nix
+++ b/pkgs/development/tools/erlang/cuter/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   setupHook = writeText "setupHook.sh" ''
-    addToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
+    appendToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
   '';
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/development/tools/misc/automake/setup-hook.sh
+++ b/pkgs/development/tools/misc/automake/setup-hook.sh
@@ -1,5 +1,5 @@
 addAclocals () {
-    addToSearchPathWithCustomDelimiter : ACLOCAL_PATH $1/share/aclocal
+    appendToSearchPathWithCustomDelimiter : ACLOCAL_PATH $1/share/aclocal
 }
 
 envHooks+=(addAclocals)

--- a/pkgs/development/tools/misc/automake/setup-hook.sh
+++ b/pkgs/development/tools/misc/automake/setup-hook.sh
@@ -1,5 +1,5 @@
 addAclocals () {
-    appendToSearchPathWithCustomDelimiter : ACLOCAL_PATH $1/share/aclocal
+    prependToSearchPathWithCustomDelimiter : ACLOCAL_PATH $1/share/aclocal
 }
 
 envHooks+=(addAclocals)

--- a/pkgs/development/tools/misc/pkgconfig/setup-hook.sh
+++ b/pkgs/development/tools/misc/pkgconfig/setup-hook.sh
@@ -1,6 +1,6 @@
 addPkgConfigPath () {
-    addToSearchPath PKG_CONFIG_PATH $1/lib/pkgconfig
-    addToSearchPath PKG_CONFIG_PATH $1/share/pkgconfig
+    appendToSearchPath PKG_CONFIG_PATH $1/lib/pkgconfig
+    appendToSearchPath PKG_CONFIG_PATH $1/share/pkgconfig
 }
 
 if test -n "$crossConfig"; then

--- a/pkgs/development/tools/misc/pkgconfig/setup-hook.sh
+++ b/pkgs/development/tools/misc/pkgconfig/setup-hook.sh
@@ -1,6 +1,6 @@
 addPkgConfigPath () {
-    appendToSearchPath PKG_CONFIG_PATH $1/lib/pkgconfig
-    appendToSearchPath PKG_CONFIG_PATH $1/share/pkgconfig
+    prependToSearchPath PKG_CONFIG_PATH $1/lib/pkgconfig
+    prependToSearchPath PKG_CONFIG_PATH $1/share/pkgconfig
 }
 
 if test -n "$crossConfig"; then

--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -31,9 +31,7 @@ stdenv.mkDerivation rec {
 
   setupHook = writeText "setupHook.sh" ''
     addOCamlPath () {
-        if test -d "''$1/lib/ocaml/${ocaml.version}/site-lib"; then
-            export OCAMLPATH="''${OCAMLPATH}''${OCAMLPATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/"
-        fi
+        prependToSearchPath OCAMLPATH "$1/lib/ocaml/${ocaml.version}/site-lib"
         export OCAMLFIND_DESTDIR="''$out/lib/ocaml/${ocaml.version}/site-lib/"
         if test -n "$createFindlibDestdir"; then
           mkdir -p $OCAMLFIND_DESTDIR

--- a/pkgs/development/web/nodejs/setup-hook.sh
+++ b/pkgs/development/web/nodejs/setup-hook.sh
@@ -1,5 +1,5 @@
 addNodePath () {
-    addToSearchPath NODE_PATH $1/lib/node_modules
+    appendToSearchPath NODE_PATH $1/lib/node_modules
 }
 
 envHooks+=(addNodePath)

--- a/pkgs/development/web/nodejs/setup-hook.sh
+++ b/pkgs/development/web/nodejs/setup-hook.sh
@@ -1,5 +1,5 @@
 addNodePath () {
-    appendToSearchPath NODE_PATH $1/lib/node_modules
+    prependToSearchPath NODE_PATH $1/lib/node_modules
 }
 
 envHooks+=(addNodePath)

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -173,7 +173,7 @@ trap "exitHandler" EXIT
 # Helper functions.
 
 
-addToSearchPathWithCustomDelimiter() {
+appendToSearchPathWithCustomDelimiter() {
     local delimiter="$1"
     local varName="$2"
     local dir="$3"
@@ -184,8 +184,8 @@ addToSearchPathWithCustomDelimiter() {
 
 PATH_DELIMITER=':'
 
-addToSearchPath() {
-    addToSearchPathWithCustomDelimiter "${PATH_DELIMITER}" "$@"
+appendToSearchPath() {
+    appendToSearchPathWithCustomDelimiter "${PATH_DELIMITER}" "$@"
 }
 
 
@@ -270,7 +270,7 @@ shopt -s nullglob
 PATH=
 for i in $initialPath; do
     if [ "$i" = / ]; then i=; fi
-    addToSearchPath PATH "$i/bin"
+    appendToSearchPath PATH "$i/bin"
 done
 
 if (( "${NIX_DEBUG:-0}" >= 1 )); then
@@ -348,7 +348,7 @@ activatePackage() {
     fi
 
     if [ -d "$pkg/bin" ]; then
-        addToSearchPath _PATH "$pkg/bin"
+        appendToSearchPath _PATH "$pkg/bin"
     fi
 
     if [ -f "$pkg/nix-support/setup-hook" ]; then

--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     fontPath=
     for i in $fontDirectories; do
       for j in $(find $i -name fonts.dir); do
-        addToSearchPathWithCustomDelimiter "," fontPath $(dirname $j)
+        appendToSearchPathWithCustomDelimiter "," fontPath $(dirname $j)
       done
     done
     sed -i -e '/^\$cmd \.= " -pn";/a$cmd .= " -fp '"$fontPath"'";' unix/vncserver

--- a/pkgs/tools/admin/tightvnc/default.nix
+++ b/pkgs/tools/admin/tightvnc/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     fontPath=
     for i in $fontDirectories; do
       for j in $(find $i -name fonts.dir); do
-        addToSearchPathWithCustomDelimiter "," fontPath $(dirname $j)
+        appendToSearchPathWithCustomDelimiter "," fontPath $(dirname $j)
       done
     done
 

--- a/pkgs/tools/bluetooth/obex-data-server/default.nix
+++ b/pkgs/tools/bluetooth/obex-data-server/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   patches = [ ./obex-data-server-0.4.6-build-fixes-1.patch ];
 
   preConfigure = ''
-  addToSearchPath PKG_CONFIG_PATH ${openobex}/lib64/pkgconfig
+  appendToSearchPath PKG_CONFIG_PATH ${openobex}/lib64/pkgconfig
   export PKG_CONFIG_PATH="${dbus_libs.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"
   '';
 

--- a/pkgs/tools/text/sgml/opensp/setup-hook.sh
+++ b/pkgs/tools/text/sgml/opensp/setup-hook.sh
@@ -1,7 +1,7 @@
 addSGMLCatalogs () {
       if test -d $1/sgml/dtd; then
           for i in $(find $1/sgml/dtd -name docbook.cat); do
-              export SGML_CATALOG_FILES="${SGML_CATALOG_FILES:+:}$i"
+              export SGML_CATALOG_FILES="$i${SGML_CATALOG_FILES:+:}${SGML_CATALOG_FILES}"
           done
       fi
 }

--- a/pkgs/tools/typesetting/tex/tetex/setup-hook.sh
+++ b/pkgs/tools/typesetting/tex/tetex/setup-hook.sh
@@ -1,7 +1,5 @@
 addTeXMFPath () {
-    if test -d "$1/share/texmf-nix"; then
-        export TEXINPUTS="${TEXINPUTS}${TEXINPUTS:+:}$1/share/texmf-nix//:"
-    fi
+    prependToSearchPath TEXINPUTS "$1/share/texmf-nix/"
 }
 
 envHooks+=(addTeXMFPath)

--- a/pkgs/tools/typesetting/tex/texlive/setup-hook.sh
+++ b/pkgs/tools/typesetting/tex/texlive/setup-hook.sh
@@ -1,7 +1,5 @@
 addTeXMFPath () {
-    if test -d "$1/share/texmf-nix"; then
-        export TEXINPUTS="${TEXINPUTS}${TEXINPUTS:+:}$1/share/texmf-nix//:"
-    fi
+    prependToSearchPath TEXINPUTS "$1/share/texmf-nix"
 }
 
 envHooks+=(addTeXMFPath)


### PR DESCRIPTION
###### Motivation for this change

This is intended to be reviewed commit-by-commit.

This does 2 things

1. Change the dependency order. Before, we did the current node before children, now we do the children before current node. Were dependencies forming a tree, this would simply be the inverse traversal, but since they in fact form a DAG, it's a bit more subtle. The opposite of the new invariant "dependencies before dependents" wasn't true: dependents weren't always processed first because it was possible that a dependency was already visited via another dependent.

   This is an observable change because the processing we are doing does not commute: arbitrary bash setup hooks certainly don't, and `PATH` concatenation doesn't either. I do think having this invariant is valuable, though, and rely on it to simplify cc-wrapper's setup hook.

2. Cyclic dependencies are now an error.  Yes, they are only possible in absurd cases, but possible nonetheless:
   ```
   └── /nix/store/asdfasdfasdf-foobar/
       ├── foo
       │   └── nix-support
       │       └── propagated-build-inputs = /nix/store/asdfasdfasdf-foobar/bar
       └── bar
           └── nix-support
               └── propagated-build-inputs = /nix/store/asdfasdfasdf-foobar/foo
   ```
   (`foo` and `bar` are cyclic). The old algo would silently work with this; the new one would naively diverge, so I made it error out instead as such a thing should never be intended. But if we agree this shouldn't happen in practice so infinite recursion is a good enough error, I can simplify things

###### Things done

~~Hoping to merge this **Monday 2017-11-13** at the latest :). Thanks!~~

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built stdenv on platform(s)
   - [ ] NixOS -- latest in progress, see nixborg build
   - [ ] macOS -- latest in progress
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---------

CC @bgamari