### PR TITLE
docs: clarify package and module option naming

### DIFF
--- a/doc/coding-conventions.xml
+++ b/doc/coding-conventions.xml
@@ -18,9 +18,9 @@
   tab settings so it’s asking for trouble.</para></listitem>
 
   <listitem><para>Use <literal>lowerCamelCase</literal> for variable
-  names, not <literal>UpperCamelCase</literal>.  TODO: naming of
-  attributes in
-  <filename>all-packages.nix</filename>?</para></listitem>
+  names, not <literal>UpperCamelCase</literal>.  Note, this rule does
+  not apply to package attribute names, which instead follow the rules
+  in <xref linkend="sec-package-naming"/>.</para></listitem>
 
   <listitem><para>Function calls with attribute set arguments are
   written as
@@ -220,9 +220,10 @@ args.stdenv.mkDerivation (args // {
 
   <listitem><para>The variable name used for the instantiated package
   in <filename>all-packages.nix</filename>, and when passing it as a
-  dependency to other functions.  This is what Nix expression authors
-  see.  It can also be used when installing using <command>nix-env
-  -iA</command>.</para></listitem>
+  dependency to other functions.  Typically this is called the
+  <emphasis>package attribute name</emphasis>.  This is what Nix
+  expression authors see.  It can also be used when installing using
+  <command>nix-env -iA</command>.</para></listitem>
 
   <listitem><para>The filename for (the directory containing) the Nix
   expression.</para></listitem>
@@ -259,12 +260,12 @@ bound to the variable name <varname>e2fsprogs</varname> in
   Also append <literal>"unstable"</literal> to the name - e.g.,
   <literal>"pkgname-unstable-2014-09-23"</literal>.</para></listitem>
 
-  <listitem><para>Dashes in the package name should be preserved
-  in new variable names, rather than converted to underscores
-  (which was convention up to around 2013 and most names
-   still have underscores instead of dashes) — e.g.,
-  <varname>http-parser</varname> instead of
-  <varname>http_parser</varname>.</para></listitem>
+  <listitem><para>Dashes in the package name should be preserved in
+  new variable names, rather than converted to underscores or camel
+  cased — e.g., <varname>http-parser</varname> instead of
+  <varname>http_parser</varname> or <varname>httpParser</varname>.  The
+  hyphenated style is preferred in all three package
+  names.</para></listitem>
 
   <listitem><para>If there are multiple versions of a package, this
   should be reflected in the variable names in

--- a/nixos/doc/manual/development/option-declarations.xml
+++ b/nixos/doc/manual/development/option-declarations.xml
@@ -22,6 +22,15 @@ options = {
 };
 </programlisting>
 
+The attribute names within the <replaceable>name</replaceable>
+attribute path must be camel cased in general but should, as an
+exception, match the
+<link
+xlink:href="https://nixos.org/nixpkgs/manual/#sec-package-naming">
+package attribute name</link> when referencing a Nixpkgs package. For
+example, the option <varname>services.nix-serve.bindAddress</varname>
+references the <varname>nix-serve</varname> Nixpkgs package.
+
 </para>
 
 <para>The function <varname>mkOption</varname> accepts the following arguments.


### PR DESCRIPTION
So, lately I've been entertaining myself by thinking about package attribute and module names. There is, from what I can tell, a general agreement about these but I was thinking it may be good to clarify it in the documentation. So, I put together this PR to try to roughly codify the current convention as I understand it.

My understanding comes from these observations:

  - The [12.1. Syntax](https://nixos.org/nixpkgs/manual/#sec-syntax) section of the Nixpkgs manual states

    > Use lowerCamelCase for variable names, not UpperCamelCase.

    It also says

    > TODO: naming of attributes in all-packages.nix?

  - In [12.2. Package naming](https://nixos.org/nixpkgs/manual/#sec-package-naming) it says

    > Dashes in the package name should be preserved in new variable names, rather than converted to underscores (which was convention up to around 2013 and most names still have underscores instead of dashes) — e.g., `http-parser` instead of `http_parser`.

    which I've taken to hold also for package attribute names but I don't know if the above text actually states this. Especially considering the TODO mentioned previously.

  - The issue tracker includes some discussions about attribute naming and my feeling is that there is a general consensus that package attribute names should be hyphenated. See, e.g., https://github.com/NixOS/nixpkgs/issues/9456.

  - For NixOS modules I haven't been able to find any authoritative source for naming modules. Looking at the names in NixOS today it seems clear that camel case is used in general but the hyphenated style is used whenever a specific package is referenced.

    For example, we have `services.dd-agent.jmxConfig` (and interestingly also `services.dd-agent.api_key`).

  - I found one example of moving from a hyphenated to a "camelized" module name. Namely, https://github.com/NixOS/nixpkgs/pull/26083, where `programs.zsh.oh-my-zsh` was aliased to `programs.zsh.ohMyZsh`. Are there further examples? This is relatively recent so would this indicate a emerging preference? In my PR I have followed the more common hyphenated style.
