### PR TITLE
buildRustPackage: make dependencies' source writable

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -43,6 +43,10 @@ in stdenv.mkDerivation (args // {
   postUnpack = ''
     eval "$cargoDepsHook"
 
+    unpackFile "$cargoDeps"
+    cargoDepsCopy=$(stripHash $(basename $cargoDeps))
+    chmod -R +w "$cargoDepsCopy"
+
     mkdir .cargo
     cat >.cargo/config <<-EOF
       [source.crates-io]
@@ -50,8 +54,10 @@ in stdenv.mkDerivation (args // {
       replace-with = 'vendored-sources'
 
       [source.vendored-sources]
-      directory = '$cargoDeps'
+      directory = '$(pwd)/$cargoDepsCopy'
     EOF
+
+    unset cargoDepsCopy
 
     export RUST_LOG=${logLevel}
     export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt


### PR DESCRIPTION
### Motivation

Some packages, such as the xcb crate, do code generation at build-time;
therefore, the dependencies' source tree must be writable.

### Testing

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

