### PR TITLE
rdedup: init at 2.0.0

### DIFF
--- a/pkgs/tools/backup/rdedup/default.nix
+++ b/pkgs/tools/backup/rdedup/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, libsodium, lzma }:
+
+rustPlatform.buildRustPackage rec {
+  name = "rdedup-${version}";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "dpc";
+    repo = "rdedup";
+    rev = "v${version}";
+    sha256 = "14r6x1wi5mwadarm0vp6qnr5mykv4g0kxz9msq76fhwghwb9k1d9";
+  };
+
+  buildInputs = [ pkgconfig libsodium lzma ];
+
+  cargoSha256 = "0wyswc4b4hkiw20gz0w94vv1qgcb2zq0cdaj9zxvyr5l0abxip9w";
+
+  meta = with stdenv.lib; {
+    description = "Data deduplication with compression and public key encryption";
+    homepage = https://github.com/dpc/rdedup;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ dywedir ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16418,6 +16418,8 @@ with pkgs;
 
   rdesktop = callPackage ../applications/networking/remote/rdesktop { };
 
+  rdedup = callPackage ../tools/backup/rdedup { };
+
   rdup = callPackage ../tools/backup/rdup { };
 
   realpine = callPackage ../applications/networking/mailreaders/realpine {


### PR DESCRIPTION
###### Motivation for this change


Add [rdedup](https://github.com/dpc/rdedup#rdedup)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

