### PR TITLE
libertinus: init at 6.4

### DIFF
--- a/pkgs/data/fonts/libertinus/default.nix
+++ b/pkgs/data/fonts/libertinus/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "libertinus-${version}";
+  version = "6.4";
+
+  src = fetchFromGitHub {
+    rev    = "v${version}";
+    owner  = "khaledhosny";
+    repo   = "libertinus";
+    sha256 = "0acnq4vpplp2s7kdnhncz61diji3wmhca04g27yqpk03ahb40x9g";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype/
+    mkdir -p $out/share/doc/${name}/
+    cp *.otf $out/share/fonts/opentype/
+    cp *.txt $out/share/doc/${name}/
+  '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "0yn526kwb4xjyf6gvf0wflqi45z5dlzicycz2q003a6if5fgqcz3";
+
+  meta = with stdenv.lib; {
+    description = "A fork of the Linux Libertine and Linux Biolinum fonts";
+    longDescription = ''
+      Libertinus fonts is a fork of the Linux Libertine and Linux Biolinum fonts
+      that started as an OpenType math companion of the Libertine font family,
+      but grown as a full fork to address some of the bugs in the fonts.
+    '';
+    homepage = https://github.com/khaledhosny/libertinus;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ siddharthist ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13388,6 +13388,8 @@ with pkgs;
 
   libertine = callPackage ../data/fonts/libertine { };
 
+  libertinus = callPackage ../data/fonts/libertinus { };
+
   libre-baskerville = callPackage ../data/fonts/libre-baskerville { };
 
   libre-bodoni = callPackage ../data/fonts/libre-bodoni { };


### PR DESCRIPTION
###### Motivation for this change
Another nice OTF math font!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

