### PR TITLE
pidginsipe: 1.22.1 -> 1.23.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/sipe/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/sipe/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, pidgin, intltool, libxml2, nss, nspr }:
 
-let version = "1.22.1"; in
+let version = "1.23.0"; in
 
 stdenv.mkDerivation {
   name = "pidgin-sipe-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/sipe/pidgin-sipe-${version}.tar.gz";
-    sha256 = "f6b7b7475e349c0214eb02814b808b04850113a91dd8e8d2c26e7179a3fd1ae8";
+    sha256 = "795811ced33fcc5affae259828f6452bfc0e0b02737ea68483e1bd9ec0459013";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Version update
* version 1.23.0 "D-Bus, IPv6, OS X 10.11+" (2017-10-28)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

