### PR TITLE
init specdris at 2017-11-11

### DIFF
--- a/pkgs/development/idris-modules/specdris.nix
+++ b/pkgs/development/idris-modules/specdris.nix
@@ -1,0 +1,43 @@
+{ build-idris-package
+, fetchgit
+, prelude
+, base
+, effects
+, lib
+, idris
+}:
+
+let
+  date = "2017-11-11";
+in
+build-idris-package {
+  name = "specdris-${date}";
+
+  src = fetchgit {
+    url = "https://github.com/pheymann/specdris";
+    rev = "88b80334b8e0b6601324e2410772d35022fc8eaa";
+    sha256 = "4813c4be1d4c3dd1dad35964b085f83cf9fb44b16824257c72b468d4bafd0e4f";
+  };
+
+  propagatedBuildInputs = [ prelude base effects ];
+
+  buildPhase = ''
+    ${idris}/bin/idris --build specdris.ipkg
+  '';
+
+  checkPhase = ''
+      cd test/
+      ${idris}/bin/idris --testpkg test.ipkg
+      cd ../
+    '';
+
+  installPhase = ''
+    ${idris}/bin/idris --install specdris.ipkg --ibcsubdir $IBCSUBDIR
+  '';
+
+  meta = {
+    description = "A testing library for Idris";
+    homepage = https://github.com/pheymann/specdris;
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Add specdris to the list of idris modules.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

