### PR TITLE
make-disk-image: use faketime to get a consistent timestamp

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -64,7 +64,7 @@ let
     ${channelSources}
   '';
 
-  prepareImageInputs = with pkgs; [ rsync utillinux parted e2fsprogs lkl fakeroot config.system.build.nixos-prepare-root ] ++ stdenv.initialPath;
+  prepareImageInputs = with pkgs; [ rsync utillinux parted e2fsprogs lkl fakeroot libfaketime config.system.build.nixos-prepare-root ] ++ stdenv.initialPath;
 
   # I'm preserving the line below because I'm going to search for it across nixpkgs to consolidate
   # image building logic. The comment right below this now appears in 4 different places in nixpkgs :)
@@ -86,7 +86,7 @@ let
       offset=0
     ''}
 
-    mkfs.${fsType} -F -L nixos -E offset=$offset $diskImage
+    faketime -f "1970-01-01 00:00:01" mkfs.${fsType} -F -L nixos -E offset=$offset $diskImage
   
     root="$PWD/root"
     mkdir -p $root
@@ -124,7 +124,15 @@ let
     fakeroot nixos-prepare-root $root ${channelSources} ${config.system.build.toplevel} closure
 
     echo "copying staging root to image..."
-    cptofs ${pkgs.lib.optionalString partitioned "-P 1"} -t ${fsType} -i $diskImage $root/* /
+    # If we don't faketime, we can end up with timestamps other than 1 on the nix store, which
+    # will confuse Nix in some situations (e.g., breaking image builds in the target image)
+    # N.B: I use 0 here, which results in timestamp = 1 in the image. It's weird but see
+    # https://github.com/lkl/linux/issues/393. Also, running under faketime makes `cptofs` super
+    # noisy and it prints out that it can't find a bunch of files, and then works anyway. We'll
+    # shut it up someday but trying to do a stderr filter through grep is running into some nasty
+    # bug in some eval nonsense we have in runInLinuxVM and I'm sick of trying to fix it.
+    faketime -f "1970-01-01 00:00:00" \
+      cptofs ${pkgs.lib.optionalString partitioned "-P 1"} -t ${fsType} -i $diskImage $root/* /
   '';
 in pkgs.vmTools.runInLinuxVM (
   pkgs.runCommand name


### PR DESCRIPTION
Backporting https://github.com/NixOS/nixpkgs/commit/f5b3f2c5a7f2b51e80ac32fb47fd1d7d3e475ad1 to 17.09 because it breaks images built on the release.

I've built images with the new code and tested that they boot, and I've checked that the timestamps in the image are indeed 1. No automated tests for that yet, but maybe someday.

Note that this makes the image generation script noisier for reasons I don't understand yet and couldn't suppress easily.

@edolstra this is the commit I asked you to wait for before you made a new batch of AMIs.