### PR TITLE
wrapFirefox: make overridable, support browserpass

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -8,6 +8,7 @@
 , google_talk_plugin, fribid, gnome3/*.gnome_shell*/
 , esteidfirefoxplugin
 , vlc_npapi
+, browserpass
 , libudev
 , kerberos
 }:
@@ -56,6 +57,7 @@ let
         );
       nativeMessagingHosts =
         ([ ]
+          ++ lib.optional (cfg.enableBrowserpass or false) browserpass
           ++ extraNativeMessagingHosts
         );
       libs = (if ffmpegSupport then [ ffmpeg ] else with gst_all; [ gstreamer gst-plugins-base ])

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -24,6 +24,8 @@ let
       (lib.toUpper (lib.substring 0 1 browserName) + lib.substring 1 (-1) browserName)
     , nameSuffix ? ""
     , icon ? browserName
+    , extraPlugins ? []
+    , extraNativeMessagingHosts ? []
     }:
 
     let
@@ -50,9 +52,11 @@ let
           ++ lib.optional (cfg.enableAdobeReader or false) adobe-reader
           ++ lib.optional (cfg.enableEsteid or false) esteidfirefoxplugin
           ++ lib.optional (cfg.enableVLC or false) vlc_npapi
+          ++ extraPlugins
         );
       nativeMessagingHosts =
         ([ ]
+          ++ extraNativeMessagingHosts
         );
       libs = (if ffmpegSupport then [ ffmpeg ] else with gst_all; [ gstreamer gst-plugins-base ])
             ++ lib.optional gssSupport kerberos

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -13,143 +13,149 @@
 }:
 
 ## configurability of the wrapper itself
+
 browser:
-{ browserName ? browser.browserName or (builtins.parseDrvName browser.name).name
-, name ? (browserName + "-" + (builtins.parseDrvName browser.name).version)
-, desktopName ? # browserName with first letter capitalized
-  (lib.toUpper (lib.substring 0 1 browserName) + lib.substring 1 (-1) browserName)
-, nameSuffix ? ""
-, icon ? browserName
-}:
 
 let
-  cfg = stdenv.lib.attrByPath [ browserName ] {} config;
-  enableAdobeFlash = cfg.enableAdobeFlash or false;
-  ffmpegSupport = browser.ffmpegSupport or false;
-  gssSupport = browser.gssSupport or false;
-  jre = cfg.jre or false;
-  icedtea = cfg.icedtea or false;
+  wrapper =
+    { browserName ? browser.browserName or (builtins.parseDrvName browser.name).name
+    , name ? (browserName + "-" + (builtins.parseDrvName browser.name).version)
+    , desktopName ? # browserName with first letter capitalized
+      (lib.toUpper (lib.substring 0 1 browserName) + lib.substring 1 (-1) browserName)
+    , nameSuffix ? ""
+    , icon ? browserName
+    }:
 
