### PR TITLE
sharutils: simplify substituteInPlace syntax to be Nix 1.11.8 compatible

### DIFF
--- a/pkgs/tools/archivers/sharutils/default.nix
+++ b/pkgs/tools/archivers/sharutils/default.nix
@@ -18,10 +18,17 @@ stdenv.mkDerivation rec {
   # that cause shar to just segfault. It isn't a problem on Linux because their sandbox
   # remaps /etc/passwd to a trivial file, but we can't do that on Darwin so I do this
   # instead. In this case, I pass in the very imaginative "submitter" as the submitter name
-  patchPhase = ''
-    substituteInPlace tests/shar-1 --replace '$''\{SHAR}' '$''\{SHAR} -s submitter'
-    substituteInPlace tests/shar-2 --replace '$''\{SHAR}' '$''\{SHAR} -s submitter'
-  '';
+
+  patchPhase = let
+      # This evaluates to a string containing:
+      #
+      #     substituteInPlace tests/shar-2 --replace '${SHAR}' '${SHAR} -s submitter'
+      #     substituteInPlace tests/shar-2 --replace '${SHAR}' '${SHAR} -s submitter'
+      shar_sub = "\${SHAR}";
+    in ''
+      substituteInPlace tests/shar-1 --replace '${shar_sub}' '${shar_sub} -s submitter'
+      substituteInPlace tests/shar-2 --replace '${shar_sub}' '${shar_sub} -s submitter'
+    '';
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change

This expression isn't parsable by Nix 1.11.8 (16.09) and I think this change makes it nicer to read too? 

cc @copumpkin 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
