### PR TITLE
gtetrinet: init at 0.7.11

### DIFF
--- a/pkgs/games/gtetrinet/default.nix
+++ b/pkgs/games/gtetrinet/default.nix
@@ -1,0 +1,47 @@
+{ fetchFromGitHub, stdenv
+, perl, perlPackages, gnome2, intltool, pkgconfig, autoconf, automake }:
+
+stdenv.mkDerivation {
+  name = "gtetrinet-0.7.11";
+
+  src = fetchFromGitHub {
+    owner = "GNOME";
+    repo = "gtetrinet";
+    rev = "6be3df83f3dc5c7cb966e6cd447182df01b93222";
+    sha256 = "1y05x8lfyxvkjg6c87cfd0xxmb22c88scx8fq3gah7hjy5i42v93";
+  };
+
+  buildInputs = [
+    perl
+    perlPackages.XMLParser
+    intltool
+    gnome2.libgnome
+    gnome2.libgnomeui
+    pkgconfig
+    autoconf
+    automake
+  ];
+
+  propagatedUserEnvPkgs = [ gnome2.GConf ];
+
+  preConfigure = ''
+    autoreconf --install --force --verbose
+    intltoolize --force
+  '';
+
+  postInstall = ''
+    mv "$out/games" "$out/bin"
+  '';
+
+  meta = {
+    description = "Client for Tetrinet, a multiplayer online Tetris game.";
+    longDescription = ''
+      GTetrinet is a client program for Tetrinet, a multiplayer tetris game
+      that is played over the internet.
+    '';
+    homepage = http://gtetrinet.sourceforge.net/;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.chris-martin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17857,6 +17857,8 @@ with pkgs;
 
   gogui = callPackage ../games/gogui {};
 
+  gtetrinet = callPackage ../games/gtetrinet { };
+
   gtypist = callPackage ../games/gtypist { };
 
   gzdoom = callPackage ../games/gzdoom { };


### PR DESCRIPTION
###### Motivation for this change

This was a great old game

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

