### PR TITLE
man-db: explicitly pass section string

### DIFF
--- a/pkgs/tools/misc/man-db/default.nix
+++ b/pkgs/tools/misc/man-db/default.nix
@@ -28,6 +28,10 @@ stdenv.mkDerivation rec {
     "--with-systemdtmpfilesdir=\${out}/lib/tmpfiles.d"
   ];
 
+  preConfigure = ''
+    configureFlagsArray+=("--with-sections=1 n l 8 3 0 2 5 4 9 6 7")
+  '';
+
   postInstall = ''
     # apropos/whatis uses program name to decide whether to act like apropos or whatis
     # (multi-call binary). `apropos` is actually just a symlink to whatis. So we need to


### PR DESCRIPTION
Work around a bug in the autoconf setup of man-db: The
list of default sections does not include section 0 (zero)
despite ``./configure --help`` advertising it. This causes
header man pages (e. g. time.h from package posix_man_pages)
to be ignored by man(1):

    $ file /run/current-system/sw/share/man/man0p/time.h.0p.gz
    /run/current-system/sw/share/man/man0p/time.h.0p.gz: gzip compressed data, from Unix
    $ man 0p time.h
    No manual entry for 0p
    No manual entry for time.h

Override the default (as defined in m4/man-arg-sections.m4)
until this is fixed upstream.

###### Motivation for this change

A category of man pages is not addressable by default.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

