### PR TITLE
syncthing-gtk: 0.9.2.3 → 0.9.2.7

### DIFF
--- a/pkgs/applications/networking/syncthing-gtk/default.nix
+++ b/pkgs/applications/networking/syncthing-gtk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, libnotify, librsvg, psmisc, gtk3, substituteAll, syncthing, wrapGAppsHook, gnome3, python2Packages }:
+{ stdenv, fetchFromGitHub, libnotify, librsvg, psmisc, gtk3, substituteAll, syncthing, wrapGAppsHook, gnome3, python2Packages, gobjectIntrospection }:
 
 python2Packages.buildPythonApplication rec {
   version = "0.9.2.7";
@@ -11,7 +11,11 @@ python2Packages.buildPythonApplication rec {
     sha256 = "08k7vkibia85klwjxbnzk67h4pphrizka5v9zxwvvv3cisjiclc2";
   };
 
-  nativeBuildInputs = [ wrapGAppsHook ];
+  nativeBuildInputs = [
+    wrapGAppsHook
+    # For setup hook populating GI_TYPELIB_PATH
+    gobjectIntrospection
+  ];
 
   buildInputs = [
     gtk3 (librsvg.override { enableIntrospection = true; })

--- a/pkgs/applications/networking/syncthing-gtk/default.nix
+++ b/pkgs/applications/networking/syncthing-gtk/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, libnotify, librsvg, psmisc, gtk3, substituteAll, syncthing, wrapGAppsHook, gnome3, python2Packages, gobjectIntrospection }:
+{ stdenv, fetchFromGitHub, libnotify, librsvg, psmisc, gtk3, substituteAll, syncthing, wrapGAppsHook, gnome3, buildPythonApplication, dateutil, pyinotify, pygobject3, bcrypt, gobjectIntrospection }:
 
-python2Packages.buildPythonApplication rec {
+buildPythonApplication rec {
   version = "0.9.2.7";
   name = "syncthing-gtk-${version}";
 
@@ -24,7 +24,7 @@ python2Packages.buildPythonApplication rec {
     gnome3.gsettings_desktop_schemas
   ];
 
-  propagatedBuildInputs = with python2Packages; [
+  propagatedBuildInputs = [
     dateutil pyinotify pygobject3 bcrypt
   ];
 

--- a/pkgs/applications/networking/syncthing-gtk/default.nix
+++ b/pkgs/applications/networking/syncthing-gtk/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, libnotify, librsvg, psmisc, gtk3, syncthing, wrapGAppsHook, gnome3, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
-  version = "0.9.2.3";
+  version = "0.9.2.7";
   name = "syncthing-gtk-${version}";
 
   src = fetchFromGitHub {
     owner = "syncthing";
     repo = "syncthing-gtk";
     rev = "v${version}";
-    sha256 = "0chl0f0kp6z0z00d1f3xjlicjfr9rzabw39wmjr66fwb5w5hcc42";
+    sha256 = "08k7vkibia85klwjxbnzk67h4pphrizka5v9zxwvvv3cisjiclc2";
   };
 
   nativeBuildInputs = [ wrapGAppsHook ];
@@ -21,7 +21,7 @@ python2Packages.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python2Packages; [
-    dateutil pyinotify pygobject3
+    dateutil pyinotify pygobject3 bcrypt
   ];
 
   patches = [

--- a/pkgs/applications/networking/syncthing-gtk/default.nix
+++ b/pkgs/applications/networking/syncthing-gtk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, libnotify, librsvg, psmisc, gtk3, syncthing, wrapGAppsHook, gnome3, python2Packages }:
+{ stdenv, fetchFromGitHub, libnotify, librsvg, psmisc, gtk3, substituteAll, syncthing, wrapGAppsHook, gnome3, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
   version = "0.9.2.7";
@@ -15,9 +15,9 @@ python2Packages.buildPythonApplication rec {
 
   buildInputs = [
     gtk3 (librsvg.override { enableIntrospection = true; })
-    libnotify psmisc
+    libnotify
     # Schemas with proxy configuration
-    syncthing gnome3.gsettings_desktop_schemas
+    gnome3.gsettings_desktop_schemas
   ];
 
   propagatedBuildInputs = with python2Packages; [
@@ -26,23 +26,27 @@ python2Packages.buildPythonApplication rec {
 
   patches = [
     ./disable-syncthing-binary-configuration.patch
+    (substituteAll {
+      src = ./paths.patch;
+      killall = "${psmisc}/bin/killall";
+      syncthing = "${syncthing}/bin/syncthing";
+    })
   ];
 
   postPatch = ''
     substituteInPlace setup.py --replace "version = get_version()" "version = '${version}'"
     substituteInPlace scripts/syncthing-gtk --replace "/usr/share" "$out/share"
     substituteInPlace syncthing_gtk/app.py --replace "/usr/share" "$out/share"
-    substituteInPlace syncthing_gtk/configuration.py --replace "/usr/bin/syncthing" "${syncthing}/bin/syncthing"
     substituteInPlace syncthing_gtk/uisettingsdialog.py --replace "/usr/share" "$out/share"
     substituteInPlace syncthing_gtk/wizard.py --replace "/usr/share" "$out/share"
     substituteInPlace syncthing-gtk.desktop --replace "/usr/bin/syncthing-gtk" "$out/bin/syncthing-gtk"
   '';
 
   meta = with stdenv.lib; {
-    description = " GTK3 & python based GUI for Syncthing ";
+    description = "GTK3 & python based GUI for Syncthing";
     maintainers = with maintainers; [ ];
     platforms = syncthing.meta.platforms;
-    homepage = "https://github.com/syncthing/syncthing-gtk";
+    homepage = https://github.com/syncthing/syncthing-gtk;
     license = licenses.gpl2;
   };
 }

--- a/pkgs/applications/networking/syncthing-gtk/default.nix
+++ b/pkgs/applications/networking/syncthing-gtk/default.nix
@@ -17,17 +17,23 @@ python2Packages.buildPythonApplication rec {
     gtk3 (librsvg.override { enableIntrospection = true; })
     libnotify psmisc
     # Schemas with proxy configuration
-    gnome3.gsettings_desktop_schemas
+    syncthing gnome3.gsettings_desktop_schemas
   ];
 
   propagatedBuildInputs = with python2Packages; [
-    syncthing dateutil pyinotify pygobject3
+    dateutil pyinotify pygobject3
   ];
 
-  patchPhase = ''
+  patches = [
+    ./disable-syncthing-binary-configuration.patch
+  ];
+
+  postPatch = ''
     substituteInPlace setup.py --replace "version = get_version()" "version = '${version}'"
     substituteInPlace scripts/syncthing-gtk --replace "/usr/share" "$out/share"
     substituteInPlace syncthing_gtk/app.py --replace "/usr/share" "$out/share"
+    substituteInPlace syncthing_gtk/configuration.py --replace "/usr/bin/syncthing" "${syncthing}/bin/syncthing"
+    substituteInPlace syncthing_gtk/uisettingsdialog.py --replace "/usr/share" "$out/share"
     substituteInPlace syncthing_gtk/wizard.py --replace "/usr/share" "$out/share"
     substituteInPlace syncthing-gtk.desktop --replace "/usr/bin/syncthing-gtk" "$out/bin/syncthing-gtk"
   '';

--- a/pkgs/applications/networking/syncthing-gtk/default.nix
+++ b/pkgs/applications/networking/syncthing-gtk/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, libnotify, librsvg, psmisc, gtk3, syncthing, python2Packages }:
+
+python2Packages.buildPythonApplication rec {
+  version = "0.9.2.3";
+  name = "syncthing-gtk-${version}";
+
+  src = fetchFromGitHub {
+    owner = "syncthing";
+    repo = "syncthing-gtk";
+    rev = "v${version}";
+    sha256 = "0chl0f0kp6z0z00d1f3xjlicjfr9rzabw39wmjr66fwb5w5hcc42";
+  };
+
+  propagatedBuildInputs = with python2Packages; [
+    syncthing dateutil pyinotify libnotify
+    (librsvg.override { withGTK = true; })
+    psmisc pygobject3 gtk3
+  ];
+
+  preFixup = ''
+    wrapProgram $out/bin/syncthing-gtk \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH"
+  '';
+
+  patchPhase = ''
+    substituteInPlace setup.py --replace "version = get_version()" "version = '${version}'"
+    substituteInPlace scripts/syncthing-gtk --replace "/usr/share" "$out/share"
+    substituteInPlace syncthing_gtk/app.py --replace "/usr/share" "$out/share"
+    substituteInPlace syncthing_gtk/wizard.py --replace "/usr/share" "$out/share"
+    substituteInPlace syncthing-gtk.desktop --replace "/usr/bin/syncthing-gtk" "$out/bin/syncthing-gtk"
+  '';
+
+  meta = with stdenv.lib; {
+    description = " GTK3 & python based GUI for Syncthing ";
+    maintainers = with maintainers; [ ];
+    platforms = syncthing.meta.platforms;
+    homepage = "https://github.com/syncthing/syncthing-gtk";
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/applications/networking/syncthing-gtk/default.nix
+++ b/pkgs/applications/networking/syncthing-gtk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, libnotify, librsvg, psmisc, gtk3, syncthing, python2Packages }:
+{ stdenv, fetchFromGitHub, libnotify, librsvg, psmisc, gtk3, syncthing, wrapGAppsHook, gnome3, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
   version = "0.9.2.3";
@@ -11,17 +11,18 @@ python2Packages.buildPythonApplication rec {
     sha256 = "0chl0f0kp6z0z00d1f3xjlicjfr9rzabw39wmjr66fwb5w5hcc42";
   };
 
-  propagatedBuildInputs = with python2Packages; [
-    syncthing dateutil pyinotify libnotify
-    (librsvg.override { withGTK = true; })
-    psmisc pygobject3 gtk3
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  buildInputs = [
+    gtk3 (librsvg.override { enableIntrospection = true; })
+    libnotify psmisc
+    # Schemas with proxy configuration
+    gnome3.gsettings_desktop_schemas
   ];
 
-  preFixup = ''
-    wrapProgram $out/bin/syncthing-gtk \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH"
-  '';
+  propagatedBuildInputs = with python2Packages; [
+    syncthing dateutil pyinotify pygobject3
+  ];
 
   patchPhase = ''
     substituteInPlace setup.py --replace "version = get_version()" "version = '${version}'"

--- a/pkgs/applications/networking/syncthing-gtk/disable-syncthing-binary-configuration.patch
+++ b/pkgs/applications/networking/syncthing-gtk/disable-syncthing-binary-configuration.patch
@@ -1,0 +1,77 @@
+--- a/find-daemon.glade
++++ b/find-daemon.glade
+@@ -112,6 +112,7 @@
+                   <object class="GtkEntry" id="vsyncthing_binary">
+                     <property name="visible">True</property>
+                     <property name="can_focus">True</property>
++                    <property name="sensitive">False</property>
+                     <property name="margin_right">20</property>
+                     <signal name="changed" handler="cb_check_value" swapped="no"/>
+                   </object>
+@@ -126,6 +127,7 @@
+                     <property name="label" translatable="yes">_Browse...</property>
+                     <property name="visible">True</property>
+                     <property name="can_focus">True</property>
++                    <property name="sensitive">False</property>
+                     <property name="receives_default">True</property>
+                     <property name="use_underline">True</property>
+                     <property name="yalign">0.51999998092651367</property>
+--- a/syncthing_gtk/configuration.py
++++ b/syncthing_gtk/configuration.py
+@@ -166,6 +166,8 @@
+ 			yield k
+ 	
+ 	def get(self, key):
++		if key == "syncthing_binary":
++			return self.REQUIRED_KEYS[key][1]
+ 		return self.values[key]
+ 	
+ 	def set(self, key, value):
+--- a/syncthing_gtk/finddaemondialog.py
++++ b/syncthing_gtk/finddaemondialog.py
+@@ -163,7 +163,7 @@
+ 		self["lblDownloadProgress"].set_markup(_("Download failed."))
+ 		self["btDownload"].set_visible(True)
+ 		self["pbDownload"].set_visible(False)
+-		self["vsyncthing_binary"].set_sensitive(True)
++		self["vsyncthing_binary"].set_sensitive(False)
+ 		self["btBrowse"].set_sensitive(True)
+ 		self["btSave"].set_sensitive(True)
+ 	
+@@ -179,7 +179,7 @@
+ 	
+ 	def cb_extract_finished(self, downloader, *a):
+ 		""" Called after extraction is finished """
+-		self["vsyncthing_binary"].set_sensitive(True)
++		self["vsyncthing_binary"].set_sensitive(False)
+ 		self["btBrowse"].set_sensitive(True)
+ 		self["vsyncthing_binary"].set_text(downloader.get_target())
+ 		self["lblDownloadProgress"].set_markup("<b>" + _("Download finished.") + "</b>")
+--- a/syncthing_gtk/wizard.py
++++ b/syncthing_gtk/wizard.py
+@@ -58,7 +58,6 @@
+ 		self.quit_button.connect("clicked", lambda *a : self.emit("cancel"))
+ 		# Pages
+ 		self.add_page(IntroPage())
+-		self.add_page(FindDaemonPage())
+ 		self.add_page(GenerateKeysPage())
+ 		self.add_page(HttpSettingsPage())
+ 		self.add_page(SaveSettingsPage())
+--- a/ui-settings.glade
++++ b/ui-settings.glade
+@@ -943,6 +943,7 @@
+                     <property name="label" translatable="yes">_Browse...</property>
+                     <property name="visible">True</property>
+                     <property name="can_focus">True</property>
++                    <property name="sensitive">False</property>
+                     <property name="receives_default">True</property>
+                     <property name="use_underline">True</property>
+                     <property name="yalign">0.51999998092651367</property>
+@@ -974,6 +975,7 @@
+                   <object class="GtkEntry" id="vsyncthing_binary">
+                     <property name="visible">True</property>
+                     <property name="can_focus">True</property>
++                    <property name="sensitive">False</property>
+                     <property name="hexpand">True</property>
+                     <signal name="changed" handler="cb_check_value" swapped="no"/>
+                   </object>

--- a/pkgs/applications/networking/syncthing-gtk/disable-syncthing-binary-configuration.patch
+++ b/pkgs/applications/networking/syncthing-gtk/disable-syncthing-binary-configuration.patch
@@ -18,7 +18,7 @@
                      <property name="yalign">0.51999998092651367</property>
 --- a/syncthing_gtk/configuration.py
 +++ b/syncthing_gtk/configuration.py
-@@ -166,6 +166,8 @@
+@@ -168,6 +168,8 @@
  			yield k
  	
  	def get(self, key):
@@ -49,10 +49,10 @@
  		self["lblDownloadProgress"].set_markup("<b>" + _("Download finished.") + "</b>")
 --- a/syncthing_gtk/wizard.py
 +++ b/syncthing_gtk/wizard.py
-@@ -58,7 +58,6 @@
+@@ -60,7 +60,6 @@
  		self.quit_button.connect("clicked", lambda *a : self.emit("cancel"))
  		# Pages
- 		self.add_page(IntroPage())
+ 		self.add_page(IntroPage(self))
 -		self.add_page(FindDaemonPage())
  		self.add_page(GenerateKeysPage())
  		self.add_page(HttpSettingsPage())

--- a/pkgs/applications/networking/syncthing-gtk/paths.patch
+++ b/pkgs/applications/networking/syncthing-gtk/paths.patch
@@ -1,0 +1,22 @@
+--- a/syncthing_gtk/configuration.py
++++ b/syncthing_gtk/configuration.py
+@@ -30,7 +30,7 @@
+ 		"autokill_daemon"			: (int, 2),	# 0 - never kill, 1 - always kill, 2 - ask
+ 		"daemon_priority"			: (int, 0), # uses nice values
+ 		"max_cpus"					: (int, 0), # 0 for all cpus
+-		"syncthing_binary"			: (str, "/usr/bin/syncthing"),
++		"syncthing_binary"			: (str, "@syncthing@"),
+ 		"syncthing_arguments"		: (str, ""),
+ 		"minimize_on_start"			: (bool, False),
+ 		"folder_as_path"			: (bool, True),
+--- a/syncthing_gtk/tools.py
++++ b/syncthing_gtk/tools.py
+@@ -303,7 +303,7 @@
+ 			return False
+ 		# signal 0 doesn't kill anything, but killall exits with 1 if
+ 		# named process is not found
+-		p = Popen(["killall", "-u", os.environ["USER"], "-q", "-s", "0", "syncthing"])
++		p = Popen(["@killall@", "-u", os.environ["USER"], "-q", "-s", "0", "syncthing"])
+ 		p.communicate()
+ 		return p.returncode == 0
+ 	else:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17189,7 +17189,7 @@ with pkgs;
 
   syncthing013 = callPackage ../applications/networking/syncthing013 { };
 
-  syncthing-gtk = callPackage ../applications/networking/syncthing-gtk { };
+  syncthing-gtk = python2Packages.callPackage ../applications/networking/syncthing-gtk { };
 
   syncthing-inotify = callPackage ../applications/networking/syncthing/inotify.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17189,6 +17189,8 @@ with pkgs;
 
   syncthing013 = callPackage ../applications/networking/syncthing013 { };
 
+  syncthing-gtk = callPackage ../applications/networking/syncthing-gtk { };
+
   syncthing-inotify = callPackage ../applications/networking/syncthing/inotify.nix { };
 
   syncthing-tray = callPackage ../applications/misc/syncthing-tray { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17329,46 +17329,8 @@ in {
 
   sybil = callPackage ../development/python-modules/sybil { };
 
-  syncthing-gtk = buildPythonPackage rec {
-    version = "0.9.2.3";
-    name = "syncthing-gtk-${version}";
-    src = pkgs.fetchFromGitHub {
-      owner = "syncthing";
-      repo = "syncthing-gtk";
-      rev = "v${version}";
-      sha256 = "0chl0f0kp6z0z00d1f3xjlicjfr9rzabw39wmjr66fwb5w5hcc42";
-    };
-
-    disabled = isPy3k;
-
-    propagatedBuildInputs = with self; [ pkgs.syncthing dateutil pyinotify
-      pkgs.libnotify
-      (pkgs.librsvg.override { withGTK = true; })
-      pkgs.psmisc pygobject3 pkgs.gtk3
-    ];
-
-    preFixup = ''
-      wrapProgram $out/bin/syncthing-gtk \
-        --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-        --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH"
-    '';
-
-    patchPhase = ''
-        substituteInPlace setup.py --replace "version = get_version()" "version = '${version}'"
-        substituteInPlace scripts/syncthing-gtk --replace "/usr/share" "$out/share"
-        substituteInPlace syncthing_gtk/app.py --replace "/usr/share" "$out/share"
-        substituteInPlace syncthing_gtk/wizard.py --replace "/usr/share" "$out/share"
-        substituteInPlace syncthing-gtk.desktop --replace "/usr/bin/syncthing-gtk" "$out/bin/syncthing-gtk"
-    '';
-
-    meta = {
-      description = " GTK3 & python based GUI for Syncthing ";
-      maintainers = with maintainers; [ ];
-      platforms = pkgs.syncthing.meta.platforms;
-      homepage = "https://github.com/syncthing/syncthing-gtk";
-      license = licenses.gpl2;
-    };
-  };
+  # legacy alias
+  syncthing-gtk = pkgs.syncthing-gtk;
 
   systemd = callPackage ../development/python-modules/systemd {
     inherit (pkgs) pkgconfig systemd;


### PR DESCRIPTION
###### Motivation for this change
* Move from python-packages to applications
* Some clean ups
* Patch to always use the syncthing binary from nixpkgs – by default, it saves the syncthing path to a config file on first run, which, of course, breaks after update+GC.
* Update to latest version

I was not able to test it fully due to https://github.com/syncthing/syncthing-gtk/issues/379 but it starts at least.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

