### PR TITLE
configuration-ghc-7.10.x.nix: Remove missing attributes.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -157,9 +157,6 @@ self: super: {
   haddock-api = self.haddock-api_2_16_1;
   haddock-library = self.haddock-library_1_2_1;
 
-  # lens-family-th >= 0.5.0.0 is GHC 8.0 only
-  lens-family-th = self.lens-family-th_0_4_1_0;
-
   # The tests in vty-ui do not build, but vty-ui itself builds.
   vty-ui = enableCabalFlag super.vty-ui "no-tests";
 

--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -204,9 +204,6 @@ self: super: {
   # also tests require bytestring>=0.10.8.1
   cereal = dontCheck (addBuildDepend super.cereal self.fail);
 
-  # Moved out from common as no longer the case for GHC8
-  ghc-mod = super.ghc-mod.override { cabal-helper = self.cabal-helper_0_6_3_1; };
-
   # The test suite requires Cabal 1.24.x or later to compile.
   comonad = dontCheck super.comonad;
   semigroupoids = dontCheck super.semigroupoids;


### PR DESCRIPTION
###### Motivation for this change
Remove missing attributes since their existence cause errors and can not serve any purpose.

Please see the problematic command example in each individual commit message.

###### Things done
* Remove missing attributes from nix expression file.
* Problematic commands was running without any error.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

