### PR TITLE
jgmenu: init at 0.7.4

### DIFF
--- a/pkgs/applications/misc/jgmenu/default.nix
+++ b/pkgs/applications/misc/jgmenu/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, pkgconfig, python3Packages, pango, librsvg, libxml2, menu-cache, xorg }:
+
+stdenv.mkDerivation rec {
+  name = "jgmenu-${version}";
+  version = "0.7.4";
+
+  src = fetchFromGitHub {
+    owner = "johanmalm";
+    repo = "jgmenu";
+    rev = "v${version}";
+    sha256 = "0vim7balxrxhbgq4jvf80lbh57xbw3qmhapy7n2iyv443ih4a7hi";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    python3Packages.wrapPython
+  ];
+
+  buildInputs = [
+    pango
+    librsvg
+    libxml2
+    menu-cache
+    xorg.libXinerama
+  ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  postFixup = ''
+    wrapPythonProgramsIn "$out/lib/jgmenu"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/johanmalm/jgmenu;
+    description = "Small X11 menu intended to be used with openbox and tint2";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15296,6 +15296,8 @@ with pkgs;
 
   jedit = callPackage ../applications/editors/jedit { };
 
+  jgmenu = callPackage ../applications/misc/jgmenu { };
+
   jigdo = callPackage ../applications/misc/jigdo { };
 
   jitsi = callPackage ../applications/networking/instant-messengers/jitsi { };


### PR DESCRIPTION
###### Motivation for this change

[`jgmenu`](https://github.com/johanmalm/jgmenu) is a stand-alone, simple and contemporary-looking menu application for Linux and BSD.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

