### PR TITLE
darwin: fixup bootstrap tools

### DIFF
--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -321,7 +321,7 @@ in rec {
       $CXX -v -o $out/bin/bar bar.cc
       $out/bin/bar
 
-      tar xvf ${hello.src}
+      tar xvf ${hello.srcTarball}
       cd hello-*
       ./configure --prefix=$out
       make


### PR DESCRIPTION
hello.src is now an IPFS thing so we need to use .srcTarball for the test.

should fix stdenvBootstrapTools.x86_64-darwin.test that is currently blocking nixpkgs-unstable:

https://hydra.nixos.org/job/nixpkgs/trunk/unstable#tabs-constituents
