### PR TITLE
inconsolata: 1.010 -> inherit google-fonts

### DIFF
--- a/pkgs/data/fonts/inconsolata/default.nix
+++ b/pkgs/data/fonts/inconsolata/default.nix
@@ -1,23 +1,13 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, google-fonts }:
 
 stdenv.mkDerivation rec {
   name = "inconsolata-${version}";
-  version = "2.001";
 
-  src = fetchFromGitHub {
-    owner = "google";
-    repo = "fonts";
-    rev = "4c3e95c802f8f12b78869ff50d552014de63f9c1";
-    sha256 = "1ndmsf4c0k36dakmps0vr7hhg5ss8m7ywja7v55xdrinvli58v2f";
-  };
+  inherit (google-fonts) src version;
 
   installPhase = ''
     install -m644 --target $out/share/fonts/truetype/inconsolata -D $src/ofl/inconsolata/*.ttf
   '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "04pdg5lzdid4b0gbzykia2jaiajc6pdbv5r8ml5ya9alyw30xza6";
 
   meta = with stdenv.lib; {
     homepage = http://www.levien.com/type/myfonts/inconsolata.html;

--- a/pkgs/data/fonts/inconsolata/default.nix
+++ b/pkgs/data/fonts/inconsolata/default.nix
@@ -1,20 +1,28 @@
-{ stdenv, fetchzip }:
+{ stdenv, fetchFromGitHub }:
 
-let
-  version = "1.010";
-in fetchzip {
+stdenv.mkDerivation rec {
   name = "inconsolata-${version}";
+  version = "2.001";
 
-  url = "http://www.levien.com/type/myfonts/Inconsolata.otf";
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "fonts";
+    rev = "4c3e95c802f8f12b78869ff50d552014de63f9c1";
+    sha256 = "1ndmsf4c0k36dakmps0vr7hhg5ss8m7ywja7v55xdrinvli58v2f";
+  };
 
-  postFetch = "install -Dm644 $downloadedFile $out/share/fonts/opentype/inconsolata.otf";
+  installPhase = ''
+    install -m644 --target $out/share/fonts/truetype/inconsolata -D $src/ofl/inconsolata/*.ttf
+  '';
 
-  sha256 = "1yyf7agabfv0ia57c7in0r33x7c8ay445zf7c3dfc83j6w85g3i7";
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "04pdg5lzdid4b0gbzykia2jaiajc6pdbv5r8ml5ya9alyw30xza6";
 
   meta = with stdenv.lib; {
     homepage = http://www.levien.com/type/myfonts/inconsolata.html;
     description = "A monospace font for both screen and print";
-    maintainers = with maintainers; [ raskin rycee ];
+    maintainers = with maintainers; [ mikoim raskin rycee ];
     license = licenses.ofl;
     platforms = platforms.all;
   };


### PR DESCRIPTION
###### Motivation for this change
The upstream moved to Google fonts repository on GitHub.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] ~Tested execution of all binary files (usually in `./result/bin/`)~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

