### PR TITLE
neovim: 0.2.0 -> 0.2.1

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, gettext, libmsgpack, libtermkey
 , libtool, libuv, luajit, luajitPackages, luaPackages, ncurses, perl, pkgconfig
-, unibilium, makeWrapper, vimUtils, xsel, gperf
+, unibilium, makeWrapper, vimUtils, xsel, gperf, callPackage
 
 , withPython ? true, pythonPackages, extraPythonPackages ? []
 , withPython3 ? true, python3Packages, extraPython3Packages ? []
@@ -45,13 +45,11 @@ let
     };
   };
 
-  rubyEnv = bundlerEnv {
-    name = "neovim-ruby-env";
-    gemdir = ./ruby_provider;
-  };
+  neovim-gem = callPackage ./ruby_provider {};
+  neovim-gem-bin =
+    "${neovim-gem}/bin/neovim-ruby-host";
 
-  rubyWrapper = ''--suffix PATH : \"${rubyEnv}/bin\" '' +
-                ''--suffix GEM_HOME : \"${rubyEnv}/${rubyEnv.ruby.gemPath}\" '';
+  rubyWrapper = ''--cmd \"let g:ruby_host_prog='${neovim-gem-bin}'\" '';
 
   pluginPythonPackages = if configure == null then [] else builtins.concatLists
     (map ({ pythonDependencies ? [], ...}: pythonDependencies)
@@ -74,20 +72,22 @@ let
     ignoreCollisions = true;
   };
   python3Wrapper = ''--cmd \"let g:python3_host_prog='$out/bin/nvim-python3'\" '';
-  pythonFlags = optionalString (withPython || withPython3) ''--add-flags "${
+  additionalFlags = optionalString (withPython || withPython3 || withRuby)
+  ''--add-flags "${
     (optionalString withPython pythonWrapper) +
-    (optionalString withPython3 python3Wrapper)
-  }"'';
+    (optionalString withPython3 python3Wrapper) +
+    (optionalString withRuby rubyWrapper)
+  }" --unset PYTHONPATH'';
 
   neovim = stdenv.mkDerivation rec {
     name = "neovim-${version}";
-    version = "0.2.0";
+    version = "0.2.1";
 
     src = fetchFromGitHub {
       owner = "neovim";
       repo = "neovim";
       rev = "v${version}";
-      sha256 = "0fhjkgjwqqmzbfn9wk10l2vq9v74zkriz5j12b1rx0gdwzlfybn8";
+      sha256 = "19ppj0i59kk70j09gap6azm0jm4y95fr5fx7n9gx377y3xjs8h03";
     };
 
     enableParallelBuilding = true;
@@ -143,7 +143,7 @@ let
     '' + optionalString withPython3 ''
       ln -s ${python3Env}/bin/python3 $out/bin/nvim-python3
     '' + optionalString (withPython || withPython3 || withRuby) ''
-      wrapProgram $out/bin/nvim ${rubyWrapper + pythonFlags}
+      wrapProgram $out/bin/nvim ${additionalFlags}
     '';
 
     meta = {

--- a/pkgs/applications/editors/neovim/ruby_provider/Gemfile
+++ b/pkgs/applications/editors/neovim/ruby_provider/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'neovim'
+gem 'neovim', '0.6.1'

--- a/pkgs/applications/editors/neovim/ruby_provider/Gemfile.lock
+++ b/pkgs/applications/editors/neovim/ruby_provider/Gemfile.lock
@@ -2,14 +2,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     msgpack (1.1.0)
-    neovim (0.5.0)
+    multi_json (1.12.2)
+    neovim (0.6.1)
       msgpack (~> 1.0)
+      multi_json (~> 1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  neovim
+  neovim (= 0.6.1)
 
 BUNDLED WITH
-   1.15.1
+   1.14.6

--- a/pkgs/applications/editors/neovim/ruby_provider/default.nix
+++ b/pkgs/applications/editors/neovim/ruby_provider/default.nix
@@ -1,0 +1,18 @@
+{ defaultGemConfig, bundlerEnv, makeWrapper, lib, ruby}:
+bundlerEnv {
+  inherit ruby;
+  name = "neovim-ruby-host";
+  gemdir = ./.;
+  gemConfig = defaultGemConfig // {
+    neovim = attrs: {
+      postInstall = let
+        dir = "${attrs.ruby.gemPath}";
+      in ''
+        wrapProgram $out/${dir}/bin/neovim-ruby-host \
+          --prefix PATH : ${attrs.ruby}/bin \
+          --unset GEM_HOME \
+          --unset GEM_PATH
+      '';
+    };
+  };
+}

--- a/pkgs/applications/editors/neovim/ruby_provider/gemset.nix
+++ b/pkgs/applications/editors/neovim/ruby_provider/gemset.nix
@@ -7,13 +7,21 @@
     };
     version = "1.1.0";
   };
-  neovim = {
-    dependencies = ["msgpack"];
+  multi_json = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1da0ha3mz63iyihldp7185b87wx86jg07023xjhbng6i28y1ksn7";
+      sha256 = "1raim9ddjh672m32psaa9niw67ywzjbxbdb8iijx3wv9k5b0pk2x";
       type = "gem";
     };
-    version = "0.5.0";
+    version = "1.12.2";
+  };
+  neovim = {
+    dependencies = ["msgpack" "multi_json"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1dnv2pdl8lwwy4av8bqc6kdlgxw88dmajm4fkdk6hc7qdx1sw234";
+      type = "gem";
+    };
+    version = "0.6.1";
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22918,12 +22918,12 @@ EOF
   trollius = callPackage ../development/python-modules/trollius {};
 
   neovim = buildPythonPackage rec {
-    version = "0.1.13";
+    version = "0.2.0";
     name = "neovim-${version}";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/n/neovim/${name}.tar.gz";
-      sha256 = "0pzk5639jjjx46a6arkwy31falmk5w1061icbml8njm3rbrwwhgx";
+      sha256 = "1ywkgbrxd95cwlglihydmffcw2d2aji6562aqncymxs3ld5y02yn";
     };
 
     buildInputs = with self; [ nose ];


### PR DESCRIPTION
###### Motivation for this change

Update Neovim and the python and ruby hosts. Now it should give more or less green `nvim -c :CheckHealth` even in a polluted environment (the ruby host will give some harmless warnings in rare cases where the parent environment uses binary gem extensions).

Would be nice if someone using it to edit python could verify this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

