### PR TITLE
git: honor $PATH for sendmail used in git-send-email command

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation {
     ./symlinks-in-bin.patch
     ./git-sh-i18n.patch
     ./ssh-path.patch
+    ./git-send-email-honor-PATH.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/version-management/git-and-tools/git/git-send-email-honor-PATH.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/git-send-email-honor-PATH.patch
@@ -1,0 +1,47 @@
+From 9a4396ddaedaf59ebee16d69900884e990b79cdd Mon Sep 17 00:00:00 2001
+From: Florian Klink <flokli@flokli.de>
+Date: Fri, 17 Nov 2017 13:21:37 +0100
+Subject: [PATCH] git-send-email: honor $PATH
+
+This will search $PATH for a sendmail binary, instead of the (previously
+fixed) list of paths.
+
+Signed-off-by: Florian Klink <flokli@flokli.de>
+---
+ Documentation/git-send-email.txt | 5 ++---
+ git-send-email.perl              | 3 ++-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Documentation/git-send-email.txt b/Documentation/git-send-email.txt
+index bac9014ac..b9b1f2c41 100644
+--- a/Documentation/git-send-email.txt
++++ b/Documentation/git-send-email.txt
+@@ -203,9 +203,8 @@ a password is obtained using 'git-credential'.
+ 	specify a full pathname of a sendmail-like program instead;
+ 	the program must support the `-i` option.  Default value can
+ 	be specified by the `sendemail.smtpServer` configuration
+-	option; the built-in default is `/usr/sbin/sendmail` or
+-	`/usr/lib/sendmail` if such program is available, or
+-	`localhost` otherwise.
++	option; the built-in default is to search in $PATH if such program is
++	available, or `localhost` otherwise.
+ 
+ --smtp-server-port=<port>::
+ 	Specifies a port different from the default port (SMTP
+diff --git a/git-send-email.perl b/git-send-email.perl
+index 2208dcc21..8e357aeab 100755
+--- a/git-send-email.perl
++++ b/git-send-email.perl
+@@ -885,7 +885,8 @@ if (defined $initial_reply_to) {
+ }
+ 
+ if (!defined $smtp_server) {
+-	foreach (qw( /usr/sbin/sendmail /usr/lib/sendmail )) {
++	my @sendmail_paths = map {"$_/sendmail"} split /:/, $ENV{PATH};
++	foreach (@sendmail_paths) {
+ 		if (-x $_) {
+ 			$smtp_server = $_;
+ 			last;
+-- 
+2.15.0
+


### PR DESCRIPTION
git-send-email will now search $PATH for a sendmail binary, instead of
the (previously fixed) list of paths.

###### Motivation for this change
This facilates out of the box usage in combination with sendmail-compatible binaries in $PATH.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

