### PR TITLE
docker-ls: init at v0.3.1

### DIFF
--- a/pkgs/tools/misc/docker-ls/default.nix
+++ b/pkgs/tools/misc/docker-ls/default.nix
@@ -1,0 +1,29 @@
+{ buildGoPackage, fetchFromGitHub, stdenv, docker }:
+
+buildGoPackage rec {
+  name = "docker-ls-${version}";
+  version = "v0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "mayflower";
+    repo = "docker-ls";
+    rev = version;
+    sha256 = "1dhadi1s3nm3r8q5a0m59fy4jdya8p7zvm22ci7ifm3mmw960xly";
+  };
+
+  goPackagePath = "github.com/mayflower/docker-ls";
+
+  meta = with stdenv.lib; {
+    description = "Tools for browsing and manipulating docker registries";
+    longDescription = ''
+      Docker-ls is a set of CLI tools for browsing and manipulating docker registries.
+      In particular, docker-ls can handle authentication and display the sha256 content digests associated
+      with tags.
+    '';
+
+    homepage = https://github.com/mayflower/docker-ls;
+    maintainers = with maintainers; [ ma27 ];
+    platforms = docker.meta.platforms;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -110,6 +110,8 @@ with pkgs;
 
   docker_compose = pythonPackages.docker_compose;
 
+  docker-ls = callPackage ../tools/misc/docker-ls { };
+
   dotfiles = callPackage ../applications/misc/dotfiles { };
 
   dotnetenv = callPackage ../build-support/dotnetenv {


### PR DESCRIPTION
###### Motivation for this change

`docker-ls` is a tools which makes browsing registries way easier.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

