### PR TITLE
anki: Enable tests

### DIFF
--- a/pkgs/games/anki/beautifulsoup.nix
+++ b/pkgs/games/anki/beautifulsoup.nix
@@ -1,6 +1,6 @@
-{ pythonPackages, isPy3k, pkgs }:
+{ buildPythonPackage, isPy3k, pkgs }:
 
-pythonPackages.buildPythonPackage rec {
+buildPythonPackage rec {
   name = "beautifulsoup-3.2.1";
   disabled = isPy3k;
 

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -1,24 +1,36 @@
-{ stdenv, lib, fetchurl, substituteAll, lame, mplayer
+{ stdenv
+, buildPythonPackage
+, callPackage
+, lib
+, python
+, fetchurl
+, substituteAll
+, lame
+, mplayer
 , libpulseaudio
+, pyqt4
+, sqlalchemy
+, pyaudio
+, httplib2
+, matplotlib
+, pytest
+, glibcLocales
+, nose
 # This little flag adds a huge number of dependencies, but we assume that
 # everyone wants Anki to draw plots with statistics by default.
 , plotsSupport ? true
-, python2Packages
 }:
 
 let
-    version = "2.0.47";
-    inherit (python2Packages) python wrapPython sqlalchemy pyaudio beautifulsoup4 httplib2 matplotlib pyqt4;
+    # Development version of anki has bumped to beautifulsoup4
+    beautifulsoup = callPackage ./beautifulsoup.nix { };
+
     qt4 = pyqt4.qt;
 
-    # Development version of anki has bumped to beautifulsoup4
-    beautifulsoup = python2Packages.callPackage ./beautifulsoup.nix {
-      pythonPackages = python2Packages;
-    };
-
-in
-stdenv.mkDerivation rec {
+in buildPythonPackage rec {
+    version = "2.0.47";
     name = "anki-${version}";
+
     src = fetchurl {
       urls = [
         "https://apps.ankiweb.net/downloads/current/${name}-source.tgz"
@@ -28,12 +40,12 @@ stdenv.mkDerivation rec {
       sha256 = "067bsidqzy1zc301i2pk4biwp2kwvgk4kydp5z5s551acinkbdgv";
     };
 
-    pythonPath = [ pyqt4 sqlalchemy pyaudio beautifulsoup httplib2 ]
-              ++ lib.optional plotsSupport matplotlib;
+    propagatedBuildInputs = [ pyqt4 sqlalchemy pyaudio beautifulsoup httplib2 ]
+                            ++ lib.optional plotsSupport matplotlib;
 
-    buildInputs = [ python wrapPython lame mplayer libpulseaudio ];
+    checkInputs = [ pytest glibcLocales nose ];
 
-    phases = [ "unpackPhase" "patchPhase" "installPhase" ];
+    buildInputs = [ lame mplayer libpulseaudio  ];
 
     patches = [
       # Disable updated version check.
@@ -46,6 +58,11 @@ stdenv.mkDerivation rec {
       })
     ];
 
+    buildPhase = ''
+      # Dummy build phase
+      # Anki does not use setup.py
+    '';
+
     postPatch = ''
       substituteInPlace oldanki/lang.py --subst-var-by anki $out
       substituteInPlace anki/lang.py --subst-var-by anki $out
@@ -56,6 +73,18 @@ stdenv.mkDerivation rec {
 
       # Remove QT translation files. We'll use the standard QT ones.
       rm "locale/"*.qm
+
+      # Skip tests using network
+      rm tests/test_sync.py
+      rm tests/test_upgrade.py
+    '';
+
+    # UTF-8 locale needed for testing
+    LC_ALL = "en_US.UTF-8";
+
+    checkPhase = ''
+      # Anki writes some files to $HOME during tests
+      env HOME=$TMP pytest
     '';
 
     installPhase = ''
@@ -87,10 +116,10 @@ stdenv.mkDerivation rec {
       wrapPythonPrograms
     '';
 
-    meta = {
+    meta = with stdenv.lib; {
       homepage = http://ankisrs.net/;
       description = "Spaced repetition flashcard program";
-      license = stdenv.lib.licenses.gpl3;
+      license = licenses.gpl3;
 
       longDescription = ''
         Anki is a program which makes remembering things easy. Because it is a lot
@@ -105,7 +134,7 @@ stdenv.mkDerivation rec {
         or even practicing guitar chords!
       '';
 
-      maintainers = with stdenv.lib.maintainers; [ the-kenny ];
-      platforms = stdenv.lib.platforms.mesaPlatforms;
+      maintainers = with maintainers; [ the-kenny ];
+      platforms = platforms.mesaPlatforms;
     };
 }

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -73,18 +73,15 @@ in buildPythonPackage rec {
 
       # Remove QT translation files. We'll use the standard QT ones.
       rm "locale/"*.qm
-
-      # Skip tests using network
-      rm tests/test_sync.py
-      rm tests/test_upgrade.py
     '';
 
     # UTF-8 locale needed for testing
     LC_ALL = "en_US.UTF-8";
 
     checkPhase = ''
-      # Anki writes some files to $HOME during tests
-      env HOME=$TMP pytest
+      # - Anki writes some files to $HOME during tests
+      # - Skip tests using network
+      env HOME=$TMP pytest --ignore tests/test_sync.py
     '';
 
     installPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17638,7 +17638,7 @@ with pkgs;
 
   angband = callPackage ../games/angband { };
 
-  anki = callPackage ../games/anki { };
+  anki = python2Packages.callPackage ../games/anki { };
 
   armagetronad = callPackage ../games/armagetronad { };
 


### PR DESCRIPTION
###### Motivation for this change
Enable tests when building `anki`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

