### PR TITLE
Munin: Fix broken plugins

### DIFF
--- a/nixos/modules/services/monitoring/munin.nix
+++ b/nixos/modules/services/monitoring/munin.nix
@@ -17,40 +17,6 @@ let
   nodeCfg = config.services.munin-node;
   cronCfg = config.services.munin-cron;
 
-  muninPlugins = pkgs.stdenv.mkDerivation {
-    name = "munin-available-plugins";
-    buildCommand = ''
-      mkdir -p $out
-
-      cp --preserve=mode ${pkgs.munin}/lib/plugins/* $out/
-
-      for file in $out/*; do
-        case "$file" in
-            */plugin.sh|*/plugins.history)
-              chmod +x "$file"
-              continue;;
-        esac
-
-        # read magic makers from the file
-        family=$(sed -nr 's/.*#%#\s+family\s*=\s*(\S+)\s*/\1/p' $file)
-        cap=$(sed -nr 's/.*#%#\s+capabilities\s*=\s*(.+)/\1/p' $file)
-
-        wrapProgram $file \
-          --set PATH "/run/wrappers/bin:/run/current-system/sw/bin" \
-          --set MUNIN_LIBDIR "${pkgs.munin}/lib" \
-          --set MUNIN_PLUGSTATE "/var/run/munin"
-
-        # munin uses markers to tell munin-node-configure what a plugin can do
-        echo "#%# family=$family" >> $file
-        echo "#%# capabilities=$cap" >> $file
-      done
-
-      # NOTE: we disable disktstats because plugin seems to fail and it hangs html generation (100% CPU + memory leak)
-      rm -f $out/diskstats
-    '';
-    buildInputs = [ pkgs.makeWrapper ];
-  };
-
   muninConf = pkgs.writeText "munin.conf"
     ''
       dbdir     /var/lib/munin
@@ -83,6 +49,29 @@ let
 
       ${nodeCfg.extraConfig}
     '';
