### PR TITLE
nix-bash-completions: init at 0.1

### DIFF
--- a/pkgs/shells/nix-bash-completions/default.nix
+++ b/pkgs/shells/nix-bash-completions/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  version = "0.1";
+  name = "nix-bash-completions-${version}";
+
+  src = fetchFromGitHub {
+    owner = "hedning";
+    repo = "nix-bash-completions";
+    rev = "v${version}";
+    sha256 = "1gb6fmnask1xmjv5j5x0jb505lyp0p4lx2kbibfnb2gi57wapxaz";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/bash-completion/completions
+    cp _* $out/share/bash-completion/completions
+  '';
+
+  meta = {
+    homepage = http://github.com/hedning/nix-bash-completions;
+    description = "Bash completions for Nix, NixOS, and NixOps";
+    license = stdenv.lib.licenses.bsd3;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = with stdenv.lib.maintainers; [ hedning ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5315,6 +5315,8 @@ with pkgs;
 
   bash-completion = callPackage ../shells/bash-completion { };
 
+  nix-bash-completions = callPackage ../shells/nix-bash-completions { };
+
   dash = callPackage ../shells/dash { };
 
   es = callPackage ../shells/es { };


### PR DESCRIPTION
Bash completion for almost all nix* commands, including nix-1.12.

###### Motivation for this change

Full bash completion support, including attribute path completion. Almost full feature parity with nix-zsh-completion :smile: 

ref nix issues: https://github.com/NixOS/nix/issues/1658 https://github.com/NixOS/nix/issues/37

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

