### PR TITLE
vimPlugins.vim-grammarous: set languagetool path

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -5,6 +5,8 @@
 , python3, boost, icu
 , ycmd, makeWrapper, rake
 , pythonPackages, python3Packages
+, substituteAll
+, languagetool
 , Cocoa ? null, git
 }:
 
@@ -1405,7 +1407,16 @@ rec {
       sha256 = "1mm8hd39q2sl4hi83c4zvrl27a8djr1pv35ch0pivg84ad9p7qq5";
     };
     dependencies = [];
-
+    # use `:GrammarousCheck` to initialize checking
+    # In neovim, you also want to use set
+    #   let g:grammarous#show_first_error = 1
+    # see https://github.com/rhysd/vim-grammarous/issues/39
+    patches = [
+      (substituteAll {
+        src = ./patches/vim-grammarous/set_default_languagetool.patch;
+        inherit languagetool;
+      })
+    ];
   };
 
   vim-puppet = buildVimPluginFrom2Nix { # created by nix#NixDerivation

--- a/pkgs/misc/vim-plugins/patches/vim-grammarous/set_default_languagetool.patch
+++ b/pkgs/misc/vim-plugins/patches/vim-grammarous/set_default_languagetool.patch
@@ -1,0 +1,11 @@
+--- vim-grammarous-51ef519.org/autoload/grammarous.vim	1970-01-01 01:00:01.000000000 +0100
++++ vim-grammarous-51ef519/autoload/grammarous.vim	2017-11-21 16:33:27.473403322 +0000
+@@ -22,7 +22,7 @@
+ let g:grammarous#enable_spell_check              = get(g:, 'grammarous#enable_spell_check', 0)
+ let g:grammarous#move_to_first_error             = get(g:, 'grammarous#move_to_first_error', 1)
+ let g:grammarous#hooks                           = get(g:, 'grammarous#hooks', {})
+-let g:grammarous#languagetool_cmd                = get(g:, 'grammarous#languagetool_cmd', '')
++let g:grammarous#languagetool_cmd                = get(g:, 'grammarous#languagetool_cmd', '@languagetool@/bin/languagetool-commandline')
+ let g:grammarous#show_first_error                = get(g:, 'grammarous#show_first_error', 0)
+ 
+ highlight default link GrammarousError SpellBad

--- a/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/vim-grammarous
+++ b/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/vim-grammarous
@@ -1,0 +1,10 @@
+    # use `:GrammarousCheck` to initialize checking
+    # In neovim, you also want to use set
+    #   let g:grammarous#show_first_error = 1
+    # see https://github.com/rhysd/vim-grammarous/issues/39
+    patches = [
+      (substituteAll {
+        src = ./patches/vim-grammarous/set_default_languagetool.patch;
+        inherit languagetool;
+      })
+    ];


### PR DESCRIPTION
Otherwise it try to install languagetool into nix store

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

