### PR TITLE
cnijfilter: init at 4.00

### DIFF
--- a/pkgs/misc/cups/drivers/cnijfilter_4_00/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter_4_00/default.nix
@@ -1,0 +1,150 @@
+{ stdenv, lib, fetchzip,
+  autoconf, automake, libtool,
+  cups, popt, libtiff, libpng,
+  ghostscript, glib, libusb, libxml2 }:
+
+/* this derivation is basically just a transcription of the rpm .spec
+   file included in the tarball */
+
+let arch = 
+  if stdenv.system == "x86_64-linux" then "64"
+    else if stdenv.system == "i686-linux" then "32"
+    else abort "Unsupported architecture";
+
+in stdenv.mkDerivation rec {
+  name = "cnijfilter-${version}";
+
+  /* important note about versions: cnijfilter packages seem to use
+     versions in a non-standard way.  the version indicates which
+     printers are supported in the package.  so this package should
+     not be "upgraded" in the usual way.
+
+     instead, if you want to include another version supporting your
+     printer, you should try to abstract out the common things (which
+     should be pretty much everything except the version and the 'pr'
+     and 'pr_id' values to loop over). */
+  version = "4.00";
+
+  src = fetchzip {
+    url = "http://gdlp01.c-wss.com/gds/5/0100005515/01/cnijfilter-source-4.00-1.tar.gz";
+    sha256 = "1f6vpx1z3qa88590i5m0s49j9n90vpk81xmw6pvj0nfd3qbvzkya";
+  };
+
+  buildInputs = [ autoconf libtool automake
+                  cups popt libtiff libpng
+                  ghostscript glib libusb libxml2 ];
+
+  # patches from https://github.com/tokiclover/bar-overlay/tree/master/net-print/cnijfilter
+  patches = [
+    ./patches/cnijfilter-3.80-1-cups-1.6.patch
+    ./patches/cnijfilter-3.80-6-cups-1.6.patch
+    ./patches/cnijfilter-4.00-4-ppd.patch
+    ./patches/cnijfilter-4.00-5-abi_x86_32.patch
+    ./patches/cnijfilter-4.00-6-headers.patch
+  ];
+
+  postPatch = ''
+    sed -i "s|/usr/lib/cups/backend|$out/lib/cups/backend|" backend/src/Makefile.am;
+    sed -i "s|/usr/lib/cups/backend|$out/lib/cups/backend|" backendnet/backend/Makefile.am;
+    sed -i "s|/usr/lib/cups/backend|$out/lib/cups/backend|" cnijbe/src/Makefile.am;
+    sed -i "s|/usr|$out|" backend/src/cnij_backend_common.c;
+    sed -i "s|/usr/bin|${ghostscript}/bin|" pstocanonij/filter/pstocanonij.c;
+  '';
+
+  configurePhase = ''
+    cd libs
+    ./autogen.sh --prefix=$out 
+
+    cd ../bscc2sts
+    ./autogen.sh 
+
+    cd ../cnijnpr
+    ./autogen.sh --prefix=$out --enable-libpath=$out/lib/bjlib
+
+    cd ../cngpij
+    ./autogen.sh --prefix=$out --enable-progpath=$out/bin
+
+    cd ../cngpijmnt
+    ./autogen.sh --prefix=$out --enable-progpath=$out/bin
+
+    cd ../pstocanonij
+    ./autogen.sh --prefix=$out --enable-progpath=$out/bin 
+
+    cd ../backend
+    ./autogen.sh --prefix=$out
+
+    cd ../backendnet
+    ./autogen.sh --prefix=$out --enable-libpath=$out/lib/bjlib --enable-progpath=$out/bin 
+
+    cd ../cmdtocanonij
+    ./autogen.sh --prefix=$out --datadir=$out/share
+
+    cd ../cnijbe
+    ./autogen.sh --prefix=$out --enable-progpath=$out/bin 
+
+    cd ../lgmon2
+    substituteInPlace src/Makefile.am \
+        --replace /usr/include/libusb-1.0 \
+                  ${libusb.dev}/include/libusb-1.0
+    ./autogen.sh --prefix=$out --enable-libpath=$out/lib/bjlib --enable-progpath=$out/bin 
+
+    cd ..;
+
+    sed -e "s,cnijlgmon2_LDADD =,cnijlgmon2_LDADD = -L../../com/libs_bin${arch}," \
+    -i lgmon2/src/Makefile.am || die
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin $out/lib/cups/filter $out/share/cups/model;
+  '';
+
+  postInstall = ''
+    set -o xtrace
+    for pr in mg2400 mg2500 mg3500 mg5500 mg6400 mg6500 mg7100 p200; do
+      cd ppd;
+      ./autogen.sh --prefix=$out --program-suffix=$pr
+      make clean;
+      make;
+      make install;
+
+      cd ../cnijfilter;
+      ./autogen.sh --prefix=$out --program-suffix=$pr --enable-libpath=/var/lib/cups/path/lib/bjlib --enable-binpath=$out/bin;
+      make clean;
+      make;
+      make install;
+
+      cd ..;
+    done;
+
+    mkdir -p $out/lib/bjlib;
+    for pr_id in 423 424 425 426 427 428 429 430; do
+      install -c -m 755 $pr_id/database/* $out/lib/bjlib;
+      install -c -s -m 755 $pr_id/libs_bin${arch}/*.so.* $out/lib;
+    done;
+
+    pushd $out/lib;
+    for so_file in *.so.*; do
+      ln -s $so_file ''${so_file/.so.*/}.so;
+      patchelf --set-rpath $out/lib $so_file;
+    done;
+    popd;
+  '';
+
+  /* the tarball includes some pre-built shared libraries.  we run
+     'patchelf --set-rpath' on them just a few lines above, so that
+     they can find each other.  but that's not quite enough.  some of
+     those libraries load each other in non-standard ways -- they
+     don't list each other in the DT_NEEDED section.  so, if the
+     standard 'patchelf --shrink-rpath' (from
+     pkgs/development/tools/misc/patchelf/setup-hook.sh) is run on
+     them, it undoes the --set-rpath.  this prevents that. */
+  dontPatchELF = true;
+
+  meta = with lib; {
+    description = "Canon InkJet printer drivers for the MG2400 MG2500 MG3500 MG5500 MG6400 MG6500 MG7100 and P200 series.";
+    homepage = https://www.canon-europe.com/support/consumer_products/products/fax__multifunctionals/inkjet/pixma_mg_series/pixma_mg5550.aspx?type=drivers&driverdetailid=tcm:13-1094072;
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ chpatrick ];
+  };
+}

