### PR TITLE
libwebcam: Init at 0.2.5

### DIFF
--- a/pkgs/os-specific/linux/libwebcam/default.nix
+++ b/pkgs/os-specific/linux/libwebcam/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchurl
+, cmake
+, pkgconfig
+, libxml2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libwebcam";
+  version = "0.2.5";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/${pname}/source/${pname}-src-${version}.tar.gz";
+    sha256 = "0hcxv8di83fk41zjh0v592qm7c0v37a3m3n3lxavd643gff1k99w";
+  };
+
+  patches = [
+    ./uvcdynctrl_symlink_support_and_take_data_dir_from_env.patch
+  ];
+
+  buildInputs = [
+    cmake
+    pkgconfig
+    libxml2
+  ];
+
+  postPatch = ''
+    substituteInPlace ./uvcdynctrl/CMakeLists.txt \
+      --replace "/lib/udev" "$out/lib/udev"
+
+    substituteInPlace ./uvcdynctrl/udev/scripts/uvcdynctrl \
+      --replace 'debug=0' 'debug=''${NIX_UVCDYNCTRL_UDEV_DEBUG:-0}' \
+      --replace 'uvcdynctrlpath=uvcdynctrl' "uvcdynctrlpath=$out/bin/uvcdynctrl"
+
+    substituteInPlace ./uvcdynctrl/udev/rules/80-uvcdynctrl.rules \
+      --replace "/lib/udev" "$out/lib/udev"
+  '';
+
+
+  preConfigure = ''
+    cmakeFlagsArray=(
+      $cmakeFlagsArray
+      "-DCMAKE_INSTALL_PREFIX=$out"
+    )
+  '';
+
+  meta = with lib; {
+    description = "The webcam-tools package";
+    platforms = platforms.linux;
+    licenses = with licenses; [ lgpl3 ];
+    maintainers = with maintainers; [ jraygauthier ];
+  };
+}

--- a/pkgs/os-specific/linux/libwebcam/uvcdynctrl_symlink_support_and_take_data_dir_from_env.patch
+++ b/pkgs/os-specific/linux/libwebcam/uvcdynctrl_symlink_support_and_take_data_dir_from_env.patch
@@ -1,0 +1,65 @@
+diff --git a/uvcdynctrl/main.c b/uvcdynctrl/main.c
+index b7befd1..f3a768c 100644
+--- a/uvcdynctrl/main.c
++++ b/uvcdynctrl/main.c
+@@ -674,27 +674,31 @@ get_filename (const char *dir_path, const char *vid)
+ 	printf ( "checking dir: %s \n", dir_path);
+ 	while ((dp = readdir(dir)) != NULL) 
+ 	{
+-		if((dp->d_type == DT_DIR) && (fnmatch("[[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]]", dp->d_name, 0) == 0))
++		if((dp->d_type == DT_DIR || dp->d_type == DT_LNK ) && (fnmatch("[[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]]", dp->d_name, 0) == 0))
+ 		{
+ 			if( strcasecmp(vid, dp->d_name) != 0)
+ 			{
+ 				/*doesn't match - clean up and move to the next entry*/
+ 				continue;
+ 			}
+-			
++
+ 			char *tmp = path_cat (dir_path, dp->d_name);
+-			printf("found dir: %s \n", dp->d_name);
++
+ 			DIR * subdir = opendir(tmp);
+-			while ((sdp = readdir(subdir)) != NULL) 
++			if ( subdir != NULL )
+ 			{
+-				if( fnmatch("*.xml", sdp->d_name, 0) == 0 )
++				printf("found dir: %s \n", dp->d_name);
++				while ((sdp = readdir(subdir)) != NULL) 
+ 				{
+-					file_list[nf-1] = path_cat (tmp, sdp->d_name);
+-					printf("found: %s \n", file_list[nf-1]);
+-					nf++;
+-					file_list = realloc(file_list,nf*sizeof(file_list));
+-					file_list[nf-1] = NULL;   
+-				} 
++					if( fnmatch("*.xml", sdp->d_name, 0) == 0 )
++					{
++						file_list[nf-1] = path_cat (tmp, sdp->d_name);
++						printf("found: %s \n", file_list[nf-1]);
++						nf++;
++						file_list = realloc(file_list,nf*sizeof(file_list));
++						file_list[nf-1] = NULL;   
++					} 
++				}
+ 			}
+ 			closedir(subdir);
+ 			free (tmp);
+@@ -869,9 +873,15 @@ main (int argc, char **argv)
+ 			pid_set = 1; /*flag pid.xml check*/
+ 			//printf("vid:%s pid:%s\n", vid, pid);
+ 		}
+-		
++
++		const char* dataDir = getenv( "NIX_UVCDYNCTRL_DATA_DIR" );
++		// When unavailable, fallback on data dir specified at build time.
++		if ( !dataDir ) {
++			dataDir = DATA_DIR;
++		}
++
+ 		/* get xml file list from DATA_DIR/vid/ */ 
+-		char **xml_files = get_filename (DATA_DIR, vid);
++		char **xml_files = get_filename (dataDir, vid);
+  
+ 		/*check for pid.xml*/
+ 		char fname[9];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9717,6 +9717,8 @@ with pkgs;
 
   libvorbis = callPackage ../development/libraries/libvorbis { };
 
+  libwebcam = callPackage ../os-specific/linux/libwebcam { };
+
   libwebp = callPackage ../development/libraries/libwebp { };
 
   libwmf = callPackage ../development/libraries/libwmf { };


### PR DESCRIPTION
###### Motivation for this change

Required dependency for some camera relying of the `uvcdynctrl`'s dev utility to add and manage dynamic control (expressed as xml files) to the uvcvideo driver.

Is one actual dependency for an upcoming `tiscamera` package (for driving cameras from The Imaging Source).

Once / if accepted, should also base some nixos module on the contained `uvcdynctrl` utility to combine the `*.xml` data from multiple camera package to be loaded by `uvcdynctrl` udev rule.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

