### PR TITLE
thunar: add wrapGAppsHook

### DIFF
--- a/pkgs/desktops/xfce/core/thunar-build.nix
+++ b/pkgs/desktops/xfce/core/thunar-build.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, intltool
 , gtk, dbus_glib, libstartup_notification, libnotify, libexif, pcre, udev
-, exo, libxfce4util, xfconf, xfce4panel
+, exo, libxfce4util, xfconf, xfce4panel, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     sed -i -e 's|thunar_dialogs_show_insecure_program (parent, _(".*"), file, exec)|1|' thunar/thunar-file.c
   '';
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
   buildInputs = [
     intltool
     gtk dbus_glib libstartup_notification libnotify libexif pcre udev


### PR DESCRIPTION
###### Motivation for this change
Make thunar support SVG icons.

I am using thunar with wayland and sway, if it matters.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

