### PR TITLE
linux_tegra: init

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-tegra.nix
+++ b/pkgs/os-specific/linux/kernel/linux-tegra.nix
@@ -1,0 +1,16 @@
+{ stdenv, hostPlatform, fetchgit, perl, buildLinux, ... } @ args:
+
+import ./generic.nix (args // rec {
+  modDirVersion = "4.13.0-rc1";
+  version = "${modDirVersion}-linux-tegra";
+  extraMeta.branch = "4.13";
+
+  src = fetchgit {
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/tegra/linux.git";
+    rev = "20e72aa386b007d96d1ce444ffc6152baf9dcb2f";
+    sha256 = "1xd0fr7hpfa9f7nfr06flbi74ilcf4lrsrgf5q5fnyv2ryzix14k";
+  };
+
+  extraMeta.hydraPlatforms = [];
+
+} // (args.argsOverride or {}))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12456,6 +12456,17 @@ with pkgs;
     ];
   };
 
+  linux_tegra = callPackage ../os-specific/linux/kernel/linux-tegra.nix {
+    kernelPatches =
+      [ kernelPatches.bridge_stp_helper
+        kernelPatches.p9_fixes
+        # See pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/README.md
+        # when adding a new linux version
+        kernelPatches.cpu-cgroup-v2."4.11"
+        kernelPatches.modinst_arg_list_too_long
+      ];
+  };
+
   linux_4_4 = callPackage ../os-specific/linux/kernel/linux-4.4.nix {
     kernelPatches =
       [ kernelPatches.bridge_stp_helper
@@ -12693,6 +12704,7 @@ with pkgs;
   linuxPackages_hardened_copperhead = linuxPackagesFor pkgs.linux_hardened_copperhead;
   linuxPackages_mptcp = linuxPackagesFor pkgs.linux_mptcp;
   linuxPackages_rpi = linuxPackagesFor pkgs.linux_rpi;
+  linuxPackages_tegra = linuxPackagesFor pkgs.linux_tegra;
   linuxPackages_4_4 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_4);
   linuxPackages_4_9 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_9);
   linuxPackages_4_13 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_13);


### PR DESCRIPTION
(Requesting review from @dezgeg)

###### Motivation for this change

This tracks the kernel.org kernel for Nvidia's ARM-based Tegra SoCs and dev boards. Tegra fixes and enhancements are often available here long before they're merged into the mainline kernel.

I've been running this kernel on both an Nvidia Jetson TK1 and a Jetson TX1 for several months. The machines are `armv7l-linux` and `aarch64-linux` build servers, respectively, for my NixOps deployments, and have been under occasional very heavy load with no issues. (The TK1's built-in NIC does hang from time to time, but this also happens on the mainline kernel. It appears to be an issue with the RealTek chipset, not a Tegra-specific problem. I have replaced it with an ASIX-based USB 3.0 Ethernet adapter, which works great.) 

The TX1's filesystem is hosted on an NVMe device on PCIe riser card, which is nice. (The TK1 runs off an SD card.)

Unfortunately, this kernel does not yet work on my Jetson TX2, but I will continue trying new versions until I can get one that does.

Note that the `linux-tegra` fork updates fairly infrequently, and often with many commits at once. The particular revision used in this commit is a few months old. The latest `linux-tegra` changes as of a few days ago did not work for me, but I try new ones from time to time and am willing to continue maintaining this derivation as long as I'm running NixOS on Jetsons, which should be for the foreseeable future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

