### PR TITLE
ibus-with-plugins: fix ibus-setup

### DIFF
--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -66,6 +66,15 @@ in stdenv.mkDerivation rec {
     sha256 = "07py16jb81kd7vkqhcia9cb2avsbg5jswp2kzf0k4bprwkxppd9n";
   };
 
+  patches = [
+    # The ibus-with-plugins wrapper will set an environment variable so that
+    # `ibus-daemon` knows where to find `ibus-setup`.
+    # This patches the pre-generated C code (generated from the original Vala
+    # source); if we want to support compilation of the original Vala source,
+    # we'll need to rework this patch.
+    ./setup-patch.patch
+  ];
+
   postPatch = ''
     # These paths will be set in the wrapper.
     sed -e "/export IBUS_DATAROOTDIR/ s/^.*$//" \
@@ -116,8 +125,10 @@ in stdenv.mkDerivation rec {
   doInstallCheck = true;
   installCheckPhase = "$out/bin/ibus version";
 
+  # The ibus-with-plugins wrapper will provide the ibus-setup executable.
+  # This is done to keep the closure small.
   postInstall = ''
-    moveToOutput "bin/ibus-setup" "$dev"
+    rm "$out/bin/ibus-setup"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/inputmethods/ibus/setup-patch.patch
+++ b/pkgs/tools/inputmethods/ibus/setup-patch.patch
@@ -1,0 +1,13 @@
+diff --git a/ui/gtk3/panel.c b/ui/gtk3/panel.c
+index f1a8eea..1fc8ce9 100644
+--- a/ui/gtk3/panel.c
++++ b/ui/gtk3/panel.c
+@@ -4527,7 +4527,7 @@ static void panel_show_setup_dialog (Panel* self) {
+ 		}
+ 		self->priv->m_setup_pid = (GPid) 0;
+ 	}
+-	_tmp3_ = g_build_filename (BINDIR, "ibus-setup", NULL);
++	_tmp3_ = g_build_filename (getenv("NIX_IBUS_SETUP_PATH"), NULL);
+ 	binary = _tmp3_;
+ 	{
+ 		const gchar* _tmp4_;


### PR DESCRIPTION
This makes ibus-daemon find ibus-setup through a env var,
so we can continue to leave Python out of the ibus closure.

###### Motivation for this change

Fixes: #31454, #30265

Related to: #31094

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

