### PR TITLE
uncrustify: 0.64 -> 0.66

### DIFF
--- a/pkgs/development/tools/misc/uncrustify/default.nix
+++ b/pkgs/development/tools/misc/uncrustify/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "uncrustify";
-  version = "0.64";
+  version = "0.66";
 
   src = fetchFromGitHub {
     owner = product;
     repo = product;
     rev = name;
-    sha256 = "0gvgv44aqrh7cmj4ji8dpbhp47cklvajlc3s9d9z24x96dhp2v97";
+    sha256 = "156y71yf2xxskvikbn6yjfv8xgnsrrjij08irv21z0n7nx35jgmm";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/tools/misc/uncrustify/default.nix
+++ b/pkgs/development/tools/misc/uncrustify/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     description = "Source code beautifier for C, C++, C#, ObjectiveC, D, Java, Pawn and VALA";
     homepage = http://uncrustify.sourceforge.net/;


### PR DESCRIPTION
###### Motivation for this change

Update to version 0.66

[ChangeLog](https://github.com/uncrustify/uncrustify/blob/master/ChangeLog)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).