### PR TITLE
migu: init at 20150712

### DIFF
--- a/pkgs/data/fonts/migu/default.nix
+++ b/pkgs/data/fonts/migu/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchzip }:
+
+stdenv.mkDerivation rec {
+  name = "migu-${version}";
+  version = "20150712";
+
+  srcs = [
+    (fetchzip {
+      url = "mirror://sourceforgejp/mix-mplus-ipa/63545/migu-1p-${version}.zip";
+      sha256 = "04wpbk5xbbcv2rzac8yzj4ww7sk2hy2rg8zs96yxc5vzj9q7svf6";
+    })
+    (fetchzip {
+      url = "mirror://sourceforgejp/mix-mplus-ipa/63545/migu-1c-${version}.zip";
+      sha256 = "1k7ymix14ac5fb44bjvbaaf24784zzpyc1jj2280c0zdnpxksyk6";
+    })
+    (fetchzip {
+      url = "mirror://sourceforgejp/mix-mplus-ipa/63545/migu-1m-${version}.zip";
+      sha256 = "07r8id83v92hym21vrqmfsfxb646v8258001pkjhgfnfg1yvw8lm";
+    })
+    (fetchzip {
+      url = "mirror://sourceforgejp/mix-mplus-ipa/63545/migu-2m-${version}.zip";
+      sha256 = "1pvzbrawh43589j8rfxk86y1acjbgzzdy5wllvdkpm1qnx28zwc2";
+    })
+  ];
+
+  unpackPhase = ":";
+
+  installPhase = ''
+    find $srcs -name '*.ttf' | xargs install -m644 --target $out/share/fonts/truetype/migu -D
+  '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "0nbpn21cxdd6gsgr3fadzjsnz84f2swpf81wmscmjgvd56ngndzh";
+
+  meta = with stdenv.lib; {
+    description = "A high-quality Japanese font based on modified M+ fonts and IPA fonts";
+    homepage = http://mix-mplus-ipa.osdn.jp/migu/;
+    license = licenses.ipa;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.mikoim ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13487,6 +13487,8 @@ with pkgs;
 
   migmix = callPackage ../data/fonts/migmix {};
 
+  migu = callPackage ../data/fonts/migu {};
+
   miscfiles = callPackage ../data/misc/miscfiles { };
 
   media-player-info = callPackage ../data/misc/media-player-info {};


### PR DESCRIPTION
###### Motivation for this change
`migu` is  high-quality Japanese font based on **modified** M+ fonts and IPA fonts

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] ~Tested execution of all binary files (usually in `./result/bin/`)~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

