### PR TITLE
oraclejdk: remove JCE option

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk9-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk9-linux.nix
@@ -7,7 +7,6 @@
 , xorg ? null
 , packageType ? "JDK" # JDK, JRE, or ServerJRE
 , pluginSupport ? true
-, installjce ? false
 , glib
 , libxml2
 , ffmpeg_2
@@ -33,16 +32,6 @@ let
   version = "9.0.1";
 
   downloadUrlBase = http://www.oracle.com/technetwork/java/javase/downloads;
-
-  jce =
-    if installjce then
-      requireFile {
-        name = "jce_policy-8.zip";
-        url = "${downloadUrlBase}/jce8-download-2133166.html";
-        sha256 = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";
-      }
-    else
-      "";
 
   rSubPaths = [
     "lib/jli"
@@ -79,8 +68,7 @@ let result = stdenv.mkDerivation rec {
       }
     else abort "unknown package Type ${packageType}";
 
-  nativeBuildInputs = [ file ]
-    ++ stdenv.lib.optional installjce unzip;
+  nativeBuildInputs = [ file ];
 
   buildInputs = [ makeWrapper ];
 
@@ -107,11 +95,6 @@ let result = stdenv.mkDerivation rec {
         rm $file
       fi
     done
-
-    if test -n "${jce}"; then
-      unzip ${jce}
-      cp -v UnlimitedJCEPolicy*/*.jar $out/lib/security
-    fi
 
     if test -z "$pluginSupport"; then
       rm -f $out/bin/javaws


### PR DESCRIPTION
###### Motivation for this change

The unlimited JCE is bundled by default with Oracle JDK 9.
http://www.oracle.com/technetwork/java/javase/terms/readme/jdk9-readme-3852447.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

