### PR TITLE
networkmanager-l2tp: 1.2.4 -> 1.2.8

### DIFF
--- a/pkgs/tools/networking/network-manager/l2tp.nix
+++ b/pkgs/tools/networking/network-manager/l2tp.nix
@@ -5,13 +5,13 @@
 stdenv.mkDerivation rec {
   name    = "${pname}${if withGnome then "-gnome" else ""}-${version}";
   pname   = "NetworkManager-l2tp";
-  version = "1.2.4";
+  version = "1.2.8";
 
   src = fetchFromGitHub {
     owner  = "nm-l2tp";
     repo   = "network-manager-l2tp";
     rev    = "${version}";
-    sha256 = "1mvn0z1vl4j9drl3dsw2dv0pppqvj29d2m07487dzzi8cbxrqj36";
+    sha256 = "110157dpamgr7r5kb8aidi0a2ap9z2m52bff94fb4nhxacz69yv8";
   };
 
   buildInputs = [ networkmanager ppp libsecret ]
@@ -31,13 +31,18 @@ stdenv.mkDerivation rec {
     intltoolize -f
   '';
 
-  configureFlags =
-    if withGnome then "--with-gnome" else "--without-gnome";
+  configureFlags = [
+    "--with-gnome=${if withGnome then "yes" else "no"}"
+    "--localstatedir=/var"
+    "--sysconfdir=$(out)/etc"
+  ];
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "L2TP plugin for NetworkManager";
     inherit (networkmanager.meta) platforms;
-    homepage = https://github.com/seriyps/NetworkManager-l2tp;
+    homepage = https://github.com/nm-l2tp/network-manager-l2tp;
     license = licenses.gpl2;
     maintainers = with maintainers; [ abbradar obadz ];
   };


### PR DESCRIPTION
###### Motivation for this change
Package update
Closes: #28546

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

