### PR TITLE
WIP: language-c: add hack to deal with _Float128 in glibc

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -978,4 +978,17 @@ self: super: {
 
   # missing dependencies: Glob >=0.7.14 && <0.8, data-fix ==0.0.4
   stack2nix = doJailbreak super.stack2nix;
+
+  # https://github.com/visq/language-c/issues/39
+  # tests are not present in hackage release, so they need to be disabled
+  # if you hit this assert you should check for a fix upstream
+  language-c = dontCheck (overrideCabal super.language-c (drv: assert (drv.version == "0.6.1"); {
+    doCheck = false;
+    src = pkgs.fetchFromGitHub {
+      owner = "corngood";
+      repo = "language-c";
+      rev = "667b019de90f6642b403eb30ce1fe7002b84a01d";
+      sha256 = "19hhihv6ngks7n0pks65713k7xfk9whsd2w483y50kdw42qyqvv7";
+    };
+  }));
 }


### PR DESCRIPTION
Fixes #31411

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

