### PR TITLE
android-udev-rules: use proper path for udev/rules.d

### DIFF
--- a/pkgs/os-specific/linux/android-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/android-udev-rules/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    install -D 51-android.rules $out/lib/udev/rules.d/51-android.rules
+    install -D 51-android.rules $out/etc/udev/rules.d/51-android.rules
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

The file **51-android.rules** don't appear properly in **/etc/udev/rules.d**

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

