### PR TITLE
Init Centos 7.3 vmTools diskImage

### DIFF
--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1310,6 +1310,17 @@ rec {
       packages = commonCentOSPackages ++ [ "procps-ng" ];
     };
 
+    centos73x86_64 = {
+      name = "centos-7.3-x86_64";
+      fullName = "CentOS 7.3 (x86_64)";
+      packagesList = fetchurl {
+        url = http://vault.centos.org/7.3.1611/os/x86_64/repodata/dd86df27191d231cc6b7c5828fadb63b08db4725aef8e2613351667e649c9ca3-primary.xml.gz;
+        sha256 = "18wwkij7wrji6dhy5y5f4m3xn21vnsnqz0n5nz31q8qx34kxz1nx";
+      };
+      urlPrefix = http://vault.centos.org/7.3.1611/os/x86_64;
+      archs = ["noarch" "x86_64"];
+      packages = commonCentOSPackages ++ [ "procps-ng" ];
+    };
   };
 
 


### PR DESCRIPTION
###### Motivation for this change
I'm looking to start building Nix RPMs for CentOS.  I've been studying the work of @abbradar [here](https://github.com/NixOS/nix/pull/1141) and, in an effort to learn more about the qemu build tools Nix provides and their interaction with RPM builds I packaged this up and tested it.  

```
nix-repl> :b pkgs.vmTools.runInLinuxImage (pkgs.runCommand "echo-release" { diskImage = pkgs.vmTools.diskImages.centos73x86_64; } "cat /etc/redhat-release ")

building '/nix/store/i4l9ff2df2xlkcg2mppvap4myzwf485j-echo-release.drv'...
Formatting '/tmp/nix-build-echo-release.drv-0/disk-image.qcow2', fmt=qcow2 size=4294967296 backing_file=/nix/store/pqlkwpjq9ib7mm4zm5vym0pak8cngrnh-centos-7.3-x86_64/disk-image.qcow2 cluster_s
<snip>
CentOS Linux release 7.3.1611 (Core)
[    0.656767] reboot: Power down
```

And testing with a patchelf build (after modifying its `release.nix` to have this attribute):
```
$ nix-build -I nixpkgs=/home/bhipple/src/nixpkgs release.nix -A rpm_centos73x86_64
$ tree result/rpms
result/rpms
└── centos-7.3-x86_64
    ├── patchelf-0.10pre1234_abcdef-1.src.rpm
    ├── patchelf-0.10pre1234_abcdef-1.x86_64.rpm
    └── patchelf-debuginfo-0.10pre1234_abcdef-1.x86_64.rpm
```

If there's anything else I should test let me know!

Not related to this PR, but ideally I'd also like to add CentOS 7.4, but it appears that the upstream project keeps the latest release at http://mirror.centos.org and doesn't archive them into the permanent vault location until the following release comes out, so if I put a link to 7.4 it'll eventually end up [like this](http://mirror.centos.org/centos-7/7.3.1611/readme).  Perhaps someone who knows more about the CentOS release schedule can enlighten me?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

