### PR TITLE
oneko: init at 1.2.5

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -697,6 +697,7 @@
   womfoo = "Kranium Gikos Mendoza <kranium@gikos.net>";
   wscott = "Wayne Scott <wsc9tt@gmail.com>";
   wyvie = "Elijah Rum <elijahrum@gmail.com>";
+  xaverdh = "Dominik Xaver Hörl <hoe.dom@gmx.de>";
   xnwdd = "Guillermo NWDD <nwdd+nixos@no.team>";
   xvapx = "Marti Serra <marti.serra.coscollano@gmail.com>";
   xwvvvvwx = "David Terry <davidterry@posteo.de>";

--- a/pkgs/applications/misc/oneko/default.nix
+++ b/pkgs/applications/misc/oneko/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, xorg, x11 }:
+
+stdenv.mkDerivation rec {
+  version = "1.2.sakura.5";
+  vname = "1.2.5";
+  name = "oneko-${vname}";
+  src = fetchurl {
+    url = "http://www.daidouji.com/oneko/distfiles/oneko-${version}.tar.gz";
+    sha256 = "2c2e05f1241e9b76f54475b5577cd4fb6670de058218d04a741a04ebd4a2b22f";
+  };
+  buildInputs = [ xorg.imake xorg.gccmakedep x11 ];
+  
+  configurePhase = "xmkmf";
+
+  installPhase = ''
+    make install BINDIR=$out/bin
+    make install.man MANPATH=$out/share/man
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Creates a cute cat chasing around your mouse cursor";
+    longDescription = ''
+    Oneko changes your mouse cursor into a mouse
+    and creates a little cute cat, which starts
+    chasing around your mouse cursor.
+    When the cat is done catching the mouse, it starts sleeping.
+    '';
+    homepage = "http://www.daidouji.com/oneko/";
+    license = licenses.publicDomain;
+    maintainers = [ maintainers.xaverdh ];
+    meta.platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10056,6 +10056,8 @@ with pkgs;
 
   olm = callPackage ../development/libraries/olm { };
 
+  oneko = callPackage ../applications/misc/oneko { };   
+
   oniguruma = callPackage ../development/libraries/oniguruma { };
 
   openal = self.openalSoft;


### PR DESCRIPTION
###### Motivation for this change

This adds the oneko package.

###### Things done

As this is my first contribution to nixos, I expect some things will not be up to standards.
Please do give some feedback if that should be the case.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

