### PR TITLE
sublime3: Use consistent program name

### DIFF
--- a/pkgs/applications/editors/sublime3/default.nix
+++ b/pkgs/applications/editors/sublime3/default.nix
@@ -61,7 +61,7 @@ in let
 
     installPhase = ''
       # Correct sublime_text.desktop to exec `sublime' instead of /opt/sublime_text
-      sed -e 's,/opt/sublime_text/sublime_text,sublime,' -i sublime_text.desktop
+      sed -e "s,/opt/sublime_text/sublime_text,$out/sublime_text," -i sublime_text.desktop
 
       mkdir -p $out
       cp -prvd * $out/
@@ -89,9 +89,15 @@ in stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out/bin
-    ln -s $sublime/sublime_text $out/bin/subl
-    ln -s $sublime/sublime_text $out/bin/sublime
-    ln -s $sublime/sublime_text $out/bin/sublime3
+
+    cat > $out/bin/subl <<-EOF
+    #!/bin/sh
+    exec $sublime/sublime_text "\$@"
+    EOF
+    chmod +x $out/bin/subl
+
+    ln $out/bin/subl $out/bin/sublime
+    ln $out/bin/subl $out/bin/sublime3
     mkdir -p $out/share/applications
     ln -s $sublime/sublime_text.desktop $out/share/applications/sublime_text.desktop
     ln -s $sublime/Icon/256x256/ $out/share/icons


### PR DESCRIPTION
###### Motivation for this change
Previously, we used symlinks to create short name aliases. Symlink `basename`s are used as `argv[0]`, and consequently as `WM_CLASS` hint when executed. This confused desktop managers, which use the hint to pair desktop files with running applications.

This patch uses exec scripts instead of symlinks just like the official deb package does, preserving the `sublime_text` prgname.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc maintainers @wmertens @demin-dmitriy @zimbatm