### PR TITLE
mendeley: 1.17.10 -> 1.17.11

### DIFF
--- a/pkgs/applications/office/mendeley/default.nix
+++ b/pkgs/applications/office/mendeley/default.nix
@@ -37,14 +37,14 @@ let
     then "i386"
     else "amd64";
 
-  shortVersion = "1.17.10-stable";
+  shortVersion = "1.17.11-stable";
 
   version = "${shortVersion}_${arch}";
 
   url = "http://desktop-download.mendeley.com/download/apt/pool/main/m/mendeleydesktop/mendeleydesktop_${version}.deb";
   sha256 = if stdenv.system == arch32
-    then "0sc9fsprdpl39q8wqbjp59pnr10c1a8gss60b81h54agjni55yrg"
-    else "02ncfdxcrdwghpch2nlfhc7d0vgjsfqn8sxjkb5yn4bf5wi8z9bq";
+    then "033855ix5qj1gwd3pa6qws5k94hgbp6rvibrrxl3rn5bvhrvvbkq"
+    else "09h6br8qhvphkvzy28y1pnh7dhyigb3w41w3kjwqj6027i46chi7";
 
   deps = [
     qt5.qtbase


### PR DESCRIPTION
###### Motivation for this change

Overdue minor update.  Been using for months, sorry O:).

Depends on qtwebkit 5.6 which is currently failing to build.

The same commit on top of 17.09 is here, if that's useful for testing:

https://github.com/dtzWill/nixpkgs/tree/update/17.09/mendeley-1.17.11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

