### PR TITLE
pythonPackages.titlecase: init at 0.12.0

### DIFF
--- a/pkgs/development/python-modules/titlecase/default.nix
+++ b/pkgs/development/python-modules/titlecase/default.nix
@@ -1,0 +1,21 @@
+{buildPythonPackage, lib, nose, fetchPypi}:
+
+buildPythonPackage rec {
+  pname = "titlecase";
+  name = "${pname}-${version}";
+  version = "0.12.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0486i99wf8ssa7sgn81fn6fv6i4rhhq6n751bc740b3hzfbpmpl4";
+  };
+
+  checkInputs = [ nose ];
+
+  meta = {
+    homepage = https://github.com/ppannuto/python-titlecase;
+    description = "Python Port of John Gruber's titlecase.pl";
+    license = lib.licenses.mit;
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -23280,6 +23280,7 @@ EOF
     };
   };
 
+  titlecase = callPackage ../development/python-modules/titlecase { };
 
   tracing = buildPythonPackage rec {
     name = "tracing-${version}";


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).