### PR TITLE
abcm2ps: 8.13.15 -> 8.13.16

### DIFF
--- a/pkgs/tools/audio/abcm2ps/default.nix
+++ b/pkgs/tools/audio/abcm2ps/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "abcm2ps-${version}";
-  version = "8.13.15";
+  version = "8.13.16";
 
   src = fetchFromGitHub {
     owner = "leesavide";
     repo = "abcm2ps";
     rev = "v${version}";
-    sha256 = "04j1s4ycd8siidj7xn7s0vwm5sj0qrhqr5qzpila2g8kjc4ldxml";
+    sha256 = "1xb37jh811b7h72wpaykck6nskwq4mvy833q6wkhcyr041p1gcp7";
   };
 
-  patchPhase = ''
+  prePatch = ''
     chmod +x configure
   '';
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

