### PR TITLE
lr: 0.4 -> 1.1

### DIFF
--- a/pkgs/tools/system/lr/default.nix
+++ b/pkgs/tools/system/lr/default.nix
@@ -2,22 +2,22 @@
 
 stdenv.mkDerivation rec {
   name = "lr-${version}";
-  version = "0.4";
+  version = "1.1";
 
   src = fetchFromGitHub {
     owner = "chneukirchen";
     repo = "lr";
     rev = "v${version}";
-    sha256 = "16qp0791s652yi86x472wwr62w6nhiyb1i662d85y5zyfagdf7dd";
+    sha256 = "171h353238s9wmhirvs2yc1151vds83a71p7wgn96wa3jpl248by";
   };
 
   makeFlags = "PREFIX=$(out)";
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/chneukirchen/lr;
     description = "List files recursively";
-    license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.all;
-    maintainers = [ stdenv.lib.maintainers.globin ];
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.globin ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Big version bump for a nice CLI tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

