### PR TITLE
wimlib: init at 1.12.0

### DIFF
--- a/pkgs/tools/archivers/wimlib/default.nix
+++ b/pkgs/tools/archivers/wimlib/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, lib, fetchurl, pkgs, makeWrapper, bash
+, cabextract ? null
+, cdrkit ? null
+, mtools ? null
+, ntfs3g ? null
+, syslinux ? null
+}:
+
+stdenv.mkDerivation rec {
+  version = "1.12.0";
+  name = "wimlib-${version}";
+
+  nativeBuildInputs = with pkgs; [ pkgconfig makeWrapper ];
+  buildInputs = with pkgs; [ openssl fuse libxml2 ntfs3g ];
+
+  src = fetchurl {
+    url = "https://wimlib.net/downloads/${name}.tar.gz";
+    sha256 = "852cf59d682a91974f715f09fa98cab621b740226adcfea7a42360be0f86464f";
+  };
+
+ prefixPackages = [ cabextract cdrkit mtools ntfs3g syslinux ];
+
+  preBuild = ''
+    substituteInPlace programs/mkwinpeimg.in --replace '/usr/lib/syslinux' "${syslinux}/share/syslinux"
+  '';
+
+  postInstall = ''
+    for prog in $out/bin/*; do
+      wrapProgram $prog --prefix PATH : ${lib.makeBinPath prefixPackages}
+    done
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    patchShebangs tests/
+    for testfile in tests/test-*; do
+      wrapProgram $testfile --prefix PATH : ${lib.makeBinPath prefixPackages}
+    done
+    make check
+  '';
+
+  meta = with lib; {
+    homepage = https://wimlib.net;
+    description = "A library and program to extract, create, and modify WIM files";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ andir ];
+    license = with licenses; [ gpl3 lgpl3 cc0 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5137,6 +5137,8 @@ with pkgs;
 
   wicd = callPackage ../tools/networking/wicd { };
 
+  wimlib = callPackage ../tools/archivers/wimlib { };
+
   wipe = callPackage ../tools/security/wipe { };
 
   wkhtmltopdf = callPackage ../tools/graphics/wkhtmltopdf {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
   - I didn't specifically call  / test all binaries. I succeeded building a WindowsPE image using it which seemed like a good enough test.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

