### PR TITLE
linux_4_14: fix iwlwifi fw reset

### DIFF
--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -62,4 +62,14 @@ rec {
     name = "tag-hardened";
     patch = ./tag-hardened.patch;
   };
+
+  # https://bugzilla.kernel.org/show_bug.cgi?id=197591#c6
+  iwlwifi_mvm_support_version_7_scan_req_umac_fw_command = rec {
+    name = "iwlwifi_mvm_support_version_7_scan_req_umac_fw_command";
+    patch = fetchpatch {
+      name = name + ".patch";
+      url = https://bugzilla.kernel.org/attachment.cgi?id=260597;
+      sha256 = "09096npxpgvlwdz3pb3m9brvxh7vy0xc9z9p8hh85xyczyzcsjhr";
+    };
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12516,6 +12516,9 @@ with pkgs;
         # when adding a new linux version
         kernelPatches.cpu-cgroup-v2."4.11"
         kernelPatches.modinst_arg_list_too_long
+
+        # https://bugzilla.kernel.org/show_bug.cgi?id=197591#c6
+        kernelPatches.iwlwifi_mvm_support_version_7_scan_req_umac_fw_command
       ]
       ++ lib.optionals ((platform.kernelArch or null) == "mips")
       [ kernelPatches.mips_fpureg_emu


### PR DESCRIPTION
Currently, moving to kernel_4_14 breaks at least Intel Wireless 8260 and
8265 cards due to a API change in the firmware, which is not yet honored
in the driver.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

