### PR TITLE
libsmbios: 2.3.2 -> 2.3.3

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -15,7 +15,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
 
   afl21 = spdx {
     spdxId = "AFL-2.1";
-    fullName = "Academic Free License";
+    fullName = "Academic Free License v2.1";
+  };
+
+  afl3 = spdx {
+    spdxId = "AFL-3.0";
+    fullName = "Academic Free License v3.0";
   };
 
   agpl3 = spdx {
@@ -426,6 +431,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "Notion modified LGPL";
   };
 
+  nposl3 = spdx {
+    spdxId = "NPOSL-3.0";
+    fullName = "Non-Profit Open Software License 3.0";
+  };
+
   ofl = spdx {
     spdxId = "OFL-1.1";
     fullName = "SIL Open Font License 1.1";
@@ -441,7 +451,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "OpenSSL License";
   };
 
-  osl = spdx {
+  osl21 = spdx {
+    spdxId = "OSL-2.1";
+    fullName = "Open Software License 2.1";
+  };
+
+  osl3 = spdx {
     spdxId = "OSL-3.0";
     fullName = "Open Software License 3.0";
   };

--- a/pkgs/servers/web-apps/restya-board/default.nix
+++ b/pkgs/servers/web-apps/restya-board/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Web-based kanban board";
-    license = licenses.osl;
+    license = licenses.osl3;
     homepage = http://restya.com;
     maintainers = with maintainers; [ tstrobel ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change
Version bump and homepage refresh (#30636)
The former home http://linux.dell.com/libsmbios/ redirects to this Dell GH repo so we know it is the official one.

Note that the C++ lib is deprecated upstream and is now disabled by default. This will reduce closure-size. 😹 
I've checked the packages depending on libsmbios (fwupd and fwupdate) and they both rely on the C lib.

I'm also adding the whole family of OSL licenses with this PR :
- Academic Free License (AFL) 2.1 and 3.0
- Open Software License (OSL) 2.1 and 3.0
- Non-Profit Open Software License (NPOSL) 3.0



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

