### PR TITLE
smartd: fix 'cat: command not found' error

### DIFF
--- a/nixos/modules/services/monitoring/smartd.nix
+++ b/nixos/modules/services/monitoring/smartd.nix
@@ -17,7 +17,7 @@ let
     #! ${pkgs.stdenv.shell}
     ${optionalString nm.enable ''
       {
-      cat << EOF
+      ${pkgs.coreutils}/bin/cat << EOF
       From: smartd on ${host} <root>
       To: undisclosed-recipients:;
       Subject: SMART error on $SMARTD_DEVICESTRING: $SMARTD_FAILTYPE
@@ -30,7 +30,7 @@ let
     ''}
     ${optionalString nw.enable ''
       {
-      cat << EOF
+      ${pkgs.coreutils}/bin/cat << EOF
       Problem detected with disk: $SMARTD_DEVICESTRING
       Warning message from smartd is:
 
@@ -41,7 +41,7 @@ let
     ${optionalString nx.enable ''
       export DISPLAY=${nx.display}
       {
-      cat << EOF
+      ${pkgs.coreutils}/bin/cat << EOF
       Problem detected with disk: $SMARTD_DEVICESTRING
       Warning message from smartd is:
 


### PR DESCRIPTION
###### Motivation for this change

This started failing when I updated from `nixos-unstable` @ cfafd6f5a81 to `nixos-unstable` @ 7ebacd1a43d.  I don't see how 7ebacd1a43d could be the reason, but I also don't see anything else that would explain it ... ?

cc @ttuegel

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).