### PR TITLE
common-updater: use nix-prefetch-url to get new hash

### DIFF
--- a/pkgs/common-updater/scripts.nix
+++ b/pkgs/common-updater/scripts.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, coreutils, gawk, gnused, diffutils, nix }:
+{ stdenv, makeWrapper, coreutils, gawk, gnused, diffutils, nix, curl, jq }:
 
 stdenv.mkDerivation {
   name = "common-updater-scripts";
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
     cp ${./scripts}/* $out/bin
 
     for f in $out/bin/*; do
-      wrapProgram $f --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils gawk gnused nix diffutils ]}
+      wrapProgram $f --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils gawk gnused nix diffutils curl jq ]}
     done
   '';
 }

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-set -e
+set -e -o pipefail
 
 die() {
     echo "$0: error: $1" >&2
     exit 1
 }
 
-# Usage: update-source-hash <attr> <version> [<new-source-hash>]
+# Usage: update-source-hash <attr> [<version>] [<new-source-hash>]
 attr=$1
 newVersion=$2
 newHash=$3
@@ -32,6 +32,20 @@ oldVersion=$(nix-instantiate --eval -E "with import ./. {}; $attr.version or (bu
 
 if [ -z "$drvName" -o -z "$oldVersion" ]; then
     die "Couldn't evaluate name and version from '$attr.name'!"
+fi
+
+if [ -z "$newVersion" ]; then
+   # works for fetchFromGitHub & fetchgit
+   url=$(nix-instantiate --eval --strict --expr "with import ./. {}; if $attr ? src.meta.homepage then $attr.src.meta.homepage else $attr.src.url")
+   if [[ -z "$url" ]] || ! [[ "$url" =~ \"https://github.com/([^\)]+)/([^\)/]+)\" ]]; then
+       die "we can only automatically check for new versions for github-based projects, got '$url'"
+   fi
+   owner=${BASH_REMATCH[1]}
+   repo=${BASH_REMATCH[2]%.git}
+   newVersion=$(curl -s "https://api.github.com/repos/${owner}/${repo}/tags" | jq -r '.[0]?.name | gsub("^v"; "")')
+   if [[ $newVersion == "" ]]; then
+       die "no tags found for $url"
+   fi
 fi
 
 if [ "$oldVersion" = "$newVersion" ]; then

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -72,9 +72,7 @@ fi
 
 # If new hash not given on the command line, recalculate it ourselves.
 if [ -z "$newHash" ]; then
-    nix-build --no-out-link -A "$attr.src" 2>"$attr.fetchlog" >/dev/null || true
-    # FIXME: use nix-build --hash here once https://github.com/NixOS/nix/issues/1172 is fixed
-    newHash=$(tail -n2 "$attr.fetchlog" | grep "output path .* has .* hash .* when .* was expected" | head -n1 | tr -dc '\040-\177' | awk '{ print $(NF-4) }')
+    newHash=$(nix-prefetch-url -A "$attr.src" 2>"$attr.fetchlog")
 fi
 
 if [ -z "$newHash" ]; then

--- a/pkgs/games/trackballs/default.nix
+++ b/pkgs/games/trackballs/default.nix
@@ -4,13 +4,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "trackballs-${version}";
-  version = "1.2.3";
+  version = "1.2.4";
 
   src = fetchFromGitHub {
     owner = "trackballs";
     repo = "trackballs";
     rev = "v${version}";
-    sha256 = "13f28frni7fkalxx4wqvmkzz7ba3d8pic9f9sd2z9wa6gbjs9zrf";
+    sha256 = "0y5y8xzfsjd0rxl5wnxdq7m9n97s5xvcqyjsckz4qxrjcc3lk297";
   };
 
   buildInputs = [ cmake zlib SDL2 SDL2_ttf SDL2_mixer SDL2_image guile gettext mesa ];


### PR DESCRIPTION
###### Motivation for this change

that way the downloaded archive is not discarded.

@dezgeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

