### PR TITLE
arangodb: Add a NixOS service

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -300,6 +300,7 @@
       kanboard = 281;
       pykms = 282;
       kodi = 283;
+      arangodb = 284;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -568,6 +569,7 @@
       kanboard = 281;
       pykms = 282;
       kodi = 283;
+      arangodb = 284;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/services/databases/arangodb.nix
+++ b/nixos/modules/services/databases/arangodb.nix
@@ -1,0 +1,69 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.arangodb;
+  stateDir = "/var/lib/arango";
+in
+with lib;
+{
+
+  ###### interface
+
+  options = {
+
+    services.arangodb = {
+
+      enable = mkOption {
+        default = false;
+        description = "Whether to enable ArangoDB database server.";
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    users.extraUsers.arangodb = {
+      name = "arangodb";
+      uid = config.ids.uids.arangodb;
+      group = "arangodb";
+      description = "ArangoDB server user";
+    };
+
+    users.extraGroups.arangodb.gid = config.ids.gids.arangodb;
+
+    systemd.services.arangodb = {
+      description = "ArangoDB server";
+
+      wantedBy = [ "multi-user.target" ];
+
+      after = [ "network.target" ];
+
+      preStart = ''
+        mkdir -p ${stateDir}
+        chown arangodb:arangodb ${stateDir}
+      '';
+
+      script = ''
+        exec ${pkgs.arangodb}/bin/arangod     \
+          --database.directory ${stateDir}    \
+          --javascript.app-path ${stateDir}   \
+          --log.file ${stateDir}/arangodb.log \
+          --working-directory ${stateDir}     \
+          --cluster.password root             \
+          > ${stateDir}/arangodb.stdout 2>&1
+      '';
+
+      serviceConfig = {
+        User = "arangodb";
+        Group = "arangodb";
+        PermissionsStartOnly = true;
+      };
+    };
+
+  };
+
+}


### PR DESCRIPTION
###### Motivation for this change

Make it easy to launch ArangoDB as a service in NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

