### PR TITLE
steam-chrootenv: add iana-etc, fixes #25443

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -32,6 +32,7 @@ let
       xdg_utils
       # Zoneinfo
       etc-zoneinfo
+      iana-etc
     ] ++ lib.optional withJava jdk
       ++ lib.optional withPrimus primus
       ++ extraPkgs pkgs;


### PR DESCRIPTION
###### Motivation for this change
Both Borderlands 2 and Borderlands: The Pre-Sequel silently crash when downloading hotfixes, as documented in #25443. This appears to be the same bug as https://github.com/flathub/com.valvesoftware.Steam/issues/5, which is fixed by having a populated /etc/services. 

###### Things done
Adding iana-etc to the chrootenv's environment makes this crash go away. I may again be messing up where the package should be added...

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

