### PR TITLE
[wip] kernel: attempt to rerun unpackPhase if sthg fishy (e.g. buildRoot unset)

### DIFF
--- a/pkgs/os-specific/linux/kernel/builder.sh
+++ b/pkgs/os-specific/linux/kernel/builder.sh
@@ -1,0 +1,8 @@
+# TODO testing if that's better
+source $stdenv/setup
+
+# that s how cmake replaces
+# if [ -z "$dontUseCmakeConfigure" -a -z "$configurePhase" ]; then
+#     setOutputFlags=
+#     configurePhase=cmakeConfigurePhase
+# fi

--- a/pkgs/os-specific/linux/kernel/config.nix
+++ b/pkgs/os-specific/linux/kernel/config.nix
@@ -1,9 +1,37 @@
-# {stdenv
+{
+  stdenv
+, lib
 # , buildRoot
 # , srcRoot
-# }:
-{
-  # runCommand = name: env: buildCommand:
+, ignoreConfigErrors, version
+# , kernelConfig
+, runCommand
+, perl, hostPlatform
+, ...
+}:
+
+with import lib.nix;
+/*
+
+# TODO we should be able to generate standalone config and config on the go
+# => we need functions with module etc
+# espcially we need a bash builder
+# TODO have a standalone
+# etait defini dans generic.nix
+
+There variables are exported to be used by the generate-config.pl script, see the buildPhase
+debug
+autoModules
+preferBuiltin
+ignoreConfigErrors
+kernel_config
+
+kernel-config is a file
+
+TODO doesn t need to be a derviation ?
+*/
+let
+
   readConfig = configfile: import (runCommand "config.nix" {} ''
     echo "{" > "$out"
     while IFS='=' read key val; do
@@ -14,53 +42,46 @@
     echo "}" >> $out
   '').outPath;
 
+  # RENAME to 'load'
+  convertKernelConfigToJson = readConfig;
+
   patchKconfig = ''
         # Patch kconfig to print "###" after every question so that
         # generate-config.pl from the generic builder can answer them.
         sed -e '/fflush(stdout);/i\printf("###");' -i scripts/kconfig/conf.c
   '';
 
-
-  # generates
+  # generates functor
+  #
   kernelConfigFun = baseConfig: kernelPatches:
     let
       configFromPatches =
         map ({extraConfig ? "", ...}: extraConfig) kernelPatches;
     in lib.concatStringsSep "\n" ([baseConfig] ++ configFromPatches);
-
-  #
-  buildKernelConfig = arch: autoModules: ''
-      cd $buildRoot
-
-      # Get a basic config file for later refinement with $generateConfig.
-      make -C ../$sourceRoot O=$PWD $kernelBaseConfig ARCH=$arch
-
-      # Create the config file.
-      echo "generating kernel configuration..."
-      echo "$kernelConfig" > kernel-config
-      DEBUG=1 ARCH=$arch KERNEL_CONFIG=kernel-config AUTO_MODULES=$autoModules \
-           PREFER_BUILTIN=$preferBuiltin SRC=../$sourceRoot perl -w $generateConfig
-    '';
-
-# TODO we should be able to generate standalone config and config on the go
-# => we need functions with module etc
-# espcially we need a bash builder
-# TODO have a standalone
-   kernelConfigDrv = stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
     inherit ignoreConfigErrors;
     name = "linux-config-${version}";
 
     generateConfig = ./generate-config.pl;
 
-    kernelConfig = kernelConfigFun config;
+    # string that will be echoed to kernel-config file
+    # writeFile
+    # echo "$kernelConfig" > kernel-config
+    kernelConfig = kernelConfigFun config kernel-patches;
 
     nativeBuildInputs = [ perl ];
 
     platformName = stdenv.platform.name;
+
+    # sthg like "defconfig"
     kernelBaseConfig = stdenv.platform.kernelBaseConfig;
+
+    # e.g. "bzImage"
     kernelTarget = stdenv.platform.kernelTarget;
     autoModules = stdenv.platform.kernelAutoModules;
     preferBuiltin = stdenv.platform.kernelPreferBuiltin or false;
+    # kernel ARCH
     arch = stdenv.platform.kernelArch;
 
     crossAttrs = let
@@ -80,9 +101,16 @@
         inherit (kernel.crossDrv) src patches preUnpack;
       };
 
+    patchKconfig = ''
+        # Patch kconfig to print "###" after every question so that
+        # generate-config.pl from the generic builder can answer them.
+        sed -e '/fflush(stdout);/i\printf("###");' -i scripts/kconfig/conf.c
+  '';
+
     prePatch = kernel.prePatch + patchKconfig;
     inherit (kernel) src patches preUnpack;
 
+    # TODO replace with config.nix buildPhase
     buildPhase = ''
       cd $buildRoot
 
@@ -99,7 +127,4 @@
     installPhase = "mv .config $out";
 
     enableParallelBuilding = true;
-  };
-
 }
-

