### PR TITLE
rdesktop: enable credssp

### DIFF
--- a/pkgs/applications/networking/remote/rdesktop/default.nix
+++ b/pkgs/applications/networking/remote/rdesktop/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, openssl, libX11} :
+{stdenv, fetchurl, openssl, libX11, libgssglue, pkgconfig} :
 
 stdenv.mkDerivation (rec {
   pname = "rdesktop";
@@ -10,12 +10,12 @@ stdenv.mkDerivation (rec {
     sha256 = "1r7c1rjmw2xzq8fw0scyb453gy9z19774z1z8ldmzzsfndb03cl8";
   };
 
-  buildInputs = [openssl libX11];
+  nativeBuildInputs = [pkgconfig];
+  buildInputs = [openssl libX11 libgssglue];
 
   configureFlags = [
     "--with-ipv6"
     "--with-openssl=${openssl.dev}"
-    "--disable-credssp"
     "--disable-smartcard"
   ];
 

--- a/pkgs/development/libraries/libgssglue/default.nix
+++ b/pkgs/development/libraries/libgssglue/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, kerberos }:
+
+stdenv.mkDerivation rec {
+  name = "libgssglue-0.4";
+
+  src = fetchurl {
+    url = "http://www.citi.umich.edu/projects/nfsv4/linux/libgssglue/${name}.tar.gz";
+    sha256 = "0fh475kxzlabwz30wz3bf7i8kfqiqzhfahayx3jj79rba1sily9z";
+  };
+
+  postPatch = ''
+    sed s:/etc/gssapi_mech.conf:$out/etc/gssapi_mech.conf: -i src/g_initialize.c
+  '';
+
+  postInstall = ''
+    mkdir -p $out/etc
+    cat <<EOF > $out/etc/gssapi_mech.conf
+    ${kerberos}/lib/libgssapi_krb5.so mechglue_internal_krb5_init
+    EOF
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.citi.umich.edu/projects/nfsv4/linux/;
+    description = "Exports a gssapi interface which calls other random gssapi libraries";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ corngood ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9195,6 +9195,8 @@ with pkgs;
     monoSupport = false;
   };
 
+  libgssglue = callPackage ../development/libraries/libgssglue { };
+
   libgsystem = callPackage ../development/libraries/libgsystem { };
 
   libgudev = callPackage ../development/libraries/libgudev { };


### PR DESCRIPTION
###### Motivation for this change

This allows kerberos authentication in rdesktop, e.g.:

```
$ kinit user@REALM
$ rdesktop machine
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

