### PR TITLE
dropbox: install xkeyboardconfig for input

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -34,7 +34,7 @@ buildFHSUserEnv {
 
   targetPkgs = pkgs: with pkgs; with xlibs; [
     libICE libSM libX11 libXcomposite libXdamage libXext libXfixes libXrender
-    libXxf86vm libxcb
+    libXxf86vm libxcb xkeyboardconfig
     curl dbus fontconfig freetype gcc glib gnutar libxml2 libxslt zlib
   ];
 


### PR DESCRIPTION
Qt applications running in an FHS env need to have xkeyboardconfig installed for
keyboard input.

Resolves: #31741

### Testing

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

