### PR TITLE
gdbgui: init at 0.9.0.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -706,6 +706,7 @@
   ylwghst = "Burim Augustin Berisa <ylwghst@onionmail.info>";
   yochai = "Yochai <yochai@titat.info>";
   yorickvp = "Yorick van Pelt <yorickvanpelt@gmail.com>";
+  yrashk = "Yurii Rashkovskii <yrashk@gmail.com>";
   yuriaisaka = "Yuri Aisaka <yuri.aisaka+nix@gmail.com>";
   yurrriq = "Eric Bailey <eric@ericb.me>";
   z77z = "Marco Maggesi <maggesi@math.unifi.it>";

--- a/pkgs/development/tools/misc/gdbgui/default.nix
+++ b/pkgs/development/tools/misc/gdbgui/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, python27Packages, gdb, pkgs }:
+let
+  deps = import ./requirements.nix { inherit pkgs; };
+in
+python27Packages.buildPythonApplication rec {
+    name = "${pname}-${version}";
+    pname = "gdbgui";
+    version = "0.9.0.1";
+
+    buildInputs = [ gdb ];
+    propagatedBuildInputs = builtins.attrValues deps.packages;
+
+    src = python27Packages.fetchPypi {
+      inherit pname version;
+      sha256 = "1gjc7dycrc4zafhrd9yib7qnh4agh7cpa6rlw4p5405rlmwmsbj3";
+    };
+
+    postInstall = ''
+      wrapProgram $out/bin/gdbgui \
+                  --prefix PATH : ${stdenv.lib.makeBinPath [ gdb ]}
+    '';
+
+    # make /etc/protocols accessible to fix socket.getprotobyname('tcp') in sandbox
+    preCheck = stdenv.lib.optionalString stdenv.isLinux ''
+      export NIX_REDIRECTS=/etc/protocols=${pkgs.iana-etc}/etc/protocols \
+             LD_PRELOAD=${pkgs.libredirect}/lib/libredirect.so
+    '';
+
+    postCheck = stdenv.lib.optionalString stdenv.isLinux ''
+      unset NIX_REDIRECTS LD_PRELOAD
+    '';
+
+    meta = with stdenv.lib; {
+      description = "A browser-based frontend for GDB";
+      license = licenses.gpl3;
+      platforms = platforms.unix;
+      maintainers = with maintainers; [ yrashk ];
+    };
+
+  }

