### PR TITLE
PySolFC: init at 2.0

### DIFF
--- a/pkgs/games/pysolfc/default.nix
+++ b/pkgs/games/pysolfc/default.nix
@@ -1,0 +1,27 @@
+{ fetchurl, python2Packages, stdenv }:
+
+python2Packages.buildPythonApplication rec {
+  name = "PySolFC-${version}";
+  version = "2.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/pysolfc/PySolFC-${version}.tar.bz2";
+    sha256 = "0v0v8iflw55f5mghglkw80j8b7lv1hffjassfhqc4y84dmz8xjyv";
+  };
+
+  patches = [
+    ./pysolfc-datadir.patch
+  ];
+
+  propagatedBuildInputs = [
+    python2Packages.tkinter
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A collection of more than 1000 solitaire card games";
+    homepage = http://pysolfc.sourceforge.net/;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ kierdavis ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/games/pysolfc/pysolfc-datadir.patch
+++ b/pkgs/games/pysolfc/pysolfc-datadir.patch
@@ -1,0 +1,19 @@
+diff --git a/pysollib/util.py b/pysollib/util.py
+index 8de3f00..26f4bc7 100644
+--- a/pysollib/util.py
++++ b/pysollib/util.py
+@@ -110,13 +110,7 @@ class DataLoader:
+         head, tail = os.path.split(argv0)
+         if not head:
+             head = os.curdir
+-        # dir where placed startup script
+-        path.append(head)
+-        path.append(os.path.join(head, "data"))
+-        path.append(os.path.join(head, os.pardir, "data"))
+-        # dir where placed pysol package
+-        path.append(os.path.join(sys.path[0], "data"))
+-        path.append(os.path.join(sys.path[0], "pysollib", "data"))
++        path.append(os.path.join(head, "..", "share", "PySolFC"))
+         # from settings.py
+         path.extend(DATA_DIRS)
+         # check path for valid directories

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18073,6 +18073,8 @@ with pkgs;
 
   privateer = callPackage ../games/privateer { };
 
+  pysolfc = callPackage ../games/pysolfc { };
+
   qweechat = callPackage ../applications/networking/irc/qweechat { };
 
   qqwing = callPackage ../games/qqwing { };


### PR DESCRIPTION
PySolFC is a solitaire game written in Python, supporting thousands of
solitaire variants.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

