### PR TITLE
copyFileFromHost: Adds support for binary files

### DIFF
--- a/nixos/lib/test-driver/Machine.pm
+++ b/nixos/lib/test-driver/Machine.pm
@@ -640,9 +640,9 @@ sub waitForWindow {
 
 sub copyFileFromHost {
     my ($self, $from, $to) = @_;
-    my $s = `cat $from` or die;
+    my $s = `base64 $from` or die;
     $s =~ s/'/'\\''/g;
-    $self->mustSucceed("echo '$s' > $to");
+    $self->mustSucceed("echo '$s' | base64 -d > $to");
 }
 
 


### PR DESCRIPTION
###### Motivation for this change
I wanted to copy binary files.
It works, but the speed is not the best. Anyone has an idea on how the transfer rate could be improved?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

