### PR TITLE
buildkite-agent:  secrecy improvements:  non-store, non-Nix-source provisioning of secrets

### DIFF
--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -86,10 +86,13 @@ in
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
         environment.HOME = "/var/lib/buildkite-agent";
+
+        ## NB: maximum care is taken so that secrets (ssh keys and the CI token)
+        ##     don't end up in the Nix store.
         preStart = ''
             ${pkgs.coreutils}/bin/mkdir -m 0700 -p /var/lib/buildkite-agent/.ssh
-            ${copyOrEcho cfg.openssh.privateKey "/var/lib/buildkite-agent/.ssh/id_rsa"     600}
-            ${copyOrEcho cfg.openssh.publicKey  "/var/lib/buildkite-agent/.ssh/id_rsa.pub" 600}
+            ${copyOrEcho (toString cfg.openssh.privateKey) "/var/lib/buildkite-agent/.ssh/id_rsa"     600}
+            ${copyOrEcho (toString cfg.openssh.publicKey)  "/var/lib/buildkite-agent/.ssh/id_rsa.pub" 600}
 
             cat > "/var/lib/buildkite-agent/buildkite-agent.cfg" <<EOF
             token="${catOrLiteral cfg.token}"


### PR DESCRIPTION
###### Motivation for this change

1. Remove the requirement to store secrets in Nix source:
   - SSH keys
   - Buildkite token
2. Make sure that the secrets don't hit the Nix store.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