-  plugins =
-     assert !(jre && icedtea);
-     ([ ]
-      ++ lib.optional enableAdobeFlash flashplayer
-      ++ lib.optional (cfg.enableDjvu or false) (djview4)
-      ++ lib.optional (cfg.enableMPlayer or false) (MPlayerPlugin browser)
-      ++ lib.optional (supportsJDK && jre && jrePlugin ? mozillaPlugin) jrePlugin
-      ++ lib.optional icedtea icedtea_web
-      ++ lib.optional (cfg.enableGoogleTalkPlugin or false) google_talk_plugin
-      ++ lib.optional (cfg.enableFriBIDPlugin or false) fribid
-      ++ lib.optional (cfg.enableGnomeExtensions or false) gnome3.gnome_shell
-      ++ lib.optional (cfg.enableTrezor or false) trezor-bridge
-      ++ lib.optional (cfg.enableBluejeans or false) bluejeans
-      ++ lib.optional (cfg.enableAdobeReader or false) adobe-reader
-      ++ lib.optional (cfg.enableEsteid or false) esteidfirefoxplugin
-      ++ lib.optional (cfg.enableVLC or false) vlc_npapi
-     );
-  nativeMessagingHosts =
-     ([ ]
-     );
-  libs = (if ffmpegSupport then [ ffmpeg ] else with gst_all; [ gstreamer gst-plugins-base ])
-         ++ lib.optional gssSupport kerberos
-         ++ lib.optionals (cfg.enableQuakeLive or false)
-         (with xorg; [ stdenv.cc libX11 libXxf86dga libXxf86vm libXext libXt alsaLib zlib libudev ])
-         ++ lib.optional (enableAdobeFlash && (cfg.enableAdobeFlashDRM or false)) hal-flash
-         ++ lib.optional (config.pulseaudio or false) libpulseaudio;
-  gst-plugins = with gst_all; [ gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-ffmpeg ];
-  gtk_modules = [ libcanberra_gtk2 ];
+    let
+      cfg = stdenv.lib.attrByPath [ browserName ] {} config;
+      enableAdobeFlash = cfg.enableAdobeFlash or false;
+      ffmpegSupport = browser.ffmpegSupport or false;
+      gssSupport = browser.gssSupport or false;
+      jre = cfg.jre or false;
+      icedtea = cfg.icedtea or false;
 
