### PR TITLE
pythonPackages.mpi4py: 2.0.0 -> 3.0.0

### DIFF
--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -1,34 +1,18 @@
-{ stdenv, fetchPypi, python, buildPythonPackage, mpi, openssh, isPy3k, isPyPy }:
+{ stdenv, fetchPypi, python, buildPythonPackage, mpi }:
 
 buildPythonPackage rec {
   pname = "mpi4py";
-  version = "2.0.0";
+  version = "3.0.0";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "10fb01595rg17ycz08a23v24akm25d13srsy2rnixam7a5ca0hv5";
+    sha256 = "1mzgd26dfv4vwbci8gq77ss9f0x26i9aqzq9b9vs9ndxhlnv0mxl";
   };
 
   passthru = {
     inherit mpi;
   };
-
-  # Rename libm.so -> libm.so.6 in test
-  # See: https://bitbucket.org/mpi4py/mpi4py/issues/28/test_dltestdl-test-failure
-  patches = [
-    ./tests.patch
-  ];
-
-  # The tests in the `test_spawn` module fail in the chroot build environment.
-  # However, they do pass in a pure, or non-pure nix-shell. Hence, we
-  # deactivate these particular tests.
-  # Unfortunately, the command-line arguments to `./setup.py test` are not
-  # correctly passed to the test-runner. Hence, these arguments are patched
-  # directly into `setup.py`.
-  prePatch = ''
-    sed 's/err = main(cmd.args or \[\])/err = main(cmd.args or ["-v", "-e", "test_spawn"])/' -i setup.py
-  '';
 
   configurePhase = "";
 
@@ -49,14 +33,6 @@ buildPythonPackage rec {
   setupPyBuildFlags = ["--mpicc=${mpi}/bin/mpicc"];
 
   buildInputs = [ mpi ];
-  # Requires openssh for tests. Tests of dependent packages will also fail,
-  # if openssh is not present. E.g. h5py with mpi support.
-  propagatedBuildInputs = [ openssh ];
-
-  disabled = isPy3k || isPyPy;
-
-  # Timing out communicating between processes when sandboxing enabled.
-  doCheck = false;
 
   meta = {
     description =


### PR DESCRIPTION
Tests run with sandboxing enabled again and we can remove some of the fixes as
they aren't necessary anymore.

PyPy and Python 3 are also supported.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

