### PR TITLE
czmq: Fix build with gcc-7

### DIFF
--- a/pkgs/development/libraries/czmq/3.x.nix
+++ b/pkgs/development/libraries/czmq/3.x.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "16k9awrhdsymx7dnmvqcnkaq8lz8x8zppy6sh7ls8prpd6mkkjlb";
   };
 
+  patches = [ ./czmq3-gcc7.patch ];
+
   # Fix build on Glibc 2.24.
   NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
 

--- a/pkgs/development/libraries/czmq/4.x.nix
+++ b/pkgs/development/libraries/czmq/4.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zeromq }:
+{ stdenv, fetchurl, fetchpatch, zeromq }:
 
 stdenv.mkDerivation rec {
   version = "4.0.2";
@@ -8,6 +8,13 @@ stdenv.mkDerivation rec {
     url = "https://github.com/zeromq/czmq/releases/download/v${version}/${name}.tar.gz";
     sha256 = "12gbh57xnz2v82x1g80gv4bwapmyzl00lbin5ix3swyac8i7m340";
   };
+
+  patches = [
+    (fetchpatch {
+      url = https://patch-diff.githubusercontent.com/raw/zeromq/czmq/pull/1618.patch;
+      sha256 = "1dssy7k0fni6djail8rz0lk8p777158jvrqhgn500i636gkxaxhp";
+    })
+  ];
 
   # Needs to be propagated for the .pc file to work
   propagatedBuildInputs = [ zeromq ];

--- a/pkgs/development/libraries/czmq/czmq3-gcc7.patch
+++ b/pkgs/development/libraries/czmq/czmq3-gcc7.patch
@@ -1,0 +1,26 @@
+diff --git a/src/zgossip_engine.inc b/src/zgossip_engine.inc
+index 37dbb4eb..727aaa9b 100644
+--- a/src/zgossip_engine.inc
++++ b/src/zgossip_engine.inc
+@@ -258,7 +258,7 @@ engine_set_log_prefix (client_t *client, const char *string)
+ {
+     if (client) {
+         s_client_t *self = (s_client_t *) client;
+-        snprintf (self->log_prefix, sizeof (self->log_prefix) - 1,
++        snprintf (self->log_prefix, sizeof (self->log_prefix),
+             "%6d:%-33s", self->unique_id, string);
+     }
+ }
+diff --git a/src/zsys.c b/src/zsys.c
+index 4d0bb8a1..f07db9c8 100644
+--- a/src/zsys.c
++++ b/src/zsys.c
+@@ -1071,7 +1071,7 @@ zsys_run_as (const char *lockfile, const char *group, const char *user)
+             }
+         }
+         //   We record the current process id in the lock file
+-        char pid_buffer [10];
++        char pid_buffer [32];
+         snprintf (pid_buffer, sizeof (pid_buffer), "%6d\n", getpid ());
+         if (write (handle, pid_buffer, strlen (pid_buffer)) != strlen (pid_buffer)) {
+             zsys_error ("cannot write to lockfile: %s", strerror (errno));


### PR DESCRIPTION
###### Motivation for this change
See tracking issue https://github.com/NixOS/nixpkgs/issues/31747

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