-in stdenv.mkDerivation {
-  inherit name;
+      plugins =
+        assert !(jre && icedtea);
+        ([ ]
+          ++ lib.optional enableAdobeFlash flashplayer
+          ++ lib.optional (cfg.enableDjvu or false) (djview4)
+          ++ lib.optional (cfg.enableMPlayer or false) (MPlayerPlugin browser)
+          ++ lib.optional (supportsJDK && jre && jrePlugin ? mozillaPlugin) jrePlugin
+          ++ lib.optional icedtea icedtea_web
+          ++ lib.optional (cfg.enableGoogleTalkPlugin or false) google_talk_plugin
+          ++ lib.optional (cfg.enableFriBIDPlugin or false) fribid
+          ++ lib.optional (cfg.enableGnomeExtensions or false) gnome3.gnome_shell
+          ++ lib.optional (cfg.enableTrezor or false) trezor-bridge
+          ++ lib.optional (cfg.enableBluejeans or false) bluejeans
+          ++ lib.optional (cfg.enableAdobeReader or false) adobe-reader
+          ++ lib.optional (cfg.enableEsteid or false) esteidfirefoxplugin
+          ++ lib.optional (cfg.enableVLC or false) vlc_npapi
+        );
+      nativeMessagingHosts =
+        ([ ]
+        );
+      libs = (if ffmpegSupport then [ ffmpeg ] else with gst_all; [ gstreamer gst-plugins-base ])
+            ++ lib.optional gssSupport kerberos
+            ++ lib.optionals (cfg.enableQuakeLive or false)
+            (with xorg; [ stdenv.cc libX11 libXxf86dga libXxf86vm libXext libXt alsaLib zlib libudev ])
+            ++ lib.optional (enableAdobeFlash && (cfg.enableAdobeFlashDRM or false)) hal-flash
+            ++ lib.optional (config.pulseaudio or false) libpulseaudio;
+      gst-plugins = with gst_all; [ gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-ffmpeg ];
+      gtk_modules = [ libcanberra_gtk2 ];
 
-  desktopItem = makeDesktopItem {
-    name = browserName;
-    exec = "${browserName}${nameSuffix} %U";
-    inherit icon;
-    comment = "";
-    desktopName = "${desktopName}${nameSuffix}";
-    genericName = "Web Browser";
-    categories = "Application;Network;WebBrowser;";
-    mimeType = stdenv.lib.concatStringsSep ";" [
-      "text/html"
-      "text/xml"
-      "application/xhtml+xml"
-      "application/vnd.mozilla.xul+xml"
-      "x-scheme-handler/http"
-      "x-scheme-handler/https"
-      "x-scheme-handler/ftp"
-    ];
-  };
+    in stdenv.mkDerivation {
+      inherit name;
 
-  buildInputs = [makeWrapper]
-    ++ lib.optional (!ffmpegSupport) gst-plugins
-    ++ lib.optional (browser ? gtk3) browser.gtk3;
+      desktopItem = makeDesktopItem {
+        name = browserName;
+        exec = "${browserName}${nameSuffix} %U";
+        inherit icon;
+        comment = "";
+        desktopName = "${desktopName}${nameSuffix}";
+        genericName = "Web Browser";
+        categories = "Application;Network;WebBrowser;";
+        mimeType = stdenv.lib.concatStringsSep ";" [
+          "text/html"
+          "text/xml"
+          "application/xhtml+xml"
+          "application/vnd.mozilla.xul+xml"
+          "x-scheme-handler/http"
+          "x-scheme-handler/https"
+          "x-scheme-handler/ftp"
+        ];
+      };
 
-  buildCommand = ''
-    if [ ! -x "${browser}/bin/${browserName}" ]
-    then
-        echo "cannot find executable file \`${browser}/bin/${browserName}'"
-        exit 1
-    fi
+      buildInputs = [makeWrapper]
+        ++ lib.optional (!ffmpegSupport) gst-plugins
+        ++ lib.optional (browser ? gtk3) browser.gtk3;
 
-    makeWrapper "$(readlink -v --canonicalize-existing "${browser}/bin/${browserName}")" \
-        "$out/bin/${browserName}${nameSuffix}" \
-        --suffix-each MOZ_PLUGIN_PATH ':' "$plugins" \
-        --suffix LD_LIBRARY_PATH ':' "$libs" \
-        --suffix-each GTK_PATH ':' "$gtk_modules" \
-        --suffix-each LD_PRELOAD ':' "$(cat $(filterExisting $(addSuffix /extra-ld-preload $plugins)))" \
-        --prefix-contents PATH ':' "$(filterExisting $(addSuffix /extra-bin-path $plugins))" \
-        --suffix PATH ':' "$out/bin" \
-        --set MOZ_APP_LAUNCHER "${browserName}${nameSuffix}" \
-        --set MOZ_SYSTEM_DIR "$out/lib/mozilla" \
-        ${lib.optionalString (!ffmpegSupport)
-            ''--prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH"''
-        + lib.optionalString (browser ? gtk3)
-            ''--prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
-              --suffix XDG_DATA_DIRS : '${gnome3.defaultIconTheme}/share'
-            ''
-         }
+      buildCommand = ''
+        if [ ! -x "${browser}/bin/${browserName}" ]
+        then
+            echo "cannot find executable file \`${browser}/bin/${browserName}'"
+            exit 1
+        fi
 
-    if [ -e "${browser}/share/icons" ]; then
-        mkdir -p "$out/share"
-        ln -s "${browser}/share/icons" "$out/share/icons"
-    else
-        mkdir -p "$out/share/icons/hicolor/128x128/apps"
-        ln -s "${browser}/lib/${browserName}-"*"/browser/icons/mozicon128.png" \
-            "$out/share/icons/hicolor/128x128/apps/${browserName}.png"
-    fi
+        makeWrapper "$(readlink -v --canonicalize-existing "${browser}/bin/${browserName}")" \
+            "$out/bin/${browserName}${nameSuffix}" \
+            --suffix-each MOZ_PLUGIN_PATH ':' "$plugins" \
+            --suffix LD_LIBRARY_PATH ':' "$libs" \
+            --suffix-each GTK_PATH ':' "$gtk_modules" \
+            --suffix-each LD_PRELOAD ':' "$(cat $(filterExisting $(addSuffix /extra-ld-preload $plugins)))" \
+            --prefix-contents PATH ':' "$(filterExisting $(addSuffix /extra-bin-path $plugins))" \
+            --suffix PATH ':' "$out/bin" \
+            --set MOZ_APP_LAUNCHER "${browserName}${nameSuffix}" \
+            --set MOZ_SYSTEM_DIR "$out/lib/mozilla" \
+            ${lib.optionalString (!ffmpegSupport)
+                ''--prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH"''
+            + lib.optionalString (browser ? gtk3)
+                ''--prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
+                  --suffix XDG_DATA_DIRS : '${gnome3.defaultIconTheme}/share'
+                ''
+            }
 
-    install -D -t $out/share/applications $desktopItem/share/applications/*
+        if [ -e "${browser}/share/icons" ]; then
+            mkdir -p "$out/share"
+            ln -s "${browser}/share/icons" "$out/share/icons"
+        else
+            mkdir -p "$out/share/icons/hicolor/128x128/apps"
+            ln -s "${browser}/lib/${browserName}-"*"/browser/icons/mozicon128.png" \
+                "$out/share/icons/hicolor/128x128/apps/${browserName}.png"
+        fi
 
-    mkdir -p $out/lib/mozilla
-    for ext in ${toString nativeMessagingHosts}; do
-        ${lndir}/bin/lndir -silent $ext/lib/mozilla $out/lib/mozilla
-    done
+        install -D -t $out/share/applications $desktopItem/share/applications/*
 
-    # For manpages, in case the program supplies them
-    mkdir -p $out/nix-support
-    echo ${browser} > $out/nix-support/propagated-user-env-packages
-  '';
+        mkdir -p $out/lib/mozilla
+        for ext in ${toString nativeMessagingHosts}; do
+            ${lndir}/bin/lndir -silent $ext/lib/mozilla $out/lib/mozilla
+        done
 
-  preferLocalBuild = true;
+        # For manpages, in case the program supplies them
+        mkdir -p $out/nix-support
+        echo ${browser} > $out/nix-support/propagated-user-env-packages
+      '';
 
-  # Let each plugin tell us (through its `mozillaPlugin') attribute
-  # where to find the plugin in its tree.
-  plugins = map (x: x + x.mozillaPlugin) plugins;
-  libs = lib.makeLibraryPath libs + ":" + lib.makeSearchPathOutput "lib" "lib64" libs;
-  gtk_modules = map (x: x + x.gtkModule) gtk_modules;
+      preferLocalBuild = true;
 
-  passthru = { unwrapped = browser; };
+      # Let each plugin tell us (through its `mozillaPlugin') attribute
+      # where to find the plugin in its tree.
+      plugins = map (x: x + x.mozillaPlugin) plugins;
+      libs = lib.makeLibraryPath libs + ":" + lib.makeSearchPathOutput "lib" "lib64" libs;
+      gtk_modules = map (x: x + x.gtkModule) gtk_modules;
 
-  disallowedRequisites = [ stdenv.cc ];
+      passthru = { unwrapped = browser; };
 
-  meta = browser.meta // {
-    description =
-      browser.meta.description
-      + " (with plugins: "
-      + lib.concatStrings (lib.intersperse ", " (map (x: x.name) plugins))
-      + ")";
-    hydraPlatforms = [];
-    priority = (browser.meta.priority or 0) - 1; # prefer wrapper over the package
-  };
-}
+      disallowedRequisites = [ stdenv.cc ];
+
+      meta = browser.meta // {
+        description =
+          browser.meta.description
+          + " (with plugins: "
+          + lib.concatStrings (lib.intersperse ", " (map (x: x.name) plugins))
+          + ")";
+        hydraPlatforms = [];
+        priority = (browser.meta.priority or 0) - 1; # prefer wrapper over the package
+      };
+    };
+in
+  lib.makeOverridable wrapper


### PR DESCRIPTION
### Motivation

1. The Firefox wrapper is now overridable so that users may inject plugins and native messaging hosts without modifying the wrapper code.
2. An option enableBrowserpass is added to enable the browserpass native messaging host.


### Testing

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

