### PR TITLE
Pkgs/dirb/copy wordlists

### DIFF
--- a/pkgs/tools/networking/dirb/default.nix
+++ b/pkgs/tools/networking/dirb/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, automake, autoconf, curl, autoreconfHook }:
+{ fetchurl, stdenv, autoreconfHook, curl }:
 
 let
   major = "2";
@@ -6,10 +6,14 @@ let
 in stdenv.mkDerivation rec {
   name = "dirb-${version}";
   version = "${major}.${minor}";
+
   src = fetchurl {
     url = "mirror://sourceforge/dirb/${version}/dirb${major}${minor}.tar.gz";
     sha256 = "0b7wc2gvgnyp54rxf1n9arn6ymrvdb633v6b3ah138hw4gg8lx7k";
   };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ curl ];
 
   unpackPhase = ''
     tar -xf $src
@@ -17,7 +21,7 @@ in stdenv.mkDerivation rec {
     export sourceRoot="dirb222"
   '';
 
-  prePatch = ''
+  postPatch = ''
     sed -i "s#/usr#$out#" src/dirb.c
   '';
 
@@ -25,9 +29,6 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/share/dirb/
     cp -r wordlists/ $out/share/dirb/
   '';
-
-  buildInputs = [ automake autoconf curl ];
-  preConfigure = "chmod +x configure";
 
   meta = {
     description = "A web content scanner";

--- a/pkgs/tools/networking/dirb/default.nix
+++ b/pkgs/tools/networking/dirb/default.nix
@@ -17,6 +17,15 @@ in stdenv.mkDerivation rec {
     export sourceRoot="dirb222"
   '';
 
+  prePatch = ''
+    sed -i "s#/usr#$out#" src/dirb.c
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/dirb/
+    cp -r wordlists/ $out/share/dirb/
+  '';
+
   buildInputs = [ automake autoconf curl ];
   preConfigure = "chmod +x configure";
 


### PR DESCRIPTION
###### Motivation for this change

The dirb package does not provide the wordlist files which are normally available in /usr/share/dirb/wordlists . In addition the software uses hardcoded `/usr/share/dirb/wordlists/common.txt`. This PR fixes both issues by installing the wordlists into the package share directory and patching the hardcoded path in `src/dirb.c`

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

