### PR TITLE
SDL: try disabling sdltest on darwin

### DIFF
--- a/pkgs/development/libraries/SDL_gfx/default.nix
+++ b/pkgs/development/libraries/SDL_gfx/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ SDL ] ;
 
-  configureFlags = [ "--disable-mmx" ];
+  configureFlags = [ "--disable-mmx" ]
+    ++ stdenv.lib.optional stdenv.isDarwin "--disable-sdltest";
 
   meta = with stdenv.lib; {
     description = "SDL graphics drawing primitives and support functions";

--- a/pkgs/development/libraries/SDL_image/default.nix
+++ b/pkgs/development/libraries/SDL_image/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  configureFlags = stdenv.lib.optional stdenv.isDarwin "--disable-sdltest";
+
   buildInputs = [ SDL libpng libjpeg libtiff libungif libXpm ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/SDL_mixer/default.nix
+++ b/pkgs/development/libraries/SDL_mixer/default.nix
@@ -12,7 +12,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ SDL libogg libvorbis fluidsynth smpeg ];
 
-  configureFlags = [ "--disable-music-ogg-shared" ] ++ lib.optional enableNativeMidi " --enable-music-native-midi-gpl";
+  configureFlags = [ "--disable-music-ogg-shared" ]
+    ++ lib.optional enableNativeMidi " --enable-music-native-midi-gpl"
+    ++ lib.optional stdenv.isDarwin "--disable-sdltest";
 
   meta = with stdenv.lib; {
     description = "SDL multi-channel audio mixer library";

--- a/pkgs/development/libraries/SDL_net/default.nix
+++ b/pkgs/development/libraries/SDL_net/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1d5c9xqlf4s1c01gzv6cxmg0r621pq9kfgxcg3197xw4p25pljjz";
   };
 
+  configureFlags = stdenv.lib.optional stdenv.isDarwin "--disable-sdltest";
+
   propagatedBuildInputs = [ SDL ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/SDL_ttf/default.nix
+++ b/pkgs/development/libraries/SDL_ttf/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ SDL freetype ];
 
+  configureFlags = stdenv.lib.optional stdenv.isDarwin "--disable-sdltest";
+
   meta = with stdenv.lib; {
     description = "SDL TrueType library";
     license = licenses.zlib;


### PR DESCRIPTION
###### Motivation for this change

This should fix the jobs that keep failing/freezing:

https://hydra.nixos.org/eval/1409367?filter=SDL_&compare=1409246&full=

Tested on @LnL7's hydra instance:

https://hydra.daiderd.com/eval/4928#tabs-now-succeed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---