### PR TITLE
pdf-tools: 0.70 -> 0.80

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -75,24 +75,14 @@ let
 
   ## START HERE
 
-  tablist = melpaBuild rec {
-    pname = "tablist";
-    inherit (pdf-tools) src version;
-    fileSpecs = [ "lisp/tablist.el" "lisp/tablist-filter.el" ];
-    meta = {
-      description = "Extended tabulated-list-mode";
-      license = gpl3;
-    };
-  };
-
   pdf-tools = melpaBuild rec {
     pname = "pdf-tools";
-    version = "0.70";
+    version = "0.80";
     src = fetchFromGitHub {
       owner = "politza";
       repo = "pdf-tools";
       rev = "v${version}";
-      sha256 = "19sy49r3ijh36m7hl4vspw5c4i8pnfqdn4ldm2sqchxigkw56ayl";
+      sha256 = "1i4647vax5na73basc5dz4lh9kprir00fh8ps4i0l1y3ippnjs2s";
     };
     nativeBuildInputs = [ external.pkgconfig ];
     buildInputs = with external; [ autoconf automake libpng zlib poppler ];


### PR DESCRIPTION
At the same time, remove the unnecessary hand-specified `tablist` package, in favor of the automatically maintained one from melpa-stable.

###### Motivation for this change

After two years, a new version came out!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

