### PR TITLE
gstreamer.gst-plugins-bad: Patch openjpeg version

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -15,6 +15,12 @@ assert gtkSupport -> gtk3 != null;
 
 let
   inherit (stdenv.lib) optional optionalString;
+
+  # OpenJPEG version is hardcoded in package source
+  openJpegVersion = with stdenv;
+    lib.concatStringsSep "." (lib.lists.take 2
+      (lib.splitString "." (lib.getVersion openjpeg)));
+
 in
 stdenv.mkDerivation rec {
   name = "gst-plugins-bad-1.12.2";
@@ -31,6 +37,10 @@ stdenv.mkDerivation rec {
     license     = licenses.lgpl2Plus;
     platforms   = platforms.linux;
   };
+
+  patchPhase = ''
+    sed -i 's/openjpeg-2.1/openjpeg-${openJpegVersion}/' ext/openjpeg/*
+  '';
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-bad/${name}.tar.xz";


### PR DESCRIPTION
###### Motivation for this change
`gstreamer.gst-plugins-bad` is broken because the source contains a hard-coded path to `openjpeg`.

This broke in https://github.com/NixOS/nixpkgs/commit/4e5725605b321805a10466238eff4d51a6c4315d which bumped the `openjpeg` version from `2.1` to `2.3`.

cc @fpletz @7c6f434c 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

