### PR TITLE
sdcv: enable Darwin build

### DIFF
--- a/pkgs/applications/misc/sdcv/default.nix
+++ b/pkgs/applications/misc/sdcv/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ glib gettext readline ];
 
   preInstall = ''
-    touch locale
+    mkdir locale
   '';
 
   NIX_CFLAGS_COMPILE = "-D__GNU_LIBRARY__"
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
     description = "Console version of StarDict";
     maintainers = with maintainers; [ lovek323 ];
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ~[ ] NixOS~
   - [x] macOS
   - ~[ ] other Linux distributions~
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- ~[ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).