### PR TITLE
kruler: init at 5.0

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -127,6 +127,7 @@ let
       kqtquickcharts = callPackage ./kqtquickcharts.nix {};
       krdc = callPackage ./krdc.nix {};
       krfb = callPackage ./krfb.nix {};
+      kruler = callPackage ./kruler.nix {};
       ktnef = callPackage ./ktnef.nix {};
       kwalletmanager = callPackage ./kwalletmanager.nix {};
       libgravatar = callPackage ./libgravatar.nix {};

--- a/pkgs/applications/kde/kruler.nix
+++ b/pkgs/applications/kde/kruler.nix
@@ -1,0 +1,17 @@
+{
+  mkDerivation, lib,
+  extra-cmake-modules, kdoctools,
+  knotifications, kwindowsystem, kxmlgui, qtx11extras
+}:
+
+mkDerivation {
+  name = "kruler";
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.vandenoever ];
+  };
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [
+    kwindowsystem knotifications kxmlgui qtx11extras
+  ];
+}


### PR DESCRIPTION
###### Motivation for this change

Add a new, useful package

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

