### PR TITLE
thespian: Python library init at 3.8.3

### DIFF
--- a/pkgs/development/python-modules/thespian/default.nix
+++ b/pkgs/development/python-modules/thespian/default.nix
@@ -9,13 +9,12 @@ buildPythonPackage rec {
     inherit pname version;
     extension = "zip";
     sha256 = "0vvwsh3waxd5ldrayr86kdcshv07bp361fl7p16g9i044vklwly4";
-    # fdbbea4edb6bad0ac0e53fc7bc6970e78e12eef4944aa4146bcdcb573201676c";
   };
 
   # Do not run the test suite: it takes a long type and uses
-  # significant system resources.  Thespian tests are performed via
-  # it's Travis CI configuration and do not need to be duplicated
-  # here.
+  # significant system resources, including requiring localhost
+  # network operations.  Thespian tests are performed via it's Travis
+  # CI configuration and do not need to be duplicated here.
   doCheck = false;
 
   meta = with lib; {

--- a/pkgs/development/python-modules/thespian/default.nix
+++ b/pkgs/development/python-modules/thespian/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchPypi, buildPythonPackage, lib }:
+
+buildPythonPackage rec {
+  version = "3.8.3";
+  pname = "thespian";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "0vvwsh3waxd5ldrayr86kdcshv07bp361fl7p16g9i044vklwly4";
+    # fdbbea4edb6bad0ac0e53fc7bc6970e78e12eef4944aa4146bcdcb573201676c";
+  };
+
+  # Do not run the test suite: it takes a long type and uses
+  # significant system resources.  Thespian tests are performed via
+  # it's Travis CI configuration and do not need to be duplicated
+  # here.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python Actor concurrency library";
+    homepage = http://thespianpy.com/;
+    license = licenses.mit;
+    maintainers = [ maintainers.kquick ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18169,6 +18169,8 @@ in {
     cudnnSupport = false;
   };
 
+  thespian = callPackage ../development/python-modules/thespian { };
+
   tidylib = buildPythonPackage rec {
     version = "0.2.4";
     name = "pytidylib-${version}";


### PR DESCRIPTION
###### Motivation for this change
New package (library for Python).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

