### PR TITLE
nixos.tests.keymap.*: increase timeouts

### DIFF
--- a/nixos/tests/keymap.nix
+++ b/nixos/tests/keymap.nix
@@ -85,9 +85,9 @@ let
     testScript = ''
       sub waitCatAndDelete ($) {
         return $machine->succeed(
-          "for i in \$(seq 600); do if [ -e '$_[0]' ]; then ".
+          "for i in \$(seq 500); do if [ -e '$_[0]' ]; then ".
           "cat '$_[0]' && rm -f '$_[0]' && exit 0; ".
-          "fi; sleep 0.1; done; echo timed out after 60 seconds >&2; exit 1"
+          "fi; sleep 0.2; done; echo timed out after 100 seconds >&2; exit 1"
         );
       };
 


### PR DESCRIPTION
I'm not sure why, but the keymap test have been timing out relatively often on Hydra lately, requiring manual restarts. Perhaps some builders tend to get overloaded.

@aszlig: any ideas?