### PR TITLE
zsh: Create package zsh-powerlevel9k

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -496,6 +496,7 @@
   Phlogistique = "Noé Rubinstein <noe.rubinstein@gmail.com>";
   phreedom = "Evgeny Egorochkin <phreedom@yandex.ru>";
   phunehehe = "Hoang Xuan Phu <phunehehe@gmail.com>";
+  pierrechevalier83 = "Pierre Chevalier <pierrechevalier83@gmail.com>";
   pierrer = "Pierre Radermecker <pierrer@pi3r.be>";
   pierron = "Nicolas B. Pierron <nixos@nbp.name>";
   piotr = "Piotr Pietraszkiewicz <ppietrasa@gmail.com>";

--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -89,8 +89,8 @@ in
         description = ''
           Enable zsh-autosuggestions
         '';
+        type = types.bool;
       };
-
     };
 
   };

--- a/pkgs/shells/zsh-powerlevel9k/default.nix
+++ b/pkgs/shells/zsh-powerlevel9k/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, zsh }:
+
+# To make use of this derivation, use
+# `programs.zsh.promptInit = "source ${pkgs.zsh-powerlevel9k}/share/zsh-powerlevel9k/powerlevel9k.zsh-theme";`
+
+stdenv.mkDerivation rec {
+  name = "powerlevel9k-${version}";
+  version = "2017-11-10";
+  src = fetchFromGitHub {
+    owner = "bhilburn";
+    repo = "powerlevel9k";
+    rev = "87acc51acab3ed4fd33cda2386abed6f98c80720";
+    sha256 = "0v1dqg9hvycdkcvklg2njff97xwr8rah0nyldv4xm39r77f4yfvq";
+  };
+
+  installPhase= ''
+    install -D powerlevel9k.zsh-theme --target-directory=$out/share/zsh-powerlevel9k
+    install -D functions/* --target-directory=$out/share/zsh-powerlevel9k/functions
+  '';
+
+  meta = {
+    description = "A beautiful theme for zsh";
+    homepage = https://github.com/bhilburn/powerlevel9k;
+    license = stdenv.lib.licenses.mit;
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.pierrechevalier83 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5314,6 +5314,8 @@ with pkgs;
 
   zsh-autosuggestions = callPackage ../shells/zsh-autosuggestions { };
 
+  zsh-powerlevel9k = callPackage ../shells/zsh-powerlevel9k { };
+
   zstd = callPackage ../tools/compression/zstd { };
   zstdmt = callPackage ../tools/compression/zstdmt { };
 


### PR DESCRIPTION
To use, add this option to your configuration.nix:
`programs.zsh.promptInit = "source ${pkgs.zsh-powerlevel9k}/share/zsh-powerlevel9k/powerlevel9k.zsh-theme";`

###### Motivation for this change
I want to be able to use the powerlevel9k prompt without all the bloat of oh-my-zsh or other

###### Things done
Created package zsh-powerlevel9k that can be enabled by overriding the zsh.promptInit variable

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

