### PR TITLE
firefox: support for native messaging hosts in wrapper

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/env_var_for_system_dir.patch
+++ b/pkgs/applications/networking/browsers/firefox/env_var_for_system_dir.patch
@@ -1,0 +1,14 @@
+diff --git a/toolkit/xre/nsXREDirProvider.cpp b/toolkit/xre/nsXREDirProvider.cpp
+index 380c1c1..255539f 100644
+--- a/toolkit/xre/nsXREDirProvider.cpp
++++ b/toolkit/xre/nsXREDirProvider.cpp
+@@ -306,7 +306,8 @@ GetSystemParentDirectory(nsIFile** aFile)
+                            "/usr/lib/mozilla"
+ #endif
+                            );
+-  rv = NS_NewNativeLocalFile(dirname, false, getter_AddRefs(localDir));
++  const char* pathVar = PR_GetEnv("MOZ_SYSTEM_DIR");
++  rv = NS_NewNativeLocalFile((pathVar && *pathVar) ? nsDependentCString(pathVar) : reinterpret_cast<const nsCString&>(dirname), false, getter_AddRefs(localDir));
+ #endif
+ 
+   if (NS_SUCCEEDED(rv)) {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -13,7 +13,7 @@ rec {
     };
 
     patches =
-      [ ./no-buildconfig.patch ]
+      [ ./no-buildconfig.patch ./env_var_for_system_dir.patch ]
       ++ lib.optional stdenv.isi686 (fetchpatch {
         url = "https://hg.mozilla.org/mozilla-central/raw-rev/15517c5a5d37";
         sha256 = "1ba487p3hk4w2w7qqfxgv1y57vp86b8g3xhav2j20qd3j3phbbn7";
@@ -37,6 +37,9 @@ rec {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
       sha512 = "d80c7219548391d8a47b6e404662ea41e6acfa264a67d69365e76dd8943077e388ab24b030850919f8fc6681c11486bdbaaf170d441c861f4a12cedbe08955ab";
     };
+
+    patches =
+      [ ./env_var_for_system_dir.patch ];
 
     meta = firefox.meta // {
       description = "A web browser built from Firefox Extended Support Release source tree";
@@ -128,6 +131,9 @@ in rec {
       rev   = "tor-browser-52.3.0esr-7.0-1-slnos";
       sha256 = "0szbf8gjbl4dnrb4igy4mq5858i1y6ki4skhdw63iqqdd8w9v4yv";
     };
+
+    patches =
+      [ ./env_var_for_system_dir.patch ];
   } // commonAttrs) {};
 
   tor-browser = tor-browser-7-0;


### PR DESCRIPTION
###### Motivation for this change
New web extensions sometimes need native binaries installed to work. However in firefox the search path for these binaries is hardcoded to `/usr/lib/mozilla/native-messaging-hosts`.
I added small patch that allows overriding that path by new env varibale MOZ_SYSTEM_DIR and enhanced the wrapper. Here is an example integration of [chrome-gnome-shell](https://github.com/deedrah/nixpkgs/commit/41aeb85a114788f670099c9a387a0f5085b2a84b).
This will allows to add existing native messaging hosts (#28882 and #24803) to firefox in similar way like plugins .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

