### PR TITLE
doc: improve rustPlatform example

### DIFF
--- a/doc/languages-frameworks/rust.md
+++ b/doc/languages-frameworks/rust.md
@@ -24,9 +24,7 @@ overlay](#using-the-rust-nightlies-overlay).
 Rust applications are packaged by using the `buildRustPackage` helper from `rustPlatform`:
 
 ```
-with rustPlatform;
-
-buildRustPackage rec {
+rustPlatform.buildRustPackage rec {
   name = "ripgrep-${version}";
   version = "0.4.0";
 
@@ -40,9 +38,9 @@ buildRustPackage rec {
   cargoSha256 = "0q68qyl2h6i0qsz82z840myxlnjay8p1w5z7hfyr8fqp7wgwa9cx";
 
   meta = with stdenv.lib; {
-    description = "A utility that combines the usability of The Silver Searcher with the raw speed of grep";
+    description = "A fast line-oriented regex search tool, similar to ag and ack";
     homepage = https://github.com/BurntSushi/ripgrep;
-    license = with licenses; [ unlicense ];
+    license = licenses.unlicense;
     maintainers = [ maintainers.tailhook ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
###### Motivation for this change

Currently quite a few of rust packages contain:
```
with rustPlatform;
 
buildRustPackage rec {
```
where the only used `rustPlatform` attr is `buildRustPackage`. This is nonsensical and confusing, and it seems to stem from the example in the manual.