### PR TITLE
why3: 0.87.3 -> 0.88.1

### DIFF
--- a/pkgs/applications/science/logic/why3/default.nix
+++ b/pkgs/applications/science/logic/why3/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name    = "why3-${version}";
-  version = "0.87.3";
+  version = "0.88.1";
 
   src = fetchurl {
-    url    = https://gforge.inria.fr/frs/download.php/file/36398/why3-0.87.3.tar.gz;
-    sha256 = "1fn9v6w1ilkrm2n4rz31w8qvjnchyvwxiqs67z3f59b5k99wb2ka";
+    url    = https://gforge.inria.fr/frs/download.php/file/37185/why3-0.88.1.tar.gz;
+    sha256 = "1qj00963si0vdrqjp79ai27g9rr8sqvly6n6nwpga6bnss98xqkw";
   };
 
   buildInputs = (with ocamlPackages; [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

Upgrade why3 from 0.87.3 to 0.88.1

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

