### PR TITLE
zotero: 4.0.29 -> 5.0.25

### DIFF
--- a/pkgs/applications/office/zotero/default.nix
+++ b/pkgs/applications/office/zotero/default.nix
@@ -1,82 +1,48 @@
-{ stdenv, fetchurl, lib, bash, firefox, perl, unzipNLS, xorg }:
+{ stdenv, fetchurl, buildFHSUserEnv, writeTextFile, bash, wrapGAppsHook, gsettings_desktop_schemas, gtk3, gnome3 }:
 
 let
+version = "5.0.25";
+meta = with stdenv.lib; {
+  homepage = https://www.zotero.org;
+  description = "Collect, organize, cite, and share your research sources";
+  license = licenses.agpl3;
+  platforms = platforms.linux;
+};
 
-  xpi = fetchurl {
-    url = "https://download.zotero.org/extension/zotero-${version}.xpi";
-    sha256 = "1dyf578yfj3xr9kkhmsvbkvraw2arghmh67ksi5c8qlxczx5i1xy";
-  };
-
-  version = "4.0.29";
-
-in
-stdenv.mkDerivation {
-  name = "zotero-${version}";
+zoteroSrc = stdenv.mkDerivation rec {
   inherit version;
+  name = "zotero-${version}-pkg";
 
   src = fetchurl {
-    url = "https://github.com/zotero/zotero-standalone-build/archive/4.0.29.2.tar.gz";
-    sha256 = "0pfip6s5dawp7wp8r5czvzlnxvvdwjja64g71h9dxyxrh49v2mxa";
+    url = "https://download.zotero.org/client/release/${version}/Zotero-${version}_linux-x86_64.tar.bz2";
+    sha256 = "1y3q5582xp4inpz137x0r9iscs1g0cjlqcfjpzl3klsq3yas688k";
   };
 
-  nativeBuildInputs = [ perl unzipNLS ];
-
-  inherit bash firefox;
-
-  phases = "unpackPhase installPhase fixupPhase";
+  buildInputs= [ wrapGAppsHook gsettings_desktop_schemas gtk3 gnome3.adwaita-icon-theme gnome3.dconf ];
+  phases = [ "unpackPhase" "installPhase" "fixupPhase"];
 
   installPhase = ''
-    mkdir -p "$out/libexec/zotero"
-    unzip "${xpi}" -d "$out/libexec/zotero"
-
-    BUILDID=`date +%Y%m%d`
-    GECKO_VERSION="${lib.removeSuffix "esr" firefox.passthru.version}"
-    UPDATE_CHANNEL="default"
-
-    # Copy branding
-    cp -R assets/branding "$out/libexec/zotero/chrome/branding"
-
-    # Adjust chrome.manifest
-    echo "" >> "$out/libexec/zotero/chrome.manifest"
-    cat assets/chrome.manifest >> "$out/libexec/zotero/chrome.manifest"
-
-    # Copy updater.ini
-    cp assets/updater.ini "$out/libexec/zotero"
-
-    # Adjust connector pref
-    perl -pi -e 's/pref\("extensions\.zotero\.httpServer\.enabled", false\);/pref("extensions.zotero.httpServer.enabled", true);/g' "$out/libexec/zotero/defaults/preferences/zotero.js"
-    perl -pi -e 's/pref\("extensions\.zotero\.connector\.enabled", false\);/pref("extensions.zotero.connector.enabled", true);/g' "$out/libexec/zotero/defaults/preferences/zotero.js"
-
-    # Copy icons
-    cp -r assets/icons "$out/libexec/zotero/chrome/icons"
-
-    # Copy application.ini and modify
-    cp assets/application.ini "$out/libexec/zotero/application.ini"
-    perl -pi -e "s/\{\{VERSION}}/$version/" "$out/libexec/zotero/application.ini"
-    perl -pi -e "s/\{\{BUILDID}}/$BUILDID/" "$out/libexec/zotero/application.ini"
-    perl -pi -e "s/^MaxVersion.*\$/MaxVersion=$GECKO_VERSION/" "$out/libexec/zotero/application.ini"
-
-    # Copy prefs.js and modify
-    cp assets/prefs.js "$out/libexec/zotero/defaults/preferences"
-    perl -pi -e 's/pref\("app\.update\.channel", "[^"]*"\);/pref\("app\.update\.channel", "'"$UPDATE_CHANNEL"'");/' "$out/libexec/zotero/defaults/preferences/prefs.js"
-    perl -pi -e 's/%GECKO_VERSION%/'"$GECKO_VERSION"'/g' "$out/libexec/zotero/defaults/preferences/prefs.js"
-
-    # Add platform-specific standalone assets
-    cp -R assets/unix "$out/libexec/zotero"
-
-    mkdir -p "$out/bin"
-    substituteAll "${./zotero.sh}" "$out/bin/zotero"
-    chmod +x "$out/bin/zotero"
+    mkdir -p $out/data
+    cp -r * $out/data
+    mkdir $out/bin
+    ln -s $out/data/zotero $out/bin/zotero
   '';
+};
 
-  doInstallCheck = true;
-  installCheckPhase = "$out/bin/zotero --version";
+fhsEnv = buildFHSUserEnv {
+  name = "zotero-fhs-env";
+  targetPkgs = pkgs: with pkgs; with xlibs; [
+    gtk3 dbus_glib
+    libXt nss
+  ];
+};
 
-  meta = with stdenv.lib; {
-    homepage = https://www.zotero.org;
-    description = "Collect, organize, cite, and share your research sources";
-    license = licenses.agpl3;
-    platforms = platforms.linux;
-    broken = true; # probably; see #20049
-  };
-}
+in writeTextFile {
+  name = "zotero";
+  destination = "/bin/zotero";
+  executable = true;
+  text = ''
+    #!${bash}/bin/bash
+    ${fhsEnv}/bin/zotero-fhs-env ${zoteroSrc}/bin/zotero
+  '';
+} // {inherit meta; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17627,9 +17627,7 @@ with pkgs;
 
   zoom-us = callPackage ../applications/networking/instant-messengers/zoom-us { };
 
-  zotero = callPackage ../applications/office/zotero {
-    firefox = firefox-esr-unwrapped;
-  };
+  zotero = callPackage ../applications/office/zotero { };
 
   zscroll = callPackage ../applications/misc/zscroll {};
 


### PR DESCRIPTION
This uses buildFHSUserenv.  The source installation probably does not work until
node2nix supports nodejs-8.x.

###### Motivation for this change
Zotero does not come bundled with newer firefox versions anymore, only standalone is supported.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

