### PR TITLE
anki: Switch dependency to beautifulsoup-3

### DIFF
--- a/pkgs/games/anki/beautifulsoup.nix
+++ b/pkgs/games/anki/beautifulsoup.nix
@@ -1,0 +1,20 @@
+{ pythonPackages, isPy3k, pkgs }:
+
+pythonPackages.buildPythonPackage rec {
+  name = "beautifulsoup-3.2.1";
+  disabled = isPy3k;
+
+  src = pkgs.fetchurl {
+    url = "http://www.crummy.com/software/BeautifulSoup/download/3.x/BeautifulSoup-3.2.1.tar.gz";
+    sha256 = "1nshbcpdn0jpcj51x0spzjp519pkmqz0n0748j7dgpz70zlqbfpm";
+  };
+
+  # error: invalid command 'test'
+  doCheck = false;
+
+  meta = {
+    homepage = http://www.crummy.com/software/BeautifulSoup/;
+    license = "bsd";
+    description = "Undemanding HTML/XML parser";
+  };
+}

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -10,6 +10,12 @@ let
     version = "2.0.47";
     inherit (python2Packages) python wrapPython sqlalchemy pyaudio beautifulsoup4 httplib2 matplotlib pyqt4;
     qt4 = pyqt4.qt;
+
+    # Development version of anki has bumped to beautifulsoup4
+    beautifulsoup = python2Packages.callPackage ./beautifulsoup.nix {
+      pythonPackages = python2Packages;
+    };
+
 in
 stdenv.mkDerivation rec {
     name = "anki-${version}";
@@ -22,7 +28,7 @@ stdenv.mkDerivation rec {
       sha256 = "067bsidqzy1zc301i2pk4biwp2kwvgk4kydp5z5s551acinkbdgv";
     };
 
-    pythonPath = [ pyqt4 sqlalchemy pyaudio beautifulsoup4 httplib2 ]
+    pythonPath = [ pyqt4 sqlalchemy pyaudio beautifulsoup httplib2 ]
               ++ lib.optional plotsSupport matplotlib;
 
     buildInputs = [ python wrapPython lame mplayer libpulseaudio ];


### PR DESCRIPTION
The current upstream development version is using 4 but the release
version is still using 3.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

