### PR TITLE
noto fonts and tools: update to newer tagged releases

### DIFF
--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -2,10 +2,10 @@
 
 rec {
   # 18MB
-  noto-fonts = let version = "git-2016-03-29"; in fetchzip {
+  noto-fonts = let version = "2017-10-24-phase3-second-cleanup"; in fetchzip {
     name = "noto-fonts-${version}";
 
-    url = https://github.com/googlei18n/noto-fonts/archive/e8b0af48b15d64bd490edab4418b5e396cf29644.zip;
+    url = "https://github.com/googlei18n/noto-fonts/archive/v${version}.zip";
     postFetch = ''
       unzip $downloadedFile
 
@@ -17,7 +17,7 @@ rec {
       cp -n noto-fonts-*/unhinted/*.ttf $out/share/fonts/noto
       cp -n noto-fonts-*/alpha/*.ttf $out/share/fonts/noto
     '';
-    sha256 = "0wphc8671dpbx3rxzmjisnjipg2c2vkhw2i6mmyamd6vvcwajd64";
+    sha256 = "013l816cq9svdji266sccscm9sf9pfn472gq9lnqkzlwaxx9qrrl";
 
     meta = with stdenv.lib; {
       inherit version;
@@ -75,14 +75,14 @@ rec {
     };
   };
   # 12MB
-  noto-fonts-emoji = let version = "git-2016-03-17"; in stdenv.mkDerivation {
+  noto-fonts-emoji = let version = "2017-09-13-design-refresh"; in stdenv.mkDerivation {
     name = "noto-fonts-emoji-${version}";
 
     src = fetchFromGitHub {
       owner = "googlei18n";
       repo = "noto-emoji";
-      rev = "c6379827aaa9cb0baca1a08a9d44ae74ca505236";
-      sha256 = "1zh1b617cjr5laha6lx0ys4k1c3az2zkgzjwc2nlb7dsdmfw1n0q";
+      rev = "v${version}";
+      sha256 = "1ixz03207kzh6jhmw8bpi77pxkfzq46dk26sr41m5kkvc14d14vl";
     };
 
     buildInputs = [ cairo ];

--- a/pkgs/data/fonts/noto-fonts/tools.nix
+++ b/pkgs/data/fonts/noto-fonts/tools.nix
@@ -1,0 +1,32 @@
+{ fetchFromGitHub, pythonPackages, lib }:
+
+pythonPackages.buildPythonPackage rec {
+  version = "2017-09-25";
+  name = "nototools-${version}";
+
+  src = fetchFromGitHub {
+    owner = "googlei18n";
+    repo = "nototools";
+    rev = "v2017-09-25-tooling-for-phase3-update";
+    sha256 = "03nzvcvwmrhfrcjhg218q2f3hfrm3vlivp4rk19sc397kh3hisiz";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ fonttools numpy ];
+
+  postPatch = ''
+    sed -ie "s^join(_DATA_DIR_PATH,^join(\"$out/third_party/ucd\",^" nototools/unicode_data.py
+  '';
+
+  postInstall = ''
+    cp -r third_party $out
+  '';
+
+  disabled = pythonPackages.isPy3k;
+
+  meta = {
+    description = "Noto fonts support tools and scripts plus web site generation";
+    license = lib.licenses.asl20;
+    homepage = https://github.com/googlei18n/nototools;
+    platform = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10985,14 +10985,14 @@ in {
   };
 
   nototools = buildPythonPackage rec {
-    version = "git-2016-03-25";
+    version = "2017-09-25";
     name = "nototools-${version}";
 
     src = pkgs.fetchFromGitHub {
       owner = "googlei18n";
       repo = "nototools";
-      rev = "4f7b067d1b18f59288e5eaee34db5b0abd3a3f63";
-      sha256 = "05brbkfg77ij4pmcrhq9302albzdalr9gv6jfdsbyyi2k8j85gbn";
+      rev = "v2017-09-25-tooling-for-phase3-update";
+      sha256 = "03nzvcvwmrhfrcjhg218q2f3hfrm3vlivp4rk19sc397kh3hisiz";
     };
 
     propagatedBuildInputs = with self; [ fonttools numpy ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10984,35 +10984,7 @@ in {
     };
   };
 
-  nototools = buildPythonPackage rec {
-    version = "2017-09-25";
-    name = "nototools-${version}";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "googlei18n";
-      repo = "nototools";
-      rev = "v2017-09-25-tooling-for-phase3-update";
-      sha256 = "03nzvcvwmrhfrcjhg218q2f3hfrm3vlivp4rk19sc397kh3hisiz";
-    };
-
-    propagatedBuildInputs = with self; [ fonttools numpy ];
-
-    postPatch = ''
-      sed -ie "s^join(_DATA_DIR_PATH,^join(\"$out/third_party/ucd\",^" nototools/unicode_data.py
-    '';
-
-    postInstall = ''
-      cp -r third_party $out
-    '';
-
-    disabled = isPy3k;
-
-    meta = {
-      description = "Noto fonts support tools and scripts plus web site generation";
-      license = licenses.asl20;
-      homepage = https://github.com/googlei18n/nototools;
-    };
-  };
+  notoTools = callPackage ../data/fonts/noto-fonts/tools.nix { };
 
   rainbowstream = buildPythonPackage rec {
     name = "rainbowstream-${version}";


### PR DESCRIPTION
###### Motivation for this change
Noto emoji had a major update in 2017.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).