### PR TITLE
Revert "qt5: Add qtnetworkauth submodule"

### DIFF
--- a/pkgs/development/libraries/qt-5/5.9/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/default.nix
@@ -82,7 +82,6 @@ let
       qtmultimedia = callPackage ../modules/qtmultimedia.nix {
         inherit gstreamer gst-plugins-base;
       };
-      qtnetworkauth = callPackage ./qtnetworkauth.nix {};
       qtquick1 = null;
       qtquickcontrols = callPackage ../modules/qtquickcontrols.nix {};
       qtquickcontrols2 = callPackage ../modules/qtquickcontrols2.nix {};
@@ -103,9 +102,9 @@ let
       env = callPackage ../qt-env.nix {};
       full = env "qt-${qtbase.version}" ([
         qtcharts qtconnectivity qtdeclarative qtdoc qtgraphicaleffects
-        qtimageformats qtlocation qtmultimedia qtnetworkauth qtquickcontrols
-        qtscript qtsensors qtserialport qtsvg qttools qttranslations
-        qtwebsockets qtx11extras qtxmlpatterns
+        qtimageformats qtlocation qtmultimedia qtquickcontrols qtscript
+        qtsensors qtserialport qtsvg qttools qttranslations qtwebsockets
+        qtx11extras qtxmlpatterns
       ] ++ optional (!stdenv.isDarwin) qtwayland
         ++ optional (stdenv.isDarwin) qtmacextras);
 

--- a/pkgs/development/libraries/qt-5/5.9/qtnetworkauth.nix
+++ b/pkgs/development/libraries/qt-5/5.9/qtnetworkauth.nix
@@ -1,7 +1,0 @@
-{ qtSubmodule, qtbase }:
-
-qtSubmodule {
-  name = "qtnetworkauth";
-  qtInputs = [ qtbase ];
-  outputs = [ "out" "dev" ];
-}


### PR DESCRIPTION
Reverts NixOS/nixpkgs#28480. These changes break Nixpkgs evaluation:

~~~
error: anonymous function at /home/simons/.nix-defexpr/pkgs/development/libraries/qt-5/5.9/qtnetworkauth.nix:1:1 called without required argument 'qtSubmodule', at /home/simons/.nix-defexpr/lib/customisation.nix:74:12
~~~