### PR TITLE
viber: 6.5.5.1481 -> 7.0.0.1035

### DIFF
--- a/pkgs/applications/networking/instant-messengers/viber/default.nix
+++ b/pkgs/applications/networking/instant-messengers/viber/default.nix
@@ -7,11 +7,11 @@ assert stdenv.system == "x86_64-linux";
 
 stdenv.mkDerivation rec {
   name = "viber-${version}";
-  version = "6.5.5.1481";
+  version = "7.0.0.1035";
 
   src = fetchurl {
     url = "http://download.cdn.viber.com/cdn/desktop/Linux/viber.deb";
-    sha256 = "0gvpaprfki04x66ga2ljksspdxd4cz455h92a7i2dnd69w1kik5s";
+    sha256 = "06mp2wvqx4y6rd5gs2mh442qcykjrrvwnkhlpx0lara331i2p0lj";
   };
 
   buildInputs = [ dpkg makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
Upstream package updated, hash has changed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

