### PR TITLE
fbterm: fix build on non-x86

### DIFF
--- a/pkgs/os-specific/linux/fbterm/default.nix
+++ b/pkgs/os-specific/linux/fbterm/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gpm, freetype, fontconfig, pkgconfig, ncurses, libx86}:
+{stdenv, lib, fetchurl, gpm, freetype, fontconfig, pkgconfig, ncurses, libx86}:
 let
   s = # Generated upstream information
   rec {
@@ -9,7 +9,8 @@ let
     url="http://fbterm.googlecode.com/files/fbterm-1.7.0.tar.gz";
     sha256="0pciv5by989vzvjxsv1jsv4bdp4m8j0nfbl29jm5fwi12w4603vj";
   };
-  buildInputs = [gpm freetype fontconfig ncurses libx86];
+  buildInputs = [gpm freetype fontconfig ncurses]
+    ++ lib.optional (stdenv.isi686 || stdenv.isx86_64) libx86;
 in
 stdenv.mkDerivation {
   inherit (s) name version;


### PR DESCRIPTION
###### Motivation for this change
It didn't want to build!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

