### PR TITLE
pythonPackages.libnacl: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/development/python-modules/libnacl/default.nix
+++ b/pkgs/development/python-modules/libnacl/default.nix
@@ -2,14 +2,14 @@
 
 buildPythonPackage rec {
   pname = "libnacl";
-  version = "1.6.0";
+  version = "1.6.1";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "saltstack";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0iaql3mrj3hf48km8177bi6nmjdar26kmqjc3jw8mrjc940v99fk";
+    sha256 = "05iamhbsqm8binqhc2zchfqdkajlx2icf8xl5vkd5fbrhw6yylad";
   };
 
   buildInputs = [ pytest ];


### PR DESCRIPTION
###### Motivation for this change
Update libnacl

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

