### PR TITLE
mysql module: fix flaky check

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -7,6 +7,11 @@ let
   cfg = config.services.mysql;
 
   mysql = cfg.package;
+  
+  isMariaDB = 
+    let
+      pName = _p: (builtins.parseDrvName (_p.name)).name;
+    in pName mysql == pName pkgs.mariadb;
 
   atLeast55 = versionAtLeast mysql.mysqlVersion "5.5";
 
@@ -59,7 +64,7 @@ in
         type = types.package;
         example = literalExample "pkgs.mysql";
         description = "
-          Which MySQL derivation to use.
+          Which MySQL derivation to use. MariaDB packages are supported too.
         ";
       };
 
@@ -360,7 +365,7 @@ in
 
             ${concatMapStrings (user:
               ''
-                ( echo "CREATE USER IF NOT EXISTS '${user.name}'@'localhost' IDENTIFIED WITH ${if mysql == pkgs.mariadb then "unix_socket" else "auth_socket"};"
+                ( echo "CREATE USER IF NOT EXISTS '${user.name}'@'localhost' IDENTIFIED WITH ${if isMariaDB then "unix_socket" else "auth_socket"};"
                   ${concatStringsSep "\n" (mapAttrsToList (database: permission: ''
                   echo "GRANT ${permission} ON ${database} TO '${user.name}'@'localhost';"
                   '') user.ensurePermissions)}


### PR DESCRIPTION
Comparing packages via equality will lead to different results when package and module are from different `nixpkgs` checkouts. See https://github.com/NixOS/nixpkgs/pull/29387#issuecomment-342147663

Also, because MariaDB is actually supported, added a note to option description to make this knowledge more discover-able. In particular, https://nixos.org/nixos/options.html#mariadb currently shows zero results, but that is wrong, because `pkgs.mysql` is actually `pkgs.mariadb`.

ping @fpletz
call for test @florianjacob 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
