### PR TITLE
nixos-option: don't eval description

### DIFF
--- a/nixos/modules/installer/tools/nixos-option.sh
+++ b/nixos/modules/installer/tools/nixos-option.sh
@@ -291,7 +291,7 @@ if test "$(evalOpt "_type" 2> /dev/null)" = '"option"'; then
   fi
   echo "Description:"
   echo
-  eval printf $(evalOpt "description")
+  echo $(evalOpt "description")
 
   echo $desc;
 


### PR DESCRIPTION
###### Motivation for this change

see https://github.com/NixOS/nixpkgs/pull/31630#issuecomment-344073438

When backticks are used in a description field of a nixos-option, the value inside a backtick will be evaluated which can cause unexpected side-effects.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

