### PR TITLE
jenkins: 2.88 -> 2.89

### DIFF
--- a/pkgs/development/tools/continuous-integration/jenkins/default.nix
+++ b/pkgs/development/tools/continuous-integration/jenkins/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "jenkins-${version}";
-  version = "2.88";
+  version = "2.89";
 
   src = fetchurl {
     url = "http://mirrors.jenkins-ci.org/war/${version}/jenkins.war";
-    sha256 = "062hnbyj73311sxhkwla6sl33zb43v8p7hjssgbh0bfvgmnlayim";
+    sha256 = "07dphsa093lcs9fk8g8f2ll7mkicrkg44pr5w8sl3dbrchb1ymg7";
   };
 
   buildCommand = ''


### PR DESCRIPTION
###### Motivation for this change

* Updates Jenkins to the [latest release](https://jenkins.io/changelog/#v2.89)
* Gets rid of the nag message in Jenkins about downloading the latest *jenkins.war* file

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---