### PR TITLE
stockfish: 7 -> 8

### DIFF
--- a/pkgs/games/stockfish/default.nix
+++ b/pkgs/games/stockfish/default.nix
@@ -7,11 +7,11 @@ in
 
 stdenv.mkDerivation rec {
 
-  name = "stockfish-7";
+  name = "stockfish-8";
 
   src = fetchurl {
     url = "https://stockfish.s3.amazonaws.com/${name}-src.zip";
-    sha256 = "0djzg3h5d9qs27snf0rr6zl6iaki1jb84v8m8k3c2lcjbj2vpwc9";
+    sha256 = "1sachz41kbni88yjxwv5y4vl0gjbnyqvp1kpdm7v56k43zr3dbbv";
   };
 
   buildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

This is a simple update of the Stockfish chess engine from version 7 to 8. The build process is almost trivial, so the only thing I had to do was update the source URL and the hash (using `nix-prefetch-url`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

