### PR TITLE
terraform: 0.10.7->0.10.8, 0.11.0, update providers

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -91,8 +91,8 @@ in {
   };
 
   terraform_0_10 = pluggable (generic {
-    version = "0.10.7";
-    sha256 = "0gjvrra255m973nzi7rpqp5dn5npnd79cnv8vjcs7wmkdj1hli0l";
+    version = "0.10.8";
+    sha256 = "11hhij0hq99xhwlg5dx5nv7y074x79wkr8hr3wc6ln0kwdk5scdf";
     patches = [ ./provider-path.patch ];
     passthru = { inherit plugins; };
   });

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -96,4 +96,11 @@ in {
     patches = [ ./provider-path.patch ];
     passthru = { inherit plugins; };
   });
+
+  terraform_0_11 = pluggable (generic {
+    version = "0.11.0";
+    sha256 = "0qsydg6bn7k6d68pd1y4j5iys9i66c690yq21axcpnjfibxgqyff";
+    patches = [ ./provider-path.patch ];
+    passthru = { inherit plugins; };
+  });
 }

--- a/pkgs/applications/networking/cluster/terraform/providers/data.nix
+++ b/pkgs/applications/networking/cluster/terraform/providers/data.nix
@@ -32,8 +32,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-aws";
-      version = "1.0.0";
-      sha256  = "1x3ldlx2iryxwfaws8ng9n0k06p7n8xqc6sjyxw73jdasxbh8wgi";
+      version = "1.3.1";
+      sha256  = "0vsvvw1qdjb69jilhjl5g8h7dn82n0n23k2v67dqywhinilafcmv";
     };
   azure =
     {
@@ -46,8 +46,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-azurerm";
-      version = "0.2.2";
-      sha256  = "1jdkj1zylrlcd2qkfkl81i0ybdpmvbvvsk0f4ahafiqp550srf2d";
+      version = "0.3.3";
+      sha256  = "0qq10gjwka0268ylzx5r7qhj0xpjh8fxrjr1fwbiq8sp6i1jb7sa";
     };
   bitbucket =
     {
@@ -84,6 +84,13 @@
       version = "0.1.0";
       sha256  = "073j0kqkccj7yrqz6j4vx722vmy6mmvmgidamkjnhhjcwm6g1jbq";
     };
+  cloudscale =
+    {
+      owner   = "terraform-providers";
+      repo    = "terraform-provider-cloudscale";
+      version = "1.0.0";
+      sha256  = "0yqiz4xywbd3568hl6va8da81fbc1hnynlz4z0vqxgi3bs8hhdhz";
+    };
   cloudstack =
     {
       owner   = "terraform-providers";
@@ -95,8 +102,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-cobbler";
-      version = "0.1.0";
-      sha256  = "1867aqlz1v7scybaia9yakaxw76lh6y2whhajv5pqy1ng58rcgiz";
+      version = "1.0.0";
+      sha256  = "0v7j9r2ic3ks2hy80mx5xay05m6r52vclsbbbf9vb0srnrvz21gy";
     };
   consul =
     {
@@ -109,8 +116,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-datadog";
-      version = "0.1.1";
-      sha256  = "0nyqybi3fl9qlhpx2n0vjz7kn3bqhf4wy93zhq3j3853zxpcjpzc";
+      version = "1.0.0";
+      sha256  = "1kabjhq7xl2mhh0gvg87a9zh8y2k0h5ghcmb86xzvx25j3jdqfg6";
     };
   digitalocean =
     {
@@ -144,15 +151,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-docker";
-      version = "0.1.0";
-      sha256  = "1nacxkyy12w4rj1bdf5ayqmmm47nwh362pcksr227rkwmsjlmg1m";
+      version = "0.1.1";
+      sha256  = "02lhbl34dq7lsby3g32969i4g9l3z6xw1v00shljd3amgyz2l2r2";
     };
   dyn =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-dyn";
-      version = "1.0.0";
-      sha256  = "0ph3516syca8f1zxmz66mh6y5kd8sc74kl0n8zixcgd6rvq0dysr";
+      version = "1.1.0";
+      sha256  = "0sx4h3drb230m69lsmafyfd2cfvwnb9gld8s6ky54115kd3nckml";
     };
   external =
     {
@@ -179,29 +186,29 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-gitlab";
-      version = "0.1.0";
-      sha256  = "1xjhpaq2agdshrl5jbq9ak2nxdy86iay5bw16zww2qc5ah21sdg2";
+      version = "1.0.0";
+      sha256  = "1kxmzdzdb6fc64i2bzch6020zfk0ygms9gh5mm1bypsyqmj4qc6r";
     };
   google =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-google";
-      version = "1.0.1";
-      sha256  = "0l0bpcfjnzlgf3g60iyfr3axw0244w99cf04z7y3bcszk5njipri";
+      version = "1.2.0";
+      sha256  = "1q3ypacsjc8779v1k81z0vs3kx6i340fa4mz26gscf85rx8bghim";
     };
   grafana =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-grafana";
-      version = "0.1.0";
-      sha256  = "1m2anc5cyn2p3yh4zn0y6wvzb0s2fz3sfdqm9psvx53266c2c81q";
+      version = "1.0.0";
+      sha256  = "0fsdin1rd7hah6pp3x568db2mmk66q0fhiplsri7vyj03n3z55v2";
     };
   heroku =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-heroku";
