### PR TITLE
cloudfoundry-cli: init at 6.32.0

### DIFF
--- a/pkgs/development/tools/cloudfoundry-cli/default.nix
+++ b/pkgs/development/tools/cloudfoundry-cli/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, buildGoPackage, fetchFromGitHub, go }:
+
+buildGoPackage rec {
+  name = "cloudfoundry-cli-${version}";
+  version = "6.32.0";
+
+  goPackagePath = "code.cloudfoundry.org/cli";
+
+  subPackages = [ "." ];
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "cloudfoundry-attic";
+    repo = "cli-with-i18n";
+    sha256 = "16r8zvahn4b98krmyb8zq9370i6572dhz88bfxb3fnddcv6zy1ng";
+  };
+
+  outputs = [ "out" ];
+
+  buildFlagsArray = ''
+    -ldflags= -X ${goPackagePath}/version.binaryVersion=${version}
+  '';
+
+  installPhase = ''
+    install -Dm555 go/bin/cli "$out/bin/cf"
+    remove-references-to -t ${go} "$out/bin/cf"
+    install -Dm444 -t "$out/share/bash-completion/completions/" "$src/ci/installers/completion/cf"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The official command line client for Cloud Foundry";
+    homepage = https://github.com/cloudfoundry/cli;
+    maintainers = with maintainers; [ ris ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7089,6 +7089,8 @@ with pkgs;
 
   "cl-launch" = callPackage ../development/tools/misc/cl-launch {};
 
+  cloudfoundry-cli = callPackage ../development/tools/cloudfoundry-cli { };
+
   coan = callPackage ../development/tools/analysis/coan { };
 
   compile-daemon = callPackage ../development/tools/compile-daemon { };


### PR DESCRIPTION
###### Motivation for this change
Add the cloudfoundry cli app.

Note that though I'm putting myself as the maintainer of this package, I am really not a Go person, and I found that to be quite an impediment when getting this damn thing to compile.

Why 6.30.0 when latest is 6.33.0? 6.30.0 is the latest version that builds with Go 1.8 - I'm intending to immediately backport this to `release-17.09` which has no `buildGoPackage` for Go 1.9 (and maybe we should leave it as such). We can give `master` a followup version bump afterwards if so desired.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

