### PR TITLE
Wesnoth MacOS

### DIFF
--- a/pkgs/development/libraries/SDL_mixer/default.nix
+++ b/pkgs/development/libraries/SDL_mixer/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--disable-music-ogg-shared" ]
     ++ lib.optional enableNativeMidi " --enable-music-native-midi-gpl"
-    ++ lib.optional stdenv.isDarwin "--disable-sdltest";
+    ++ lib.optionals stdenv.isDarwin [ "--disable-sdltest" "--disable-smpegtest" ];
 
   meta = with stdenv.lib; {
     description = "SDL multi-channel audio mixer library";

--- a/pkgs/games/wesnoth/default.nix
+++ b/pkgs/games/wesnoth/default.nix
@@ -43,6 +43,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.wesnoth.org/;
     license = licenses.gpl2;
     maintainers = with maintainers; [ kkallio abbradar ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

These changes get Wesnoth building on MacOS.

However, graphics aren't being displayed correctly! The menu looks like this:

<img width="799" alt="screen shot 2017-11-15 at 8 25 05 am" src="https://user-images.githubusercontent.com/19036/32840917-a20d5b40-c9de-11e7-8315-c7bdbcb4b63f.png">

Does anyone have ideas on how to fix this? Currently I'm out of things to try.

/cc @LnL7 @copumpkin 

Console log looks normal:

```
Battle for Wesnoth v1.12.6
Started on Wed Nov 15 08:25:00 2017

Fontconfig error: Cannot load default config file

Data directory: /nix/store/1w5vz4p6gp08xsk2w7a7h8g5hxkfb1zn-wesnoth-1.12.6/share/wesnoth
User configuration directory: /Users/mbauer/.config/wesnoth
User data directory: /Users/mbauer/.local/share/wesnoth/1.12
Cache directory: /Users/mbauer/.cache/wesnoth
Checking video mode: 800x600x32...
setting mode to 800x600x32
```
