### PR TITLE
lib/generators: add mkValueString to mkKeyValueDefault generator

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -22,11 +22,15 @@ rec {
    * character sep. If sep appears in k, it is escaped.
    * Helper for synaxes with different separators.
    *
-   * mkKeyValueDefault ":" "f:oo" "bar"
+   * mkValueString specifies how values should be formatted.
+   *
+   * mkKeyValueDefault {} ":" "f:oo" "bar"
    * > "f\:oo:bar"
    */
-  mkKeyValueDefault = sep: k: v:
-    "${libStr.escape [sep] k}${sep}${toString v}";
+  mkKeyValueDefault = {
+    mkValueString ? toString
+  }: sep: k: v:
+    "${libStr.escape [sep] k}${sep}${mkValueString v}";
 
 
   /* Generate a key-value-style config file from an attrset.
@@ -34,7 +38,7 @@ rec {
    * mkKeyValue is the same as in toINI.
    */
   toKeyValue = {
-    mkKeyValue ? mkKeyValueDefault "="
+    mkKeyValue ? mkKeyValueDefault {} "="
   }: attrs:
     let mkLine = k: v: mkKeyValue k v + "\n";
     in libStr.concatStrings (libAttr.mapAttrsToList mkLine attrs);
@@ -64,7 +68,7 @@ rec {
     # apply transformations (e.g. escapes) to section names
     mkSectionName ? (name: libStr.escape [ "[" "]" ] name),
     # format a setting line from key and value
-    mkKeyValue    ? mkKeyValueDefault "="
+    mkKeyValue    ? mkKeyValueDefault {} "="
   }: attrsOfAttrs:
     let
         # map function to string for each key val

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -201,7 +201,7 @@ runTests {
 # in alphabetical order
 
   testMkKeyValueDefault = {
-    expr = generators.mkKeyValueDefault ":" "f:oo" "bar";
+    expr = generators.mkKeyValueDefault {} ":" "f:oo" "bar";
     expected = ''f\:oo:bar'';
   };
 


### PR DESCRIPTION
This means the generation of values can now be influenced, even down from e.g.
an INI generator.
Breaks the interface of `mkKeyValueDefault` to match its interface to other
generator functions. It might me sensible to rename `mkKeyValue` and
`mkKeyValueSet` to conform to the `toX`-style of generator functions.

- [x] tested by running `lib/tests/misc.nix`
- [x] used new argument in project