--- a/pkgs/os-specific/linux/kernel/config.nix
+++ b/pkgs/os-specific/linux/kernel/config.nix
@@ -3,6 +3,17 @@
 # , srcRoot
 # }:
 {
+  # runCommand = name: env: buildCommand:
+  readConfig = configfile: import (runCommand "config.nix" {} ''
+    echo "{" > "$out"
+    while IFS='=' read key val; do
+      [ "x''${key#CONFIG_}" != "x$key" ] || continue
+      no_firstquote="''${val#\"}";
+      echo '  "'"$key"'" = "'"''${no_firstquote%\"}"'";' >> "$out"
+    done < "${configfile}"
+    echo "}" >> $out
+  '').outPath;
+
   patchKconfig = ''
         # Patch kconfig to print "###" after every question so that
         # generate-config.pl from the generic builder can answer them.

--- a/pkgs/os-specific/linux/kernel/config.nix
+++ b/pkgs/os-specific/linux/kernel/config.nix
@@ -89,7 +89,8 @@ stdenv.mkDerivation rec {
 
     # e.g. "bzImage"
     kernelTarget = stdenv.platform.kernelTarget;
-    autoModules = stdenv.platform.kernelAutoModules;
+    # HHHAAAACCKKK
+    autoModules = false; # stdenv.platform.kernelAutoModules;
     preferBuiltin = stdenv.platform.kernelPreferBuiltin or false;
     # kernel ARCH
     arch = stdenv.platform.kernelArch;

--- a/pkgs/os-specific/linux/kernel/config.nix
+++ b/pkgs/os-specific/linux/kernel/config.nix
@@ -1,0 +1,87 @@
+# {stdenv
+# , buildRoot
+# , srcRoot
+# }:
+{
+  patchKconfig = ''
+        # Patch kconfig to print "###" after every question so that
+        # generate-config.pl from the generic builder can answer them.
+        sed -e '/fflush(stdout);/i\printf("###");' -i scripts/kconfig/conf.c
+  '';
+
+
+  #
+  buildKernelConfig = arch: autoModules: ''
+      cd $buildRoot
+
+      # Get a basic config file for later refinement with $generateConfig.
+      make -C ../$sourceRoot O=$PWD $kernelBaseConfig ARCH=$arch
+
+      # Create the config file.
+      echo "generating kernel configuration..."
+      echo "$kernelConfig" > kernel-config
+      DEBUG=1 ARCH=$arch KERNEL_CONFIG=kernel-config AUTO_MODULES=$autoModules \
+           PREFER_BUILTIN=$preferBuiltin SRC=../$sourceRoot perl -w $generateConfig
+    '';
+
+}
+# TODO we should be able to generate standalone config and config on the go
+# => we need functions with module etc
+# espcially we need a bash builder
+# TODO have a standalone
+   stdenv.mkDerivation {
+    inherit ignoreConfigErrors;
+    name = "linux-config-${version}";
+
+    generateConfig = ./generate-config.pl;
+
+    kernelConfig = kernelConfigFun config;
+
+    nativeBuildInputs = [ perl ];
+
+    platformName = stdenv.platform.name;
+    kernelBaseConfig = stdenv.platform.kernelBaseConfig;
+    kernelTarget = stdenv.platform.kernelTarget;
+    autoModules = stdenv.platform.kernelAutoModules;
+    preferBuiltin = stdenv.platform.kernelPreferBuiltin or false;
+    arch = stdenv.platform.kernelArch;
+
+    crossAttrs = let
+        cp = hostPlatform.platform;
+      in {
+        arch = cp.kernelArch;
+        platformName = cp.name;
+        kernelBaseConfig = cp.kernelBaseConfig;
+        kernelTarget = cp.kernelTarget;
+        autoModules = cp.kernelAutoModules;
+
+        # Just ignore all options that don't apply (We are lazy).
+        ignoreConfigErrors = true;
+
+        kernelConfig = kernelConfigFun configCross;
+
+        inherit (kernel.crossDrv) src patches preUnpack;
+      };
+
+    prePatch = kernel.prePatch + patchKconfig;
+    inherit (kernel) src patches preUnpack;
+
+    buildPhase = ''
+      cd $buildRoot
+
+      # Get a basic config file for later refinement with $generateConfig.
+      make -C ../$sourceRoot O=$PWD $kernelBaseConfig ARCH=$arch
+
+      # Create the config file.
+      echo "generating kernel configuration..."
+      echo "$kernelConfig" > kernel-config
+      DEBUG=1 ARCH=$arch KERNEL_CONFIG=kernel-config AUTO_MODULES=$autoModules \
+           PREFER_BUILTIN=$preferBuiltin SRC=../$sourceRoot perl -w $generateConfig
+    '';
+
+    installPhase = "mv .config $out";
+
+    enableParallelBuilding = true;
+  }
+
+

--- a/pkgs/os-specific/linux/kernel/config.nix
+++ b/pkgs/os-specific/linux/kernel/config.nix
@@ -128,12 +128,14 @@ stdenv.mkDerivation rec {
 
     # need to be in srcRoot before launching this !
     buildConfigCommands = ''
-      cd $buildRoot
       set -x
+      echo $PWD
+      cd $buildRoot
 
       # Get a basic config file for later refinement with $generateConfig.
       # make O=$buildRoot $kernelBaseConfig ARCH=$arch
-      make -C ../$sourceRoot O=$buildRoot $kernelBaseConfig ARCH=$arch
+      # /$sourceRoot
+      make -C .. O=$buildRoot $kernelBaseConfig ARCH=$arch
 
       # Create the config file.
       echo "generating kernel configuration..."

--- a/pkgs/os-specific/linux/kernel/config.nix
+++ b/pkgs/os-specific/linux/kernel/config.nix
@@ -132,7 +132,7 @@ stdenv.mkDerivation rec {
       echo $PWD
       cd $buildRoot
 
-      # Get a basic config file for later refinement with $generateConfig.
+      # Get a basic config file for later refinement with $ generateConfig.
       # make O=$buildRoot $kernelBaseConfig ARCH=$arch
       # /$sourceRoot
       make -C .. O=$buildRoot $kernelBaseConfig ARCH=$arch
@@ -142,7 +142,9 @@ stdenv.mkDerivation rec {
       echo "${kernelConfig}" > $buildRoot/kernel-config
       echo "Printing kernel config"
       # TODO SRC ?
-      DEBUG=1 ARCH=$arch KERNEL_CONFIG=$buildRoot/kernel-config AUTO_MODULES=$autoModules \
+      DEBUG=1 ARCH=$arch KERNEL_CONFIG=$buildRoot/kernel-config \
+        AUTO_MODULES=${builtins.toString autoModules} \
+           ignoreConfigErrors=${builtins.toString ignoreConfigErrors} \
            PREFER_BUILTIN=$preferBuiltin SRC=. BUILD_FOLDER=$buildRoot perl -w ${generateConfig}
     '';
 

--- a/pkgs/os-specific/linux/kernel/config.nix
+++ b/pkgs/os-specific/linux/kernel/config.nix
@@ -29,6 +29,9 @@ kernel_config
 kernel-config is a file
 
 TODO doesn t need to be a derviation ?
+can 't we justr override the source or split into two derivations:
+- standalone
+- embedded
 */
 let
 
@@ -111,20 +114,24 @@ stdenv.mkDerivation {
     inherit (kernel) src patches preUnpack;
 
     # TODO replace with config.nix buildPhase
-    buildPhase = ''
-      cd $buildRoot
+    buildPhase =  buildConfigCommands;
+    buildConfigCommands = ''
+      # cd $buildRoot
+      set -x
 
       # Get a basic config file for later refinement with $generateConfig.
-      make -C ../$sourceRoot O=$PWD $kernelBaseConfig ARCH=$arch
+      make O=$buildRoot $kernelBaseConfig ARCH=$arch
+      # make -C ../$sourceRoot O=$PWD $kernelBaseConfig ARCH=$arch
 
       # Create the config file.
       echo "generating kernel configuration..."
       echo "$kernelConfig" > kernel-config
+      # TODO SRC ?
       DEBUG=1 ARCH=$arch KERNEL_CONFIG=kernel-config AUTO_MODULES=$autoModules \
-           PREFER_BUILTIN=$preferBuiltin SRC=../$sourceRoot perl -w $generateConfig
+           PREFER_BUILTIN=$preferBuiltin SRC=. perl -w $generateConfig
     '';
 
-    installPhase = "mv .config $out";
+    installPhase = "mv $buildRoot/.config $out";
 
     enableParallelBuilding = true;
 }

--- a/pkgs/os-specific/linux/kernel/config.nix
+++ b/pkgs/os-specific/linux/kernel/config.nix
@@ -20,6 +20,8 @@
         sed -e '/fflush(stdout);/i\printf("###");' -i scripts/kconfig/conf.c
   '';
 
+
+  # generates
   kernelConfigFun = baseConfig: kernelPatches:
     let
       configFromPatches =
@@ -44,7 +46,7 @@
 # => we need functions with module etc
 # espcially we need a bash builder
 # TODO have a standalone
-   kernelConfig = stdenv.mkDerivation {
+   kernelConfigDrv = stdenv.mkDerivation {
     inherit ignoreConfigErrors;
     name = "linux-config-${version}";
 

--- a/pkgs/os-specific/linux/kernel/config.nix
+++ b/pkgs/os-specific/linux/kernel/config.nix
@@ -114,6 +114,7 @@ stdenv.mkDerivation rec {
     patchKconfig = ''
         # Patch kconfig to print "###" after every question so that
         # generate-config.pl from the generic builder can answer them.
+        echo "Patching Kconfig"
         sed -e '/fflush(stdout);/i\printf("###");' -i scripts/kconfig/conf.c
   '';
 
@@ -132,14 +133,15 @@ stdenv.mkDerivation rec {
 
       # Get a basic config file for later refinement with $generateConfig.
       # make O=$buildRoot $kernelBaseConfig ARCH=$arch
-      make -C ../$sourceRoot O=$PWD $kernelBaseConfig ARCH=$arch
+      make -C ../$sourceRoot O=$buildRoot $kernelBaseConfig ARCH=$arch
 
       # Create the config file.
       echo "generating kernel configuration..."
-      echo "$kernelConfig" > kernel-config
+      echo "${kernelConfig}" > $buildRoot/kernel-config
+      echo "Printing kernel config"
       # TODO SRC ?
-      DEBUG=1 ARCH=$arch KERNEL_CONFIG=kernel-config AUTO_MODULES=$autoModules \
-           PREFER_BUILTIN=$preferBuiltin SRC=. perl -w ${generateConfig}
+      DEBUG=1 ARCH=$arch KERNEL_CONFIG=$buildRoot/kernel-config AUTO_MODULES=$autoModules \
+           PREFER_BUILTIN=$preferBuiltin SRC=. BUILD_FOLDER=$buildRoot perl -w ${generateConfig}
     '';
 
     installPhase = "mv $buildRoot/.config $out";

--- a/pkgs/os-specific/linux/kernel/config.nix
+++ b/pkgs/os-specific/linux/kernel/config.nix
@@ -20,6 +20,11 @@
         sed -e '/fflush(stdout);/i\printf("###");' -i scripts/kconfig/conf.c
   '';
 
+  kernelConfigFun = baseConfig: kernelPatches:
+    let
+      configFromPatches =
+        map ({extraConfig ? "", ...}: extraConfig) kernelPatches;
+    in lib.concatStringsSep "\n" ([baseConfig] ++ configFromPatches);
 
   #
   buildKernelConfig = arch: autoModules: ''
@@ -35,12 +40,11 @@
            PREFER_BUILTIN=$preferBuiltin SRC=../$sourceRoot perl -w $generateConfig
     '';
 
-}
 # TODO we should be able to generate standalone config and config on the go
 # => we need functions with module etc
 # espcially we need a bash builder
 # TODO have a standalone
-   stdenv.mkDerivation {
+   kernelConfig = stdenv.mkDerivation {
     inherit ignoreConfigErrors;
     name = "linux-config-${version}";
 
@@ -93,6 +97,7 @@
     installPhase = "mv .config $out";
 
     enableParallelBuilding = true;
-  }
+  };
 
+}
 

--- a/pkgs/os-specific/linux/kernel/generate-config.pl
+++ b/pkgs/os-specific/linux/kernel/generate-config.pl
@@ -15,10 +15,12 @@ use Cwd;
 
 my $wd = getcwd;
 
+# exported via nix
 my $debug = $ENV{'DEBUG'};
 my $autoModules = $ENV{'AUTO_MODULES'};
 my $preferBuiltin = $ENV{'PREFER_BUILTIN'};
-    
+my $ignoreConfigErrors = $ENV{'ignoreConfigErrors'};
+
 $SIG{PIPE} = 'IGNORE';
 
 # Read the answers.
@@ -137,7 +139,7 @@ while (<CONFIG>) {
 close CONFIG;
 
 foreach my $name (sort (keys %answers)) {
-    my $f = $requiredAnswers{$name} && $ENV{'ignoreConfigErrors'} ne "1"
+    my $f = $requiredAnswers{$name} && $ignoreConfigErrors ne "1"
         ? sub { die "error: " . $_[0]; } : sub { warn "warning: " . $_[0]; };
     &$f("unused option: $name\n") unless defined $config{$name};
     &$f("option not set correctly: $name (wanted '$answers{$name}', got '$config{$name}')\n")

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -59,8 +59,9 @@ let
     configDrv = callPackage ./config.nix {
     inherit ignoreConfigErrors;
 
-    inherit version src kernelPatches stdenv;
+    inherit version src kernelPatches stdenv config;
     # modDirVersion
+    inherit kernel;
     };
 
   # TODO moved it
@@ -86,6 +87,7 @@ let
     # TODO fix later
     # crossConfigfile = configfile.crossDrv or configfile;
 
+    # erase parent config ???!
     config = { CONFIG_MODULES = "y"; CONFIG_FW_LOADER = "m"; };
 
     crossConfig = { CONFIG_MODULES = "y"; CONFIG_FW_LOADER = "m"; };

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -30,7 +30,7 @@
 , ignoreConfigErrors ? stdenv.platform.name != "pc"
 , extraMeta ? {}
 , hostPlatform
-, callPackage
+# , callPackage
 , ...
 } @ args:
 
@@ -56,7 +56,7 @@ let
   config = configWithPlatform stdenv.platform;
   configCross = configWithPlatform hostPlatform.platform;
 
-    configDrv = callPackage ./config.nix {
+    configDrv = stdenv.lib.callPackage ./config.nix {
     inherit ignoreConfigErrors;
 
     inherit version src kernelPatches stdenv config;

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -30,7 +30,8 @@
 , ignoreConfigErrors ? stdenv.platform.name != "pc"
 , extraMeta ? {}
 , hostPlatform
-# , callPackage
+, callPackage
+# , pkgs
 , ...
 } @ args:
 
@@ -56,7 +57,7 @@ let
   config = configWithPlatform stdenv.platform;
   configCross = configWithPlatform hostPlatform.platform;
 
-    configDrv = stdenv.lib.callPackage ./config.nix {
+    configDrv = callPackage ./config.nix {
     inherit ignoreConfigErrors;
 
     inherit version src kernelPatches stdenv config;

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -6,7 +6,7 @@
 , # The kernel version.
   version
 
-, # Overrides to the kernel config.
+, # Appended verbatim to kernel .config
   extraConfig ? ""
 
 , # The version number used for the module directory
@@ -54,6 +54,7 @@ let
 
   # TODO moved it
   # callPackage ./config.nix {};
+  # configfile = stdenv.mkDerivation {
   configfile = (import ./config.nix);
 
     # TODO le transformer plutot en

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -54,8 +54,9 @@ let
     features = kernelFeatures; # Ensure we know of all extra patches, etc.
   };
 
-  config = configWithPlatform stdenv.platform;
-  configCross = configWithPlatform hostPlatform.platform;
+  # CARE I modified the line below
+  config = configWithPlatform hostPlatform;
+  configCross = configWithPlatform hostPlatform;
 
     configDrv = callPackage ./config.nix {
     inherit ignoreConfigErrors;

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -54,9 +54,8 @@ let
     features = kernelFeatures; # Ensure we know of all extra patches, etc.
   };
 
-  # CARE I modified the line below
-  config = configWithPlatform hostPlatform;
-  configCross = configWithPlatform hostPlatform;
+  config = configWithPlatform stdenv.platform;
+  configCross = configWithPlatform hostPlatform.platform;
 
     configDrv = callPackage ./config.nix {
     inherit ignoreConfigErrors;

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -51,14 +51,10 @@ let
   config = configWithPlatform stdenv.platform;
   configCross = configWithPlatform hostPlatform.platform;
 
-  kernelConfigFun = baseConfig:
-    let
-      configFromPatches =
-        map ({extraConfig ? "", ...}: extraConfig) kernelPatches;
-    in lib.concatStringsSep "\n" ([baseConfig] ++ configFromPatches);
 
   # TODO moved it
-  # configfile = callPackage
+  # callPackage ./config.nix {};
+  configfile = (import ./config.nix);
 
     # TODO le transformer plutot en
   kernel = buildLinux {

--- a/pkgs/os-specific/linux/kernel/lib.nix
+++ b/pkgs/os-specific/linux/kernel/lib.nix
@@ -1,0 +1,63 @@
+# this should be
+#
+{
+  stdenv
+, lib
+# , buildRoot
+# , srcRoot
+# , ignoreConfigErrors: version, kernelConfig, runCommand
+, version
+, runCommand
+}:
+rec {
+  # runCommand = name: env: buildCommand:
+  /* generate a file config.nix with {
+      key=val;
+    }
+    from a kernel .config file passed as "configfile"
+    key#CONFIG_ removes "CONFIG_" prefix
+    */
+  readConfig = configfile: import (runCommand "config.nix" {} ''
+    echo "{" > "$out"
+    while IFS='=' read key val; do
+      [ "x''${key#CONFIG_}" != "x$key" ] || continue
+      no_firstquote="''${val#\"}";
+      echo '  "'"$key"'" = "'"''${no_firstquote%\"}"'";' >> "$out"
+    done < "${configfile}"
+    echo "}" >> $out
+  '').outPath;
+
+  # RENAME to 'load'
+  convertKernelConfigToJson = readConfig;
+
+  patchKconfig = ''
+        # Patch kconfig to print "###" after every question so that
+        # generate-config.pl from the generic builder can answer them.
+        sed -e '/fflush(stdout);/i\printf("###");' -i scripts/kconfig/conf.c
+  '';
+
+  # generates functor
+  #
+  kernelConfigFun = baseConfig: kernelPatches:
+    let
+      configFromPatches =
+        map ({extraConfig ? "", ...}: extraConfig) kernelPatches;
+    in lib.concatStringsSep "\n" ([baseConfig] ++ configFromPatches);
+
+  # TODO check bash variables exist -u
+  buildKernelConfig = arch: autoModules: ''
+      # cd $buildRoot
+
+      # Get a basic config file for later refinement with $generateConfig.
+      # make -C ../$sourceRoot O=$PWD $kernelBaseConfig ARCH=$arch
+      make -C .. O=$PWD $kernelBaseConfig ARCH=$arch
+
+      # Create the config file.
+      echo "generating kernel configuration..."
+      echo "$kernelConfig" > kernel-config
+      DEBUG=1 ARCH=$arch KERNEL_CONFIG=kernel-config AUTO_MODULES=$autoModules \
+           PREFER_BUILTIN=$preferBuiltin SRC=../$sourceRoot perl -w $generateConfig
+    '';
+}
+
+

--- a/pkgs/os-specific/linux/kernel/linux-4.9.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.9.nix
@@ -1,10 +1,8 @@
-{ stdenv, hostPlatform, fetchurl, perl, buildLinux, callPackage, ... } @ args:
+{ stdenv, hostPlatform, ignoreConfigErrors ? true, fetchurl, perl, buildLinux, callPackage, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.9.65";
   extraMeta.branch = "4.9";
-
-  ignoreConfigErrors = true;
 
   extraConfig=''
     VIRTIO_PCI y

--- a/pkgs/os-specific/linux/kernel/linux-4.9.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.9.nix
@@ -1,8 +1,18 @@
-{ stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, hostPlatform, fetchurl, perl, buildLinux, callPackage, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.9.65";
   extraMeta.branch = "4.9";
+
+  ignoreConfigErrors = true;
+
+  extraConfig=''
+    VIRTIO_PCI y
+    VIRTIO_PCI_LEGACY y
+    VIRTIO_BALLOON m
+    VIRTIO_INPUT m
+    VIRTIO_MMIO m
+    '';
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-mptcp.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp.nix
@@ -1,5 +1,6 @@
 { stdenv, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
+# ~ linux_mptcp = callPackage generic.nix (linux_mptcp.nix)
 import ./generic.nix (rec {
   mptcpVersion = "0.93";
   modDirVersion = "4.9.60";

--- a/pkgs/os-specific/linux/kernel/linux-mptcp.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp.nix
@@ -1,4 +1,4 @@
-{ stdenv, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
+{ stdenv, callPackage, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
 # ~ linux_mptcp = callPackage generic.nix (linux_mptcp.nix)
 import ./generic.nix (rec {
@@ -44,4 +44,4 @@ import ./generic.nix (rec {
     TCP_CONG_BALIA m
 
   '' + (args.extraConfig or "");
-} // args // (args.argsOverride or {}))
+} // removeAttrs args ["extraConfig"])

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -132,13 +132,19 @@ let
 
     # preConfigure = buildConfigPhase;
 
+
+    # we are in $sourceRoot
     configurePhase = let
 
         # if configfile is valid file
-        linkConfig = if (true) then ''ln -sv ${configfile} $buildRoot/.config
-        '' else ''
-          # TODO generate CONFIG !!!
-          '';
+        linkConfig = if (configfile) then ''
+          ln -sv ${configfile} $buildRoot/.config
+        '' else
+        configDrv.buildConfigCommands
+        # ''
+        #   # TODO generate CONFIG !!!
+        #   ''
+          ;
 
       in ''
         # if [ -z "$buildRoot" ]; then

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -298,7 +298,8 @@ stdenv.mkDerivation ((drvAttrs config stdenv.platform (kernelPatches ++ nativeKe
   makeFlags = commonMakeFlags ++ [
     "ARCH=${stdenv.platform.kernelArch}"
   ]
-  # ++ stdenv.lib.optional enableParallelBuilding "-j${cfg.buildCores}";
+  # {cfg.buildCores}
+  ++ stdenv.lib.optional enableParallelBuilding "-j4"
     # cfg.buildCores # TODO set
     ;
 

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -1,9 +1,9 @@
 # defines buildLinux, aka returns a function
-{ runCommand, nettools, bc, perl, gmp, libmpc, mpfr, kmod, openssl
+{ runCommand, stdenv, nettools, bc, perl, gmp, libmpc, mpfr, kmod, openssl
 , libelf ? null
 , utillinux ? null
 , writeTextFile, ubootTools
-callPackage
+# , callPackage
 , hostPlatform
 }:
 
@@ -18,7 +18,7 @@ let
   #   done < "${configfile}"
   #   echo "}" >> $out
   # '').outPath;
-  confHelpers = callPackage ./config.nix {};
+  confHelpers = stdenv.lib.callPackage ./config.nix {};
 in {
   # Allow overriding stdenv on each buildLinux call
   stdenv,
@@ -215,7 +215,7 @@ let
         unlink $out/lib/modules/${modDirVersion}/source
 
         mkdir -p $dev/lib/modules/${modDirVersion}/build
-        cp -dpR ../$sourceRoot $dev/lib/modules/${modDirVersion}/source
+        cp -dpR .. $dev/lib/modules/${modDirVersion}/source
         cd $dev/lib/modules/${modDirVersion}/source
 
         cp $buildRoot/{.config,Module.symvers} $dev/lib/modules/${modDirVersion}/build
@@ -321,7 +321,7 @@ stdenv.mkDerivation ((drvAttrs config stdenv.platform (kernelPatches ++ nativeKe
     "ARCH=${stdenv.platform.kernelArch}"
   ]
   # {cfg.buildCores}
-  ++ stdenv.lib.optional enableParallelBuilding "-j4"
+  # ++ stdenv.lib.optional enableParallelBuilding "-j4"
     # cfg.buildCores # TODO set
     ;
 

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -60,7 +60,7 @@ let
   inherit (stdenv.lib)
     hasAttr getAttr optional optionalString optionalAttrs maintainers platforms;
 
-  platform = hostPlatform;
+  platform = stdenv.platform;
 
   installkernel = writeTextFile { name = "installkernel"; executable=true; text = ''
     #!${stdenv.shell} -e

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -153,9 +153,9 @@ let
           # we should be in $sourceRoot
           # assume we are in the $sourceRoot folder
           # echo "buildRoot is not set"
-          echo "buildRoot is not set"
           mkdir build
           export buildRoot="$PWD/build"
+          echo "buildRoot was not set, now is $buildRoot"
         # fi
         runHook preConfigure
         ''

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -6,6 +6,7 @@
 }:
 
 let
+  # TODO import from config
   readConfig = configfile: import (runCommand "config.nix" {} ''
     echo "{" > "$out"
     while IFS='=' read key val; do
@@ -31,7 +32,7 @@ in {
   # Patches for cross compiling only
   crossKernelPatches ? [],
   # The native kernel .config file
-  configfile ? null,
+  configfile,
   # The cross kernel .config file
   crossConfigfile ? configfile,
   # Manually specified nixexpr representing the config

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -1,3 +1,4 @@
+# defines buildLinux
 { runCommand, nettools, bc, perl, gmp, libmpc, mpfr, kmod, openssl
 , libelf ? null
 , utillinux ? null
@@ -16,6 +17,7 @@ let
     done < "${configfile}"
     echo "}" >> $out
   '').outPath;
+  confHelpers = import ./config.nix;
 in {
   # Allow overriding stdenv on each buildLinux call
   stdenv,
@@ -37,8 +39,8 @@ in {
   crossConfigfile ? configfile,
   # Manually specified nixexpr representing the config
   # If unspecified, this will be autodetected from the .config
-  # config ? stdenv.lib.optionalAttrs allowImportFromDerivation (readConfig configfile),
-  config ? null,
+  config ? stdenv.lib.optionalAttrs allowImportFromDerivation (readConfig configfile),
+  # config ? null,
   # Cross-compiling config
   crossConfig ? if allowImportFromDerivation then (readConfig crossConfigfile) else config,
   # Whether to utilize the controversial import-from-derivation feature to parse the config
@@ -94,10 +96,10 @@ let
       inherit src;
 
       # why this
-      # preUnpack = ''
+      preUnpack = ''
       #   mkdir build
       #   export buildRoot="$PWD/build"
-      # '';
+      '';
       autoModules = stdenv.platform.kernelAutoModules;
       preferBuiltin = stdenv.platform.kernelPreferBuiltin or false;
       arch = stdenv.platform.kernelArch;
@@ -111,41 +113,28 @@ let
             sed -i "$mf" -e 's|/usr/bin/||g ; s|/bin/||g ; s|/sbin/||g'
         done
         sed -i Makefile -e 's|= depmod|= ${kmod}/bin/depmod|'
-      '' +
-      # Patch kconfig to print "###" after every question so that
-      # generate-config.pl from the generic builder can answer them.
       ''
-        sed -e '/fflush(stdout);/i\printf("###");' -i scripts/kconfig/conf.c
-      '';
+      # if no configfile set then it means we have to generate it on the go
+      + stdenv.lib.optionalString (configfile == null) confHelpers.patchKconfig;
 
       # imported from generic.nix
-    buildConfigPhase = ''
 
-      echo "buildRoot  set to $buildRoot"
-      cd $buildRoot
-
-      # Get a basic config file for later refinement with $generateConfig.
-      make -C ../$sourceRoot O=$PWD ${kernelBaseConfig} ARCH=$arch
-
-      # Create the config file.
-      echo "generating kernel configuration..."
-      echo "$kernelConfig" > kernel-config
-      DEBUG=1 ARCH=$arch KERNEL_CONFIG=kernel-config AUTO_MODULES=$autoModules \
-           PREFER_BUILTIN=$preferBuiltin SRC=../$sourceRoot perl -w $generateConfig
-    '';
-
-    preConfigure = buildConfigPhase;
+    # preConfigure = buildConfigPhase;
 
       configurePhase = ''
-        if [ -z "$buildRoot" ]; then
+        # if [ -z "$buildRoot" ]; then
 
+          # we should be in $sourceRoot
           # assume we are in the $sourceRoot folder
+          # echo "buildRoot is not set"
           echo "buildRoot is not set"
           mkdir build
           export buildRoot="$PWD/build"
-        fi
+        # fi
         runHook preConfigure
 
+        # reads the existing .config file and prompts the user for options in
+        # the current kernel source that are not found in the file.
         make $makeFlags "''${makeFlagsArray[@]}" oldconfig
         runHook postConfigure
 
@@ -294,6 +283,7 @@ stdenv.mkDerivation ((drvAttrs config stdenv.platform (kernelPatches ++ nativeKe
   # concatenated from drvAttrs
   # configurePhase = ''
   #   '';
+  # TODO add an output for the config ?
 
   makeFlags = commonMakeFlags ++ [
     "ARCH=${stdenv.platform.kernelArch}"

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -90,7 +90,7 @@ let
 
       preUnpack = ''
         mkdir build
-        export buildRoot="$(pwd)/build"
+        export buildRoot="$PWD/build"
       '';
 
       patches = map (p: p.patch) kernelPatches;
@@ -109,8 +109,8 @@ let
 
           # assume we are in the $sourceRoot folder
           echo "buildRoot is not set"
-          mkdir -p ../build
-          export buildRoot=$(pwd)/../build
+          mkdir build
+          export buildRoot="$PWD/build"
         fi
 
         ln -sv ${configfile} $buildRoot/.config

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -5,7 +5,9 @@
 , writeTextFile, ubootTools
 # , callPackage
 
-# in fact this should be a set like https://github.com/NixOS/nixpkgs/issues/24388
+# in fact this refers to a system (see lib/systems/examples.nix) and not a "platform"
+# since this sometimes call
+# should be a set like https://github.com/NixOS/nixpkgs/issues/24388
 , hostPlatform
 }:
 

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -105,7 +105,16 @@ let
 
       configurePhase = ''
         runHook preConfigure
+        if [ -z "$buildRoot" ]; then
+
+          # assume we are in the $sourceRoot folder
+          echo "buildRoot is not set"
+          mkdir -p ../build
+          export buildRoot=$(pwd)/../build
+        fi
+
         ln -sv ${configfile} $buildRoot/.config
+        # ln -sv ${configfile} ''${buildRoot:=$(pwd)/../build}/.config
         make $makeFlags "''${makeFlagsArray[@]}" oldconfig
         runHook postConfigure
 

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -137,9 +137,10 @@ let
     configurePhase = let
 
         # if configfile is valid file
-        linkConfig = if (configfile) then ''
+        linkConfig = if (configfile != null) then ''
           ln -sv ${configfile} $buildRoot/.config
         '' else
+        # TODO la le kernel config n est pas genere
         configDrv.buildConfigCommands
         # ''
         #   # TODO generate CONFIG !!!
@@ -163,7 +164,6 @@ let
         +
         ''
 
-        # ln -sv ${configfile} $buildRoot/.config
 
         # reads the existing .config file and prompts the user for options in
         # the current kernel source that are not found in the file.

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -56,6 +56,7 @@ let
 
   commonMakeFlags = [
     "O=$(buildRoot)"
+
   ] ++ stdenv.lib.optionals (stdenv.platform ? kernelMakeFlags)
     stdenv.platform.kernelMakeFlags;
 
@@ -259,6 +260,8 @@ stdenv.mkDerivation ((drvAttrs config stdenv.platform (kernelPatches ++ nativeKe
   makeFlags = commonMakeFlags ++ [
     "ARCH=${stdenv.platform.kernelArch}"
   ];
+  # ++ stdenv.lib.optional enableParallelBuilding "-j{}";
+    # cfg.buildCores # TODO set
 
   karch = stdenv.platform.kernelArch;
 

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -105,10 +105,9 @@ let
 
       # why this
       preUnpack = ''
-      #   mkdir build
-      #   export buildRoot="$PWD/build"
       '';
-      autoModules = stdenv.platform.kernelAutoModules;
+      # HAAAACCKKKKK
+      autoModules = false; # stdenv.platform.kernelAutoModules;
       preferBuiltin = stdenv.platform.kernelPreferBuiltin or false;
       arch = stdenv.platform.kernelArch;
       kernelBaseConfig = stdenv.platform.kernelBaseConfig;

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -31,12 +31,13 @@ in {
   # Patches for cross compiling only
   crossKernelPatches ? [],
   # The native kernel .config file
-  configfile,
+  configfile ? null,
   # The cross kernel .config file
   crossConfigfile ? configfile,
   # Manually specified nixexpr representing the config
   # If unspecified, this will be autodetected from the .config
-  config ? stdenv.lib.optionalAttrs allowImportFromDerivation (readConfig configfile),
+  # config ? stdenv.lib.optionalAttrs allowImportFromDerivation (readConfig configfile),
+  config ? null,
   # Cross-compiling config
   crossConfig ? if allowImportFromDerivation then (readConfig crossConfigfile) else config,
   # Whether to utilize the controversial import-from-derivation feature to parse the config
@@ -54,6 +55,7 @@ let
     cp -av $3 $4
   ''; };
 
+  # flags common to the cross-compiled and native builds
   commonMakeFlags = [
     "O=$(buildRoot)"
 
@@ -82,17 +84,23 @@ let
 
       installsFirmware = (config.isEnabled "FW_LOADER") &&
         (isModular || (config.isDisabled "FIRMWARE_IN_KERNEL"));
-    in (optionalAttrs isModular { outputs = [ "out" "dev" ]; }) // {
+    in (optionalAttrs isModular { outputs = [ "out" "dev" ]; }) // rec {
       passthru = {
-        inherit version modDirVersion config kernelPatches configfile;
+        inherit version modDirVersion  kernelPatches configfile;
+        # inherit config;
       };
 
       inherit src;
 
-      preUnpack = ''
-        mkdir build
-        export buildRoot="$PWD/build"
-      '';
+      # why this
+      # preUnpack = ''
+      #   mkdir build
+      #   export buildRoot="$PWD/build"
+      # '';
+      autoModules = stdenv.platform.kernelAutoModules;
+      preferBuiltin = stdenv.platform.kernelPreferBuiltin or false;
+      arch = stdenv.platform.kernelArch;
+      kernelBaseConfig = stdenv.platform.kernelBaseConfig;
 
       patches = map (p: p.patch) kernelPatches;
 
@@ -102,10 +110,32 @@ let
             sed -i "$mf" -e 's|/usr/bin/||g ; s|/bin/||g ; s|/sbin/||g'
         done
         sed -i Makefile -e 's|= depmod|= ${kmod}/bin/depmod|'
+      '' +
+      # Patch kconfig to print "###" after every question so that
+      # generate-config.pl from the generic builder can answer them.
+      ''
+        sed -e '/fflush(stdout);/i\printf("###");' -i scripts/kconfig/conf.c
       '';
 
+      # imported from generic.nix
+    buildConfigPhase = ''
+
+      echo "buildRoot  set to $buildRoot"
+      cd $buildRoot
+
+      # Get a basic config file for later refinement with $generateConfig.
+      make -C ../$sourceRoot O=$PWD ${kernelBaseConfig} ARCH=$arch
+
+      # Create the config file.
+      echo "generating kernel configuration..."
+      echo "$kernelConfig" > kernel-config
+      DEBUG=1 ARCH=$arch KERNEL_CONFIG=kernel-config AUTO_MODULES=$autoModules \
+           PREFER_BUILTIN=$preferBuiltin SRC=../$sourceRoot perl -w $generateConfig
+    '';
+
+    preConfigure = buildConfigPhase;
+
       configurePhase = ''
-        runHook preConfigure
         if [ -z "$buildRoot" ]; then
 
           # assume we are in the $sourceRoot folder
@@ -113,9 +143,8 @@ let
           mkdir build
           export buildRoot="$PWD/build"
         fi
+        runHook preConfigure
 
-        ln -sv ${configfile} $buildRoot/.config
-        # ln -sv ${configfile} ''${buildRoot:=$(pwd)/../build}/.config
         make $makeFlags "''${makeFlagsArray[@]}" oldconfig
         runHook postConfigure
 
@@ -221,6 +250,8 @@ let
         make firmware_install $makeFlags "''${makeFlagsArray[@]}" \
           $installFlags "''${installFlagsArray[@]}"
       '');
+      # TODO add it as an output
+    # installPhase = "mv .config $out";
 
       requiredSystemFeatures = [ "big-parallel" ];
 
@@ -245,6 +276,8 @@ in
 assert stdenv.lib.versionAtLeast version "4.15" -> libelf != null;
 assert stdenv.lib.versionAtLeast version "4.15" -> utillinux != null;
 stdenv.mkDerivation ((drvAttrs config stdenv.platform (kernelPatches ++ nativeKernelPatches) configfile) // {
+# config ? stdenv.lib.optionalAttrs allowImportFromDerivation (readConfig configfile),
+# stdenv.mkDerivation ((drvAttrs config stdenv.platform (kernelPatches ++ nativeKernelPatches) configfile) // rec {
   name = "linux-${version}";
 
   enableParallelBuilding = true;
@@ -257,11 +290,16 @@ stdenv.mkDerivation ((drvAttrs config stdenv.platform (kernelPatches ++ nativeKe
 
   hardeningDisable = [ "bindnow" "format" "fortify" "stackprotector" "pic" ];
 
+  # concatenated from drvAttrs
+  # configurePhase = ''
+  #   '';
+
   makeFlags = commonMakeFlags ++ [
     "ARCH=${stdenv.platform.kernelArch}"
-  ];
-  # ++ stdenv.lib.optional enableParallelBuilding "-j{}";
+  ]
+  # ++ stdenv.lib.optional enableParallelBuilding "-j${cfg.buildCores}";
     # cfg.buildCores # TODO set
+    ;
 
   karch = stdenv.platform.kernelArch;
 


### PR DESCRIPTION
When trying to compile/hack the kernel, nixos would keep asking me to
generate the .config file. That was because I had skipped the
unpackPhase. 
Also if one exits the nix-shell (voluntarely or because of an error) and wants to resume the configure phase, it fails too because '$buildRoot' is not set; it is set during the unpackPhase.

My tackle on that is that there is a great chance the nix-shell was resumed from the unpacked folder.
Then the configurePhase sets the buildRoot accordingly, assuming we are in the unpacked folder.

I could have done it via a preConfigure hook but either way the current
situation is not good since one doesn"t know why he is asked to generate
the config. Dying with a message "set $buildRoot" could be an option.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

