### PR TITLE
neomutt: wrapProgram to add lib/neomutt to PATH

### DIFF
--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchFromGitHub, which, autoreconfHook, writeScript, ncurses, perl
-, cyrus_sasl, gss, gpgme, kerberos, libidn, notmuch, openssl, lmdb, libxslt, docbook_xsl, docbook_xml_dtd_42 }:
+{ stdenv, fetchFromGitHub, which, autoreconfHook, makeWrapper, writeScript,
+ncurses, perl , cyrus_sasl, gss, gpgme, kerberos, libidn, notmuch, openssl,
+lmdb, libxslt, docbook_xsl, docbook_xml_dtd_42 }:
 
 let
   muttWrapper = writeScript "mutt" ''
@@ -26,7 +27,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     cyrus_sasl gss gpgme kerberos libidn ncurses
-    notmuch openssl perl lmdb
+    notmuch openssl perl lmdb makeWrapper
   ];
 
   nativeBuildInputs = [ autoreconfHook docbook_xsl docbook_xml_dtd_42 libxslt.bin which ];
@@ -65,6 +66,7 @@ in stdenv.mkDerivation rec {
 
   postInstall = ''
     cp ${muttWrapper} $out/bin/mutt
+    wrapProgram "$out/bin/neomutt" --prefix PATH : "$out/lib/neomutt"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
This is needed to have the auxillary tools `pgpewrap`, `pgpring` and `smime_keys` in PATH.

Fixes #31609.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

