### PR TITLE
python3.buildEnv: pick outputs correctly, refactor

### DIFF
--- a/pkgs/development/interpreters/python/wrapper.nix
+++ b/pkgs/development/interpreters/python/wrapper.nix
@@ -1,59 +1,76 @@
+/* Create a Python executable that knows about additional packages. */
+
 { stdenv, python, buildEnv, makeWrapper
 , extraLibs ? []
 , extraOutputsToInstall ? []
 , postBuild ? ""
 , ignoreCollisions ? false }:
 
-# Create a python executable that knows about additional packages.
-let
-  recursivePthLoader = import ../../python-modules/recursive-pth-loader/default.nix { stdenv = stdenv; python = python; };
-  env = let
-    paths = stdenv.lib.closePropagation (extraLibs ++ [ python recursivePthLoader ] ) ;
-  in buildEnv {
-    name = "${python.name}-env";
+with stdenv.lib;
 
-    inherit paths;
-    inherit ignoreCollisions extraOutputsToInstall;
+let
+  recursivePthLoader = import ../../python-modules/recursive-pth-loader/default.nix {
+    inherit stdenv python;
+  };
+  inputs = extraLibs ++ [ python recursivePthLoader ];
+  # https://git.io/vFV56
+  pickOutputs = drv:
+    if (drv.outputUnspecified or false) && (drv.meta.outputsToInstall or null) != null
+    then (map (out: getOutput out drv) drv.meta.outputsToInstall)
+    else [ drv ]
+    ++ filter isNull (map (out: getOutput out drv) extraOutputsToInstall);
+  closePropagation' = drvs:
+    map (drv: drv // { outputUnspecified = true; }) (closePropagation drvs);
+  paths = concatLists (map pickOutputs (closePropagation' inputs));
+  self = buildEnv {
+    inherit ignoreCollisions extraOutputsToInstall paths;
+    inherit (python) meta;
+
+    name = "${python.name}-env";
+    buildInputs = [ makeWrapper ];
 
     postBuild = ''
-      . "${makeWrapper}/nix-support/setup-hook"
-
-      if [ -L "$out/bin" ]; then
-          unlink "$out/bin"
+      if [ -L $out/bin ]; then
+        unlink $out/bin
       fi
-      mkdir -p "$out/bin"
 
-      for path in ${stdenv.lib.concatStringsSep " " paths}; do
-        if [ -d "$path/bin" ]; then
-          cd "$path/bin"
-          for prg in *; do
-            if [ -f "$prg" ]; then
-              rm -f "$out/bin/$prg"
-              if [ -x "$prg" ]; then
-                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set PYTHONHOME "$out" --set PYTHONNOUSERSITE "true"
-              fi
+      mkdir -p $out/bin
+
+      for path in ${concatStringsSep " " paths}; do
+        if [ -d $path/bin ]; then
+          cd $path/bin
+          for x in *; do
+            if [ -f $x ] && [ -x $x ]; then
+              rm -f $out/bin/$x
+              makeWrapper $path/bin/$x $out/bin/$x \
+                --set PYTHONHOME $out \
+                --set PYTHONNOUSERSITE true
             fi
           done
         fi
       done
-    '' + postBuild;
 
-    inherit (python) meta;
+      ${postBuild}
+    '';
 
     passthru = python.passthru // {
-      interpreter = "${env}/bin/${python.executable}";
       inherit python;
+      interpreter = "${self}/bin/${python.executable}";
       env = stdenv.mkDerivation {
         name = "interactive-${python.name}-environment";
-        nativeBuildInputs = [ env ];
+        nativeBuildInputs = [ self ];
 
         buildCommand = ''
-          echo >&2 ""
-          echo >&2 "*** Python 'env' attributes are intended for interactive nix-shell sessions, not for building! ***"
-          echo >&2 ""
+	  cat >&2 << EOF
+
+*** Python 'env' attributes are intended for interactive nix-shell sessions, not for building! ***
+
+EOF
           exit 1
         '';
-    };
+      };
     };
   };
-in env
+in
+
+self


### PR DESCRIPTION
###### Motivation for this change

See discussion in #31094.

This copies some of the output picking logic from buildEnv. Includes a local version of closePropagation that sets `outputUnspecified` to all derivations it produces.

/cc @FRidh 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

