### PR TITLE
atom: 1.21.2->1.22.0; 1.22.0-beta1->1.23.0-beta0

### DIFF
--- a/pkgs/applications/editors/atom/beta.nix
+++ b/pkgs/applications/editors/atom/beta.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "atom-beta-${version}";
-  version = "1.22.0-beta1";
+  version = "1.23.0-beta0";
 
   src = fetchurl {
     url = "https://github.com/atom/atom/releases/download/v${version}/atom-amd64.deb";
-    sha256 = "0qggj0j0cnkzqwgvzw2fb1z10rvvx9jh0ymhdy1aca18hms44p3d";
+    sha256 = "1vfc8jin07kivdmyw88vbzinbjsb6py9n2ggpvy4cccagnvxwj2y";
     name = "${name}.deb";
   };
 

--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "atom-${version}";
-  version = "1.21.2";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "https://github.com/atom/atom/releases/download/v${version}/atom-amd64.deb";
-    sha256 = "0snhhp8rjmk750snyzkqzwvi7f915pbc6qpa3vf0f57syf47m7vl";
+    sha256 = "1jxw0m1hfaisf1f875wr28f0mr3h0wjml6pjhfxbybvcblpnd27k";
     name = "${name}.deb";
   };
 


### PR DESCRIPTION
###### Motivation for this change
Atom is outdated, so should be updated.

###### Things done
Bumped Atom to 1.22.0 (stable) and 1.23.0-beta0 (beta branch). 

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Thanks for your time,
Brenton

