### PR TITLE
nixos-container: Make show-ip work together with ipv4 + netmask

### DIFF
--- a/nixos/tests/containers-bridge.nix
+++ b/nixos/tests/containers-bridge.nix
@@ -69,6 +69,12 @@ import ./make-test.nix ({ pkgs, ...} : {
       $machine->succeed("ping -n -c 1 $ip6");
       $machine->succeed("curl --fail http://[$ip6]/ > /dev/null");
 
+      # Check that nixos-container show-ip works in case of an ipv4 address with
+      # subnetmask in CIDR notation.
+      my $result = $machine->succeed("nixos-container show-ip webserver");
+      chomp $result;
+      $result eq $ip or die;
+
       # Stop the container.
       $machine->succeed("nixos-container stop webserver");
       $machine->fail("curl --fail --connect-timeout 2 http://$ip/ > /dev/null");

--- a/pkgs/tools/virtualization/nixos-container/nixos-container.pl
+++ b/pkgs/tools/virtualization/nixos-container/nixos-container.pl
@@ -331,7 +331,7 @@ elsif ($action eq "run") {
 
 elsif ($action eq "show-ip") {
     my $s = read_file($confFile) or die;
-    $s =~ /^LOCAL_ADDRESS=([0-9\.]+)$/m or die "$0: cannot get IP address\n";
+    $s =~ /^LOCAL_ADDRESS=([0-9\.]+)(\/[0-9]+)?$/m or die "$0: cannot get IP address\n";
     print "$1\n";
 }
 


### PR DESCRIPTION
###### Motivation for this change
The containers local address can be given as ipv4 only or with a subnetmask in
CIDR notation in the container configuration, see [1]. This works fine but the
'nixos-container show-ip' only supports plain ipv4 addresses without the netmask
suffix.

[1] https://github.com/NixOS/nixpkgs/blob/9939032e35bb144bc8f6b57ed6325089910f738c/nixos/modules/virtualisation/containers.nix#L382

###### Things done
- Changed the regex to also match in case of a CIDR netmask suffix.
- Modified an exiting test to also cover this case.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

