### PR TITLE
folly: 2017.07.24.00 -> 2017.11.06.00

### DIFF
--- a/pkgs/development/libraries/folly/default.nix
+++ b/pkgs/development/libraries/folly/default.nix
@@ -3,22 +3,14 @@
 
 stdenv.mkDerivation rec {
   name = "folly-${version}";
-  version = "2017.07.24.00";
+  version = "2017.11.06.00";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "folly";
     rev = "v${version}";
-    sha256 = "1cmqrm9yjxrw4xr1kcgzl0s7vcvp125wcgb0cz7whssgj11mf169";
+    sha256 = "11sn4gwqw94ygc2s4bzqy5k67v3rr20gy375brdcrl5rv0r2hhc0";
   };
-
-  patches = [
-    # Fix compilation
-    (fetchpatch {
-      url = "https://github.com/facebook/folly/commit/9fc87c83d93f092859823ec32289ed1b6abeb683.patch";
-      sha256 = "0ix0grqlzm16hwa4rjbajjck8kr9lksh6c3gn7p3ihbbchsmlhvl";
-    })
-  ];
 
   nativeBuildInputs = [ autoreconfHook python pkgconfig ];
   buildInputs = [ libiberty boost libevent double_conversion glog google-gflags openssl ];


### PR DESCRIPTION
###### Motivation for this change
Updated to latest upstream version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

