### PR TITLE
lxtask: init at 0.1.8

### DIFF
--- a/pkgs/desktops/lxde/core/lxtask/default.nix
+++ b/pkgs/desktops/lxde/core/lxtask/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, pkgconfig, intltool, gtk3 }:
+
+stdenv.mkDerivation rec {
+  name = "lxtask-${version}";
+  version = "0.1.8";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/lxde/${name}.tar.xz";
+    sha256 = "0h7g1fdngv939z1d05nzs86dplww5a3bpm0isxd7p1bjby047d6z";
+  };
+
+  nativeBuildInputs = [ pkgconfig intltool ];
+  
+  buildInputs = [ gtk3 ];
+
+  configureFlags = [ "--enable-gtk3" ];
+
+  meta = {
+    description = "Lightweight and desktop independent task manager";
+    longDescription = ''
+      LXTask is a lightweight task manager derived from xfce4 task manager
+      with all xfce4 dependencies removed, some bugs fixed, and some
+      improvement of UI. Although being part of LXDE, the Lightweight X11
+      Desktop Environment, it's totally desktop independent and only
+      requires pure gtk+.
+    '';
+    homepage = https://wiki.lxde.org/en/LXTask; 
+    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6485,6 +6485,8 @@ with pkgs;
     gtk2 = gtk2-x11;
   };
 
+  lxtask = callPackage ../desktops/lxde/core/lxtask { };
+
   kona = callPackage ../development/interpreters/kona {};
 
   lolcode = callPackage ../development/interpreters/lolcode { };


### PR DESCRIPTION
###### Motivation for this change

Add new package [LXTask](https://wiki.lxde.org/en/LXTask).

LXTask is the standard task manager and system monitor of LXDE. It is extremely lightweight and depends only on Gtk+.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).