### PR TITLE
godot will crash if it is built with gcc6

### DIFF
--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gcc, scons, pkgconfig, libX11, libXcursor
+{ stdenv, fetchFromGitHub, gcc5, scons, pkgconfig, libX11, libXcursor
 , libXinerama, libXrandr, libXrender, freetype, openssl, alsaLib
 , libpulseaudio, mesa_glu, zlib }:
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    gcc scons libX11 libXcursor libXinerama libXrandr libXrender
+    gcc5 scons libX11 libXcursor libXinerama libXrandr libXrender
     freetype openssl alsaLib libpulseaudio mesa_glu zlib
   ];
 


### PR DESCRIPTION
see issue #31584

###### Motivation for this change
I was experiencing a crash


###### Things done

I tested this on the 17.09 branch with nix-shell -i nixpkgs=~/nixpkgs -p godot --pure

With that godot binary I no longer experienced the  crash outlined in issue #31584 .

It should be noted that without the --pure option godot still seemed to link against gcc-6 and crashed...

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

