### PR TITLE
meson: append install_rpath via patchelf

### DIFF
--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -9,6 +9,8 @@ python3Packages.buildPythonApplication rec {
     sha256 = "0qn5hyzvam3rimn7g3671s1igj7fbkwdnf5nc8jr4d5swy25mq61";
   };
 
+  patchPhase = "cat ${./depfixer_patchelf.py} >> mesonbuild/scripts/depfixer.py";
+
   postFixup = ''
     pushd $out/bin
     # undo shell wrapper as meson tools are called with python
@@ -16,10 +18,6 @@ python3Packages.buildPythonApplication rec {
       mv ".$i-wrapped" "$i"
     done
     popd
-  '';
-
-  postPatch = ''
-    sed -i -e 's|e.fix_rpath(install_rpath)||' mesonbuild/scripts/meson_install.py
   '';
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/development/tools/build-managers/meson/depfixer_patchelf.py
+++ b/pkgs/development/tools/build-managers/meson/depfixer_patchelf.py
@@ -1,0 +1,35 @@
+import subprocess
+
+def _patchelf(*args):
+    p = subprocess.Popen(['patchelf'] + list(args), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p.wait()
+    if p.returncode == 0:
+        return p.communicate()[0].rstrip()
+    else:
+        return None
+
+class PatchElf(Elf):
+    def print_soname(self):
+        print(_patchelf('--print-soname', self.bfile) or 'This file does not have a soname.')
+
+    def print_rpath(self):
+        print(_patchelf('--print-rpath', self.bfile) or 'This file does not have a runpath.')
+
+    def fix_rpath(self, install_rpath):
+        if install_rpath:
+            old_rpath = _patchelf('--print-rpath', self.bfile)
+            if old_rpath:
+                new_rpath = old_rpath + b':' + bytes(install_rpath, 'utf-8')
+                if len(old_rpath) < len(new_rpath):
+                    if self.verbose:
+                        print('Expanding rpath beyond original capacity, setting dontStrip:')
+                        print('https://github.com/NixOS/nixpkgs/pull/31228')
+                    open('.nix-dont-strip', 'a').close()
+            else:
+                new_rpath = install_rpath
+            _patchelf('--set-rpath', new_rpath, self.bfile)
+
+    def remove_rpath_entry(self):
+        _patchelf('--remove-rpath', self.bfile)
+
+Elf = PatchElf

--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -20,3 +20,13 @@ if [ -z "$dontUseMesonConfigure" -a -z "$configurePhase" ]; then
     setOutputFlags=
     configurePhase=mesonConfigurePhase
 fi
+
+mesonPreFixupPhase() {
+    for f in $(find . -name .nix-dont-strip); do
+        echo "Found $f, setting dontStrip"
+        export dontStrip=1
+        rm $f
+    done
+}
+
+preFixupPhases+=(mesonPreFixupPhase)


### PR DESCRIPTION
###### Motivation for this change

This is based on @jtojnar's work in #31228. When `patchelf` has to grow rpath beyond original capacity, it sets `dontStrip`, to work around NixOS/patchelf#10.
 
Fixes #31222. Currently in the process of rebuilding stuff with patched `meson`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

