### PR TITLE
maintainers: Add ixmatus to the maintainers set

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -284,6 +284,7 @@
   infinisil = "Silvan Mosberger <infinisil@icloud.com>";
   ironpinguin = "Michele Catalano <michele@catalano.de>";
   ivan-tkatchev = "Ivan Tkatchev <tkatchev@gmail.com>";
+  ixmatus = "Parnell Springmeyer <parnell@digitalmentat.com>";
   j-keck = "Jürgen Keck <jhyphenkeck@gmail.com>";
   jagajaga = "Arseniy Seroka <ars.seroka@gmail.com>";
   jammerful = "jammerful <jammerful@gmail.com>";


### PR DESCRIPTION
This change adds Parnell Springmeyer, `ixmatus`, to the `maintainers` set.