### PR TITLE
gtk-doc: clean up XML_CATALOG_FILES patch

### DIFF
--- a/pkgs/development/tools/documentation/gtk-doc/respect-xml-catalog-files-var.patch
+++ b/pkgs/development/tools/documentation/gtk-doc/respect-xml-catalog-files-var.patch
@@ -1,28 +1,13 @@
-diff --git a/m4/gtkdoc_jh_check_xml_catalog.m4 b/m4/gtkdoc_jh_check_xml_catalog.m4
-index 618c1c9..1842a0d 100644
 --- a/m4/gtkdoc_jh_check_xml_catalog.m4
 +++ b/m4/gtkdoc_jh_check_xml_catalog.m4
-@@ -10,7 +10,21 @@ AC_DEFUN([JH_CHECK_XML_CATALOG],
+@@ -5,8 +5,8 @@
+ [
+ 	AC_REQUIRE([JH_PATH_XML_CATALOG],[JH_PATH_XML_CATALOG(,[:])])dnl
+ 	AC_MSG_CHECKING([for ifelse([$2],,[$1],[$2]) in XML catalog])
+-	if $jh_found_xmlcatalog && \
+-		AC_RUN_LOG([$XMLCATALOG --noout "$XML_CATALOG_FILE" "$1" >&2]); then
++	# empty argument forces libxml to use XML_CATALOG_FILES variable
++	if AC_RUN_LOG([$XMLCATALOG --noout "" "$1" >&2]); then
  		AC_MSG_RESULT([found])
  		ifelse([$3],,,[$3])
  	else
--		AC_MSG_RESULT([not found])
--		ifelse([$4],,[AC_MSG_ERROR([could not find ifelse([$2],,[$1],[$2]) in XML catalog])],[$4])
-+		jh_check_xml_catalog_saved_ifs="$IFS"
-+		IFS=' '
-+		for f in $XML_CATALOG_FILES; do
-+			if [[ -f "$f" ]] && \
-+				AC_RUN_LOG([$XMLCATALOG --noout "$f" "$1" >&2]); then
-+				jh_found_xmlcatalog=true
-+				AC_MSG_RESULT([found])
-+				ifelse([$3],,,[$3])
-+				break
-+			fi
-+		done
-+		IFS="$jh_check_xml_catalog_saved_ifs"
-+		if ! $jh_found_xmlcatalog; then
-+			AC_MSG_RESULT([not found])
-+			ifelse([$4],,[AC_MSG_ERROR([could not find ifelse([$2],,[$1],[$2]) in XML catalog])],[$4])
-+		fi
- 	fi
- ])


### PR DESCRIPTION
###### Motivation for this change
libxml2 1.9.7 supports the XML_CATALOG_FILES environment variable natively by using empty catalogfile argument.

The change does not have any effect on the package – directory trees are identical, up to self-referring hashes. Apparently, the various packages have a copy of the m4 files in their source trees so we will need to patch them too when we want to enable building docs for them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

