### PR TITLE
awscli: 1.11.162 -> 1.11.185

### DIFF
--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -1,0 +1,44 @@
+{ buildPythonPackage
+, fetchPypi
+, dateutil
+, jmespath
+, docutils
+, ordereddict
+, simplejson
+, mock
+, nose
+}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "botocore";
+  version = "1.7.43";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wyyj7sk7dh9v7i1g5jc5maqdadvbs4khi7srz0095cywkjqpysc";
+  };
+
+  propagatedBuildInputs = [
+    dateutil
+    jmespath
+    docutils
+    ordereddict
+    simplejson
+  ];
+
+  checkInputs = [ mock nose ];
+
+  checkPhase = ''
+    nosetests -v
+  '';
+
+  # Network access
+  doCheck = false;
+
+  meta = {
+    homepage = https://github.com/boto/botocore;
+    license = "bsd";
+    description = "A low-level interface to a growing number of Amazon Web Services";
+  };
+}

--- a/pkgs/development/python-modules/s3transfer/default.nix
+++ b/pkgs/development/python-modules/s3transfer/default.nix
@@ -1,0 +1,53 @@
+{ stdenv
+, fetchPypi
+, pythonOlder
+, buildPythonPackage
+, docutils
+, mock
+, nose
+, coverage
+, wheel
+, unittest2
+, botocore
+, futures
+}:
+
+buildPythonPackage rec {
+  pname = "s3transfer";
+  version = "0.1.11";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0yfrfnf404cxzn3iswibqjxklsl0b1lwgqiml6pwiqj79a7zbwbn";
+  };
+
+  foo = 1;
+
+  propagatedBuildInputs =
+    [ botocore
+    ] ++ stdenv.lib.optional (pythonOlder "3") futures;
+
+  buildInputs = [
+    docutils
+    mock
+    nose
+    coverage
+    wheel
+    unittest2
+  ];
+
+  checkPhase = ''
+    pushd s3transfer/tests
+    nosetests -v unit/ functional/
+    popd
+  '';
+
+  # version on pypi has no tests/ dir
+  doCheck = false;
+
+  meta = {
+    homepage = https://github.com/boto/s3transfer;
+    license = stdenv.lib.licenses.asl20;
+    description = "A library for managing Amazon S3 transfers";
+  };
+}

--- a/pkgs/tools/admin/aws_shell/default.nix
+++ b/pkgs/tools/admin/aws_shell/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, awscli
+, prompt_toolkit
+, boto3
+, configobj
+, pygments
+}:
+
+buildPythonPackage rec {
+  pname = "aws-shell";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1pw9lrdjl24n6lrs6lnqpyiyic8bdxgvhyqvb2rx6kkbjrfhhgv5";
+  };
+
+  # Why does it propagate packages that are used for testing?
+  propagatedBuildInputs = [
+    awscli
+    prompt_toolkit
+    boto3
+    configobj
+    pygments
+  ];
+
+  #Checks are failing due to missing TTY, which won't exist.
+  doCheck = false;
+  preCheck = ''
+    mkdir -p check-phase
+    export HOME=$(pwd)/check-phase
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/awslabs/aws-shell;
+    description = "An integrated shell for working with the AWS CLI";
+    license = licenses.asl20;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, botocore
+, bcdoc
+, s3transfer
+, six
+, colorama
+, docutils
+, rsa
+, pyyaml
+, groff
+, less
+}:
+
+let
+  colorama_3_7 = colorama.overrideAttrs (old: rec {
+    name = "${pname}-${version}";
+    pname = "colorama";
+    version = "0.3.7";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "0avqkn6362v7k2kg3afb35g4sfdvixjgy890clip4q174p9whhz0";
+    };
+  });
+
+in buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "awscli";
+  version = "1.11.185";
+  namePrefix = "";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "18rskl6sla456z4hkq2gmmm03fqc4rqw5pfiqdyc7a2v9kljv4ah";
+  };
+
+  # No tests included
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    botocore
+    bcdoc
+    s3transfer
+    six
+    colorama_3_7
+    docutils
+    rsa
+    pyyaml
+    groff
+    less
+  ];
+
+  postInstall = ''
+    mkdir -p $out/etc/bash_completion.d
+    echo "complete -C $out/bin/aws_completer aws" > $out/etc/bash_completion.d/awscli
+    mkdir -p $out/share/zsh/site-functions
+    mv $out/bin/aws_zsh_completer.sh $out/share/zsh/site-functions
+    rm $out/bin/aws.cmd
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://aws.amazon.com/cli/;
+    description = "Unified tool to manage your AWS services";
+    license = stdenv.lib.licenses.asl20;
+    maintainers = with maintainers; [ muflax ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -511,7 +511,7 @@ with pkgs;
 
   avfs = callPackage ../tools/filesystems/avfs { };
 
-  awscli = pythonPackages.awscli; # Should be moved out of python-packages.nix
+  awscli = pythonPackages.callPackage ../tools/admin/awscli { };
 
   awsebcli = callPackage ../tools/virtualization/awsebcli {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -517,7 +517,7 @@ with pkgs;
 
   awslogs = callPackage ../tools/admin/awslogs { };
 
-  aws_shell = python2Packages.aws_shell; # Should be moved out of python-packages.nix
+  aws_shell = pythonPackages.callPackage ../tools/admin/aws_shell { };
 
   azure-cli = nodePackages.azure-cli;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -789,37 +789,6 @@ in {
     };
   };
 
-  aws_shell = buildPythonPackage rec {
-    name = "aws-shell-${version}";
-    version = "0.1.1";
-    src = pkgs.fetchurl {
-        sha256 = "1pw9lrdjl24n6lrs6lnqpyiyic8bdxgvhyqvb2rx6kkbjrfhhgv5";
-        url = "mirror://pypi/a/aws-shell/aws-shell-${version}.tar.gz";
-      };
-
-    # Why does it propagate packages that are used for testing?
-    propagatedBuildInputs = with self; [
-      awscli prompt_toolkit boto3 configobj pygments
-    ];
-
-    #Checks are failing due to missing TTY, which won't exist.
-    doCheck = false;
-    preCheck = ''
-      mkdir -p check-phase
-      export HOME=$(pwd)/check-phase
-    '';
-
-    disabled = isPy35;
-
-
-    meta = {
-      homepage = https://github.com/awslabs/aws-shell;
-      description = "An integrated shell for working with the AWS CLI";
-      license = licenses.asl20;
-      maintainers = [ ];
-    };
-  };
-
   azure = buildPythonPackage rec {
     version = "0.11.0";
     name = "azure-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -735,60 +735,6 @@ in {
     };
   };
 
