### PR TITLE
sqlite-jdbc: init at 3.20.0

### DIFF
--- a/pkgs/servers/sql/sqlite/jdbc/default.nix
+++ b/pkgs/servers/sql/sqlite/jdbc/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "3.20.0";
+  pname = "sqlite-jdbc";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/xerial/${pname}/downloads/${name}.jar";
+    sha256 = "0wxfxnq2ghiwy2mwz3rljgmy1lciafhrw80lprvqz6iw8l51qfql";
+  };
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    install -D "${src}" "$out/share/java/${name}.jar"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/xerial/sqlite-jdbc";
+    description = "SQLite JDBC Driver";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jraygauthier ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10738,6 +10738,8 @@ with pkgs;
 
   sqlite-interactive = appendToName "interactive" (sqlite.override { interactive = true; }).bin;
 
+  sqlite-jdbc = callPackage ../servers/sql/sqlite/jdbc { };
+
   sqlcipher = lowPrio (callPackage ../development/libraries/sqlcipher {
     readline = null;
     ncurses = null;


### PR DESCRIPTION
###### Motivation for this change

Missing jdbc driver. Used with the shemaspy package which has its own PR: #31815.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested indirectly via schemaspy.