### PR TITLE
gnumeric: 1.12.35 -> 1.12.36; goffice: 0.10.35 -> 0.10.36

### DIFF
--- a/pkgs/applications/office/gnumeric/default.nix
+++ b/pkgs/applications/office/gnumeric/default.nix
@@ -9,11 +9,11 @@ let
   isonum = fetchurl { url = http://www.oasis-open.org/docbook/xml/4.5/ent/isonum.ent; sha256 = "04b62dw2g3cj9i4vn9xyrsrlz8fpmmijq98dm0nrkky31bwbbrs3"; };
   isogrk1 = fetchurl { url = http://www.oasis-open.org/docbook/xml/4.5/ent/isogrk1.ent; sha256 = "04b23anhs5wr62n4rgsjirzvw7rpjcsf8smz4ffzaqh3b0vw90vm"; };
 in stdenv.mkDerivation rec {
-  name = "gnumeric-1.12.35";
+  name = "gnumeric-1.12.36";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnumeric/1.12/${name}.tar.xz";
-    sha256 = "77b1e3ce523578a807767ad71680fb865ac021d7bfadf93eada99ae094c06c0a";
+    sha256 = "3cbfe25f26bd31b832efed2827ac35c3c1600bed9ccd233a4037a9f4d7c54848";
   };
 
   configureFlags = "--disable-component";

--- a/pkgs/development/libraries/goffice/default.nix
+++ b/pkgs/development/libraries/goffice/default.nix
@@ -2,11 +2,11 @@
 , libgsf, libxml2, libxslt, cairo, pango, librsvg, libspectre }:
 
 stdenv.mkDerivation rec {
-  name = "goffice-0.10.35";
+  name = "goffice-0.10.36";
 
   src = fetchurl {
     url = "mirror://gnome/sources/goffice/0.10/${name}.tar.xz";
-    sha256 = "c19001afca09dc5446e06605a113d81a57124018a09c5889aeebba16cf1d5738";
+    sha256 = "cfe65fc0a665538704c7bab8541784291cf0781df8b4cff73cb0a513ee0baad6";
   };
 
   nativeBuildInputs = [ pkgconfig intltool ];


### PR DESCRIPTION
###### Motivation for this change

http://gnumeric.org/announcements/1.12/gnumeric-1.12.36.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

