### PR TITLE
Remove "argsOverride" from linux kernel

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -27,9 +27,11 @@
 , extraMeta ? {}
 , hostPlatform
 , ...
-}:
+} @ args:
 
 assert stdenv.isLinux;
+
+if args ? argsOverride then throw "'argsOverride' is deprecated for linux kernels." else
 
 let
 

--- a/pkgs/os-specific/linux/kernel/linux-4.13.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.13.nix
@@ -1,6 +1,6 @@
 { stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
-import ./generic.nix (args // rec {
+import ./generic.nix (rec {
   version = "4.13.15";
   extraMeta.branch = "4.13";
 
@@ -8,4 +8,4 @@ import ./generic.nix (args // rec {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
     sha256 = "1cnixf90pi9xsb8p1sncwcnl5acp8b46xxxmsizk335knmn919g4";
   };
-} // (args.argsOverride or {}))
+} // args)

--- a/pkgs/os-specific/linux/kernel/linux-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14.nix
@@ -2,7 +2,7 @@
 
 with stdenv.lib;
 
-import ./generic.nix (args // rec {
+import ./generic.nix (rec {
   version = "4.14.1";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
@@ -15,4 +15,4 @@ import ./generic.nix (args // rec {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
     sha256 = "1rsdrdapjw8lhm8dyckwxfihykirbkincm5k0lwwx1pr09qgdfbg";
   };
-} // (args.argsOverride or {}))
+} // args)

--- a/pkgs/os-specific/linux/kernel/linux-4.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.4.nix
@@ -1,6 +1,6 @@
 { stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
-import ./generic.nix (args // rec {
+import ./generic.nix (rec {
   version = "4.4.100";
   extraMeta.branch = "4.4";
 
@@ -8,4 +8,4 @@ import ./generic.nix (args // rec {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
     sha256 = "0kyi3cplkd839alyd6vsw2cqkb523zfsrjb2d6ygcddxqjcwsdlr";
   };
-} // (args.argsOverride or {}))
+} // args)

--- a/pkgs/os-specific/linux/kernel/linux-4.9.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.9.nix
@@ -1,6 +1,6 @@
 { stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
-import ./generic.nix (args // rec {
+import ./generic.nix (rec {
   version = "4.9.64";
   extraMeta.branch = "4.9";
 
@@ -8,4 +8,4 @@ import ./generic.nix (args // rec {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
     sha256 = "1h1h71nyiwvx2jy3j3yjazya6gz3k47bhm00mm311syaplhp0qhr";
   };
-} // (args.argsOverride or {}))
+} // args)

--- a/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
+++ b/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
@@ -4,7 +4,7 @@ let
   modDirVersion = "4.9.61";
   tag = "r76";
 in
-import ./generic.nix (args // rec {
+import ./generic.nix (rec {
   version = "${modDirVersion}-ti-${tag}";
   inherit modDirVersion;
 
@@ -22,4 +22,4 @@ import ./generic.nix (args // rec {
   } // (args.features or {});
 
   extraMeta.hydraPlatforms = [];
-} // (args.argsOverride or {}))
+} // args)

--- a/pkgs/os-specific/linux/kernel/linux-hardened-copperhead.nix
+++ b/pkgs/os-specific/linux/kernel/linux-hardened-copperhead.nix
@@ -15,7 +15,7 @@ let
 
   modDirVersion = "${modVersion}-hardened";
 in
-import ./generic.nix (args // {
+import ./generic.nix ( {
   inherit modDirVersion;
 
   version = "${version}-${revision}";
@@ -27,4 +27,4 @@ import ./generic.nix (args // {
     repo = "linux-hardened";
     rev = "${version}.${revision}";
   };
-} // (args.argsOverride or {}))
+} // args)

--- a/pkgs/os-specific/linux/kernel/linux-mptcp.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp.nix
@@ -43,4 +43,4 @@ import ./generic.nix (rec {
     TCP_CONG_BALIA m
 
   '' + (args.extraConfig or "");
-} // args // (args.argsOverride or {}))
+} //  args)

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -4,7 +4,7 @@ let
   modDirVersion = "4.9.59";
   tag = "1.20171029";
 in
-stdenv.lib.overrideDerivation (import ./generic.nix (args // rec {
+stdenv.lib.overrideDerivation (import ./generic.nix (rec {
   version = "${modDirVersion}-${tag}";
   inherit modDirVersion;
 
@@ -20,7 +20,7 @@ stdenv.lib.overrideDerivation (import ./generic.nix (args // rec {
   } // (args.features or {});
 
   extraMeta.hydraPlatforms = [];
-})) (oldAttrs: {
+} // (removeAttrs args ["features"]))) (oldAttrs: {
   postConfigure = ''
     # The v7 defconfig has this set to '-v7' which screws up our modDirVersion.
     sed -i $buildRoot/.config -e 's/^CONFIG_LOCALVERSION=.*/CONFIG_LOCALVERSION=""/'

--- a/pkgs/os-specific/linux/kernel/linux-samus-4.12.nix
+++ b/pkgs/os-specific/linux/kernel/linux-samus-4.12.nix
@@ -2,7 +2,7 @@
 
 assert stdenv.is64bit;
 
-import ./generic.nix (args // rec {
+import ./generic.nix (rec {
   version = "4.12.2";
   extraMeta.branch = "4.12-2";
 
@@ -15,4 +15,4 @@ import ./generic.nix (args // rec {
     }; in "${upstream}/build/linux";
 
   extraMeta.hydraPlatforms = [];
-} // (args.argsOverride or {}))
+} // args)

--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -1,6 +1,6 @@
 { stdenv, hostPlatform, fetchgit, perl, buildLinux, ... } @ args:
 
-import ./generic.nix (args // rec {
+import ./generic.nix (rec {
   version = "4.11.2017.08.23";
   modDirVersion = "4.11.0";
   extraMeta.branch = "master";
@@ -19,5 +19,5 @@ import ./generic.nix (args // rec {
   # Should the testing kernels ever be built on Hydra?
   extraMeta.hydraPlatforms = [];
 
-} // (args.argsOverride or {}))
+} // args)
 

--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -1,6 +1,6 @@
 { stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
-import ./generic.nix (args // rec {
+import ./generic.nix (rec {
   version = "4.14-rc8";
   modDirVersion = "4.14.0-rc8";
   extraMeta.branch = "4.14";
@@ -13,4 +13,4 @@ import ./generic.nix (args // rec {
   # Should the testing kernels ever be built on Hydra?
   extraMeta.hydraPlatforms = [];
 
-} // (args.argsOverride or {}))
+} // args)


### PR DESCRIPTION
###### Motivation for this change

It is a bit strange to use these argsOverride attribute because it does not play well with the .override mechanism. The current situation is also inconsistent since #31596 was merged.

###### Things done

This patch unifies the syntax for all the kernels by removing the argsOverride support and merging the input args after the default values, making everything overridable.
A deprecation warning was also introduced for users relying on that feature.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested that all the derivations are strictly unchanged by this patch.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
