### PR TITLE
usbip: Init at ${kernel.version}

### DIFF
--- a/pkgs/os-specific/linux/usbip/default.nix
+++ b/pkgs/os-specific/linux/usbip/default.nix
@@ -8,7 +8,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook libtool ];
   buildInputs = [ udev ];
 
-  sourceRoot = "${kernel.name}/tools/usb/usbip";
+  postUnpack = ''
+    cd tools/usb/usbip
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/torvalds/linux/tree/master/tools/usb/usbip;

--- a/pkgs/os-specific/linux/usbip/default.nix
+++ b/pkgs/os-specific/linux/usbip/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, lib, kernel, udev, autoconf, automake, libtool }:
+
+stdenv.mkDerivation rec {
+  name = "usbip-${kernel.name}";
+
+  src = kernel.src;
+
+  buildInputs = [ udev autoconf automake libtool ];
+
+  preConfigure = ''
+    cd tools/usb/usbip/
+    ./autogen.sh
+  '';
+
+  meta = {
+    homepage = https://github.com/torvalds/linux/tree/master/tools/usb/usbip;
+    description = "allows to pass USB device from server to client over the network";
+    license = lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/usbip/default.nix
+++ b/pkgs/os-specific/linux/usbip/default.nix
@@ -1,15 +1,16 @@
-{ stdenv, kernel, udev, autoreconfHook, libtool }:
+{ stdenv, kernel, udev, autoconf, automake, libtool }:
 
 stdenv.mkDerivation rec {
   name = "usbip-${kernel.name}";
 
   src = kernel.src;
 
-  nativeBuildInputs = [ autoreconfHook libtool ];
+  nativeBuildInputs = [ autoconf automake libtool ];
   buildInputs = [ udev ];
 
-  postUnpack = ''
+  preConfigure = ''
     cd tools/usb/usbip
+    ./autogen.sh
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/usbip/default.nix
+++ b/pkgs/os-specific/linux/usbip/default.nix
@@ -1,21 +1,19 @@
-{ stdenv, lib, kernel, udev, autoconf, automake, libtool }:
+{ stdenv, kernel, udev, autoreconfHook, libtool }:
 
 stdenv.mkDerivation rec {
   name = "usbip-${kernel.name}";
 
   src = kernel.src;
 
-  buildInputs = [ udev autoconf automake libtool ];
+  nativeBuildInputs = [ autoreconfHook libtool ];
+  buildInputs = [ udev ];
 
-  preConfigure = ''
-    cd tools/usb/usbip/
-    ./autogen.sh
-  '';
+  sourceRoot = "${kernel.name}/tools/usb/usbip";
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/torvalds/linux/tree/master/tools/usb/usbip;
     description = "allows to pass USB device from server to client over the network";
-    license = lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12718,6 +12718,8 @@ with pkgs;
 
     tp_smapi = callPackage ../os-specific/linux/tp_smapi { };
 
+    usbip = callPackage ../os-specific/linux/usbip { };
+
     v86d = callPackage ../os-specific/linux/v86d { };
 
     vhba = callPackage ../misc/emulators/cdemu/vhba.nix { };


### PR DESCRIPTION
###### Motivation for this change

Our kernel has the userspace modules for `usbip` (usb-over-ip) but lacks the necessary userspace tools.

With this package I was able to attach a simple wireless mouse receiver plugged into a raspberry-pi over a wireless network to my notebook running NixOS.

I'm not entirely sure if this approach (`src = kernel.src` etc.) is the right one for this situation. If there's a better way to package userspace tools in the kernel source tree, please tell me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

