### PR TITLE
Emacs fixes

### DIFF
--- a/pkgs/applications/editors/emacs-modes/ess-R-object-popup/default.nix
+++ b/pkgs/applications/editors/emacs-modes/ess-R-object-popup/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation {
+  name = "ess-R-object-popup-20130302";
+
+  src = fetchgit {
+    url = "https://github.com/myuhe/ess-R-object-popup.el.git";
+    rev = "7e1f601bfba72de0fda44d9c82f96028ecbb9948";
+    sha256 = "0q8pbaa6wahli6fh0kng5zmnypsxi1fr2bzs2mfk3h8vf4nikpv0";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/emacs/site-lisp
+    cp *.el *.elc $out/share/emacs/site-lisp/
+  '';
+
+  meta = {
+    description = "Popup descriptions of R objects";
+    homepage = https://github.com/myuhe/ess-R-object-popup.el;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/applications/editors/emacs-modes/filesets-plus/default.nix
+++ b/pkgs/applications/editors/emacs-modes/filesets-plus/default.nix
@@ -1,0 +1,22 @@
+{ fetchurl, lib, stdenv, melpaBuild }:
+
+melpaBuild {
+  pname = "filesets-plus";
+  version = "20170222.55";
+
+  src = fetchurl {
+    url = "https://www.emacswiki.org/emacs/download/filesets%2b.el";
+    sha256 = "0iajkgh0n3pbrwwxx9rmrrwz8dw2m7jsp4mggnhq7zsb20ighs00";
+    name = "filesets+.el";
+  };
+
+  recipeFile = fetchurl {
+    url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/filesets-plus+";
+    sha256 = "1wn99cb53ykds87lg9mrlfpalrmjj177nwskrnp9wglyqs65lk4g";
+    name = "filesets-plus";
+  };
+
+  meta = {
+    homepage = "https://melpa.org/#/filesets+";
+  };
+}

--- a/pkgs/applications/editors/emacs-modes/font-lock-plus/default.nix
+++ b/pkgs/applications/editors/emacs-modes/font-lock-plus/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, melpaBuild }:
+{ fetchurl, lib, stdenv, melpaBuild }:
 
 melpaBuild {
   pname = "font-lock-plus";
@@ -16,7 +16,7 @@ melpaBuild {
     name = "font-lock-plus";
   };
 
-  meta = with stdenv.lib; {
+  meta = {
     homepage = "https://melpa.org/#/font-lock+";
     license = lib.licenses.gpl2Plus;
   };

--- a/pkgs/applications/editors/emacs-modes/header2/default.nix
+++ b/pkgs/applications/editors/emacs-modes/header2/default.nix
@@ -1,0 +1,23 @@
+{ fetchurl, lib, stdenv, melpaBuild }:
+
+melpaBuild {
+  pname = "header2";
+  version = "20170223.1949";
+
+  src = fetchurl {
+    url = "https://www.emacswiki.org/emacs/download/header2.el";
+    sha256 = "0cv74cfihr13jrgyqbj4x0na659djfyrhflxni6jdbgbysi4zf6k";
+    name = "header2.el";
+  };
+
+  recipeFile = fetchurl {
+    url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/header2";
+    sha256 = "1dg25krx3wxma2l5vb2ji7rpfp17qbrl62jyjpa52cjfsvyp6v06";
+    name = "header2";
+  };
+
+  meta = {
+    homepage = "https://melpa.org/#/header2";
+    license = lib.licenses.gpl3;
+  };
+}

--- a/pkgs/applications/editors/emacs-modes/helm-words/default.nix
+++ b/pkgs/applications/editors/emacs-modes/helm-words/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation {
+  name = "helm-words-20150413";
+
+  src = fetchgit {
+    url = "https://github.com/pronobis/helm-words.git";
+    rev = "637aa3a7e9cfd34e0127472c5b1f993a4da26185";
+    sha256 = "19l8vysjygscr1nsddjz2yv0fjhbsswfq40rdny8zsmaa6qhpj35";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/emacs/site-lisp
+    cp *.el *.elc $out/share/emacs/site-lisp/
+  '';
+
+  meta = {
+    description = "Emacs major mode for jade and stylus";
+    homepage = https://github.com/brianc/helm-words;
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/applications/editors/emacs-modes/hexrgb/default.nix
+++ b/pkgs/applications/editors/emacs-modes/hexrgb/default.nix
@@ -1,0 +1,23 @@
+{ fetchurl, lib, stdenv, melpaBuild }:
+
+melpaBuild {
+  pname = "hexrgb";
+  version = "20170304.1017";
+
+  src = fetchurl {
+    url = "https://www.emacswiki.org/emacs/download/hexrgb.el";
+    sha256 = "1aj1fsc3wr8174xs45j2wc2mm6f8v6zs40xn0r4qisdw0plmsbsy";
+    name = "hexrgb.el";
+  };
+
+  recipeFile = fetchurl {
+    url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/hexrgb";
+    sha256 = "0mzqslrrf7sc262syj3ja7b7rnbg80dwf2p9bzxdrzx6b8vvsx06";
+    name = "hexrgb";
+  };
+
+  meta = {
+    homepage = "https://melpa.org/#/hexrgb";
+    license = lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/applications/editors/emacs-modes/lib-requires/default.nix
+++ b/pkgs/applications/editors/emacs-modes/lib-requires/default.nix
@@ -1,0 +1,23 @@
+{ fetchurl, lib, stdenv, melpaBuild }:
+
+melpaBuild {
+  pname = "lib-requires";
+  version = "20170307.757";
+
+  src = fetchurl {
+    url = "https://www.emacswiki.org/emacs/download/lib-requires.el";
+    sha256 = "04lrkdjrhsgg7vgvw1mkr9a5m9xlyvjvnj2aj6w453bgmnp1mbvv";
+    name = "lib-requires.el";
+  };
+
+  recipeFile = fetchurl {
+    url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/lib-requires";
+    sha256 = "1g22jh56z8rnq0h80wj10gs38yig1rk9xmk3kmhmm5mm6b14iwdx";
+    name = "lib-requires";
+  };
+
+  meta = {
+    homepage = "https://melpa.org/#/lib-requires";
+    license = lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -51,9 +51,6 @@ self:
       cmake-mode = markBroken (dontConfigure super.cmake-mode);
 
       # upstream issue: missing file header
-      cn-outline = markBroken super.cn-outline;
-
-      # upstream issue: missing file header
       connection = markBroken super.connection;
 
       # upstream issue: missing file header

--- a/pkgs/applications/editors/emacs-modes/org-mac-link/default.nix
+++ b/pkgs/applications/editors/emacs-modes/org-mac-link/default.nix
@@ -1,0 +1,31 @@
+{stdenv, fetchurl, emacs}:
+
+stdenv.mkDerivation rec {
+  name = "org-mac-link-1.2";
+
+  src = fetchurl {
+    url = "https://raw.githubusercontent.com/stuartsierra/org-mode/master/contrib/lisp/org-mac-link.el";
+    sha256 = "1gkzlfbhg289r1hbqd25szan1wizgk6s99h9xxjip5bjv0jywcx5";
+  };
+
+  phases = [ "buildPhase" "installPhase"];
+
+  buildInputs = [ emacs ];
+
+  buildPhase = ''
+    cp $src org-mac-link.el
+    emacs --batch -f batch-byte-compile org-mac-link.el
+  '';
+
+  installPhase = ''
+    install -d $out/share/emacs/site-lisp
+    install org-mac-link.el $out/share/emacs/site-lisp
+  '';
+
+  meta = {
+    description = "Insert org-mode links to items selected in various Mac apps";
+    homepage = http://orgmode.org/worg/org-contrib/org-mac-link.html;
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/applications/editors/emacs-modes/perl-completion/default.nix
+++ b/pkgs/applications/editors/emacs-modes/perl-completion/default.nix
@@ -1,0 +1,23 @@
+{stdenv, fetchurl}:
+
+stdenv.mkDerivation rec {
+  name = "perl-completion";
+
+  src = fetchurl {
+    url = "http://emacswiki.org/emacs/download/perl-completion.el";
+    sha256 = "0x6qsgs4hm87k0z9q3g4p6508kc3y123j5jayll3jf3lcl2vm6ks";
+  };
+
+  phases = [ "installPhase"];
+
+  installPhase = ''
+    install -d $out/share/emacs/site-lisp
+    install $src $out/share/emacs/site-lisp/perl-completion.el
+  '';
+
+  meta = {
+    description = "Minor mode provides useful features for editing perl codes";
+    homepage = http://emacswiki.org/emacs/PerlCompletion;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/applications/editors/emacs-modes/railgun/default.nix
+++ b/pkgs/applications/editors/emacs-modes/railgun/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation {
+  name = "railgun-2012-10-17";
+
+  src = fetchgit {
+    url = "https://github.com/mbriggs/railgun.el.git";
+    rev = "66aaa1b091baef53a69d0d7425f48d184b865fb8";
+    sha256 = "00x09vjd3jz5f73qkf5v1y402zn8vl8dsyfwlq9z646p18ba7gyh";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/emacs/site-lisp
+    cp *.el *.elc $out/share/emacs/site-lisp/
+  '';
+
+  meta = {
+    description = "Propel yourself through a rails project with the power of magnets";
+    homepage = https://github.com/mbriggs/railgun.el;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/applications/editors/emacs-modes/redshank/default.nix
+++ b/pkgs/applications/editors/emacs-modes/redshank/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation rec {
+  pname = "redshank";
+  name = "${pname}-20120510";
+
+  src = fetchgit {
+    url = "http://www.foldr.org/~michaelw/projects/redshank.git";
+    rev = "f98e68f532e622bcd464292ca4a9cf5fbea14ebb";
+    sha256 = "1jdkgvd5xy9hl5q611jwah2n05abjp7qcy9sj4k1z11x0ii62b6p";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/emacs/site-lisp
+    cp *.el *.elc $out/share/emacs/site-lisp/
+  '';
+
+  meta = {
+    description = "Common Lisp Editing Extensions (for Emacs)";
+    homepage = http://www.foldr.org/~michaelw/emacs/redshank/;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/applications/editors/emacs-modes/stgit/default.nix
+++ b/pkgs/applications/editors/emacs-modes/stgit/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "stgit";
+  name = "${pname}-2009-10-28";
+
+  unpackPhase = "true";
+
+  src = fetchurl {
+    url = "https://raw.githubusercontent.com/miracle2k/stgit/master/contrib/stgit.el";
+    sha256 = "0pl8q480633vdkylr85s7cbd4653xpzwklnxrwm8xhsnvw9d501q";
+    name = "stgit.el";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/emacs/site-lisp
+    cp $src $out/share/emacs/site-lisp/stgit.el
+  '';
+
+  meta = {
+    description = "An emacs mode for Stgit";
+    homepage = http://procode.org/stgit/;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/applications/editors/emacs-modes/thingatpt-plus/default.nix
+++ b/pkgs/applications/editors/emacs-modes/thingatpt-plus/default.nix
@@ -1,0 +1,23 @@
+{ fetchurl, lib, stdenv, melpaBuild }:
+
+melpaBuild {
+  pname = "thingatpt-plus";
+  version = "20170307.1539";
+
+  src = fetchurl {
+    url = "https://www.emacswiki.org/emacs/download/thingatpt+.el";
+    sha256 = "1k9y354315gvhbdk0m9xpjx24w1bwrnzlnfiils8xgdwnw4py99a";
+    name = "thingatpt+.el";
+  };
+
+  recipeFile = fetchurl {
+    url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/thingatpt+";
+    sha256 = "0w031lzjl5phvzsmbbxn2fpziwkmdyxsn08h6b9lxbss1prhx7aa";
+    name = "thingatpt-plus";
+  };
+
+  meta = {
+    homepage = "https://melpa.org/#/thingatpt+";
+    license = lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/applications/editors/emacs-modes/yaoddmuse/default.nix
+++ b/pkgs/applications/editors/emacs-modes/yaoddmuse/default.nix
@@ -1,0 +1,30 @@
+{stdenv, fetchurl, emacs}:
+
+stdenv.mkDerivation rec {
+  name = "yaoddmuse-0.1.2";
+
+  src = fetchurl {
+    url = "http://emacswiki.org/emacs/download/yaoddmuse.el";
+    sha256 = "0vlllq3xmnlni0ws226pqxj68nshclbl5rgqv6y11i3yvzgiazr6";
+  };
+
+  phases = [ "buildPhase" "installPhase"];
+
+  buildInputs = [ emacs ];
+
+  buildPhase = ''
+    cp $src yaoddmuse.el
+    emacs --batch -f batch-byte-compile yaoddmuse.el
+  '';
+
+  installPhase = ''
+    install -d $out/share/emacs/site-lisp
+    install yaoddmuse.el $out/share/emacs/site-lisp
+  '';
+
+  meta = {
+    description = "Comprehensive Emacs integration with Oddmuse wikis";
+    homepage = http://emacswiki.org/emacs/Yaoddmuse;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/applications/editors/emacs-modes/zeitgeist/default.nix
+++ b/pkgs/applications/editors/emacs-modes/zeitgeist/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, emacs }:
+
+stdenv.mkDerivation {
+  name = "zeitgeist-20120221";
+
+  unpackPhase = "true";
+
+  src = fetchurl {
+    url = "https://raw.githubusercontent.com/alexmurray/dotfiles/master/.emacs.d/vendor/zeitgeist.el";
+    sha256 = "0fssx3lp8ar3b1ichbagir7z17habv367l7zz719ipycr24rf1nw";
+  };
+
+  buildInputs = [ emacs ];
+
+  installPhase = ''
+    mkdir -p $out/share/emacs/site-lisp
+    cp $src $out/share/emacs/site-lisp/zeitgeist.el
+  '';
+
+  meta = {
+    description = "Integreate Emacs with Zeitgeist";
+    homepage = http://zeitgeist-project.com/;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -206,6 +206,9 @@ let
     };
   };
 
+  ess-R-object-popup =
+    callPackage ../applications/editors/emacs-modes/ess-R-object-popup { };
+
   find-file-in-project = melpaBuild rec {
     pname = "find-file-in-project";
     version = "3.5";
@@ -225,6 +228,8 @@ let
       license = gpl3Plus;
     };
   };
+
+  filesets-plus = callPackage ../applications/editors/emacs-modes/filesets-plus { };
 
   font-lock-plus = callPackage ../applications/editors/emacs-modes/font-lock-plus { };
 
@@ -257,6 +262,12 @@ let
     };
   };
 
+  hexrgb = callPackage ../applications/editors/emacs-modes/hexrgb { };
+
+  header2 = callPackage ../applications/editors/emacs-modes/header2 { };
+
+  helm-words = callPackage ../applications/editors/emacs-modes/helm-words { };
+
   hindent = melpaBuild rec {
     pname = "hindent";
     version = external.hindent.version;
@@ -271,6 +282,8 @@ let
   };
 
   icicles = callPackage ../applications/editors/emacs-modes/icicles { };
+
+  redshank = callPackage ../applications/editors/emacs-modes/redshank { };
 
   rtags = melpaBuild rec {
     pname = "rtags";
@@ -295,6 +308,9 @@ let
     };
   };
 
+  lib-requires =
+    callPackage ../applications/editors/emacs-modes/lib-requires { };
+
   lui = melpaBuild rec {
     pname   = "lui";
     version = circe.version;
@@ -311,6 +327,14 @@ let
     inherit lib;
   };
 
+  org-mac-link =
+    callPackage ../applications/editors/emacs-modes/org-mac-link { };
+
+  perl-completion =
+    callPackage ../applications/editors/emacs-modes/perl-completion { };
+
+  railgun = callPackage ../applications/editors/emacs-modes/railgun { };
+
   gn = callPackage ../applications/editors/emacs-modes/gn { };
 
   shorten = melpaBuild rec {
@@ -323,6 +347,8 @@ let
       license = gpl3Plus;
     };
   };
+
+  stgit = callPackage ../applications/editors/emacs-modes/stgit { };
 
   structured-haskell-mode = melpaBuild rec {
     pname = "shm";
@@ -338,6 +364,8 @@ let
       platforms = external.structured-haskell-mode.meta.platforms;
     };
   };
+
+  thingatpt-plus = callPackage ../applications/editors/emacs-modes/thingatpt-plus { };
 
   tramp = callPackage ../applications/editors/emacs-modes/tramp { };
 
@@ -359,6 +387,10 @@ let
       license = gpl3Plus;
     };
   };
+
+  yaoddmuse = callPackage ../applications/editors/emacs-modes/yaoddmuse { };
+
+  zeitgeist = callPackage ../applications/editors/emacs-modes/zeitgeist { };
 
   };
 


### PR DESCRIPTION
###### Motivation for this change
This adds a bunch of packages back in that have been removed by MELPA. This is the only way I've found to be able to get the package set to evaluate. Lots of these packages were done quickly and not in a 'proper' way but the whole point is just to get emacsPackagesNg to evaluate again. 

In the future, we should make sure that this evaluates when merging Emacs packages updates (it hadn't been for a couple of weeks):

```
nix-env -f. -qaA emacsPackagesNg
```

Can we somehow get this into a blocking test? (recurseIntoAttrs maybe?)
