### PR TITLE
wp-cli: 1.4.0 -> 1.4.1

### DIFF
--- a/pkgs/development/tools/wp-cli/default.nix
+++ b/pkgs/development/tools/wp-cli/default.nix
@@ -2,11 +2,11 @@
 
 let
   name = "wp-cli-${version}";
-  version = "1.4.0";
+  version = "1.4.1";
 
   src = fetchurl {
     url    = "https://github.com/wp-cli/wp-cli/releases/download/v${version}/${name}.phar";
-    sha256 = "0rav5a6znx81gwaxin1ib10sbfg16bgdnnyv1zn5sjify3f1wpqj";
+    sha256 = "0fyfwpsbm9s3khxq8876ah85vjwfd5r4a59aix3zjmhq2v7j8n9j";
   };
 
   completion = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

New upstream release available, see [release notes](https://make.wordpress.org/cli/2017/11/13/version-1-4-1-released/).

/cc @peterhoeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

