### PR TITLE
[stable/17.09]  yara: 3.6.0 -> 3.6.3 (fixes CVE-2017-11328)

### DIFF
--- a/pkgs/tools/security/yara/default.nix
+++ b/pkgs/tools/security/yara/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, libtool, pcre
+{ stdenv, fetchpatch, fetchFromGitHub, autoconf, automake, libtool, pcre
 , withCrypto ? true, openssl
 , enableMagic ? true, file
 , enableCuckoo ? true, jansson
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.6.0";
+  version = "3.6.3";
   name = "yara-${version}";
 
   src = fetchFromGitHub {
     owner = "VirusTotal";
     repo = "yara";
     rev = "v${version}";
-    sha256 = "05nadqpvihdyxym11mn6n02rzv2ng8ga7j9l0g5gnjx366gcai42";
+    sha256 = "13znbdwin9lvql43wpms5hh13h8rk5x5wajgmphz18rxwp8h7j78";
   };
 
   # FIXME: this is probably not the right way to make it work
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The pattern matching swiss knife for malware researchers";
-    homepage    = http://plusvic.github.io/yara/;
+    homepage    = http://virustotal.github.io/yara/;
     license     = licenses.asl20;
     platforms   = stdenv.lib.platforms.all;
   };


### PR DESCRIPTION
###### Motivation for this change
Fixes Heap-Overflow.

Details at [1].

[1] https://nvd.nist.gov/vuln/detail/CVE-2017-11328

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

