### PR TITLE
pythonPackages.pyqt5: Add optional support for qtconnectivity

### DIFF
--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -1,6 +1,7 @@
 { lib, fetchurl, pythonPackages, pkgconfig, makeWrapper, qmake
 , lndir, qtbase, qtsvg, qtwebkit, qtwebengine, dbus_libs
 , withWebSockets ? false, qtwebsockets
+, withConnectivity ? false, qtconnectivity
 }:
 
 let
@@ -27,7 +28,7 @@ in buildPythonPackage {
 
   buildInputs = [
     lndir qtbase qtsvg qtwebkit qtwebengine dbus_libs
-  ] ++ lib.optional withWebSockets qtwebsockets;
+  ] ++ lib.optional withWebSockets qtwebsockets ++ lib.optional withConnectivity qtconnectivity;
 
   propagatedBuildInputs = [ sip ];
 


### PR DESCRIPTION
###### Motivation for this change

PyQt5 is missing the generated wrappers for the QtConnectivity module, which I needed for a private project.
The dependency is optional because most of the software using pyqt5 doesn't need the missing modules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

