### PR TITLE
make-dbus-conf: prefer local build

### DIFF
--- a/pkgs/development/libraries/dbus/make-dbus-conf.nix
+++ b/pkgs/development/libraries/dbus/make-dbus-conf.nix
@@ -11,6 +11,7 @@
 runCommand "dbus-1"
   {
     inherit serviceDirectories suidHelper;
+    preferLocalBuild = true;
     XML_CATALOG_FILES = writeText "dbus-catalog.xml" ''
       <?xml version="1.0"?>
       <!DOCTYPE catalog PUBLIC


### PR DESCRIPTION
###### Motivation for this change

I use remote builders to upgrade my laptop (`nix.buildMachines` option), and after a mass rebuild the final step that takes a lot of time looks like this (for the brevity of the example, I've interrupted the last step before running the switch again):

```
# nixos-rebuild switch
building Nix...
building the system configuration...
these derivations will be built:
  /nix/store/sacraxp35l3k0mcz92bmisf7rrqvxbdf-dbus-1.drv
  /nix/store/5ny75i0xcwic0plq30jrpjax9jfx5d5i-unit-dbus.service.drv
  /nix/store/2rwjbklbxzsgl6s6mnyrvj34svgdkyxk-system-units.drv
  /nix/store/s3p5db30hjp1aw847ml5q7xmsrrhr671-user-units.drv
  /nix/store/yxmxcclkchff3x18srpdz6h0aybb5qsz-etc.drv
  /nix/store/r8yw56k71dpn8wq30jp539kk5v7qaf4f-nixos-system-orivej-18.03.git.f575062.drv
copying 500 missing paths (5000 MiB) to ‘user@build-machine’...
```

All of this derivations prefer local build except [dbus-1](https://github.com/NixOS/nixpkgs/blob/f575062f9764b02fb04609e0afb0403e48435d7e/pkgs/development/libraries/dbus/make-dbus-conf.nix#L11). If I enable it for dbus-1, the switch finishes instantaneously. Previously I had to rerun the switch with `--no-build-hook` when I wanted it to finish fast.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).