### PR TITLE
dolphinEmuMaster: Enable Darwin building

### DIFF
--- a/pkgs/development/libraries/wxwidgets/3.1/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.1/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, fetchFromGitHub
+, wxGTK30
+}:
+
+with stdenv.lib;
+
+wxGTK30.overrideAttrs (oldAttrs : rec {
+    name = "wxwidgets-${version}";
+    version = "3.1.0";
+    src = fetchFromGitHub {
+        owner = "wxWidgets";
+        repo = "wxWidgets";
+        rev = "v${version}";
+        sha256 = "14kl1rsngm70v3mbyv1mal15iz2b18k97avjx8jn7s81znha1c7f";
+    };
+})

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -3,12 +3,21 @@
 , openal, libXdmcp, portaudio, libusb, libevdev
 , libpulseaudio ? null
 , curl
+
+, qt5
 # - Inputs used for Darwin
 , CoreBluetooth, cf-private, ForceFeedback, IOKit, OpenGL
 , wxGTK
 , libpng
 , hidapi
+
+# options
+, dolphin-wxgui ? true
+, dolphin-qtgui ? false
 }:
+# XOR: ensure only wx XOR qt are enabled
+assert dolphin-wxgui || dolphin-qtgui;
+assert !(dolphin-wxgui && dolphin-qtgui);
 
 stdenv.mkDerivation rec {
   name = "dolphin-emu-20170902";
@@ -24,7 +33,8 @@ stdenv.mkDerivation rec {
     "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include"
     "-DGTK2_INCLUDE_DIRS=${gtk2.dev}/include/gtk-2.0"
     "-DENABLE_LTO=True"
-  ] ++ stdenv.lib.optionals stdenv.isDarwin [ "-DOSX_USE_DEFAULT_SEARCH_PATH=True" ];
+  ] ++ stdenv.lib.optionals (!dolphin-qtgui)  [ "-DENABLE_QT2=False" ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ "-DOSX_USE_DEFAULT_SEARCH_PATH=True" ];
 
   enableParallelBuilding = true;
 
@@ -34,7 +44,8 @@ stdenv.mkDerivation rec {
                   gettext libpthreadstubs libXrandr libXext libSM readline openal
                   libXdmcp portaudio libusb libpulseaudio libpng hidapi
                 ] ++ stdenv.lib.optionals stdenv.isDarwin [ wxGTK CoreBluetooth cf-private ForceFeedback IOKit OpenGL ]
