### PR TITLE
gixy: init at 0.1.8

### DIFF
--- a/pkgs/development/python-modules/configargparse/default.nix
+++ b/pkgs/development/python-modules/configargparse/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "ConfigArgParse";
+  version = "0.12.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fgkiqh6r3rbkdq3k8c48m85g52k96686rw3a6jg4lcncrkpvk98";
+  };
+
+  # no tests in tarball
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A drop-in replacement for argparse";
+    homepage = https://github.com/zorro3/ConfigArgParse;
+    license = licenses.mit;
+    maintainer = [ maintainers.willibutz ];
+  };
+}

--- a/pkgs/tools/admin/gixy/default.nix
+++ b/pkgs/tools/admin/gixy/default.nix
@@ -1,0 +1,41 @@
+{ lib, fetchFromGitHub, python }:
+
+python.pkgs.buildPythonApplication rec {
+  name = "gixy-${version}";
+  version = "0.1.8";
+
+  # package is only compatible with python 2.7 and 3.5+
+  disabled = with python.pkgs; !(pythonAtLeast "3.5" || isPy27);
+
+  src = fetchFromGitHub {
+    owner = "yandex";
+    repo = "gixy";
+    rev = "v${version}";
+    sha256 = "0dg8j8pqlzdvmyfkphrizfqzggr64npb9mnm1dcwm6c3z6k2b0ii";
+  };
+
+  postPatch = ''
+    sed -ie '/argparse/d' setup.py
+  '';
+
+  propagatedBuildInputs = with python.pkgs; [
+    cached-property
+    ConfigArgParse
+    pyparsing
+    jinja2
+    nose
+    six
+  ];
+
+  meta = with lib; {
+    description = "Nginx configuration static analyzer";
+    longDescription = ''
+      Gixy is a tool to analyze Nginx configuration.
+      The main goal of Gixy is to prevent security misconfiguration and automate flaw detection.
+    '';
+    homepage = https://github.com/yandex/gixy;
+    license = licenses.mpl20;
+    maintainers = [ maintainers.willibutz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1096,6 +1096,8 @@ with pkgs;
 
   gist = callPackage ../tools/text/gist { };
 
+  gixy = callPackage ../tools/admin/gixy { };
+
   glide = callPackage ../development/tools/glide { };
 
   glock = callPackage ../development/tools/glock { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8641,28 +8641,7 @@ in {
     buildInputs = with self; [ nose ];
   };
 
-  ConfigArgParse = buildPythonPackage rec {
-    name = "ConfigArgParse-${version}";
-    version = "0.9.3";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/C/ConfigArgParse/ConfigArgParse-${version}.tar.gz";
-      sha256 = "0a984pvv7370yz7zbkl6s6i7yyl9myahx0m9jkjvg3hz5q8mf70l";
-    };
-
-    # no tests in tarball
-    doCheck = false;
-    propagatedBuildInputs = with self; [
-
-    ];
-    buildInputs = with self; [
-
-    ];
-
-    meta = with stdenv.lib; {
-      homepage = "https://github.com/zorro3/ConfigArgParse";
-    };
-  };
+  ConfigArgParse = callPackage ../development/python-modules/configargparse { };
 
   jsonschema = callPackage ../development/python-modules/jsonschema { };
 


### PR DESCRIPTION
gixy is a nginx static configuration analyzer.

###### Things done
- also updated pythonPackages.ConfigArgParse to the most recent version (0.9.3 -> 0.12.0), as [gixy depends on at least v0.11.0](https://github.com/yandex/gixy/blob/020f6b08e8fa9711c4a0b28ca48588c6ec3f36f9/requirements.txt#L6)
- added myself as maintainer
- bumped certbot as the ConfigArgParse update broke the current version
- bumped simp_le to the latest version (0.2.0 -> 0.6.0) as well because it depended on `acme<0.12,>=0.11`, which changed to 0.12 [with the certbot update](https://github.com/NixOS/nixpkgs/blob/a5d75f0f18a0af23fe6b01fc971fe2db39db151d/pkgs/development/python-modules/acme/default.nix#L6) above
- as requested I moved ConfigArgParse to `development/python-modules` and gixy to `tools/admin`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested [`acme`] via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

