### PR TITLE
rustracer: 2.0.9 -> 2.0.12

### DIFF
--- a/pkgs/development/compilers/rust/rust-src.nix
+++ b/pkgs/development/compilers/rust/rust-src.nix
@@ -1,0 +1,11 @@
+{ stdenv, rustc }:
+
+stdenv.mkDerivation {
+  name = "rust-src";
+  src = rustc.src;
+  phases = [ "unpackPhase" "installPhase" ];
+  installPhase = ''
+    mv src $out
+    rm -rf $out/{ci,doc,driver,etc,grammar,llvm,rt,rtstartup,rustllvm,test,tools,vendor}
+  '';
+}

--- a/pkgs/development/tools/rust/racer/default.nix
+++ b/pkgs/development/tools/rust/racer/default.nix
@@ -1,31 +1,32 @@
-{ stdenv, fetchFromGitHub, rustPlatform, makeWrapper }:
+{ stdenv, fetchFromGitHub, rustPlatform, makeWrapper, rustup, substituteAll }:
 
 rustPlatform.buildRustPackage rec {
   name = "racer-${version}";
-  version = "2.0.9";
+  version = "2.0.12";
 
   src = fetchFromGitHub {
     owner = "racer-rust";
     repo = "racer";
     rev = version;
-    sha256 = "06k50f2vj2w08afh3nrlhs0amcvw2i45bhfwr70sgs395xicjswp";
+    sha256 = "0y1xlpjr8y8gsmmrjlykx4vwzf8akk42g35kg3kc419ry4fli945";
   };
 
-  cargoSha256 = "1w5imxyqlyv24dvzncq6dy01zn2x8p1aciyvzh8ac1x1wdjcacjc";
+  cargoSha256 = "1h3jv4hajdv6k309kjr6b6298kxmd0faw081i3788sl794k9mp0j";
 
-  buildInputs = [ makeWrapper ];
+  # rustup is required for test
+  buildInputs = [ makeWrapper rustup ];
 
   preCheck = ''
     export RUST_SRC_PATH="${rustPlatform.rustcSrc}"
   '';
-
+  patches = [
+    (substituteAll {
+      src = ./rust-src.patch;
+      inherit (rustPlatform) rustcSrc;
+    })
+    ./ignore-tests.patch
+  ];
   doCheck = true;
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp -p target/release/racer $out/bin/
-    wrapProgram $out/bin/racer --set RUST_SRC_PATH "${rustPlatform.rustcSrc}"
-  '';
 
   meta = with stdenv.lib; {
     description = "A utility intended to provide Rust code completion for editors and IDEs";

--- a/pkgs/development/tools/rust/racer/ignore-tests.patch
+++ b/pkgs/development/tools/rust/racer/ignore-tests.patch
@@ -1,0 +1,22 @@
+diff -Naur --strip-trailing-cr source.org/src/racer/nameres.rs source/src/racer/nameres.rs
+--- source.org/src/racer/nameres.rs	2017-11-15 20:37:38.571644733 +0000
++++ source/src/racer/nameres.rs	2017-11-15 20:23:20.521324031 +0000
+@@ -577,6 +577,7 @@
+     out.into_iter()
+ }
+ 
++#[ignore]
+ #[test]
+ fn test_do_file_search() {
+     let cache = core::FileCache::default();
+diff -Naur --strip-trailing-cr source.org/src/racer/util.rs source/src/racer/util.rs
+--- source.org/src/racer/util.rs	2017-11-15 19:37:55.095344120 +0000
++++ source/src/racer/util.rs	2017-11-15 20:22:53.746624158 +0000
+@@ -475,6 +475,7 @@
+ 
+ }
+ 
++#[ignore]
+ #[test]
+ fn test_get_rust_src_path_missing() {
+     use std::env;

--- a/pkgs/development/tools/rust/racer/rust-src.patch
+++ b/pkgs/development/tools/rust/racer/rust-src.patch
@@ -1,0 +1,10 @@
+--- source.org/src/racer/util.rs	1970-01-01 01:00:01.000000000 +0100
++++ source/src/racer/util.rs	2017-11-15 16:50:12.904216242 +0000
+@@ -384,6 +384,7 @@
+     debug!("Nope. Trying default paths: /usr/local/src/rust/src and /usr/src/rust/src");
+ 
+     let default_paths = [
++        "@rustcSrc@",
+         "/usr/local/src/rust/src",
+         "/usr/src/rust/src",
+     ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6239,13 +6239,9 @@ with pkgs;
         inherit rust;
       };
 
-      rustcSrc = stdenv.mkDerivation {
-        name = "rust-src";
-        src = rust.rustc.src;
-        phases = ["unpackPhase" "installPhase"];
-        installPhase = "mv src $out";
+      rustcSrc = callPackage ../development/compilers/rust/rust-src.nix {
+        inherit (rust) rustc;
       };
-
     });
 
   cargo-edit = callPackage ../tools/package-management/cargo-edit { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

