### PR TITLE
neovim: 0.2.0 -> 0.2.1

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, gettext, libmsgpack, libtermkey
-, libtool, libuv, luajit, luajitPackages, luaPackages, ncurses, perl, pkgconfig
+, libtool, libuv, luaPackages, ncurses, perl, pkgconfig
 , unibilium, makeWrapper, vimUtils, xsel, gperf
 
 , withPython ? true, pythonPackages, extraPythonPackages ? []
@@ -19,13 +19,13 @@ let
   # Note: this is NOT the libvterm already in nixpkgs, but some NIH silliness:
   neovimLibvterm = stdenv.mkDerivation rec {
     name = "neovim-libvterm-${version}";
-    version = "2016-10-07";
+    version = "2017-11-05";
 
     src = fetchFromGitHub {
       owner = "neovim";
       repo = "libvterm";
-      rev = "5a748f97fbf27003e141002b58933a99f3addf8d";
-      sha256 = "1fnd57f5n9h7z50a4vj7g96k6ndsdknjqsibgnxi9ndhyz244qbx";
+      rev = "4ca7ebf7d25856e90bc9d9cc49412e80be7c4ea8";
+      sha256 = "05kyvvz8af90mvig11ya5xd8f4mbvapwyclyrihm9lwas706lzf6";
     };
 
     buildInputs = [ perl ];
@@ -81,13 +81,13 @@ let
 
   neovim = stdenv.mkDerivation rec {
     name = "neovim-${version}";
-    version = "0.2.0";
+    version = "0.2.1";
 
     src = fetchFromGitHub {
       owner = "neovim";
       repo = "neovim";
       rev = "v${version}";
-      sha256 = "0fhjkgjwqqmzbfn9wk10l2vq9v74zkriz5j12b1rx0gdwzlfybn8";
+      sha256 = "19ppj0i59kk70j09gap6azm0jm4y95fr5fx7n9gx377y3xjs8h03";
     };
 
     enableParallelBuilding = true;
@@ -99,7 +99,6 @@ let
       ncurses
       neovimLibvterm
       unibilium
-      luajit
       luaPackages.lua
       gperf
     ] ++ optional withJemalloc jemalloc
@@ -115,7 +114,7 @@ let
     LUA_PATH = stdenv.lib.concatStringsSep ";" (map luaPackages.getLuaPath lualibs);
     LUA_CPATH = stdenv.lib.concatStringsSep ";" (map luaPackages.getLuaCPath lualibs);
 
-    lualibs = [ luaPackages.mpack luaPackages.lpeg luajitPackages.lpeg luaPackages.luabitop ];
+    lualibs = [ luaPackages.mpack luaPackages.lpeg luaPackages.luabitop ];
 
     cmakeFlags = [
       "-DLUA_PRG=${luaPackages.lua}/bin/lua"
@@ -163,7 +162,7 @@ let
       # those contributions were copied from Vim (identified in the commit logs
       # by the vim-patch token). See LICENSE for details."
       license = with licenses; [ asl20 vim ];
-      maintainers = with maintainers; [ manveru garbas ];
+      maintainers = with maintainers; [ manveru garbas rvolosatovs ];
       platforms   = platforms.unix;
     };
   };

--- a/pkgs/applications/editors/neovim/neovim-remote.nix
+++ b/pkgs/applications/editors/neovim/neovim-remote.nix
@@ -4,7 +4,7 @@ with stdenv.lib;
 
 pythonPackages.buildPythonPackage rec {
   name = "neovim-remote-${version}";
-  version = "v1.6.0";
+  version = "v1.8.6";
   disabled = !pythonPackages.isPy3k;
 
   src = fetchFromGitHub {

--- a/pkgs/applications/editors/neovim/ruby_provider/Gemfile.lock
+++ b/pkgs/applications/editors/neovim/ruby_provider/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     msgpack (1.1.0)
-    neovim (0.5.0)
+    neovim (0.5.1)
       msgpack (~> 1.0)
 
 PLATFORMS
@@ -12,4 +12,4 @@ DEPENDENCIES
   neovim
 
 BUNDLED WITH
-   1.15.1
+   1.14.6

--- a/pkgs/applications/editors/neovim/ruby_provider/gemset.nix
+++ b/pkgs/applications/editors/neovim/ruby_provider/gemset.nix
@@ -11,9 +11,9 @@
     dependencies = ["msgpack"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1da0ha3mz63iyihldp7185b87wx86jg07023xjhbng6i28y1ksn7";
+      sha256 = "08xn7r4g13wl4bhvkmp4hx3x0ppvifs1x2iiqh8jl9f1jb4jhfcp";
       type = "gem";
     };
-    version = "0.5.0";
+    version = "0.5.1";
   };
 }

--- a/pkgs/development/libraries/libmpack/default.nix
+++ b/pkgs/development/libraries/libmpack/default.nix
@@ -2,20 +2,17 @@
 
 stdenv.mkDerivation rec {
   name = "libmpack-${version}";
-  version = "1.0.3-rev${rev}";
-  rev = "80bd55ea677e70b041f65a4b99438c1f059cce4b";
+  version = "1.0.5";
   src = fetchFromGitHub {
     owner = "tarruda";
     repo = "libmpack";
-    inherit rev;
-    sha256 = "1whnbgxd5580h59kvc2xgx6ymw7nk9kz6r4ajgsfv6c6h2xbwbl3";
+    rev = version;
+    sha256 = "0rai5djdkjz7bsn025k5489in7r1amagw1pib0z4qns6b52kiar2";
   };
   LIBTOOL = "libtool";
   buildInputs = [ libtool ];
-  installPhase = ''
-    mkdir -p $out/lib/libmpack
-    cp -R build/* $out/lib/libmpack
-    rm -rf $out/lib/libmpack/debug
+  preInstall = ''
+    export PREFIX=$out
   '';
   meta = with stdenv.lib; {
     description = "Simple implementation of msgpack in C";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17007,7 +17007,9 @@ with pkgs;
 
   vimpc = callPackage ../applications/audio/vimpc { };
 
-  neovim = callPackage ../applications/editors/neovim { };
+  neovim = callPackage ../applications/editors/neovim {
+    luaPackages = luajitPackages;
+  };
 
   neovim-qt = libsForQt5.callPackage ../applications/editors/neovim/qt.nix { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -23096,12 +23096,12 @@ EOF
   trollius = callPackage ../development/python-modules/trollius {};
 
   neovim = buildPythonPackage rec {
-    version = "0.1.13";
+    version = "0.2.0";
     name = "neovim-${version}";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/n/neovim/${name}.tar.gz";
-      sha256 = "0pzk5639jjjx46a6arkwy31falmk5w1061icbml8njm3rbrwwhgx";
+      sha256 = "1ywkgbrxd95cwlglihydmffcw2d2aji6562aqncymxs3ld5y02yn";
     };
 
     buildInputs = with self; [ nose ];


### PR DESCRIPTION
* neovimLibvterm: 5a748f97 -> 4ca7ebf7
* neovim ruby: 0.5.0 -> 0.5.1
* pythonPackages.neovim: 0.1.13 -> 0.2.0
* libmpack: 1.0.3-rev80bd55ea6 -> 1.0.5
* luaPackages.mpack: switched to new source location, 1.0.7_ef025224a7
* only one set of lua packages, switched to luajit

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

