### PR TITLE
services.postgres: fix quoting in the description of `superUser`

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -153,7 +153,7 @@ in
         default= if versionAtLeast config.system.stateVersion "17.09" then "postgres" else "root";
         internal = true;
         description = ''
-          NixOS traditionally used `root` as superuser, most other distros use `postgres`.
+          NixOS traditionally used 'root' as superuser, most other distros use 'postgres'.
           From 17.09 we also try to follow this standard. Internal since changing this value
           would lead to breakage while setting up databases.
         '';


### PR DESCRIPTION
__Note:__ instead of this we could also quote strings in `nixos-option` properly, however I'm not sure if the issue I experienced is actually expected behavior.

###### Motivation for this change


`nixos-option` evals the description and the '`' is used to
define shell commands.

Due to this, the following error appears:

```
$ nixos-option services.postgresql.superUser
Value:
"root"

Default:
"root"

Description:

/run/current-system/sw/bin/nixos-option: line 294: root: command not found
/run/current-system/sw/bin/nixos-option: line 294: postgres: command not found
NixOS traditionally used  as superuser, most other distros use .
From 17.09 we also try to follow this standard. Internal since changing this value
would lead to breakage while setting up databases.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

