### PR TITLE
Backport nix-bash-completions

### DIFF
--- a/pkgs/shells/nix-bash-completions/default.nix
+++ b/pkgs/shells/nix-bash-completions/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "0.2";
+  version = "0.4";
   name = "nix-bash-completions-${version}";
 
   src = fetchFromGitHub {
     owner = "hedning";
     repo = "nix-bash-completions";
     rev = "v${version}";
-    sha256 = "0clr3c0zf73pnabab4n5b5x8cd2yilksvvlp4i0rj0cfbr1pzxgr";
+    sha256 = "08gl9xnk738p180hpn3l7ggrz5zlky4pam7v74kb0gavjxm4fa2f";
   };
 
   installPhase = ''

--- a/pkgs/shells/nix-bash-completions/default.nix
+++ b/pkgs/shells/nix-bash-completions/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  version = "0.1";
+  name = "nix-bash-completions-${version}";
+
+  src = fetchFromGitHub {
+    owner = "hedning";
+    repo = "nix-bash-completions";
+    rev = "v${version}";
+    sha256 = "1gb6fmnask1xmjv5j5x0jb505lyp0p4lx2kbibfnb2gi57wapxaz";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/bash-completion/completions
+    cp _* $out/share/bash-completion/completions
+  '';
+
+  meta = {
+    homepage = http://github.com/hedning/nix-bash-completions;
+    description = "Bash completions for Nix, NixOS, and NixOps";
+    license = stdenv.lib.licenses.bsd3;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = with stdenv.lib.maintainers; [ hedning ];
+  };
+}

--- a/pkgs/shells/nix-bash-completions/default.nix
+++ b/pkgs/shells/nix-bash-completions/default.nix
@@ -1,26 +1,26 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "0.1";
+  version = "0.2";
   name = "nix-bash-completions-${version}";
 
   src = fetchFromGitHub {
     owner = "hedning";
     repo = "nix-bash-completions";
     rev = "v${version}";
-    sha256 = "1gb6fmnask1xmjv5j5x0jb505lyp0p4lx2kbibfnb2gi57wapxaz";
+    sha256 = "0clr3c0zf73pnabab4n5b5x8cd2yilksvvlp4i0rj0cfbr1pzxgr";
   };
 
   installPhase = ''
     mkdir -p $out/share/bash-completion/completions
-    cp _* $out/share/bash-completion/completions
+    cp _nix $out/share/bash-completion/completions
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://github.com/hedning/nix-bash-completions;
     description = "Bash completions for Nix, NixOS, and NixOps";
-    license = stdenv.lib.licenses.bsd3;
-    platforms = stdenv.lib.platforms.all;
-    maintainers = with stdenv.lib.maintainers; [ hedning ];
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ hedning ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5231,6 +5231,8 @@ with pkgs;
 
   bash-completion = callPackage ../shells/bash-completion { };
 
+  nix-bash-completions = callPackage ../shells/nix-bash-completions { };
+
   dash = callPackage ../shells/dash { };
 
   es = callPackage ../shells/es { };


### PR DESCRIPTION
###### Motivation for this change
nix-bash-completions is awesome and we need it in NixOS 17.09!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

