### PR TITLE
stdenv setup: Always use both propagated files

### DIFF
--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -164,8 +164,6 @@ _multioutDevs() {
 }
 
 # Make the "dev" propagate other outputs needed for development.
-# Note: with current cross-building setup, all packages are "native" if not cross-building;
-# however, if cross-building, the outputs are non-native. We have to choose the right file.
 _multioutPropagateDev() {
     if [ "$outputs" = "out" ]; then return; fi;
 
@@ -193,16 +191,8 @@ _multioutPropagateDev() {
         return
     fi
 
-    local propagatedBuildInputsFile
-    if [ -z "$crossConfig" ]; then
-        propagatedBuildInputsFile=propagated-native-build-inputs
-    else
-        propagatedBuildInputsFile=propagated-build-inputs
-    fi
-
     mkdir -p "${!propagaterOutput}"/nix-support
     for output in $propagatedBuildOutputs; do
-        echo -n " ${!output}" >> "${!propagaterOutput}"/nix-support/$propagatedBuildInputsFile
+        echo -n " ${!output}" >> "${!propagaterOutput}"/nix-support/propagated-build-inputs
     done
 }
-

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -101,7 +101,7 @@ rec {
         mkdir -p $out/nix-support
         cp ${script} $out/nix-support/setup-hook
       '' + lib.optionalString (deps != []) ''
-        printWords ${toString deps} > $out/nix-support/propagated-native-build-inputs
+        printWords ${toString deps} > $out/nix-support/propagated-build-inputs
       '' + lib.optionalString (substitutions != {}) ''
         substituteAll ${script} $out/nix-support/setup-hook
       '');

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -58,11 +58,7 @@ let
                     # Propagate $dev so that this setup hook is propagated
                     # But only if there is a separate $dev output
                     if [ "$outputDev" != out ]; then
-                        if [ -n "$crossConfig" ]; then
-                          propagatedBuildInputs="$propagatedBuildInputs @dev@"
-                        else
-                          propagatedNativeBuildInputs="$propagatedNativeBuildInputs @dev@"
-                        fi
+                        propagatedBuildInputs="$propagatedBuildInputs @dev@"
                     fi
                 fi
               '';

--- a/pkgs/development/compilers/openjdk-darwin/8.nix
+++ b/pkgs/development/compilers/openjdk-darwin/8.nix
@@ -33,7 +33,7 @@ let
       # any package that depends on the JRE has $CLASSPATH set up
       # properly.
       mkdir -p $out/nix-support
-      printWords ${setJavaClassPath} > $out/nix-support/propagated-native-build-inputs
+      printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
 
       install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${freetype}/lib/libfreetype.6.dylib $out/jre/lib/libfontmanager.dylib
 

--- a/pkgs/development/compilers/openjdk-darwin/default.nix
+++ b/pkgs/development/compilers/openjdk-darwin/default.nix
@@ -23,7 +23,7 @@ let
       # any package that depends on the JRE has $CLASSPATH set up
       # properly.
       mkdir -p $out/nix-support
-      printWords ${setJavaClassPath} > $out/nix-support/propagated-native-build-inputs
+      printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
 
       install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${freetype}/lib/libfreetype.6.dylib $out/jre/lib/libfontmanager.dylib
 

--- a/pkgs/development/compilers/openjdk/7.nix
+++ b/pkgs/development/compilers/openjdk/7.nix
@@ -184,13 +184,13 @@ let
     preFixup = ''
       prefix=$jre stripDirs "$stripDebugList" "''${stripDebugFlags:--S}"
       patchELF $jre
-      propagatedNativeBuildInputs+=" $jre"
+      propagatedBuildInputs+=" $jre"
 
       # Propagate the setJavaClassPath setup hook from the JRE so that
       # any package that depends on the JRE has $CLASSPATH set up
       # properly.
       mkdir -p $jre/nix-support
-      printWords ${setJavaClassPath} > $jre/nix-support/propagated-native-build-inputs
+      printWords ${setJavaClassPath} > $jre/nix-support/propagated-build-inputs
 
       # Set JAVA_HOME automatically.
       mkdir -p $out/nix-support

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -206,13 +206,13 @@ let
     preFixup = ''
       prefix=$jre stripDirs "$stripDebugList" "''${stripDebugFlags:--S}"
       patchELF $jre
-      propagatedNativeBuildInputs+=" $jre"
+      propagatedBuildInputs+=" $jre"
 
       # Propagate the setJavaClassPath setup hook from the JRE so that
       # any package that depends on the JRE has $CLASSPATH set up
       # properly.
       mkdir -p $jre/nix-support
-      printWords ${setJavaClassPath} > $jre/nix-support/propagated-native-build-inputs
+      printWords ${setJavaClassPath} > $jre/nix-support/propagated-build-inputs
 
       # Set JAVA_HOME automatically.
       mkdir -p $out/nix-support

--- a/pkgs/development/compilers/openjdk/9.nix
+++ b/pkgs/development/compilers/openjdk/9.nix
@@ -204,14 +204,14 @@ let
     preFixup = ''
       prefix=$jre stripDirs "$stripDebugList" "''${stripDebugFlags:--S}"
       patchELF $jre
-      propagatedNativeBuildInputs+=" $jre"
+      propagatedBuildInputs+=" $jre"
 
       # Propagate the setJavaClassPath setup hook from the JRE so that
       # any package that depends on the JRE has $CLASSPATH set up
       # properly.
       mkdir -p $jre/nix-support
       #TODO or printWords?  cf https://github.com/NixOS/nixpkgs/pull/27427#issuecomment-317293040
-      echo -n "${setJavaClassPath}" > $jre/nix-support/propagated-native-build-inputs
+      echo -n "${setJavaClassPath}" > $jre/nix-support/propagated-build-inputs
 
       # Set JAVA_HOME automatically.
       mkdir -p $out/nix-support

--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -166,7 +166,7 @@ let result = stdenv.mkDerivation rec {
     ln -s $jrePath/lib/${architecture}/libnpjp2.so $jrePath/lib/${architecture}/plugins
 
     mkdir -p $out/nix-support
-    printWords ${setJavaClassPath} > $out/nix-support/propagated-native-build-inputs
+    printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
 
     # Set JAVA_HOME automatically.
     cat <<EOF >> $out/nix-support/setup-hook

--- a/pkgs/development/compilers/oraclejdk/jdk9-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk9-linux.nix
@@ -124,7 +124,7 @@ let result = stdenv.mkDerivation rec {
     ln -s $out $out/jre
 
     mkdir -p $out/nix-support
-    printWords ${setJavaClassPath} > $out/nix-support/propagated-native-build-inputs
+    printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
 
     # Set JAVA_HOME automatically.
     cat <<EOF >> $out/nix-support/setup-hook

--- a/pkgs/development/compilers/zulu/8.nix
+++ b/pkgs/development/compilers/zulu/8.nix
@@ -54,7 +54,7 @@ in stdenv.mkDerivation rec {
     find $out -name "*.so" -exec patchelf --set-rpath "$rpath" {} \;
 
     mkdir -p $out/nix-support
-    printWords ${setJavaClassPath} > $out/nix-support/propagated-native-build-inputs
+    printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
 
     # Set JAVA_HOME automatically.
     cat <<EOF >> $out/nix-support/setup-hook

--- a/pkgs/development/compilers/zulu/default.nix
+++ b/pkgs/development/compilers/zulu/default.nix
@@ -51,7 +51,7 @@ in stdenv.mkDerivation rec {
     find $out -name "*.so" -exec patchelf --set-rpath "$rpath" {} \;
 
     mkdir -p $out/nix-support
-    printWords ${setJavaClassPath} > $out/nix-support/propagated-native-build-inputs
+    printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
 
     # Set JAVA_HOME automatically.
     cat <<EOF >> $out/nix-support/setup-hook

--- a/pkgs/development/interpreters/python/wrap.sh
+++ b/pkgs/development/interpreters/python/wrap.sh
@@ -83,7 +83,7 @@ wrapPythonProgramsIn() {
 
 # Adds the lib and bin directories to the PYTHONPATH and PATH variables,
 # respectively. Recurses on any paths declared in
-# `propagated-native-build-inputs`, while avoiding duplicating paths by
+# `propagated-build-inputs`, while avoiding duplicating paths by
 # flagging the directories it has visited in `pythonPathsSeen`.
 _addToPythonPath() {
     local dir="$1"
@@ -96,7 +96,7 @@ _addToPythonPath() {
     addToSearchPath program_PATH $dir/bin
 
     # Inspect the propagated inputs (if they exist) and recur on them.
-    local prop="$dir/nix-support/propagated-native-build-inputs"
+    local prop="$dir/nix-support/propagated-build-inputs"
     if [ -e $prop ]; then
         local new_path
         for new_path in $(cat $prop); do

--- a/pkgs/development/libraries/grantlee/5/setup-hook.sh
+++ b/pkgs/development/libraries/grantlee/5/setup-hook.sh
@@ -4,20 +4,14 @@ providesGrantleeRuntime() {
     [ -d "$1/$grantleePluginPrefix" ]
 }
 
-_grantleeCrossEnvHook() {
-    if providesQtRuntime "$1"; then
+_grantleeEnvHook() {
+    if providesGrantleeRuntime "$1"; then
         propagatedBuildInputs+=" $1"
         propagatedUserEnvPkgs+=" $1"
     fi
 }
-crossEnvHooks+=(_grantleeCrossEnvHook)
-
-_grantleeEnvHook() {
-    if providesGrantleeRuntime "$1"; then
-        propagatedNativeBuildInputs+=" $1"
-        if [ -z "$crossConfig" ]; then
-        propagatedUserEnvPkgs+=" $1"
-        fi
-    fi
-}
-envHooks+=(_grantleeEnvHook)
+if [ "$crossEnv" ]; then
+    crossEnvHooks+=(_grantleeEnvHook)
+else
+    envHooks+=(_grantleeEnvHook)
+fi

--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -56,11 +56,7 @@ let
                     # Propagate $dev so that this setup hook is propagated
                     # But only if there is a separate $dev output
                     if [ "$outputDev" != out ]; then
-                        if [ -n "$crossConfig" ]; then
-                          propagatedBuildInputs="$propagatedBuildInputs @dev@"
-                        else
-                          propagatedNativeBuildInputs="$propagatedNativeBuildInputs @dev@"
-                        fi
+                        propagatedBuildInputs="$propagatedBuildInputs @dev@"
                     fi
                 fi
               '';

--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     moveToOutput share/man/man1 "$bin"
   '' + optionalString pythonSupport ''
     mkdir -p $py/nix-support
-    echo ${libxml2.py} >> $py/nix-support/propagated-native-build-inputs
+    echo ${libxml2.py} >> $py/nix-support/propagated-build-inputs
     moveToOutput lib/python2.7 "$py"
   '';
 

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -33,7 +33,7 @@ addToQMAKEPATH() {
 # package depending on the building package. (This is necessary in case
 # the building package does not provide runtime dependencies itself and so
 # would not be propagated to the user environment.)
-qtCrossEnvHook() {
+qtEnvHook() {
     addToQMAKEPATH "$1"
     if providesQtRuntime "$1"; then
         if [ "z${!outputBin}" != "z${!outputDev}" ]; then
@@ -42,20 +42,11 @@ qtCrossEnvHook() {
         propagatedUserEnvPkgs+=" $1"
     fi
 }
-crossEnvHooks+=(qtCrossEnvHook)
-
-qtEnvHook() {
-    addToQMAKEPATH "$1"
-    if providesQtRuntime "$1"; then
-        if [ "z${!outputBin}" != "z${!outputDev}" ]; then
-            propagatedNativeBuildInputs+=" $1"
-        fi
-        if [ -z "$crossConfig" ]; then
-        propagatedUserEnvPkgs+=" $1"
-        fi
-    fi
-}
-envHooks+=(qtEnvHook)
+if [ "$crossConfig" ]; then
+   crossEnvHooks+=(qtEnvHook)
+else
+   envHooks+=(qtEnvHook)
+fi
 
 postPatchMkspecs() {
     local bin="${!outputBin}"

--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -34,8 +34,8 @@ postFixup() {
     # dependencies in the user environment (since Perl modules don't
     # have something like an RPATH, so the only way to find the
     # dependencies is to have them in the PERL5LIB variable).
-    if test -e $out/nix-support/propagated-native-build-inputs; then
-        ln -s $out/nix-support/propagated-native-build-inputs $out/nix-support/propagated-user-env-packages
+    if test -e $out/nix-support/propagated-build-inputs; then
+        ln -s $out/nix-support/propagated-build-inputs $out/nix-support/propagated-user-env-packages
     fi
 }
 

--- a/pkgs/development/r-modules/generic-builder.nix
+++ b/pkgs/development/r-modules/generic-builder.nix
@@ -41,8 +41,8 @@ stdenv.mkDerivation ({
   '';
 
   postFixup = ''
-    if test -e $out/nix-support/propagated-native-build-inputs; then
-        ln -s $out/nix-support/propagated-native-build-inputs $out/nix-support/propagated-user-env-packages
+    if test -e $out/nix-support/propagated-build-inputs; then
+        ln -s $out/nix-support/propagated-build-inputs $out/nix-support/propagated-user-env-packages
     fi
   '';
 

--- a/pkgs/servers/monitoring/munin/default.nix
+++ b/pkgs/servers/monitoring/munin/default.nix
@@ -102,8 +102,8 @@ stdenv.mkDerivation rec {
     find "$out/lib/plugins" -type f -print0 | xargs -0 -L1 \
         sed -i -e "s|/usr/bin/||g" -e "s|/usr/sbin/||g" -e "s|\<bc\>|${bc}/bin/bc|g"
 
-    if test -e $out/nix-support/propagated-native-build-inputs; then
-        ln -s $out/nix-support/propagated-native-build-inputs $out/nix-support/propagated-user-env-packages
+    if test -e $out/nix-support/propagated-build-inputs; then
+        ln -s $out/nix-support/propagated-build-inputs $out/nix-support/propagated-user-env-packages
     fi
 
     for file in "$out"/bin/munindoc "$out"/sbin/munin-* "$out"/lib/munin-* "$out"/www/cgi/*; do

--- a/pkgs/servers/x11/xorg/builder.sh
+++ b/pkgs/servers/x11/xorg/builder.sh
@@ -16,22 +16,18 @@ postInstall() {
 
     echo "propagating requisites $requires"
 
+    if test -n "$crossConfig"; then
+        local pkgs=("${crossPkgs[@]}")
+    else
+        local pkgs=("${nativePkgs[@]}")
+    fi
     for r in $requires; do
-        if test -n "$crossConfig"; then
-            for p in "${crossPkgs[@]}"; do
-                if test -e $p/lib/pkgconfig/$r.pc; then
-                    echo "  found requisite $r in $p"
-                    propagatedBuildInputs="$propagatedBuildInputs $p"
-                fi
-            done
-        else
-            for p in "${nativePkgs[@]}"; do
-                if test -e $p/lib/pkgconfig/$r.pc; then
-                    echo "  found requisite $r in $p"
-                    propagatedNativeBuildInputs="$propagatedNativeBuildInputs $p"
-                fi
-            done
-        fi
+        for p in "${pkgs[@]}"; do
+            if test -e $p/lib/pkgconfig/$r.pc; then
+                echo "  found requisite $r in $p"
+                propagatedBuildInputs+=" $p"
+            fi
+        done
     done
 }
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -239,12 +239,12 @@ isScript() {
 
 # printf unfortunately will print a trailing newline regardless
 printLines() {
-    [[ "$#" -gt 0 ]] || return 0
+    (( "$#" > 0 )) || return 0
     printf '%s\n' "$@"
 }
 
 printWords() {
-    [[ "$#" -gt 0 ]] || return 0
+    (( "$#" > 0 )) || return 0
     printf '%s ' "$@"
 }
 
@@ -302,9 +302,9 @@ runHook addInputsHook
 
 # Recursively find all build inputs.
 findInputs() {
-    local pkg="$1"
-    local var="$2"
-    local propagatedBuildInputsFile="$3"
+    local pkg="$1"; shift
+    local var="$1"; shift
+    local propagatedBuildInputsFiles=("$@")
 
     # TODO(@Ericson2314): Restore using associative array once Darwin
     # nix-shell doesn't use impure bash. This should replace the O(n)
@@ -324,12 +324,16 @@ findInputs() {
         exit 1
     fi
 
-    if [ -f "$pkg/nix-support/$propagatedBuildInputsFile" ]; then
+    local file
+    for file in "${propagatedBuildInputsFiles[@]}"; do
+        file="$pkg/nix-support/$file"
+        [[ -f "$file" ]] || continue
+
         local pkgNext
-        for pkgNext in $(< "$pkg/nix-support/$propagatedBuildInputsFile"); do
-            findInputs "$pkgNext" "$var" "$propagatedBuildInputsFile"
+        for pkgNext in $(< "$file"); do
+            findInputs "$pkgNext" "$var" "${propagatedBuildInputsFiles[@]}"
         done
-    fi
+    done
 }
 
 # Add package to the future PATH and run setup hooks
@@ -362,25 +366,20 @@ if [ -z "${crossConfig:-}" ]; then
     for i in ${nativeBuildInputs:-} ${buildInputs:-} \
              ${defaultNativeBuildInputs:-} ${defaultBuildInputs:-} \
              ${propagatedNativeBuildInputs:-} ${propagatedBuildInputs:-}; do
-        findInputs "$i" nativePkgs propagated-native-build-inputs
-    done
-
-    for i in "${nativePkgs[@]}"; do
-        activatePackage "$i"
+        findInputs "$i" nativePkgs propagated-native-build-inputs propagated-build-inputs
     done
 else
-    for i in ${buildInputs:-} ${defaultBuildInputs:-} ${propagatedBuildInputs:-}; do
-        findInputs "$i" crossPkgs propagated-build-inputs
-    done
-
     for i in ${nativeBuildInputs:-} ${defaultNativeBuildInputs:-} ${propagatedNativeBuildInputs:-}; do
         findInputs "$i" nativePkgs propagated-native-build-inputs
     done
-
-    for i in "${nativePkgs[@]}" "${crossPkgs[@]}"; do
-        activatePackage "$i"
+    for i in ${buildInputs:-} ${defaultBuildInputs:-} ${propagatedBuildInputs:-}; do
+        findInputs "$i" crossPkgs propagated-build-inputs
     done
 fi
+
+for i in ${nativePkgs+"${nativePkgs[@]}"} ${crossPkgs+"${crossPkgs[@]}"}; do
+    activatePackage "$i"
+done
 
 
 # Set the relevant environment variables to point to the build inputs
@@ -898,30 +897,18 @@ fixupPhase() {
 
     # Propagate build inputs and setup hook into the development output.
 
-    if [ -z "${crossConfig:-}" ]; then
-        # Not cross-compiling - propagatedBuildInputs are handled identically to propagatedNativeBuildInputs
-        local propagated="$propagatedNativeBuildInputs"
-        if [ -n "${propagatedBuildInputs:-}" ]; then
-            propagated+="${propagated:+ }$propagatedBuildInputs"
-        fi
-        if [ -n "${propagated:-}" ]; then
-            mkdir -p "${!outputDev}/nix-support"
-            # shellcheck disable=SC2086
-            printWords $propagated > "${!outputDev}/nix-support/propagated-native-build-inputs"
-        fi
-    else
-        if [ -n "${propagatedBuildInputs:-}" ]; then
-            mkdir -p "${!outputDev}/nix-support"
-            # shellcheck disable=SC2086
-            printWords $propagatedBuildInputs > "${!outputDev}/nix-support/propagated-build-inputs"
-        fi
-
-        if [ -n "${propagatedNativeBuildInputs:-}" ]; then
-            mkdir -p "${!outputDev}/nix-support"
-            # shellcheck disable=SC2086
-            printWords $propagatedNativeBuildInputs > "${!outputDev}/nix-support/propagated-native-build-inputs"
-        fi
+    if [ -n "${propagatedBuildInputs:-}" ]; then
+        mkdir -p "${!outputDev}/nix-support"
+        # shellcheck disable=SC2086
+        printWords $propagatedBuildInputs > "${!outputDev}/nix-support/propagated-build-inputs"
     fi
+
+    if [ -n "${propagatedNativeBuildInputs:-}" ]; then
+        mkdir -p "${!outputDev}/nix-support"
+        # shellcheck disable=SC2086
+        printWords $propagatedNativeBuildInputs > "${!outputDev}/nix-support/propagated-native-build-inputs"
+    fi
+
 
     if [ -n "${setupHook:-}" ]; then
         mkdir -p "${!outputDev}/nix-support"

--- a/pkgs/tools/filesystems/ceph/generic.nix
+++ b/pkgs/tools/filesystems/ceph/generic.nix
@@ -227,9 +227,9 @@ stdenv.mkDerivation {
     wrapProgram $out/sbin/ceph-create-keys ${wrapArgs}
     wrapProgram $out/sbin/ceph-disk ${wrapArgs}
 
-    # Bring in lib as a native build input
+    # Bring in lib as a run-time dependency
     mkdir -p $out/nix-support
-    echo "$lib" > $out/nix-support/propagated-native-build-inputs
+    echo "$lib" > $out/nix-support/propagated-build-inputs
 
     # Fix the python library loading
     find $lib/lib -name \*.pyc -or -name \*.pyd -exec rm {} \;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9748,7 +9748,7 @@ with pkgs;
     # the hook to find catalogs is hidden by buildEnv
     postBuild = ''
       mkdir "$out/nix-support"
-      cp '${libxml2.dev}/nix-support/propagated-native-build-inputs' "$out/nix-support/"
+      cp '${libxml2.dev}/nix-support/propagated-build-inputs' "$out/nix-support/"
     '';
   };
 


### PR DESCRIPTION
###### Motivation for this change

This continues #23374, which always kept around both attributes, by always including both propagated files: `propgated-native-build-inputs` and `propagated-build-inputs`. `nativePkgs` and `crossPkgs` are still defined as before, however, so this change should only barely observable.

This is an incremental step to fully keeping the dependencies separate in all cases, as is done in https://github.com/NixOS/nixpkgs/pull/26805 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

