### PR TITLE
[stable/17.09] ffmpeg: 3.3.4 -> 3.3.5 (CVE-2017-15186)

### DIFF
--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -231,11 +231,11 @@ assert nvenc -> nvidia-video-sdk != null && nonfreeLicensing;
 
 stdenv.mkDerivation rec {
   name = "ffmpeg-full-${version}";
-  version = "3.3.4";
+  version = "3.3.5";
 
   src = fetchurl {
     url = "https://www.ffmpeg.org/releases/ffmpeg-${version}.tar.xz";
-    sha256 = "0mx9dvad3lkyhvsrblf280x2bz6dxajya1ylnspbdzldj0dpxfcq";
+    sha256 = "00nq8ng2p16yb48acargaz1hlp9kq24vfwvkqjlslz4a7864k4x8";
   };
 
   patchPhase = ''patchShebangs .

--- a/pkgs/development/libraries/ffmpeg/3.3.nix
+++ b/pkgs/development/libraries/ffmpeg/3.3.nix
@@ -6,7 +6,7 @@
 
 callPackage ./generic.nix (args // rec {
   version = "${branch}";
-  branch = "3.3.4";
-  sha256 = "0zmczggi95fbsq9nz33mpln1y3p1gqniqc4x5smp871idhkykxay";
+  branch = "3.3.5";
+  sha256 = "02h6y5sadqmci2ssalaxg65wa69ldscj05311zym8zijibzlqhqv";
   darwinFrameworks = [ Cocoa CoreMedia ];
 })


### PR DESCRIPTION
###### Motivation for this change

Potential (remote) DOS with crafted AVI files in ffmpeg <= 3.3.4.

More details at [1].

[1] http://www.openwall.com/lists/oss-security/2017/10/20/4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

