### PR TITLE
makeWrapper: quote variables

### DIFF
--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -47,7 +47,7 @@ makeWrapper() {
             varName="${params[$((n + 1))]}"
             value="${params[$((n + 2))]}"
             n=$((n + 2))
-            echo "export $varName=\"$value\"" >> "$wrapper"
+            echo "export $varName=${value@Q}" >> "$wrapper"
         elif [[ "$p" == "--unset" ]]; then
             varName="${params[$((n + 1))]}"
             n=$((n + 1))
@@ -63,9 +63,9 @@ makeWrapper() {
             n=$((n + 3))
             if test -n "$value"; then
                 if test "$p" = "--suffix"; then
-                    echo "export $varName=\$$varName\${$varName:+$separator}$value" >> "$wrapper"
+                    echo "export $varName=\$$varName\${$varName:+${separator@Q}}${value@Q}" >> "$wrapper"
                 else
-                    echo "export $varName=$value\${$varName:+$separator}\$$varName" >> "$wrapper"
+                    echo "export $varName=${value@Q}\${$varName:+${separator@Q}}\$$varName" >> "$wrapper"
                 fi
             fi
         elif [[ "$p" == "--suffix-each" ]]; then
@@ -74,7 +74,7 @@ makeWrapper() {
             values="${params[$((n + 3))]}"
             n=$((n + 3))
             for value in $values; do
-                echo "export $varName=\$$varName\${$varName:+$separator}$value" >> "$wrapper"
+                echo "export $varName=\$$varName\${$varName:+$separator}${value@Q}" >> "$wrapper"
             done
         elif [[ ("$p" == "--suffix-contents") || ("$p" == "--prefix-contents") ]]; then
             varName="${params[$((n + 1))]}"
@@ -82,10 +82,11 @@ makeWrapper() {
             fileNames="${params[$((n + 3))]}"
             n=$((n + 3))
             for fileName in $fileNames; do
+                contents="$(cat "$fileName")"
                 if test "$p" = "--suffix-contents"; then
-                    echo "export $varName=\$$varName\${$varName:+$separator}$(cat "$fileName")" >> "$wrapper"
+                    echo "export $varName=\$$varName\${$varName:+$separator}${contents@Q}" >> "$wrapper"
                 else
-                    echo "export $varName=$(cat "$fileName")\${$varName:+$separator}\$$varName" >> "$wrapper"
+                    echo "export $varName=${contents@Q}\${$varName:+$separator}\$$varName" >> "$wrapper"
                 fi
             done
         elif [[ "$p" == "--add-flags" ]]; then


### PR DESCRIPTION
###### Motivation for this change

Fix things like `--prefix FOO ' ' 'bar baz'`

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

