### PR TITLE
dotty: init at 0.4.0-RC1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -325,6 +325,7 @@
   kaiha = "Kai Harries <kai.harries@gmail.com>";
   kamilchm = "Kamil Chmielewski <kamil.chm@gmail.com>";
   kampfschlaefer = "Arnold Krille <arnold@arnoldarts.de>";
+  karolchmist = "karolchmist <info+nix@chmist.com>";
   kentjames = "James Kent <jameschristopherkent@gmail.com";
   kevincox = "Kevin Cox <kevincox@kevincox.ca>";
   khumba = "Bryan Gardiner <bog@khumba.net>";

--- a/pkgs/development/compilers/scala/dotty.nix
+++ b/pkgs/development/compilers/scala/dotty.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, makeWrapper, jre }:
+
+stdenv.mkDerivation rec {
+  version = "0.4.0-RC1";
+  name = "dotty-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/lampepfl/dotty/releases/download/${version}/${name}.tar.gz";
+    sha256 = "1d1ab08b85bd6898ce6273fa50818de0d314fc6e5377fb6ee05494827043321b";
+  };
+
+  propagatedBuildInputs = [ jre ] ;
+  buildInputs = [ makeWrapper ] ;
+
+  installPhase = ''
+    mkdir -p $out
+    mv * $out
+
+    for p in $out/bin/* ; do
+      file=$(basename $p)
+
+      # no need to wrap common
+      if [[ "$file" = "common" ]] ; then
+        continue
+      fi
+
+      wrapProgram $p --set JAVA_HOME ${jre}
+    done    
+  '';
+
+  meta = {
+    description = "Research platform for new language concepts and compiler technologies for Scala.";
+    longDescription = ''
+       Dotty is a platform to try out new language concepts and compiler technologies for Scala.
+       The focus is mainly on simplification. We remove extraneous syntax (e.g. no XML literals),
+       and try to boil down Scala’s types into a smaller set of more fundamental constructs.
+       The theory behind these constructs is researched in DOT, a calculus for dependent object types.
+    '';
+    homepage = http://dotty.epfl.ch/;
+    license = stdenv.lib.licenses.bsd3;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/compilers/scala/dotty.nix
+++ b/pkgs/development/compilers/scala/dotty.nix
@@ -16,19 +16,21 @@ stdenv.mkDerivation rec {
     mkdir -p $out
     mv * $out
 
-    for p in $out/bin/* ; do
-      file=$(basename $p)
-
-      # no need to wrap common
-      if [[ "$file" = "common" ]] ; then
-        continue
-      fi
-
-      wrapProgram $p --set JAVA_HOME ${jre}
-    done    
+    mkdir -p $out/shared
+    mv $out/bin/common $out/shared
   '';
 
-  meta = {
+  fixupPhase = ''
+    for file in $out/bin/* ; do
+      substituteInPlace $file \
+        --replace '$PROG_HOME/bin/common' $out/shared/common
+
+      wrapProgram $file \
+        --set JAVA_HOME ${jre}
+    done
+  '';
+
+  meta = with stdenv.lib; {
     description = "Research platform for new language concepts and compiler technologies for Scala.";
     longDescription = ''
        Dotty is a platform to try out new language concepts and compiler technologies for Scala.
@@ -37,7 +39,8 @@ stdenv.mkDerivation rec {
        The theory behind these constructs is researched in DOT, a calculus for dependent object types.
     '';
     homepage = http://dotty.epfl.ch/;
-    license = stdenv.lib.licenses.bsd3;
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = [maintainers.karolchmist];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6264,6 +6264,7 @@ with pkgs;
   scala_2_10 = callPackage ../development/compilers/scala/2.10.nix { };
   scala_2_11 = callPackage ../development/compilers/scala/2.11.nix { };
   scala_2_12 = callPackage ../development/compilers/scala { jre = jre8; };
+  scala_dotty = callPackage ../development/compilers/scala/dotty.nix { jre = jre8;};
   scala = scala_2_12;
 
   scalafmt = callPackage ../development/tools/scalafmt { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5479,6 +5479,8 @@ with pkgs;
 
   devpi-client = callPackage ../development/tools/devpi-client {};
 
+  dotty = callPackage ../development/compilers/scala/dotty.nix { jre = jre8;};
+
   drumstick = callPackage ../development/libraries/drumstick { };
 
   ecl = callPackage ../development/compilers/ecl { };
@@ -6264,7 +6266,6 @@ with pkgs;
   scala_2_10 = callPackage ../development/compilers/scala/2.10.nix { };
   scala_2_11 = callPackage ../development/compilers/scala/2.11.nix { };
   scala_2_12 = callPackage ../development/compilers/scala { jre = jre8; };
-  scala_dotty = callPackage ../development/compilers/scala/dotty.nix { jre = jre8;};
   scala = scala_2_12;
 
   scalafmt = callPackage ../development/tools/scalafmt { };


### PR DESCRIPTION
###### Motivation for this change

Dotty is a platform to try out new language concepts and compiler technologies for Scala. The focus is mainly on simplification. The theory behind these constructs is researched in DOT, a calculus for dependent object types. 

http://dotty.epfl.ch/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

