### PR TITLE
pythonPackages.yowsup: disable python2 build

### DIFF
--- a/pkgs/development/python-modules/yowsup/default.nix
+++ b/pkgs/development/python-modules/yowsup/default.nix
@@ -1,9 +1,15 @@
-{ buildPythonPackage, stdenv, fetchFromGitHub, six, python-axolotl, pytest }:
+{ buildPythonPackage, stdenv, fetchFromGitHub, six, python-axolotl, pytest
+, isPy3k
+}:
 
 buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "yowsup";
   version = "2.5.2";
+
+  # python2 is currently incompatible with yowsup:
+  # https://github.com/tgalal/yowsup/issues/2325#issuecomment-343516519
+  disabled = !isPy3k;
 
   src = fetchFromGitHub {
     owner = "tgalal";


### PR DESCRIPTION
###### Motivation for this change

I'm not exactly sure why, but it seems as the python2 build
of yowsup is breaking.
see https://github.com/tgalal/yowsup/issues/2325

It seems to be recommended to use python3 for building and disable
the usage of python2 which fixed the build.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

