### PR TITLE
Fix hydra on release-17.09 by upgrading: 2017-09-14 -> 2017-10-26

### DIFF
--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -62,15 +62,15 @@ let
   };
 in releaseTools.nixBuild rec {
   name = "hydra-${version}";
-  version = "2017-09-14";
+  version = "2017-10-26";
 
   inherit stdenv;
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "hydra";
-    rev = "b828224fee451ad26e87cfe4eeb9c0704ee1062b";
-    sha256 = "05xv10ldsa1rahxbbgh5kwvl1dv4yvc8idczpifgb55fgqj8zazm";
+    rev = "2cdc84f34f4de647dd89c5ef503782a3a48ff623";
+    sha256 = "1gcp22ldyc914aik4yhlzy60ym7z8513pvp0ag5637j44nz0rf7h";
   };
 
   buildInputs =


### PR DESCRIPTION
###### Motivation for this change

Currently `hydra` fails to build on `release-17.09` because `nixUnstable` got upgraded:

```
$ nix-build -A hydra
these derivations will be built:
  /nix/store/xii3bpaz4cfc5hgzk0iwqa8gr2x4in8c-hydra-2017-09-14.drv
building path(s) ‘/nix/store/al2c699sjrrsm6kpqklmlvm2siynqpm1-hydra-2017-09-14’
...
hydra-eval-jobs.cc:13:26: fatal error: common-opts.hh: No such file or directory
 #include "common-opts.hh"
                          ^
compilation terminated.
```

This is fixed by cherry-picking 286faa28341e53a8152e5170f8c57b26ea66378b on `release-17.09` which upgrades hydra to the latest HEAD which can build against the latest `nixUnstable` (https://github.com/NixOS/hydra/commit/2cdc84f34f4de647dd89c5ef503782a3a48ff623). 

@orivej ping.

###### Things done

`nix-build nixos/tests/hydra.nix` succeeds.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