-                  ++ stdenv.lib.optionals stdenv.isLinux  [ bluez libevdev  ];
+                  ++ stdenv.lib.optionals stdenv.isLinux  [ bluez libevdev  ]
+                  ++ stdenv.lib.optionals dolphin-qtgui [ qt5.qtbase ];
 
   # - Change install path to Applications relative to $out
   # - Allow Dolphin to use nix-provided libraries instead of building them

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -66,6 +66,6 @@ stdenv.mkDerivation rec {
     maintainers = with stdenv.lib.maintainers; [ MP2E ];
     # x86_32 is an unsupported platform.
     # Enable generic build if you really want a JIT-less binary.
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -20,12 +20,12 @@ assert dolphin-wxgui || dolphin-qtgui;
 assert !(dolphin-wxgui && dolphin-qtgui);
 
 stdenv.mkDerivation rec {
-  name = "dolphin-emu-20170902";
+  name = "dolphin-emu-20171218";
   src = fetchFromGitHub {
     owner = "dolphin-emu";
     repo = "dolphin";
-    rev = "b073db51e5f3df8c9890e09a3f4f8a2276c31e3f";
-    sha256 = "0pr5inkd7swc6s7im7axhvmkdbqidhrha2wpflnr25aiwq0dzm10";
+    rev = "438e8b64a4b080370c7a65ed23af52838a4e7aaa";
+    sha256 = "0rrd0g1vg9jk1p4wdr6w2z34cabb7pgmpwfcl2a372ark3vi4ysc";
   };
 
   cmakeFlags = [
@@ -64,6 +64,7 @@ stdenv.mkDerivation rec {
     description = "Gamecube/Wii/Triforce emulator for x86_64 and ARM";
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ MP2E ];
+    branch = "master";
     # x86_32 is an unsupported platform.
     # Enable generic build if you really want a JIT-less binary.
     platforms = [ "x86_64-linux" "x86_64-darwin" ];

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -1,7 +1,14 @@
-{ stdenv, gcc, pkgconfig, cmake, bluez, ffmpeg, libao, mesa, gtk2, glib
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, bluez, ffmpeg, libao, mesa, gtk2, glib
 , pcre, gettext, libpthreadstubs, libXrandr, libXext, libSM, readline
-, openal, libXdmcp, portaudio, fetchFromGitHub, libusb, libevdev
-, libpulseaudio ? null }:
+, openal, libXdmcp, portaudio, libusb, libevdev
+, libpulseaudio ? null
+, curl
+# - Inputs used for Darwin
+, CoreBluetooth, cf-private, ForceFeedback, IOKit, OpenGL
+, wxGTK
+, libpng
+, hidapi
+}:
 
 stdenv.mkDerivation rec {
   name = "dolphin-emu-20170902";
@@ -17,14 +24,17 @@ stdenv.mkDerivation rec {
     "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include"
     "-DGTK2_INCLUDE_DIRS=${gtk2.dev}/include/gtk-2.0"
     "-DENABLE_LTO=True"
-  ];
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [ "-DOSX_USE_DEFAULT_SEARCH_PATH=True" ];
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gcc cmake bluez ffmpeg libao mesa gtk2 glib pcre
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [ curl ffmpeg libao mesa gtk2 glib pcre
                   gettext libpthreadstubs libXrandr libXext libSM readline openal
-                  libevdev libXdmcp portaudio libusb libpulseaudio ];
+                  libXdmcp portaudio libusb libpulseaudio libpng hidapi
+                ] ++ stdenv.lib.optionals stdenv.isDarwin [ wxGTK CoreBluetooth cf-private ForceFeedback IOKit OpenGL ]
+                  ++ stdenv.lib.optionals stdenv.isLinux  [ bluez libevdev  ];
 
   meta = {
     homepage = http://dolphin-emu.org/;

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -35,6 +35,15 @@ stdenv.mkDerivation rec {
                   libXdmcp portaudio libusb libpulseaudio libpng hidapi
                 ] ++ stdenv.lib.optionals stdenv.isDarwin [ wxGTK CoreBluetooth cf-private ForceFeedback IOKit OpenGL ]
                   ++ stdenv.lib.optionals stdenv.isLinux  [ bluez libevdev  ];
+
+  # - Change install path to Applications relative to $out
+  # - Allow Dolphin to use nix-provided libraries instead of building them
+  preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
+    sed -i -e 's,/Applications,Applications,g' Source/Core/DolphinWX/CMakeLists.txt
+    sed -i -e 's,if(LIBUSB_FOUND AND NOT APPLE),if(LIBUSB_FOUND),g' CMakeLists.txt
+    sed -i -e 's,if(NOT APPLE),if(true),g' CMakeLists.txt
+  '';
+
   preInstall = stdenv.lib.optionalString stdenv.isDarwin ''
     mkdir -p "$out/Applications"
   '';

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -12,12 +12,12 @@ stdenv.mkDerivation rec {
     sha256 = "0pr5inkd7swc6s7im7axhvmkdbqidhrha2wpflnr25aiwq0dzm10";
   };
 
-  cmakeFlags = ''
-    -DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include
-    -DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include
-    -DGTK2_INCLUDE_DIRS=${gtk2.dev}/include/gtk-2.0
-    -DENABLE_LTO=True
-  '';
+  cmakeFlags = [
+    "-DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include"
+    "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include"
+    "-DGTK2_INCLUDE_DIRS=${gtk2.dev}/include/gtk-2.0"
+    "-DENABLE_LTO=True"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -35,6 +35,9 @@ stdenv.mkDerivation rec {
                   libXdmcp portaudio libusb libpulseaudio libpng hidapi
                 ] ++ stdenv.lib.optionals stdenv.isDarwin [ wxGTK CoreBluetooth cf-private ForceFeedback IOKit OpenGL ]
                   ++ stdenv.lib.optionals stdenv.isLinux  [ bluez libevdev  ];
+  preInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    mkdir -p "$out/Applications"
+  '';
 
   meta = {
     homepage = http://dolphin-emu.org/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11152,6 +11152,8 @@ with pkgs;
     withMesa = lib.elem system lib.platforms.mesaPlatforms;
   };
 
+  wxGTK31 = callPackage ../development/libraries/wxwidgets/3.1 {};
+
   wxmac = callPackage ../development/libraries/wxwidgets/3.0/mac.nix {
     inherit (darwin.apple_sdk.frameworks) AGL Cocoa Kernel;
     inherit (darwin.stubs) setfile rez derez;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1829,8 +1829,11 @@ with pkgs;
   dotnetfx40 = callPackage ../development/libraries/dotnetfx40 { };
 
   dolphinEmu = callPackage ../misc/emulators/dolphin-emu { };
-  dolphinEmuMaster = callPackage ../misc/emulators/dolphin-emu/master.nix { };
-
+  dolphinEmuMaster = callPackage ../misc/emulators/dolphin-emu/master.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreBluetooth ForceFeedback IOKit OpenGL;
+    inherit (darwin) cf-private;
+    wxGTK = wxGTK31;
+  };
   doomseeker = callPackage ../applications/misc/doomseeker { };
 
   slade = callPackage ../applications/misc/slade {


### PR DESCRIPTION
###### Motivation for this change
This PR enables Darwin building for Dolphin.

###### Things done
It also adds the required WXGTK31 package and cleans up how we patch mbedtls on darwin.

Dolphin generates an application bundle instead of a binary in bin on Darwin, but I can add a symlink to the binary if needed.

Potential improvement: go through the list of External deps and use nix-provided ones to reduce the binary size.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

