### PR TITLE
nixos/tests: add a test for config.users.mutableUsers.

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -95,6 +95,7 @@ in rec {
         #(all nixos.tests.lightdm)
         (all nixos.tests.login)
         (all nixos.tests.misc)
+        (all nixos.tests.mutableUsers)
         (all nixos.tests.nat.firewall)
         (all nixos.tests.nat.standalone)
         (all nixos.tests.networking.scripted.loopback)

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -290,6 +290,7 @@ in rec {
   tests.mongodb = callTest tests/mongodb.nix {};
   tests.mumble = callTest tests/mumble.nix {};
   tests.munin = callTest tests/munin.nix {};
+  tests.mutableUsers = callTest tests/mutable-users.nix {};
   tests.mysql = callTest tests/mysql.nix {};
   tests.mysqlBackup = callTest tests/mysql-backup.nix {};
   tests.mysqlReplication = callTest tests/mysql-replication.nix {};

--- a/nixos/tests/mutable-users.nix
+++ b/nixos/tests/mutable-users.nix
@@ -1,0 +1,39 @@
+# Mutable users tests.
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "mutable-users";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ gleber ];
+  };
+
+  nodes = {
+    machine = { config, lib, pkgs, ... }: {
+      users.mutableUsers = false;
+    };
+    mutable = { config, lib, pkgs, ... }: {
+      users.mutableUsers = true;
+    };
+  };
+
+  testScript = {nodes, ...}: let
+    immutableSystem = nodes.machine.config.system.build.toplevel;
+    mutableSystem = nodes.mutable.config.system.build.toplevel;
+  in ''
+    $machine->start();
+    $machine->waitForUnit("default.target");
+
+    # Machine starts in immutable mode. Add a user and test if reactivating
+    # configuration removes the user.
+    $machine->fail("cat /etc/passwd | grep ^foobar:");
+    $machine->succeed("sudo useradd foobar");
+    $machine->succeed("cat /etc/passwd | grep ^foobar:");
+    $machine->succeed("${immutableSystem}/bin/switch-to-configuration test");
+    $machine->fail("cat /etc/passwd | grep ^foobar:");
+
+    # In immutable mode passwd is not wrapped, while in mutable mode it is
+    # wrapped.
+    $machine->succeed('which passwd | grep /run/current-system/');
+    $machine->succeed("${mutableSystem}/bin/switch-to-configuration test");
+    $machine->succeed('which passwd | grep /run/wrappers/');
+  '';
+})


### PR DESCRIPTION
It's in preparation to add an assertion for #4990.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

