### PR TITLE
[stable/17.09] system-config-printer: fix python path

### DIFF
--- a/pkgs/tools/misc/system-config-printer/default.nix
+++ b/pkgs/tools/misc/system-config-printer/default.nix
@@ -18,50 +18,47 @@ stdenv.mkDerivation rec {
 
   patches = [ ./detect_serverbindir.patch ];
 
-  buildInputs =
-    [ intltool pkgconfig glib udev libusb1 cups xmlto
-      libxml2 docbook_xml_dtd_412 docbook_xsl desktop_file_utils
-      pythonPackages.python pythonPackages.wrapPython
-      libnotify gobjectIntrospection gdk_pixbuf pango atk
-      libgnome_keyring3
-    ];
+  buildInputs = [
+    intltool pkgconfig glib udev libusb1 cups xmlto
+    libxml2 docbook_xml_dtd_412 docbook_xsl desktop_file_utils
+
+    libnotify gobjectIntrospection gdk_pixbuf pango atk
+    libgnome_keyring3
+
+    (pythonPackages.python.withPackages (ps: with ps; [
+      pycups pycurl dbus-python pygobject3 requests pycairo pysmbc
+    ]))
+  ];
 
   nativeBuildInputs = [ wrapGAppsHook ];
 
-  pythonPath = with pythonPackages;
-    [ pycups pycurl dbus-python pygobject3 requests pycairo pythonPackages.pycurl ];
-
-  configureFlags =
-    [ "--with-udev-rules"
-      "--with-udevdir=$(out)/etc/udev"
-      "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
-    ];
+  configureFlags = [
+    "--with-udev-rules"
+    "--with-udevdir=$(out)/etc/udev"
+    "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
+  ];
 
   stripDebugList = [ "bin" "lib" "etc/udev" ];
 
-  postInstall =
-    ''
-      buildPythonPath "$out $pythonPath"
-      gappsWrapperArgs+=(
-        --prefix PATH : "$program_PATH"
-        --set CUPS_DATADIR "${cups-filters}/share/cups"
-      )
+  postInstall = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "$program_PATH"
+      --prefix PYTHONPATH : "$out/${pythonPackages.python.sitePackages}"
+      --set CUPS_DATADIR "${cups-filters}/share/cups"
+    )
 
-      find $out/share/system-config-printer -name \*.py -type f -perm -0100 -print0 | while read -d "" f; do
-        patchPythonScript "$f"
-      done
+    # The below line will be unneeded when the next upstream release arrives.
+    sed -i -e "s|/usr/local/bin|$out/bin|" \
+      "$out/share/dbus-1/services/org.fedoraproject.Config.Printing.service"
 
-      # The below line will be unneeded when the next upstream release arrives.
-      sed -i -e "s|/usr/local/bin|$out/bin|" "$out/share/dbus-1/services/org.fedoraproject.Config.Printing.service"
+    # Manually expand literal "$(out)", which have failed to expand
+    sed -e "s|ExecStart=\$(out)|ExecStart=$out|" \
+      -i "$out/etc/systemd/system/configure-printer@.service"
+  '';
 
-      # Manually expand literal "$(out)", which have failed to expand
-      sed -e "s|ExecStart=\$(out)|ExecStart=$out|" \
-          -i "$out/etc/systemd/system/configure-printer@.service"
-    '';
-
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://cyberelk.net/tim/software/system-config-printer/;
-    platforms = stdenv.lib.platforms.linux;
-    license = stdenv.lib.licenses.gpl2;
+    platforms = platforms.linux;
+    license = licenses.gpl2;
   };
 }


### PR DESCRIPTION
propagated dependencies were not added to PYTHONPATH

(cherry picked from commit b69cbfa269879d9bcf919c0489728cbc9d4c0f3e)

###### Motivation for this change

Installed a vanilla gnome3 with printing enabled. Figured out the printer configuration dialog wasn't working.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

