### PR TITLE
spark: provided-hadoop -> nixpkgs hadoop

### DIFF
--- a/pkgs/applications/networking/cluster/spark/default.nix
+++ b/pkgs/applications/networking/cluster/spark/default.nix
@@ -1,19 +1,15 @@
-{ stdenv, fetchzip, makeWrapper, jre, pythonPackages, coreutils
+{ stdenv, fetchzip, makeWrapper, jre, pythonPackages, coreutils, hadoop
 , RSupport? true, R
 , mesosSupport ? true, mesos
 , version
 }:
 
 let
-  versionMap = {
-    "2.2.1" = {
-                hadoopVersion = "hadoop2.7";
-                sparkSha256 = "10nxsf9a6hj1263sxv0cbdqxdb8mb4cl6iqq32ljq9ydvk32s99c";
-              };
-  };
+  sha256 = {
+    "1.6.3" = "142hw73wf20d846l83ydx0yg7qj5qxywm4h7qrhwnd7lsy2sbnjf";
+    "2.2.1" = "10nxsf9a6hj1263sxv0cbdqxdb8mb4cl6iqq32ljq9ydvk32s99c";
+  }.${version};
 in
-
-with versionMap.${version};
 
 with stdenv.lib;
 
@@ -22,15 +18,15 @@ stdenv.mkDerivation rec {
   name = "spark-${version}";
 
   src = fetchzip {
-    url    = "mirror://apache/spark/${name}/${name}-bin-${hadoopVersion}.tgz";
-    sha256 = sparkSha256;
+    inherit sha256;
+    url    = "mirror://apache/spark/${name}/${name}-bin-without-hadoop.tgz";
   };
 
   buildInputs = [ makeWrapper jre pythonPackages.python pythonPackages.numpy ]
     ++ optional RSupport R
     ++ optional mesosSupport mesos;
 
-  untarDir = "${name}-bin-${hadoopVersion}";
+  untarDir = "${name}-bin-without-hadoop";
   installPhase = ''
     mkdir -p $out/{lib/${untarDir}/conf,bin,/share/java}
     mv * $out/lib/${untarDir}
@@ -42,6 +38,7 @@ stdenv.mkDerivation rec {
     cat > $out/lib/${untarDir}/conf/spark-env.sh <<- EOF
     export JAVA_HOME="${jre}"
     export SPARK_HOME="$out/lib/${untarDir}"
+    export SPARK_DIST_CLASSPATH=$(${hadoop}/bin/hadoop classpath)
     export PYSPARK_PYTHON="${pythonPackages.python}/bin/${pythonPackages.python.executable}"
     export PYTHONPATH="\$PYTHONPATH:$PYTHONPATH"
     ${optionalString RSupport
@@ -63,7 +60,7 @@ stdenv.mkDerivation rec {
     homepage         = "http://spark.apache.org";
     license          = stdenv.lib.licenses.asl20;
     platforms        = stdenv.lib.platforms.all;
-    maintainers      = with maintainers; [ thoughtpolice offline ];
+    maintainers      = with maintainers; [ thoughtpolice offline kamilchm ];
     repositories.git = git://git.apache.org/spark.git;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

spark should use nixpkgs provided hadoop to make it consistent
for bigger Nix hadoop + spark setup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

