### PR TITLE
cudnn*_cudatoolkit*: use public NVIDIA mirror

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -13,7 +13,7 @@ in
     version = "4";
     cudatoolkit = cudatoolkit_7;
     srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v4.0-prod.tgz";
-    sha256 = "0zgr6qdbc29qw6sikhrh6diwwz7150rqc8a49f2qf37j2rvyyr2f";
+    sha256 = "01a4v5j4v9n2xjqcc4m28c3m67qrvsx87npvy7zhx7w8smiif2fd";
   };
 
   cudnn_cudatoolkit_7_5 = generic rec {

--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -9,9 +9,10 @@ in
 
 {
   cudnn_cudatoolkit_7 = generic rec {
-    version = "4.0";
+    # Old URL is v4 instead of v4.0 for some reason...
+    version = "4";
     cudatoolkit = cudatoolkit_7;
-    srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v${version}-prod.tgz";
+    srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v4.0-prod.tgz";
     sha256 = "0zgr6qdbc29qw6sikhrh6diwwz7150rqc8a49f2qf37j2rvyyr2f";
   };
 

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -5,24 +5,18 @@
 
 { stdenv
 , lib
-, requireFile
 , cudatoolkit
+, fetchurl
 }:
 
 stdenv.mkDerivation rec {
   name = "cudatoolkit-${cudatoolkit.majorVersion}-cudnn-${version}";
 
   inherit version;
-
-  src = requireFile rec {
-    name = srcName;
+  src = fetchurl {
+    # URL from NVIDIA docker containers: https://gitlab.com/nvidia/cuda/blob/centos7/7.0/runtime/cudnn4/Dockerfile
+    url = "https://developer.download.nvidia.com/compute/redist/cudnn/v${version}/${srcName}";
     inherit sha256;
-    message = ''
-      This nix expression requires that ${name} is already part of the store.
-      Register yourself to NVIDIA Accelerated Computing Developer Program, retrieve the cuDNN library
-      at https://developer.nvidia.com/cudnn, and run the following command in the download directory:
-      nix-prefetch-url file://\$PWD/${name}
-    '';
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
This PR dramatically simplifies the use of cudnn libraries on NixOS, which is used by most machine learning packages for gpu acceleration.

Previously, you would have to go through the NVIDIA developer portal and manually use nix-prefetch to add the tarballs to the store. 
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

