### PR TITLE
Fix multiple cves

### DIFF
--- a/pkgs/development/libraries/libexif/default.nix
+++ b/pkgs/development/libraries/libexif/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gettext }:
+{ stdenv, fetchurl, fetchpatch, gettext }:
 
 stdenv.mkDerivation rec {
   name = "libexif-0.6.21";
@@ -7,6 +7,21 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/libexif/${name}.tar.bz2";
     sha256 = "06nlsibr3ylfwp28w8f5466l6drgrnydgxrm4jmxzrmk5svaxk8n";
   };
+
+  prePatch = let
+   patchName = "CVE-2017-7544.patch";
+   rawPatch = (fetchpatch {
+     name = "CVE-2017-7544.patch";
+     stripLen = 0;
+     url = https://sourceforge.net/p/libexif/bugs/_discuss/thread/fc394c4b/489a/attachment/xx.pat;
+     sha256 = "1qgk8hgnxr8d63jsc4vljxz9yg33mbml280dq4a6050rmk9wq4la";
+   });
+   in
+  ''
+    cp ${rawPatch} ${patchName}
+    sed -i 's|libexif/|${name}/libexif/|' ${patchName};
+    patches="${patchName}"
+  '';
 
   buildInputs = [ gettext ];
 

--- a/pkgs/development/libraries/libextractor/default.nix
+++ b/pkgs/development/libraries/libextractor/default.nix
@@ -7,11 +7,11 @@ assert gtkSupport -> glib != null && gtk3 != null;
 assert videoSupport -> ffmpeg != null && libmpeg2 != null;
 
 stdenv.mkDerivation rec {
-  name = "libextractor-1.4";
+  name = "libextractor-1.6";
 
   src = fetchurl {
     url = "mirror://gnu/libextractor/${name}.tar.gz";
-    sha256 = "0v7ns5jhsyp1wzvbaydfgxnva5zd63gkzm9djhckmam9liq824l4";
+    sha256 = "17gnpgspdhfgcr27j8sn9105vb4lw22yqdrhic62l79q5v5avm16";
   };
 
   preConfigure =

--- a/pkgs/development/libraries/qpdf/default.nix
+++ b/pkgs/development/libraries/qpdf/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchurl, pcre, zlib, perl }:
+{ stdenv, fetchurl, libjpeg, pcre, zlib, perl }:
 
-let version = "6.0.0";
+let version = "7.0.0";
 in
 stdenv.mkDerivation rec {
   name = "qpdf-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/qpdf/qpdf/${version}/${name}.tar.gz";
-    sha256 = "0csj2p2gkxrc0rk8ykymlsdgfas96vzf1dip3y1x7z1q9plwgzd9";
+    sha256 = "0py6p27fx4qrwq9mvcybna42b0bdi359x38lzmggxl5a9khqvl7y";
   };
 
   nativeBuildInputs = [ perl ];
 
-  buildInputs = [ pcre zlib ];
+  buildInputs = [ pcre zlib libjpeg ];
 
   postPatch = ''
     patchShebangs qpdf/fix-qdf

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchFromGitHub, fetchurl, pkgconfig, libusb, readline, libewf, perl, zlib, openssl,
+{stdenv, fetchFromGitHub, fetchurl, fetchpatch, pkgconfig, libusb, readline, libewf, perl, zlib, openssl,
 gtk2 ? null, vte ? null, gtkdialog ? null,
 python ? null,
 ruby ? null,
@@ -13,15 +13,23 @@ let
   inherit (stdenv.lib) optional;
 in
 stdenv.mkDerivation rec {
-  version = "2.0.0";
+  version = "2.0.1";
   name = "radare2-${version}";
 
   src = fetchFromGitHub {
     owner = "radare";
     repo = "radare2";
     rev = version;
-    sha256 = "1ahai9x6jc15wjzdbdkri3rc88ark2i5s8nv2pxcp0wwldvawlzi";
+    sha256 = "031ndvinsypagpkdszxjq0hj91ijq9zx4dzk53sz7il7s3zn65c7";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2017-15385.patch";
+      url = https://github.com/radare/radare2/commit/21a6f570ba33fa9f52f1bba87f07acc4e8c178f4.patch;
+      sha256 = "19qg5j9yr5r62nrq2b6mscxsz0wyyfah2z5jz8dvj9kqxq186d43";
+    })
+  ];
 
   postPatch = let
     cs_ver = "3.0.4"; # version from $sourceRoot/shlr/Makefile

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPackages, fetchurl
+{ stdenv, lib, buildPackages, fetchurl, fetchpatch
 , enableStatic ? false
 , enableMinimal ? false
 , useMusl ? false, musl
@@ -39,7 +39,19 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ] ++ lib.optionals enableStatic [ "fortify" ];
 
