### PR TITLE
wordpress: 4.7.4 -> 4.7.6

### DIFF
--- a/nixos/tests/wordpress.nix
+++ b/nixos/tests/wordpress.nix
@@ -10,6 +10,7 @@ import ./make-test.nix ({ pkgs, ... }:
     { web =
         { config, pkgs, ... }:
         {
+          time.timeZone = "UTC";
           services.mysql = {
             enable = true;
             package = pkgs.mysql;

--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -2,8 +2,8 @@
 { fetchFromGitHub, lib } : fetchFromGitHub {
   owner = "WordPress";
   repo = "WordPress";
-  rev = "4.7.4";
-  sha256 = "1ia9d3n085x2r6pvdrv4rk6gdp6xhjhpsq5g7a6448xzv9hf14ri";
+  rev = "4.7.6";
+  sha256 = "0da44nqb6ny0r2z9m93zvigxzjz1k1ggxfc1320yy3f77ini82jr";
   meta = {
     homepage = https://wordpress.org;
     description = "WordPress is open source software you can use to create a beautiful website, blog, or app.";


### PR DESCRIPTION
###### Motivation for this change

This is for 17.09.

Update to the most recent maintenance and security release in 4.7.x series:

- https://codex.wordpress.org/Version_4.7.5
- https://codex.wordpress.org/Version_4.7.6

Fixes broken test.

Not sure if such a version bump is appropriate for the stable release but submitting this on account of multiple security fixes included.

/cc @basvandijk 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

