### PR TITLE
yakuake: 3.0.3 -> 3.0.4

### DIFF
--- a/pkgs/applications/misc/yakuake/default.nix
+++ b/pkgs/applications/misc/yakuake/default.nix
@@ -18,15 +18,14 @@
 , qtx11extras
 }:
 
-let
+mkDerivation rec {
   pname = "yakuake";
-  version = "3.0.3";
-in mkDerivation rec {
+  version = "3.0.4";
   name = "${pname}-${version}";
 
     src = fetchurl {
       url = "http://download.kde.org/stable/${pname}/${version}/src/${name}.tar.xz";
-      sha256 = "ef51aa3325916d352fde17870cf706397e41105103e4c9289cc4032a1b8609a7";
+      sha256 = "1q31p1cqhz8b2bikqjrr7fww86kaq723ib4ys2zwablfa1ybbqhh";
     };
 
     buildInputs = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