-  patches = [ ./busybox-in-store.patch ];
+  patches = [
+    ./busybox-in-store.patch 
+    (fetchpatch {
+      name = "CVE-2017-15873.patch";
+      url = "https://git.busybox.net/busybox/patch/?id=0402cb32df015d9372578e3db27db47b33d5c7b0";
+      sha256 = "1s3xqifd0dww19mbnzrks0i1az0qwd884sxjzrx33d6a9jxv4dzn";
+    })
+    (fetchpatch {
+      name = "CVE-2017-15874.patch";
+      url = "https://git.busybox.net/busybox/patch/?id=9ac42c500586fa5f10a1f6d22c3f797df11b1f6b";
+      sha256 = "0169p4ylz9zd14ghhb39yfjvbdca2kb21pphylfh9ny7i484ahql";
+    })
+  ];
 
   configurePhase = ''
     export KCONFIG_NOTIMESTAMP=1

--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lua }:
+{ stdenv, fetchurl, fetchpatch, lua }:
 
 stdenv.mkDerivation rec {
   version = "4.0.2";
@@ -8,6 +8,14 @@ stdenv.mkDerivation rec {
     url = "http://download.redis.io/releases/${name}.tar.gz";
     sha256 = "04s8cgvwjj1979s3hg8zkwc9pyn3jkjpz5zidp87kfcipifr385i";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2017-15047.patch";
+      url = https://github.com/antirez/redis/commit/ffcf7d5ab1e98d84c28af9bea7be76c6737820ad.patch;
+      sha256 = "0cgx3lm0n7jxhsly8v9hdvy6vlamj3ck2jsid4fwyapz6907h64l";
+    })
+  ];
 
   buildInputs = [ lua ];
   makeFlags = "PREFIX=$(out)";

--- a/pkgs/tools/backup/partclone/default.nix
+++ b/pkgs/tools/backup/partclone/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "partclone-${version}";
-  version = "0.2.89";
+  version = "0.3.11";
 
   src = fetchFromGitHub {
     owner = "Thomas-Tsai";
     repo = "partclone";
     rev = version;
-    sha256 = "0gw47pchqshhm00yf34qgxh6bh2jfryv0sm7ghwn77bv5gzwr481";
+    sha256 = "1gw47pchqshhm00yf34qgxh6bh2jfryv0sm7ghwn77bv5gzwr481";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/tools/compression/rzip/default.nix
+++ b/pkgs/tools/compression/rzip/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, bzip2}:
+{stdenv, fetchurl, fetchpatch, bzip2}:
 
 stdenv.mkDerivation {
   name = "rzip-2.1";
@@ -7,6 +7,14 @@ stdenv.mkDerivation {
     sha256 = "4bb96f4d58ccf16749ed3f836957ce97dbcff3e3ee5fd50266229a48f89815b7";
   };
   buildInputs = [ bzip2 ];
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2017-8364-fill-buffer.patch";
+      url = https://sources.debian.net/data/main/r/rzip/2.1-4.1/debian/patches/80-CVE-2017-8364-fill-buffer.patch;
+      sha256 = "0jcjlx9ksdvxvjyxmyzscx9ar9992iy5icw0sc3n0p09qi4d6x1r";
+    })
+  ];
 
   meta = {
     homepage = http://rzip.samba.org/;

--- a/pkgs/tools/security/yara/default.nix
+++ b/pkgs/tools/security/yara/default.nix
@@ -5,14 +5,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.6.0";
+  version = "3.6.3";
   name = "yara-${version}";
 
   src = fetchFromGitHub {
     owner = "VirusTotal";
     repo = "yara";
     rev = "v${version}";
-    sha256 = "05nadqpvihdyxym11mn6n02rzv2ng8ga7j9l0g5gnjx366gcai42";
+    sha256 = "13znbdwin9lvql43wpms5hh13h8rk5x5wajgmphz18rxwp8h7j78";
   };
 
   # FIXME: this is probably not the right way to make it work


### PR DESCRIPTION
###### Motivation for this change

I created a new tool to generate a list of packages affected by CVEs and started working through the list for the unstable channel.
This is just the ones that seemed fixable and where proper upstream commits/patches could be found.
The complete list from my WIP tool can be found [here](https://epsilon.rammhold.de/andi/nix-updates/).

Some of the commits might be worth backporting to stable.

- e8a3ce0 busybox
- 0b4e8b9 libexif
- f8b53a7 redis
- 4b759a0 rzip
- e15d6e1 yara (minor version bump)
- 8312eaf radare2 (minor version bump + patch)

I am not so sure about the others since they might involve bumping versions. Is that something we do for an already released stable version?


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

