### PR TITLE
hwinfo: 21.38 -> 21.50

### DIFF
--- a/pkgs/development/libraries/libx86emu/default.nix
+++ b/pkgs/development/libraries/libx86emu/default.nix
@@ -1,27 +1,29 @@
-{ stdenv, fetchurl, perl }:
+{ stdenv, fetchFromGitHub, perl }:
 
 stdenv.mkDerivation rec {
   name = "libx86emu-${version}";
-  version = "1.5";
+  version = "1.12";
 
-  src = fetchurl {
-    url = "https://github.com/wfeldt/libx86emu/archive/${version}.tar.gz";
-    sha256 = "1im6w6m0bl6ajynx4hc028lad8v10whv4y7w9zxndzh3j4mi3aa8";
+  src = fetchFromGitHub {
+    owner = "wfeldt";
+    repo = "libx86emu";
+    rev = version;
+    sha256 = "0dlzvwdkk0vc6qf0a0zzbxki3pig1mda8p3fa54rxqaxkwp4mqr6";
   };
 
-  buildInputs = [ perl ];
+  nativeBuildInputs = [ perl ];
 
+  postUnpack = "rm $sourceRoot/git2log";
   patchPhase = ''
     # VERSION is usually generated using Git
     echo "${version}" > VERSION
-    sed -i 's|/usr/|/|g' Makefile
+    substituteInPlace Makefile --replace "/usr" "/"
   '';
 
-  makeFlags = [ "shared" ];
+  buildFlags = [ "shared" ];
+  enableParallelBuilding = true;
 
-  installPhase = ''
-    make install DESTDIR=$out/ LIBDIR=lib
-  '';
+  installFlags = [ "DESTDIR=$(out)" "LIBDIR=/lib" ];
 
   meta = with stdenv.lib; {
     description = "x86 emulation library";

--- a/pkgs/tools/system/hwinfo/default.nix
+++ b/pkgs/tools/system/hwinfo/default.nix
@@ -2,30 +2,32 @@
 
 stdenv.mkDerivation rec {
   name = "hwinfo-${version}";
-  version = "21.38";
+  version = "21.50";
 
   src = fetchFromGitHub {
     owner = "opensuse";
     repo = "hwinfo";
     rev = "${version}";
-    sha256 = "17a1nx906gdl9br1wf6xmhjy195szaxxmyb119vayw4q112rjdql";
+    sha256 = "1kkq979qqdalxdm6f0gyl3l9nk5rm6i6rbms43rmy52jfda5f5bv";
   };
 
   patchPhase = ''
-    # VERSION and changelog is usually generated using Git
-    echo "${version}" > VERSION
+    # VERSION and changelog are usually generated using Git
+    # unless HWINFO_VERSION is defined (see Makefile)
+    export HWINFO_VERSION="${version}"
     sed -i 's|^\(TARGETS\s*=.*\)\<changelog\>\(.*\)$|\1\2|g' Makefile
 
-    sed -i 's|lex isdn_cdb.lex|${flex}/bin/flex isdn_cdb.lex|g' src/isdn/cdb/Makefile
-    sed -i 's|/sbin|/bin|g' Makefile
-    sed -i 's|/usr/|/|g' Makefile
+    substituteInPlace Makefile --replace "/sbin" "/bin" --replace "/usr/" "/"
+    substituteInPlace src/isdn/cdb/Makefile --replace "lex isdn_cdb.lex" "flex isdn_cdb.lex"
+    substituteInPlace hwinfo.pc.in --replace "prefix=/usr" "prefix=$out"
   '';
 
-  installPhase = ''
-    make install DESTDIR=$out
-  '';
+  nativeBuildInputs = [ flex ];
+  buildInputs = [ libx86emu perl ];
 
-  buildInputs = [ libx86emu flex perl ];
+  makeFlags = [ "LIBDIR=/lib" ];
+
+  installFlags = [ "DESTDIR=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "Hardware detection tool from openSUSE";


### PR DESCRIPTION
###### Motivation for this change
Update `hwinfo` and its `libx86emu` dependency to latest stable releases 
Also fixed the pkgconfig .pc file of hwinfo (prefix was wrong)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

