### PR TITLE
melpaStablePackages.caml: don't run configure

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-stable-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-stable-packages.nix
@@ -45,6 +45,11 @@ self:
       # upstream issue: missing file header
       bufshow = markBroken super.bufshow;
 
+      # upstream issue: comes with a broken configure file
+      caml = super.caml.overrideAttrs (oldAttrs: rec {
+        configureScript = "true";
+      });
+
       # part of a larger package
       # upstream issue: missing package version
       cmake-mode = markBroken (dontConfigure super.cmake-mode);


### PR DESCRIPTION
###### Motivation for this change
The caml-mode package is extracted by Melpa from the full Ocaml repository. That repository contains a file called "configure" with non-standard arguments, which is not needed to build/extract the Emacs mode. Nevertheless we automatically run configure as part of configurePhase, and it breaks due to the non-standard arguments, which breaks the build as a whole.

I don't think is the correct way to disable configurePhase, but this at least works on my system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

