### PR TITLE
 make-disk-image: add compressed option to compress qcow2 images

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -33,17 +33,17 @@
 
 , name ? "nixos-disk-image"
 
-, # Disk image format, one of qcow2, vpc, raw.
+, # Disk image format, one of qcow2, qcow2-compressed, vpc, raw.
   format ? "raw"
-
-, # Whether to compress the image, applicable only when the format is qcow2.
-  compressed ? false
 }:
 
 with lib;
 
-let
-  compress = optionalString compressed (assert format == "qcow2"; "-c");
+let format' = format; in let
+
+  format = if (format' == "qcow2-compressed") then "qcow2" else format;
+
+  compress = optionalString (format' == "qcow2-compressed") "-c";
 
   filename = "nixos." + {
     qcow2 = "qcow2";

--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -35,11 +35,16 @@
 
 , # Disk image format, one of qcow2, vpc, raw.
   format ? "raw"
+
+, # Whether to compress the image, applicable only when the format is qcow2.
+  compressed ? false
 }:
 
 with lib;
 
 let
+  compress = optionalString compressed (assert format == "qcow2"; "-c");
+
   filename = "nixos." + {
     qcow2 = "qcow2";
     vpc   = "vhd";
@@ -136,7 +141,7 @@ in pkgs.vmTools.runInLinuxVM (
         ${if format == "raw" then ''
           mv $diskImage $out/${filename}
         '' else ''
-          ${pkgs.qemu}/bin/qemu-img convert -f raw -O ${format} $diskImage $out/${filename}
+          ${pkgs.qemu}/bin/qemu-img convert -f raw -O ${format} ${compress} $diskImage $out/${filename}
         ''}
         diskImage=$out/${filename}
         ${postVM}

--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -40,11 +40,11 @@
 with lib;
 
 let
-  extensions = {
+  filename = "nixos." + {
     qcow2 = "qcow2";
     vpc   = "vhd";
     raw   = "img";
-  };
+  }.${format};
 
   nixpkgs = cleanSource pkgs.path;
 
@@ -125,7 +125,7 @@ let
     fakeroot nixos-prepare-root $root ${channelSources} ${config.system.build.toplevel} closure
 
     echo "copying staging root to image..."
-    cptofs ${pkgs.lib.optionalString partitioned "-P 1"} -t ${fsType} -i $diskImage $root/* /
+    cptofs ${optionalString partitioned "-P 1"} -t ${fsType} -i $diskImage $root/* /
   '';
 in pkgs.vmTools.runInLinuxVM (
   pkgs.runCommand name
@@ -134,12 +134,11 @@ in pkgs.vmTools.runInLinuxVM (
       exportReferencesGraph = [ "closure" metaClosure ];
       postVM = ''
         ${if format == "raw" then ''
-          mv $diskImage $out/nixos.img
-          diskImage=$out/nixos.img
+          mv $diskImage $out/${filename}
         '' else ''
-          ${pkgs.qemu}/bin/qemu-img convert -f raw -O ${format} $diskImage $out/nixos.${extensions.${format}}
-          diskImage=$out/nixos.${extensions.${format}}
+          ${pkgs.qemu}/bin/qemu-img convert -f raw -O ${format} $diskImage $out/${filename}
         ''}
+        diskImage=$out/${filename}
         ${postVM}
       '';
       memSize = 1024;


### PR DESCRIPTION
###### Motivation for this change

Compressed images take less space (about 3 times less), are faster to upload and to download to provision new instances. I'm interested in using this with qemu and OpenStack. I'm not going to test if compressed images are supported by Amazon or other cloud providers.

The commits are easier to review separately.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - nixos/tests/ec2.nix
  - nixos/tests/ec2.nix with `compressed` defaulted to `true`
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
