### PR TITLE
firmware-linux-nonfree: 2017-07-05 -> 2017-10-09-iwlwifi-fw-2017-11-03

### DIFF
--- a/pkgs/os-specific/linux/firmware/firmware-linux-nonfree/default.nix
+++ b/pkgs/os-specific/linux/firmware/firmware-linux-nonfree/default.nix
@@ -1,22 +1,47 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchgit, runCommand, git, cacert, gnupg }:
 
 stdenv.mkDerivation rec {
   name = "firmware-linux-nonfree-${version}";
-  version = "2017-07-05";
+  version = "2017-10-09-${src.iwlRev}";
 
-  # This repo is built by merging the latest versions of
+  # The src runCommand automates the process of building a merged repository of both
+  #
   # http://git.kernel.org/cgit/linux/kernel/git/firmware/linux-firmware.git/
-  # and
   # http://git.kernel.org/cgit/linux/kernel/git/iwlwifi/linux-firmware.git/
-  # for any given date. This gives us up to date iwlwifi firmware as well as
+  #
+  # This gives us up to date iwlwifi firmware as well as
   # the usual set of firmware. firmware/linux-firmware usually lags kernel releases
   # so iwlwifi cards will fail to load on newly released kernels.
-  src = fetchFromGitHub {
-    owner = "fpletz";
-    repo = "linux-firmware";
-    rev = version;
-    sha256 = "0vlk043y7c32g4d9hz93j64x372qqrwsq65mh8s5s5xrvamja2if";
-  };
+  #
+  # To update, go to the above repositories and look for latest tags / commits, then
+  # update version to the more recent commit date
+
+  src = runCommand "firmware-linux-nonfree-src-merged-${version}" {
+    # When updating this, you need to let it run with a wrong hash, in order to find out the desired hash
+    baseRev = "bf04291309d3169c0ad3b8db52564235bbd08e30";
+    iwlRev = "iwlwifi-fw-2017-11-03";
+
+    # randomly mutate the hash to break out of fixed hash, when updating
+    outputHash = "11izv1vpq9ixlqdss19lzs5q289d7jxr5kgf6iymk4alxznffd8z";
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    buildInputs = [ git gnupg ];
+    NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  } ''
+    git init src && (
+      cd src
+      git config user.email "build-daemon@nixos.org"
+      git config user.name "Nixos Build Daemon $name"
+      git remote add base git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
+      git remote add iwl git://git.kernel.org/pub/scm/linux/kernel/git/iwlwifi/linux-firmware.git
+      git fetch base $baseRev
+      git checkout -b work FETCH_HEAD
+      git fetch iwl $iwlRev
+      git merge FETCH_HEAD)
+    rm -rf src/.git
+    cp -a src $out
+  '';
 
   preInstall = ''
     mkdir -p $out


### PR DESCRIPTION
###### Motivation for this change

- update and automate merging

The automated merging process should eliminate the need for keeping a
nixos-specific merged repository around

fixes #29806

###### Things done

Wrote a little fixed-hash derivation for git-fetch-merging the source. Should ease the maintenance burden a bit.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

