### PR TITLE
nix-zsh-completions: 0.3.2 -> 0.3.3

### DIFF
--- a/pkgs/shells/nix-zsh-completions/default.nix
+++ b/pkgs/shells/nix-zsh-completions/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub }:
 
 let
-  version = "0.3.2";
+  version = "0.3.3";
 in
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "spwhitt";
     repo = "nix-zsh-completions";
     rev = "${version}";
-    sha256 = "0i306k50g07n9smy68npma1k90sv173zy12jdi8wm7h1sj53m5rv";
+    sha256 = "0gvqm6grz3s0llz20sa18n5d2anmsrk892lcv7blv8rai151whpw";
   };
 
   installPhase = ''


### PR DESCRIPTION
Some minor fixes.

###### Motivation for this change
Minor fixes:
- nix-env: Fix regression where completing some option arguments offers up garbage
- nix-env: Only complete main operators until one is supplied on the command line
- nix: Don't run completion if `nix` isn't found in path

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

