### PR TITLE
microcodeIntel: 20170707 -> 20171117

### DIFF
--- a/pkgs/os-specific/linux/microcode/intel.nix
+++ b/pkgs/os-specific/linux/microcode/intel.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "microcode-intel-${version}";
-  version = "20170707";
+  version = "20171117";
 
   src = fetchurl {
-    url = "https://downloadmirror.intel.com/26925/eng/microcode-${version}.tgz";
-    sha256 = "14zf7fbhg0msa3bm0kl139pclmkfm83s6l86x48sr9sjpxllgm2g";
+    url = "https://downloadmirror.intel.com/27337/eng/microcode-${version}.tgz";
+    sha256 = "1p14ypbg28bdkbza6dx6dpjrdr5p13vmgrh2cw0y1v2qzalivgck";
   };
 
   buildInputs = [ libarchive ];


### PR DESCRIPTION
###### Motivation for this change
From the changelog:

```
Intel Processor Microcode Package for Linux
20171117 Release

-- New Platforms --
CFL U0 (06-9e-0a:22) 70
CFL B0 (06-9e-0b:2) 72
SKX H0 (06-55-04:b7) 2000035
GLK B0 (06-7a-01:1) 1e
APL Bx (06-5c-09:3) 2c
-- Updates --
KBL Y0 (06-8e-0a:c0) 66->70
-- Removed files --
SKX H0 (06-55-04:97) 2000022
```




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

