### PR TITLE
nix-zsh-completions: 0.3.3 -> 0.3.5, nix-bash-completions: 0.4 -> 0.5

### DIFF
--- a/pkgs/shells/nix-bash-completions/default.nix
+++ b/pkgs/shells/nix-bash-completions/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "0.4";
+  version = "0.5";
   name = "nix-bash-completions-${version}";
 
   src = fetchFromGitHub {
     owner = "hedning";
     repo = "nix-bash-completions";
     rev = "v${version}";
-    sha256 = "08gl9xnk738p180hpn3l7ggrz5zlky4pam7v74kb0gavjxm4fa2f";
+    sha256 = "095dbbqssaxf0y85xw73gajif6lzy2aja4scg3plplng3k9zbldz";
   };
 
   installPhase = ''

--- a/pkgs/shells/nix-zsh-completions/default.nix
+++ b/pkgs/shells/nix-zsh-completions/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub }:
 
 let
-  version = "0.3.3";
+  version = "0.3.5";
 in
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "spwhitt";
     repo = "nix-zsh-completions";
     rev = "${version}";
-    sha256 = "0gvqm6grz3s0llz20sa18n5d2anmsrk892lcv7blv8rai151whpw";
+    sha256 = "1fp565qbzbbwj99rq3c28gpq8gcnlxb2glj05382zimas1dfd0y9";
   };
 
   installPhase = ''


### PR DESCRIPTION
These have no dependencies and should be safe to backport to 17.09.

###### Motivation for this change

New version of nix-zsh-completions ([changelog](https://github.com/spwhitt/nix-zsh-completions/releases/tag/0.3.4)) and nix-bash-completions ([changelog](https://github.com/hedning/nix-bash-completions/releases/tag/v0.5)).

Some highlights:
- Attribute completion for cached repos specified with an url, eg. `nix-build channel:nixos-17.09 -A ...`. This is somewhat untested on 1.12 as nix on my machine refuses to download any repos due to lack of signatures.
- `--include|-I` completion for all compatible commands. (only `nix` takes the includes into account when completing attribute paths though)
- All file like completion now should work sanely in bash, ie. just like `ls` and similar commands

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

