### PR TITLE
rstudio: fix build error about missing qt plugin

### DIFF
--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchurl, fetchpatch, makeDesktopItem, cmake, boost, zlib, openssl,
-R, qt5, libuuid, hunspellDicts, unzip, ant, jdk, gnumake, makeWrapper, pandoc
+{ stdenv, fetchurl, fetchpatch, makeDesktopItem, cmake, boost, zlib, openssl
+, R, qtbase, qtwebkit, qtwebchannel, libuuid, hunspellDicts, unzip, ant, jdk
+, gnumake, makeWrapper, pandoc
 }:
 
 let
@@ -12,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake unzip ant jdk makeWrapper pandoc ];
 
-  buildInputs = [ boost zlib openssl R qt5.full qt5.qtwebkit qt5.qtwebchannel libuuid ];
+  buildInputs = [ boost zlib openssl R qtbase qtwebkit qtwebchannel libuuid ];
 
   src = fetchurl {
     url = "https://github.com/rstudio/rstudio/archive/v${version}.tar.gz";


### PR DESCRIPTION
###### Motivation for this change

RStudio failed to build after fe0ab944db2176e6757ae89aeebea16ab8dc69d0 (pr #31357)

part of build log:
```
CMake Error at /nix/store/dz9488m52zgf8p36q9qji5xga50pbisd-qt-5.9.1/lib/cmake/Qt5Gui/Qt5GuiConfig.cmake:13 (message):
  The imported target "Qt5::Gui" references the file

     "/nix/store/1m2paiq8z7g9vz3gykw44yimqb6v6109-qtbase-5.9.1-bin/lib/qt-5.9/plugins/imageformats/libqicns.so"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     "/nix/store/dz9488m52zgf8p36q9qji5xga50pbisd-qt-5.9.1/lib/cmake/Qt5Gui/Qt5Gui_QICNSPlugin.cmake"

  but not all the files it references.
```
The log says it cannot find `libqicns.so`, which is a library provided by `qtimageformats`.

I guess the error is caused by the incorrect way to specify qt dependencies, this commit fixes it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

