### PR TITLE
tini: 0.13.1 -> 0.16.1

### DIFF
--- a/pkgs/applications/virtualization/tini/default.nix
+++ b/pkgs/applications/virtualization/tini/default.nix
@@ -1,20 +1,25 @@
 { stdenv, fetchFromGitHub, cmake, glibc }:
 
 stdenv.mkDerivation rec {
-  version = "0.13.1";
+  version = "0.16.1";
   name = "tini-${version}";
+
   src = fetchFromGitHub {
     owner = "krallin";
     repo = "tini";
     rev = "v${version}";
-    sha256 ="1g4n8v5d197zcb41fcpbhip2x342383zw1d2zkv57w73vkqgv6z6";
+    sha256 ="1abvjwjk7xhsbx60niy4ykcj3xvrxcl6zx8z1v827jsn47wzpikp";
   };
+
   patchPhase = "sed -i /tini-static/d CMakeLists.txt";
+
   NIX_CFLAGS_COMPILE = [
     "-DPR_SET_CHILD_SUBREAPER=36"
     "-DPR_GET_CHILD_SUBREAPER=37"
   ];
+
   buildInputs = [ cmake glibc glibc.static ];
+
   meta = with stdenv.lib; {
     description = "A tiny but valid init for containers";
     homepage = https://github.com/krallin/tini;


### PR DESCRIPTION
###### Motivation for this change
There have been a few bugfixes since 0.13.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

