### PR TITLE
flink: init at 1.3.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -400,6 +400,7 @@
   mbakke = "Marius Bakke <mbakke@fastmail.com>";
   mbbx6spp = "Susan Potter <me@susanpotter.net>";
   mbe = "Brandon Edens <brandonedens@gmail.com>";
+  mbode = "Maximilian Bode <maxbode@gmail.com>";
   mboes = "Mathieu Boespflug <mboes@tweag.net>";
   mbrgm = "Marius Bergmann <marius@yeai.de>";
   mcmtroffaes = "Matthias C. M. Troffaes <matthias.troffaes@gmail.com>";

--- a/pkgs/applications/networking/cluster/flink/default.nix
+++ b/pkgs/applications/networking/cluster/flink/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchzip, jre,
+  version ? "1.3" }:
+
+let
+  versionMap = {
+    "1.3" = {
+      flinkVersion = "1.3.2";
+      scalaVersion = "2.11";
+      sha256 = "0dr8c1z4ncza6qp2zcklbmn0gj0l1rics3c8fiminkp8bl454ijg";
+    };
+  };
+in
+
+with versionMap.${version};
+
+stdenv.mkDerivation rec {
+  name = "flink-${flinkVersion}";
+
+  src = fetchzip {
+    url    = "mirror://apache/flink/${name}/${name}-bin-hadoop27-scala_${scalaVersion}.tgz";
+    inherit sha256;
+  };
+
+  buildInputs = [ jre ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R bin conf examples lib opt resources $out
+    rm $out/bin/*.bat
+    chmod +x $out/bin\/*
+
+    cat <<EOF >> $out/conf/flink-conf.yaml
+    env.java.home: ${jre}"
+    env.log.dir: /tmp/flink-logs
+    EOF
+  '';
+
+  meta = with stdenv.lib; {
+    description      = "An open-source stream processing framework for distributed, high-performing, always-available, and accurate data streaming applications.";
+    homepage         = "https://flink.apache.org";
+    downloadPage     = "https://flink.apache.org/downloads.html";
+    license          = stdenv.lib.licenses.asl20;
+    platforms        = stdenv.lib.platforms.all;
+    maintainers      = with maintainers; [ mbode ];
+    repositories.git = git://git.apache.org/flink.git;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14658,6 +14658,9 @@ with pkgs;
 
   fldigi = callPackage ../applications/audio/fldigi { };
 
+  flink = flink_1_3;
+  flink_1_3 = callPackage ../applications/networking/cluster/flink { version = "1.3"; };
+
   fluidsynth = callPackage ../applications/audio/fluidsynth {
      inherit (darwin.apple_sdk.frameworks) CoreServices CoreAudio AudioUnit;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

