### PR TITLE
pytest-flake8: 0.8.1 -> 0.9.1

### DIFF
--- a/pkgs/development/python-modules/pytest-flake8/default.nix
+++ b/pkgs/development/python-modules/pytest-flake8/default.nix
@@ -3,7 +3,7 @@
 buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "pytest-flake8";
-  version = "0.8.1";
+  version = "0.9.1";
 
   # although pytest is a runtime dependency, do not add it as
   # propagatedBuildInputs in order to allow packages depend on another version
@@ -13,18 +13,8 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1za5i09gz127yraigmcl443w6149714l279rmlfxg1bl2kdsc45a";
+    sha256 = "0032l4x2i5qn7ikaaw0kjs9f4ccpas21j564spyxwmx50wnhf5p7";
   };
-
-  patches = [
-    # Fix pytest strict mode (pull request #24)
-    # https://github.com/tholo/pytest-flake8/pull/24
-    (fetchpatch {
-      name = "fix-compatibility-with-pytest-strict-mode.patch";
-      url = "https://github.com/tholo/pytest-flake8/commit/434e1b07b4b77bfe1ddb9b2b54470c6c3815bb1a.patch";
-      sha256 = "0idwgkwwysx2cibnykd81yxrgqzkpf42j99jmpnanqzi99qnc3wx";
-    })
-  ];
 
   checkPhase = ''
     pytest --ignore=nix_run_setup.py .


### PR DESCRIPTION
###### Motivation for this change

pytest-flake8 0.8.1 was broken with the newest flake8 in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

