### PR TITLE
stdman: d860212 -> 2017.04.02

### DIFF
--- a/pkgs/data/documentation/stdman/default.nix
+++ b/pkgs/data/documentation/stdman/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "stdman-${version}";
-  version = "d860212";
+  version = "2017.04.02";
 
   src = fetchFromGitHub {
     owner = "jeaye";
     repo = "stdman";
-    rev = "d860212767ca60472e33aa3bad22a3eac834b1f8";
-    sha256 = "09c5gjhcz97ghfrv9zkgfb1wckvmqnhbzga0xidbm1ir7640di8l";
+    rev = "${version}";
+    sha256 = "1wfxd9ca8b9l976rnlhjd0sp364skfm99wxi633swwwjvhy26sgm";
   };
 
   outputDevdoc = "out";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ curl ];
 
   meta = with stdenv.lib; {
-    description = "Formatted C++11/14 stdlib man pages (cppreference)";
+    description = "Formatted C++17 stdlib man pages (cppreference)";
     longDescription = "stdman is a tool that parses archived HTML
       files from cppreference and generates groff-formatted manual
       pages for Unix-based systems. The goal is to provide excellent


### PR DESCRIPTION
###### Motivation for this change
C++17 is a thing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

