### PR TITLE
Test: Revert "libbsd, libtiger: fix meta evaluation"

### DIFF
--- a/pkgs/development/libraries/libbsd/default.nix
+++ b/pkgs/development/libraries/libbsd/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     homepage = https://libbsd.freedesktop.org/;
     license = licenses.bsd3;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ matthewbauer ];
+    maintainers = with maintainer; [ matthewbauer ];
   };
 }

--- a/pkgs/development/libraries/libtiger/default.nix
+++ b/pkgs/development/libraries/libtiger/default.nix
@@ -16,6 +16,6 @@ stdenv.mkDerivation rec {
     homepage = https://code.google.com/archive/p/libtiger/;
     description = "A rendering library for Kate streams using Pango and Cairo";
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ matthewbauer ];
+    maintainers = with lib; [ matthewbauer ];
   };
 }


### PR DESCRIPTION
This reverts commit f80a55ca37a6130784587bebb8f55718a62f3e69.

See if broken meta correctly marks the PR as broken.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

