### PR TITLE
linux_mptcp: makes linux_mptcp.override works

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-mptcp.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp.nix
@@ -1,6 +1,6 @@
 { stdenv, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
-import ./generic.nix (args // rec {
+import ./generic.nix (rec {
   mptcpVersion = "0.93";
   modDirVersion = "4.9.60";
   version = "${modDirVersion}-mptcp_v${mptcpVersion}";
@@ -43,4 +43,4 @@ import ./generic.nix (args // rec {
     TCP_CONG_BALIA m
 
   '' + (args.extraConfig or "");
-} // (args.argsOverride or {}))
+} // args // (args.argsOverride or {}))


### PR DESCRIPTION
I needed to override some parameters because of an error I had:
"Error: modDirVersion specified in the Nix expression is wrong, it should be: 4.9.60+"

but the following override would not be taken into account
```
  pkg.override ({
    modDirVersion="4.9.60+";
    src=pkgs.lib.cleanSource /home/teto/mptcp;
  })
```

because the override would be overriden by the nixpkgs parameters 
because of concatenation order (https://nixos.org/nix/manual/#sec-language-operators); it was `args // hardcoded` and I reversed it to `hardcoded // args`

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

