### PR TITLE
fetchgitlocal: fix permission problem

### DIFF
--- a/pkgs/build-support/fetchgitlocal/default.nix
+++ b/pkgs/build-support/fetchgitlocal/default.nix
@@ -1,27 +1,26 @@
 { runCommand, git, nix }: src:
 
 let
+  tmpFolder =  "/tmp/fetchgitlocal-${builtins.toString currentTime}";
+  currentTime = builtins.currentTime; # impure, do every time
+
   srcStr = toString src;
 
-  # Adds the current directory (respecting ignored files) to the git store, and returns the hash
+  # Adds the current directory in the index (respecting ignored files) to the git store,
+  # and returns the hash
   gitHashFile = runCommand "put-in-git" {
       nativeBuildInputs = [ git ];
-      dummy = builtins.currentTime; # impure, do every time
+      dummy = currentTime;
       preferLocalBuild = true;
     } ''
-      cd ${srcStr}
-      DOT_GIT=$(git rev-parse --resolve-git-dir .git) # path to repo
+      # we need write access to update index
+      cp -r ${srcStr}/.git ${tmpFolder}
+      chmod a+w ${tmpFolder}
+      export GIT_DIR=${tmpFolder}
 
-      cp $DOT_GIT/index $DOT_GIT/index-user # backup index
-      git reset # reset index
-      git add . # add current directory
-
-      # hash of current directory
-      # remove trailing newline
-      git rev-parse $(git write-tree) \
-        | tr -d '\n' > $out
-
-      mv $DOT_GIT/index-user $DOT_GIT/index # restore index
+      # `tr` to remove trailing newline
+      res="$(git rev-parse --show-prefix)"
+      git write-tree --prefix="$res" | tr -d '\n' > $out
     '';
 
   gitHash = builtins.readFile gitHashFile; # cache against git hash
@@ -32,9 +31,13 @@ let
     } ''
       mkdir $out
 
+      # git annoyingly breaks without doing this since the hash does
+      # not correspond to repo root.
+      cd $(git -C ${srcStr} rev-parse --show-toplevel)
+
       # dump tar of *current directory* at given revision
-      git -C ${srcStr} archive --format=tar ${gitHash} \
-        | tar xf - -C $out
+      hash="${gitHash}"
+      git archive --format=tar $hash | tar xv -C $out
     '';
 
 in nixPath


### PR DESCRIPTION

###### Motivation for this change
Attempt to make fetchgitLocal usable again; see  https://github.com/NixOS/nixpkgs/issues/10873 and https://github.com/NixOS/nixpkgs/issues/31363

###### Things done

It was not possible to change the git index within the /nix/store/ so we
copy the git folder from /nix/store/ into /tmp and operates on it via GIT_DIR.

Would be cool if someone else could try it to make sure it works. Looked ok here on my project.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

