### PR TITLE
fonts: fix fontconfig.localConf when used with penultimate

### DIFF
--- a/nixos/modules/config/fonts/fontconfig-penultimate.nix
+++ b/nixos/modules/config/fonts/fontconfig-penultimate.nix
@@ -52,6 +52,8 @@ let
       </fontconfig>
     '';
 
+  localConf = pkgs.writeText "fc-local.conf" cfg.localConf;
+
   # The configuration to be included in /etc/font/
   penultimateConf = pkgs.runCommand "font-penultimate-conf" {} ''
     support_folder=$out/etc/fonts/conf.d
@@ -106,6 +108,12 @@ let
       ${pkgs.fontconfig-penultimate}/etc/fonts/conf.d/51-local.conf \
       $latest_folder/51-local.conf \
       --replace local.conf /etc/fonts/${latestVersion}/local.conf
+
+    # local.conf (indirect priority 51)
+    ${optionalString (cfg.localConf != "") ''
+    ln -s ${localConf}        $out/etc/fonts/local.conf
+    ln -s ${localConf}        $out/etc/fonts/${latestVersion}/local.conf
+    ''}
 
     ln -s ${defaultFontsConf} $support_folder/52-default-fonts.conf
     ln -s ${defaultFontsConf} $latest_folder/52-default-fonts.conf


### PR DESCRIPTION
Fixes #31500

###### Motivation for this change
This makes the `fonts.fontconfig.localConf` option work as expected when `fonts.fontconfig.penultimate` is enabled.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

