### PR TITLE
nixos/network-interfaces: Add " around network interface names

### DIFF
--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -923,7 +923,9 @@ in
     assertions =
       (flip map interfaces (i: {
         assertion = i.subnetMask == null;
-        message = "The networking.interfaces.${i.name}.subnetMask option is defunct. Use prefixLength instead.";
+        message = ''
+          The networking.interfaces."${i.name}".subnetMask option is defunct. Use prefixLength instead.
+        '';
       })) ++ (flip map interfaces (i: {
         # With the linux kernel, interface name length is limited by IFNAMSIZ
         # to 16 bytes, including the trailing null byte.
@@ -934,7 +936,9 @@ in
         '';
       })) ++ (flip map slaveIfs (i: {
         assertion = i.ip4 == [ ] && i.ipAddress == null && i.ip6 == [ ] && i.ipv6Address == null;
-        message = "The networking.interfaces.${i.name} must not have any defined ips when it is a slave.";
+        message = ''
+          The networking.interfaces."${i.name}" must not have any defined ips when it is a slave.
+        '';
       })) ++ [
         {
           assertion = cfg.hostId == null || (stringLength cfg.hostId == 8 && isHexString cfg.hostId);


### PR DESCRIPTION
in assertion messages to avoid misinterpretations when the interface name contains a dot, making the output consistent with the new assertion against too-long interface names.

###### Motivation for this change
Was brought up by @4z3 at https://github.com/NixOS/nixpkgs/pull/30127#discussion_r149908314

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

