### PR TITLE
msmtp: add sendmail symlink to $out/bin

### DIFF
--- a/pkgs/applications/networking/msmtp/default.nix
+++ b/pkgs/applications/networking/msmtp/default.nix
@@ -40,6 +40,8 @@ in stdenv.mkDerivation rec {
     substitute scripts/msmtpq/msmtp-queue $out/bin/msmtp-queue \
       --replace @msmtpq@ $out/bin/msmtpq
 
+    ln -s msmtp $out/bin/sendmail
+
     chmod +x $out/bin/*
   '';
 


### PR DESCRIPTION
This is useful for applications expecting a 'sendmail' binary in $PATH,
similar how nullmailer and ssmtp do it, too.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

