### PR TITLE
lkl: 2017-10-18 -> 2017-11-10, make-disk-image: do not fake time for cptofs 

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -33,7 +33,8 @@
 
 , name ? "nixos-disk-image"
 
-, format ? "raw"
+, # Disk image format, one of qcow2, vpc, raw.
+  format ? "raw"
 }:
 
 with lib;
@@ -45,7 +46,7 @@ let
     raw   = "img";
   };
 
-  nixpkgs = lib.cleanSource pkgs.path;
+  nixpkgs = cleanSource pkgs.path;
 
   channelSources = pkgs.runCommand "nixos-${config.system.nixosVersion}" {} ''
     mkdir -p $out
@@ -73,7 +74,7 @@ let
   targets = map (x: x.target) contents;
 
   prepareImage = ''
-    export PATH=${pkgs.lib.makeSearchPathOutput "bin" "bin" prepareImageInputs}
+    export PATH=${makeSearchPathOutput "bin" "bin" prepareImageInputs}
 
     mkdir $out
     diskImage=nixos.raw
@@ -87,7 +88,7 @@ let
     ''}
 
     faketime -f "1970-01-01 00:00:01" mkfs.${fsType} -F -L nixos -E offset=$offset $diskImage
-  
+
     root="$PWD/root"
     mkdir -p $root
 
@@ -132,7 +133,7 @@ let
     # shut it up someday but trying to do a stderr filter through grep is running into some nasty
     # bug in some eval nonsense we have in runInLinuxVM and I'm sick of trying to fix it.
     faketime -f "1970-01-01 00:00:00" \
-      cptofs ${pkgs.lib.optionalString partitioned "-P 1"} -t ${fsType} -i $diskImage $root/* /
+      cptofs ${optionalString partitioned "-P 1"} -t ${fsType} -i $diskImage $root/* /
   '';
 in pkgs.vmTools.runInLinuxVM (
   pkgs.runCommand name

--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -65,7 +65,7 @@ let
     ${channelSources}
   '';
 
-  prepareImageInputs = with pkgs; [ rsync utillinux parted e2fsprogs lkl fakeroot libfaketime config.system.build.nixos-prepare-root ] ++ stdenv.initialPath;
+  prepareImageInputs = with pkgs; [ rsync utillinux parted e2fsprogs lkl fakeroot config.system.build.nixos-prepare-root ] ++ stdenv.initialPath;
 
   # I'm preserving the line below because I'm going to search for it across nixpkgs to consolidate
   # image building logic. The comment right below this now appears in 4 different places in nixpkgs :)
@@ -87,7 +87,7 @@ let
       offset=0
     ''}
 
-    faketime -f "1970-01-01 00:00:01" mkfs.${fsType} -F -L nixos -E offset=$offset $diskImage
+    mkfs.${fsType} -F -L nixos -E offset=$offset $diskImage
 
     root="$PWD/root"
     mkdir -p $root
@@ -125,15 +125,7 @@ let
     fakeroot nixos-prepare-root $root ${channelSources} ${config.system.build.toplevel} closure
 
     echo "copying staging root to image..."
-    # If we don't faketime, we can end up with timestamps other than 1 on the nix store, which
-    # will confuse Nix in some situations (e.g., breaking image builds in the target image)
-    # N.B: I use 0 here, which results in timestamp = 1 in the image. It's weird but see
-    # https://github.com/lkl/linux/issues/393. Also, running under faketime makes `cptofs` super
-    # noisy and it prints out that it can't find a bunch of files, and then works anyway. We'll
-    # shut it up someday but trying to do a stderr filter through grep is running into some nasty
-    # bug in some eval nonsense we have in runInLinuxVM and I'm sick of trying to fix it.
-    faketime -f "1970-01-01 00:00:00" \
-      cptofs ${optionalString partitioned "-P 1"} -t ${fsType} -i $diskImage $root/* /
+    cptofs ${pkgs.lib.optionalString partitioned "-P 1"} -t ${fsType} -i $diskImage $root/* /
   '';
 in pkgs.vmTools.runInLinuxVM (
   pkgs.runCommand name

--- a/pkgs/applications/virtualization/lkl/default.nix
+++ b/pkgs/applications/virtualization/lkl/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, bc, python, fuse, libarchive }:
 
 stdenv.mkDerivation rec {
-  name = "lkl-2017-10-18";
-  rev  = "bfb315c4612c38427e3239d0a427a125d9ba0ede";
+  name = "lkl-2017-11-10";
+  rev  = "52a6a643c7d1dd3031c0cbec75e1ac7a999f3d57";
 
   outputs = [ "dev" "lib" "out" ];
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     inherit rev;
     owner  = "lkl";
     repo   = "linux";
-    sha256 = "172ccn2gsybnji7giiqq63bvp9nsw8kri88pjlvinwpwsv7x81aa";
+    sha256 = "1i5ywrfxqpykjjalwh9g4rwd4s186cqk3j806d327a67xb2ivxnp";
   };
 
   # Fix a /usr/bin/env reference in here that breaks sandboxed builds


### PR DESCRIPTION
###### Motivation for this change

New LKL has fixed https://github.com/lkl/linux/issues/393, so we can partially revert f5b3f2c5a7f2b51e80ac32fb47fd1d7d3e475ad1. I've confirmed that `/nix/store` paths in the resulting image are dated `1970-01-01 00:00:01`.

@copumpkin Should we remove `faketime` for `mkfs`? What purpose does it serve?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - nixos/tests/ec2.nix
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
