### PR TITLE
makeWrapper: add --set-default

### DIFF
--- a/pkgs/applications/networking/cluster/mesos/default.nix
+++ b/pkgs/applications/networking/cluster/mesos/default.nix
@@ -14,6 +14,8 @@ let
   #   src/common/command_utils.cpp
   # https://github.com/NixOS/nixpkgs/issues/13783
   tarWithGzip = lib.overrideDerivation gnutar (oldAttrs: {
+    # Original builder is bash 4.3.42 from bootstrap tools, too old for makeWrapper.
+    builder = "${bash}/bin/bash";
     buildInputs = (oldAttrs.buildInputs or []) ++ [ makeWrapper ];
     postInstall = (oldAttrs.postInstall or "") + ''
       wrapProgram $out/bin/tar --prefix PATH ":" "${gzip}/bin"

--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -48,6 +48,16 @@ makeWrapper() {
             value="${params[$((n + 2))]}"
             n=$((n + 2))
             echo "export $varName=${value@Q}" >> "$wrapper"
+        elif [[ "$p" == "--set-default" ]]; then
+            varName="${params[$((n + 1))]}"
+            value="${params[$((n + 2))]}"
+            n=$((n + 2))
+            echo "export $varName=\${$varName-${value@Q}}" >> "$wrapper"
+        elif [[ "$p" == "--set-eval" ]]; then
+            varName="${params[$((n + 1))]}"
+            value="${params[$((n + 2))]}"
+            n=$((n + 2))
+            echo "export $varName=\$(eval echo ${value@Q})" >> "$wrapper"
         elif [[ "$p" == "--unset" ]]; then
             varName="${params[$((n + 1))]}"
             n=$((n + 1))

--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -53,11 +53,6 @@ makeWrapper() {
             value="${params[$((n + 2))]}"
             n=$((n + 2))
             echo "export $varName=\${$varName-${value@Q}}" >> "$wrapper"
-        elif [[ "$p" == "--set-eval" ]]; then
-            varName="${params[$((n + 1))]}"
-            value="${params[$((n + 2))]}"
-            n=$((n + 2))
-            echo "export $varName=\$(eval echo ${value@Q})" >> "$wrapper"
         elif [[ "$p" == "--unset" ]]; then
             varName="${params[$((n + 1))]}"
             n=$((n + 1))

--- a/pkgs/development/compilers/dmd/2.067.1.nix
+++ b/pkgs/development/compilers/dmd/2.067.1.nix
@@ -146,7 +146,7 @@ stdenv.mkDerivation rec {
 
       wrapProgram $out/bin/dmd \
           --prefix PATH ":" "${stdenv.cc}/bin" \
-          --set CC "$""{CC:-$CC""}"
+          --set-default CC "$CC"
 
       cd $out/bin
       tee dmd.conf << EOF

--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -152,7 +152,7 @@ stdenv.mkDerivation rec {
 
       wrapProgram $out/bin/dmd \
           --prefix PATH ":" "${stdenv.cc}/bin" \
-          --set CC "$""{CC:-$CC""}"
+          --set-default CC "$CC"
 
       cd $out/bin
       tee dmd.conf << EOF

--- a/pkgs/misc/emulators/retrofe/default.nix
+++ b/pkgs/misc/emulators/retrofe/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     wrapProgram "$out/bin/retrofe" \
       --prefix GST_PLUGIN_PATH : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
-      --set-eval RETROFE_PATH '$''\{RETROFE_PATH:-$PWD}'
+      --run 'export RETROFE_PATH=''${RETROFE_PATH:-$PWD}'
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/misc/emulators/retrofe/default.nix
+++ b/pkgs/misc/emulators/retrofe/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     wrapProgram "$out/bin/retrofe" \
       --prefix GST_PLUGIN_PATH : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
-      --set    RETROFE_PATH      "\''${RETROFE_PATH:-\$PWD}"
+      --set-eval RETROFE_PATH '$''\{RETROFE_PATH:-$PWD}'
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/nosql/apache-jena/fuseki-binary.nix
+++ b/pkgs/servers/nosql/apache-jena/fuseki-binary.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     for i in "$out"/bin/*; do
       wrapProgram "$i" \
         --prefix "PATH" : "${java}/bin/" \
-        --set "FUSEKI_HOME" '"''${FUSEKI_HOME:-'"$out"'}"' \
+        --set-default "FUSEKI_HOME" "$out" \
         ;
     done
   '';

--- a/pkgs/tools/text/popfile/default.nix
+++ b/pkgs/tools/text/popfile/default.nix
@@ -44,8 +44,8 @@ stdenv.mkDerivation rec {
       wrapProgram "$path" \
         --prefix PERL5LIB : $PERL5LIB:$out/bin \
         --set POPFILE_ROOT $out/bin \
-        --set POPFILE_USER \$\{POPFILE_USER:-\$HOME/.popfile\} \
-        --run "test -d \$POPFILE_USER || mkdir -m 0700 -p \$POPFILE_USER"
+        --set-eval POPFILE_USER '$''\{POPFILE_USER:-$HOME/.popfile}' \
+        --run 'test -d "$POPFILE_USER" || mkdir -m 0700 -p "$POPFILE_USER"'
     done
   '';
 

--- a/pkgs/tools/text/popfile/default.nix
+++ b/pkgs/tools/text/popfile/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       wrapProgram "$path" \
         --prefix PERL5LIB : $PERL5LIB:$out/bin \
         --set POPFILE_ROOT $out/bin \
-        --set-eval POPFILE_USER '$''\{POPFILE_USER:-$HOME/.popfile}' \
+        --run 'export POPFILE_USER=''${POPFILE_USER:-$HOME/.popfile}' \
         --run 'test -d "$POPFILE_USER" || mkdir -m 0700 -p "$POPFILE_USER"'
     done
   '';


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/31497#issuecomment-345195640

After #31497 starter quoting all values, there arouse the need to left some values evaluated.

`--set-default var value` expands to `export var=${var-value}`, where value is not evaluated and literally assigned to var unless it is already set.

~~`--set-eval var value` expands to `export var=$(eval echo value)`, where value is evaluated by `eval`.~~ `--run 'export var=expr'` should be used instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).