### PR TITLE
php: Fix php pcre by using external lib

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -109,6 +109,7 @@ in rec {
         (all nixos.tests.nfs3)
         (all nixos.tests.nfs4)
         (all nixos.tests.openssh)
+        (all nixos.tests.php-pcre)
         (all nixos.tests.printing)
         (all nixos.tests.proxy)
         (all nixos.tests.sddm.default)

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -40,6 +40,7 @@ in rec {
         nat
         nfs3
         openssh
+        php-pcre
         proxy
         simple;
       installer = {

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -309,6 +309,7 @@ in rec {
   tests.pam-oath-login = callTest tests/pam-oath-login.nix {};
   #tests.panamax = hydraJob (import tests/panamax.nix { system = "x86_64-linux"; });
   tests.peerflix = callTest tests/peerflix.nix {};
+  tests.php-pcre = callTest tests/php-pcre.nix {};
   tests.postgresql = callSubTests tests/postgresql.nix {};
   tests.pgmanage = callTest tests/pgmanage.nix {};
   tests.postgis = callTest tests/postgis.nix {};

--- a/nixos/tests/php-pcre.nix
+++ b/nixos/tests/php-pcre.nix
@@ -1,0 +1,44 @@
+
+let testString = "can-use-subgroups"; in
+
+import ./make-test.nix ({ pkgs, ...}: {
+  name = "php-httpd-pcre-jit-test";
+  machine = { config, lib, pkgs, ... }: {
+    time.timeZone = "UTC";
+    services.httpd = {
+      enable = true;
+      adminAddr = "please@dont.contact";
+      extraSubservices = lib.singleton {
+        function = f: {
+          enablePHP = true;
+          phpOptions = "pcre.jit = true";
+
+          extraConfig =
+          let
+            testRoot = pkgs.writeText "index.php"
+            ''
+              <?php
+                preg_match('/(${testString})/', '${testString}', $result);
+                var_dump($result);
+              ?>
+            '';
+          in
+            ''
+              Alias / ${testRoot}/
+
+              <Directory ${testRoot}>
+                Require all granted
+              </Directory>
+            '';
+        };
+      };
+    };
+  };
+  testScript = { nodes, ... }:
+  ''
+    $machine->waitForUnit('httpd.service');
+    # Ensure php evaluation by matching on the var_dump syntax
+    $machine->succeed('curl -vvv -s http://127.0.0.1:80/index.php \
+      | grep "string(${toString (builtins.stringLength testString)}) \"${testString}\""');
+  '';
+})

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -1,3 +1,5 @@
+# pcre functionality is tested in nixos/tests/php-pcre.nix
+
 { lib, stdenv, fetchurl, composableDerivation, autoconf, automake, flex, bison
 , mysql, libxml2, readline, zlib, curl, postgresql, gettext
 , openssl, pcre, pkgconfig, sqlite, config, libjpeg, libpng, freetype
@@ -91,7 +93,6 @@ let
           configureFlags = [ "--enable-pcntl" ];
         };
 
-        # pcre functionality is tested in nixos/tests/php-pcre.nix
         pcre = {
           configureFlags = ["--with-pcre-regex=${pcre.dev} PCRE_LIBDIR=${pcre}"];
           buildInputs = [ pcre ];

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -23,7 +23,7 @@ let
       enableParallelBuilding = true;
 
       nativeBuildInputs = [ pkgconfig ];
-      buildInputs = [ flex bison ]
+      buildInputs = [ flex bison pcre ]
         ++ lib.optional stdenv.isLinux systemd;
 
       CXXFLAGS = lib.optional stdenv.cc.isClang "-std=c++11";
@@ -91,11 +91,6 @@ let
 
         pcntl = {
           configureFlags = [ "--enable-pcntl" ];
-        };
-
-        pcre = {
-          configureFlags = ["--with-pcre-regex=${pcre.dev} PCRE_LIBDIR=${pcre}"];
-          buildInputs = [ pcre ];
         };
 
         readline = {
@@ -247,7 +242,6 @@ let
         curlWrappersSupport = (!php7) && (config.php.curlWrappers or true);
         gettextSupport = config.php.gettext or true;
         pcntlSupport = config.php.pcntl or true;
-        pcreSupport = config.php.pcreExternal or true;
         postgresqlSupport = config.php.postgresql or true;
         pdo_pgsqlSupport = config.php.pdo_pgsql or true;
         readlineSupport = config.php.readline or true;
@@ -293,6 +287,7 @@ let
 
       configureFlags = [
         "--with-config-file-scan-dir=/etc/php.d"
+        "--with-pcre-regex=${pcre.dev} PCRE_LIBDIR=${pcre}"
       ] ++ lib.optional stdenv.isDarwin "--with-iconv=${libiconv}"
         ++ lib.optional stdenv.isLinux  "--with-fpm-systemd";
 

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -91,6 +91,7 @@ let
           configureFlags = [ "--enable-pcntl" ];
         };
 
+        # pcre functionality is tested in nixos/tests/php-pcre.nix
         pcre = {
           configureFlags = ["--with-pcre-regex=${pcre.dev} PCRE_LIBDIR=${pcre}"];
           buildInputs = [ pcre ];

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, composableDerivation, autoconf, automake, flex, bison
 , mysql, libxml2, readline, zlib, curl, postgresql, gettext
-, openssl, pkgconfig, sqlite, config, libjpeg, libpng, freetype
+, openssl, pcre, pkgconfig, sqlite, config, libjpeg, libpng, freetype
 , libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, freetds
 , uwimap, pam, gmp, apacheHttpd, libiconv, systemd }:
 
@@ -89,6 +89,11 @@ let
 
         pcntl = {
           configureFlags = [ "--enable-pcntl" ];
+        };
+
+        pcre = {
+          configureFlags = ["--with-pcre-regex=${pcre.dev} PCRE_LIBDIR=${pcre}"];
+          buildInputs = [ pcre ];
         };
 
         readline = {
@@ -240,6 +245,7 @@ let
         curlWrappersSupport = (!php7) && (config.php.curlWrappers or true);
         gettextSupport = config.php.gettext or true;
         pcntlSupport = config.php.pcntl or true;
+        pcreSupport = config.php.pcreExternal or true;
         postgresqlSupport = config.php.postgresql or true;
         pdo_pgsqlSupport = config.php.pdo_pgsql or true;
         readlineSupport = config.php.readline or true;


### PR DESCRIPTION
###### Motivation for this change
Fixes #31451 
Fixes #31499

###### Things done
Tested using https://gist.github.com/srhb/2d9f5354cdf16c96ec3356f4c5383303
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

