### PR TITLE
Update rust.md

### DIFF
--- a/doc/languages-frameworks/rust.md
+++ b/doc/languages-frameworks/rust.md
@@ -9,11 +9,12 @@ date: 2017-03-05
 To install the rust compiler and cargo put
 
 ```
-rust
+rustc
+cargo
 ```
 
 into the `environment.systemPackages` or bring them into
-scope with `nix-shell -p rust`.
+scope with `nix-shell -p rustc cargo`.
 
 For daily builds (beta and nightly) use either rustup from
 nixpkgs or use the [Rust nightlies


### PR DESCRIPTION
###### Motivation for this change

Using `rust` instead of `rustc cargo` doesn't work in either `systemPackages` or `nix-shell -p`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

