### PR TITLE
albert: 0.12.0 -> 0.14.7

### DIFF
--- a/pkgs/applications/misc/albert/default.nix
+++ b/pkgs/applications/misc/albert/default.nix
@@ -1,25 +1,30 @@
-{ mkDerivation, lib, fetchFromGitHub, makeWrapper, qtbase, qtsvg, qtx11extras, muparser, cmake }:
+{ mkDerivation, lib, fetchFromGitHub, makeWrapper, qtbase, qtdeclarative, qtsvg, qtx11extras, muparser,
+  cmake, python3 }:
 
 mkDerivation rec {
   name    = "albert-${version}";
-  version = "0.12.0";
+  version = "0.14.7";
 
   src = fetchFromGitHub {
     owner  = "albertlauncher";
     repo   = "albert";
     rev    = "v${version}";
-    sha256 = "120l7hli2l4qj2s126nawc4dsy4qvwvb0svc42hijry4l8imdhkq";
+    sha256 = "1ryjrbrbgignhkvsv4021l4am8ml7g8v4bs5cp5jj288k4p2rf4n";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake makeWrapper ];
 
-  buildInputs = [ qtbase qtsvg qtx11extras muparser ];
+  buildInputs = [ qtbase qtdeclarative qtsvg qtx11extras muparser python3 ];
 
   enableParallelBuilding = true;
 
+  # We don't have virtualbox sdk so disable plugin
+  cmakeFlags = [ "-DBUILD_VIRTUALBOX=OFF" "-DCMAKE_INSTALL_LIBDIR=libs" ];
+
   postPatch = ''
-    sed -i "/QStringList dirs = {/a    \"$out/lib\"," \
-      src/lib/albert/src/albert/extensionmanager.cpp
+    sed -i "/QStringList dirs = {/a    \"$out/libs\"," \
+      lib/albertcore/src/core/albert.cpp
   '';
 
   preBuild = ''


### PR DESCRIPTION
###### Motivation for this change

Update package to latest version

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

