### PR TITLE
ricty: init at 4.1.0

### DIFF
--- a/pkgs/data/fonts/ricty/default.nix
+++ b/pkgs/data/fonts/ricty/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, google-fonts, migu, fontforge, which }:
+
+stdenv.mkDerivation rec {
+  name = "ricty-${version}";
+  version = "4.1.0";
+
+  src = fetchurl {
+      url = "http://www.rs.tus.ac.jp/yyusa/ricty/ricty_generator-${version}.sh";
+      sha256 = "1cv0xh81fi6zdjb62zqjw46kbc89jvwbyllw1x1xbnpz2il6aavf";
+  };
+
+  unpackPhase = ''
+    install -m 0770 $src ricty_generator.sh
+  '';
+
+  patchPhase = ''
+    sed -i 's/fonts_directories=".*"/fonts_directories="$inconsolata $migu"/' ricty_generator.sh
+  '';
+
+  buildInputs = [ google-fonts migu fontforge which ];
+
+  buildPhase = ''
+    inconsolata=${google-fonts} migu=${migu} ./ricty_generator.sh auto
+  '';
+
+  installPhase = ''
+    install -m644 --target $out/share/fonts/truetype/ricty -D Ricty-*.ttf
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A high-quality Japanese font based on Inconsolata and Migu 1M";
+    homepage = http://www.rs.tus.ac.jp/yyusa/ricty.html;
+    license = licenses.unfree;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.mikoim ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19535,6 +19535,8 @@ with pkgs;
     pythonPackages = python3Packages;
   };
 
+  ricty = callPackage ../data/fonts/ricty { };
+
   rss-glx = callPackage ../misc/screensavers/rss-glx { };
 
   runit = callPackage ../tools/system/runit { };


### PR DESCRIPTION
###### Motivation for this change

Ricty is Japanese font for coding and programming.

This PR depends on #31966.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] ~Tested execution of all binary files (usually in `./result/bin/`)~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


