### PR TITLE
enlightenment: 0.21.10 -> 0.22.0

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -61,7 +61,7 @@ in
       '';
     }];
 
-    security.wrappers.e_freqset.source = "${e.enlightenment.out}/bin/e_freqset";
+    security.wrappers = (import (builtins.toPath "${e.enlightenment}/e-wrappers.nix")).security.wrappers;
 
     environment.etc = singleton
       { source = xcfg.xkbDir;

--- a/pkgs/desktops/enlightenment/enlightenment.nix
+++ b/pkgs/desktops/enlightenment/enlightenment.nix
@@ -1,51 +1,56 @@
-{ stdenv, fetchurl, pkgconfig, efl, xcbutilkeysyms, libXrandr, libXdmcp,
-libxcb, libffi, pam, alsaLib, luajit, bzip2, libpthreadstubs, gdbm, libcap,
-mesa_glu, xkeyboard_config, pcre }:
+{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, efl,
+  xcbutilkeysyms, libXrandr, libXdmcp, libxcb, libffi, pam, alsaLib,
+  luajit, bzip2, libpthreadstubs, gdbm, libcap, mesa_glu,
+  xkeyboard_config, pcre
+}:
 
 stdenv.mkDerivation rec {
   name = "enlightenment-${version}";
-  version = "0.21.10";
+  version = "0.22.0";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/apps/enlightenment/${name}.tar.xz";
-    sha256 = "053zmlpjx45xg2rbbxyjh0phhgbsnmsnypzz2bib545klp51bfcv";
+    sha256 = "0xmrvryr35idd7fyqgshfhvy2053bs3vwrxbx681pi6rgpdvjghv";
   };
 
-  nativeBuildInputs = [ (pkgconfig.override { vanilla = true; }) ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    (pkgconfig.override { vanilla = true; })
+    gettext
+  ];
 
   buildInputs = [
-    efl libXdmcp libxcb xcbutilkeysyms libXrandr libffi pam alsaLib
-    luajit bzip2 libpthreadstubs gdbm pcre
+    efl
+    libXdmcp
+    libxcb
+    xcbutilkeysyms
+    libXrandr
+    libffi
+    pam
+    alsaLib
+    luajit
+    bzip2
+    libpthreadstubs
+    gdbm
+    pcre
   ] ++
     stdenv.lib.optionals stdenv.isLinux [ libcap ];
 
-  preConfigure = ''
-    export USER_SESSION_DIR=$prefix/lib/systemd/user
+  # Instead of setting owner to root and permissions to setuid/setgid
+  # (which is not allowed for files in /nix/store) of some
+  # enlightenment programs, the file $out/e-wrappers.nix is created,
+  # containing the needed configuration for that purpose. It can be
+  # used in the enlightenment module.
+  patches = [ ./enlightenment.suid-exes.patch ];
 
-    substituteInPlace src/modules/xkbswitch/e_mod_parse.c \
-      --replace "/usr/share/X11/xkb/rules/xorg.lst" "${xkeyboard_config}/share/X11/xkb/rules/base.lst"
-
-    substituteInPlace "src/bin/e_import_config_dialog.c" \
-      --replace "e_prefix_bin_get()" "\"${efl}/bin\""
-  '';
+  mesonFlags = [ "-Dsystemdunitdir=lib/systemd/user" ];
 
   enableParallelBuilding = true;
 
-  # this is a hack and without this cpufreq module is not working. does the following:
-  #   1. moves the "freqset" binary to "e_freqset",
-  #   2. linkes "e_freqset" to enlightenment/bin so that,
-  #   3. wrappers.setuid detects it and places wrappers in /run/wrappers/bin/e_freqset,
-  #   4. and finally, links /run/wrappers/bin/e_freqset to original destination where enlightenment wants it
-  postInstall = ''
-    export CPUFREQ_DIRPATH=`readlink -f $out/lib/enlightenment/modules/cpufreq/linux-gnu-*`;
-    mv $CPUFREQ_DIRPATH/freqset $CPUFREQ_DIRPATH/e_freqset
-    ln -sv $CPUFREQ_DIRPATH/e_freqset $out/bin/e_freqset
-    ln -sv /run/wrappers/bin/e_freqset $CPUFREQ_DIRPATH/freqset
-  '';
-
   meta = with stdenv.lib; {
     description = "The Compositing Window Manager and Desktop Shell";
-    homepage = http://enlightenment.org/;
+    homepage = https://www.enlightenment.org;
     license = licenses.bsd2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ matejc tstrobel ftrvxmtrx romildo ];

--- a/pkgs/desktops/enlightenment/enlightenment.suid-exes.patch
+++ b/pkgs/desktops/enlightenment/enlightenment.suid-exes.patch
@@ -1,0 +1,25 @@
+--- enlightenment-0.22.0.orig/meson/meson_inst.sh	2017-09-25 10:55:43.000000000 -0300
++++ enlightenment-0.22.0/meson/meson_inst.sh	2017-11-12 09:04:33.356050746 -0200
+@@ -1,6 +1,19 @@
+-#!/bin/sh
++#!/bin/sh -x
++
++w="$out"/e-wrappers.nix
++
++echo "# Wrappers for programs installed by enlightenment that should be setuid" > $w
++echo "" >> $w
++echo "{" >> $w
++echo "  security.wrappers = {" >> $w
+ 
+ for x in "$@" ; do
+-	chown root "$DESTDIR/$x"
+-	chmod a=rx,u+xs "$DESTDIR/$x"
++	f="$DESTDIR/$x";
++	b=$(basename "$f".orig)
++	mv -v "$f"{,.orig}
++	ln -sv /run/wrappers/bin/"$b" "$f"
++	echo "    \"$b\".source = \"$f\";" >> $w
+ done
++
++echo "  };" >> $w
++echo "}" >> $w


### PR DESCRIPTION
###### Motivation for this change

- Update to version [0.22.0](https://www.enlightenment.org/news/e22_release)
- Switch build tools from autotools to meson
- Change handling of setuid programs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).