### PR TITLE
 opencryptoki, pkcs11-helper, simple-tpm-pk11

### DIFF
--- a/pkgs/development/libraries/pkcs11helper/default.nix
+++ b/pkgs/development/libraries/pkcs11helper/default.nix
@@ -2,20 +2,22 @@
 
 stdenv.mkDerivation rec {
   name = "pkcs11-helper-${version}";
-  version = "1.21";
+  version = "1.22";
 
   src = fetchFromGitHub {
     owner = "OpenSC";
     repo = "pkcs11-helper";
     rev = "${name}";
-    sha256 = "17a2cssycl7fh44xikmhszigx57vvn0h2sjsnmsy3772kfj796b1";
+    sha256 = "01v3zv6sr5phqhr2f21fl2rmcnmkp9518dkq82g1v2y9ysjksg7q";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ openssl ];
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
-    homepage = https://www.opensc-project.org/opensc/wiki/pkcs11-helper;
+    homepage = https://github.com/OpenSC/pkcs11-helper;
     license = with licenses; [ bsd3 gpl2 ];
     description = "Library that simplifies the interaction with PKCS#11 providers";
     platforms = platforms.unix;

--- a/pkgs/tools/security/simple-tpm-pk11/default.nix
+++ b/pkgs/tools/security/simple-tpm-pk11/default.nix
@@ -1,27 +1,29 @@
-{ stdenv, fetchgit, trousers, openssl, opencryptoki, automake, autoconf, libtool }:
+{ stdenv, fetchFromGitHub, trousers, openssl, opencryptoki, autoreconfHook, libtool }:
 
 stdenv.mkDerivation rec {
-  name = "simple-tpm-pk11-2016-07-12";
+  name = "simple-tpm-pk11-${version}";
+  version = "0.06";
 
-  src = fetchgit {
-    url = "https://github.com/ThomasHabets/simple-tpm-pk11";
-    rev = "6f1f7a6b96ac82965e977cfecb88d930f1d70243";
-    sha256 = "06vf3djp29slh7hrh4hlh3npyl277fy7d77jv9mxa1sk1idjklxc";
+  src = fetchFromGitHub {
+    owner = "ThomasHabets";
+    repo = "simple-tpm-pk11";
+    rev = version;
+    sha256 = "0vpbaklr4r1a2am0pqcm6m41ph22mkcrq33y8ab5h8qkhkvhd6a6";
   };
 
-  buildInputs = [ trousers openssl opencryptoki automake autoconf libtool ];
+  nativeBuildInputs = [ autoreconfHook libtool ];
+  buildInputs = [ trousers openssl opencryptoki ];
 
-  preConfigure = "sh bootstrap.sh";
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Simple PKCS11 provider for TPM chips";
     longDescription = ''
       A simple library for using the TPM chip to secure SSH keys.
-      '';
+    '';
     homepage    = https://github.com/ThomasHabets/simple-tpm-pk11;
-    license     = stdenv.lib.licenses.asl20;
-    maintainers = with stdenv.lib; [ maintainers.tstrobel ];
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ tstrobel ];
     platforms   = platforms.unix;
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change
Refresh of unattended packages loosely related
Plus homepages refresh (#30636)

- opencryptoki: update to v3.8.1
- pkcs11-helper: update to v1.22
- simple-tpm-pk11: update to v0.06 (and yes this 'stable' release is more recent than the git rev previously fetched)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

