### PR TITLE
Package hexd and pixd

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -217,6 +217,7 @@
   falsifian = "James Cook <james.cook@utoronto.ca>";
   fare = "Francois-Rene Rideau <fahree@gmail.com>";
   fgaz = "Francesco Gazzetta <francygazz@gmail.com>";
+  FireyFly = "Jonas Höglund <nix@firefly.nu>";
   flokli = "Florian Klink <flokli@flokli.de>";
   florianjacob = "Florian Jacob <projects+nixos@florianjacob.de>";
   flosse = "Markus Kohlhase <mail@markus-kohlhase.de>";

--- a/pkgs/tools/misc/hexd/default.nix
+++ b/pkgs/tools/misc/hexd/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "hexd-${version}";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "FireyFly";
+    repo = "hexd";
+    rev = "v${version}";
+    sha256 = "1lm0mj5c71id5kpqar8n44023s1kymb3q45nsz0hjh9v7p8libp0";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    description = "Colourful, human-friendly hexdump tool";
+    homepage = https://github.com/FireyFly/hexd;
+    maintainers = [ maintainers.FireyFly ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/pixd/default.nix
+++ b/pkgs/tools/misc/pixd/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "pixd-${version}";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "FireyFly";
+    repo = "pixd";
+    rev = "v${version}";
+    sha256 = "1vmkbs39mg5vwmkzfcrxqm6p8zr9sj4qdwng9icmyf5k34c34xdg";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    description = "Colourful visualization tool for binary files";
+    homepage = https://github.com/FireyFly/pixd;
+    maintainers = [ maintainers.FireyFly ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2600,6 +2600,7 @@ with pkgs;
   hevea = callPackage ../tools/typesetting/hevea { };
 
   hexd = callPackage ../tools/misc/hexd { };
+  pixd = callPackage ../tools/misc/pixd { };
 
   hhpc = callPackage ../tools/misc/hhpc { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2599,6 +2599,8 @@ with pkgs;
 
   hevea = callPackage ../tools/typesetting/hevea { };
 
+  hexd = callPackage ../tools/misc/hexd { };
+
   hhpc = callPackage ../tools/misc/hhpc { };
 
   hiera-eyaml = callPackage ../tools/system/hiera-eyaml { };


### PR DESCRIPTION
###### Motivation for this change
Packaging `hexd` and `pixd`, two closely related utilities I wrote.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - (shouldn't be applicable I believe)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  - (no other packages should be affected since I'm introducing two new ones, so this should be vacuously true, but feels cheeky to check this box)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

`hexd` is a simple hexdump tool which colourises different ranges of bytes with different colours, which makes it easy to spot patterns in the data. It also provides some useful flags, such as the ability to only hexdump a specific range of a file (or of several files). 

`pixd` is based on `hexd` but tweaked to use half-block characters and 24-bit colours, displaying each byte as a coloured half-block. Each of the 256 byte values gets assigned to a unique colour taken from a colour palette (which is overridable with an environment variable), again for purposes of showing the structure and repeating patterns. That said, in practice I find `hexd` to be a lot more useful for reverse-engineering purposes, personally.

I wrote pixd this spring, and although it was mostly an experiment in visualizing arbitrary binary data, a lot of people seemed to like it and it got packaged in some other assorted distros (mostly ones related to computer security, penetration testing and so on). I thought I might as well write my own nix derivations for them, and having written them I thought I might as well contribute them back as well. :) 

That said, I've been using NixOS for a grand total of a week now, and these are the second and third nix derivations I've written, so it'd be great if they were thoroughly reviewed and I'd be happy for any suggestions of improvements/changes. (The first one I wrote was me packaging pangoterm, and although I'm intending to pull-request it too, it's not quite ready for that yet. Since `hexd` and `pixd` basically amount to `make && make install` I figured they're good newbie derivations for me too.)