### PR TITLE
vista-fonts-chs: init at 1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -111,6 +111,7 @@
   changlinli = "Changlin Li <mail@changlinli.com>";
   chaoflow = "Florian Friesdorf <flo@chaoflow.net>";
   chattered = "Phil Scott <me@philscotted.com>";
+  ChengCat = "Yucheng Zhang <yu@cheng.cat>";
   choochootrain = "Hurshal Patel <hurshal@imap.cc>";
   chpatrick = "Patrick Chilton <chpatrick@gmail.com>";
   chris-martin = "Chris Martin <ch.martin@gmail.com>";

--- a/pkgs/data/fonts/vista-fonts-chs/default.nix
+++ b/pkgs/data/fonts/vista-fonts-chs/default.nix
@@ -1,0 +1,36 @@
+{stdenv, fetchzip, cabextract}:
+
+# Modified from vista-fonts
+
+fetchzip {
+  name = "vista-fonts-chs-1";
+
+  url = http://download.microsoft.com/download/d/6/e/d6e2ff26-5821-4f35-a18b-78c963b1535d/VistaFont_CHS.EXE;
+
+  postFetch = ''
+    ${cabextract}/bin/cabextract --lowercase --filter '*.TTF' $downloadedFile
+
+    mkdir -p $out/share/fonts/truetype
+    cp *.ttf $out/share/fonts/truetype
+
+    # Set up no-op font configs to override any aliases set up by
+    # other packages.
+    mkdir -p $out/etc/fonts/conf.d
+    substitute ${./no-op.conf} $out/etc/fonts/conf.d/30-msyahei.conf \
+      --subst-var-by fontname "Microsoft YaHei"
+  '';
+
+  sha256 = "1zwrgck84k80gpg7493jdnxnv9ajxk5c7qndinnmqydnrw239zbw";
+
+  meta = {
+    description = "TrueType fonts from Microsoft Windows Vista For Simplified Chinese (Microsoft YaHei)";
+    homepage = https://www.microsoft.com/typography/fonts/family.aspx?FID=350;
+    license = stdenv.lib.licenses.unfree;
+    maintainers = [ stdenv.lib.maintainers.ChengCat ];
+
+    # Set a non-zero priority to allow easy overriding of the
+    # fontconfig configuration files.
+    priority = 5;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/data/fonts/vista-fonts-chs/no-op.conf
+++ b/pkgs/data/fonts/vista-fonts-chs/no-op.conf
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- This configuation is intentionally left empty in order to
+       override any other font package that may wish to set up an
+       alias for the @fontname@ font. If you actually do
+       want to have the alias then please change the priority of that
+       package; see the Nix manual page for nix-env for details. -->
+</fontconfig>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13598,6 +13598,8 @@ with pkgs;
 
   vistafonts = callPackage ../data/fonts/vista-fonts { };
 
+  vistafonts-chs = callPackage ../data/fonts/vista-fonts-chs { };
+
   wireless-regdb = callPackage ../data/misc/wireless-regdb { };
 
   wqy_microhei = callPackage ../data/fonts/wqy-microhei { };


### PR DESCRIPTION
###### Motivation for this change
Add fonts for Simplified Chinese.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

