### PR TITLE
perlPackages.LWPAuthenOAuth: fix meta.license

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8189,7 +8189,7 @@ let self = _self // overrides; _self = with self; {
     propagatedBuildInputs = [ LWP URI ];
     meta = {
       description = "Generate signed OAuth requests";
-      license = stdenv.lib.licenses.unknown;
+      license = "unknown";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change
Fixing eval after commit ff1d281e557d84a8341e62f89ffbeb0748b455ba
@grahamc @edolstra 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