-  awscli =
-  let
-    colorama_3_7 = self.colorama.overrideAttrs (old: rec {
-      name = "${pname}-${version}";
-      pname = "colorama";
-      version = "0.3.7";
-      src = fetchPypi {
-        inherit pname version;
-        sha256 = "0avqkn6362v7k2kg3afb35g4sfdvixjgy890clip4q174p9whhz0";
-      };
-    });
-  in buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "awscli";
-    version = "1.11.162";
-    namePrefix = "";
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "0ff17fdzzncrzl7ps1cyrs0c5f82ncbvflnjz8sd1vkcmn9yij8r";
-    };
-
-    # No tests included
-    doCheck = false;
-
-    propagatedBuildInputs = with self; [
-      botocore
-      bcdoc
-      s3transfer
-      six
-      colorama_3_7
-      docutils
-      rsa
-      pyyaml
-      pkgs.groff
-      pkgs.less
-    ];
-
-    postInstall = ''
-      mkdir -p $out/etc/bash_completion.d
-      echo "complete -C $out/bin/aws_completer aws" > $out/etc/bash_completion.d/awscli
-      mkdir -p $out/share/zsh/site-functions
-      mv $out/bin/aws_zsh_completer.sh $out/share/zsh/site-functions
-      rm $out/bin/aws.cmd
-    '';
-
-    meta = {
-      homepage = https://aws.amazon.com/cli/;
-      description = "Unified tool to manage your AWS services";
-      license = stdenv.lib.licenses.asl20;
-      maintainers = with maintainers; [ muflax ];
-    };
-  };
-
   azure = buildPythonPackage rec {
     version = "0.11.0";
     name = "azure-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8352,14 +8352,12 @@ in {
   };
 
   fastimport = callPackage ../development/python-modules/fastimport { };
- 
+
   feedgen = callPackage ../development/python-modules/feedgen { };
 
   feedgenerator = callPackage ../development/python-modules/feedgenerator {
     inherit (pkgs) glibcLocales;
   };
-
-  s3transfer = callPackage ../development/python-modules/s3transfer { };
 
   feedparser = buildPythonPackage (rec {
     name = "feedparser-5.2.1";
@@ -17813,38 +17811,7 @@ in {
     };
   };
 
-  s3transfer = buildPythonPackage rec {
-    version = "0.1.10";
-    name = "s3transfer-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/s/s3transfer/${name}.tar.gz";
-      sha256 = "1h8g9bknvxflxkpbnxyfxmk8pvgykbbk9ljdvhqh6z4vjc2926ms";
-    };
-
-    foo = 1;
-
-    propagatedBuildInputs =
-      [ self.botocore
-      ] ++ stdenv.lib.optional (pythonOlder "3") self.futures;
-
-    buildInputs = with self; [ docutils mock nose coverage wheel unittest2 ];
-
-    checkPhase = ''
-      pushd s3transfer/tests
-      nosetests -v unit/ functional/
-      popd
-    '';
-
-    # version on pypi has no tests/ dir
-    doCheck = false;
-
-    meta = {
-      homepage = https://github.com/boto/s3transfer;
-      license = stdenv.lib.licenses.asl20;
-      description = "A library for managing Amazon S3 transfers";
-    };
-  };
+  s3transfer = callPackage ../development/python-modules/s3transfer { };
 
   seqdiag = callPackage ../development/python-modules/seqdiag { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2066,39 +2066,7 @@ in {
     };
   };
 
-  botocore = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "botocore";
-    version = "1.7.20";
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "16sy35bp9i2g9785l8jzcd4ddc2nydqs3wnkqwi36xx6l3bdbn13";
-    };
-
-    propagatedBuildInputs = with self; [
-      dateutil
-      jmespath
-      docutils
-      ordereddict
-      simplejson
-    ];
-
-    checkInputs = with self; [ mock nose ];
-
-    checkPhase = ''
-      nosetests -v
-    '';
-
-    # Network access
-    doCheck = false;
-
-    meta = {
-      homepage = https://github.com/boto/botocore;
-      license = "bsd";
-      description = "A low-level interface to a growing number of Amazon Web Services";
-    };
-  };
+  botocore = callPackage ../development/python-modules/botocore { };
 
   bottle = buildPythonPackage rec {
     version = "0.12.11";
@@ -8390,6 +8358,8 @@ in {
   feedgenerator = callPackage ../development/python-modules/feedgenerator {
     inherit (pkgs) glibcLocales;
   };
+
+  s3transfer = callPackage ../development/python-modules/s3transfer { };
 
   feedparser = buildPythonPackage (rec {
     name = "feedparser-5.2.1";


### PR DESCRIPTION
###### Motivation for this change
Upstream API updates.

Had to update `botocore` and `s3transfer` for this.

`awscli` and `aws_shell` no longer lives in `pythonPackages`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

