### PR TITLE
README.md: Remove Travis build status + use HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [<img src="http://nixos.org/logo/nixos-hires.png" width="500px" alt="logo" />](https://nixos.org/nixos)
 
-[![Build Status](https://travis-ci.org/NixOS/nixpkgs.svg?branch=master)](https://travis-ci.org/NixOS/nixpkgs)
 [![Code Triagers Badge](https://www.codetriage.com/nixos/nixpkgs/badges/users.svg)](https://www.codetriage.com/nixos/nixpkgs)
 
 Nixpkgs is a collection of packages for the [Nix](https://nixos.org/nix/) package

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[<img src="http://nixos.org/logo/nixos-hires.png" width="500px" alt="logo" />](https://nixos.org/nixos)
+[<img src="https://nixos.org/logo/nixos-hires.png" width="500px" alt="logo" />](https://nixos.org/nixos)
 
 [![Code Triagers Badge](https://www.codetriage.com/nixos/nixpkgs/badges/users.svg)](https://www.codetriage.com/nixos/nixpkgs)
 
 Nixpkgs is a collection of packages for the [Nix](https://nixos.org/nix/) package
-manager. It is periodically built and tested by the [hydra](http://hydra.nixos.org/)
+manager. It is periodically built and tested by the [Hydra](https://hydra.nixos.org/)
 build daemon as so-called channels. To get channel information via git, add
 [nixpkgs-channels](https://github.com/NixOS/nixpkgs-channels.git) as a remote:
 
@@ -22,7 +22,7 @@ release and `nixos-unstable` for the latest successful build of master:
 
 For pull-requests, please rebase onto nixpkgs `master`.
 
-[NixOS](https://nixos.org/nixos/) linux distribution source code is located inside
+[NixOS](https://nixos.org/nixos/) Linux distribution source code is located inside
 `nixos/` folder.
 
 * [NixOS installation instructions](https://nixos.org/nixos/manual/#ch-installation)


### PR DESCRIPTION
Should be fine, just wanted to make sure I didn't miss anything :smile:.

## Motivation for this change

### README: Use HTTPS for all hyperlinks
    
They redirect to HTTPS anyway. This also contains some minor content
changes.

### Remove the Travis build status image from the README
    
This information isn't useful anymore since we disabled all Travis CI
builds in 44917c46b1c398997a2e0786903000d44b6ab668.