### PR TITLE
kompose: init at 1.5.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -642,6 +642,7 @@
   theuni = "Christian Theune <ct@flyingcircus.io>";
   ThomasMader = "Thomas Mader <thomas.mader@gmail.com>";
   thoughtpolice = "Austin Seipp <aseipp@pobox.com>";
+  thpham = "Thomas Pham <thomas.pham@ithings.ch>";
   timbertson = "Tim Cuthbertson <tim@gfxmonk.net>";
   timokau = "Timo Kaufmann <timokau@zoho.com>";
   titanous = "Jonathan Rudenberg <jonathan@titanous.com>";

--- a/pkgs/applications/networking/cluster/kompose/default.nix
+++ b/pkgs/applications/networking/cluster/kompose/default.nix
@@ -2,12 +2,12 @@
 
 buildGoPackage rec {
   name = "kompose-${version}";
-  version = "v1.5.0";
+  version = "1.5.0";
 
   goPackagePath = "github.com/kubernetes/kompose";
 
   src = fetchFromGitHub {
-    rev = version;
+    rev = "v${version}";
     owner = "kubernetes";
     repo = "kompose";
     sha256 = "1r5f8jbr2c1xxb5fpfgy23w4m30zahhmrw23jlk1hpx2w1pi1iyh";

--- a/pkgs/applications/networking/cluster/kompose/default.nix
+++ b/pkgs/applications/networking/cluster/kompose/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "kompose-${version}";
+  version = "v1.5.0";
+
+  goPackagePath = "github.com/kubernetes/kompose";
+
+  src = fetchFromGitHub {
+    rev = version;
+    owner = "kubernetes";
+    repo = "kompose";
+    sha256 = "1r5f8jbr2c1xxb5fpfgy23w4m30zahhmrw23jlk1hpx2w1pi1iyh";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A tool to help users who are familiar with docker-compose move to Kubernetes";
+    homepage = https://github.com/kubernetes/kompose;
+    license = licenses.asl20;
+    maintainers = with maintainers; [thpham];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19386,6 +19386,8 @@ with pkgs;
 
   keynav = callPackage ../tools/X11/keynav { };
 
+  kompose = callPackage ../applications/networking/cluster/kompose { };
+
   kops = callPackage ../applications/networking/cluster/kops { };
 
   lilypond = callPackage ../misc/lilypond { guile = guile_1_8; };


### PR DESCRIPTION
###### Motivation for this change

Add kubernetes [kompose](https://github.com/kubernetes/kompose) tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

