### PR TITLE
apt-cacher-ng: 0.9.1 -> 3.1

### DIFF
--- a/pkgs/servers/http/apt-cacher-ng/default.nix
+++ b/pkgs/servers/http/apt-cacher-ng/default.nix
@@ -1,17 +1,28 @@
-{ stdenv, fetchurl, cmake, doxygen, zlib, openssl, bzip2, pkgconfig, libpthreadstubs }:
+{ stdenv
+, bzip2
+, cmake
+, doxygen
+, fetchurl
+, fuse
+, lzma
+, openssl
+, pkgconfig
+, systemd
+, tcp_wrappers
+, zlib
+}:
 
 stdenv.mkDerivation rec {
   name = "apt-cacher-ng-${version}";
-  version = "0.9.1";
+  version = "3.1";
 
   src = fetchurl {
     url = "http://ftp.debian.org/debian/pool/main/a/apt-cacher-ng/apt-cacher-ng_${version}.orig.tar.xz";
-    sha256 = "1d686knvig1niapc1ib2045f7jfad3m4jvz6gkwm276fqvm4p694";
+    sha256 = "0p8cdig70vz1dgw2v8brjin5wqrk8amncphyf11f53bza5grlc91";
   };
 
-  NIX_LDFLAGS = "-lpthread";
   nativeBuildInputs = [ cmake doxygen pkgconfig ];
-  buildInputs = [ zlib openssl bzip2 libpthreadstubs ];
+  buildInputs = [ bzip2 fuse lzma openssl systemd tcp_wrappers zlib ];
 
   meta = with stdenv.lib; {
     description = "A caching proxy specialized for linux distribution files";


### PR DESCRIPTION
###### Motivation for this change
Looking through the issues #31747 caught my attention. This fixes building with gcc7 & bumps the version to the most recent release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

