### PR TITLE
linux: Automatic modDirVersion / branch

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -10,7 +10,7 @@
   extraConfig ? ""
 
 , # The version number used for the module directory
-  modDirVersion ? version
+  modVersion ? null
 
 , # An attribute set whose attributes express the availability of
   # certain features in this kernel.  E.g. `{iwlwifi = true;}'
@@ -118,7 +118,7 @@ let
   };
 
   kernel = buildLinux {
-    inherit version modDirVersion src kernelPatches stdenv;
+    inherit version src kernelPatches stdenv;
 
     configfile = configfile.nativeDrv or configfile;
 
@@ -127,6 +127,12 @@ let
     config = { CONFIG_MODULES = "y"; CONFIG_FW_LOADER = "m"; };
 
     crossConfig = { CONFIG_MODULES = "y"; CONFIG_FW_LOADER = "m"; };
+
+    modDirVersion = if (modVersion == null) then
+        # modDirVersion needs to be x.y.z, will automatically add .0 if needed
+        with lib; (concatStrings (intersperse "." (take 3 (splitString "." "${version}.0"))))
+      else
+        modVersion;
   };
 
   passthru = {

--- a/pkgs/os-specific/linux/kernel/linux-4.13.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.13.nix
@@ -2,7 +2,6 @@
 
 import ./generic.nix (args // rec {
   version = "4.13.15";
-  extraMeta.branch = "4.13";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14.nix
@@ -1,15 +1,7 @@
 { stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
-with stdenv.lib;
-
 import ./generic.nix (args // rec {
   version = "4.14.1";
-
-  # modDirVersion needs to be x.y.z, will automatically add .0 if needed
-  modDirVersion = concatStrings (intersperse "." (take 3 (splitString "." "${version}.0")));
-
-  # branchVersion needs to be x.y
-  extraMeta.branch = concatStrings (intersperse "." (take 2 (splitString "." version)));
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.4.nix
@@ -2,7 +2,6 @@
 
 import ./generic.nix (args // rec {
   version = "4.4.100";
-  extraMeta.branch = "4.4";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.9.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.9.nix
@@ -2,7 +2,6 @@
 
 import ./generic.nix (args // rec {
   version = "4.9.64";
-  extraMeta.branch = "4.9";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
+++ b/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
@@ -1,12 +1,13 @@
 { stdenv, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
 let
-  modDirVersion = "4.9.61";
+  modVersion = "4.9.61";
   tag = "r76";
 in
 import ./generic.nix (args // rec {
-  version = "${modDirVersion}-ti-${tag}";
-  inherit modDirVersion;
+  inherit modVersion;
+
+  version = "${modVersion}-ti-${tag}";
 
   src = fetchFromGitHub {
     owner = "beagleboard";

--- a/pkgs/os-specific/linux/kernel/linux-hardened-copperhead.nix
+++ b/pkgs/os-specific/linux/kernel/linux-hardened-copperhead.nix
@@ -7,19 +7,12 @@ let
   revision = "a";
   sha256 = "16bb1jvip50v62slp6cy96zncjhjzp3hvh29jc8ilcpxgyipmhlc";
 
-  # modVersion needs to be x.y.z, will automatically add .0 if needed
-  modVersion = concatStrings (intersperse "." (take 3 (splitString "." "${version}.0")));
-
-  # branchVersion needs to be x.y
-  branchVersion = concatStrings (intersperse "." (take 2 (splitString "." version)));
-
-  modDirVersion = "${modVersion}-hardened";
+  modVersion = "${version}-hardened";
 in
 import ./generic.nix (args // {
-  inherit modDirVersion;
+  inherit modVersion;
 
   version = "${version}-${revision}";
-  extraMeta.branch = "${branchVersion}";
 
   src = fetchFromGitHub {
     inherit sha256;

--- a/pkgs/os-specific/linux/kernel/linux-mptcp.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp.nix
@@ -2,13 +2,10 @@
 
 import ./generic.nix (rec {
   mptcpVersion = "0.93";
-  modDirVersion = "4.9.60";
-  version = "${modDirVersion}-mptcp_v${mptcpVersion}";
+  modVersion = "4.9.60";
+  version = "${modVersion}-mptcp_v${mptcpVersion}";
 
-  extraMeta = {
-    branch = "4.4";
-    maintainers = with stdenv.lib.maintainers; [ teto layus ];
-  };
+  extraMeta.maintainers = with stdenv.lib.maintainers; [ teto layus ];
 
   src = fetchFromGitHub {
     owner = "multipath-tcp";

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -1,12 +1,13 @@
 { stdenv, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
 let
-  modDirVersion = "4.9.59";
+  modVersion = "4.9.59";
   tag = "1.20171029";
 in
 stdenv.lib.overrideDerivation (import ./generic.nix (args // rec {
-  version = "${modDirVersion}-${tag}";
-  inherit modDirVersion;
+  inherit modVersion;
+
+  version = "${modVersion}-${tag}";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";

--- a/pkgs/os-specific/linux/kernel/linux-samus-4.12.nix
+++ b/pkgs/os-specific/linux/kernel/linux-samus-4.12.nix
@@ -4,13 +4,13 @@ assert stdenv.is64bit;
 
 import ./generic.nix (args // rec {
   version = "4.12.2";
-  extraMeta.branch = "4.12-2";
+  revision = "4.12-2";
 
   src =
     let upstream = fetchFromGitHub {
       owner = "raphael";
       repo = "linux-samus";
-      rev = "v${extraMeta.branch}";
+      rev = "v${revision}";
       sha256 = "1dr74i79p8r13522w2ppi8gnjd9bhngc9d2hsn91ji6f5a8fbxx9";
     }; in "${upstream}/build/linux";
 

--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -2,7 +2,7 @@
 
 import ./generic.nix (args // rec {
   version = "4.11.2017.08.23";
-  modDirVersion = "4.11.0";
+  modVersion = "4.11.0";
   extraMeta.branch = "master";
   extraMeta.maintainers = [ stdenv.lib.maintainers.davidak ];
 

--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -2,8 +2,7 @@
 
 import ./generic.nix (args // rec {
   version = "4.14-rc8";
-  modDirVersion = "4.14.0-rc8";
-  extraMeta.branch = "4.14";
+  modVersion = "4.14.0-rc8";
 
   src = fetchurl {
     url = "https://git.kernel.org/torvalds/t/linux-${version}.tar.gz";

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -226,6 +226,9 @@ let
           maintainers.thoughtpolice
         ];
         platforms = platforms.linux;
+
+        # branch needs to be x.y
+        branch = with stdenv.lib; concatStrings (intersperse "." (take 2 (splitString "." version)));
       };
     };
 in


### PR DESCRIPTION
###### Motivation for this change
This allows for `meta.branch` and `modDirVersion` to be determined automatically.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

