### PR TITLE
eccodes: 2.2.0 -> 2.5.0

### DIFF
--- a/pkgs/development/libraries/eccodes/default.nix
+++ b/pkgs/development/libraries/eccodes/default.nix
@@ -6,11 +6,11 @@
 with stdenv.lib; 
 stdenv.mkDerivation rec {
   name = "eccodes-${version}";
-  version = "2.2.0";
+  version = "2.5.0";
 
   src = fetchurl {
-    url = https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-2.2.0-Source.tar.gz;
-    sha256 = "1hzl0akjfxphqivnaj2kg131w8ki80ba3872h0a45f4pchci4h8s";
+    url = "https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-${version}-Source.tar.gz";
+    sha256 = "0kiff19gk0w7ij0kx5ydqpsmdq499ylxxxq79lrgss218jy49aqq";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change
Bump the eccodes version

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

