### PR TITLE
pythonPackages.nbconvert: fix failing tests on darwin

### DIFF
--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   checkPhase = ''
     mkdir tmp
-    LC_ALL=en_US.utf8 HOME=`realpath tmp` py.test -v
+    LC_ALL=en_US.UTF-8 HOME=`realpath tmp` py.test -v
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

nbconvert is failing to install on my darwin machine because of failing tests caused by `LC_ALL` being set to `en_US.utf8` instead of `en_US.UTF-8`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
