### PR TITLE
pythonPackages.locustio: 0.7.2 -> 0.8 &  pythonPackages.gevent: 1.1.2 -> 1.2.2

### DIFF
--- a/pkgs/development/python-modules/gevent/default.nix
+++ b/pkgs/development/python-modules/gevent/default.nix
@@ -1,19 +1,12 @@
 { stdenv, fetchurl, buildPythonPackage, isPyPy, python, libev, greenlet }:
 
 buildPythonPackage rec {
-  name = "gevent-1.1.2";
+  name = "gevent-1.2.2";
 
   src = fetchurl {
     url = "mirror://pypi/g/gevent/${name}.tar.gz";
-    sha256 = "cb15cf73d69a2eeefed330858f09634e2c50bf46da9f9e7635730fcfb872c02c";
+    sha256 = "0bbbjvi423y9k9xagrcsimnayaqymg6f2dj76m9z3mjpkjpci4a7";
   };
-
-  # Why do we have this patch?
-  postPatch = ''
-    substituteInPlace libev/ev.c --replace \
-      "ecb_inline void ecb_unreachable (void) ecb_noreturn" \
-      "ecb_inline ecb_noreturn void ecb_unreachable (void)"
-  '';
 
   buildInputs = [ libev ];
   propagatedBuildInputs = stdenv.lib.optionals (!isPyPy) [ greenlet ];

--- a/pkgs/development/python-modules/locustio/default.nix
+++ b/pkgs/development/python-modules/locustio/default.nix
@@ -1,0 +1,32 @@
+{ buildPythonPackage
+, fetchPypi
+, mock
+, unittest2
+, msgpack
+, requests
+, flask
+, gevent
+, pyzmq
+}:
+
+buildPythonPackage rec {
+  pname = "locustio";
+  version = "0.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0y3r2g31z7g120c7v91zdvcakwfxv2acbgs4flarv5yza2knl11c";
+  };
+
+  patchPhase = ''
+    sed -i s/"pyzmq=="/"pyzmq>="/ setup.py
+  '';
+
+  propagatedBuildInputs = [ msgpack requests flask gevent pyzmq ];
+  buildInputs = [ mock unittest2 ];
+
+  meta = {
+    homepage = http://locust.io/;
+    description = "A load testing tool";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10435,22 +10435,7 @@ in {
     fuse = pkgs.fuse;  # use "real" fuse, not the python module
   };
 
-  locustio = buildPythonPackage rec {
-    name = "locustio-0.7.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/l/locustio/${name}.tar.gz";
-      sha256 = "c9ca6fdfe6a6fb187a3d54ddf9b1518196348e8f20537f0a14ca81a264ffafa2";
-    };
-
-    propagatedBuildInputs = [ self.msgpack self.requests self.flask self.gevent self.pyzmq ];
-    buildInputs = [ self.mock self.unittest2 ];
-
-    meta = {
-      homepage = http://locust.io/;
-      description = "A load testing tool";
-    };
-  };
+  locustio = callPackage ../development/python-modules/locustio { };
 
   llvmlite = callPackage ../development/python-modules/llvmlite {llvm=pkgs.llvm_4;};
 


### PR DESCRIPTION
###### Motivation for this change
Adds python 3 support and unbreaks `pythonPackages.locustio` in hydra. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

