### PR TITLE
signal-desktop: Add @ixmatus to the list of maintainers

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -79,9 +79,10 @@ in
 
     meta = {
       description = "Signal Private Messenger for the Desktop.";
-      homepage = https://signal.org/;
-      license = lib.licenses.gpl3;
-      platforms = [
+      homepage    = https://signal.org/;
+      license     = lib.licenses.gpl3;
+      maintainers = [ lib.maintainers.ixmatus ];
+      platforms   = [
         "x86_64-linux"
       ];
     };


### PR DESCRIPTION
###### Motivation for this change
My username had not been added to the set of maintainers when I submitted PR #31335. I submitted a change in PR #31681 adding my username to the set of maintainers. This change updates the `signal-desktop` derivation meta attribute with my username in the list of maintainers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

