### PR TITLE
clamav: apply patch for CVE-2017-6420

### DIFF
--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, bzip2, libiconv, libxml2, openssl, ncurses, curl
+{ stdenv, fetchurl, fetchpatch, zlib, bzip2, libiconv, libxml2, openssl, ncurses, curl
 , libmilter, pcre }:
 
 stdenv.mkDerivation rec {
@@ -9,6 +9,14 @@ stdenv.mkDerivation rec {
     url = "https://www.clamav.net/downloads/production/${name}.tar.gz";
     sha256 = "0yh2q318bnmf2152g2h1yvzgqbswn0wvbzb8p4kf7v057shxcyqn";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2017-6420.patch";
+      url = "https://github.com/vrtadmin/clamav-devel/commit/dfc00cd3301a42b571454b51a6102eecf58407bc.patch";
+      sha256 = "08w3p3a4pmi0cmcmyxkagsbn3g0jgx1jqlc34pn141x0qzrlqr60";
+    })
+  ];
 
   # don't install sample config files into the absolute sysconfdir folder
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

```The wwunpack function in libclamav/wwunpack.c in ClamAV 0.99.2 allows remote attackers to cause denial of service (use-after-free) via a crafted PE file with WWPack compression.```

Details at [1].

[1] https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-6420




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

