### PR TITLE
tortoisehg: fix license dialog

### DIFF
--- a/pkgs/applications/version-management/tortoisehg/default.nix
+++ b/pkgs/applications/version-management/tortoisehg/default.nix
@@ -18,6 +18,8 @@ python2Packages.buildPythonApplication rec {
     buildPhase = "";
     installPhase = ''
       ${python2Packages.python.executable} setup.py install --prefix=$out
+      mkdir -p $out/share/doc/tortoisehg
+      cp COPYING.txt $out/share/doc/tortoisehg/Copying.txt.gz
       ln -s $out/bin/thg $out/bin/tortoisehg     #convenient alias
     '';
 


### PR DESCRIPTION
Upstream issue:
https://bitbucket.org/tortoisehg/thg/issues/4934/copyingtxt-not-installed-by-setuppy-on

While upstream is preparing a proper fix, we can install the missing file manually.
The license dialog can be accessed with `Help -> About TortoiseHg -> License`
Originally discovered while testing https://github.com/NixOS/nixpkgs/pull/31240

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
