### PR TITLE
neomutt: use mime.types from mime_types

### DIFF
--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, which, autoreconfHook, makeWrapper, writeScript,
 ncurses, perl , cyrus_sasl, gss, gpgme, kerberos, libidn, notmuch, openssl,
-lmdb, libxslt, docbook_xsl, docbook_xml_dtd_42 }:
+lmdb, libxslt, docbook_xsl, docbook_xml_dtd_42, mime-types }:
 
 let
   muttWrapper = writeScript "mutt" ''
@@ -28,6 +28,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     cyrus_sasl gss gpgme kerberos libidn ncurses
     notmuch openssl perl lmdb
+    mime-types
   ];
 
   nativeBuildInputs = [
@@ -44,8 +45,9 @@ in stdenv.mkDerivation rec {
     done
 
     # allow neomutt to map attachments to their proper mime.types if specified wrongly
+    # and use a far more comprehensive list than the one shipped with neomutt
     substituteInPlace sendlib.c \
-      --replace /etc/mime.types $out/etc/mime.types
+      --replace /etc/mime.types ${mime-types}/etc/mime.types
   '';
 
   configureFlags = [
@@ -72,7 +74,6 @@ in stdenv.mkDerivation rec {
 
   postInstall = ''
     cp ${muttWrapper} $out/bin/mutt
-    mv $out/share/doc/neomutt/mime.types $out/etc
     wrapProgram "$out/bin/neomutt" --prefix PATH : "$out/lib/neomutt"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

The mime.types file shipped with neomutt is pretty basic so we use the one from
apache instead as it vastly improves the handling of attachments.

The format is the same, so we simply copy it in place.

Cc:  @cstrahan @erikryb @jfrankenau @vrthra 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

