### PR TITLE
python-i3ipc: init at 1.3.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -283,6 +283,7 @@
   iblech = "Ingo Blechschmidt <iblech@speicherleck.de>";
   igsha = "Igor Sharonov <igor.sharonov@gmail.com>";
   ikervagyok = "Balázs Lengyel <ikervagyok@gmail.com>";
+  ilya-kolpakov = "Ilya Kolpakov <ilya.kolpakov@gmail.com>";
   infinisil = "Silvan Mosberger <infinisil@icloud.com>";
   ironpinguin = "Michele Catalano <michele@catalano.de>";
   ivan-tkatchev = "Ivan Tkatchev <tkatchev@gmail.com>";

--- a/pkgs/development/python-modules/i3ipc/default.nix
+++ b/pkgs/development/python-modules/i3ipc/default.nix
@@ -1,0 +1,28 @@
+{ pkgs, buildPythonPackage, enum-compat }:
+
+let
+  version = "1.3.0";
+  sha256 = "1rw9mq18np6bf8xp8vvc21bi5q8xjmj8dck2vsa1hy8bk434259m";
+
+in buildPythonPackage rec {
+  name = "i3ipc-${version}";
+  inherit version;
+
+  src = pkgs.fetchFromGitHub {
+    owner = "acrisci";
+    repo = "i3ipc-python";
+    rev = "refs/tags/v${version}";
+    inherit sha256;
+    fetchSubmodules = true; # because a tag is used
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = [ enum-compat ];
+
+  meta = {
+    homepage = "https://github.com/acrisci/i3ipc-python";
+    description = "An improved library to control i3wm";
+    license = pkgs.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/i3ipc/default.nix
+++ b/pkgs/development/python-modules/i3ipc/default.nix
@@ -1,21 +1,26 @@
-{ pkgs, buildPythonPackage, enum-compat }:
+{ lib, fetchFromGitHub, buildPythonPackage, enum-compat }:
 
 let
   version = "1.3.0";
   sha256 = "1rw9mq18np6bf8xp8vvc21bi5q8xjmj8dck2vsa1hy8bk434259m";
 
 in buildPythonPackage rec {
-  name = "i3ipc-${version}";
+  pname = "i3ipc";
   inherit version;
 
-  src = pkgs.fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "acrisci";
     repo = "i3ipc-python";
     rev = "refs/tags/v${version}";
     inherit sha256;
-    fetchSubmodules = true; # because a tag is used
+    fetchSubmodules = true; # Fetching by tag does not work otherwise
   };
 
+  # Current version does not have tests specified in setup.py.
+  # To enable the tests during the build one needs to
+  # 1) patch `i3ipc` source adding tests to `setup.py`
+  # 2) make `pytest`, `Xvfb` and `i3` available to the test runner.
+  #    (by adding the relevant packages to `nativeBuildInputs`)
   doCheck = false;
 
   propagatedBuildInputs = [ enum-compat ];
@@ -23,6 +28,7 @@ in buildPythonPackage rec {
   meta = {
     homepage = "https://github.com/acrisci/i3ipc-python";
     description = "An improved library to control i3wm";
-    license = pkgs.lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.ilya-kolpakov ];
+    license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5879,6 +5879,8 @@ in {
     };
   };
 
+  i3ipc = callPackage ../development/python-modules/i3ipc { };
+
   jdcal = buildPythonPackage rec {
     version = "1.0";
     name = "jdcal-${version}";


### PR DESCRIPTION
###### Motivation for this change

The package [i3ipc-python](https://github.com/ziberna/i3-py) is a better-maintained alternative to [i3-py](https://github.com/ziberna/i3-py) which is currently in nixpkgs. Contributors: 26 vs 3.  Last commit: 19 days ago vs 6 years ago

###### Things done

- [ ] Tested using sandboxing
  - Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested the library
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).