### PR TITLE
Nodejs: Minor updates

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -2,14 +2,14 @@
 , ApplicationServices, CoreServices }:
 
 stdenv.mkDerivation rec {
-  version = "1.15.0";
+  version = "1.16.1";
   name = "libuv-${version}";
 
   src = fetchFromGitHub {
     owner = "libuv";
     repo = "libuv";
     rev = "v${version}";
-    sha256 = "092hxqjvbb6d03h3msc38359w2kixba1ansyrsbyqq8iqiqwnkw0";
+    sha256 = "06p3xy276spqbr9xzbs7qlpdk34qsn87s2qmp6xn4j7v3bnqja7z";
   };
 
   postPatch = let

--- a/pkgs/development/web/nodejs/v8.nix
+++ b/pkgs/development/web/nodejs/v8.nix
@@ -5,7 +5,7 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "8.9.0";
-    sha256 = "128ir6rkdz1xj55hbflw0sh7snrrvjwgvxmgnka7cyhjkvw5i0mf";
+    version = "8.9.1";
+    sha256 = "1q0p9zl260pd8038yvn13lw5whs480dy11ar2ijcm2hgyqhhq5pg";
     patches = lib.optionals stdenv.isDarwin [ ./no-xcode-v7.patch ];
   }

--- a/pkgs/development/web/nodejs/v9.nix
+++ b/pkgs/development/web/nodejs/v9.nix
@@ -5,7 +5,7 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "9.0.0";
-    sha256 = "19az7mxcb3d1aj0f7gvhriyyghn1rwn0425924pa84d6j1mbsljv";
+    version = "9.2.0";
+    sha256 = "1hmvwfbavk2axqz9kin8b5zsld25gznhvlz55h3yl6nwx9iz5jk4";
     patches = lib.optionals stdenv.isDarwin [ ./no-xcode-v7.patch ];
   }


### PR DESCRIPTION
###### Motivation for this change
~~Fix for CVE-2017-3736.~~

~~From upstream PR https://github.com/nodejs/node/pull/16691~~
~~This upgrades to OpenSSL-1.0.2m . It includes the fix of the moderate severity of CVE-2017-3736 that affects Node in RSA calculations of TLS and crypto modules but the attack is said to be very difficult.~~

Edit: As @vcunat points out we are already using the system `OpenSSL` so it does not have any security impact. This is just a normal update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

