### PR TITLE
rtl8723bs: Only include in enableAllFirmware if valid

### DIFF
--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -37,8 +37,9 @@ in {
       hardware.firmware = with pkgs; [
         firmwareLinuxNonfree
         intel2200BGFirmware
-        rtl8723bs-firmware
         rtl8192su-firmware
+      ] ++ optionals (versionOlder config.boot.kernelPackages.kernel.version "4.13") [
+        rtl8723bs-firmware
       ];
     })
     (mkIf cfg.enableAllFirmware {


### PR DESCRIPTION
###### Motivation for this change
- Only include  `rtl8723bs` in `enableAllFirmware` if valid
- Fix installer test

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @aszlig 

_Marked as WIP until the installer test has run successfully for me_