### PR TITLE
gdm: start gdm on tty7 rather than default tty1

### DIFF
--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -122,7 +122,6 @@ in
       "rc-local.service"
       "systemd-machined.service"
       "systemd-user-sessions.service"
-      "getty@tty1.service"
     ];
 
     systemd.services.display-manager.serviceConfig = {

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -125,8 +125,6 @@ in
       "getty@tty1.service"
     ];
 
-    systemd.services."getty@tty1".enable = false;
-    systemd.services.display-manager.conflicts = [ "getty@tty1.service" ];
     systemd.services.display-manager.serviceConfig = {
       # Restart = "always"; - already defined in xserver.nix
       KillMode = "mixed";

--- a/pkgs/desktops/gnome-3/core/gdm/default.nix
+++ b/pkgs/desktops/gnome-3/core/gdm/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--sysconfdir=/etc"
                      "--localstatedir=/var"
                      "--with-plymouth=yes"
+                     "--with-initial-vt=7"
                      "--with-systemdsystemunitdir=$(out)/etc/systemd/system" ];
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
- Fixes nixos-rebuild switch/test issue with GNOME
  https://github.com/NixOS/nixpkgs/issues/21439
- The solution was given here:
  https://github.com/deedrah/nixpkgs/commit/d761e66a41e09bb0a1ebe31612f3678f9ba801a1#commitcomment-25382880

###### Motivation for this change

I can't use nixos-rebuild switch at the moment. I was waiting for someone else to create a pull request, but I thought I might as well.

###### Things done

As per comments on ticket, went for solution that was brought forward by @deedrah and @bjornfor: start gdm on tty7.
Tested and works for me with gnome 3.24 + gdm + X11.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

