### PR TITLE
php: tidySupport option

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -4,7 +4,7 @@
 , mysql, libxml2, readline, zlib, curl, postgresql, gettext
 , openssl, pcre, pkgconfig, sqlite, config, libjpeg, libpng, freetype
 , libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, freetds
-, uwimap, pam, gmp, apacheHttpd, libiconv, systemd, libsodium }:
+, uwimap, pam, gmp, apacheHttpd, libiconv, systemd, libsodium, libtidy }:
 
 let
 
@@ -230,6 +230,11 @@ let
           configureFlags = ["--with-sodium=${libsodium.dev}"];
           buildInputs = [libsodium];
         };
+
+        tidy = {
+          configureFlags = [ "--with-tidy=${libtidy}" ];
+          buildInputs = [ libtidy ];
+        };
       };
 
       cfg = {
@@ -270,6 +275,7 @@ let
         ztsSupport = config.php.zts or false;
         calendarSupport = config.php.calendar or true;
         sodiumSupport = (lib.versionAtLeast version "7.2") && config.php.sodium or true;
+        tidySupport = php7 && config.php.tidy or true;
       };
 
       hardeningDisable = [ "bindnow" ];


### PR DESCRIPTION
###### Motivation for this change

I had something that needed the libtidy bindings in php, so I added this.

###### Things done

 I only tested this in a very basic way: build and check phpinfo()

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

