### PR TITLE
skypeforlinux: 5.5.0.1 -> 8.11.0.4

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, dpkg, makeWrapper
-, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib, glibc, gnome2, libsecret
-, libnotify, nspr, nss, systemd, xorg, libv4l, libstdcxx5 }:
+, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib, glibc, gnome2
+, libnotify, libpulseaudio, libsecret, libstdcxx5, libv4l, nspr, nss, systemd, xorg }:
 
 let
 
-  version = "5.5.0.1";
+  version = "8.11.0.4";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
@@ -17,9 +17,8 @@ let
     fontconfig
     freetype
     glib
-    libsecret
     glibc
-    libstdcxx5
+    libsecret
 
     gnome2.GConf
     gnome2.gdk_pixbuf
@@ -29,10 +28,12 @@ let
     gnome2.gnome_keyring
 
     libnotify
+    libpulseaudio
     nspr
     nss
     stdenv.cc.cc
     systemd
+    libstdcxx5
     libv4l
 
     xorg.libxkbfile
@@ -54,7 +55,7 @@ let
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_${version}_amd64.deb";
-        sha256 = "1r65qlsjwp0n0fmlhvbp71h03b3x73r26jk9f4q687sjqnzmkvcr";
+        sha256 = "1dq7k4zlqqsx7786phialia5xbpc3cp1wrjhqrvga09yg4dl505c";
       }
     else
       throw "Skype for linux is not supported on ${stdenv.system}";
@@ -82,8 +83,8 @@ in stdenv.mkDerivation {
 
   postFixup = ''
     for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* -or -name \*.node\* \) ); do
-                patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
-                patchelf --set-rpath ${rpath}:$out/share/skypeforlinux $file || true
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+      patchelf --set-rpath ${rpath}:$out/share/skypeforlinux $file || true
     done
 
     ln -s "$out/share/skypeforlinux/skypeforlinux" "$out/bin/skypeforlinux"
@@ -92,15 +93,13 @@ in stdenv.mkDerivation {
     substituteInPlace $out/share/applications/skypeforlinux.desktop \
       --replace /usr/bin/ $out/bin/ \
       --replace /usr/share/ $out/share/
-
   '';
 
   meta = with stdenv.lib; {
     description = "Linux client for skype";
     homepage = https://www.skype.com;
     license = licenses.unfree;
-    maintainers = with stdenv.lib.maintainers; [ panaeon ];
+    maintainers = with stdenv.lib.maintainers; [ panaeon jraygauthier ];
     platforms = [ "x86_64-linux" ];
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

Previous beta version what put out of service by Microsoft.
Now use latest and it works fine (both video and sound).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