--- a/pkgs/development/tools/misc/gdbgui/requirements.nix
+++ b/pkgs/development/tools/misc/gdbgui/requirements.nix
@@ -1,0 +1,404 @@
+# generated using pypi2nix tool (version: 1.8.1)
+# See more at: https://github.com/garbas/pypi2nix
+#
+# COMMAND:
+#   pypi2nix -V 2.7 -r requirements.txt
+#
+
+{ pkgs ? import <nixpkgs> {}
+}:
+
+let
+
+  inherit (pkgs) makeWrapper;
+  inherit (pkgs.stdenv.lib) fix' extends inNixShell;
+
+  pythonPackages =
+  import "${toString pkgs.path}/pkgs/top-level/python-packages.nix" {
+    inherit pkgs;
+    inherit (pkgs) stdenv;
+    python = pkgs.python27Full;
+    # patching pip so it does not try to remove files when running nix-shell
+    overrides =
+      self: super: {
+        bootstrapped-pip = super.bootstrapped-pip.overrideDerivation (old: {
+          patchPhase = old.patchPhase + ''
+            sed -i               -e "s|paths_to_remove.remove(auto_confirm)|#paths_to_remove.remove(auto_confirm)|"                -e "s|self.uninstalled = paths_to_remove|#self.uninstalled = paths_to_remove|"                  $out/${pkgs.python35.sitePackages}/pip/req/req_install.py
+          '';
+        });
+      };
+  };
+
+  commonBuildInputs = [];
+  commonDoCheck = false;
+
+  withPackages = pkgs':
+    let
+      pkgs = builtins.removeAttrs pkgs' ["__unfix__"];
+      interpreter = pythonPackages.buildPythonPackage {
+        name = "python27Full-interpreter";
+        buildInputs = [ makeWrapper ] ++ (builtins.attrValues pkgs);
+        buildCommand = ''
+          mkdir -p $out/bin
+          ln -s ${pythonPackages.python.interpreter}               $out/bin/${pythonPackages.python.executable}
+          for dep in ${builtins.concatStringsSep " "               (builtins.attrValues pkgs)}; do
+            if [ -d "$dep/bin" ]; then
+              for prog in "$dep/bin/"*; do
+                if [ -f $prog ]; then
+                  ln -s $prog $out/bin/`basename $prog`
+                fi
+              done
+            fi
+          done
+          for prog in "$out/bin/"*; do
+            wrapProgram "$prog" --prefix PYTHONPATH : "$PYTHONPATH"
+          done
+          pushd $out/bin
+          ln -s ${pythonPackages.python.executable} python
+          ln -s ${pythonPackages.python.executable}               python2
+          popd
+        '';
+        passthru.interpreter = pythonPackages.python;
+      };
+    in {
+      __old = pythonPackages;
+      inherit interpreter;
+      mkDerivation = pythonPackages.buildPythonPackage;
+      packages = pkgs;
+      overrideDerivation = drv: f:
+        pythonPackages.buildPythonPackage (drv.drvAttrs // f drv.drvAttrs //                                            { meta = drv.meta; });
+      withPackages = pkgs'':
+        withPackages (pkgs // pkgs'');
+    };
+
+  python = withPackages {};
+
+  generated = self: {
+
+    "Flask" = python.mkDerivation {
+      name = "Flask-0.12.2";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/eb/12/1c7bd06fcbd08ba544f25bf2c6612e305a70ea51ca0eda8007344ec3f123/Flask-0.12.2.tar.gz"; sha256 = "49f44461237b69ecd901cc7ce66feea0319b9158743dd27a2899962ab214dac1"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [
+      self."Jinja2"
+      self."Werkzeug"
+      self."click"
+      self."itsdangerous"
+    ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://github.com/pallets/flask/";
+        license = licenses.bsdOriginal;
+        description = "A microframework based on Werkzeug, Jinja2 and good intentions";
+      };
+    };
+
+
+
+    "Flask-Compress" = python.mkDerivation {
+      name = "Flask-Compress-1.4.0";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/0e/2a/378bd072928f6d92fd8c417d66b00c757dc361c0405a46a0134de6fd323d/Flask-Compress-1.4.0.tar.gz"; sha256 = "468693f4ddd11ac6a41bca4eb5f94b071b763256d54136f77957cfee635badb3"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [
+      self."Flask"
+    ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "https://libwilliam.github.io/flask-compress/";
+        license = licenses.mit;
+        description = "Compress responses in your Flask app with gzip.";
+      };
+    };
+
+
+
+    "Flask-SocketIO" = python.mkDerivation {
+      name = "Flask-SocketIO-2.9.2";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/e7/e0/c50a1b47498897b228764667cd006ca7d45374b79a8e5e2fa3e03ba4717c/Flask-SocketIO-2.9.2.tar.gz"; sha256 = "0fb686f9d85f4f34dc6609f62fa96fe15176a6ea7e6179149d319fabc54c543b"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [
+      self."Flask"
+      self."python-engineio"
+      self."python-socketio"
+    ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://github.com/miguelgrinberg/Flask-SocketIO/";
+        license = licenses.mit;
+        description = "Socket.IO integration for Flask applications";
+      };
+    };
+
+
+
+    "Jinja2" = python.mkDerivation {
+      name = "Jinja2-2.10";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/56/e6/332789f295cf22308386cf5bbd1f4e00ed11484299c5d7383378cf48ba47/Jinja2-2.10.tar.gz"; sha256 = "f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [
+      self."MarkupSafe"
+    ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://jinja.pocoo.org/";
+        license = licenses.bsdOriginal;
+        description = "A small but fast and easy to use stand-alone template engine written in pure python.";
+      };
+    };
+
+
+
+    "MarkupSafe" = python.mkDerivation {
+      name = "MarkupSafe-1.0";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"; sha256 = "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [ ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://github.com/pallets/markupsafe";
+        license = licenses.bsdOriginal;
+        description = "Implements a XML/HTML/XHTML Markup safe string for Python";
+      };
+    };
+
+
+
+    "Pygments" = python.mkDerivation {
+      name = "Pygments-2.2.0";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/71/2a/2e4e77803a8bd6408a2903340ac498cb0a2181811af7c9ec92cb70b0308a/Pygments-2.2.0.tar.gz"; sha256 = "dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [ ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://pygments.org/";
+        license = licenses.bsdOriginal;
+        description = "Pygments is a syntax highlighting package written in Python.";
+      };
+    };
+
+
+
+    "Werkzeug" = python.mkDerivation {
+      name = "Werkzeug-0.12.2";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/56/41/c095a77eb2dd69bf278dd664a97d3416af04e9ba1a00b8c138f772741d31/Werkzeug-0.12.2.tar.gz"; sha256 = "903a7b87b74635244548b30d30db4c8947fe64c5198f58899ddcd3a13c23bb26"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [ ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://werkzeug.pocoo.org/";
+        license = licenses.bsdOriginal;
+        description = "The Swiss Army knife of Python web development";
+      };
+    };
+
+
+
+    "click" = python.mkDerivation {
+      name = "click-6.7";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/click-6.7.tar.gz"; sha256 = "f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [ ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://github.com/mitsuhiko/click";
+        license = licenses.bsdOriginal;
+        description = "A simple wrapper around optparse for powerful command line utilities.";
+      };
+    };
+
+
+
+    "enum-compat" = python.mkDerivation {
+      name = "enum-compat-0.0.2";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/95/6e/26bdcba28b66126f66cf3e4cd03bcd63f7ae330d29ee68b1f6b623550bfa/enum-compat-0.0.2.tar.gz"; sha256 = "939ceff18186a5762ae4db9fa7bfe017edbd03b66526b798dd8245394c8a4192"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [
+      self."enum34"
+    ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "https://github.com/jstasiak/enum-compat";
+        license = licenses.mit;
+        description = "enum/enum34 compatibility package";
+      };
+    };
+
+
+
+    "enum34" = python.mkDerivation {
+      name = "enum34-1.1.6";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/bf/3e/31d502c25302814a7c2f1d3959d2a3b3f78e509002ba91aea64993936876/enum34-1.1.6.tar.gz"; sha256 = "8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [ ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "https://bitbucket.org/stoneleaf/enum34";
+        license = licenses.bsdOriginal;
+        description = "Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4";
+      };
+    };
+
+
+
+    "eventlet" = python.mkDerivation {
+      name = "eventlet-0.21.0";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/cb/ec/eae487c106a7e38f86ac4cadafb3eec77d29996f64ca0c7015067538069b/eventlet-0.21.0.tar.gz"; sha256 = "08faffab88c1b08bd53ea28bf084a572c89f7e7648bd9d71e6116ac17a51a15d"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [
+      self."enum-compat"
+      self."greenlet"
+    ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://eventlet.net";
+        license = licenses.mit;
+        description = "Highly concurrent networking library";
+      };
+    };
+
+
+
+    "gevent" = python.mkDerivation {
+      name = "gevent-1.2.2";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/1b/92/b111f76e54d2be11375b47b213b56687214f258fd9dae703546d30b837be/gevent-1.2.2.tar.gz"; sha256 = "4791c8ae9c57d6f153354736e1ccab1e2baf6c8d9ae5a77a9ac90f41e2966b2d"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [
+      self."greenlet"
+    ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://www.gevent.org/";
+        license = licenses.mit;
+        description = "Coroutine-based network library";
+      };
+    };
+
+
+
+    "greenlet" = python.mkDerivation {
+      name = "greenlet-0.4.12";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/be/76/82af375d98724054b7e273b5d9369346937324f9bcc20980b45b068ef0b0/greenlet-0.4.12.tar.gz"; sha256 = "e4c99c6010a5d153d481fdaf63b8a0782825c0721506d880403a3b9b82ae347e"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [ ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "https://github.com/python-greenlet/greenlet";
+        license = licenses.mit;
+        description = "Lightweight in-process concurrent programming";
+      };
+    };
+
+
+
+    "itsdangerous" = python.mkDerivation {
+      name = "itsdangerous-0.24";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/dc/b4/a60bcdba945c00f6d608d8975131ab3f25b22f2bcfe1dab221165194b2d4/itsdangerous-0.24.tar.gz"; sha256 = "cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [ ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://github.com/mitsuhiko/itsdangerous";
+        license = licenses.bsdOriginal;
+        description = "Various helpers to pass trusted data to untrusted environments and back.";
+      };
+    };
+
+
+
+    "pygdbmi" = python.mkDerivation {
+      name = "pygdbmi-0.7.4.4";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/bb/1c/8c8cbd0bb5cf513a905e3ca461cfad578e708a74417182f2a00943136f83/pygdbmi-0.7.4.4.tar.gz"; sha256 = "34cd00925ca98aed87decb6a0451fa094cf31386dc457b47a62bcbf8d905a3d3"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [ ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "https://github.com/cs01/pygdbmi";
+        license = licenses.mit;
+        description = "Parse gdb machine interface output with Python";
+      };
+    };
+
+
+
+    "pypugjs" = python.mkDerivation {
+      name = "pypugjs-4.2.2";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/21/bb/d541110bd5a5c1ecd9dab2778dc9a39ca5a5e9962845e9d3e598962ee3ca/pypugjs-4.2.2.tar.gz"; sha256 = "c99a72a78766d9462d94379a6b489f9864ecdeeeeaf8d0f34b2ce04963f6ec8c"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [
+      self."six"
+    ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://github.com/matannoam/pypugjs";
+        license = licenses.mit;
+        description = "PugJS syntax template adapter for Django, Jinja2, Mako and Tornado templates - copy of PyJade with the name changed";
+      };
+    };
+
+
+
+    "python-engineio" = python.mkDerivation {
+      name = "python-engineio-2.0.1";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/ae/61/199d5693cb077d12fb82baa9505215e0654e50e3cd4d5f3331029312b55f/python-engineio-2.0.1.tar.gz"; sha256 = "266fca0c4ed4576c873458ef06fdc7ae20942210f5e9c5f9bd039debcc672c30"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [
+      self."six"
+    ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://github.com/miguelgrinberg/python-engineio/";
+        license = licenses.mit;
+        description = "Engine.IO server";
+      };
+    };
+
+
+
+    "python-socketio" = python.mkDerivation {
+      name = "python-socketio-1.8.3";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/39/23/b0955fe05bed6d6621754d3b5043e5478cf57646e1e4c1cf55a6fc3f2acb/python-socketio-1.8.3.tar.gz"; sha256 = "822433bcda86924367bccfc64083bae60bd64c89c8fc07f79530458ce5a6dcea"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [
+      self."python-engineio"
+      self."six"
+    ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://github.com/miguelgrinberg/python-socketio/";
+        license = licenses.mit;
+        description = "Socket.IO server";
+      };
+    };
+
+
+
+    "six" = python.mkDerivation {
+      name = "six-1.11.0";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/16/d8/bc6316cf98419719bd59c91742194c111b6f2e85abac88e496adefaf7afe/six-1.11.0.tar.gz"; sha256 = "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [ ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://pypi.python.org/pypi/six/";
+        license = licenses.mit;
+        description = "Python 2 and 3 compatibility utilities";
+      };
+    };
+
+  };
+  localOverridesFile = ./requirements_override.nix;
+  overrides = import localOverridesFile { inherit pkgs python; };
+  commonOverrides = [
+
+  ];
+  allOverrides =
+    (if (builtins.pathExists localOverridesFile)
+     then [overrides] else [] ) ++ commonOverrides;
+
+in python.withPackages
+   (fix' (pkgs.lib.fold
+            extends
+            generated
+            allOverrides
+         )
+   )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7257,6 +7257,8 @@ with pkgs;
 
   gede = callPackage ../development/tools/misc/gede { };
 
+  gdbgui = callPackage ../development/tools/misc/gdbgui { };
+
   pmd = callPackage ../development/tools/analysis/pmd { };
 
   jdepend = callPackage ../development/tools/analysis/jdepend { };


### PR DESCRIPTION
Feature rich browser-based frontend with data structure visualizations
(like DDD), and gdb terminal access. Compatible with C, C++, golang,
Rust, fortran. Written in Python and JavaScript

gdbgui is at the top of the GDB Front Ends
list on https://sourceware.org/gdb/wiki/GDB%20Front%20Ends

###### Motivation for this change

gdbgui is not present in nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

