### PR TITLE
Adds missing documentation for copyFileFromHost in NixOS tests

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.xml
+++ b/nixos/doc/manual/development/writing-nixos-tests.xml
@@ -262,6 +262,16 @@ startAll;
     <literal>waitForWindow(qr/Terminal/)</literal>.</para></listitem>
   </varlistentry>
 
+  <varlistentry>
+    <term><methodname>copyFileFromHost</methodname></term>
+    <listitem><para>Copies a file from host to machine, e.g.,
+    <literal>copyFileFromHost("myfile", "/etc/my/important/file")</literal>.</para>
+    <para>The first argument is the file on the host. The file needs to be
+    accessible while building the nix derivation. The second argument is
+    the location of the file on the machine.</para>
+    </listitem>
+  </varlistentry>
+
 </variablelist>
 
 </para>


### PR DESCRIPTION
###### Motivation for this change
Documentation was missing :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

