### PR TITLE
schemaspy: init at 6.0.0-rc2

### DIFF
--- a/pkgs/development/tools/database/schemaspy/default.nix
+++ b/pkgs/development/tools/database/schemaspy/default.nix
@@ -1,0 +1,43 @@
+{ lib, stdenv, fetchurl, jre, makeWrapper, graphviz }:
+
+stdenv.mkDerivation rec {
+  version = "6.0.0-rc2";
+  name = "schemaspy-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/schemaspy/schemaspy/releases/download/v${version}/${name}.jar";
+    sha256 = "0ph1l62hy163m2hgybhkccqbcj6brna1vdbr7536zc37lzjxq9rn";
+  };
+
+  unpackPhase = "true";
+
+  buildInputs = [
+    jre
+    makeWrapper
+  ];
+
+  buildPhase = "true";
+
+  wrappedPath = lib.makeBinPath [
+    graphviz
+  ];
+
+  installPhase =
+    ''
+      mkdir -p "$out/share/java"
+      cp ${src} "$out/share/java/${name}.jar"
+
+      mkdir -p $out/bin
+      makeWrapper ${jre}/bin/java $out/bin/schemaspy \
+        --add-flags "-jar $out/share/java/${name}.jar" \
+        --prefix PATH : "$wrappedPath"
+    '';
+
+  meta = with lib; {
+    homepage = "http://schemaspy.org";
+    description = "Document your database simply and easily";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jraygauthier ];
+  };
+}
+

--- a/pkgs/development/tools/database/schemaspy/default.nix
+++ b/pkgs/development/tools/database/schemaspy/default.nix
@@ -13,25 +13,23 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     jre
-    makeWrapper
   ];
 
-  buildPhase = "true";
+  nativeBuildInputs = [
+    makeWrapper
+  ];
 
   wrappedPath = lib.makeBinPath [
     graphviz
   ];
 
-  installPhase =
-    ''
-      mkdir -p "$out/share/java"
-      cp ${src} "$out/share/java/${name}.jar"
+  installPhase = ''
+    install -D ${src} "$out/share/java/${name}.jar"
 
-      mkdir -p $out/bin
-      makeWrapper ${jre}/bin/java $out/bin/schemaspy \
-        --add-flags "-jar $out/share/java/${name}.jar" \
-        --prefix PATH : "$wrappedPath"
-    '';
+    makeWrapper ${jre}/bin/java $out/bin/schemaspy \
+      --add-flags "-jar $out/share/java/${name}.jar" \
+      --prefix PATH : "$wrappedPath"
+  '';
 
   meta = with lib; {
     homepage = "http://schemaspy.org";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7597,6 +7597,8 @@ with pkgs;
 
   shellcheck = haskell.lib.justStaticExecutables haskellPackages.ShellCheck;
 
+  schemaspy = callPackage ../development/tools/database/schemaspy { };
+
   shncpd = callPackage ../tools/networking/shncpd { };
 
   sigrok-cli = callPackage ../development/tools/sigrok-cli { };


### PR DESCRIPTION
###### Motivation for this change

Missing package. Allows one to retrieve a beautiful documentation of any database using its jdbc driver.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

