### PR TITLE
nixopsUnstable: don't depend on external URLs

### DIFF
--- a/pkgs/tools/package-management/nixops/unstable.nix
+++ b/pkgs/tools/package-management/nixops/unstable.nix
@@ -1,10 +1,39 @@
-{ callPackage, fetchurl }:
+{ callPackage, lib, path, fetchFromGitHub }:
 
-callPackage ./generic.nix (rec {
-  version = "2017-05-22";
-  src = fetchurl {
-    # Sadly hydra doesn't offer download links
-    url = "https://static.domenkozar.com/nixops-1.5.1pre2169_8f4a67c.tar.bz2";
-    sha256 = "0rma5npgkhlknmvm8z0ps54dsr07za1f32p6d6na3nis784h0slw";
+let
+  rev = "92034401b5291070a93ede030e718bb82b5e6da4";
+
+  src = fetchFromGitHub {
+    owner = "NixOS";
+    repo  = "nixops";
+    inherit rev;
+    sha256 = "139mmf8ag392w5mn419k7ajp3pgcz6q349n7vm7gsp3g4sck2jjn";
   };
-})
+
+  nixopsSrc = {
+    outPath = src;
+    revCount = 0;
+    shortRev = lib.substring 0 6 rev;
+    inherit rev;
+  };
+
+  officialRelease = false;
+
+  release = import (src + "/release.nix") {
+    inherit nixopsSrc;
+    inherit officialRelease;
+    nixpkgs = path;
+  };
+
+  version = "1.6" + (
+    if officialRelease
+    then ""
+    else "pre${toString nixopsSrc.revCount}_${nixopsSrc.shortRev}"
+  );
+
+  releaseName = "nixops-${version}";
+
+in callPackage ./generic.nix {
+  inherit version;
+  src = release.tarball + "/tarballs/${releaseName}.tar.bz2";
+}


### PR DESCRIPTION
###### Motivation for this change

Upgrading `nixopsUnstable` is currently difficult because you have to generate a tarball, put it somewhere online and point the derivation to it (for example we currently use `https://static.domenkozar.com/nixops-1.5.1pre2169_8f4a67c.tar.bz2`). 

Ideally, we only have to specify a git revision and sha256. 

###### Things done

Instead of downloading a tarball from an external URL we build the tarball ourself by downloading nixops's source code from GitHub and importing the release.nix file.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@domenkozar ping.
