### PR TITLE
slack: 2.8.2 -> 2.9.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -4,7 +4,7 @@
 
 let
 
-  version = "2.8.2";
+  version = "2.9.0";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
@@ -46,7 +46,7 @@ let
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "https://downloads.slack-edge.com/linux_releases/slack-desktop-${version}-amd64.deb";
-        sha256 = "019gzij6m1y9bv561nhbhgf2njp2svjqi5hs907pdjf7xwciwrkm";
+        sha256 = "1ddfvsy4lr7hcnzxbk4crczylj1qwm9av02xms4w2p0k0c8nhvvc";
       }
     else
       throw "Slack is not supported on ${stdenv.system}";


### PR DESCRIPTION
###### Motivation for this change

Slack released a new upstream version. Since their changelogs are never exhaustive and sometimes they sneak vague security patches in it is probably best to keep the package updated...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

