### PR TITLE
Csu: fix build with CoreFoundation

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/Csu/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Csu/default.nix
@@ -1,24 +1,22 @@
 { stdenv, appleDerivation }:
 
 appleDerivation {
-  postUnpack = ''
-    substituteInPlace $sourceRoot/Makefile \
-      --replace "/usr/lib" "/lib" \
-      --replace "/usr/local/lib" "/lib" \
-      --replace "/usr/bin" "" \
-      --replace "/bin/" "" \
+  prePatch = ''
+    substituteInPlace Makefile \
+      --replace /usr/lib /lib \
+      --replace /usr/local/lib /lib \
+      --replace /usr/bin "" \
+      --replace /bin/ "" \
       --replace "CC = " "CC = cc #" \
-      --replace "SDK_DIR = " "SDK_DIR = . #"
+      --replace "SDK_DIR = " "SDK_DIR = . #" \
+
+    # Mac OS didn't support rpaths back before 10.5, but we don't care about it.
+    substituteInPlace Makefile \
+      --replace -mmacosx-version-min=10.4 -mmacosx-version-min=10.6 \
+      --replace -mmacosx-version-min=10.5 -mmacosx-version-min=10.6
   '';
 
-  # Mac OS didn't support rpaths back before 10.5, and this package intentionally builds stubs targeting versions prior to that
-  NIX_DONT_SET_RPATH = "1";
-  NIX_NO_SELF_RPATH  = "1";
-
-  installPhase = ''
-    export DSTROOT=$out
-    make install
-  '';
+  installFlags = [ "DSTROOT=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "Apple's common startup stubs for darwin";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

