### PR TITLE
plex: 1.9.5 -> 1.9.7

### DIFF
--- a/pkgs/servers/plex/default.nix
+++ b/pkgs/servers/plex/default.nix
@@ -6,9 +6,9 @@
 let
   plexPass = throw "Plex pass has been removed at upstream's request; please unset nixpkgs.config.plex.pass";
   plexpkg = if enablePlexPass then plexPass else {
-    version = "1.9.5.4339";
-    vsnHash = "46276db8d";
-    sha256 = "09zc2wfpvan2j9h88x1f57lpfiqvml2m5m2azhphi4hb31sd3hch";
+    version = "1.9.7.4441";
+    vsnHash = "e5eb5d5a1";
+    sha256 = "1haqs61vpplikwh4ili355l89a6xjg41xacgx9s8bd5amq8m3bgn";
   };
 
 in stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Motivation for this change

New version of plex released.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

