### PR TITLE
pytorch: fix sha256 hash

### DIFF
--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     owner  = "pytorch";
     repo   = "pytorch";
     rev    = "v${version}";
-    sha256 = "112mp3r70d8f15dhxm6k7912b5i6c2q8hv9462s808y84grr2jdm";
+    sha256 = "1s3f46ga1f4lfrcj3lpvvhgkdr1pi8i2hjd9xj9qiz3a9vh2sj4n";
   };
 
   checkPhase = ''
@@ -22,7 +22,7 @@ buildPythonPackage rec {
      git
      numpy.blas
   ];
-  
+
   propagatedBuildInputs = [
     cffi
     numpy
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   preConfigure = ''
     export NO_CUDA=1
   '';
-  
+
   meta = {
     description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration.";
     homepage = http://pytorch.org/;


### PR DESCRIPTION
###### Motivation for this change
pytorch 0.2.0 installation failed due to wrong sha256 hash.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md
https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

