### PR TITLE
catch: 1.9.6 -> 1.11.0

### DIFF
--- a/pkgs/development/libraries/catch/default.nix
+++ b/pkgs/development/libraries/catch/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "catch-${version}";
-  version = "1.9.6";
+  version = "1.11.0";
 
   src = fetchFromGitHub {
-    owner = "philsquared";
+    owner = "catchorg";
     repo = "Catch";
     rev = "v${version}";
-    sha256 = "0nqnyw6haa2771748ycag4hhjb8ni32cv4f7w3h0pji212542xan";
+    sha256 = "0v9yw7ydvhydp78hh7cmaif4h73k5qxqpm1g7xn8i882i3s84s2s";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/libjson-rpc-cpp/default.nix
+++ b/pkgs/development/libraries/libjson-rpc-cpp/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
              -DCMAKE_BUILD_TYPE=Release
   '';
 
-  installPhase = '' 
+  installPhase = ''
     mkdir -p $out
 
     function fixRunPath {
@@ -55,6 +55,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ cmake jsoncpp argtable curl libmicrohttpd doxygen catch ];
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "C++ framework for json-rpc (json remote procedure call)";


### PR DESCRIPTION
###### Motivation for this change

Update to version [1.11.0](https://github.com/catchorg/Catch2/releases/tag/v1.11.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).