### PR TITLE
firewall: fix rpfilter blocking dhcp offers when no ip was bound yet

### DIFF
--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -125,6 +125,9 @@ let
       ip46tables -t raw -N nixos-fw-rpfilter 2> /dev/null || true
       ip46tables -t raw -A nixos-fw-rpfilter -m rpfilter ${optionalString (cfg.checkReversePath == "loose") "--loose"} -j RETURN
 
+      # Allows this host to act as a DHCP4 client without first having to use APIPA
+      iptables -t raw -A nixos-fw-rpfilter -p udp --sport 67 --dport 68 -j RETURN
+
       # Allows this host to act as a DHCPv4 server
       iptables -t raw -A nixos-fw-rpfilter -s 0.0.0.0 -d 255.255.255.255 -p udp --sport 68 --dport 67 -j RETURN
 


### PR DESCRIPTION
When first bringing up an interface, the DHCP server's offer gets dropped by our firewall because of rpfilter.

Basically no packets will ever match for reverse-path as we don't have an IP address yet, hence nothing would route back through the interface. 

`dhcpcd` then after 10 seconds switches to auto-configuration (APIPA) giving the interface a `169.254.*.*` address. It then retries a dhcp request. Only now the OFFER does pass the rpfilter.

This change fixes the initial drops and allows us to gain a proper ip address almost instantly

