### PR TITLE
glib: Add variable for overriding schemas

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -150,7 +150,7 @@ in {
           export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}${mimeAppsList}/share
 
           # Override gsettings-desktop-schema
-          export XDG_DATA_DIRS=${nixos-gsettings-desktop-schemas}/share/gsettings-schemas/nixos-gsettings-overrides''${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS
+          export NIX_GSETTINGS_OVERRIDES_DIR=${nixos-gsettings-desktop-schemas}/share/gsettings-schemas/nixos-gsettings-overrides/glib-2.0/schemas
 
           # Let nautilus find extensions
           export NAUTILUS_EXTENSION_DIR=${config.system.path}/lib/nautilus/extensions-3.0/

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -55,7 +55,8 @@ stdenv.mkDerivation rec {
   };
 
   patches = optional stdenv.isDarwin ./darwin-compilation.patch
-    ++ optional doCheck ./skip-timer-test.patch;
+    ++ optional doCheck ./skip-timer-test.patch
+    ++ [ ./schema-override-variable.patch ];
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev";

--- a/pkgs/development/libraries/glib/schema-override-variable.patch
+++ b/pkgs/development/libraries/glib/schema-override-variable.patch
@@ -1,0 +1,12 @@
+--- a/gio/gsettingsschema.c
++++ b/gio/gsettingsschema.c
+@@ -352,6 +352,9 @@
+ 
+       try_prepend_data_dir (g_get_user_data_dir ());
+ 
++      if ((path = g_getenv ("NIX_GSETTINGS_OVERRIDES_DIR")) != NULL)
++        try_prepend_dir (path);
++
+       if ((path = g_getenv ("GSETTINGS_SCHEMA_DIR")) != NULL)
+         try_prepend_dir (path);
+ 


### PR DESCRIPTION
This is a part of [GNOME 3.26 update](https://github.com/NixOS/nixpkgs/pull/29392). I would like to get input from glib maintainers (@lovek323, @raskin) & co.

I assume we prefer introducing custom enviroment variable to blocking an existing one? Though, if we used the existing one, user could always override it, only losing the defaults from NixOS module.

###### Motivation for this change
For some reason, the GNOME 3.26 update broke the overrides. It turns out the overrides now need to come before the overridden schemas in the `XDG_DATA_DIRS` variable. This is not possible in general due to applications prefixing the variable (e.g. in `wrapGAppsHook`).

To fix this, a new environment variable `NIX_GSETTINGS_OVERRIDES_DIR` was introduced. It has greater priority than `XDG_DATA_DIRS` but lower than `GSETTINGS_SCHEMA_DIR`. A separate variable was chosen in order not to block the built-in one for users.

###### Things done

I tested the module with `GSETTINGS_SCHEMA_DIR` variable, which is basically the same. Will test with the proper one once it builds.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

