### PR TITLE
libftdi1: 1.3 -> 1.4

### DIFF
--- a/pkgs/development/libraries/libftdi/1.x.nix
+++ b/pkgs/development/libraries/libftdi/1.x.nix
@@ -9,11 +9,11 @@ assert pythonSupport -> python != null && swig != null;
 assert docSupport -> doxygen != null;
 
 stdenv.mkDerivation rec {
-  name = "libftdi1-1.3";
+  name = "libftdi1-1.4";
 
   src = fetchurl {
     url = "http://www.intra2net.com/en/developer/libftdi/download/${name}.tar.bz2";
-    sha256 = "1x41mbzh4qy7mrv2n86r2cr176rx03iacn0a99c3dkzv9g4rb34s";
+    sha256 = "0x0vncf6i92slgrn0h7ghkskqbglbs534220qa84d0qg114zndpc";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Version 1.4 supports new FTDI chips.

###### Things done
Using libftdi1 in a productive environment.

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

