### PR TITLE
kernel config: Enable MEDIA_CONTROLLER

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -571,6 +571,7 @@ with stdenv.lib;
   ${optionalString (versionOlder version "4.14") ''
     MEDIA_RC_SUPPORT y
   ''}
+  MEDIA_CONTROLLER y
   MEDIA_USB_SUPPORT y
   MEDIA_PCI_SUPPORT y
   MEDIA_ANALOG_TV_SUPPORT y


### PR DESCRIPTION
With this disabled, cameras would not get a `/dev/mediaX` entry matching
the `/dev/videoX` which broke any application (e.g: `uvcdynctrl -l`,
`media-ctl -p`) depending on this interface.

Should also be applied to 17.09.

###### Motivation for this change

Broken utilities which work seamlessly on Ubuntu 16.04 but are unusable on Nixos (because of the missing config). Unable to properly setup a camera from "The Imaging Source".


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested configure seamlessly with all supported kernels:

~~~
  linuxPackages_beagleboard.kernel
  linuxPackages_hardened_copperhead.kernel
  linuxPackages_mptcp.kernel
  linuxPackages_rpi.kernel
  linuxPackages_4_4.kernel
  linuxPackages_4_9.kernel
  linuxPackages_4_13.kernel
  linuxPackages_4_14.kernel
~~~ 

Tested complete build with `linuxPackages_4_9.kernel`, booted with it and now successfully used `uvcdynctrl -l`, `media-ctl -p` and broken gstreamer pipelines with my camera. `/dev/media0` now show up when I plug my usb camera.

