### PR TITLE
stdenv: Move devhelp books to outputDevdoc

### DIFF
--- a/doc/multiple-output.xml
+++ b/doc/multiple-output.xml
@@ -68,7 +68,7 @@
 
       <varlistentry><term><varname>
         $outputDevdoc</varname></term><listitem><para>
-        is for <emphasis>developer</emphasis> documentation.  Currently we count gtk-doc in there.  It goes to <varname>devdoc</varname> or is removed (!) by default.  This is because e.g. gtk-doc tends to be rather large and completely unused by nixpkgs users.
+        is for <emphasis>developer</emphasis> documentation.  Currently we count gtk-doc and devhelp books in there.  It goes to <varname>devdoc</varname> or is removed (!) by default.  This is because e.g. gtk-doc tends to be rather large and completely unused by nixpkgs users.
       </para></listitem></varlistentry>
 
       <varlistentry><term><varname>

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -140,6 +140,7 @@ _multioutDocs() {
     moveToOutput share/info "${!outputInfo}"
     moveToOutput share/doc "${!outputDoc}"
     moveToOutput share/gtk-doc "${!outputDevdoc}"
+    moveToOutput share/devhelp/books "${!outputDevdoc}"
 
     # the default outputMan is in $bin
     moveToOutput share/man "${!outputMan}"

--- a/pkgs/desktops/gnome-2/bindings/libglademm/default.nix
+++ b/pkgs/desktops/gnome-2/bindings/libglademm/default.nix
@@ -7,7 +7,9 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/libglademm/2.6/${name}.tar.bz2";
     sha256 = "1hrbg9l5qb7w0xvr7013qamkckyj0fqc426c851l69zpmhakqm1q";
   };
-  
+
+  outputs = [ "out" "devdoc" ];
+
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ intltool ];
   

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -12,6 +12,8 @@ let
       inherit sha256;
     };
 
+    outputs = [ "out" "devdoc" ];
+
     nativeBuildInputs = [ pkgconfig flex bison libxslt ] ++ extraNativeBuildInputs;
 
     buildInputs = [ glib libiconv ] ++ libintlOrEmpty ++ extraBuildInputs;

--- a/pkgs/development/libraries/libxmlxx/default.nix
+++ b/pkgs/development/libraries/libxmlxx/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1sb3akryklvh2v6m6dihdnbpf1lkx441v972q9hlz1sq6bfspm2a";
   };
 
+  outputs = [ "out" "devdoc" ];
+
   nativeBuildInputs = [ pkgconfig perl ];
 
   propagatedBuildInputs = [ libxml2 glibmm ];

--- a/pkgs/development/libraries/libxmlxx/v3.nix
+++ b/pkgs/development/libraries/libxmlxx/v3.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "19kik79fmg61nv0by0a5f9wchrcfjwzvih4v2waw01hqflhqvp0r";
   };
 
+  outputs = [ "out" "devdoc" ];
+
   nativeBuildInputs = [ pkgconfig perl ];
 
   buildInputs = [ glibmm ];


### PR DESCRIPTION
###### Motivation for this change
For cleaner nix expressions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