--- a/pkgs/misc/cups/drivers/cnijfilter_4_00/patches/cnijfilter-3.80-1-cups-1.6.patch
+++ b/pkgs/misc/cups/drivers/cnijfilter_4_00/patches/cnijfilter-3.80-1-cups-1.6.patch
@@ -1,0 +1,62 @@
+--- a/cngpij/cngpij/bjcups.c
++++ a/cngpij/cngpij/bjcups.c
+@@ -698,8 +719,8 @@
+ 	else {
+ 		pRequest = ippNew();
+ 		
+-		pRequest->request.op.operation_id = CUPS_GET_PRINTERS;
+-		pRequest->request.op.request_id   = 1;
++		ippSetOperation(pRequest, CUPS_GET_PRINTERS);
++		ippSetRequestId(pRequest, 1);
+ 		
+ 		pLanguage = bjcupsLangDefault();	// cupsLangDefault() -> bjcupsLangDefault() for cups-1.1.19
+ 		
+@@ -708,29 +729,29 @@
+ 		ippAddString(pRequest, IPP_TAG_OPERATION, IPP_TAG_URI, "printer-uri", NULL, NULL);
+ 		
+ 		if ((pResponse = cupsDoRequest(pHTTP, pRequest, "/")) != NULL) {
+-			if (pResponse->request.status.status_code > IPP_OK_CONFLICT) {
++			if (ippGetStatusCode(pResponse) > IPP_OK_CONFLICT) {
+ 				fputs("ERROR: IPP ERROR\n", stderr);
+ 				goto onErr;
+ 			}
+ 			else {
+-				pAttribute = pResponse->attrs;
++				pAttribute = ippFirstAttribute(pResponse);
+ 
+ 				while (pAttribute != NULL) {
+-					while (pAttribute != NULL && pAttribute->group_tag != IPP_TAG_PRINTER) {
+-						pAttribute = pAttribute->next;
++					while (pAttribute != NULL && ippGetGroupTag(pAttribute) != IPP_TAG_PRINTER) {
++						pAttribute = ippNextAttribute(pResponse);
+ 					}
+ 					if (pAttribute == NULL) {
+ 						break;
+ 					}
+ 					
+-					while (pAttribute != NULL && pAttribute->group_tag == IPP_TAG_PRINTER) {
+-						if (strcmp(pAttribute->name, "printer-name") == 0 && pAttribute->value_tag == IPP_TAG_NAME) {
+-							pPrinter = pAttribute->values[0].string.text;
++					while (pAttribute != NULL && ippGetGroupTag(pAttribute) == IPP_TAG_PRINTER) {
++						if (strcmp(ippGetName(pAttribute), "printer-name") == 0 && ippGetValueTag(pAttribute) == IPP_TAG_NAME) {
++							pPrinter = ippGetString(pAttribute, 0, NULL);
+ 						}
+-						if (strcmp(pAttribute->name, "device-uri") == 0 && pAttribute->value_tag == IPP_TAG_URI) {
+-							pDUri = pAttribute->values[0].string.text;
++						if (strcmp(ippGetName(pAttribute), "device-uri") == 0 && ippGetValueTag(pAttribute) == IPP_TAG_URI) {
++							pDUri = ippGetString(pAttribute, 0, NULL);
+ 						}
+-						pAttribute = pAttribute->next;
++						pAttribute = ippNextAttribute(pResponse);
+ 					}
+ 
+ 					if (strcasecmp(pDestName, pPrinter) == 0) {
+@@ -739,7 +760,7 @@
+ 					}
+ 					
+ 					if (pAttribute != NULL)
+-						 pAttribute = pAttribute->next;
++						pAttribute = ippNextAttribute(pResponse);
+ 				}
+ 			}
+

--- a/pkgs/misc/cups/drivers/cnijfilter_4_00/patches/cnijfilter-3.80-6-cups-1.6.patch
+++ b/pkgs/misc/cups/drivers/cnijfilter_4_00/patches/cnijfilter-3.80-6-cups-1.6.patch
@@ -1,0 +1,87 @@
+diff --git a/cngpijmnt/src/getipc.c b/cngpijmnt/src/getipc.c
+index 8688032..54c7933 100755
+--- a/cngpijmnt/src/getipc.c
++++ b/cngpijmnt/src/getipc.c
+@@ -42,7 +42,7 @@ int GetIPCData(LPIPCU pipc, char *sname)
+ 	int server_fd;
+ 	int client_fd;
+ 	char buf[128];
+-	size_t len;
++	socklen_t len;
+ 	short ret = RET_ERROR;
+ 
+ 	if( (server_fd = socket(PF_UNIX, SOCK_STREAM, 0)) < 0 )
+
+--- a/cngpijmnt/src/main.c	2016-11-12 23:39:03.534855723 +0100
++++ b/cngpijmnt/src/main.c	2016-11-12 23:47:02.521847145 +0100
+@@ -308,8 +308,8 @@
+ 					*pResponse;					// Pointer to CUPS IPP response.
+ 	ipp_attribute_t	*pAttribute;				// Pointer to CUPS attributes.
+ 	cups_lang_t		*pLanguage;					// Pointer to language.
+-	char			*pPrinter = NULL;			// Pointer to printer name.
+-	char			*pDUri = NULL;				// Pointer to Device uri.
++	const char			*pPrinter = NULL;			// Pointer to printer name.
++	const char			*pDUri = NULL;				// Pointer to Device uri.
+ 	short			retVal = -1;	// Return value.
+ /*** Parameters end ***/
+ 	
+@@ -321,8 +321,8 @@
+ 	else {
+ 		pRequest = ippNew();
+ 		
+-		pRequest->request.op.operation_id = CUPS_GET_PRINTERS;
+-		pRequest->request.op.request_id   = 1;
++		ippSetOperation(pRequest, CUPS_GET_PRINTERS);
++		ippSetRequestId(pRequest, 1);
+ 		
+ 		pLanguage = bjcupsLangDefault();	// cupsLangDefault() -> bjcupsLangDefault() for cups-1.1.19
+ 		
+@@ -331,29 +331,29 @@
+ 		ippAddString(pRequest, IPP_TAG_OPERATION, IPP_TAG_URI, "printer-uri", NULL, NULL);
+ 		
+ 		if ((pResponse = cupsDoRequest(pHTTP, pRequest, "/")) != NULL) {
+-			if (pResponse->request.status.status_code > IPP_OK_CONFLICT) {
++			if (ippGetStatusCode(pResponse) > IPP_OK_CONFLICT) {
+ 				fputs("ERROR: IPP ERROR\n", stderr);
+ 				goto onErr;
+ 			}
+ 			else {
+-				pAttribute = pResponse->attrs;
++				pAttribute = ippFirstAttribute(pResponse);
+ 
+ 				while (pAttribute != NULL) {
+-					while (pAttribute != NULL && pAttribute->group_tag != IPP_TAG_PRINTER) {
+-						pAttribute = pAttribute->next;
++					while (pAttribute != NULL && ippGetGroupTag(pAttribute) != IPP_TAG_PRINTER) {
++						pAttribute = ippNextAttribute(pResponse);
+ 					}
+ 					if (pAttribute == NULL) {
+ 						break;
+ 					}
+ 					
+-					while (pAttribute != NULL && pAttribute->group_tag == IPP_TAG_PRINTER) {
+-						if (strcmp(pAttribute->name, "printer-name") == 0 && pAttribute->value_tag == IPP_TAG_NAME) {
+-							pPrinter = pAttribute->values[0].string.text;
++					while (pAttribute != NULL && ippGetGroupTag(pAttribute) == IPP_TAG_PRINTER) {
++						if (strcmp(ippGetName(pAttribute), "printer-name") == 0 && ippGetValueTag(pAttribute) == IPP_TAG_NAME) {
++							pPrinter = ippGetString(pAttribute, 0, NULL);
+ 						}
+-						if (strcmp(pAttribute->name, "device-uri") == 0 && pAttribute->value_tag == IPP_TAG_URI) {
+-							pDUri = pAttribute->values[0].string.text;
++						if (strcmp(ippGetName(pAttribute), "device-uri") == 0 && ippGetValueTag(pAttribute) == IPP_TAG_URI) {
++							pDUri = ippGetString(pAttribute, 0, NULL);
+ 						}
+-						pAttribute = pAttribute->next;
++						pAttribute = ippNextAttribute(pResponse);
+ 					}
+ 
+ 					if (strcasecmp(pDestName, pPrinter) == 0) {
+@@ -362,7 +362,7 @@
+ 					}
+ 					
+ 					if (pAttribute != NULL)
+-						 pAttribute = pAttribute->next;
++						 pAttribute = ippNextAttribute(pResponse);
+ 				}
+ 			}
+ 			

--- a/pkgs/misc/cups/drivers/cnijfilter_4_00/patches/cnijfilter-4.00-4-ppd.patch
+++ b/pkgs/misc/cups/drivers/cnijfilter_4_00/patches/cnijfilter-4.00-4-ppd.patch
@@ -1,0 +1,10 @@
+--- a/backend/src/cnij_backend_common.c	2016-11-13 00:08:34.600824006 +0100
++++ a/backend/src/cnij_backend_common.c	2016-11-13 00:08:52.037823694 +0100
+@@ -37,6 +37,7 @@
+ // CUPS Header
+ #include <cups/cups.h>
+ #include <cups/ipp.h>
++#include <cups/ppd.h>
+ 
+ // Header file for CANON
+ #include "cnij_backend_common.h"

--- a/pkgs/misc/cups/drivers/cnijfilter_4_00/patches/cnijfilter-4.00-5-abi_x86_32.patch
+++ b/pkgs/misc/cups/drivers/cnijfilter_4_00/patches/cnijfilter-4.00-5-abi_x86_32.patch
@@ -1,0 +1,45 @@
+--- a/backendnet/configure.in	2014-08-11 08:38:46.034984462 +0200
++++ a/backendnet/configure.in	2014-08-11 08:35:42.902985813 +0200
+@@ -19,7 +19,11 @@
+ AC_DEFINE_UNQUOTED(BJLIB_PATH, "$enable_libpath")
+ AC_SUBST(BJLIB_PATH)
+ 
+-ARC=`getconf LONG_BIT`
++case "$ABI" in
++    x86) ARC=32;;
++    amd64) ARC=64;;
++    *) ARC=`getconf LONG_BIT`;;
++esac
+ AC_SUBST(ARC)
+ 
+ # Checks for programs.
+--- a/cnijfilter/configure.in	2014-08-11 08:39:44.426984031 +0200
++++ a/cnijfilter/configure.in	2014-08-11 08:35:19.788985984 +0200
+@@ -43,7 +43,11 @@
+ esac
+ AC_SUBST(CNCL_LIB_ID)
+ 
+-ARC=`getconf LONG_BIT`
++case "$ABI" in
++    x86) ARC=32;;
++    amd64) ARC=64;;
++    *) ARC=`getconf LONG_BIT`;;
++esac
+ AC_SUBST(ARC)
+ 
+ AC_PROG_CC
+--- a/cnijnpr/configure.in	2014-08-11 08:41:12.712983380 +0200
++++ a/cnijnpr/configure.in	2014-08-11 08:40:44.354983589 +0200
+@@ -37,7 +37,11 @@
+ 
+ CFLAGS="-O2"
+ 
+-ARC=`getconf LONG_BIT`
++case "$ABI" in
++    x86) ARC=32;;
++    amd64) ARC=64;;
++    *) ARC=`getconf LONG_BIT`;;
++esac
+ AC_SUBST(ARC)
+ 
+ AC_OUTPUT(Makefile

--- a/pkgs/misc/cups/drivers/cnijfilter_4_00/patches/cnijfilter-4.00-6-headers.patch
+++ b/pkgs/misc/cups/drivers/cnijfilter_4_00/patches/cnijfilter-4.00-6-headers.patch
@@ -1,0 +1,11 @@
+--- a/cnijnpr/src/cnijnpr.c	2016-11-13 21:51:33.844977618 +0100
++++ a/cnijnpr/src/cnijnpr.c	2016-11-13 21:52:03.129977094 +0100
+@@ -34,6 +34,8 @@
+ #include <sys/ioctl.h>
+ #include <net/if.h>
+ #include <sys/sysctl.h>
++#include <sys/types.h>
++#include <unistd.h>
+ #include <config.h>
+ #include <fcntl.h>
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19233,6 +19233,10 @@ with pkgs;
   # this driver ships with pre-compiled 32-bit binary libraries
   cnijfilter_2_80 = callPackage_i686 ../misc/cups/drivers/cnijfilter_2_80 { };
 
+  cnijfilter_4_00 = callPackage ../misc/cups/drivers/cnijfilter_4_00 {
+    libusb = libusb1;
+  };
+
   cnijfilter2 = callPackage ../misc/cups/drivers/cnijfilter2 {
     libusb = libusb1;
   };


### PR DESCRIPTION
###### Motivation for this change
Add the driver for certain Canon printers. I can safely say this was my most painful printer setup experience. :D

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

