### PR TITLE
Optimize Nix build CPU utilization with NIX_MAX_CORES

### DIFF
--- a/pkgs/applications/audio/mixxx/default.nix
+++ b/pkgs/applications/audio/mixxx/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     runHook preBuild
     mkdir -p "$out"
     scons \
-      -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES \
+      -j$NIX_BUILD_CORES -l$NIX_MAX_CORES \
       $sconsFlags "prefix=$out"
     runHook postBuild
   '';

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -252,12 +252,10 @@ let
     buildPhase = let
       # Build paralelism: on Hydra the build was frequently running into memory
       # exhaustion, and even other users might be running into similar issues.
-      # -j is halved to avoid memory problems, and -l is slightly increased
-      # so that the build gets slight preference before others
-      # (it will often be on "critical path" and at risk of timing out)
+      # -j is halved to avoid memory problems.
       buildCommand = target: ''
         ninja -C "${buildPath}"  \
-          -j$(( ($NIX_BUILD_CORES+1) / 2 )) -l$(( $NIX_BUILD_CORES+1 )) \
+          -j$(( ($NIX_BUILD_CORES+1) / 2 )) -l$NIX_MAX_CORES \
           "${target}"
         (
           source chrome/installer/linux/common/installer.include

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -188,7 +188,7 @@ stdenv.mkDerivation {
        '')
 
    + stdenv.lib.optionalString withManual ''# Install man pages and Info manual
-       make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES PERL_PATH="${perl}/bin/perl" cmd-list.made install install-info \
+       make -j$NIX_BUILD_CORES -l$NIX_MAX_CORES PERL_PATH="${perl}/bin/perl" cmd-list.made install install-info \
          -C Documentation ''
 
    + (if guiSupport then ''

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -51,7 +51,7 @@ callPackage ./common.nix { inherit stdenv; } {
 
     postInstall = ''
       if test -n "$installLocales"; then
-          make -j''${NIX_BUILD_CORES:-1} -l''${NIX_BUILD_CORES:-1} localedata/install-locales
+          make -j''${NIX_BUILD_CORES:-1} -l''${NIX_MAX_CORES:-} localedata/install-locales
       fi
 
       test -f $out/etc/ld.so.cache && rm $out/etc/ld.so.cache

--- a/pkgs/development/libraries/qtscriptgenerator/default.nix
+++ b/pkgs/development/libraries/qtscriptgenerator/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   '';
 
   buildPhase = ''
-    makeFlags="SHELL=$SHELL ''${enableParallelBuilding:+-j$NIX_BUILD_CORES -l$NIX_BUILD_CORES}"
+    makeFlags="SHELL=$SHELL ''${enableParallelBuilding:+-j$NIX_BUILD_CORES -l$NIX_MAX_CORES}"
     make $makeFlags -C generator
 
     # Set QTDIR, see https://code.google.com/archive/p/qtscriptgenerator/issues/38

--- a/pkgs/development/tools/build-managers/ninja/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/ninja/setup-hook.sh
@@ -12,10 +12,11 @@ ninjaBuildPhase() {
         fi
 
         # shellcheck disable=SC2086
-        local flagsArray=( \
-            -j"$buildCores" -l"$NIX_BUILD_CORES" \
-            $ninjaFlags "${ninjaFlagsArray[@]}" \
-            $buildFlags "${buildFlagsArray[@]}")
+        local flagsArray=(
+            -j"$buildCores" -l"$NIX_MAX_CORES"
+            $ninjaFlags "${ninjaFlagsArray[@]}"
+            $buildFlags "${buildFlagsArray[@]}"
+        )
 
         echoCmd 'build flags' "${flagsArray[@]}"
         ninja "${flagsArray[@]}"

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -829,7 +829,7 @@ buildPhase() {
         # Old bash empty array hack
         # shellcheck disable=SC2086
         local flagsArray=(
-            ${enableParallelBuilding:+-j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES}}
+            ${enableParallelBuilding:+-j${NIX_BUILD_CORES} -l${NIX_MAX_CORES}}
             $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
             $buildFlags ${buildFlagsArray+"${buildFlagsArray[@]}"}
         )
@@ -849,7 +849,7 @@ checkPhase() {
     # Old bash empty array hack
     # shellcheck disable=SC2086
     local flagsArray=(
-        ${enableParallelBuilding:+-j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES}}
+        ${enableParallelBuilding:+-j${NIX_BUILD_CORES} -l${NIX_MAX_CORES}}
         $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
         ${checkFlags:-VERBOSE=y} ${checkFlagsArray+"${checkFlagsArray[@]}"}
         ${checkTarget:-check}

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -453,6 +453,22 @@ fi
 export NIX_INDENT_MAKE=1
 
 
+# Guess the optimal parallelism using the same formula as Ninja; return nothing
+# if it can not be determined.  (Note that "make" ignores "-l" without value.)
+guessParallelism() {
+    local n=$(getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || true)
+    if [ "$n" -ge 1 ]; then
+        if [ "$n" -le 2 ]; then
+            expr "$n" + 1
+        else
+            expr "$n" + 2
+        fi
+    fi
+}
+
+# NIX_MAX_CORES is the optimal load average (when known).
+: ${NIX_MAX_CORES=$(guessParallelism)}
+
 # Normalize the NIX_BUILD_CORES variable. The value might be 0, which
 # means that we're supposed to try and auto-detect the number of
 # available CPU cores at run-time.
@@ -460,12 +476,7 @@ export NIX_INDENT_MAKE=1
 if [ -z "${NIX_BUILD_CORES:-}" ]; then
   NIX_BUILD_CORES="1"
 elif [ "$NIX_BUILD_CORES" -le 0 ]; then
-  NIX_BUILD_CORES=$(nproc 2>/dev/null || true)
-  if expr >/dev/null 2>&1 "$NIX_BUILD_CORES" : "^[0-9][0-9]*$"; then
-    :
-  else
-    NIX_BUILD_CORES="1"
-  fi
+  NIX_BUILD_CORES=${NIX_MAX_CORES:-1}
 fi
 export NIX_BUILD_CORES
 

--- a/pkgs/tools/X11/xsettingsd/default.nix
+++ b/pkgs/tools/X11/xsettingsd/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     mkdir -p "$out"
     scons \
-      -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES \
+      -j$NIX_BUILD_CORES -l$NIX_MAX_CORES \
       "prefix=$out"
   '';
   


### PR DESCRIPTION
###### Motivation for this change

When `build-cores` is less than the number of CPUs, `make -l$NIX_BUILD_CORES` keeps the remaining CPUs unutilized, even when `max-jobs` is greater than 1. This is good if you want to dedicate those CPUs to something other than Nix builds, and it is bad if you want to balance `build-cores` with `max-jobs` to maximize utilization of the system without overloading it. To achieve the latter goal `make -l` should be given the optimal load average which is now available in `$NIX_MAX_CORES`.

The implementation mirrors Ninja:
https://github.com/ninja-build/ninja/blob/e234a7bd/src/ninja.cc#L222-L233
https://github.com/ninja-build/ninja/blob/e234a7bd/src/util.cc#L473-L481
(`getconf _NPROCESSORS_ONLN` works on Linux and Darwin.)

If keeping some CPUs unused is desirable, Nix may add an option and export `NIX_MAX_CORES` with its value for the builder.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
