### PR TITLE
qdigidoc: fix build with glibc 2.26

### DIFF
--- a/pkgs/tools/security/qdigidoc/default.nix
+++ b/pkgs/tools/security/qdigidoc/default.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
                   openldap gettext desktop_file_utils makeWrapper
                 ];
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     description = "Qt based UI application for verifying and signing digital signatures";
     homepage = http://www.id.ee/;

--- a/pkgs/tools/security/qdigidoc/default.nix
+++ b/pkgs/tools/security/qdigidoc/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1a7nsi28q57ic99hrb6x83qlvpqvzvk6acbfl6ncny2j4yaxa4jl";
   };
 
-  patches = [ ./certs.patch ];
+  patches = [ ./certs.patch ./glibc-2_26.patch ];
 
   unpackPhase = ''
     mkdir src
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
                   hicolor_icon_theme libdigidocpp opensc shared_mime_info
                   openldap gettext desktop_file_utils makeWrapper
                 ];
-  
+
   meta = with stdenv.lib; {
     description = "Qt based UI application for verifying and signing digital signatures";
     homepage = http://www.id.ee/;

--- a/pkgs/tools/security/qdigidoc/glibc-2_26.patch
+++ b/pkgs/tools/security/qdigidoc/glibc-2_26.patch
@@ -1,0 +1,221 @@
+diff --git a/common/google-breakpad/src/client/linux/dump_writer_common/ucontext_reader.cc b/common/google-breakpad/src/client/linux/dump_writer_common/ucontext_reader.cc
+index b20a68b..38f1375 100644
+--- a/common/google-breakpad/src/client/linux/dump_writer_common/ucontext_reader.cc
++++ b/common/google-breakpad/src/client/linux/dump_writer_common/ucontext_reader.cc
+@@ -36,19 +36,19 @@ namespace google_breakpad {
+ 
+ // Minidump defines register structures which are different from the raw
+ // structures which we get from the kernel. These are platform specific
+-// functions to juggle the ucontext and user structures into minidump format.
++// functions to juggle the ucontext_t and user structures into minidump format.
+ 
+ #if defined(__i386__)
+ 
+-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.gregs[REG_ESP];
+ }
+ 
+-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.gregs[REG_EIP];
+ }
+ 
+-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
++void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                                     const struct _libc_fpstate* fp) {
+   const greg_t* regs = uc->uc_mcontext.gregs;
+ 
+@@ -88,15 +88,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
+ 
+ #elif defined(__x86_64)
+ 
+-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.gregs[REG_RSP];
+ }
+ 
+-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.gregs[REG_RIP];
+ }
+ 
+-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
++void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                                     const struct _libc_fpstate* fpregs) {
+   const greg_t* regs = uc->uc_mcontext.gregs;
+ 
+@@ -145,15 +145,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
+ 
+ #elif defined(__ARM_EABI__)
+ 
+-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.arm_sp;
+ }
+ 
+-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.arm_pc;
+ }
+ 
+-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc) {
++void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc) {
+   out->context_flags = MD_CONTEXT_ARM_FULL;
+ 
+   out->iregs[0] = uc->uc_mcontext.arm_r0;
+@@ -184,15 +184,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc) {
+ 
+ #elif defined(__aarch64__)
+ 
+-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.sp;
+ }
+ 
+-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.pc;
+ }
+ 
+-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
++void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                                     const struct fpsimd_context* fpregs) {
+   out->context_flags = MD_CONTEXT_ARM64_FULL;
+ 
+@@ -210,15 +210,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
+ 
+ #elif defined(__mips__)
+ 
+-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.gregs[MD_CONTEXT_MIPS_REG_SP];
+ }
+ 
+-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.pc;
+ }
+ 
+-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc) {
++void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc) {
+   out->context_flags = MD_CONTEXT_MIPS_FULL;
+ 
+   for (int i = 0; i < MD_CONTEXT_MIPS_GPR_COUNT; ++i)
+diff --git a/common/google-breakpad/src/client/linux/dump_writer_common/ucontext_reader.h b/common/google-breakpad/src/client/linux/dump_writer_common/ucontext_reader.h
+index b6e77b4..2de80b7 100644
+--- a/common/google-breakpad/src/client/linux/dump_writer_common/ucontext_reader.h
++++ b/common/google-breakpad/src/client/linux/dump_writer_common/ucontext_reader.h
+@@ -39,23 +39,23 @@
+ 
+ namespace google_breakpad {
+ 
+-// Wraps platform-dependent implementations of accessors to ucontext structs.
++// Wraps platform-dependent implementations of accessors to ucontext_t structs.
+ struct UContextReader {
+-  static uintptr_t GetStackPointer(const struct ucontext* uc);
++  static uintptr_t GetStackPointer(const ucontext_t* uc);
+ 
+-  static uintptr_t GetInstructionPointer(const struct ucontext* uc);
++  static uintptr_t GetInstructionPointer(const ucontext_t* uc);
+ 
+-  // Juggle a arch-specific ucontext into a minidump format
++  // Juggle a arch-specific ucontext_t into a minidump format
+   //   out: the minidump structure
+   //   info: the collection of register structures.
+ #if defined(__i386__) || defined(__x86_64)
+-  static void FillCPUContext(RawContextCPU *out, const ucontext *uc,
++  static void FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                              const struct _libc_fpstate* fp);
+ #elif defined(__aarch64__)
+-  static void FillCPUContext(RawContextCPU *out, const ucontext *uc,
++  static void FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                              const struct fpsimd_context* fpregs);
+ #else
+-  static void FillCPUContext(RawContextCPU *out, const ucontext *uc);
++  static void FillCPUContext(RawContextCPU *out, const ucontext_t *uc);
+ #endif
+ };
+ 
+diff --git a/common/google-breakpad/src/client/linux/handler/exception_handler.cc b/common/google-breakpad/src/client/linux/handler/exception_handler.cc
+index 3e2d196..b6d02ef 100644
+--- a/common/google-breakpad/src/client/linux/handler/exception_handler.cc
++++ b/common/google-breakpad/src/client/linux/handler/exception_handler.cc
+@@ -404,9 +404,9 @@ bool ExceptionHandler::HandleSignal(int sig, siginfo_t* info, void* uc) {
+   // Fill in all the holes in the struct to make Valgrind happy.
+   memset(&context, 0, sizeof(context));
+   memcpy(&context.siginfo, info, sizeof(siginfo_t));
+-  memcpy(&context.context, uc, sizeof(struct ucontext));
++  memcpy(&context.context, uc, sizeof(ucontext_t));
+ #if defined(__aarch64__)
+-  struct ucontext *uc_ptr = (struct ucontext*)uc;
++  ucontext_t* uc_ptr = (ucontext_t*)uc;
+   struct fpsimd_context *fp_ptr =
+       (struct fpsimd_context*)&uc_ptr->uc_mcontext.__reserved;
+   if (fp_ptr->head.magic == FPSIMD_MAGIC) {
+@@ -414,9 +414,9 @@ bool ExceptionHandler::HandleSignal(int sig, siginfo_t* info, void* uc) {
+   }
+ #elif !defined(__ARM_EABI__)  && !defined(__mips__)
+   // FP state is not part of user ABI on ARM Linux.
+-  // In case of MIPS Linux FP state is already part of struct ucontext
++  // In case of MIPS Linux FP state is already part of ucontext_t
+   // and 'float_state' is not a member of CrashContext.
+-  struct ucontext *uc_ptr = (struct ucontext*)uc;
++  ucontext_t* uc_ptr = (ucontext_t*)uc;
+   if (uc_ptr->uc_mcontext.fpregs) {
+     memcpy(&context.float_state,
+            uc_ptr->uc_mcontext.fpregs,
+@@ -440,7 +440,7 @@ bool ExceptionHandler::SimulateSignalDelivery(int sig) {
+   // ExceptionHandler::HandleSignal().
+   siginfo.si_code = SI_USER;
+   siginfo.si_pid = getpid();
+-  struct ucontext context;
++  ucontext_t context;
+   getcontext(&context);
+   return HandleSignal(sig, &siginfo, &context);
+ }
+diff --git a/common/google-breakpad/src/client/linux/handler/exception_handler.h b/common/google-breakpad/src/client/linux/handler/exception_handler.h
+index 591c310..42f4055 100644
+--- a/common/google-breakpad/src/client/linux/handler/exception_handler.h
++++ b/common/google-breakpad/src/client/linux/handler/exception_handler.h
+@@ -191,11 +191,11 @@ class ExceptionHandler {
+   struct CrashContext {
+     siginfo_t siginfo;
+     pid_t tid;  // the crashing thread.
+-    struct ucontext context;
++    ucontext_t context;
+ #if !defined(__ARM_EABI__) && !defined(__mips__)
+     // #ifdef this out because FP state is not part of user ABI for Linux ARM.
+-    // In case of MIPS Linux FP state is already part of struct
+-    // ucontext so 'float_state' is not required.
++    // In case of MIPS Linux FP state is already part of ucontext_t so
++    // 'float_state' is not required.
+     fpstate_t float_state;
+ #endif
+   };
+diff --git a/common/google-breakpad/src/client/linux/microdump_writer/microdump_writer.cc b/common/google-breakpad/src/client/linux/microdump_writer/microdump_writer.cc
+index 494e2a2..c00436b 100644
+--- a/common/google-breakpad/src/client/linux/microdump_writer/microdump_writer.cc
++++ b/common/google-breakpad/src/client/linux/microdump_writer/microdump_writer.cc
+@@ -328,7 +328,7 @@ class MicrodumpWriter {
+ 
+   void* Alloc(unsigned bytes) { return dumper_->allocator()->Alloc(bytes); }
+ 
+-  const struct ucontext* const ucontext_;
++  const ucontext_t* const ucontext_;
+ #if !defined(__ARM_EABI__) && !defined(__mips__)
+   const google_breakpad::fpstate_t* const float_state_;
+ #endif
+diff --git a/common/google-breakpad/src/client/linux/minidump_writer/minidump_writer.cc b/common/google-breakpad/src/client/linux/minidump_writer/minidump_writer.cc
+index 8406ffe..7e6fe52 100644
+--- a/common/google-breakpad/src/client/linux/minidump_writer/minidump_writer.cc
++++ b/common/google-breakpad/src/client/linux/minidump_writer/minidump_writer.cc
+@@ -1221,7 +1221,7 @@ class MinidumpWriter {
+   const int fd_;  // File descriptor where the minidum should be written.
+   const char* path_;  // Path to the file where the minidum should be written.
+ 
+-  const struct ucontext* const ucontext_;  // also from the signal handler
++  const ucontext_t* const ucontext_;  // also from the signal handler
+ #if !defined(__ARM_EABI__) && !defined(__mips__)
+   const google_breakpad::fpstate_t* const float_state_;  // ditto
+ #endif


### PR DESCRIPTION
###### Motivation for this change
While running `nox-review` on https://github.com/NixOS/nixpkgs/pull/31428 I noticed this was not  building.

Since glibc 2.26, `struct ucontext` no longer exists but is wrapped in a `typedef ucontext_t`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @jagajaga 