### PR TITLE
python.pkgs.pybfd: support split libbfd and libopcodes

### DIFF
--- a/pkgs/development/python-modules/pybfd/default.nix
+++ b/pkgs/development/python-modules/pybfd/default.nix
@@ -1,25 +1,27 @@
-{ lib, buildPythonPackage, isPyPy, isPy3k, fetchurl, gdb, libbfd }:
+{ lib, fetchFromGitHub, buildPythonPackage, isPyPy, isPy3k, libbfd, libopcodes }:
 
 buildPythonPackage rec {
   name = "pybfd-0.1.1";
 
   disabled = isPyPy || isPy3k;
 
-  src = fetchurl {
-    url = "mirror://pypi/p/pybfd/${name}.tar.gz";
-    sha256 = "d99b32ad077e704ddddc0b488c83cae851c14919e5cbc51715d00464a1932df4";
+  src = fetchFromGitHub {
+    owner = "orivej";
+    repo = "pybfd";
+    rev = "a2c3a7b94a3c9f7a353b863f69a79174c6a41ebe";
+    sha256 = "0wrz234dz25hs0ajzcz5w8lzc1yzf64wqa8fj01hhr4yy23vjkcr";
   };
 
-  preConfigure = ''
-    substituteInPlace setup.py \
-      --replace '"/usr/include"' '"${gdb}/include"' \
-      --replace '"/usr/lib"' '"${libbfd}/lib"'
-  '';
+  LIBBFD_INCLUDE_DIR = "${libbfd.dev}/include";
+  LIBBFD_LIBRARY = "${libbfd}/lib/libbfd.so";
+  LIBOPCODES_INCLUDE_DIR = "${libopcodes.dev}/include";
+  LIBOPCODES_LIBRARY = "${libopcodes}/lib/libopcodes.so";
 
   meta = {
     homepage = https://github.com/Groundworkstech/pybfd;
     description = "A Python interface to the GNU Binary File Descriptor (BFD) library";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ orivej ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

PR #30484 (f8741c38cd546e3ff18ce9d708de14ff2aae68ab) has split libbfd and libopcodes from binutils and gdb.  The original pybfd setup.py is completely unsuitable to handle that.  This commit replaces the original source with a [fork](https://github.com/orivej/pybfd) with a [patched](https://github.com/orivej/pybfd/commit/a2c3a7b94a3c9f7a353b863f69a79174c6a41ebe) setup.py. It builds on `staging` and passes self tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).