### PR TITLE
minikube: Add vmnet as buildInput on darwin

### DIFF
--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -1,4 +1,5 @@
 { stdenv, buildGoPackage, fetchFromGitHub, fetchurl, go-bindata, kubernetes, libvirt, qemu, docker-machine-kvm,
+  vmnet,
   gpgme, makeWrapper }:
 
 let
@@ -36,7 +37,8 @@ in buildGoPackage rec {
 
   # kubernetes is here only to shut up a loud warning when generating the completions below. minikube checks very eagerly
   # that kubectl is on the $PATH, even if it doesn't use it at all to generate the completions
-  buildInputs = [ go-bindata makeWrapper kubernetes gpgme ];
+  buildInputs = [ go-bindata makeWrapper kubernetes gpgme ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ vmnet ];
   subPackages = [ "cmd/minikube" ];
 
   preBuild = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15661,7 +15661,9 @@ with pkgs;
 
   minidjvu = callPackage ../applications/graphics/minidjvu { };
 
-  minikube = callPackage ../applications/networking/cluster/minikube { };
+  minikube = callPackage ../applications/networking/cluster/minikube {
+    inherit (darwin.apple_sdk.frameworks) vmnet;
+  };
 
   minitube = callPackage ../applications/video/minitube { };
 


### PR DESCRIPTION
This should fix https://github.com/NixOS/nixpkgs/issues/30133.

###### Motivation for this change

Just upgraded minikube on my darwin box and ran into #30133. When comparing to the xhyve derivation I found that the build input vmnet was not declared and gave it a shot. This did the trick for me and allowed me be build the current minikube on my darwin box.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS (`nix-build -A minikube --argstr system x86_64-linux`, did only fetch binaries)
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files `result-bin/bin/minikube`
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

