### PR TITLE
borgbackup: Make build on darwin possible

### DIFF
--- a/pkgs/tools/backup/borg/default.nix
+++ b/pkgs/tools/backup/borg/default.nix
@@ -19,8 +19,8 @@ python3Packages.buildPythonApplication rec {
     lz4 openssl python3Packages.setuptools_scm
   ] ++ stdenv.lib.optionals stdenv.isLinux [ acl ];
   propagatedBuildInputs = with python3Packages; [
-    cython llfuse msgpack
-  ];
+    cython msgpack
+  ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [ llfuse ];
 
   preConfigure = ''
     export BORG_OPENSSL_PREFIX="${openssl.dev}"

--- a/pkgs/tools/backup/borg/default.nix
+++ b/pkgs/tools/backup/borg/default.nix
@@ -16,8 +16,8 @@ python3Packages.buildPythonApplication rec {
     sphinx guzzle_sphinx_theme
   ];
   buildInputs = [
-    acl lz4 openssl python3Packages.setuptools_scm
-  ];
+    lz4 openssl python3Packages.setuptools_scm
+  ] ++ stdenv.lib.optionals stdenv.isLinux [ acl ];
   propagatedBuildInputs = with python3Packages; [
     cython llfuse msgpack
   ];


### PR DESCRIPTION
###### Motivation for this change
The borgbackup package of the current master branch refuses to build on darwin because of some dependencies which are only available for the linux platform. These dependecies (acl and fuse) are optional for the borgbackup software. Therefore i removed them depending on the current platform.

After these changes the borgbackup package can be installed on darwin. But the removed llfuse package breaks features which rely on FUSE (only on darwin). Would be very cool to get them to work again but i am not very familiar with FUSE and the fuse package in nixpkgs. I am even not sure if it's possibile to get FUSE to work on darwin. But all other features seem to work fine and the software is very useful without it. Also the borgbackup folks themself say that it's ok to remove the fuse dependency if it's not avaiable, see: https://github.com/borgbackup/borg/blob/72232a9bd573aeb4818b36c9c8764b6008e9283e/setup.py#L32

###### Things done
Make acl and llfuse build inputs optional depending on current platform.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
   Completed without errors. Looks like nothing depends on it, only borgbackup itself was built.
- [x] Tested execution of all binary files (usually in `./result/bin/`)
    As said before features which require FUSE support are broken on darwin, e.g. mounting a backup into filesystem with "borg mount /path/to/repo /path/to/mountpoint". Therefore i assume that "bin/borgfs" is also broken which is a wrapper around "borg mount" to use in the fstab.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @nckx @flokli 