### PR TITLE
pius: 2.0.11 -> 2.2.4

### DIFF
--- a/pkgs/tools/security/pius/default.nix
+++ b/pkgs/tools/security/pius/default.nix
@@ -1,13 +1,15 @@
-{ fetchurl, stdenv, python, gnupg }:
+{ fetchFromGitHub, stdenv, python, gnupg }:
 
 let version = "2.0.11"; in
 stdenv.mkDerivation {
   name = "pius-${version}";
   namePrefix = "";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/pgpius/pius/${version}/pius-${version}.tar.bz2";
-    sha256 = "0pdbyqz6k0bm182cz81ss7yckmpms5qhrrw0wcr4a1srzcjyzf5f";
+  src = fetchFromGitHub {
+    owner = "jaymzh";
+    repo = "pius";
+    rev = "v${version}";
+    sha256 = "0msqhk0bhnq0f3crr0zf3dc9qb01ghib25fh3sz9dbprxclr5ps9";
   };
 
   buildInputs = [ python ];

--- a/pkgs/tools/security/pius/default.nix
+++ b/pkgs/tools/security/pius/default.nix
@@ -1,7 +1,7 @@
-{ fetchFromGitHub, stdenv, python, gnupg }:
+{ fetchFromGitHub, stdenv, pythonPackages, gnupg }:
 
-let version = "2.0.11"; in
-stdenv.mkDerivation {
+let version = "2.2.4"; in
+pythonPackages.buildPythonApplication {
   name = "pius-${version}";
   namePrefix = "";
 
@@ -9,23 +9,13 @@ stdenv.mkDerivation {
     owner = "jaymzh";
     repo = "pius";
     rev = "v${version}";
-    sha256 = "0msqhk0bhnq0f3crr0zf3dc9qb01ghib25fh3sz9dbprxclr5ps9";
+    sha256 = "1yk6ngpk55yjdnzhm5sj675xbzwp7rir816a3aris647gsph1vlx";
   };
 
-  buildInputs = [ python ];
-
   patchPhase = ''
-    sed -i "pius" -e's|/usr/bin/gpg|${gnupg}/bin/gpg|g'
-  '';
-
-  dontBuild = true;
-
-  installPhase = ''
-    mkdir -p "$out/bin"
-    cp -v pius "$out/bin"
-
-    mkdir -p "$out/doc/pius-${version}"
-    cp -v README "$out/doc/pius-${version}"
+    for file in libpius/constants.py pius-keyring-mgr; do
+      sed -i "$file" -E -e's|/usr/bin/gpg2?|${gnupg}/bin/gpg|g'
+    done
   '';
 
   meta = {

--- a/pkgs/tools/security/pius/default.nix
+++ b/pkgs/tools/security/pius/default.nix
@@ -33,6 +33,6 @@ pythonPackages.buildPythonApplication {
     license = stdenv.lib.licenses.gpl2;
 
     platforms = stdenv.lib.platforms.gnu;
-    maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
+    maintainers = with stdenv.lib.maintainers; [ fuuzetsu kierdavis ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

pius 2.0.11 is incompatible with the current version of gpg ("ERROR: GnuPG reported an unknown error"), so an update is required.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

