### PR TITLE
cctools, darwin-bintuils: Don't always bring in headers

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
@@ -23,7 +23,7 @@ appleDerivation rec {
       (cd $dep/include && find . -name '*.h' | cpio -pdm $out/include)
     done
 
-    (cd ${cctools}/include/mach-o && find . -name '*.h' | cpio -pdm $out/include/mach-o)
+    (cd ${cctools.dev}/include/mach-o && find . -name '*.h' | cpio -pdm $out/include/mach-o)
 
     cat <<EOF > $out/include/TargetConditionals.h
     #ifndef __TARGETCONDITIONALS__

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -37,17 +37,12 @@ stdenv.mkDerivation {
       ln -sf "${cctools}/bin/$i" "$out/bin/$i"
     done
 
-    for i in ${stdenv.lib.getDev binutils-raw}/include/*.h; do
-      ln -s "$i" "$out/include/$(basename $i)"
-    done
-
     for i in ${cctools}/include/*; do
       ln -s "$i" "$out/include/$(basename $i)"
     done
 
     # FIXME: this will give us incorrect man pages for bits of cctools
     ln -s ${binutils-raw.out}/share $out/share
-    ln -s ${binutils-raw.out}/lib $out/lib
 
     ln -s ${cctools}/libexec $out/libexec
   '';

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -37,10 +37,6 @@ stdenv.mkDerivation {
       ln -sf "${cctools}/bin/$i" "$out/bin/$i"
     done
 
-    for i in ${cctools}/include/*; do
-      ln -s "$i" "$out/include/$(basename $i)"
-    done
-
     # FIXME: this will give us incorrect man pages for bits of cctools
     ln -s ${binutils-raw.out}/share $out/share
 

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -29,6 +29,8 @@ let
       sha256 = "0l45mvyags56jfi24rawms8j2ihbc45mq7v13pkrrwppghqrdn52";
     };
 
+    outputs = [ "out" "dev" ];
+
     nativeBuildInputs = [ autoconf automake libtool_2 ];
     buildInputs = [ libuuid ] ++
       # Only need llvm and clang if the stdenv isn't already clang-based (TODO: just make a stdenv.cc.isClang)


### PR DESCRIPTION
###### Motivation for this change

Basically the goal is separation of concerns / mirroring GNU Binutils.

 -  Give cctools a dev output for the headers

 - Darwin binutils don't try to include headers from GNU binutils as it doesn't produce any (that's now the libbfd derivation's responsibility). Also don't include any from cctools; just use the default "out" output not "dev.

The headers are included with Libsystem, which is where I'd guess anything that uses them would be finding them anyways.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

