### PR TITLE
nextcloud-client: fix build after qt updates

### DIFF
--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, cmake, pkgconfig, qtbase, qtwebkit, qtkeychain, sqlite
+{ stdenv, fetchgit, cmake, pkgconfig, qtbase, qtwebkit, qtkeychain, qttools, sqlite
 , inotify-tools, withGnomeKeyring ? false, makeWrapper, libgnome_keyring }:
 
 stdenv.mkDerivation rec {
@@ -12,9 +12,12 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [ ./find-sql.patch ];
+  patchFlags = "-d client -p1";
+
   nativeBuildInputs = [ pkgconfig cmake ];
 
-  buildInputs = [ qtbase qtwebkit qtkeychain sqlite ]
+  buildInputs = [ qtbase qtwebkit qtkeychain qttools sqlite ]
     ++ stdenv.lib.optional stdenv.isLinux inotify-tools
     ++ stdenv.lib.optional withGnomeKeyring makeWrapper;
 

--- a/pkgs/applications/networking/nextcloud-client/find-sql.patch
+++ b/pkgs/applications/networking/nextcloud-client/find-sql.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/modules/QtVersionAbstraction.cmake b/cmake/modules/QtVersionAbstraction.cmake
+index 5bd853c84..93ddf3cf8 100644
+--- a/cmake/modules/QtVersionAbstraction.cmake
++++ b/cmake/modules/QtVersionAbstraction.cmake
+@@ -17,6 +17,7 @@ if( Qt5Core_FOUND )
+     message(STATUS "Found Qt5 core, checking for further dependencies...")
+     find_package(Qt5Network REQUIRED)
+     find_package(Qt5Xml REQUIRED)
++    find_package(Qt5Sql REQUIRED)
+     find_package(Qt5Concurrent REQUIRED)
+     if(UNIT_TESTING)
+         find_package(Qt5Test REQUIRED)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3561,7 +3561,7 @@ with pkgs;
 
   nextcloud = callPackage ../servers/nextcloud { };
 
-  nextcloud-client = libsForQt56.callPackage ../applications/networking/nextcloud-client { };
+  nextcloud-client = libsForQt5.callPackage ../applications/networking/nextcloud-client { };
 
   nextcloud-news-updater = callPackage ../servers/nextcloud/news-updater.nix { };
 


### PR DESCRIPTION
Probably necessary after restructuring/updates in #31462

###### Motivation for this change
Missing Sql was the reason qt was downgraded in the first place: fdcb4fa4b8d100215c1fa6cb1fc585d7476740c1
This fix might apply identically to owncloud-client.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
