### PR TITLE
Harden ssh config defaults and remove old host key support

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -72,6 +72,29 @@ following incompatible changes:</para>
       <option>services.pgmanage</option>.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      <emphasis role="strong">
+        The OpenSSH service no longer enables support for DSA keys by default,
+        which could cause a system lock out. Update your keys or, unfavorably,
+        re-enable DSA support manually.
+      </emphasis>
+    </para>
+
+    <para>
+      DSA support was
+      <link xlink:href="https://www.openssh.com/legacy.html">deprecated in OpenSSH 7.0</link>,
+      due to it being too weak. To re-enable support, add
+      <literal>PubkeyAcceptedKeyTypes +ssh-dss</literal> to the end of your
+      <option>services.openssh.extraConfig</option>.
+    </para>
+
+    <para>
+      After updating the keys to be stronger, anyone still on a pre-17.03
+      version is safe to jump to 17.03, as vetted
+      <link xlink:href="https://search.nix.gsc.io/?q=stateVersion">here</link>.
+    </para>
+  </listitem>
 </itemizedlist>
 
 </section>

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -358,6 +358,21 @@ in
           HostKey ${k.path}
         '')}
 
+        ### Recommended settings from both:
+        # https://stribika.github.io/2015/01/04/secure-secure-shell.html
+        # and
+        # https://wiki.mozilla.org/Security/Guidelines/OpenSSH#Modern_.28OpenSSH_6.7.2B.29
+
+        KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+        Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+        MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com
+
+        # LogLevel VERBOSE logs user's key fingerprint on login.
+        # Needed to have a clear audit track of which key was used to log in.
+        LogLevel VERBOSE
+
+        # Use kernel sandbox mechanisms where possible in unprivileged processes.
+        UsePrivilegeSeparation sandbox
       '';
 
     assertions = [{ assertion = if cfg.forwardX11 then cfgc.setXAuthLocation else true;

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -54,8 +54,6 @@ let
     ));
   in listToAttrs (map mkAuthKeyFile usersWithKeys);
 
-  supportOldHostKeys = !versionAtLeast config.system.stateVersion "15.07";
-
 in
 
 {
@@ -191,9 +189,6 @@ in
         default =
           [ { type = "rsa"; bits = 4096; path = "/etc/ssh/ssh_host_rsa_key"; }
             { type = "ed25519"; path = "/etc/ssh/ssh_host_ed25519_key"; }
-          ] ++ optionals supportOldHostKeys
-          [ { type = "dsa"; path = "/etc/ssh/ssh_host_dsa_key"; }
-            { type = "ecdsa"; bits = 521; path = "/etc/ssh/ssh_host_ecdsa_key"; }
           ];
         description = ''
           NixOS can automatically generate SSH host keys.  This option
@@ -363,14 +358,6 @@ in
           HostKey ${k.path}
         '')}
 
-        # Allow DSA client keys for now. (These were deprecated
-        # in OpenSSH 7.0.)
-        PubkeyAcceptedKeyTypes +ssh-dss
-
-        # Re-enable DSA host keys for now.
-        ${optionalString supportOldHostKeys ''
-          HostKeyAlgorithms +ssh-dss
-        ''}
       '';
 
     assertions = [{ assertion = if cfg.forwardX11 then cfgc.setXAuthLocation else true;


### PR DESCRIPTION
###### Motivation for this change
To better harden the SSH service by default. This was originally mentioned by @jpierre03 here: https://github.com/NixOS/nixpkgs/issues/20161#issuecomment-274335279 -- I'm just looking to get the ball rolling.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Things to note

This breaks backward compatibility with anyone using `supportOldHostKeys`. If people want that, I think `extraConfig` will do the trick.

---