### PR TITLE
i3status-rust: init at 0.9.0.2017-11-09

### DIFF
--- a/pkgs/applications/window-managers/i3/status-rust.nix
+++ b/pkgs/applications/window-managers/i3/status-rust.nix
@@ -1,0 +1,27 @@
+{ stdenv, rustPlatform, fetchFromGitHub, pkgconfig, dbus, gperftools }:
+
+rustPlatform.buildRustPackage rec {
+  name = "i3status-rust-${version}";
+  version = "0.9.0.2017-11-09";
+
+  src = fetchFromGitHub {
+    owner = "greshake";
+    repo = "i3status-rust";
+    rev = "5daf2cdd611bed3db804d011d5d5af34b558e615";
+    sha256 = "0j6h7x5mm3m7wq0if20qxc9z3qw29xgf5qb3sqwdbdpz8ykpqdgk";
+  };
+
+  cargoSha256 = "1197hp6d4z14j0r22bvw9ly294li0ivg6yfql4lgi27hbvzag71h";
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ dbus gperftools ];
+
+  meta = with stdenv.lib; {
+    description = "Very resource-friendly and feature-rich replacement for i3status";
+    homepage = https://github.com/greshake/i3status-rust;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.backuitist ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15148,6 +15148,8 @@ with pkgs;
 
   i3status = callPackage ../applications/window-managers/i3/status.nix { };
 
+  i3status-rust = callPackage ../applications/window-managers/i3/status-rust.nix { };
+
   i810switch = callPackage ../os-specific/linux/i810switch { };
 
   icewm = callPackage ../applications/window-managers/icewm {};


### PR DESCRIPTION
###### Motivation for this change

New bar for i3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

