### PR TITLE
electron-cash: 2.9.3 -> 2.9.4

### DIFF
--- a/pkgs/applications/misc/electron-cash/default.nix
+++ b/pkgs/applications/misc/electron-cash/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchFromGitHub, python2Packages }:
+{ stdenv, fetchurl, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
-  version = "2.9.3";
+  version = "2.9.4";
   name = "electron-cash-${version}";
 
-  src = fetchFromGitHub {
-    owner = "fyookball";
-    repo = "electrum";
-    rev = version;
-    sha256 = "1r39b5ag5fipzgr84pzb53cfm8a4dy53257608754dwr1gfpma3v";
+  src = fetchurl {
+    url = "https://electroncash.org/downloads/${version}/win-linux/Electron-Cash-${version}.tar.gz";
+    # Verified using official SHA-1 and signature from
+    # https://github.com/fyookball/keys-n-hashes
+    sha256 = "1y8mzwa6bb8zj4l92wm4c2icnr42wmhbfz6z5ymh356gwll914vh";
   };
 
   propagatedBuildInputs = with python2Packages; [
@@ -42,8 +42,8 @@ python2Packages.buildPythonApplication rec {
     mv $out/lib/python2.7/site-packages/nix/store"/"*/share $out
     rm -rf $out/lib/python2.7/site-packages/nix
 
-    substituteInPlace $out/share/applications/electron.desktop \
-      --replace "Exec=electrum %u" "Exec=$out/bin/electrum %u"
+    substituteInPlace $out/share/applications/electron-cash.desktop \
+      --replace "Exec=electron-cash %u" "Exec=$out/bin/electron-cash %u"
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION
###### Motivation for this change

To bump electron-cash version. I've also switched the package to downloading the tarball from the official source URL to allow verification using the upstream digital signature. Should be backported to stable because this version is needed for the Bitcoin Cash hard fork on the 13th Nov.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @Lassulus