### PR TITLE
anura: init at 20171110

### DIFF
--- a/pkgs/games/anura/default.nix
+++ b/pkgs/games/anura/default.nix
@@ -1,0 +1,30 @@
+{ SDL2 , SDL2_image, SDL2_ttf, SDL2_mixer
+, stdenv, pkgconfig, icu, boost, glew, cairo
+, fetchgit, which
+}:
+stdenv.mkDerivation {
+  name = "anura";
+  version = "20171110";
+
+  nativeBuildInputs = [  pkgconfig icu.dev which ];
+  buildInputs = [ boost SDL2.dev SDL2_image SDL2_mixer SDL2_ttf glew cairo ];
+
+  installPhase = ''
+      mkdir -p $out/bin
+      install -p anura $out/bin/anura
+  '';
+
+  src = fetchgit {
+    url = https://github.com/anura-engine/anura.git;
+    rev = "fee247c573005777de9f6eb67debc83988818898";
+    fetchSubmodules = true;
+    sha256 = "03j6ld0g8kh5x6d2qna1rrp8jzs587a5zw2qz71w5ryqn8w4jdil";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Game engine used by argentum, frogatto";
+    licenses = licenses.gpl3;
+    homepage = https://github.com/anura-engine/anura;
+    maintainers = [ maintainers.teto ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -438,6 +438,8 @@ with pkgs;
 
   ansifilter = callPackage ../tools/text/ansifilter {};
 
+  anura = callPackage ../games/anura { };
+
   apktool = callPackage ../development/tools/apktool {
     buildTools = androidenv.buildTools;
   };


### PR DESCRIPTION
anura is the game engine that powers 2 great games:
- https://frogatto.com/ 
- http://argentumage.com/

The game engine works, the problem is that games are basically folders in "${anura}/modules" so not sure how to make the game installable without triggering a recompile of anura.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

