### PR TITLE
ccl: fix build with glibc 2.26

### DIFF
--- a/pkgs/development/compilers/ccl/default.nix
+++ b/pkgs/development/compilers/ccl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchsvn, gcc, glibc, m4, coreutils }:
+{ stdenv, fetchsvn, fetchpatch, gcc, glibc, m4, coreutils }:
 
 let
   options = rec {
@@ -39,12 +39,18 @@ stdenv.mkDerivation rec {
     sha256 = cfg.sha256;
   };
 
+  patches = fetchpatch {
+    name = "ccl-1.11-glibc-2.26.patch";
+    url = https://patch-diff.githubusercontent.com/raw/Clozure/ccl/pull/80.patch;
+    sha256 = "02v6287w0nppfpvkn9dyd5rvq2zkgd47ia9gs17hrww2hgzr6agd";
+  };
+
   buildInputs = [ gcc glibc m4 ];
 
   CCL_RUNTIME = cfg.runtime;
   CCL_KERNEL = cfg.kernel;
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace lisp-kernel/${CCL_KERNEL}/Makefile \
       --replace "svnversion" "echo ${revision}" \
       --replace "/bin/rm"    "${coreutils}/bin/rm" \


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
