### PR TITLE
neovim: ruby and python isolation

### DIFF
--- a/pkgs/applications/editors/neovim/ruby_provider/Gemfile.lock
+++ b/pkgs/applications/editors/neovim/ruby_provider/Gemfile.lock
@@ -2,8 +2,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     msgpack (1.1.0)
-    neovim (0.5.1)
+    multi_json (1.12.2)
+    neovim (0.6.1)
       msgpack (~> 1.0)
+      multi_json (~> 1.0)
 
 PLATFORMS
   ruby

--- a/pkgs/applications/editors/neovim/ruby_provider/gemset.nix
+++ b/pkgs/applications/editors/neovim/ruby_provider/gemset.nix
@@ -7,13 +7,21 @@
     };
     version = "1.1.0";
   };
-  neovim = {
-    dependencies = ["msgpack"];
+  multi_json = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "08xn7r4g13wl4bhvkmp4hx3x0ppvifs1x2iiqh8jl9f1jb4jhfcp";
+      sha256 = "1raim9ddjh672m32psaa9niw67ywzjbxbdb8iijx3wv9k5b0pk2x";
       type = "gem";
     };
-    version = "0.5.1";
+    version = "1.12.2";
+  };
+  neovim = {
+    dependencies = ["msgpack" "multi_json"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1dnv2pdl8lwwy4av8bqc6kdlgxw88dmajm4fkdk6hc7qdx1sw234";
+      type = "gem";
+    };
+    version = "0.6.1";
   };
 }


### PR DESCRIPTION
the code has been taken from #31604 and fixed so that :CheckHealth for
ruby provider is also green (ruby and gem are required to be in PATH).

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

