### PR TITLE
enlightenment: fix names of setuid wrapped files

### DIFF
--- a/pkgs/desktops/enlightenment/enlightenment.suid-exes.patch
+++ b/pkgs/desktops/enlightenment/enlightenment.suid-exes.patch
@@ -1,5 +1,5 @@
 --- enlightenment-0.22.0.orig/meson/meson_inst.sh	2017-09-25 10:55:43.000000000 -0300
-+++ enlightenment-0.22.0/meson/meson_inst.sh	2017-11-12 09:04:33.356050746 -0200
++++ enlightenment-0.22.0/meson/meson_inst.sh	2017-11-15 08:31:03.336844920 -0200
 @@ -1,6 +1,19 @@
 -#!/bin/sh
 +#!/bin/sh -x
@@ -18,7 +18,7 @@
 +	b=$(basename "$f".orig)
 +	mv -v "$f"{,.orig}
 +	ln -sv /run/wrappers/bin/"$b" "$f"
-+	echo "    \"$b\".source = \"$f\";" >> $w
++	echo "    \"$b\".source = \"$f.orig\";" >> $w
  done
 +
 +echo "  };" >> $w


### PR DESCRIPTION
###### Motivation for this change

The names of the files that setuid wrapped are missing the suffix `.orig` and because of that the `enlightenment` module cannot run successfully.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).