### PR TITLE
ebook2cw: init at 0.8.2

### DIFF
--- a/pkgs/applications/misc/ebook2cw/configfile.patch
+++ b/pkgs/applications/misc/ebook2cw/configfile.patch
@@ -1,0 +1,11 @@
+--- a/ebook2cw.c	2017-11-08 19:52:58.298131348 -0700
++++ b/ebook2cw.c	2017-11-08 19:53:02.588231067 -0700
+@@ -136,7 +136,7 @@
+ 	char isomap[256][4]; 		/* by these strings */
+ 	char utf8map[256][8];
+ 
+-	char configfile[1025];
++	char configfile[2048];
+ 
+ 	char id3_author[80],
+ 		id3_title[80],

--- a/pkgs/applications/misc/ebook2cw/default.nix
+++ b/pkgs/applications/misc/ebook2cw/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchsvn, lame, libvorbis }:
+
+stdenv.mkDerivation rec {
+
+  name = "ebook2cw-${version}";
+  version = "0.8.2";
+
+  src = fetchsvn {
+    url = "svn://svn.fkurz.net/ebook2cw/tags/${name}";
+    sha256 = "1mvp3nz3k76v757792n9b7fcm5jm3jcwarl1k7cila9fi0c2rsiw";
+  };
+
+  buildInputs = [ lame libvorbis ];
+
+  patches = [ ./configfile.patch ];
+
+  postPatch = ''
+    substituteInPlace Makefile --replace gcc cc
+  '';
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Convert ebooks to Morse MP3s/OGGs";
+    homepage = http://fkurz.net/ham/ebook2cw.html;
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ earldouglas ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -124,6 +124,8 @@ with pkgs;
 
   dump1090 = callPackage ../applications/misc/dump1090 { };
 
+  ebook2cw = callPackage ../applications/misc/ebook2cw { };
+
   vsenv = callPackage ../build-support/vsenv {
     vs = vs90wrapper;
   };


### PR DESCRIPTION
###### Motivation for this change

Allow Nix users to easily install and run ebook2cw

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

