### PR TITLE
 git-secret: init at 0.2.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -358,6 +358,7 @@
   linus = "Linus Arver <linusarver@gmail.com>";
   lluchs = "Lukas Werling <lukas.werling@gmail.com>";
   lnl7 = "Daiderd Jordan <daiderd@gmail.com>";
+  lo1tuma = "Mathias Schreck <schreck.mathias@gmail.com>";
   loskutov = "Ignat Loskutov <ignat.loskutov@gmail.com>";
   lovek323 = "Jason O'Conal <jason@oconal.id.au>";
   lowfatcomputing = "Andreas Wagner <andreas.wagner@lowfatcomputing.org>";

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -84,6 +84,8 @@ rec {
 
   git-remote-hg = callPackage ./git-remote-hg { };
 
+  git-secret = callPackage ./git-secret { };
+
   git-stree = callPackage ./git-stree { };
 
   git2cl = callPackage ./git2cl { };

--- a/pkgs/applications/version-management/git-and-tools/git-secret/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-secret/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper, git, gnupg }:
+
+let
+  version = "0.2.2";
+  repo = "git-secret";
+
+in stdenv.mkDerivation {
+  name = "${repo}-${version}";
+
+  src = fetchFromGitHub {
+    inherit repo;
+    owner = "sobolevn";
+    rev = "v${version}";
+    sha256 = "0vn9jibp97z7kc828wka1k0d7a9wx4skd6cnqy60kagfc00l0bzh";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp git-secret $out/bin
+
+    wrapProgram $out/bin/git-secret \
+      --prefix PATH : "${lib.makeBinPath [ git gnupg ]}"
+
+    cp -R man $out/
+  '';
+
+  meta = {
+    description = "A bash-tool to store your private data inside a git repository.";
+    homepage = http://git-secret.io;
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.lo1tuma ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/applications/version-management/git-and-tools/git-secret/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-secret/default.nix
@@ -17,17 +17,17 @@ in stdenv.mkDerivation {
   buildInputs = [ makeWrapper ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp git-secret $out/bin
+    install -D git-secret $out/bin/git-secret
 
     wrapProgram $out/bin/git-secret \
       --prefix PATH : "${lib.makeBinPath [ git gnupg ]}"
 
-    cp -R man $out/
+    mkdir $out/share
+    cp -r man $out/share
   '';
 
   meta = {
-    description = "A bash-tool to store your private data inside a git repository.";
+    description = "A bash-tool to store your private data inside a git repository";
     homepage = http://git-secret.io;
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.lo1tuma ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14843,7 +14843,7 @@ with pkgs;
 
   gitAndTools = recurseIntoAttrs (callPackage ../applications/version-management/git-and-tools {});
 
-  inherit (gitAndTools) git gitFull gitSVN git-cola svn2git git-radar transcrypt git-crypt;
+  inherit (gitAndTools) git gitFull gitSVN git-cola svn2git git-radar git-secret transcrypt git-crypt;
 
   gitMinimal = git.override {
     withManual = false;


### PR DESCRIPTION
###### Motivation for this change

[git-secret](http://git-secret.io/) is a bash tool to store your private data inside a git repo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

