### PR TITLE
nettle: 3.3 -> 3.4

### DIFF
--- a/pkgs/development/libraries/nettle/default.nix
+++ b/pkgs/development/libraries/nettle/default.nix
@@ -1,10 +1,10 @@
 { callPackage, fetchurl, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "3.3";
+  version = "3.4";
 
   src = fetchurl {
     url = "mirror://gnu/nettle/nettle-${version}.tar.gz";
-    sha256 = "07mif3af077763vc35s1x8vzhzlgqcgxh67c1xr13jnhslkjd526";
+    sha256 = "150y8655h629wn946dvzasq16qxsc1m9nf58mifvhl350bgl4ymf";
   };
 })


### PR DESCRIPTION
###### Motivation for this change


This is both a bugfix release and a feature release (see http://lists.gnu.org/archive/html/info-gnu/2017-11/msg00007.html). I am not sure if we want to backport it to `release-17.09` (my preference would be yes). @globin @fpletz I let you decide to port it or not.

BR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