-      version = "0.1.0";
-      sha256  = "1f72lm95bnkhaf2accypdn7xsxcgkqri5fq5mriya4n34c61z3l6";
+      version = "0.1.1";
+      sha256  = "0i5pdb05qkd6h9zyr88ppsiii6g6zjc5096xblizvmiww7mp81gn";
     };
   http =
     {
@@ -235,8 +242,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-kubernetes";
-      version = "1.0.0";
-      sha256  = "1kh7a83f98v6b4v3zj84ddhrg2hya4nmvrw0mjc26q12g4z2d5g6";
+      version = "1.0.1";
+      sha256  = "0s8h8nxsl07bhvynmgps07giqr2xmxizk1rcx4xivfc3q5mkvnhb";
     };
   librato =
     {
@@ -259,6 +266,13 @@
       version = "0.1.0";
       sha256  = "11fkb84gqcq59wk5kqn3h428jrc2gkl659zxmkdldad6jdll9ypa";
     };
+  logicmonitor =
+    {
+      owner   = "terraform-providers";
+      repo    = "terraform-provider-logicmonitor";
+      version = "1.0.0";
+      sha256  = "106y74w9nhqs65h26ipyjg636zcrnpn5s8r49sg4kh4ynvnrkv8v";
+    };
   mailgun =
     {
       owner   = "terraform-providers";
@@ -270,8 +284,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-mysql";
-      version = "0.1.0";
-      sha256  = "0vjr97xf15va9qypjb9318h1nxr0sd6ydcy7ijnqb8538v3581mv";
+      version = "1.0.0";
+      sha256  = "1vkr1gg9adrkzlbdy0w0wn1ap5zla1k54kxfmd5jndw4hzgysi82";
     };
   newrelic =
     {
@@ -319,8 +333,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-openstack";
-      version = "0.2.2";
-      sha256  = "1027pqv1cvyvakn4kgivd720g9na38nam5bb5fjyd4d04xpq9v90";
+      version = "1.0.0";
+      sha256  = "0ddy62psapajbgnf7f998cnwiyak3lnk43vj0rl230dhnma9crpm";
     };
   opsgenie =
     {
@@ -340,8 +354,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-packet";
-      version = "1.0.0";
-      sha256  = "0ibz9k1yfqkfsmqmv1pl2jwzbld0l6f7zd8y80iw0v5wswclswya";
+      version = "1.1.0";
+      sha256  = "0848y78jri1kzd70xcgv0p62yww46d0kr9zpqwh32m866xx5isfi";
     };
   pagerduty =
     {
@@ -368,8 +382,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-profitbricks";
-      version = "0.1.2";
-      sha256  = "105l0rijqmp7kmd7wygnhnj02q7y1rz0r8pj2mjzncb5pr48m3qp";
+      version = "1.0.0";
+      sha256  = "15j66mm7mkwblwncb5s0xbcz7jz99mzswhppzxchwkbk3325syyx";
     };
   rabbitmq =
     {
@@ -382,8 +396,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-rancher";
-      version = "1.0.0";
-      sha256  = "1fs8p0l8f79b1s2g0p5zlq1has9i7w3bmv76vrm79076v7w2v0d6";
+      version = "1.1.1";
+      sha256  = "1gs62yd31kywg2yhnikli1khai1n0lwy8pb3g7k5ad8ibffjskmz";
     };
   random =
     {
@@ -403,8 +417,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-scaleway";
-      version = "0.1.1";
-      sha256  = "145wfcr5zjjk8vgx5xjf1hqh6h8jqxkhxbvv9x1w34i5bv809ch6";
+      version = "1.0.0";
+      sha256  = "0zp9hhvlcn6cpnblwrr03icbagzk745b0lrm5bs23crbnddal905";
     };
   softlayer =
     {
@@ -438,22 +452,22 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-terraform";
-      version = "1.0.0";
-      sha256  = "0icyyi4h48yh5235p5svm4p0jzbqqm1f3846dqy37czhjfcrn3gh";
+      version = "1.0.2";
+      sha256  = "1aj6g6l68n9kqmxfjlkwwxnac7fhha6wrmvsw4yylf0qyssww75v";
     };
   tls =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-tls";
-      version = "1.0.0";
-      sha256  = "063ai5zipmkwq0nr5c25gqsr970r8aba12ynxg9x8cnay0zn9s95";
+      version = "1.0.1";
+      sha256  = "0mzm1pkqgcslz3j4an1vpx92hnqa53ly0kp3zix8kp2kfnn17qky";
     };
   triton =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-triton";
-      version = "0.2.1";
-      sha256  = "0ds2anr65xx9kdjv6x68lcxgl3js6l0m2cbx3kwx5465m01m3gxz";
+      version = "0.3.0";
+      sha256  = "0x8cws41mpxcwd4hf380gizhdnnfs2df5pwcc417sbp2706cai1h";
     };
   ultradns =
     {
@@ -466,8 +480,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-vault";
-      version = "0.1.0";
-      sha256  = "1rr4gaqfr6panjjdb5xx9vbq7701zjps0l75zi526kij1pph98p1";
+      version = "1.0.0";
+      sha256  = "1v4b8zs0s48gqgsh719hwi69i4h8i5vvp2g5m881z5yzv7n7haqw";
     };
   vcd =
     {
@@ -480,7 +494,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-vsphere";
-      version = "0.4.1";
-      sha256  = "0afxvjx9zb9ym0cs8j15s6nfp20rmmifjdc098wcfjmgnw6p7f01";
+      version = "0.4.2";
+      sha256  = "0k9mndxfiq5drcz2qhqasc7cqra0mfdwwwblb1m6lyg7flg7dli0";
     };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19561,6 +19561,7 @@ with pkgs;
     terraform_0_8
     terraform_0_9
     terraform_0_10
+    terraform_0_11
     ;
 
   # Terraform with all the plugins, both to get Hydra to build all plugins for us and for


### PR DESCRIPTION
###### Motivation for this change
Newer versions of terraform were released.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---