### PR TITLE
pypcap: 1.1.6 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/pypcap/default.nix
+++ b/pkgs/development/python-modules/pypcap/default.nix
@@ -1,14 +1,13 @@
-{ stdenv, lib, writeText, buildPythonPackage, fetchPypi, isPy3k, libpcap, dpkt }:
+{ stdenv, lib, writeText, buildPythonPackage, fetchPypi, libpcap, dpkt }:
 
 buildPythonPackage rec {
   pname = "pypcap";
-  version = "1.1.6";
+  version = "1.2.0";
   name = "${pname}-${version}";
-  disabled = isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1cx7qm0w2a91g5z8k3kmlwz0b8dkr0h8dlb64rwgyhp2laa33syi";
+    sha256 = "0n01xjgg8n5mf1cs9yg9ljsx1kvir8cm6wwrd2069fawjxdbk0b9";
   };
 
   patches = [
@@ -31,7 +30,8 @@ buildPythonPackage rec {
       '')
   ];
 
-  buildInputs = [ libpcap dpkt ];
+  buildInputs = [ libpcap ];
+  nativeBuildInputs = [ dpkt ];
 
   meta = {
     homepage = https://github.com/pynetwork/pypcap;


### PR DESCRIPTION
###### Motivation for this change
This PR updates pypcap to the current version which supports Python 3 now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

