### PR TITLE
Add basic ZFS tests

### DIFF
--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -1,0 +1,85 @@
+{ system ? builtins.currentSystem }:
+
+with import ../lib/testing.nix { inherit system; };
+
+let
+
+  makeTest = import ./make-test.nix;
+
+  makeZfsTest = name:
+    { kernelPackage ? pkgs.linuxPackages_latest
+    , enableUnstable ? false
+    , extraTest ? ""
+    }:
+    makeTest {
+      name = "zfs-" + name;
+      meta = with pkgs.stdenv.lib.maintainers; {
+        maintainers = [ adisbladis ];
+      };
+
+      machine = { config, lib, pkgs, ... }:
+        {
+          virtualisation.emptyDiskImages = [ 4096 ];
+          networking.hostId = "deadbeef";
+          boot.kernelPackages = kernelPackage;
+          boot.supportedFilesystems = [ "zfs" ];
+          boot.zfs.enableUnstable = enableUnstable;
+
+          environment.systemPackages = with pkgs; [
+            parted
+          ];
+        };
+
+      testScript = ''
+        $machine->succeed("modprobe zfs");
+        $machine->succeed("zpool status");
+
+        $machine->succeed("ls /dev");
+
+        $machine->succeed(
+          "mkdir /tmp/mnt",
+
+          "udevadm settle",
+          "parted --script /dev/vdb mklabel msdos",
+          "parted --script /dev/vdb -- mkpart primary 1024M -1s",
+          "udevadm settle",
+
+          "zpool create rpool /dev/vdb1",
+          "zfs create -o mountpoint=legacy rpool/root",
+          "mount -t zfs rpool/root /tmp/mnt",
+          "udevadm settle",
+
+          "umount /tmp/mnt",
+          "zpool destroy rpool",
+          "udevadm settle"
+
+        );
+
+      '' + extraTest;
+
+    };
+
+
+in {
+
+  stable = makeZfsTest "stable" { };
+
+  unstable = makeZfsTest "unstable" {
+    enableUnstable = true;
+    extraTest = ''
+      $machine->succeed(
+        "echo password | zpool create -o altroot='/tmp/mnt' -O encryption=aes-256-gcm -O keyformat=passphrase rpool /dev/vdb1",
+        "zfs create -o mountpoint=legacy rpool/root",
+        "mount -t zfs rpool/root /tmp/mnt",
+        "udevadm settle",
+
+        "umount /tmp/mnt",
+        "zpool destroy rpool",
+        "udevadm settle"
+      );
+    '';
+  };
+
+  installer = (import ./installer.nix { }).zfsroot;
+
+}


### PR DESCRIPTION
###### Motivation for this change
Add some basic testing for `zfs` to be able to discover regressions in newer kernels more easily.

These are all currently failing because of `linuxPackages_4_14` being both lts and latest (but did succeed when testing with `linuxPackages_4_13`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

