### PR TITLE
minijail: init at android-8.0.0_r34

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -487,6 +487,7 @@
   patternspandemic = "Brad Christensen <patternspandemic@live.com>";
   pawelpacana = "Paweł Pacana <pawel.pacana@gmail.com>";
   pbogdan = "Piotr Bogdan <ppbogdan@gmail.com>";
+  pcarrier = "Pierre Carrier <pc@rrier.ca>";
   periklis = "theopompos@gmail.com";
   pesterhazy = "Paulus Esterhazy <pesterhazy@gmail.com>";
   peterhoeg = "Peter Hoeg <peter@hoeg.com>";

--- a/pkgs/tools/system/minijail/default.nix
+++ b/pkgs/tools/system/minijail/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchgit, libcap }:
+
+stdenv.mkDerivation rec {
+  shortname = "minijail";
+  name = "${shortname}-${version}";
+  version = "android-8.0.0_r34";
+
+  src = fetchgit {
+    url = "https://android.googlesource.com/platform/external/minijail";
+    rev = version;
+    sha256 = "1d0q08cgks6h6ffsw3zw8dz4rm9y2djj2pwwy3xi6flx7vwy0psf";
+  };
+
+  buildInputs = [ libcap ];
+
+  makeFlags = [ "LIBDIR=$(out)/lib" ];
+
+  preConfigure = ''
+    substituteInPlace common.mk --replace /bin/echo echo
+    sed -i '/#include <asm\/siginfo.h>/ d' signal_handler.c
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp -v *.so $out/lib
+    mkdir -p $out/include
+    cp -v libminijail.h $out/include
+    mkdir -p $out/bin
+    cp minijail0 $out/bin
+  '';
+
+  meta = {
+    homepage = https://android.googlesource.com/platform/external/minijail/;
+    description = "Sandboxing library and application using Linux namespaces and capabilities";
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [pcarrier];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3372,6 +3372,8 @@ with pkgs;
 
   miniball = callPackage ../development/libraries/miniball { };
 
+  minijail = callPackage ../tools/system/minijail { };
+
   minixml = callPackage ../development/libraries/minixml { };
 
   mir-qualia = callPackage ../tools/text/mir-qualia {


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
