### PR TITLE
armadillo: 7.800.1 -> 8.300.0

### DIFF
--- a/pkgs/development/libraries/armadillo/default.nix
+++ b/pkgs/development/libraries/armadillo/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, cmake, openblasCompat, superlu, hdf5 }:
 
 stdenv.mkDerivation rec {
-  version = "7.800.1";
+  version = "8.300.0";
   name = "armadillo-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/arma/armadillo-${version}.tar.xz";
-    sha256 = "1nxq2jp4jlvinynv0l04rpdzpnkzdsng0d5vi3hilc0hlsjnbnjs";
+    sha256 = "0g6wcfrmb2hndz995wrlc80v6d39mhxf26lmycaqv5bjfq050ic5";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/armadillo/use-unix-config-on-OS-X.patch
+++ b/pkgs/development/libraries/armadillo/use-unix-config-on-OS-X.patch
@@ -1,10 +1,9 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -84,7 +84,7 @@ message(STATUS "DETECT_HDF5                = ${DETECT_HDF5}"               )
- ##
- ## Find LAPACK and BLAS libraries, or their optimised versions
- ##
--
+@@ -152,6 +152,7 @@ message(STATUS "DETECT_HDF5                = ${DETECT_HDF5}"               )
+
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake_aux/Modules/")
+
 +set(APPLE false)
  if(APPLE)
    


### PR DESCRIPTION
###### Motivation for this change
Bump armadillo version.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

