### PR TITLE
ruby-zoom: 4.1.0 -> 5.0.1

### DIFF
--- a/pkgs/tools/text/ruby-zoom/Gemfile.lock
+++ b/pkgs/tools/text/ruby-zoom/Gemfile.lock
@@ -1,16 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    djinni (2.0.1)
-      fagin (~> 0.1, >= 0.1.2)
-      ruby-terminfo (~> 0.1, >= 0.1.1)
-    fagin (0.1.2)
-    hilighter (0.1.7)
+    djinni (2.1.1)
+      fagin (~> 1.0, >= 1.0.0)
+    fagin (1.0.0)
+    hilighter (1.1.0)
     json_config (0.1.2)
-    ruby-terminfo (0.1.1)
-    ruby-zoom (4.1.0)
-      djinni (~> 2.0, >= 2.0.1)
-      hilighter (~> 0.1, >= 0.1.3)
+    ruby-zoom (5.0.1)
+      djinni (~> 2.1, >= 2.1.1)
+      fagin (~> 1.0, >= 1.0.0)
+      hilighter (~> 1.1, >= 1.1.0)
       json_config (~> 0.1, >= 0.1.2)
       scoobydoo (~> 0.1, >= 0.1.4)
     scoobydoo (0.1.4)
@@ -22,4 +21,4 @@ DEPENDENCIES
   ruby-zoom
 
 BUNDLED WITH
-   1.13.1
+   1.14.6

--- a/pkgs/tools/text/ruby-zoom/gemset.nix
+++ b/pkgs/tools/text/ruby-zoom/gemset.nix
@@ -1,27 +1,28 @@
 {
   djinni = {
+    dependencies = ["fagin"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0wl4q4qs1nyla5n2b2ys6n3i35gvli8xb8mxz2xv0ik306cikqm6";
+      sha256 = "00zfgd7zx2p9xjc64xm4iwdxq2bb6n1z09nw815c2f4lvlaq269f";
       type = "gem";
     };
-    version = "2.0.1";
+    version = "2.1.1";
   };
   fagin = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "17d419vkfr26gdbad97fg2ikskhn82vs3bnxlzd27w6lwyf13qxk";
+      sha256 = "0jryqrgb5jvz0m7p91c2bhn6gdwxn9jfdaq3cfkirc3y7yfzv131";
       type = "gem";
     };
-    version = "0.1.2";
+    version = "1.0.0";
   };
   hilighter = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1a9a9clgd6kx63a82msjzi6abznfqivsgmds7qaqwb1dsl1nznbh";
+      sha256 = "0sy59nfcfk4p1fnrdkipi0mvsj9db17chrx7lb2jg3majbr1wz59";
       type = "gem";
     };
-    version = "0.1.7";
+    version = "1.1.0";
   };
   json_config = {
     source = {
@@ -31,21 +32,14 @@
     };
     version = "0.1.2";
   };
-  ruby-terminfo = {
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0rl4ic5pzvrpgd42z0c1s2n3j39c9znksblxxvmhkzrc0ckyg2cm";
-      type = "gem";
-    };
-    version = "0.1.1";
-  };
   ruby-zoom = {
+    dependencies = ["djinni" "fagin" "hilighter" "json_config" "scoobydoo"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "132pk0zp3rayvvbccfs5ksigg9zpflp9734b4r0jz5aimmv2qpvp";
+      sha256 = "0115kbz6l8srzizs77k9l0585lg93x90kg49jjpan7ssm786q05j";
       type = "gem";
     };
-    version = "4.1.0";
+    version = "5.0.1";
   };
   scoobydoo = {
     source = {


### PR DESCRIPTION

###### Motivation for this change

This version adds support for `ripgrep` as the underlying search tool. 

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

