### PR TITLE
ckb: update to ckb-next 0.2.8

### DIFF
--- a/pkgs/tools/misc/ckb/ckb-animations-location.patch
+++ b/pkgs/tools/misc/ckb/ckb-animations-location.patch
@@ -1,12 +1,12 @@
 diff --git a/src/ckb/animscript.cpp b/src/ckb/animscript.cpp
-index d0b7f46..d7a3459 100644
+index f49a64c..d7a3459 100644
 --- a/src/ckb/animscript.cpp
 +++ b/src/ckb/animscript.cpp
 @@ -30,7 +30,7 @@ QString AnimScript::path(){
  #ifdef __APPLE__
      return QDir(QApplication::applicationDirPath() + "/../Resources").absoluteFilePath("ckb-animations");
  #else
--    return QDir(QApplication::applicationDirPath()).absoluteFilePath("ckb-animations");
+-    return QDir("/usr/lib").absoluteFilePath("ckb-animations");
 +    return QDir(QApplication::applicationDirPath() + "/../libexec").absoluteFilePath("ckb-animations");
  #endif
  }

--- a/pkgs/tools/misc/ckb/default.nix
+++ b/pkgs/tools/misc/ckb/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, libudev, pkgconfig, qtbase, qmake, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.2.6";
-  name = "ckb-${version}";
+  version = "0.2.8";
+  name = "ckb-next-${version}";
 
   src = fetchFromGitHub {
-    owner = "ccMSC";
-    repo = "ckb";
+    owner = "mattanger";
+    repo = "ckb-next";
     rev = "v${version}";
-    sha256 = "04h50qdzsbi77mj62jghr52i35vxvmhnvsb7pdfdq95ryry8bnwm";
+    sha256 = "0b3h1d54mdyfcx46zvsd7dfqf2656h4jjkiw044170gnfdzxjb3w";
   };
 
   buildInputs = [
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Driver and configuration tool for Corsair keyboards and mice";
-    homepage = https://github.com/ccMSC/ckb;
+    homepage = https://github.com/mattanger/ckb-next;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ kierdavis ];


### PR DESCRIPTION
The original ckb is no longer maintained. ckb-next is an
active fork with a number of new patches and features.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

