### PR TITLE
zfsUnstable fixes for kernel 4.14

### DIFF
--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -13,6 +13,7 @@ let
   common = { version
     , sha256
     , rev ? "spl-${version}"
+    , broken ? false
     } @ args : stdenv.mkDerivation rec {
       name = "spl-${configFile}-${version}${optionalString buildKernel "-${kernel.version}"}";
 
@@ -52,7 +53,7 @@ let
           kernel.
         '';
 
-        broken = kernel != null && stdenv.lib.versionAtLeast kernel.version "4.14";
+        inherit broken;
 
         homepage = http://zfsonlinux.org/;
         platforms = platforms.linux;
@@ -67,11 +68,13 @@ in
     splStable = common {
       version = "0.7.3";
       sha256 = "0j8mb9ky3pjz9hnz5w6fajpzajl15jq3p0xvxb6lhpqj3rjzsqxb";
+
+      broken = kernel != null && stdenv.lib.versionAtLeast kernel.version "4.14";
     };
 
     splUnstable = common {
-      version = "2017-10-31";
-      rev = "35a44fcb8d6e346f51be82dfe57562c2ea0c6a9c";
-      sha256 = "193clx7b4p4qhgivmhc88dva0186rnhyv58fx0fwnb5zbx70dam1";
+      version = "2017-11-16";
+      rev = "ed19bccfb651843fa208232b3a2d3d22a4152bc8";
+      sha256 = "08ihjbf5fhcnhq9zavcwswg9djlbalbx1bil4rcv6i3d617wammb";
     };
 }

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -159,10 +159,10 @@ in {
     incompatibleKernelVersion = null;
 
     # this package should point to a version / git revision compatible with the latest kernel release
-    version = "2017-11-12";
+    version = "2017-11-16";
 
-    rev = "5277f208f290ea4e2204800a66c3ba20a03fe503";  
-    sha256 = "0hhlhv4g678j1w45813xfrk8zza0af59cdkmib9bkxy0cn0jsnd6";
+    rev = "d4a72f23863382bdf6d0ae33196f5b5decbc48fd";
+    sha256 = "0q2gkkj11hy8m8cjd70g99bs69ldxvc17ym0x1pgwvs4722hzpha";
     isUnstable = true;
 
     extraPatches = [


### PR DESCRIPTION
###### Motivation for this change
zfsUnstable broke on kernel 4.14

Verified working with tests from https://github.com/NixOS/nixpkgs/pull/31618 and manually on my laptop.

Stable is still broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

