### PR TITLE
newsboat: init at 2.10.1

### DIFF
--- a/pkgs/applications/networking/feedreaders/newsboat/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsboat/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchzip, asciidoc, sqlite, curl, pkgconfig, libxml2, stfl
+, json-c-0-11 , ncurses , gettext, libiconv, makeWrapper, perl, fetchpatch }:
+
+stdenv.mkDerivation rec {
+  name = "newsboat-${version}";
+  version = "2.10.1";
+
+  src = fetchzip {
+    url = "https://newsboat.org/releases/${version}/${name}.tar.xz";
+    sha256 = "019bm8j9vbpj39vs6xhrj34cd9ipjyqpwkl5psaks2w6g7wzyp1p";
+  };
+
+  buildInputs
+    # use gettext instead of libintlOrEmpty so we have access to the msgfmt
+    # command
+    = [ asciidoc sqlite curl pkgconfig libxml2
+      stfl json-c-0-11 ncurses gettext perl libiconv ]
+      ++ stdenv.lib.optional stdenv.isDarwin makeWrapper;
+
+  postPatch = ''
+    substituteInPlace config.sh \
+      --replace "ncurses5.4" "ncurses"
+    substituteInPlace ./Makefile \
+      --replace "a2x" "${asciidoc}/bin/a2x --no-xmllint"
+  '';
+
+  installFlags = [ "prefix=$(out)" ];
+
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    cp -r $src/contrib $out
+    for prog in $out/bin/*; do
+      wrapProgram "$prog" --prefix DYLD_LIBRARY_PATH : "${stfl}/lib"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    homepage    = http://www.newsboat.org;
+    description = "An open-source RSS/Atom feed reader for text terminals";
+    maintainers = with maintainers; [ nicknovitski ];
+    license     = licenses.mit;
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3555,6 +3555,8 @@ with pkgs;
 
   newsbeuter = callPackage ../applications/networking/feedreaders/newsbeuter { };
 
+  newsboat = callPackage ../applications/networking/feedreaders/newsboat { };
+
   nextcloud = callPackage ../servers/nextcloud { };
 
   nextcloud-client = libsForQt56.callPackage ../applications/networking/nextcloud-client { };


### PR DESCRIPTION
This is a fork of newsbeuter, which is now unmaintained.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- ~[ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).