### PR TITLE
Load libinput xorg config correctly

### DIFF
--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -198,6 +198,13 @@ in {
 
     environment.systemPackages = [ pkgs.xorg.xf86inputlibinput ];
 
+    environment.etc = [
+      (let cfgPath = "X11/xorg.conf.d/40-libinput.conf"; in {
+        source = pkgs.xorg.xf86inputlibinput.out + "/share/" + cfgPath;
+        target = cfgPath;
+      })
+    ];
+
     services.udev.packages = [ pkgs.libinput ];
 
     services.xserver.config =

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -700,7 +700,6 @@ in
         Section "InputClass"
           Identifier "Keyboard catchall"
           MatchIsKeyboard "on"
-          Option "XkbRules" "base"
           Option "XkbModel" "${cfg.xkbModel}"
           Option "XkbLayout" "${cfg.layout}"
           Option "XkbOptions" "${cfg.xkbOptions}"


### PR DESCRIPTION
###### Motivation for this change
evdev is broken in GNOME (https://github.com/NixOS/nixpkgs/issues/31670) so we need to use libinput. GNOME enables libinput but the NixOS module did not load the Xorg configuration resulting in libinput not being used.

I also had switch the base xkb rules to evdev. Not sure what the difference is ([asked here](https://unix.stackexchange.com/questions/406688/what-is-the-difference-between-base-and-evdev-xkb-rules)) but the latter does not seem to produce a mangled keyboard layout.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Tried with GNOME 3.24 and 3.26.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

