### PR TITLE
php: Fix php pcre symbol collissions

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -314,7 +314,7 @@ let
         outputsToInstall = [ "out" "dev" ];
       };
 
-      patches = if !php7 then [ ./fix-paths.patch ] else [ ./fix-paths-php7.patch ];
+      patches = if !php7 then [ ./fix-paths.patch ] else [ ./fix-paths-php7.patch ./fix-pcre.patch ];
 
       postPatch = lib.optional stdenv.isDarwin ''
         substituteInPlace configure --replace "-lstdc++" "-lc++"

--- a/pkgs/development/interpreters/php/fix-pcre.patch
+++ b/pkgs/development/interpreters/php/fix-pcre.patch
@@ -1,0 +1,33 @@
+--- php-7.1.11/main/php_compat.h	2017-10-25 09:04:42.000000000 +0200
++++ php-7.1.11/main/php_compat2.h	2017-11-11 16:38:08.373273355 +0100
+@@ -28,6 +28,30 @@
+ #endif
+ 
+ #if defined(HAVE_BUNDLED_PCRE) || !defined(PHP_VERSION)
++#define pcre_jit_stack_free       php_pcre_jit_stack_free
++#define pcre_get_compiled_regex_c php_pcre_get_compiled_regex_c
++#define pcre_jit_free_unused_memo php_pcre_jit_free_unused_memo
++#define pcre_get_compiled_regex   php_pcre_get_compiled_regex
++#define pcre_stack_guard          php_pcre_stack_guard
++#define pcre_get_compiled_regex_e php_pcre_get_compiled_regex_e
++#define pcre_globals_id           php_pcre_globals_id
++#define pcre_jit_stack_alloc      php_pcre_jit_stack_alloc
++#define pcre_free_study           php_pcre_free_study
++#define pcre_assign_jit_stack     php_pcre_assign_jit_stack
++#define pcre_clean_cache          php_pcre_clean_cache
++#define pcre_functions            php_pcre_functions
++#define pcre_module_entry         php_pcre_module_entry
++#define pcre_jit_stack_free       php_pcre_jit_stack_free
++#define pcre_get_compiled_regex_c php_pcre_get_compiled_regex_c
++#define pcre_jit_free_unused_memo php_pcre_jit_free_unused_memo
++#define pcre_get_compiled_regex   php_pcre_get_compiled_regex
++#define pcre_stack_guard          php_pcre_stack_guard
++#define pcre_get_compiled_regex_e php_pcre_get_compiled_regex_e
++#define pcre_globals_id           php_pcre_globals_id
++#define pcre_jit_stack_alloc      php_pcre_jit_stack_alloc
++#define pcre_free_study           php_pcre_free_study
++#define pcre_assign_jit_stack     php_pcre_assign_jit_stack
++#define pcre_jit_exec             php_pcre_jit
+ #define pcre_compile			php_pcre_compile
+ #define pcre_compile2			php_pcre_compile2
+ #define pcre_copy_substring		php_pcre_copy_substring


### PR DESCRIPTION
###### Motivation for this change
Fixes #31451 #31499

###### Things done
Tested using https://gist.github.com/srhb/2d9f5354cdf16c96ec3356f4c5383303
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

