### PR TITLE
racket: reenable docs by default

### DIFF
--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -3,7 +3,7 @@
 , glib, gmp, gtk2, libedit, libffi, libjpeg
 , libpng, libtool, mpfr, openssl, pango, poppler
 , readline, sqlite
-, disableDocs ? true
+, disableDocs ? false
 }:
 
 let


### PR DESCRIPTION
###### Motivation for this change

More than two years ago, @domenkozar disabled the documentation for racket in 89cec0c096d3b06c61553d616cabbab229ea616f because of intermittent build failures.  However this causes [problems with raco](https://github.com/NixOS/nixpkgs/pull/12611#issuecomment-261862944), of course disables documentation in drracket, and breaks the documentation and help functions in emacs.

It seems like the [build failures have been fixed now](https://github.com/racket/racket/commit/e0506038ba2a0ab1fda664aa6232964499a3c5b9#diff-dac9fee779d8a90655dc8bda889a7396).  So we should reenable docs by default.
cc maintainers @henrytill @vrthra 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

