### PR TITLE
minikube: Use localkube

### DIFF
--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -34,6 +34,10 @@ in buildGoPackage rec {
     sha256 = "1f7kjn26y7knmab5avj8spb40ny1y0jix5j5p0dqfjvg9climl0h";
   };
 
+  patches = [
+    ./localkube.patch
+  ];
+
   # kubernetes is here only to shut up a loud warning when generating the completions below. minikube checks very eagerly
   # that kubectl is on the $PATH, even if it doesn't use it at all to generate the completions
   buildInputs = [ go-bindata makeWrapper kubernetes gpgme ];

--- a/pkgs/applications/networking/cluster/minikube/localkube.patch
+++ b/pkgs/applications/networking/cluster/minikube/localkube.patch
@@ -1,0 +1,20 @@
+diff --git a/pkg/minikube/bootstrapper/localkube/localkube.go b/pkg/minikube/bootstrapper/localkube/localkube.go
+index 1c4b5000..c9f120d4 100644
+--- a/pkg/minikube/bootstrapper/localkube/localkube.go
++++ b/pkg/minikube/bootstrapper/localkube/localkube.go
+@@ -113,14 +113,9 @@ func (lk *LocalkubeBootstrapper) UpdateCluster(config bootstrapper.KubernetesCon
+
+ 	copyableFiles := []assets.CopyableFile{}
+ 	var localkubeFile assets.CopyableFile
+-	var err error
+
+ 	//add url/file/bundled localkube to file list
+-	lCacher := localkubeCacher{config}
+-	localkubeFile, err = lCacher.fetchLocalkubeFromURI()
+-	if err != nil {
+-		return errors.Wrap(err, "Error updating localkube from uri")
+-	}
++	localkubeFile = assets.NewBinDataAsset("out/localkube", "/", "localkube", "0777")
+ 	copyableFiles = append(copyableFiles, localkubeFile)
+
+ 	// user added files


### PR DESCRIPTION
###### Motivation for this change
Fixes #31602

The minikube guys changed the behaviour of how they load localkube.
Since they always try to download a remote version and store it (in /nix/store for us), the remote pull did not work.
This reverts to the old behaviour that uses the bundled localkube

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @moretea 
