### PR TITLE
nix-bash-completions: 0.2 -> 0.3

### DIFF
--- a/pkgs/shells/nix-bash-completions/default.nix
+++ b/pkgs/shells/nix-bash-completions/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "0.2";
+  version = "0.3";
   name = "nix-bash-completions-${version}";
 
   src = fetchFromGitHub {
     owner = "hedning";
     repo = "nix-bash-completions";
     rev = "v${version}";
-    sha256 = "0clr3c0zf73pnabab4n5b5x8cd2yilksvvlp4i0rj0cfbr1pzxgr";
+    sha256 = "1p4hk79prk9b4avjk5df5jml6b4xxfsln6rxz0k94b3v5f00xxsf";
   };
 
   installPhase = ''


### PR DESCRIPTION
Various bugfixes, including support for completing attribute paths when
supplying '<nixpkgs>' syntax as file input.

###### Motivation for this change

[Some bug fixes and improvements:](https://github.com/hedning/nix-bash-completions/releases/edit/v0.3)
- All commands should now complete attribute paths when supplying `'<nixpkgs>` as file input
- nix-env: `-A` only worked for `-i`/`--install`, now works for all main operations
- nix-env will now only complete main operations until one has been supplied
- nix-env --switch-generation will now complete generations
- nix-channel: completes channel names properly now

And a few other minor improvements.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

