### PR TITLE
Update sssd integration with pam as documented by RedHat

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -222,6 +222,11 @@ let
           password, KDE will prompt separately after login.
         '';
       };
+      sssdStrictAccess = mkOption {
+        default = false;
+        type = types.bool;
+        description = "enforce sssd access control";
+      };
 
       text = mkOption {
         type = types.nullOr types.lines;
@@ -241,11 +246,13 @@ let
       text = mkDefault
         (''
           # Account management.
-          account sufficient pam_unix.so
+          account ${if cfg.sssdStrictAccess then "required" else "sufficient"} pam_unix.so
           ${optionalString use_ldap
               "account sufficient ${pam_ldap}/lib/security/pam_ldap.so"}
-          ${optionalString config.services.sssd.enable
+          ${optionalString (config.services.sssd.enable && cfg.sssdStrictAccess==false)
               "account sufficient ${pkgs.sssd}/lib/security/pam_sss.so"}
+          ${optionalString (config.services.sssd.enable && cfg.sssdStrictAccess)
+              "account [default=bad success=ok user_unknown=ignore] ${pkgs.sssd}/lib/security/pam_sss.so"}
           ${optionalString config.krb5.enable
               "account sufficient ${pam_krb5}/lib/security/pam_krb5.so"}
 


### PR DESCRIPTION
###### Motivation for this change
I was working on setting up an integration for NixOS instances with FreeIPA using SSSD.
In the SSSD config file i specify the groups/users that are allowed to access the server.
When setting up SSSD some changes on the pam services occurs. these changes do not allow the required behavior the way it is now as when i allow just a certain ldap user to access the server, he will just be able to access. So i needed to re-declare the pam.sshd module and add SSSD modules to the PAM configuration as specified in RedHat [documentation](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/5/html/Deployment_Guide/Configuration_Options-PAM_Configuration_Options.html) (Check 4. ).
re-declaring the module is obviously not good practice so the option I am asking you to include will allows to include SSSD module in pam the way as Redhat specified if set to true or keep it as it is if it is false (the default state).
Please let me know if you need any further explanation or if i can improve my pull request as it is my first time contributing to an open source project :) .

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