+
+  pluginConf = pkgs.writeText "munin-plugin-conf"
+    ''
+      [hddtemp_smartctl]
+      user root
+      group root
+
+      [meminfo]
+      user root
+      group root
+
+      [ipmi*]
+      user root
+      group root
+    '';
+
+  pluginConfDir = pkgs.stdenv.mkDerivation {
+    name = "munin-plugin-conf.d";
+    buildCommand = ''
+      mkdir $out
+      ln -s ${pluginConf} $out/nixos-config
+    '';
+  };
 in
 
 {
@@ -179,17 +168,22 @@ in
       description = "Munin Node";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      path = [ pkgs.munin ];
+      path = with pkgs; [ munin smartmontools "/run/current-system/sw" "/run/wrappers" ];
+      environment.MUNIN_LIBDIR = "${pkgs.munin}/lib";
       environment.MUNIN_PLUGSTATE = "/var/run/munin";
+      environment.MUNIN_LOGDIR = "/var/log/munin";
       preStart = ''
         echo "updating munin plugins..."
 
         mkdir -p /etc/munin/plugins
         rm -rf /etc/munin/plugins/*
-        PATH="/run/wrappers/bin:/run/current-system/sw/bin" ${pkgs.munin}/sbin/munin-node-configure --shell --families contrib,auto,manual --config ${nodeConf} --libdir=${muninPlugins} --servicedir=/etc/munin/plugins 2>/dev/null | ${pkgs.bash}/bin/bash
+        ${pkgs.munin}/bin/munin-node-configure --suggest --shell --families contrib,auto,manual --config ${nodeConf} --libdir=${pkgs.munin}/lib/plugins --servicedir=/etc/munin/plugins --sconfdir=${pluginConfDir} 2>/dev/null | ${pkgs.bash}/bin/bash
+
+        # NOTE: we disable disktstats because plugin seems to fail and it hangs html generation (100% CPU + memory leak)
+        rm /etc/munin/plugins/diskstats || true
       '';
       serviceConfig = {
-        ExecStart = "${pkgs.munin}/sbin/munin-node --config ${nodeConf} --servicedir /etc/munin/plugins/";
+        ExecStart = "${pkgs.munin}/sbin/munin-node --config ${nodeConf} --servicedir /etc/munin/plugins/ --sconfdir=${pluginConfDir}";
       };
     };
 

--- a/pkgs/servers/monitoring/munin/adding_sconfdir_munin-node.patch
+++ b/pkgs/servers/monitoring/munin/adding_sconfdir_munin-node.patch
@@ -1,0 +1,41 @@
+commit af5fa3623bb9a73052f9154be4a0f38c60ea42a2
+Author: Kjetil Orbekk <kjetil.orbekk@gmail.com>
+Date:   Thu Nov 23 21:21:36 2017 -0500
+
+    node: add --sconfdir to set plugin configuration dir
+
+diff --git a/node/sbin/munin-node b/node/sbin/munin-node
+index 909c8c4e..0ccf3941 100755
+--- a/node/sbin/munin-node
++++ b/node/sbin/munin-node
+@@ -100,9 +100,11 @@ sub parse_args
+     my @ORIG_ARGV  = @ARGV;
+ 
+     my $servicedir_cmdline;
++    my $sconfdir_cmdline;
+     print_usage_and_exit() unless GetOptions(
+         "config=s"     => \$conffile,
+         "servicedir=s" => \$servicedir_cmdline,
++        "sconfdir=s"   => \$sconfdir_cmdline,
+         "debug!"       => \$DEBUG,
+         "pidebug!"     => \$PIDEBUG,
+         "paranoia!"    => \$paranoia,
+@@ -112,6 +114,7 @@ sub parse_args
+ 
+     # We untaint the args brutally, since the sysadm should know what he does
+     $servicedir = $1 if defined $servicedir_cmdline && $servicedir_cmdline =~ m/(.*)/;
++    $sconfdir = $1 if defined $sconfdir_cmdline && $sconfdir_cmdline =~ m/(.*)/;
+ 
+     # Reset ARGV (for HUPing)
+     @ARGV = @ORIG_ARGV;
+@@ -175,6 +178,10 @@ Use E<lt>fileE<gt> as configuration file. [@@CONFDIR@@/munin-node.conf]
+ 
+ Override plugin directory [@@CONFDIR@@/plugins/]
+ 
++=item B<< --sconfdir <dir> >>
++
++Override plugin configuration directory [@@CONFDIR@@/plugin-conf.d/]
++
+ =item B< --[no]paranoia >
+ 
+ Only run plugins owned by root. Check permissions as well. [--noparanoia]

--- a/pkgs/servers/monitoring/munin/default.nix
+++ b/pkgs/servers/monitoring/munin/default.nix
@@ -3,14 +3,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.0.33";
+  version = "2.0.34";
   name = "munin-${version}";
 
   src = fetchFromGitHub {
     owner = "munin-monitoring";
     repo = "munin";
     rev = version;
-    sha256 = "0rs05b7926mjd58sdry33i91m1h3v3svl0wg2gmhljl8wqidac5w";
+    sha256 = "0mb5m0nc3nr9781d3s99sjdssmvkv37gxyplzr6d73i4hi31m7fr";
   };
 
   buildInputs = [ 

--- a/pkgs/servers/monitoring/munin/default.nix
+++ b/pkgs/servers/monitoring/munin/default.nix
@@ -67,6 +67,8 @@ stdenv.mkDerivation rec {
 
     # https://github.com/munin-monitoring/munin/pull/134
     ./adding_servicedir_munin-node.patch
+
+    ./preserve_environment.patch
   ];
 
   preBuild = ''

--- a/pkgs/servers/monitoring/munin/default.nix
+++ b/pkgs/servers/monitoring/munin/default.nix
@@ -68,6 +68,7 @@ stdenv.mkDerivation rec {
     # https://github.com/munin-monitoring/munin/pull/134
     ./adding_servicedir_munin-node.patch
 
+    ./adding_sconfdir_munin-node.patch
     ./preserve_environment.patch
   ];
 

--- a/pkgs/servers/monitoring/munin/preserve_environment.patch
+++ b/pkgs/servers/monitoring/munin/preserve_environment.patch
@@ -1,0 +1,41 @@
+commit d94c29b7397362857b81d8c877a989fdb28490d8
+Author: Kjetil Orbekk <kjetil.orbekk@gmail.com>
+Date:   Tue Nov 21 15:37:42 2017 -0500
+
+    Keep environment variables instead of overwriting them.
+
+diff --git a/common/lib/Munin/Common/Defaults.pm b/common/lib/Munin/Common/Defaults.pm
+index 131f52c0..bbf42697 100644
+--- a/common/lib/Munin/Common/Defaults.pm
++++ b/common/lib/Munin/Common/Defaults.pm
+@@ -71,7 +71,7 @@ sub export_to_environment {
+ 
+     my %defaults = %{$class->get_defaults()};
+     while (my ($k, $v) = each %defaults) {
+-        $ENV{$k} = $v;
++        $ENV{$k} = $ENV{$k} || $v;
+     }
+ 
+     return
+diff --git a/node/lib/Munin/Node/Service.pm b/node/lib/Munin/Node/Service.pm
+index 1b4f6114..be58bd77 100644
+--- a/node/lib/Munin/Node/Service.pm
++++ b/node/lib/Munin/Node/Service.pm
+@@ -122,7 +122,7 @@ sub export_service_environment {
+     # We append the USER to the MUNIN_PLUGSTATE, to avoid CVE-2012-3512
+     my $uid = $self->_resolve_uid($service);
+     my $user = getpwuid($uid);
+-    $ENV{MUNIN_PLUGSTATE} = "$Munin::Common::Defaults::MUNIN_PLUGSTATE/$user";
++    $ENV{MUNIN_PLUGSTATE} = "$ENV{MUNIN_PLUGSTATE}/$user";
+ 
+     # Provide a consistent default state-file.
+     $ENV{MUNIN_STATEFILE} = "$ENV{MUNIN_PLUGSTATE}/$service-$ENV{MUNIN_MASTER_IP}";
+@@ -243,7 +243,7 @@ sub exec_service
+ 
+     # XXX - Create the statedir for the user
+     my $uid = $self->_resolve_uid($service);
+-    Munin::Node::OS->mkdir_subdir("$Munin::Common::Defaults::MUNIN_PLUGSTATE", $uid);
++    Munin::Node::OS->mkdir_subdir("$ENV{MUNIN_PLUGSTATE}", $uid);
+ 
+     $self->change_real_and_effective_user_and_group($service);
+ 


### PR DESCRIPTION
###### Motivation for this change

The munin-node service used wrapProgram to inject environment variables.
This doesn't work because munin plugins depend on argv[0], which is
overwritten when the executable is a script with a shebang line.

Instead, rely on environment variables passed to the systemd units. This
requires another minor patch to munin.

Also fixes https://github.com/NixOS/nixpkgs/issues/23049 by disabling the
apc_nis plugin.

###### Things done

The munin.nix test passes.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

