### PR TITLE
afew: re-enable tests, update maintainers

### DIFF
--- a/pkgs/development/python-modules/afew/default.nix
+++ b/pkgs/development/python-modules/afew/default.nix
@@ -21,8 +21,6 @@ buildPythonPackage rec {
     chardet
   ] ++ stdenv.lib.optional (!isPy3k) subprocess32;
 
-  doCheck = false;
-
   postInstall = ''
     wrapProgram $out/bin/afew \
       --prefix LD_LIBRARY_PATH : ${notmuch}/lib

--- a/pkgs/development/python-modules/afew/default.nix
+++ b/pkgs/development/python-modules/afew/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/afewmail/afew;
     description = "An initial tagging script for notmuch mail";
-    maintainers = with maintainers; [ garbas ];
+    maintainers = with maintainers; [ garbas andir flokli ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
This re-enables tests, and adds me and @andir as maintainers, too.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

