### PR TITLE
migmix: init at 20150712

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -414,6 +414,7 @@
   michelk = "Michel Kuhlmann <michel@kuhlmanns.info>";
   midchildan = "midchildan <midchildan+nix@gmail.com>";
   mikefaille = "Michaël Faille <michael@faille.io>";
+  mikoim = "Eshin Kunishima <ek@esh.ink>";
   miltador = "Vasiliy Solovey <miltador@yandex.ua>";
   mimadrid = "Miguel Madrid <mimadrid@ucm.es>";
   mirdhyn = "Merlin Gaillard <mirdhyn@gmail.com>";

--- a/pkgs/data/fonts/migmix/default.nix
+++ b/pkgs/data/fonts/migmix/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchzip }:
+
+stdenv.mkDerivation rec {
+  name = "migmix-${version}";
+  version = "20150712";
+
+  srcs = [
+    (fetchzip {
+      url = "mirror://sourceforgejp/mix-mplus-ipa/63544/migmix-1p-${version}.zip";
+      sha256 = "0wp44axcalaak04nj3dgpx0vk13nqa3ihx2vjv4acsgv83x8ciph";
+    })
+    (fetchzip {
+      url = "mirror://sourceforgejp/mix-mplus-ipa/63544/migmix-2p-${version}.zip";
+      sha256 = "0y7s3rbxrp5bv56qgihk8b847lqgibfhn2wlkzx7z655fbzdgxw9";
+    })
+    (fetchzip {
+      url = "mirror://sourceforgejp/mix-mplus-ipa/63544/migmix-1m-${version}.zip";
+      sha256 = "1sfym0chy8ilyd9sr3mjc0bf63vc33p05ynpdc11miivxn4qsshx";
+    })
+    (fetchzip {
+      url = "mirror://sourceforgejp/mix-mplus-ipa/63544/migmix-2m-${version}.zip";
+      sha256 = "0hg04rvm39fh4my4akmv4rhfc14s3ipz2aw718h505k9hppkhkch";
+    })
+  ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype/migmix
+    find ${toString srcs} -name '*.ttf' | xargs -I % cp % $out/share/fonts/truetype/migmix
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A high-quality Japanese font based on M+ fonts and IPA fonts";
+    homepage = http://mix-mplus-ipa.osdn.jp/migmix;
+    license = stdenv.lib.licenses.ipa;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ maintainers.mikoim ];
+  };
+}

--- a/pkgs/data/fonts/migmix/default.nix
+++ b/pkgs/data/fonts/migmix/default.nix
@@ -23,18 +23,22 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  phases = [ "installPhase" ];
+  unpackPhase = ":";
 
   installPhase = ''
     mkdir -p $out/share/fonts/truetype/migmix
-    find ${toString srcs} -name '*.ttf' | xargs -I % cp % $out/share/fonts/truetype/migmix
+    find $srcs -name '*.ttf' | xargs install -m644 --target $out/share/fonts/truetype/migmix
   '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "1fhh8wg6lxwrnsg9rl4ihffl0bsp1wqa5gps9fx60kr6j9wpvmbg";
 
   meta = with stdenv.lib; {
     description = "A high-quality Japanese font based on M+ fonts and IPA fonts";
     homepage = http://mix-mplus-ipa.osdn.jp/migmix;
-    license = stdenv.lib.licenses.ipa;
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.ipa;
+    platforms = platforms.unix;
     maintainers = [ maintainers.mikoim ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13471,6 +13471,8 @@ with pkgs;
 
   meslo-lg = callPackage ../data/fonts/meslo-lg {};
 
+  migmix = callPackage ../data/fonts/migmix {};
+
   miscfiles = callPackage ../data/misc/miscfiles { };
 
   media-player-info = callPackage ../data/misc/media-player-info {};


### PR DESCRIPTION
###### Motivation for this change
migmix is one of high-quality free Japanese font.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] ~Tested execution of all binary files (usually in `./result/bin/`)~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

