### PR TITLE
meson: pass library install paths to g-ir-scanner

### DIFF
--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -18,6 +18,15 @@ python3Packages.buildPythonApplication rec {
     popd
   '';
 
+  patches = [
+    # Unlike libtool, vanilla Meson does not pass any information
+    # about the path library will be installed to to g-ir-scanner,
+    # breaking the GIR when path other than ${!outputLib}/lib is used.
+    # We patch Meson to add a --fallback-library-path argument with
+    # library install_dir to g-ir-scanner.
+    ./gir-fallback-path.patch
+  ];
+
   postPatch = ''
     sed -i -e 's|e.fix_rpath(install_rpath)||' mesonbuild/scripts/meson_install.py
   '';

--- a/pkgs/development/tools/build-managers/meson/gir-fallback-path.patch
+++ b/pkgs/development/tools/build-managers/meson/gir-fallback-path.patch
@@ -1,0 +1,13 @@
+--- a/mesonbuild/modules/gnome.py
++++ b/mesonbuild/modules/gnome.py
+@@ -427,6 +427,10 @@
+         scan_command += ['--no-libtool', '--namespace=' + ns, '--nsversion=' + nsversion, '--warn-all',
+                          '--output', '@OUTPUT@']
+ 
++        fallback_libpath = girtarget.get_custom_install_dir()[0]
++        if fallback_libpath is not None and isinstance(fallback_libpath, str) and len(fallback_libpath) > 0 and fallback_libpath[0] == "/":
++            scan_command += ['--fallback-library-path=' + fallback_libpath]
++
+         header = kwargs.pop('header', None)
+         if header:
+             if not isinstance(header, str):


### PR DESCRIPTION
###### Motivation for this change
We are patching g-ir-scanner to produce absolute paths in the GIR files. When an application uses an internal library placed in a non-standard path (e.g. $out/lib/gnome-shell), the scanner needs to be informed. For autotools-based apps, the full path was obtained from libtool-wrapped files; with Meson, this is no longer possible – we need to pass the path information in some other way.

This commit channels the `--fallback-library-path` option added to g-ir-scanner in aforementioned patch.

This is part of GNOME 3.26 update (#29392) and it is required for GNOME Shell and Polari.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @aszlig (author of `--fallback-library-path` option in the [gobjectIntospection patch](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch))
cc @mbe, @rasendubi (meson maintainers)