### PR TITLE
vagrant: 2.0.0 -> 2.0.1 (fixes vagrant with virtualbox 5.2)

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -1,14 +1,8 @@
-{ stdenv, fetchurl, fetchpatch, dpkg, curl, libarchive, openssl, ruby, buildRubyGem, libiconv
+{ stdenv, fetchurl, fetchpatch, dpkg, curl, libarchive, openssl, rake, ruby, buildRubyGem, libiconv
 , libxml2, libxslt, libffi, makeWrapper, p7zip, xar, gzip, cpio }:
 
 let
   version = "2.0.1";
-  rake = buildRubyGem {
-    inherit ruby;
-    gemName = "rake";
-    version = "10.4.2";
-    sha256 = "1rn03rqlf1iv6n87a78hkda2yqparhhaivfjpizblmxvlw2hk5r8";
-  };
 
   url = if stdenv.isLinux
     then "https://releases.hashicorp.com/vagrant/${version}/vagrant_${version}_${arch}.deb"

--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -2,7 +2,7 @@
 , libxml2, libxslt, libffi, makeWrapper, p7zip, xar, gzip, cpio }:
 
 let
-  version = "2.0.0";
+  version = "2.0.1";
   rake = buildRubyGem {
     inherit ruby;
     gemName = "rake";
@@ -17,9 +17,9 @@ let
       else "system ${stdenv.system} not supported";
 
   sha256 = {
-    "x86_64-linux"  = "184amybyxqlxqr8fk6lyx2znmci1fazsiby90q7d1xx2ihz3hm5x";
-    "i686-linux"    = "19r1m5jila40x69m1qz2hslz7v1hdg8wwdhcq8d5qjnzwfmlw2qz";
-    "x86_64-darwin" = "154400iqs01235bclr8ic7g9jv01lfs766bmv7p8784r3xsblvsr";
+    "x86_64-linux"  = "0kyqchjsy747vbvhqiynz81kik8g0xqpkv70rz7hyr9x7fl9i51g";
+    "i686-linux"    = "0p3xhxy6shkd0393wjyj8qycdn3zqv60vnyz1b6zclz0kfah07zs";
+    "x86_64-darwin" = "01hr5j9k31hsdlcwv3srzk0lphd8w0n9z95jvfkschdyjm9clpwm";
   }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   arch = builtins.replaceStrings ["-linux" "-darwin"] ["" ""] stdenv.system;


### PR DESCRIPTION
###### Motivation for this change


With the recent virtualbox bump to 5.2 vagrant is no longer able to interface with virtualbox. Version 2.01 fixes that.

While doing that I figured that the custom rake gem doesn't seem to have any purpose anymore. Our standard `pkgs.rake` works just as well so that is the 2nd commit in this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

