### PR TITLE
geany: 1.31 -> 1.32

### DIFF
--- a/pkgs/applications/editors/geany/default.nix
+++ b/pkgs/applications/editors/geany/default.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 let
-  version = "1.31";
+  version = "1.32";
 in
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://download.geany.org/${name}.tar.bz2";
-    sha256 = "30fdb906bb76c4251a8bcf83ee267db28c26ef6ab867668a782cec1164a3aba5";
+    sha256 = "8b7be10b95d0614eb07f845ba2280f7c026eacd5739d8fac4d5d26606f8c3c2d";
   };
 
   NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;


### PR DESCRIPTION
###### Motivation for this change
New upstream release

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

