### PR TITLE
nixopsUnstable: upgrade to HEAD and use a tarball from hydra

### DIFF
--- a/pkgs/tools/package-management/nixops/unstable.nix
+++ b/pkgs/tools/package-management/nixops/unstable.nix
@@ -1,10 +1,13 @@
 { callPackage, fetchurl }:
 
+# To upgrade pick the hydra job of the nixops revision that you want to upgrade
+# to from: https://hydra.nixos.org/job/nixops/master/tarball
+# Then copy the URL to the tarball.
+
 callPackage ./generic.nix (rec {
-  version = "2017-05-22";
+  version = "1.6pre2276_9203440";
   src = fetchurl {
-    # Sadly hydra doesn't offer download links
-    url = "https://static.domenkozar.com/nixops-1.5.1pre2169_8f4a67c.tar.bz2";
-    sha256 = "0rma5npgkhlknmvm8z0ps54dsr07za1f32p6d6na3nis784h0slw";
+    url = "https://hydra.nixos.org/build/64518294/download/2/nixops-${version}.tar.bz2";
+    sha256 = "1cl0869nl67fr5xk0jl9cvqbmma7d4vz5xbg56jpl7casrr3i51x";
   };
 })


### PR DESCRIPTION
###### Motivation for this change

This is a better version of https://github.com/NixOS/nixpkgs/pull/31869 that downloads a tarball from hydra of the latest nixops like @domenkozar suggested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

