### PR TITLE
stellarium: 0.15.0 -> 0.16.1

### DIFF
--- a/pkgs/applications/science/astronomy/stellarium/default.nix
+++ b/pkgs/applications/science/astronomy/stellarium/default.nix
@@ -1,23 +1,23 @@
 { mkDerivation, lib, fetchurl
 , cmake, freetype, libpng, mesa, gettext, openssl, perl, libiconv
 , qtscript, qtserialport, qttools
-, qtmultimedia
+, qtmultimedia, qtlocation
 }:
 
 mkDerivation rec {
   name = "stellarium-${version}";
-  version = "0.15.0";
+  version = "0.16.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/stellarium/${name}.tar.gz";
-    sha256 = "0il751lgnfkx35h1m8fzwwnrygpxjx2a80gng1i1rbybkykf7l3l";
+    sha256 = "087x6mbcn2yj8d3qi382vfkzgdwmanxzqi5l1x3iranxmx9c40dh";
   };
 
   nativeBuildInputs = [ cmake perl ];
 
   buildInputs = [
     freetype libpng mesa openssl libiconv qtscript qtserialport qttools
-    qtmultimedia
+    qtmultimedia qtlocation
   ];
 
   meta = with lib; {
@@ -26,6 +26,6 @@ mkDerivation rec {
     license = licenses.gpl2;
 
     platforms = platforms.linux; # should be mesaPlatforms, but we don't have qt on darwin
-    maintainers = [ maintainers.peti ];
+    maintainers = with maintainers; [ peti ma27 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The 0.16-releases contain several useful new features:
https://launchpad.net/stellarium/0.16/0.16.1

I also added myself as maintainer to have more people available if the
package breaks a release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

