### PR TITLE
Rename Jetbrains' Go IDE Gogland to goland

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -77,15 +77,15 @@ let
       };
     });
 
-  buildGogland = { name, version, src, license, description, wmClass, update-channel }:
+  buildGoland = { name, version, src, license, description, wmClass, update-channel }:
     lib.overrideDerivation (mkJetBrainsProduct {
       inherit name version src wmClass jdk;
-      product = "Gogland";
+      product = "Goland";
       meta = with stdenv.lib; {
         homepage = https://www.jetbrains.com/go/;
         inherit description license;
         longDescription = ''
-          Gogland is the codename for a new commercial IDE by JetBrains
+          Goland is the codename for a new commercial IDE by JetBrains
           aimed at providing an ergonomic environment for Go development.
           The new IDE extends the IntelliJ platform with the coding assistance
           and tool integrations specific for the Go language
@@ -96,9 +96,9 @@ let
     }) (attrs: {
       postFixup = (attrs.postFixup or "") + ''
         interp="$(cat $NIX_CC/nix-support/dynamic-linker)"
-        patchelf --set-interpreter $interp $out/gogland*/plugins/intellij-go-plugin/lib/dlv/linux/dlv
+        patchelf --set-interpreter $interp $out/goland*/plugins/intellij-go-plugin/lib/dlv/linux/dlv
 
-        chmod +x $out/gogland*/plugins/intellij-go-plugin/lib/dlv/linux/dlv
+        chmod +x $out/goland*/plugins/intellij-go-plugin/lib/dlv/linux/dlv
       '';
     });
 
@@ -250,17 +250,17 @@ in
     update-channel = "datagrip_2017_2";
   };
 
-  gogland = buildGogland rec {
-    name = "gogland-${version}";
-    version = "173.2696.28"; /* updated by script */
+  goland = buildGoland rec {
+    name = "goland-${version}";
+    version = "173.3727.79"; /* updated by script */
     description = "Up and Coming Go IDE";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/go/${name}.tar.gz";
-      sha256 = "07nz2pf7fnjxsvc82vihk2i880cji349czxzshr1dk50ixlydq7n"; /* updated by script */
+      sha256 = "0bmd7r3h76pg0s9m3i5qv7zfkcj3gannj0c12cw087b831ga7ccz"; /* updated by script */
     };
-    wmClass = "jetbrains-gogland";
-    update-channel = "gogland_1.0_EAP";
+    wmClass = "jetbrains-goland";
+    update-channel = "goland_1.0_EAP";
   };
 
   idea-community = buildIdea rec {

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -239,12 +239,12 @@ in
 
   datagrip = buildDataGrip rec {
     name = "datagrip-${version}";
-    version = "2017.2.2"; /* updated by script */
+    version = "2017.2.3"; /* updated by script */
     description = "Your Swiss Army Knife for Databases and SQL";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/datagrip/${name}.tar.gz";
-      sha256 = "1l8y65fw9g5ckzwpcgigm2qwy8fhpw2hil576rphsnx6qvnh4swn"; /* updated by script */
+      sha256 = "0yp5h8ps5hfi07gsz14pp61skibfx48klg8qmc4f6q6xzcfdqxsf"; /* updated by script */
     };
     wmClass = "jetbrains-datagrip";
     update-channel = "datagrip_2017_2";


### PR DESCRIPTION
###### Motivation for this change

The product is called Goland on the [product page](https://www.jetbrains.com/go/) and Gogland inside the [nix-expression](https://github.com/NixOS/nixpkgs/blob/502539e2c8a8f7d54b11c56ead318e1167115204/pkgs/applications/editors/jetbrains/default.nix#L80).
After fixing `default.nix` the update script found a new version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

