### PR TITLE
dns-root-data: use a stable URL that I maintain anyway

### DIFF
--- a/pkgs/data/misc/dns-root-data/default.nix
+++ b/pkgs/data/misc/dns-root-data/default.nix
@@ -3,7 +3,13 @@
 let
 
   rootHints = fetchurl {
-    url = "https://www.internic.net/domain/named.root";
+    # Original source https://www.internic.net/domain/named.root
+    # occasionally suffers from pointless hash changes,
+    # and having stable sources for older versions has advantages, too.
+    urls = map (prefix: prefix + "cc5e14a264912/etc/root.hints") [
+      "https://gitlab.labs.nic.cz/knot/knot-resolver/raw/"
+      "https://raw.githubusercontent.com/CZ-NIC/knot-resolver/"
+    ];
     sha256 = "0vdrff4l8s8grif52dnh091s8qydhh88k25zqd9rj66sf1qwcwxl";
   };
 
@@ -24,6 +30,6 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "DNS root data including root zone and DNSSEC key";
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ fpletz vcunat ];
   };
 }


### PR DESCRIPTION
See #31855.

/cc maintainer @fpletz.