### PR TITLE
Update HDF5 and add option to compile Fortran2003 interface

### DIFF
--- a/pkgs/tools/misc/hdf5/1_8.nix
+++ b/pkgs/tools/misc/hdf5/1_8.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, fetchurl
+, gcc
+, removeReferencesTo
+, cpp ? false
+, gfortran ? null
+, zlib ? null
+, szip ? null
+, mpi ? null
+, enableShared ? true
+}:
+
+# cpp and mpi options are mutually exclusive
+# (--enable-unsupported could be used to force the build)
+assert !cpp || mpi == null;
+
+# No point splitting version 1.8.18 into multiple outputs.
+# The library /lib/libhdf5.so has a reference to gcc-wrapper
+
+let inherit (stdenv.lib) optional optionals; in
+
+stdenv.mkDerivation rec {
+  version = "1.8.18";
+  name = "hdf5-${version}";
+  src = fetchurl {
+    url = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/${name}/src/${name}.tar.bz2";
+    sha256 = "13542vrnl1p35n8vbq0wzk40vddmm33q5nh04j98c7r1yjnxxih1";
+ };
+
+  passthru = {
+    mpiSupport = (mpi != null);
+    inherit mpi;
+  };
+
+  nativeBuildInputs = [ removeReferencesTo ];
+
+  buildInputs = []
+    ++ optional (gfortran != null) gfortran
+    ++ optional (szip != null) szip;
+
+  propagatedBuildInputs = []
+    ++ optional (zlib != null) zlib
+    ++ optional (mpi != null) mpi;
+
+  configureFlags = []
+    ++ optional cpp "--enable-cxx"
+    ++ optional (gfortran != null) "--enable-fortran"
+    ++ optional (szip != null) "--with-szlib=${szip}"
+    ++ optionals (mpi != null) ["--enable-parallel" "CC=${mpi}/bin/mpicc"]
+    ++ optional enableShared "--enable-shared";
+
+  patches = [./bin-mv.patch];
+
+  postInstall = ''
+    find "$out" -type f -exec remove-references-to -t ${stdenv.cc} '{}' +
+  '';
+
+  meta = {
+    description = "Data model, library, and file format for storing and managing data";
+    longDescription = ''
+      HDF5 supports an unlimited variety of datatypes, and is designed for flexible and efficient
+      I/O and for high volume and complex data. HDF5 is portable and is extensible, allowing
+      applications to evolve in their use of HDF5. The HDF5 Technology suite includes tools and
+      applications for managing, manipulating, viewing, and analyzing data in the HDF5 format.
+    '';
+    license = stdenv.lib.licenses.free; # BSD-like
+    homepage = https://www.hdfgroup.org/HDF5/;
+    platforms = stdenv.lib.platforms.unix;
+    broken = (gfortran != null) && stdenv.isDarwin;
+  };
+}

--- a/pkgs/tools/misc/hdf5/1_8.nix
+++ b/pkgs/tools/misc/hdf5/1_8.nix
@@ -20,11 +20,11 @@ assert !cpp || mpi == null;
 let inherit (stdenv.lib) optional optionals; in
 
 stdenv.mkDerivation rec {
-  version = "1.8.18";
+  version = "1.8.19";
   name = "hdf5-${version}";
   src = fetchurl {
     url = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/${name}/src/${name}.tar.bz2";
-    sha256 = "13542vrnl1p35n8vbq0wzk40vddmm33q5nh04j98c7r1yjnxxih1";
+    sha256 = "0f3jfbqpaaq21ighi40qzs52nb52kc2d2yjk541rjmsx20b3ih2r" ;
  };
 
   passthru = {

--- a/pkgs/tools/misc/hdf5/1_8.nix
+++ b/pkgs/tools/misc/hdf5/1_8.nix
@@ -4,6 +4,7 @@
 , removeReferencesTo
 , cpp ? false
 , gfortran ? null
+, fortran2003 ? false
 , zlib ? null
 , szip ? null
 , mpi ? null
@@ -13,6 +14,9 @@
 # cpp and mpi options are mutually exclusive
 # (--enable-unsupported could be used to force the build)
 assert !cpp || mpi == null;
+
+# Need a Fortran compiler for Fortran2003 bindings
+assert fortran2003 -> gfortran != null;
 
 # No point splitting version 1.8.18 into multiple outputs.
 # The library /lib/libhdf5.so has a reference to gcc-wrapper
@@ -45,6 +49,7 @@ stdenv.mkDerivation rec {
   configureFlags = []
     ++ optional cpp "--enable-cxx"
     ++ optional (gfortran != null) "--enable-fortran"
+    ++ optional fortran2003 "--enable-fortran2003"
     ++ optional (szip != null) "--with-szlib=${szip}"
     ++ optionals (mpi != null) ["--enable-parallel" "CC=${mpi}/bin/mpicc"]
     ++ optional enableShared "--enable-shared";

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -14,17 +14,14 @@
 # (--enable-unsupported could be used to force the build)
 assert !cpp || mpi == null;
 
-# No point splitting version 1.8.18 into multiple outputs.
-# The library /lib/libhdf5.so has a reference to gcc-wrapper
-
 let inherit (stdenv.lib) optional optionals; in
 
 stdenv.mkDerivation rec {
-  version = "1.8.18";
+  version = "1.10.1";
   name = "hdf5-${version}";
   src = fetchurl {
-    url = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/${name}/src/${name}.tar.bz2";
-    sha256 = "13542vrnl1p35n8vbq0wzk40vddmm33q5nh04j98c7r1yjnxxih1";
+    url = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/${name}/src/${name}.tar.bz2";
+    sha256 = "1wpbi15za7kbsvih88kfcxblw412pjndl16x88dgnqr47piy2p4w";
  };
 
   passthru = {
@@ -59,8 +56,8 @@ stdenv.mkDerivation rec {
     description = "Data model, library, and file format for storing and managing data";
     longDescription = ''
       HDF5 supports an unlimited variety of datatypes, and is designed for flexible and efficient
-      I/O and for high volume and complex data. HDF5 is portable and is extensible, allowing 
-      applications to evolve in their use of HDF5. The HDF5 Technology suite includes tools and 
+      I/O and for high volume and complex data. HDF5 is portable and is extensible, allowing
+      applications to evolve in their use of HDF5. The HDF5 Technology suite includes tools and
       applications for managing, manipulating, viewing, and analyzing data in the HDF5 format.
     '';
     license = stdenv.lib.licenses.free; # BSD-like

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2582,6 +2582,12 @@ with pkgs;
     mpi = null;
   };
 
+  hdf5_1_8 = callPackage ../tools/misc/hdf5/1_8.nix {
+    gfortran = null;
+    szip = null;
+    mpi = null;
+  };
+
   hdf5-mpi = appendToName "mpi" (hdf5.override {
     szip = null;
     mpi = pkgs.openmpi;


### PR DESCRIPTION
###### Motivation for this change
The HDF5 package is updated from 1.8.18 to 1.10.1, as recommended on the [HDF5 group website](https://www.hdfgroup.org/downloads/hdf5/).
In addition, the possibility to compile the Fortran2003 interface is exposed _via_ the `fortran2003` option for the 1.8.19 version of the package.

###### Things done

- [x] Add a `hdf5_1_8`, updated from 1.8.18 to 1.8.19, to still provide the older version of HDF5.
- [x] Add a `fortran2003` option to `hdf5_1_8`. This allows compiling the Fortran2003 bindings, by passing `--enable-fortran2003` to the configure script. This option was removed from 1.10.1, for which `--enable-fortran` suffices to get the newer bindings compiled.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

