### PR TITLE
bcat: init at 0.6.2

### DIFF
--- a/pkgs/tools/text/bcat/Gemfile
+++ b/pkgs/tools/text/bcat/Gemfile
@@ -1,0 +1,2 @@
+source 'http://rubygems.org'
+gem 'bcat'

--- a/pkgs/tools/text/bcat/Gemfile.lock
+++ b/pkgs/tools/text/bcat/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    bcat (0.6.2)
+      rack (~> 1.0)
+    rack (1.6.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bcat
+
+BUNDLED WITH
+   1.15.4

--- a/pkgs/tools/text/bcat/default.nix
+++ b/pkgs/tools/text/bcat/default.nix
@@ -1,0 +1,15 @@
+{ lib, bundlerApp }:
+
+bundlerApp {
+  pname = "bcat";
+  gemdir = ./.;
+  exes = [ "bcat" "btee" "a2h" ];
+
+  meta = with lib; {
+    description = "Pipe to browser utility";
+    homepage    = http://rtomayko.github.com/bcat/;
+    license     = licenses.mit;
+    maintainers = [ maintainers.jraygauthier ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/tools/text/bcat/gemset.nix
+++ b/pkgs/tools/text/bcat/gemset.nix
@@ -1,0 +1,19 @@
+{
+  bcat = {
+    dependencies = ["rack"];
+    source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "0w2wwlngcs7f4lmvifixrb89bjkw2lx8z0nn72w360hz394ic651";
+      type = "gem";
+    };
+    version = "0.6.2";
+  };
+  rack = {
+    source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "19m7aixb2ri7p1n0iqaqx8ldi97xdhvbxijbyrrcdcl6fv5prqza";
+      type = "gem";
+    };
+    version = "1.6.8";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -709,6 +709,8 @@ with pkgs;
 
   bdf2psf = callPackage ../tools/misc/bdf2psf { };
 
+  bcat = callPackage ../tools/text/bcat {};
+
   bcache-tools = callPackage ../tools/filesystems/bcache-tools { };
 
   bchunk = callPackage ../tools/cd-dvd/bchunk { };


### PR DESCRIPTION
###### Motivation for this change

Missing, really useful package, in particular in combination with pandoc on the cli.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

