### PR TITLE
 thunderbird: 52.4.0 -> 52.5.0 [Critical security fixes]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,595 +1,595 @@
 {
-  version = "52.4.0";
+  version = "52.5.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ar/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ar/thunderbird-52.5.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "28a0114c665250f419d77f1f3898af6533e1b8b82b546ecd3ca9baf801751fd189239093eaecdabab9a9318fd47020b647086a31676158a21656ff7c477dbbf8";
+      sha512 = "e848c7a44222be7bc637dc2d0356028e67c4093f48e4eb9c66e0c02731f41b2e1f2d09cd7765ee984137fcef4d498aac8cfee39b31c0fe5187347107b2cd12a3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ast/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ast/thunderbird-52.5.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "f7b9d53202597ef666ca87eb1f8cbb439af386eb78460558e8bef33502a7eac591d43751beb52319d046d780fb38a78e685fa8cb3baaa6abfef439bed6ab3d1a";
+      sha512 = "a9f8888ab021e696c8460d75ba1f843f8b31555f3f6f95e9af7f9c6d910ea1c3d68bab3d5adc6c0f70e6d8d9227db4176a7db762d28c1ff19addc95e0a756826";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/be/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/be/thunderbird-52.5.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "a9a39cf4477e469774f2ce7b7012948911009ff2ab26948a177f3efa9e8ccbcb7d7f3d3ab609742fe1d177253dcdeacb78f7b4a9874f3156f6f54203d0ed42ef";
+      sha512 = "4d903b23dcaf17d41c6b9f3d7a3ec936ecc01f19b93ecba88a5fe826f715b606064a6e2737611697c072e887f3776cf10ddba7e26a66dc4b91c3658129171580";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/bg/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/bg/thunderbird-52.5.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "38fc89a687344467f98cb2e31967aa53f3c502a8f288b5d65e6aa91a578b250c17750ea998d32d58511920a0a5a1224e77e2691a381b7526585e341712d82cbd";
+      sha512 = "6d34b3c3e907a16125f26f5f6365b5c3f2127ccf725753e94495b5dafedf3c506e71017d2b4699b755f8940ad0ea4241d6cfc00e958d4642c928c68a7e278fdb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/bn-BD/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/bn-BD/thunderbird-52.5.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "437d943339c4955b5264f95bdd4aaa2a91d448a393e6561bbb41c078a960100962c1d51bad73172c5f5cd691f713ab34c218ff5c3e3cde3641d8a6ad604f6d75";
+      sha512 = "74106efb92c5ba792a3f10dc0ea19d2fc38012f1f761c0e9b9753f8b067e2771a9c4691df55197a9b5e23024f73688bbc26d24357f0eef95b8b305bccad5d9f1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/br/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/br/thunderbird-52.5.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "5c43e3cc4366792b7c7a44ae36fe2bd9e6b459f540868dcee767193826648b03a4e4a447f83f5787036e48c96e75639a305304e050a91f0925d9ee4db97e5b75";
+      sha512 = "2477afe645f7c0e0005a4817a42d24075dfabfce2724446bcd4fce50b72b7408895261544537be0e3dbdf8323e1af07215ca277c9e69261d575cdf4fc1f242ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ca/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ca/thunderbird-52.5.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "c2243ee5f160f786ebced364432b4a3b489699a3f024a8da327cfaa3c5e2d0d58884870311416fcb019723d5bfec8294440c701c6c453c15346f5f765c4449c0";
+      sha512 = "810c5295bcde18217b77e2f147a70a5e94798b92c40d659c47f3f113624f049b788ba9fdcdc22608cc57719e8236372636e6ca46ce7fde309b70fc05e3036f47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/cs/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/cs/thunderbird-52.5.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "332faf549d1d988defdce1531fb4cc81e5f1565423f3e24ebfe16581275224539ed50857dec04c8aa66cc55372a76b676816831d08842bbafd227ca3058f9b5b";
+      sha512 = "f8e033ed566d6b076213e33c489fcfcab520a0e1c3ce5c89c78c7443b360e55136e90b518428527a682854a24cb9b303a6c3475a59950d9546c1becd5db2a46a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/cy/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/cy/thunderbird-52.5.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "bfe220ed1e1d8d156f0c1cf7ea11b0778bc0b23f7335b90c65bf581c9e2cd22db9a7f5d48d7a6a95f1d21693714a216d2a24249f36aed7ce097f205d4d05d6f3";
+      sha512 = "27ade0c53cee3fe125420eb7fdeb5b013771d34af735bacd59af6681836d81acddda3b3b9cefe3f8a05b70703c040d6692732c427db13e5dd971848c078ae7ab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/da/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/da/thunderbird-52.5.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "dcff4359821cb6b24ba129671a1716394afd642a5c4b887a1905baf82cf5d2a94512a547780cd42b1478f443f59db5a3363a52d719824af050dd69af54f97a02";
+      sha512 = "11de17a749643d35bcee49ebb1aa62caeb6806fd0025125363f228593979e873fbf8a927bc451c2e4a5332f431937c00601ff380d74e48bed60cfea5399b891b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/de/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/de/thunderbird-52.5.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "f5071c052814eab801f3d2c98751c05486b211f23b511b27a1ad5810634b763ada3bd890288e4934c16a28742ef023ef089de9d84a188f6e19d07f471b289583";
+      sha512 = "3d2408f523d55471f0bcdcb3a05e66381d390f56987b448a40118b1f0e3fb66cba8ed64cb3178694873f5ee0c7f5a74303ffa288eddf7192a4f519d537ecb65d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/dsb/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/dsb/thunderbird-52.5.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "522d365f32b28620a7936cf5a8fb230db6fee8c1ae055a27e6649cff8559811684168eacf019ec16d6268e405607a576d46e1d5ba4759c1e3fd10736d7560370";
+      sha512 = "d1f560111bd8d8eac360ed39b0ac741ca10c480ec528cad48e9bf6544d17e12fe2f41d4abe4caa3549b448fd1fb55416ed84fa864dd60fe0cabd91766e754992";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/el/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/el/thunderbird-52.5.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "ecf3dcadb1a82310494063cc317ee248b91c30594ba89a9c58a71349a423cf9e66c5bd06be4d1488ee6cd5027187bae1364144037b9ac3cd4bc8af7cd4396810";
+      sha512 = "22c3270759d095c4672694c0885d3960d87cb9f53eedcf7c030f8a38f204d4809914b3fe1cd144f32555508eded73999907c64df2d9ae9494c69ce879180278f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/en-GB/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/en-GB/thunderbird-52.5.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "8ddde6cd0270cffc26cdb4c4513213405b71ea4315d69a3b1bef602bbd58eca30bc09d0ddd41996cd77881e2d678dd13a93d07fa833210780dba146a931db383";
+      sha512 = "3e778e8f60101d2371ce7eb369c3f80c26fdc8164f5fcc78b8f65f2986288388e06d1413387b493ae479bd95b3af7fdd76f88365aa5803c4e9e3bb23e4f3aa59";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/en-US/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/en-US/thunderbird-52.5.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "edf130b3b061f15137e6eb83c9674642f0f475de56b293d4acde60f1e7ebcf0d262085fa2a513787ac201ceec5552c029167cec5ad0556baa7b0dd3b52ae4c3f";
+      sha512 = "d4eb0d90d621b28cc706bca0f6884361b7fd53cb02dd9ecccfc3f6027634353cc8f4c911824ebe6bf1d7bbfb06318258daad32fd47687f2f3b930c90da4b8830";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/es-AR/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/es-AR/thunderbird-52.5.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "931644cbf5e7b4f032f607a52a78f553a7a2ee8fc77fb7d0e73e6d276a6a1ba4a724cc91921c5ef5ac5ad21a3536ffbff264b80eb8d8a658133a24ca0b869456";
+      sha512 = "0088b0380aa533e4c2818e0b384f5edafeaa3c84256e81eefd0dff95f27adc32c8a22b3368576d13aa1276674f519333b5c3f4a825fcc38da1abd0751c48f996";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/es-ES/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/es-ES/thunderbird-52.5.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "c2673d9f6b347493e3fc807cec86f55300a6e894c9c1edd7f7bec63cb073fdda2e9cf7794269f02f744280788bbcb8e42ee6249c317aabc57f91cbaa3635492f";
+      sha512 = "251cf4cba82dbc10bc38039348894843b8f5c76875be72ce5ea1cb26cf26939055350e61a86e8ed9f63964bb95e99aac5442389c87588829e45e9ef41709ac7b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/et/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/et/thunderbird-52.5.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "dd634f76848fb990b4fb1bd28e2cceafca651280ece9ead3aad6b9746d0eaeef76b5ad925163a68367d84f66949e799e2649cf358ad0949ee4f2538c71b8914b";
+      sha512 = "609bfd8fd7f8dc17b52173de9916133e0cd52e41e66a488ee2bd1aea5078cb9e08084c10d0b20be36204bfc3f785574500e2bbf9a81f307394b169068ef3ff07";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/eu/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/eu/thunderbird-52.5.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "1c9f04cc1b32ffb21bfacb186f327aa945f36f12ae316a9cff8b2a4f8584ff8847ac5be1c8bd898ea1a71fbf3294a2f54b270eb6f0b63abb3da3178c6a125600";
+      sha512 = "ebbc42c9d491f0f0e9ac5528d58c5d8604a913d77fb3d4548cb0127e356817c729c1ce87fd7874ae6f688268ab64b8b898611780b5c6b11707b455f529ab5f65";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/fi/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/fi/thunderbird-52.5.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "03880d8334ede087a419443e9fb56bcf6727c652f435a366b4b49fb6116a62225686297ba82f298378e03267dc1aa50e90d75b81ea277a7afeb93331c45c3459";
+      sha512 = "807b4fe85c2b751e815dd4ac19b0e80199f391f7a8fe7e7f5c1f7f75e896620ddc7b758aae076bd44f9cd7774b2020640f858e139db57b508919d78caa77d913";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/fr/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/fr/thunderbird-52.5.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "6f9909df3329a32d6d0c2203b484fdaa8b54a17849283bffcb04298601a284a6fe30eac20ec6b3a97ad2e8e3d4e0360c6145e87baa2af11049ae0d94fe9dcd44";
+      sha512 = "d2d6e92815ed9176a2743578c32ac82150d4097eee6bf31356a9bc1cc1ba649c86008d301654e291bf0bf5ae2d81c13d941c4203aaa9dd3c4110d36a34f28140";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/fy-NL/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/fy-NL/thunderbird-52.5.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "b20f130ad4a9b0f8448707945773cc76198e04854a0114a06379fd33c3d5abd9abb1f14e4f145df9c1c46e5d1e09522af640ded99f4f20543fd444e365d81fb9";
+      sha512 = "bb5e34f15d63abecc4b68a74cf818def59caa2de47c9ab71458ca79839fd29f3fc2476b5e38a95d5d5252acb03595f0e065bcba5eaba6ff2eba29be66607f417";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ga-IE/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ga-IE/thunderbird-52.5.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "3fd6839351470d65f14165e3633c80950270ede2c4c9e658c001424126ffbf29c7bde86a720ca33e50cbe9a5306f0339c5cd491371e3ad03a6ee575c75889d63";
+      sha512 = "e6f84323e42ad5a0df546307ba0a87be57d1ead7b7a807ffed4cb977b5b4c19c91ce8058794da07fb1ce678e4f8e59838454deb9a19232a5cd7d60c6cbbce74c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/gd/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/gd/thunderbird-52.5.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "a7aae188c866586606f9adb82d5110bc2b89a6bd757191e798b9b2dc799916ae56cbc82932f4b8da76e88a3c1f5ffc828c58aee0cd8f83ede19bde2be2164b79";
+      sha512 = "1e28be9ff5c3ccefc320e020dbe574f9d5f8319eaa79e441ab7f1283557eca01501a2e0f4aca6af6e58157b4c1686422d70a258010657803ceb272b900ad3e3a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/gl/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/gl/thunderbird-52.5.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "3cdab0c553f1d09cdb4dfd1160371eec3d1f878329dcf2f81a177f17647f8dd9b73566a56427d2a593f70f6aecfec951e3dfc2a389c838a4069e5f4db68c10eb";
+      sha512 = "db2d76733fb97558d05b3ccb963ad82ab6886d1db32923bb73e4a62bbd80353fb7d7cbe4e1a82fc9095d582e467fe9a045d82be0aeb319fddcdc88c530733381";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/he/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/he/thunderbird-52.5.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "b71593a5c7cf8fe3960c701f5bce270366f5717b7ccd2a5f20dcdf402d1435b79db06662629deb4bd28e24b251fd2fa1a71a9e932f132e2df7a25ab5a8849de3";
+      sha512 = "1b4640496d3a1acc7b8a146c8642f25dbc5dcccb7a164fb49a0ddad41e5a43d571936111154838b149bcee091205f0212926618ba5f233aaee051d5def345889";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/hr/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/hr/thunderbird-52.5.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "d55deeebb9605565ae3c062c8617d7e351f2f514c13f00507d75a5da4ef8e8d845247147d2aa111d4e78c57ceb01404ed3ac2bb69883bddab7b59ce0ff5eff35";
+      sha512 = "5d4e361e7597b4dd0a896e38e31cf737dc1d51e87c09490a298147e4f0f395989567de2edff69f862fccc860dd0c18b24d2f91356736294c71429d22f47eab4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/hsb/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/hsb/thunderbird-52.5.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "c177a0e3c6074eef1abf086fa34e95b09f39a1529ce640927b7be6ee8b7ee8c740ba4e2afbadefe3fa83314cb7c3223499b1a5f08e3b4e381b60bee1ffbdac7c";
+      sha512 = "40b51097b472a36078a7de4ed35446baf9a3a5806a92f13d49cb0024ca154e511195e6b470959b6084ba689c4475224acb81010f417618686a4e99efc624754d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/hu/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/hu/thunderbird-52.5.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "1442a03fa4367d1f33337d0e88a193de8a6992ab8aa91e28e4a46b8f1860a3cc346d15c00d745b5074b8dec1beca5dba182b5fe2e87827e7ea83b82aba28b721";
+      sha512 = "01a11e4e59c527e43d13c5c12dd95665bea7aad105d9ee9988e94671e394b7a55c2e85154e1bfb200d9290373de32d7c33ad1364e6cf2c189d8c9d8b52fb813a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/hy-AM/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/hy-AM/thunderbird-52.5.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "c01325976516765a14a196ff04eb3296a2dfd81670cbf4d693682e78795b14b54f4d2801566f0ccd52c52f0b7100b6040f4e3540c4f3cb8c8b92038e059df45d";
+      sha512 = "bc3c78d1d3da660c66b64930d295f3e79467684d178c831ae4f2eceb9d9c7753e5f1b60453fca674346da5e6eaf3c835df7340f0cdeb0e9040be546aa69d0cfc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/id/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/id/thunderbird-52.5.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "db56686b1d8713da9584e03633bcb2b14706c0b44d24484d6625de638eddcbdad1b1afacecf7dba52db6d18b2bbaaa15ea5f4d492366c24c5e2e212050f16c12";
+      sha512 = "d377473cce2365f60aa5a65680daa2569716f3c331d20427f3d9002a72b42c0356e112f943db228a026f0d8cd5319168a9f718f3144b4c0a93ea3209c9003680";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/is/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/is/thunderbird-52.5.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "5423202ebccaddd114393e5a2038b2efbe93fd528dc3d7b659987ab5aa2a4ad82921b3b835249285135be67216eed03de6d58b72800d9c7bf87ec812a37f21ab";
+      sha512 = "bf41f55ef16c9ec322d732174a1076e5ab6a5db12f861891bb0ad1becf2b630b7504155505789e9ff7778b6c708642da55630aa20c0c18ccf11734572f62bab4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/it/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/it/thunderbird-52.5.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "b64e31155c73f13cd84bb4488e63df5c95473957c792f63f8cf25308d2b860b084aa6beb519a7666fde83d3db25e28ffb1064ddd0abca73ff631924cfa83d7f6";
+      sha512 = "eef60e791ffabfae57c4e9f4094a39c8cb5c61ad4a8296aa111c6ff4e14f05bd86d4f9e682859ba6ae4e8d0c10001403d21bf8fa54e7c5688ca9e0ff06b4d2fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ja/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ja/thunderbird-52.5.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "8852c526663f69b038ded6bb1382e02de700eab741cb04ccb8d3e329ee4534477a6ea402134a76fe82a020bad279c66e70bc06b0ed8d0fbaea9aaeaafa051b44";
+      sha512 = "43dfc61aebfd6b80651900b1bd066e3c731e06854bb375d2eba206733d4bffb42f9b0116fbea0853f2aa440a6873cbe9e188ed528cff25c8634d7afb59e9d3c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/kab/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/kab/thunderbird-52.5.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "b08dc52afb713142e11805c5b99f73a11bd3c16756dc5bbb6a0c3de13cc801f27438887d8733cf4b97d70d4741abcb0d8782b9e6f6ffc359f38318f1702fcb7f";
+      sha512 = "e75c653e6dcaa6a3116aba962afc6196c29e9194235b726e3ba0b4fe050129512f6d67358a2ce9e2b6879f6f52c6ada583af10b70cddde7ee0b8fa72edacc40d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ko/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ko/thunderbird-52.5.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "0de39397e4401ad939dbce0c02e35505c593398bc2078ad19d680a797a8cfa3f0950a810c8650634e3d40ea3b5265f9e193b77408f1588b51575d87446a336c9";
+      sha512 = "52e29e6b2996a59dc4ffeee6f7a35f7a491e1d44af370ab1537d0a45c8d9ab8b1bf972a24f1f2efbcb6fa1d8e9b7b15c7b0c00d5aaf24546fe7860c7a6f97afb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/lt/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/lt/thunderbird-52.5.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "13842d9f210dd192e2072c138d8d0778e85d028dde92b08e616dff6ba62f84b6aa36363a259dca69bb006850de2fb8c42fd93874a4befa970d817aad34d47b57";
+      sha512 = "d935c882dd6a9a3ad5a6c5609047a6e3c2c4146b198e8c28657ad166d7b6ad826e6db0e4c88944214521f0cda0907281b50a6088432b574d1ee13e5c504c939a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/nb-NO/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/nb-NO/thunderbird-52.5.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "ec9c96abe94ac17139e9fa83ac2d7ca8ddc6889e7286a4d31e61625db6daea3969fcbaa0796ae0bea41e3a433ed3e170a73c4be1a177bedcbfcf705e306e28e9";
+      sha512 = "bd607e451f2601483aa4d59cf6225318a3bf1b2066d0f6b76c64025de0b20a8c8d8211f95b953440505248905d5b4dac569cdc610fe4d9d658a6ecc124966b82";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/nl/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/nl/thunderbird-52.5.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "52e117078f1871bfc7b549a47617d277c763267f7033136c9715223d8f876184c0b5012b193a5f497e1fdba78b902a3c38651e0115829b0f5ca7f0cbb1c439d3";
+      sha512 = "4767403a33047512f301617dfdc779f92e001114a06f31244e5b9a648ed4a7a96c6fa16194a803682417d151f2f9d61da241065f15cdd2e5953eb5ef41220093";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/nn-NO/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/nn-NO/thunderbird-52.5.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "24258bbf5e3643544ba5db26fab9678f7e2a44b390ee993be4a304d148b5a57674158afd308d6ef93a86c8e525b37e1aee55ed07be6953301f164a2da00688d4";
+      sha512 = "f2fd66bc8a520f90fb65e5f737ea25e44f5e3270429cfcf878e4b128f1facfc3bd29282586aa6ba73478de04cb796322436d14580d86fb5861072b6722e2ef87";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/pa-IN/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/pa-IN/thunderbird-52.5.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "e9d8b4e6019d4cf1ce562e6cc9b9aeac0e93d8b9ac9283c7e8f260b4d611fe2bd0bf6d71c9f82c9d2cbfba5770659d21cfb03fc2deb36b80be0a424178a65936";
+      sha512 = "8e4c38febf02e61b874f931b0cf03221781ed9543f9b7a392ca9122f101622c20135f0fd94e5ee7696d0741a9910e1d1031fad3c825941d54da1f56a2533b61f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/pl/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/pl/thunderbird-52.5.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "81ced2424282fe6dc7ca6f5e043f6c42ae87cddef900b73fddfe6cd8c488a90e3099824b57d0971816a60c3f43ce66e1799195ae21369958b2e8085018017267";
+      sha512 = "3e6fda867feb132f37913a8b2bda2ff2736f4d804e274f01c306d387b3c48fe30aa04b6f85eb4a7fb444036bdd4b3fcd4f68cbb53244d85b5064aa36c3588cde";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/pt-BR/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/pt-BR/thunderbird-52.5.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "4120b94c13a9fcf1aa31a2abc3fdde27ef8c0354550ae8511b61641745cdd5eaec16e1ddd1d22193ca6680f070b71c188d94cdc75a40fa1596fa88ed59545b28";
+      sha512 = "662e0616d12fcb7dcfcb98a4e07228509ae7ad731c93d2c90a7bb7ebc3bd0f9636563a70977db14733c832220258eede361526b01132dd02a4e44b16acc6a5e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/pt-PT/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/pt-PT/thunderbird-52.5.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "a89dd739da5262713c99aa9aa28544e48710e80b83770810b240681ff0546c3b3faa37b48ae56c018a6d1d625f0411df557ced12eddfb3a1198eea474418eb68";
+      sha512 = "8037be03b26263f3a1e69c4971cb70db50f95356c97e3252f76f080f5a7961c1b2ac5aea09d2e142994c5fc91c91ab8db738e5a104795e8506a06c997977930a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/rm/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/rm/thunderbird-52.5.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "3665bad7a0d1f2d725d0a44ad55918228c2d9cef49112fb19d2c3d885d1ec62af89c15aa0ce96ddebdabf97c8a5e10fdd58d892c085e5b9d17bab6658e7bf444";
+      sha512 = "93a76b870c15b61a1135e405f76897a86674e1fad2dfa9b3a71cab83f99c9369b7363a395e813536492a25133548f227f5254795cd20de78f127c969fa3ff5aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ro/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ro/thunderbird-52.5.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "07afa28b22705e0e84e17026d04111cb9a5283838fcb94225e2c05da1fa0692770b17052c52d8cfcdb7bd3372fdbba9cd9ed9bc16f6f59f2e3ab6f4308543d91";
+      sha512 = "4a535aac1f6666d20c7aee65ee974bd545cd4aba56fd0ea2655d89a532b60bcbb174b8046792365041b431d3d3099e0c273c5ce83f1e1f3599a476028b482f37";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ru/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ru/thunderbird-52.5.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "189c40a8d950496d62f980180502ad342621caf3a2ddffb0fe4f813c9c2d4a25aa375d8ad70c8b7e8ff85f09607bc2ced3366524346a70eed731bd8d9409e5d2";
+      sha512 = "ec56cb45428ce24497ad398716f99f49d6a5787a042855dd5839e5185d43763ea87b89090bf15c571841aa0526f5b4b0fec8958bd673a39ccf33ad5f2937b33a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/si/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/si/thunderbird-52.5.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "0b6ee1e5ca86472a5cc67cdc242a6b62aeea50609661e369c8dd3dfac5a774f50eaf0a68973b1fe5d6d9bdf6a385c52a90b8711c80facbf9fb301981a7aae395";
+      sha512 = "e1b19b27571cc833de579d1460d27629042529480546cf3de11a39608b8d599ffd19451ae3df96390009e95b87521f17e5843bc77251c923823d3b0529167f17";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/sk/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/sk/thunderbird-52.5.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "9c1f164a2da43aeb51e8b64115618590ba0e9284f3eca8b16d3792b33e269a0acc253314ab7943cbaee94ffc2ae321247b4982798d9d48608e85a935afcb6faf";
+      sha512 = "d20d0649426fbcc812b536d368ec5785b32def01b91d67776d5776a7fb45d9c723e1c455d20eedc7825370b03e484634ea42fb55dab5b3c860167cbeb8596c7b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/sl/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/sl/thunderbird-52.5.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "5d4698be05af9f9181af63eb3ca6718feb1c74c81f0a6fbc82217791c911dc5f14ab433d32f6484ced2cd75d5db4b76aff3bbe420d619afcddfcbcaef25873e7";
+      sha512 = "c37ecb24cc9bfe2d31459590d0882fd9cf196e822a18105b61150db4049bd52c31bad2a05ebfb710bf1d1d879a22b3e6fdca08ec81663e1c1735a4a2d157b4b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/sq/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/sq/thunderbird-52.5.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "32d62e6dfe28c67cc7b0e2cd27c96fd7c7e1079790eb73a8731af44e8a62f8fd1ea2e7298dc772e3014fc8255f022f38bbd5478430629140d0dca9ba0daa401e";
+      sha512 = "0ed120ba3b39f884784269a6098242b8e1298bb4287749b901c2702d06c6824f762942bfe05a0dc1966c19e883239b09312139ee7eeb2cb22995d47aa2d124cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/sr/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/sr/thunderbird-52.5.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "6aca04c1b4378489239cef6b5032ef6dfd6d39d84308c335d03e97ea7c48acf021f6cffe35d652e117f71e6ae3f31f54e5ca73a44b4dc51dedcb3f5faf7d016f";
+      sha512 = "5e83710d06507a40705ae5177e4749c31aed4e932efc0c51f8da6a4b30d598328601f8a53b9fc0dc35cadcc130bb637771454d9cf55e8dec2b934287213e17f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/sv-SE/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/sv-SE/thunderbird-52.5.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "099e22013b8d6791857c378c0f94373ca42d35bbc442cf273c9de2360ab8e64d712eccaedd5a13915ee19a195b6c9f04748ba738e7bbf9b8153edc4c66070d31";
+      sha512 = "4cbb20b1d818f0238cb0d5235ea82a1984b8dd632467ca91e3f3f4e8ba58de904603d1135c8a7ea359188f1b01a6ffe8d654a2d0a73b4af1f3862011d697f755";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/ta-LK/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ta-LK/thunderbird-52.5.0.tar.bz2";
       locale = "ta-LK";
       arch = "linux-x86_64";
-      sha512 = "d3c95f37ffbbc5ef78b7c050a4e091bd9f36fa9529ed7c38e25f5495694c1b792d0bfcf53d15b74b52239acb21bd0d235ceb07c7f68f99e1b31e59e6f6282aaf";
+      sha512 = "3c2397e9b9e8abbbef10af15cd35ba086336daa5c317ba60d4489786b3ae4fee89457f2b34c0b42ea550000e8536ca3fee94032848b11dbb2c4cb6fe489efe6c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/tr/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/tr/thunderbird-52.5.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "2f79b9d45d747424a65271033a75a86ff503694d88a30238452fbf817ba153c4638395d3e59f5f6cc662ab3361d2304d5a4c925957d9d6e6d7bddf34947acdf7";
+      sha512 = "9360797bca24f5477120d93665f9b4aa1614463558b6646e2813b31fac5b5bf84d5e88a752696c28fb51613c288482e3d88197ded2310b66515582b11f81aeb0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/uk/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/uk/thunderbird-52.5.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "e0d891b4cc082e32d3f6af318f9224e996a8ed3c7e1385bb86a5e2f963239999712c444fed00d779320f6b06efb38f3eb97023e353f91eeb7831b44a870c6394";
+      sha512 = "ee521d20fd5e7cc3f803f74ef5a9ecc4c1df8b149668489b28cc212ad2d5c765bda838904ad726b92b5e0e2eb35c2ba6fd4f48ac7c700e41e896e0e976fe2028";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/vi/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/vi/thunderbird-52.5.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "5a9e13e126c7bc8ef435b8edde1896b9773ce1dfc39fe3fe1bb31e54fe4f592acdb3db360fe0890eb35b1896aeed0954bbd051fde6116b07cb513b1390ee56e7";
+      sha512 = "3d7b7cd1f83e80290f460829b49b6893a73871456cd10ab22da482381ece0ac14fac3e5c0e2fdf1e61d463b7c211c33ec8d98120fc0bc17d2052bbbcd4e16af8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/zh-CN/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/zh-CN/thunderbird-52.5.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "b0374f022c2a259076d52bc0dc142098975f9f1d3a886192332fd1c1b2a5c9dabc0d3fc1a7fc0f28f6f17979931b9c78a9682be1226ff751446c5427a5219a51";
+      sha512 = "c0f9902bacbb659f5f012f30b6190d4e3e53baa7e4473cf231da0b7c509beb98e49f0e4fd1ca3ed9917c54279609ce5fba1c51b80b12aeafedb82a83218856d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-x86_64/zh-TW/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/zh-TW/thunderbird-52.5.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "7e289afc737339be5a3db5869125d891da65fb75a62b7670c3880943ae11bda33122f81cab46bfa95223c45662684b8fb66ec11cfc5f375e024f4d57be098684";
+      sha512 = "64dbbbe05b3ade46901686fa4733cc7c25570d1f02b378a2b2855b75905e687db9f97db852bb53e2baaa1010a0ff365bbd90060eb7cec7db745faf014c5e5564";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ar/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ar/thunderbird-52.5.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "872ceb5933a562d352cb3bfc6e9cc95a7485625e5256380cae367d38a560f75bd7964fed1becfa5359db3befbe4aa249f114df307cf14e2db75dd047d87e5c53";
+      sha512 = "1e6449d23bb937d07fd28049ef4e36b64c1f36edf3f4def640dfa6412d354ec6acd5b1642e0b266f18334f3ab7806a9cbb016946c0a36ec4222cfcae39339bcf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ast/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ast/thunderbird-52.5.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "9955dde6ae54c096dbc5e5a28729963a72997fda97505657ccec6e0b5f95f35508815fe663f266932c79ef91463ef6c5da79ace4c19149b17dde9655dbe8017f";
+      sha512 = "38f0fddb28d8a894798e9811599e706e60ff80131b22568e3dc70ff7f43388acd6de5ee4485587c59fdba8f790b393f4f16cef6bcdd86b928f3fa1bfff7297e8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/be/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/be/thunderbird-52.5.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "94106fb12bf932f3a8217f3252b4f76394f13cb19c602d1b4a67e4477c3a0c781c3481ac973e40af7b306fdb32c88d4c70f8302b14e693c7270e2afab0dc2539";
+      sha512 = "0966c3fdbf73a51d2c7776918abba4b77392dfe2308aee36970cffcbbc3e1de537625c0b5881a85eea74817b33055278d976af719773579885b3294746a3ae50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/bg/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/bg/thunderbird-52.5.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "194a420d07f952f7d088cb15fd14dce30e352dac13e543321e94fc60b7780678ea1ba51d450aac2d7566a8f23a583cba70e3aed373602ac896e0be13d234f8f2";
+      sha512 = "a0a792063a3eaad2d15f4b726c9ed170f59f99b1ba9c966fdcd6471865dcf2f25284ab5e4e28641a66fa8ddcb019f8b8f521d69f5ed5e8d1ebc2729abd9be8b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/bn-BD/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/bn-BD/thunderbird-52.5.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "08a439a7fe40121f318131b035e7a5a1b44a56a6f3434b2854136103b0e11fd720540352ed04bde23f33c7ef75cb57eabbe86425c8f2e440f92c9260ddf1a902";
+      sha512 = "ea583cbba8a0080a5529fb91988a0ee1c7aada1447b616e1ae43b6eff86dde87768cb4fe90fdede8454ad5240d266bc5e6ba9f1e5e05f2ad82cd3ef68ba374d3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/br/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/br/thunderbird-52.5.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "68984b8fb564e24f3e331504a0c8a2e88cc1021319b2a47beeffd145eb42a19bd555aca495ac60612efb191830c273c473e0c3cd5844f109e78a4908834926b1";
+      sha512 = "18060c8473e82554ff793ba495ba6760c7d7d8c2ccf8fdafbb41589c57474baa0a88808d154a29f6359c657bec40d9d164e53066d44bead78d4661b229522783";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ca/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ca/thunderbird-52.5.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "2202c43a63bb283d9eef16c27e0d6125d43284b9c1acdb8cbbdc71f3a9d6f6d527c4a03363dced911321f28399a86ef25defd294befddb8fae41912e17c2fdef";
+      sha512 = "f63dc5e923d8e60470fa4e4bc5adb8ef629a82dcca84a87a6e742e9d34a8709cd0946a85bf5822b19b5ff5c1c34b6e290439f3e3418e4ab86844a0ff54c2632a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/cs/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/cs/thunderbird-52.5.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "d01c6ba52794d3850656c1538e46b64eb69a7c1e3a17347ab5cfda9fb1e91976a4bfc7096f7d12bdf2f15625387aec7066b0a25879d979687c955058b92ce6c7";
+      sha512 = "72e1a77e10105a757c51542bb236d10c417f96f58c3875b63112c71848ce023c8754971bcd34dc5d2a48719070939d3733df9dbe4d2218e7bae7e89049d067cd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/cy/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/cy/thunderbird-52.5.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "3d056c91e1599e91249774cb21d8fbc887b7bab38546aca1815ca9c49fbf4d641bab2427f03ea993a72dc29793feb1cb0cb26217a4f6827e9e0d9d3cb5e3ca0c";
+      sha512 = "4901eb53235ac29cdf685dbee78db301abc1f088ea9df585e388814c8f48d81aa0daf816f927b0c7d6df7985d8dd1e64c0c1cc26026f3ad9625251a72b666692";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/da/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/da/thunderbird-52.5.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "c940d26284c8ab0a45bc6a55b67b467df7ac160c8774f0e2e2deb9082ea9500142a1d3c8851031a7e7a1763fdf5348c14de57d7168c3f1bb23fed3cf31a1b09e";
+      sha512 = "0f061a7ad1e3b113d7b954487d661b4ca57a0ae861770c44081257a069e324388ba506b27ef0123a240cd949edb4ae60f500712c0addeed146cb922c76bbdc32";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/de/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/de/thunderbird-52.5.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "b1b63590885f30797ae9825f2286deca69a82a73e7c407be87fa92280b904c0605e7047a402bf6ce1e13936933a27efaa2b35d534b23f745a2ab4a9538d31b47";
+      sha512 = "12ecdd09f77035ece4161c97cf4ae8bffab6a7eb46c7b9a2f7323dbcbdcf4f3d1bfcf5fab4d40b2887fbf64b541c0d5bac54f1b8f73ce7e31bfa201e955077c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/dsb/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/dsb/thunderbird-52.5.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "fc81fbfcc6533d34fde2e08351dea6d7e2a561a3620a6d0d225dc1081f59d9927ceb0abfca7c2d21b1cc727c0319646a2f386c022524178e90aa6bba344371c3";
+      sha512 = "54fe7ff647565d5b82843d879ce3f791b2962bb034ec2ec2d5ea85cea3019ddae49f9f45384751d1a2d0f879aff4203a61687a4432ebdb948fd30569b6ddd7be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/el/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/el/thunderbird-52.5.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "baf8d0a52fbb12afdccd003209614ce8d5b4062336744ee783a6c3e7eb5a542c4da233fb680f320226f3681b440ab1d0717616a3664051d231b6638729903b00";
+      sha512 = "d667a2d4f3782c30b308cfa6dd13ad321f6b7108d95f05c68dabe085228de28439f8e851920205404e48849829e65a07601ddcc553f3c73b08e233175805f046";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/en-GB/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/en-GB/thunderbird-52.5.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "0f5fac2fd3da05cbdece404fe3d170ef49574b5abff07a17120d189338140fadbc0971c7be05656544819df2b1987fd86c0f9fdfcd312e540035e70877212342";
+      sha512 = "ed7d40db832e9abf89d0d1e497f1b276dec7836e494b616eee8db1557cddd33f6f700bc9f17db0324f7a3b191ea425a7701b7e2b10630c21ab07f3c709039312";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/en-US/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/en-US/thunderbird-52.5.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "1f3a640d140fa305e115158d98aadf95d180b396aa3935de4505f0f94f510d206ae6e45adf36572cb160175383d0aaad11c3244003e4a99dae613e1a749430cf";
+      sha512 = "9ffe74492c2fe29523a34b02ab869f9660aa1c33b16e45a026c4404e714b9cb6a5d2b24e73c7ac2f52e22f21e6e88e9a7686edbeb2c0876594054b17222d9ad5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/es-AR/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/es-AR/thunderbird-52.5.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "42525a75e154fdf263f276330a998f127de697519a79b447d4860403c40ca2a6caec0a225a978461ae776e56218313a3fa31441817cbb13db34cd47afb9a5eb8";
+      sha512 = "9f154f4fcb465925d445cbaecad4495d12d6381f0afd502973c4869890dfcd77366fa90bba835016729343947e064772163529528bfa76d52fc87bba5e9af1d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/es-ES/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/es-ES/thunderbird-52.5.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "86b47481b760206b49f87d15a917754d875203d83613c0c8b83e181f95986e6252ff26cd6dd6f7c6545f9d4da4801f6f236fa82dcce0d0172f19228b4eb5fe33";
+      sha512 = "4dc72ba78d8de913ab2b3a76920e0f4e3bb75cd880c3a8a55af72cc38334906e5786b24feb0db7d1e12db845f995c28e3342b5bb1bd4600c70de6b9fba012194";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/et/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/et/thunderbird-52.5.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "4bbfa1fde3a6270b49989747b4b27c284abb89819c46119cc3f2f90f0cad1648e49a2e1e01a35ef193eed4cf504a3e027138ea30a225c3d75347aa062d56afeb";
+      sha512 = "64279f558880cd6f6653e9387b479f08dcff440a23dc9a7bda664f09ca641cea05a268bea7cb7ee6495910fc67f1294f78bb163d09d70df06f335486d46d7ee9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/eu/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/eu/thunderbird-52.5.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "292fd0f2db956e5bc86a84d5edf51e3e36141610c99f75b1dd8af0f086fa8bc4a4e5a4e1c3d085587b6bf2d6e3435bc70ee66d379809886a391d67e2c243d762";
+      sha512 = "90185fb2a72b648af46b83470b2c57ab8784baad2c75c32920a5e6e1d5e03b5fd3a5ffad04cd52ea73a942c4ccc9b02d71ef7ca4887d3d089ba8f13745087b79";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/fi/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/fi/thunderbird-52.5.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "b8df95d4ca36efdc4370821068590b1d7e3fb9f348afeb18a0a02c977027312457aaa59c38ee02908e944f166d485576522ea0cb087b28fa857963107e43ced7";
+      sha512 = "3d8fbda9afd0bb82db6baba04d06682c5083a8a05cb941552c5ae2abfa0fd7e9ea9e020423877f3141922485a69c1af5d48235dda29fb4b583c1f4435a747f59";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/fr/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/fr/thunderbird-52.5.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "7880654b4133e50ee248b6e287d52ba867361b900fbbdd149c6f06c9d5df1d0b57ce6d9d9bed3e1ab68e90b0ddf874d0b2427553b24ea39f267f576c63357bca";
+      sha512 = "669723deede608bb8239ee5a04dcccfccf3680e32da494d28fe5380714b012a322caca38eb3b6ccb3c136a3a9742f917a5614f1183ee08b80d760fa5cb19493a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/fy-NL/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/fy-NL/thunderbird-52.5.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "4784b06aeb705141d84103bf46635e6ba6a7f7795b40e654f63c783a63ee19d54843c211eac90c4246c5131ecc8808940e560f2fd2a2543522cef13bf3828938";
+      sha512 = "c35371dc26545e5f1b30a1c866538380e8d6cd21456e1415260cfdcde3c37f6f301f1a5ebfcba4d6a5612ed3809f7a27e5a5470fd5f5b7146b923ab15a5046a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ga-IE/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ga-IE/thunderbird-52.5.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "91b4145d82a4748ef2cfe6d4d46c9e92c3a54a55f72ab1c28135363471d68ee028064ec0c0bb334fb731c6577305177a06d85b2a9d820d9e2a44fb01ac961beb";
+      sha512 = "1f5eaa4928e7b56ad27937b6a49f90fc5739149dfa8119563eb6153cd1d850243ce3a15e42d6e5a7a7c306401c97424b5ebbb6bbc7d20102aab09723c91925a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/gd/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/gd/thunderbird-52.5.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "4e979ce305a014de612c0f3797b9f8c8d89445f05972a24d8c13cd01160aa2c15007b0e505f9a0cb354f8cf65e286ba52eae8a6bbdcf4c7cf4e89809e0ce530a";
+      sha512 = "61c1f4d9769981149a5961c096d9826e737ed356582b90d09efc437c38f93d9897ee84489f33e3fdc20787dd9d437ed58a5592bc5f586748d3e5897ddda38b20";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/gl/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/gl/thunderbird-52.5.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "b3081eee4473c097b37b9070cdcdd8eb48e1cf69ee63fd76f1eee0d5ed84009b69d0b31fb38c36f7d5137b78d0ab32087a8e668f1ad01e6ef96984ecd973af11";
+      sha512 = "cd23d74ddd303be4d86e4c63d5d2186ce3d0237caa62b0a48987b63c63322898f591e4b2c7a5fa5d219c49cb28070fde5cd933050dc0c0e6b9aefdd5f03e5b1d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/he/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/he/thunderbird-52.5.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "2781cc8fcac549ea394629ba1d7c43c683ea25b4d3c5807f7a4da50541e47ba18ed4d4080e7f3c785be8e71e0a8e2ae0cb9a24e348f830b71b7398efd06863e5";
+      sha512 = "58d98ff08576c3cd3d5a8637b8ba8dbab1b7e61942f4dd772ca48e3fb447a2dbcefe2cb9ed8cd3e86ffd0d9f8ba33366dbe01d744a825bf513861ea870d69ecc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/hr/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/hr/thunderbird-52.5.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "d42587bb96454e3ee24b964dee1de0f51283b2c3316dd25e798a8809d2289306bf6eba6078f664f87720e7038b14f009640fdb4d3acf211195dc881e6e207c6c";
+      sha512 = "770a4a095993a9a84266b15e461645c4446ba6370092f1d0984d2ebcf836d24538276f63f9513dcaa537a4f016bb699169dafb14a68450f1e13050679800c5b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/hsb/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/hsb/thunderbird-52.5.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "49e3ee2559c124db79e2dbb2fe74291a377ccf1fbd75b450c8d4913000a055cea855fad03369e7420391faf114e160e35b02d432de847e673e352b731986bb84";
+      sha512 = "35f0a061f152d871636723b4690d3a3ff7172abb5adf0644b02e44fd23583e9a9d8ea68890a5313d74d190a6d293798b5ae8969a38b1166cd942a3d17b0246f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/hu/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/hu/thunderbird-52.5.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "fad46a1ea3e8a1df49e4ba836c68b1744577fdfec319d9dc0b2bd8756d4dc859cb5af7484791b83f2260bd40d1ae64f19539f8f4b3977252a1f559b7df9fef35";
+      sha512 = "a4e9dd6ad2295cde7d7e5bfa8efee3c68123ae11d7535f0c076e29b18b952320ef39e4c92e8ad4aa66f63d8490b5737ee849e425378db04df8c794bb64f5393e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/hy-AM/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/hy-AM/thunderbird-52.5.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "6a34e03e5e272c847f674bd8c48cee66fb659cbf88251debe505c54011b029cea7b7e8a9722c61b3e603d66aaa4313a5971fdbf2035fd06d305cf229cd8b2afa";
+      sha512 = "8006eedb925424458cc9e084b367d4b8f16f78a6245159c61f13b75455404adf13eba353b4141cc555d82d4d6060deae9f97633884ba6d3b18d88af8bf93c4c7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/id/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/id/thunderbird-52.5.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "1cce3d3653b474219f00f4555990406b661a14c4198f3d246624def4e5a3ad3ea393a74f6c80e0f17b5799784e212778ccb8b56bda31c5e48a55193bef09c417";
+      sha512 = "df166f9e33adadd2e38290d1ea92a035c9cd0d910c1b246906ed38181c8db12bba29e69b4a909594a79b8b3eccc23131f34236afb40d6746793cdbda3a195bcd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/is/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/is/thunderbird-52.5.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "f3604e918502d16ba92e65e9def425efbb829a261d2c433ce83ec89d6ebfebbfcddd1b01508f953ec3c26166c6d01112486cdab6d1a0fe1e6a582f0566900b89";
+      sha512 = "1a05df69389d95d9920e133e085a0d3a05eb917b1b28c24fe9d8cdce316e19319fe08aa7a3fec304153fa0f59a0b8a630f9c44fa1d9c0310de03fc102172dbc4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/it/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/it/thunderbird-52.5.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "458bc19bd6b08f6834e310f7ec4591ad4e84067ae2373864ca9019c20551abbcbc067467fffada229000dda01369da3c28967df522182d8eda1a147d136b6315";
+      sha512 = "c446fa3e15e9eb72aff880f928f5c8a0b2b0c96632c243db4f5c377bd2dab56ccfb569a8500e9778ac5a4459ca634dc6d2ec1ec0f05aaa2980d3f45109fa2ffa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ja/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ja/thunderbird-52.5.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "05faf43b8b0f616bf552988a577891e816fe36b208b7d6292c9896a6946386815e117278feef33063b4f2eb7b5ec89aebc59e1d4432021969bf3b95e750defa3";
+      sha512 = "c7699f90c49fc4bca1580c749ccc446a95cb9f1a5a48cfee3b2a566ba13e073a4e405ba7b17ebff704f719639e323332f533db19f7c82007300322330f2b3983";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/kab/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/kab/thunderbird-52.5.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "594669d5518b0be87095527b3013799812c9f45254434523903ad19edb2ebd4bc32409df6f646b1d1e953098e126673427400238a056e0a8c44b672009a12a2c";
+      sha512 = "5c098954ce0e642c76c3597d419bcd5f286d62af96ccf2726bd00cefe12036708217cc6829c39cd669a21ed0cdfd8a6d511b8a55e8dafefa8c3940040e99d9a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ko/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ko/thunderbird-52.5.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "db3e6c9efbeeed833384256814a713a5bf3d2a220a74c88fd28f91ec0dd6c7600d77e18ce66c9dc9f1929f5da7452c5904f012fa8f5e4fa04084892e17b2647f";
+      sha512 = "0a435742a13454634ef563b704d1618ce492a997814466ece1066e244160494e2092588b5cbbe5d1a7076b89c895b5f1a3288a377b547d454eb411960e3faeb4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/lt/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/lt/thunderbird-52.5.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "2b8e8b74bbba2a72dc88a8dba457189cad1c902c0bf2cbc54bf989c6444c8b164238f1d9e21c2c8e470df5198d8586cd613b40292b737c04f4c2d834d298dc13";
+      sha512 = "0ffbe8a40179cdce48423c70ce871ebbce066932cf9ab21560ba3107d2794198a7c8f5d5d3fefa58627beac4faa2ed398a09c429a47b261153f3045fe5779883";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/nb-NO/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/nb-NO/thunderbird-52.5.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "bf99756bb7bc5fa699cae5ef3da5a3614e57483b2892e2f6f769699ef3478e22847ddeaf63fc0c521cd1fbcccbdf9bc5054430a5cdbb50e26e371818cae404fb";
+      sha512 = "d44ece21a5ce26df33d7ea04f56cf2a21dc67bb053212a71a2a30dbabb7894bc9cd5b8a07f86906c882fda29603d2c8ff16d675c8e8bef8ec362be8c824624a9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/nl/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/nl/thunderbird-52.5.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "80170d51276bb77de4af8d45d5869069c7d9c6db7ad6d5786fd4c2c5cfb0a20ceb1cdce7b5dbf99a79dca329efa5d9a53d4ed738cbe7f77bdcb65a8b6e2e7511";
+      sha512 = "8c2489dd4d860fc657893986f268746512cef54943b19f7c129013e5a6a8db8f4a8fb0ef22b1cfdc41306bbd63d1c81131989af7161d310cabe2427e21ab4702";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/nn-NO/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/nn-NO/thunderbird-52.5.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "f223dd33108a750563a498e92b53cd3e68e3d50fdb1a08e295a9c3e893c20908ea56c9c5312874469b2f96d1046f754df55bc38d1595d5b811b7ed659e267d98";
+      sha512 = "57270f4645bc1d82f3602a49aad11bb6261a2be39200b3284ee65082df363b5870b1cacbaeb3802a83f6ef1554a4d6a2c6e6b2720aa2b9d29b7a86208d676f6a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/pa-IN/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/pa-IN/thunderbird-52.5.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "a418fea2521ff6971d68d975823bd0917580450a7ff38975455b891c8e3cbcfdf51c40502fa072ebc1f43ce93a3b07ce93db369edfbd511beee5dfc5041a0a84";
+      sha512 = "7a7464cbf08e418c56c979abba5ef7120f1202073ab630ef4ce070aa1b55520597dda0b0f31e7afc50e14c8c4fe0f33759a2278035d5db5f21edacb6d521672c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/pl/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/pl/thunderbird-52.5.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "05adc7298c91853b373756944d360589caeef6a999f6c5ea9babe3b12ff9409909040b69b641b69b78bd17bddda59f9828e294f5cd5f7d7061cc3f51eb3c48b3";
+      sha512 = "ae0b8da805a3b055bbb64a3c0f1d3562f44fae08751026b8300c130f4a2629a1a17857d2be2468c9e2ddb2a082155d35a26b7b1f0c99369b2031a90b34aa2443";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/pt-BR/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/pt-BR/thunderbird-52.5.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "4a2503e3a1daf5b9cb26acf25720c4d0fdc7a170bd454a185e4cf2cd9c9429dcbdee4c13e59e11a2a275d88513b1ae31dffae8bdf70c3196249e432360fbe705";
+      sha512 = "f61d66c71c2144aba0781f82370318fcff0637d4bb28cda3703f099718691f13bbbc51eaa4252ef1fbd1dbe821032597e41adb80b1abec89a2bc50df043f5099";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/pt-PT/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/pt-PT/thunderbird-52.5.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "cb02054a64a74c2e1f936594f001dd721e3016cc68cf705c0413a732153bbe45aaa14736d38b22358bda5f3d059f7306087c27faf040d91bd7f92066403e65c1";
+      sha512 = "ad0d63ab9389e3c4cf6985835dc4277d3ac5cf79e09457331f87629c8f9a58e95ce7b68c2eec8973ab445cc8f8c50c0b01b78ebd0ada042f4fa6a2d2bc838241";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/rm/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/rm/thunderbird-52.5.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "8e745e5d1e5a4d3f432bf8c5f90906a22c8d2fe4c6d77ec032cb7eccae1f2f9e7cf0620dd3ef378414d6f34cc25346ff44b7fbee05016f34c49a0c8c5959184c";
+      sha512 = "5e5f96598101695ad0d16a7f3aea38c42d875b3d7b7e2eb529786f16cc008ca8b20bfcb24d2b975cdd2e114d00c1d17f8901f19fa84263f64506d9d75568e6be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ro/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ro/thunderbird-52.5.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "20d9b9666704c87f73f4c8cbe8d09cf79349e811f4c4da93f2754886cc89fabf7c2388430f9f072a3918b38984742adab48ada320dd75761a7443f3be1198a8e";
+      sha512 = "82a0324bc4724460d5aafa194a78d611c1d11cc347446d5c2203e9fb40a45f6c7ffb0e17aa87b603af8b3ae5847fa91cac529ae878a6981c9c754ea91b8b6b52";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ru/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ru/thunderbird-52.5.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "ff7c64ed9a4403e24b7f0f9fb06bc4b96153fbe7d30b94ea7e145d33dc24bb1b2807db8d6e3398dc84e13f68d9c5c4fbaacc3027cd46ee58fecaa8b7b17b27a7";
+      sha512 = "508d949263abd425ff805f417cfa60736d391e1dc99b53dca2243c4c93487ad2889ac6a9bd8beed59b4e09bc82ba31b9c5cbc9fe084ee3b5fde74baaa2720a7e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/si/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/si/thunderbird-52.5.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "b2358e6df5f5cda477c530dddd9d27e35a8919aa346b66521336fb0cddd2821bb7dd867f4ad005c135ce040a1eb64ad9f1feef81a268a299ca2170312f7c89ef";
+      sha512 = "e9869c86acbba32bab6b536f2542b498e9de0a306558b3115ffaf143f83c5a5010ead37573ed7ce9565c42b6306d98b4f92da866ba62f5c4042dd537f66e377e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/sk/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/sk/thunderbird-52.5.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "fc3eae35914d2a2ec6d44bf6348f71872f7ccb09d25ed974843b8010526f219437e6530c4d86825d027f1593da0943e0b9a5557bf41d4095e4e9d37108a94c3a";
+      sha512 = "1297d9a8ed5d062790766ee5cb66a1c3b67526326440b5d3f27b712440c0e3525ab2231774e02436bfad4b8ccf1006e5a16d2fce4be26bf2c757427228f7fed7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/sl/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/sl/thunderbird-52.5.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "532b87d22bd05194470801cccf242ffbae57685e69a836c8179e2fc562bdf2aba196f214b7a66006ef90d7fb1781d66e1ea62c2cf95820402deb9a73122ad143";
+      sha512 = "734d57ba493e160547953debc20b1d5565c31b0e6e5b486344f5da65aa4cbc77fa7790f49f4ad6322a633232fbcca2f21bdeae7f4abb2aa8cf13e5741519d706";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/sq/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/sq/thunderbird-52.5.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "b621973b1f76f2d789afa854917e20b7b48e3381344da29e07b8c5bfd469162c47d51e9552ab2428895c45dab9662d8fdc2704e65c96faa4afbddc4649a77dec";
+      sha512 = "e7a21ce516318f46d467f987dd244174ed2533bdeeeba41c2fff3a838ebb78047febabe6f3e86ab57bcc12f0b1418fb7ac195ca044a7c84eda404e152690b554";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/sr/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/sr/thunderbird-52.5.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "d26812c232168c30c6a76dad5f3f7e20fe88cd75fc63f863bca255fa353928b8d3988c56abbb649266e52b8d31d70182c59ded496607aae17d7d2d0409ecc53a";
+      sha512 = "132fbcd2a7890ac413dbc3b1651a02227b741a8a31e2406780f36415fd47ed75503968a93414ec31384f28ecf1e14753f0e1bb2988468d973dfac9ab45787519";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/sv-SE/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/sv-SE/thunderbird-52.5.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "294e141cabec4edab0695e7c8e29149543e4cf4d451cfe9ba038a6997a822e02f223045ac3a8ac25b99a1e847740fac4d9d5c0b5ce0c5d69d331d823bf8e4899";
+      sha512 = "6e07841987bba5fcd69f790fc8a292ad7a3d71bcd802d16081145f243a71d49c8c57c5b6ad60ebfe1a550d62b1c9713843a83066893a397889f925e8b88904ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/ta-LK/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ta-LK/thunderbird-52.5.0.tar.bz2";
       locale = "ta-LK";
       arch = "linux-i686";
-      sha512 = "9c9b79cf21e64461b8a78dd0f7816346ada2cce0ef4bce4da291497c9fd1aa414c199d57265390e5b885828b1efa38f9883882870b84a5b3a64ffffb47da79e1";
+      sha512 = "978b1ba5f77271906ea67b37637b31a9c1da0f97453ea4e140adff8558ee2b01fe32f3018a48b141198cd0ad9f9d927ce213100be3f3310b020bfb3ff8b1d69c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/tr/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/tr/thunderbird-52.5.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "61a671ae2804b06143e636c9e8ae0badb460bf9cbb3555213bf43aa2d56b2a9f13ca3a13362f2a9b7ecafb4b03451093ea2f817a104cc7d4555e11b1ffb18103";
+      sha512 = "2531185c167e66b77c6b7f968927a64a9e8de56580fd82c7b2408bfac71523738610b740650644eeee4c485dbf532a8da92367bdc574733d0df0d749613bd6b4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/uk/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/uk/thunderbird-52.5.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "629ede67d8bbfd6b1233d2030234fed7f99915045131caa11edce99b6e9c314b7cfd6ef457d26a0e628b525bb78c05426e8c078364ade5e606dfaba90200feee";
+      sha512 = "3f9eed73e2e85528deef2f2ffcbc166d2a836d363693f6ece98adeabe872a6aaa77facd16efd918fac9eefebed68ff35c59750d7116545a6540c9e1aede45c51";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/vi/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/vi/thunderbird-52.5.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "728644651b7eff73be44bceccf8038bca79e020fbaad87d74fb1ff4856554766e6494e1e16a0d93187615f5f8cb663fc3233855d66e8cf0996fe597c9645273c";
+      sha512 = "fa776aca6c434491925e6fcd1802f047fcdcc2ae817805ffae0c873e17f1ad233836954544d85ac378ab28fb607c9cbc5b1808a12bbfa1d9337c8e47de4eddd7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/zh-CN/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/zh-CN/thunderbird-52.5.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "ef5a81e04ed973fd2ed576d1654f1ada7d9cefb6943bf604bee53053fedc4b2127c780ac2ff3c9b568813699f29f744950e899bc71733cd8d385368e1d0c07c2";
+      sha512 = "ddc20a6b05b48d6bcbc59c585b4a2365cee6d526ddef29e3dd04d38c8632c5c7ddda9eab24f2850dd2614bb7acc6e982ae4673c2b51c679eb5afd48047bf6fca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.4.0/linux-i686/zh-TW/thunderbird-52.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/zh-TW/thunderbird-52.5.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "ddf5a00621d6916c6033f81589c9376a8aaba3bf12810a2fd41358af323d9f6354384a5b938f299855d27a1272d36e99ca3f45a8ab8299aa7afc118d942ae624";
+      sha512 = "aa527aeaa6b10d785e3fa3a8052c5dfa70f9aae2601119aed7dfd60e8af30f03cc1b4d93f749c36be4e54bbce6071fe66fb1937fa392b8391ca695e55ffe68ab";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -22,11 +22,11 @@ let
   wrapperTool = if enableGTK3 then wrapGAppsHook else makeWrapper;
 in stdenv.mkDerivation rec {
   name = "thunderbird-${version}";
-  version = "52.4.0";
+  version = "52.5.0";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "6ac39cecca9e53b51754d7a8bd7cae228d197eb234b03a2386c16fd665f4f7a67f10bbdf981c20b3f7a21a5ef67e2771154a3dd9f249c6a884c48a9e59bcfc78";
+    sha512 = "b9b599e5853887bd518e5a57f6fd04751bb78f553f97b260cd9ba7268c4cff307be40b81b00f1320f5a5156e5c67115595b2d389f931c265d0c3448f56fb8319";
   };
 
   # New sed no longer tolerates this mistake.


### PR DESCRIPTION
###### Motivation for this change

- Critical security fixes.
- Other bug fixes and improvements.

https://www.mozilla.org/en-US/thunderbird/52.5.0/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2017-26/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

