### PR TITLE
gnome3.gsettings_desktop_schemas: do not depend on gnome-backgrounds

### DIFF
--- a/pkgs/desktops/gnome-3/core/gsettings-desktop-schemas/default.nix
+++ b/pkgs/desktops/gnome-3/core/gsettings-desktop-schemas/default.nix
@@ -5,11 +5,15 @@
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
-  postPatch = ''
-    for file in "background" "screensaver"; do
-      substituteInPlace "schemas/org.gnome.desktop.$file.gschema.xml.in" \
-        --replace "@datadir@" "${gnome3.gnome-backgrounds}/share/"
-    done
+  preInstall = ''
+    mkdir -p $out/share/gsettings-schemas/${name}/glib-2.0/schemas
+    cat - > $out/share/gsettings-schemas/${name}/glib-2.0/schemas/remove-backgrounds.gschema.override <<- EOF
+      [org.gnome.desktop.background]
+      picture-uri='''
+
+      [org.gnome.desktop.screensaver]
+      picture-uri='''
+    EOF
   '';
 
   buildInputs = [ glib gobjectIntrospection ];


### PR DESCRIPTION
###### Motivation for this change
We intend to make all GTK apps depend on the desktop schemas (https://github.com/NixOS/nixpkgs/pull/31891). Since the schemas depend on gnome-backgrounds to determine the default wallpaper path, it would increase the closure size significantly for smaller apps.

We could split out the org.gnome.desktop.background and screensaver schemas but that would make the packaging unnecessarily complicated. Instead we remove the backgrounds dependency since they are not used (outside of GNOME) or they will be replaced by a different set by the NixOS module. There will be no background when running GNOME manually but that can be easily fixed.

See also #29766

###### Things done

I tested it with both GNOME 3.24 and GNOME 3.26.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

