### PR TITLE
 electrum: 2.9.3 -> 3.0.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -424,6 +424,7 @@
   mog = "Matthew O'Gorman <mog-lists@rldn.net>";
   montag451 = "montag451 <montag451@laposte.net>";
   moosingin3space = "Nathan Moos <moosingin3space@gmail.com>";
+  moredread = "André-Patrick Bubel <code@apb.name>";
   moretea = "Maarten Hoogendoorn <maarten@moretea.nl>";
   mornfall = "Petr Ročkai <me@mornfall.net>";
   MostAwesomeDude = "Corbin Simpson <cds@corbinsimpson.com>";

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -1,24 +1,24 @@
-{ stdenv, fetchurl, python2Packages }:
+{ stdenv, fetchurl, python3, python3Packages }:
 
-python2Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   name = "electrum-${version}";
-  version = "2.9.3";
+  version = "3.0.2";
 
   src = fetchurl {
     url = "https://download.electrum.org/${version}/Electrum-${version}.tar.gz";
-    sha256 = "0d0fzb653g7b8ka3x90nl21md4g3n1fv11czdxpdq3s9yr6js6f2";
+    sha256 = "0lsg513lxs8qqpr7c0ibb7pma69hxiy3zqybganh6vs9byy7bzsd";
   };
 
-  propagatedBuildInputs = with python2Packages; [
+  propagatedBuildInputs = with python3Packages; [
     dns
     ecdsa
-    jsonrpclib
+    jsonrpclib-pelix
     matplotlib
     pbkdf2
     protobuf
     pyaes
     pycrypto
-    pyqt4
+    pyqt5
     pysocks
     qrcode
     requests
@@ -35,7 +35,7 @@ python2Packages.buildPythonApplication rec {
 
   preBuild = ''
     sed -i 's,usr_share = .*,usr_share = "'$out'/share",g' setup.py
-    pyrcc4 icons.qrc -o gui/qt/icons_rc.py
+    pyrcc5 icons.qrc -o gui/qt/icons_rc.py
     # Recording the creation timestamps introduces indeterminism to the build
     sed -i '/Created: .*/d' gui/qt/icons_rc.py
   '';
@@ -43,12 +43,14 @@ python2Packages.buildPythonApplication rec {
   postInstall = ''
     # Despite setting usr_share above, these files are installed under
     # $out/nix ...
-    mv $out/lib/python2.7/site-packages/nix/store"/"*/share $out
-    rm -rf $out/lib/python2.7/site-packages/nix
+    mv $out/${python3.sitePackages}/nix/store"/"*/share $out
+    rm -rf $out/${python3.sitePackages}/nix
 
     substituteInPlace $out/share/applications/electrum.desktop \
       --replace "Exec=electrum %u" "Exec=$out/bin/electrum %u"
   '';
+
+  doCheck = false;
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/pkgs/development/python-modules/jsonrpclib-pelix/default.nix
+++ b/pkgs/development/python-modules/jsonrpclib-pelix/default.nix
@@ -1,0 +1,22 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "jsonrpclib-pelix";
+  version = "0.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qs95vxplxwspbrqy8bvc195s58iy43qkf75yrjfql2sim8b25sl";
+  };
+
+  meta = with lib; {
+    description = "JSON RPC client library - Pelix compatible fork";
+    homepage = https://pypi.python.org/pypi/jsonrpclib-pelix/;
+    license = lib.licenses.asl20;
+    maintainers = with maintainers; [ moredread ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5908,6 +5908,8 @@ in {
     };
   };
 
+  jsonrpclib-pelix = callPackage ../development/python-modules/jsonrpclib-pelix {};
+
   jsonwatch = buildPythonPackage rec {
     name = "jsonwatch-0.2.0";
 


### PR DESCRIPTION
###### Motivation for this change

Upgrading electrum to the latest version. As it doesn't support Python 2 anymore, it is now built against Python 3. For this, _jsonrpclib-pelix_ is needed, a fork of _jsonrpclib_, that works with Python 3. See the first of the commit in the PR. If this is acceptable, would you, @joachifm, also be the maintainer of the new package?

I couldn't test it built against master, as I get an error message when I run the binary. I think it's an incompatibility of the QT5 runtime library. See the comment below for details. I backported it to 17.09 (only needs a later version of protobuf, e.g. protobuf3_2), and there it works fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

