### PR TITLE
lib: add isInStore and isPath, slighly change isStorePath

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -84,7 +84,7 @@ let
       toLower toUpper addContextFrom splitString removePrefix
       removeSuffix versionOlder versionAtLeast getVersion nameFromURL
       enableFeature fixedWidthString fixedWidthNumber isStorePath
-      toInt readPathsFromFile fileContents;
+      isInStore isPath toInt readPathsFromFile fileContents;
     inherit (stringsWithDeps) textClosureList textClosureMap
       noDepEntry fullDepEntry packEntry stringAfter;
     inherit (customisation) overrideDerivation makeOverridable

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -219,8 +219,7 @@ rec {
 
     path = mkOptionType {
       name = "path";
-      # Hacky: there is no ‘isPath’ primop.
-      check = x: builtins.substring 0 1 (toString x) == "/";
+      check = x: isString x || isPath x;
       merge = mergeOneOption;
     };
 


### PR DESCRIPTION
- isStorePath now returns true for paths
- isPath returns true only when the type of value is path
- isInStore just asserts that the path is prefixed with store dir

###### Motivation for this change

Groundwork for https://github.com/NixOS/nixpkgs/issues/24288#issuecomment-344681430

This adds better tooling to differentiate between string and path types. Also allows to see if path is in nix store or just a regular one.

I plan to add docs once we agree this is a good idea.