### PR TITLE
texstudio: 2.12.4 -> 2.12.6

### DIFF
--- a/pkgs/applications/editors/texstudio/default.nix
+++ b/pkgs/applications/editors/texstudio/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "texstudio";
-  version = "2.12.4";
+  version = "2.12.6";
   name = "${pname}-${version}";
   altname="Texstudio";
 
   src = fetchurl {
     url = "mirror://sourceforge/texstudio/${name}.tar.gz";
-    sha256 = "03917faqyy0a1k6b86blc2fcards5a1819ydgkc4jlhwiaym4iyw";
+    sha256 = "18rxd7ra5k2f7s4c296b3v3pqhxjmfix9xpy9i1g4jm87ygqrbnd";
   };
 
   nativeBuildInputs = [ qmake4Hook pkgconfig ];


### PR DESCRIPTION
changelog:
```
- use Breeze window theme on KDE Plasma 5 (thanks to Alexander Wilms)
- support single-finger panning gesture on most config dialog components
- support single-finger panning touch gesture on log viewer
- pdf viewer scroll tool: support single-finger panning gesture
- center width-constrained documents in the editor (optional)
- add document tab context menu entries "Close" and "Close All Other Documents"
- improved layout of config build page
- add system check for language tool
- change search defaults to case-insensitive (feature-requests#1254)
- tags for beamer
- change preview default to embedded pdf
- handle preview failures more gracefully, i.e. no warning pop-ups
- repect preview settings (panel,etc) also for hover preview
- show hover preview as tooltip in case of inline-mode
- warn if compiler commands are actually a command list
- several improvements to the latex parser
- notify that a restart is required when switching between modern and classic style
- improved LanguageTool communication: better error handling
- add reset to default button for some LT settings
- add 200ms delay before showing auto-hidden viewer toolbar to prevent flicker
- eye candy for pdf circular magnifier (adapted code from texworks)
- show pdf highlight in magnifier
- capslock does not close completer any more
- alternative approach for determine directories from complete texts
- use cache for previews
- auto open completer when starting to type in references, packages etc.
- scripting: editor.cutBuffer
- subframetitle in structure view
- enable inputMethod (e.g. ^) in completer
- change default for complete non-text chacters to off, as it tends to cause unexpected behaviour
- fix word separation with punctuation
- fix: remove incorrect warning "Unknown magic comment" for "% !TeX TS-program = "
- fix: avoid compile fail if magic comment program is spelled wrongly
- fix: duplicate lines in autogenerated cwl files
- fix multi line argument interpretation
- fix pdfviewer in enlarged mode
- fix editing of basic shortcuts
- fix number in length keyVals
- fix flickering in structure view
- fix crash with qimage cache
- fix crash when restoring centralVSplitterState (bug 2175)
- fix highlighting of current entry in structure
- fix Open Terminal not working on windows QTBUG-57687 (bug 2178)
- fix column detection for tabu/longtabu
```

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

