### PR TITLE
openal-soft: 1.17.2 -> 1.18.2

### DIFF
--- a/pkgs/development/libraries/openal-soft/default.nix
+++ b/pkgs/development/libraries/openal-soft/default.nix
@@ -10,12 +10,12 @@ assert alsaSupport -> alsaLib != null;
 assert pulseSupport -> libpulseaudio != null;
 
 stdenv.mkDerivation rec {
-  version = "1.17.2";
+  version = "1.18.2";
   name = "openal-soft-${version}";
 
   src = fetchurl {
     url = "http://kcat.strangesoft.net/openal-releases/${name}.tar.bz2";
-    sha256 = "051k5fy8pk4fd9ha3qaqcv08xwbks09xl5qs4ijqq2qz5xaghhd3";
+    sha256 = "10kydm8701a2kppiss9sdidn1820cmzhqgx1b2bsa5dsgzic32lz";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change
Update to latest upstream version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (All working with the exception of [unvanquished](https://github.com/NixOS/nixpkgs/blob/master/pkgs/games/unvanquished/default.nix), which was also not working prior to this change.)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

