### PR TITLE
[wip] Rely on propagated findXMLCatalogs hook

### DIFF
--- a/pkgs/applications/version-management/cvs-fast-export/default.nix
+++ b/pkgs/applications/version-management/cvs-fast-export/default.nix
@@ -29,7 +29,6 @@ mkDerivation rec {
 
   preBuild = ''
     makeFlagsArray=(
-      XML_CATALOG_FILES="${docbook_xml_dtd_45}/xml/dtd/docbook/catalog.xml ${docbook_xsl}/xml/xsl/docbook/catalog.xml"
       LIBS=""
       prefix="$out"
     )

--- a/pkgs/applications/version-management/reposurgeon/default.nix
+++ b/pkgs/applications/version-management/reposurgeon/default.nix
@@ -31,7 +31,6 @@ in mkDerivation rec {
 
   preBuild = ''
     makeFlagsArray=(
-      XML_CATALOG_FILES="${docbook_xml_dtd_412}/xml/dtd/docbook/catalog.xml ${docbook_xsl}/xml/xsl/docbook/catalog.xml"
       prefix="$out"
       pyinclude="-I${python}/include/python2.7"
       pylib="-L${python}/lib -lpython2.7"

--- a/pkgs/data/sgml+xml/schemas/docbook-5.0/default.nix
+++ b/pkgs/data/sgml+xml/schemas/docbook-5.0/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, unzip }:
+{ lib, stdenv, fetchurl, unzip, findXMLCatalogs }:
 
 stdenv.mkDerivation {
   name = "docbook5-5.0";
@@ -9,6 +9,8 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ unzip ];
+
+  propagatedBuildInputs = [ findXMLCatalogs ];
 
   installPhase =
     ''

--- a/pkgs/os-specific/linux/lxc/default.nix
+++ b/pkgs/os-specific/linux/lxc/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoreconfHook pkgconfig perl docbook2x python3Packages.wrapPython
+    docbook_xml_dtd_45
   ];
   buildInputs = [
     pam libapparmor gnutls libselinux libseccomp libcap
@@ -31,8 +32,6 @@ stdenv.mkDerivation rec {
   postPatch = ''
     sed -i '/chmod u+s/d' src/lxc/Makefile.am
   '';
-
-  XML_CATALOG_FILES = "${docbook_xml_dtd_45}/xml/dtd/docbook/catalog.xml";
 
   configureFlags = [
     "--enable-pam"

--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -15,9 +15,7 @@ stdenv.mkDerivation rec {
     "DB2MAN=docbook2man"
   ];
 
-  XML_CATALOG_FILES = "${docbook_xml_dtd_45}/xml/dtd/docbook/catalog.xml";
-
-  nativeBuildInputs = [ pkgconfig docbook2x flex bison ];
+  nativeBuildInputs = [ pkgconfig docbook2x docbook_xml_dtd_45 flex bison ];
   buildInputs = [ libmnl libnftnl gmp readline ];
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/shadow/respect-xml-catalog-files-var.patch
+++ b/pkgs/os-specific/linux/shadow/respect-xml-catalog-files-var.patch
@@ -1,0 +1,30 @@
+diff --git a/acinclude.m4 b/acinclude.m4
+index dd01f165..e23160ee 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -46,9 +46,21 @@ AC_DEFUN([JH_CHECK_XML_CATALOG],
+     ifelse([$3],,,[$3
+ ])dnl
+   else
+-    AC_MSG_RESULT([not found])
+-    ifelse([$4],,
+-       [AC_MSG_ERROR([could not find ifelse([$2],,[$1],[$2]) in XML catalog])],
+-       [$4])
++    jh_check_xml_catalog_saved_ifs="$IFS"
++    IFS=' '
++    for f in $XML_CATALOG_FILES; do
++      if [[ -f "$f" ]] && \
++        AC_RUN_LOG([$XMLCATALOG --noout "$f" "$1" >&2]); then
++        jh_found_xmlcatalog=true
++        AC_MSG_RESULT([found])
++        ifelse([$3],,,[$3])
++        break
++      fi
++    done
++    IFS="$jh_check_xml_catalog_saved_ifs"
++    if ! $jh_found_xmlcatalog; then
++      AC_MSG_RESULT([not found])
++      ifelse([$4],,[AC_MSG_ERROR([could not find ifelse([$2],,[$1],[$2]) in XML catalog])],[$4])
++    fi
+   fi
+ ])

--- a/pkgs/os-specific/linux/sssd/default.nix
+++ b/pkgs/os-specific/linux/sssd/default.nix
@@ -7,9 +7,6 @@
   docbook_xsl, docbook_xml_dtd_44,
   withSudo ? false }:
 
-let
-  docbookFiles = "${docbook_xsl}/share/xml/docbook-xsl/catalog.xml:${docbook_xml_dtd_44}/xml/dtd/docbook/catalog.xml";
-in
 stdenv.mkDerivation rec {
   name = "sssd-${version}";
   version = "1.16.4";
@@ -23,7 +20,6 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-I${libxml2.dev}/include/libxml2";
 
   preConfigure = ''
-    export SGML_CATALOG_FILES="${docbookFiles}"
     export PYTHONPATH=${ldap}/lib/python2.7/site-packages
     export PATH=$PATH:${openldap}/libexec
 
@@ -39,7 +35,7 @@ stdenv.mkDerivation rec {
       --with-syslog=journald
       --without-selinux
       --without-semanage
-      --with-xml-catalog-path=''${SGML_CATALOG_FILES%%:*}
+      --with-xml-catalog-path=$(echo "$XML_CATALOG_FILES" | sed "s/ *\([^ ]*\).*/\1/")
       --with-ldb-lib-dir=$out/modules/ldb
       --with-nscd=${glibc.bin}/sbin/nscd
     )
@@ -48,6 +44,7 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+  nativeBuildInputs = [ docbook_xsl docbook_xml_dtd_44 ];
   buildInputs = [ augeas dnsutils c-ares curl cyrus_sasl ding-libs libnl libunistring nss
                   samba nfs-utils doxygen python python3 popt
                   talloc tdb tevent pkgconfig ldb pam openldap pcre kerberos
@@ -56,7 +53,7 @@ stdenv.mkDerivation rec {
                   nss_wrapper ncurses Po4a http-parser jansson ];
 
   makeFlags = [
-    "SGML_CATALOG_FILES=${docbookFiles}"
+    "SGML_CATALOG_FILES="
   ];
 
   installFlags = [

--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -151,7 +151,7 @@ stdenv.mkDerivation rec {
     sha256 = "1w71nk527lq504njmaf0vzr93pgahkgzzxzglrq6bay8cw2rvnvq";
   };
 
-  buildInputs = [ python2 unzip ];
+  buildInputs = [ python2 unzip docbook_xml_dtd_45 docbook_xsl_ns docbook_xsl ];
 
   # install filters early, so their shebangs are patched too
   patchPhase = with stdenv.lib; ''
@@ -239,7 +239,7 @@ stdenv.mkDerivation rec {
     # cannot find their neighbours (e.g. pdflatex doesn't find mktextfm).
     # We can remove PATH= when those impurities are fixed.
     # TODO: Is this still necessary when using texlive?
-    sed -e "s|^ENV =.*|ENV = dict(XML_CATALOG_FILES='${docbook_xml_dtd_45}/xml/dtd/docbook/catalog.xml ${docbook_xsl_ns}/xml/xsl/docbook/catalog.xml ${docbook_xsl}/xml/xsl/docbook/catalog.xml', PATH='${stdenv.lib.makeBinPath [ texlive coreutils gnused ]}')|" \
+    sed -e "s|^ENV =.*|ENV = dict(XML_CATALOG_FILES='$XML_CATALOG_FILES', PATH='${stdenv.lib.makeBinPath [ texlive coreutils gnused ]}')|" \
         -e "s|^ASCIIDOC =.*|ASCIIDOC = '$out/bin/asciidoc'|" \
         -e "s|^XSLTPROC =.*|XSLTPROC = '${libxslt.bin}/bin/xsltproc'|" \
         -e "s|^DBLATEX =.*|DBLATEX = '${dblatexFull}/bin/dblatex'|" \


### PR DESCRIPTION
###### Motivation for this change
We want to rely propagated `findXMLCatalogs` hook instead of manually specifying XML catalog paths all the time. Cherry-picked from #30457.

###### Things done

Needs to be tested.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

