### PR TITLE
freesweep: init at 1.0.1

### DIFF
--- a/pkgs/games/freesweep/default.nix
+++ b/pkgs/games/freesweep/default.nix
@@ -1,0 +1,35 @@
+{ fetchurl, ncurses, stdenv,
+  updateAutotoolsGnuConfigScriptsHook }:
+
+stdenv.mkDerivation rec {
+  name = "freesweep-${version}";
+  version = "1.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/rwestlund/freesweep/archive/v${version}.tar.gz";
+    sha256 = "0l2kf14558lsq9qd2hs0kcyn9bbl1jdbzwrvcs6mnyjl7zpizcpj";
+  };
+
+  nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
+  buildInputs = [ ncurses ];
+
+  preConfigure = ''
+    configureFlags="$configureFlags --with-prefsdir=$out/share"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D -m 0555 freesweep $out/bin/freesweep
+    install -D -m 0444 sweeprc $out/share/sweeprc
+    install -D -m 0444 freesweep.6 $out/share/man/man6/freesweep.6
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A console minesweeper-style game written in C for Unix-like systems";
+    homepage = https://github.com/rwestlund/freesweep;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ kierdavis ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17875,6 +17875,8 @@ with pkgs;
     boost = boost160;
   };
 
+  freesweep = callPackage ../games/freesweep { };
+
   frotz = callPackage ../games/frotz { };
 
   fsg = callPackage ../games/fsg {


### PR DESCRIPTION
Freesweep is a console minesweeper game.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

