### PR TITLE
libmpack: fix darwin build

### DIFF
--- a/pkgs/development/interpreters/lua-5/5.1.nix
+++ b/pkgs/development/interpreters/lua-5/5.1.nix
@@ -8,7 +8,8 @@ let
   };
 in
 stdenv.mkDerivation rec {
-  name = "lua-5.1.5";
+  name = "lua-${version}";
+  version = "5.1.5";
   luaversion = "5.1";
 
   src = fetchurl {

--- a/pkgs/development/libraries/libmpack/default.nix
+++ b/pkgs/development/libraries/libmpack/default.nix
@@ -9,11 +9,11 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "0rai5djdkjz7bsn025k5489in7r1amagw1pib0z4qns6b52kiar2";
   };
-  LIBTOOL = "libtool";
-  buildInputs = [ libtool ];
-  preInstall = ''
-    export PREFIX=$out
-  '';
+
+  nativeBuildInputs = [ libtool ];
+
+  makeFlags = [ "LIBTOOL=libtool" "PREFIX=$(out)" ];
+
   meta = with stdenv.lib; {
     description = "Simple implementation of msgpack in C";
     homepage = https://github.com/tarruda/libmpack/;

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -614,34 +614,30 @@ let
   };
 
   mpack = buildLuaPackage rec {
-    name = "lua-mpack-${version}";
-    version = "1.0.7_${rev}";
-    rev = "ef025224a799066b818120fb1f30a308543a6e99";
+    name = "mpack-${version}";
+    version = "1.0.7";
 
     src = fetchFromGitHub {
       owner = "libmpack";
       repo = "libmpack-lua";
-      inherit rev;
+      rev = version;
       sha256 = "1nydi6xbmxwl1fmi32v5v8n74msnmzblzqaqnb102w6vkinampsb";
     };
 
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ libmpack ]; # ++ [ libtool lua ];
+    buildInputs = [ libmpack ];
     dontBuild = true;
 
-    preInstall = ''
-      mkdir -p $out/lib/lua/${lua.luaversion}
-      export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${libmpack}
+    postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+      substituteInPlace Makefile \
+        --replace '-shared' '-bundle -undefined dynamic_lookup -all_load'
     '';
-
-    NIX_CFLAGS_COMPILE = "-Wno-error -fpic";
 
     installFlags = [
       "USE_SYSTEM_LUA=yes"
       "USE_SYSTEM_MPACK=yes"
-      "MPACK_LUA_VERSION=${(builtins.parseDrvName lua.name).version}"
-      "LUA_INCLUDE=-I${lua}/include"
-      "LUA_CMOD_INSTALLDIR=$$out/lib/lua/${lua.luaversion}"
+      "MPACK_LUA_VERSION=${lua.version}"
+      "LUA_CMOD_INSTALLDIR=$(out)/lib/lua/${lua.luaversion}"
     ];
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
On darwin we need the correct prefix during the buildPhase, otherwise
the dynamic libraries have an incorrect install_name.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

