### PR TITLE
cmocka: 1.0.1 -> 1.1.1

### DIFF
--- a/pkgs/development/libraries/cmocka/default.nix
+++ b/pkgs/development/libraries/cmocka/default.nix
@@ -1,25 +1,14 @@
-{ fetchurl, stdenv, cmake, fetchpatch }:
+{ fetchurl, stdenv, cmake }:
 
 stdenv.mkDerivation rec {
   name = "cmocka-${version}";
-  version = "1.0.1";
+  majorVersion = "1.1";
+  version = "${majorVersion}.1";
 
   src = fetchurl {
-    url = "https://cmocka.org/files/1.0/cmocka-${version}.tar.xz";
-    sha256 = "0fvm6rdalqcxckbddch8ycdw6n2ckldblv117n09chi2l7bm0q5k";
+    url = "https://cmocka.org/files/${majorVersion}/cmocka-${version}.tar.xz";
+    sha256 = "f02ef48a7039aa77191d525c5b1aee3f13286b77a13615d11bc1148753fc0389";
   };
-
-  patches = [
-    # This fixes the build for clang-3.7.0 and thus Darwin.
-    # See https://open.cryptomilk.org/issues/43 for more info.
-    #
-    # The patch is already merged to upstream, so it should be removed
-    # here on next release.
-    (fetchpatch {
-      url = "https://git.cryptomilk.org/projects/cmocka.git/patch/?id=1b595a80934fa95234fb290913cfe533f740d965";
-      sha256 = "1fg8xwb1mrrmw4dqa65ghnvgfdkpi0lv4j2gq0lm9ayvsi3v00vp";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
###### Motivation for this change

package updated

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

