### PR TITLE
hedgewars: 0.9.22 -> 0.9.23

### DIFF
--- a/pkgs/games/hedgewars/default.nix
+++ b/pkgs/games/hedgewars/default.nix
@@ -1,25 +1,25 @@
-{ SDL_image, SDL_ttf, SDL_net, fpc, qt4, ghcWithPackages, ffmpeg, freeglut
-, stdenv, makeWrapper, fetchurl, cmake, pkgconfig, lua5_1, SDL, SDL_mixer
+{ SDL2_image, SDL2_ttf, SDL2_net, fpc, qt4, ghcWithPackages, ffmpeg, freeglut
+, stdenv, makeWrapper, fetchurl, cmake, pkgconfig, lua5_1, SDL2, SDL2_mixer
 , zlib, libpng, mesa, physfs
 }:
 
 let
   ghc = ghcWithPackages (pkgs: with pkgs; [
           network vector utf8-string bytestring-show random hslogger
-          dataenc SHA entropy pkgs.zlib
+          SHA entropy pkgs.zlib sandi regex-tdfa
         ]);
 in
 stdenv.mkDerivation rec {
-  version = "0.9.22";
+  version = "0.9.23";
   name = "hedgewars-${version}";
   src = fetchurl {
-    url = "http://download.gna.org/hedgewars/hedgewars-src-${version}.tar.bz2";
-    sha256 = "14i1wvqbqib9h9092z10g4g0y14r5sp2fdaksvnw687l3ybwi6dn";
+    url = "http://www.hedgewars.org/download/releases/hedgewars-src-${version}.tar.bz2";
+    sha256 = "12df5ar3zk186ah51c3myr4hlzyybcshmf1w1wf6vr9b0h44jbns";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    SDL_ttf SDL_net cmake lua5_1 SDL SDL_mixer SDL_image fpc
+    SDL2_ttf SDL2_net cmake lua5_1 SDL2 SDL2_mixer SDL2_image fpc
     qt4 ghc ffmpeg freeglut makeWrapper physfs
   ];
 
@@ -28,11 +28,11 @@ stdenv.mkDerivation rec {
   '';
 
   preBuild = ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath ${SDL_image}/lib
-                                     -rpath ${SDL_mixer}/lib
-                                     -rpath ${SDL_net}/lib
-                                     -rpath ${SDL_ttf}/lib
-                                     -rpath ${SDL.out}/lib
+    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath ${SDL2_image}/lib
+                                     -rpath ${SDL2_mixer}/lib
+                                     -rpath ${SDL2_net}/lib
+                                     -rpath ${SDL2_ttf}/lib
+                                     -rpath ${SDL2.out}/lib
                                      -rpath ${libpng.out}/lib
                                      -rpath ${lua5_1}/lib
                                      -rpath ${mesa}/lib


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

