### PR TITLE
tzdata: Use hard- instead of symbol-linking

### DIFF
--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -33,7 +33,8 @@ stdenv.mkDerivation rec {
   postInstall =
     ''
       rm $out/share/zoneinfo-posix
-      ln -s . $out/share/zoneinfo/posix
+      cp -rl $out/share/zoneinfo $out/share/posix
+      mv $out/share/posix $out/share/zoneinfo/posix
       mv $out/share/zoneinfo-leaps $out/share/zoneinfo/right
 
       mkdir -p "$dev/include"

--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -33,8 +33,8 @@ stdenv.mkDerivation rec {
   postInstall =
     ''
       rm $out/share/zoneinfo-posix
-      cp -rl $out/share/zoneinfo $out/share/posix
-      mv $out/share/posix $out/share/zoneinfo/posix
+      mkdir $out/share/zoneinfo/posix
+      ( cd $out/share/zoneinfo/posix; ln -s ../* .; rm posix )
       mv $out/share/zoneinfo-leaps $out/share/zoneinfo/right
 
       mkdir -p "$dev/include"


### PR DESCRIPTION
###### Motivation for this change

Upstream software parses ${tzdata}/share/zoneinfo files.
Because of the symbolic posix link pointing to the local dir, the upstream software parses the contents of the zoneinfo directory multiple times because it follows symlinks and an error occurs because of this.
This PR changes the posix symlink to a hardlink to have a normal directory for posix like Fedora does.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

