### PR TITLE
google-cloud-sdk: disable gce as a dependency by default (fixes #31369)

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -1,8 +1,18 @@
-{ stdenv, lib, fetchurl, python, cffi, cryptography, pyopenssl, crcmod, google-compute-engine, makeWrapper }:
+# Make sure that the "with-gce" flag is set when building `google-cloud-sdk`
+# for GCE hosts. This flag prevents "google-compute-engine" from being a
+# default dependency which is undesirable because this package is
+#
+#   1) available only on GNU/Linux (requires `systemd` in particular)
+#   2) intended only for GCE guests (and is useless elsewhere)
+#   3) used by `google-cloud-sdk` only on GCE guests
+#
 
-# other systems not supported yet
+{ stdenv, lib, fetchurl, makeWrapper, python, cffi, cryptography, pyopenssl,
+  crcmod, google-compute-engine, with-gce ? false }:
+
 let
-  pythonInputs = [ cffi cryptography pyopenssl crcmod google-compute-engine ];
+  pythonInputs = [ cffi cryptography pyopenssl crcmod ]
+                 ++ lib.optional (with-gce) google-compute-engine;
   pythonPath = lib.makeSearchPath python.sitePackages pythonInputs;
 
   baseUrl = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads";

--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -5,19 +5,20 @@ let
   pythonInputs = [ cffi cryptography pyopenssl crcmod google-compute-engine ];
   pythonPath = lib.makeSearchPath python.sitePackages pythonInputs;
 
+  baseUrl = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads";
   sources = name: system: {
     i686-linux = {
-      url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${name}-linux-x86.tar.gz";
+      url = "${baseUrl}/${name}-linux-x86.tar.gz";
       sha256 = "0aq938s1w9mzj60avmcc68kgll54pl7635vl2mi89f6r56n0xslp";
     };
 
     x86_64-darwin = {
-      url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${name}-darwin-x86_64.tar.gz";
+      url = "${baseUrl}/${name}-darwin-x86_64.tar.gz";
       sha256 = "13k2i1svry9q800s1jgf8jss0rzfxwk6qci3hsy1wrb9b2mwlz5g";
     };
 
     x86_64-linux = {
-      url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${name}-linux-x86_64.tar.gz";
+      url = "${baseUrl}/${name}-linux-x86_64.tar.gz";
       sha256 = "1kvaz8p1iflsi85wwi7lb6km6frj70xsricyz1ah0sw3q71zyqmc";
     };
   }.${system};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2364,6 +2364,7 @@ with pkgs;
   google-authenticator = callPackage ../os-specific/linux/google-authenticator { };
 
   google-cloud-sdk = python2.pkgs.google-cloud-sdk;
+  google-cloud-sdk-gce = python2.pkgs.google-cloud-sdk-gce;
 
   google-fonts = callPackage ../data/fonts/google-fonts { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5445,6 +5445,7 @@ in {
   };
 
   google-cloud-sdk = callPackage ../tools/admin/google-cloud-sdk { };
+  google-cloud-sdk-gce = callPackage ../tools/admin/google-cloud-sdk { with-gce=true; };
 
   google-compute-engine = callPackage ../tools/virtualization/google-compute-engine { };
 


### PR DESCRIPTION
###### Motivation for this change
The commit https://github.com/NixOS/nixpkgs/commit/b241bcf38881be764180c66fa9c713d0d44135c5 made `google-compute-engine` a dependency for `google-cloud-sdk` which make it impossible to build `google-cloud-sdk` on MacOS (https://github.com/NixOS/nixpkgs/issues/31679). In general, `google-compute-engine` is a package intended for GCE guest images and `google-cloud-sdk` needs `google-compute-engine` only when running on GCE.

This commit introduces a new attribute `forGceInstance` which controls whether `google-compute-engine` is included as a dependency and is `false` by default. Moreover, this commit includes the override for this package with `forGceInstance` set to true in the default NixOS configuration for GCE at nixos/modules/virtualisation/google-compute-image.nix.

Maintainers @stephenmw @zimbatm 

###### Things done

- [ ] Tested using sandboxing 
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change 
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md]

