### PR TITLE
fdupes: 20150902 -> 1.6.1

### DIFF
--- a/pkgs/tools/misc/fdupes/default.nix
+++ b/pkgs/tools/misc/fdupes/default.nix
@@ -1,31 +1,28 @@
-{stdenv, fetchFromGitHub}:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "fdupes-20150902";
+  name = "fdupes-${version}";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
-    owner = "jbruchon";
-    repo  = "fdupes-jody";
-    rev   = "414b1fd64c0a739d4c52228eb72487782855b939";
-    sha256 = "1q6jcj79pljm1f24fqgk8x53xz2x0p1986znw75iljxqyzbvw0ap";
+    owner = "adrianlopezroche";
+    repo  = "fdupes";
+    rev   = "v${version}";
+    sha256 = "19b6vqblddaw8ccw4sn0qsqzbswlhrz8ia6n4m3hymvcxn8skpz9";
   };
 
-  makeFlags = "PREFIX=\${out}";
+  makeFlags = "PREFIX=$(out)";
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Identifies duplicate files residing within specified directories";
     longDescription = ''
-      FDUPES compares inodes' stats, hash sums, and byte by byte file
-      contents to find duplicate files within a set of directories and
-      then applies various actions to those sets, e.g.:
-      * remove some of the duplicates,
-      * turn all the files in a set into hardlinks.
+      fdupes searches the given path for duplicate files.
+      Such files are found by comparing file sizes and MD5 signatures,
+      followed by a byte-by-byte comparison.
     '';
-    homepage = src.meta.homepage;
-    license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.all;
-    maintainers = [
-      stdenv.lib.maintainers.z77z
-    ];
+    homepage = https://github.com/adrianlopezroche/fdupes;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.z77z ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The former Google Code now officially redirects to this GH repo and there has been new dev since.

The 'fdupes-jody' patchset became the jdupes fork : see #26920

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

