### PR TITLE
braincurses: init at 1.1.0

### DIFF
--- a/pkgs/games/braincurses/default.nix
+++ b/pkgs/games/braincurses/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "braincurses-${version}";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "bderrly";
+    repo = "braincurses";
+    rev = version;
+    sha256 = "0gpny9wrb0zj3lr7iarlgn9j4367awj09v3hhxz9r9a6yhk4anf5";
+  };
+
+  buildInputs = [ ncurses ];
+
+  # There is no install target in the Makefile
+  installPhase = ''
+    install -Dt $out/bin braincurses
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/bderrly/braincurses;
+    description = "A version of the classic game Mastermind";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ dotlambda ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17678,6 +17678,8 @@ with pkgs;
 
   blobby = callPackage ../games/blobby { };
 
+  braincurses = callPackage ../games/braincurses { };
+
   brogue = callPackage ../games/brogue { };
 
   bsdgames = callPackage ../games/bsdgames { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

