### PR TITLE
Glusterfs 3.12.3 backport for 17.09

### DIFF
--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -15,10 +15,10 @@ let
     #       The command
     #         find /nix/store/...-glusterfs-.../ -name '*.py' -executable
     #       can help with finding new Python scripts.
-    version = "3.12.1";
+    version = "3.12.2";
     name="${baseName}-${version}";
     url="https://github.com/gluster/glusterfs/archive/v${version}.tar.gz";
-    sha256 = "14l6p2zyjsrnjvf0lipq32p517zk813nqv06pjq6kcqkmy038wdv";
+    sha256 = "1jghc76d1p4fby4pm8q0cgmkkf75cjafaa5sk9xlpjhzr2ad8l4n";
   };
   buildInputs = [
     fuse bison flex_2_5_35 openssl ncurses readline

--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -15,10 +15,10 @@ let
     #       The command
     #         find /nix/store/...-glusterfs-.../ -name '*.py' -executable
     #       can help with finding new Python scripts.
-    version = "3.12.2";
+    version = "3.12.3";
     name="${baseName}-${version}";
     url="https://github.com/gluster/glusterfs/archive/v${version}.tar.gz";
-    sha256 = "1jghc76d1p4fby4pm8q0cgmkkf75cjafaa5sk9xlpjhzr2ad8l4n";
+    sha256 = "16ra4qr4ds011mmxaqdhdj7slcx8yv0xh6ww7bwsz7f1gn9sr10h";
   };
   buildInputs = [
     fuse bison flex_2_5_35 openssl ncurses readline


### PR DESCRIPTION
###### Motivation for this change

17.09 backport of #31782

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [X] Tested on my production cluster

---

FYI @bachp 
