### PR TITLE
proofgeneral_HEAD: 2017-05-06 -> 2017-11-06

### DIFF
--- a/pkgs/applications/editors/emacs-modes/proofgeneral/HEAD.nix
+++ b/pkgs/applications/editors/emacs-modes/proofgeneral/HEAD.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation (rec {
   name = "ProofGeneral-unstable-${version}";
-  version = "2017-05-06";
+  version = "2017-11-06";
 
   src = fetchFromGitHub {
     owner = "ProofGeneral";
     repo = "PG";
-    rev = "574b0992e3cb4b7a4ad88400b9a5ab0198a96ca5";
-    sha256 = "1c1pgdmy58h78s53g0ga9b5ilbsibz0dr2lk52xgbs3q5m22v5fh";
+    rev = "2eab72c33751768c8a6cde36b978ea4a36b91843";
+    sha256 = "1l3n48d6d4l5q3wkhdyp8dc6hzdw1ckdzr57dj8rdm78j87vh2cg";
   };
 
   buildInputs = [ emacs texinfo perl which ] ++ stdenv.lib.optional enableDoc texLive;


### PR DESCRIPTION
###### Motivation for this change

(correct) support for latest version of Coq (8.7.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

