### PR TITLE
GHC 8.2.2 in 17.09

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -9,7 +9,7 @@
 
 let
   inherit (bootPkgs) ghc;
-  version = "8.2.1.20171030";
+  version = "8.2.1.20171108";
 
   commonBuildInputs = [ alex autoconf automake ghc happy hscolour perl python3 sphinx ];
   commonPreConfigure =  ''
@@ -26,8 +26,8 @@ in stdenv.mkDerivation (rec {
   name = "ghc-${version}";
 
   src = fetchurl {
-    url = "https://downloads.haskell.org/~ghc/8.2.2-rc2/${name}-src.tar.xz";
-    sha256 = "0m2lx13yscgxmb18nrzhgg5h4kwzcnxdw7rjcqwx4dcwl1k0a724";
+    url = "https://downloads.haskell.org/~ghc/8.2.2-rc3/${name}-src.tar.xz";
+    sha256 = "13h55vcrs243bv4hv8i4jq80rsx5hvhi09r3rcs562d8zk7k665w";
   };
 
   postPatch = "patchShebangs .";

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -9,7 +9,7 @@
 
 let
   inherit (bootPkgs) ghc;
-  version = "8.2.1.20171108";
+  version = "8.2.2";
 
   commonBuildInputs = [ alex autoconf automake ghc happy hscolour perl python3 sphinx ];
   commonPreConfigure =  ''
@@ -26,8 +26,8 @@ in stdenv.mkDerivation (rec {
   name = "ghc-${version}";
 
   src = fetchurl {
-    url = "https://downloads.haskell.org/~ghc/8.2.2-rc3/${name}-src.tar.xz";
-    sha256 = "13h55vcrs243bv4hv8i4jq80rsx5hvhi09r3rcs562d8zk7k665w";
+    url = "https://downloads.haskell.org/~ghc/8.2.2/${name}-src.tar.xz";
+    sha256 = "1z05vkpaj54xdypmaml50hgsdpw29dhbs2r7magx0cm199iw73mv";
   };
 
   postPatch = "patchShebangs .";

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -1,0 +1,119 @@
+{ stdenv, lib, fetchurl, bootPkgs, perl, ncurses, libiconv, binutils, coreutils
+, autoconf, automake, happy, alex, python3, sphinx, hscolour
+, buildPlatform, targetPlatform , selfPkgs, cross ? null
+
+  # If enabled GHC will be build with the GPL-free but slower integer-simple
+  # library instead of the faster but GPLed integer-gmp library.
+, enableIntegerSimple ? false, gmp
+}:
+
+let
+  inherit (bootPkgs) ghc;
+  version = "8.2.1.20171030";
+
+  commonBuildInputs = [ alex autoconf automake ghc happy hscolour perl python3 sphinx ];
+  commonPreConfigure =  ''
+    sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
+  '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
+    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    export NIX_LDFLAGS+=" -no_dtrace_dof"
+  '' + stdenv.lib.optionalString enableIntegerSimple ''
+    echo "INTEGER_LIBRARY=integer-simple" > mk/build.mk
+  '';
+in stdenv.mkDerivation (rec {
+  inherit version;
+  name = "ghc-${version}";
+
+  src = fetchurl {
+    url = "https://downloads.haskell.org/~ghc/8.2.2-rc2/${name}-src.tar.xz";
+    sha256 = "0m2lx13yscgxmb18nrzhgg5h4kwzcnxdw7rjcqwx4dcwl1k0a724";
+  };
+
+  postPatch = "patchShebangs .";
+
+  patches = [ ./ghc-gold-linker.patch ];
+
+  preConfigure = commonPreConfigure;
+
+  buildInputs = commonBuildInputs;
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "CC=${stdenv.cc}/bin/cc"
+    "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
+    "--datadir=$doc/share/doc/ghc"
+  ] ++ stdenv.lib.optional (! enableIntegerSimple) [
+    "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
+  ] ++ stdenv.lib.optional stdenv.isDarwin [
+    "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
+  ];
+
+  # required, because otherwise all symbols from HSffi.o are stripped, and
+  # that in turn causes GHCi to abort
+  stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!stdenv.isDarwin) "--keep-file-symbols";
+
+  checkTarget = "test";
+
+  postInstall = ''
+    paxmark m $out/lib/${name}/bin/{ghc,haddock}
+
+    # Install the bash completion file.
+    install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/ghc
+
+    # Patch scripts to include "readelf" and "cat" in $PATH.
+    for i in "$out/bin/"*; do
+      test ! -h $i || continue
+      egrep --quiet '^#!' <(head -n 1 $i) || continue
+      sed -i -e '2i export PATH="$PATH:${stdenv.lib.makeBinPath [ binutils coreutils ]}"' $i
+    done
+  '';
+
+  outputs = [ "out" "doc" ];
+
+  passthru = {
+    inherit bootPkgs;
+  } // stdenv.lib.optionalAttrs (targetPlatform != buildPlatform) {
+    crossCompiler = selfPkgs.ghc.override {
+      cross = targetPlatform;
+      bootPkgs = selfPkgs;
+    };
+  };
+
+  meta = {
+    homepage = http://haskell.org/ghc;
+    description = "The Glasgow Haskell Compiler";
+    maintainers = with stdenv.lib.maintainers; [ marcweber andres peti ];
+    inherit (ghc.meta) license platforms;
+  };
+
+} // stdenv.lib.optionalAttrs (cross != null) {
+  name = "${cross.config}-ghc-${version}";
+
+  preConfigure = commonPreConfigure + ''
+    sed 's|#BuildFlavour  = quick-cross|BuildFlavour  = perf-cross|' mk/build.mk.sample > mk/build.mk
+  '';
+
+  configureFlags = [
+    "CC=${stdenv.ccCross}/bin/${cross.config}-cc"
+    "LD=${stdenv.binutils}/bin/${cross.config}-ld"
+    "AR=${stdenv.binutils}/bin/${cross.config}-ar"
+    "NM=${stdenv.binutils}/bin/${cross.config}-nm"
+    "RANLIB=${stdenv.binutils}/bin/${cross.config}-ranlib"
+    "--target=${cross.config}"
+    "--enable-bootstrap-with-devel-snapshot"
+  ] ++
+    # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
+    lib.optional (cross.config or null == "aarch64-apple-darwin14") "--disable-large-address-space";
+
+  buildInputs = commonBuildInputs ++ [ stdenv.ccCross stdenv.binutils ];
+
+  dontSetConfigureCross = true;
+
+  passthru = {
+    inherit bootPkgs cross;
+    cc = "${stdenv.ccCross}/bin/${cross.config}-cc";
+    ld = "${stdenv.binutils}/bin/${cross.config}-ld";
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -83,6 +83,13 @@ in rec {
       sphinx = pkgs.python3Packages.sphinx;
       selfPkgs = packages.ghc821;
     };
+    ghc822 = callPackage ../development/compilers/ghc/8.2.2.nix rec {
+      bootPkgs = packages.ghc802;
+      inherit (bootPkgs) hscolour alex happy;
+      inherit buildPlatform targetPlatform;
+      sphinx = pkgs.python3Packages.sphinx;
+      selfPkgs = packages.ghc822;
+    };
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix rec {
       bootPkgs = packages.ghc802;
       inherit (bootPkgs) alex happy;
@@ -173,6 +180,10 @@ in rec {
     };
     ghc821 = callPackage ../development/haskell-modules {
       ghc = compiler.ghc821;
+      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.2.x.nix { };
+    };
+    ghc822 = callPackage ../development/haskell-modules {
+      ghc = compiler.ghc822;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.2.x.nix { };
     };
     ghcHEAD = callPackage ../development/haskell-modules {


### PR DESCRIPTION
###### Motivation for this change

I want GHC 8.2.2 in `release-17.09`. To achieve this, I ran

```bash
git cherry-pick -x --strategy-option=theirs --no-merges --first-parent `git log --reverse --format=format:%H ..origin/master -- pkgs/development/compilers/ghc/8.2.2.nix`
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

