### PR TITLE
lirc: 0.9.4 -> 0.10.0 + more driver

### DIFF
--- a/pkgs/development/libraries/lirc/default.nix
+++ b/pkgs/development/libraries/lirc/default.nix
@@ -2,11 +2,11 @@
 , libxslt, systemd, libusb, libftdi1 }:
 
 stdenv.mkDerivation rec {
-  name = "lirc-0.10.0";
+  name = "lirc-0.10.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/lirc/${name}.tar.bz2";
-    sha256 = "0lzmqcw0sc28s19yd4bqvl52p4f77razq50w7z92a4xrn7l2sz75";
+    sha256 = "1whlyifvvc7w04ahq07nnk1h18wc8j7c6wnvlb6mszravxh3qxcb";
   };
 
   postPatch = ''

--- a/pkgs/development/libraries/lirc/default.nix
+++ b/pkgs/development/libraries/lirc/default.nix
@@ -1,31 +1,41 @@
-{ stdenv, fetchurl, alsaLib, bash, help2man, pkgconfig, xlibsWrapper, python3, libxslt }:
+{ stdenv, fetchurl, alsaLib, bash, help2man, pkgconfig, xlibsWrapper
+, python3Packages, libxslt, systemd, libusb, libftdi1 }:
 
 stdenv.mkDerivation rec {
-  name = "lirc-0.9.4";
+  name = "lirc-0.9.4d";
 
   src = fetchurl {
     url = "mirror://sourceforge/lirc/${name}.tar.bz2";
-    sha256 = "19c6ldjsdnk1md66q3nb035ja1xj217k8iabhxpsb8rs10a6kwi6";
+    sha256 = "1as19rnaz9vpp58kbk9q2lch51vf2fdi27bl19f8d6s8bg1ii3y6";
   };
 
-  preBuild = "patchShebangs .";
+  postPatch = ''
+    patchShebangs .
+
+    # fix overriding PYTHONPATH
+    sed -i 's,PYTHONPATH=,PYTHONPATH=$(PYTHONPATH):,' \
+      doc/Makefile.in
+  '';
+
+  preConfigure = ''
+    # use empty inc file instead of a from linux kernel generated one
+    touch lib/lirc/input_map.inc
+  '';
 
   nativeBuildInputs = [ pkgconfig help2man ];
 
-  buildInputs = [ alsaLib xlibsWrapper python3 libxslt ];
+  buildInputs = [ alsaLib xlibsWrapper libxslt systemd libusb libftdi1 ]
+  ++ (with python3Packages; [ python pyyaml ]);
 
   configureFlags = [
-    "--with-driver=devinput"
     "--sysconfdir=/etc"
     "--localstatedir=/var"
-    "--enable-sandboxed"
+    "--with-systemdsystemunitdir=$(out)/lib/systemd/system"
   ];
 
-  makeFlags = [ "m4dir=$(out)/m4" ];
-
   installFlags = [
-    "sysconfdir=\${out}/etc"
-    "localstatedir=\${TMPDIR}"
+    "sysconfdir=$out/etc"
+    "localstatedir=$TMPDIR"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/lirc/default.nix
+++ b/pkgs/development/libraries/lirc/default.nix
@@ -2,17 +2,19 @@
 , libxslt, systemd, libusb, libftdi1 }:
 
 stdenv.mkDerivation rec {
-  name = "lirc-0.9.4d";
+  name = "lirc-0.10.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/lirc/${name}.tar.bz2";
-    sha256 = "1as19rnaz9vpp58kbk9q2lch51vf2fdi27bl19f8d6s8bg1ii3y6";
+    sha256 = "0lzmqcw0sc28s19yd4bqvl52p4f77razq50w7z92a4xrn7l2sz75";
   };
 
   postPatch = ''
     patchShebangs .
 
     # fix overriding PYTHONPATH
+    sed -i 's,^PYTHONPATH *= *,PYTHONPATH := $(PYTHONPATH):,' \
+      Makefile.in
     sed -i 's,PYTHONPATH=,PYTHONPATH=$(PYTHONPATH):,' \
       doc/Makefile.in
   '';
@@ -25,12 +27,14 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig help2man ];
 
   buildInputs = [ alsaLib xlibsWrapper libxslt systemd libusb libftdi1 ]
-  ++ (with python3.pkgs; [ python pyyaml ]);
+  ++ (with python3.pkgs; [ python pyyaml setuptools ]);
 
   configureFlags = [
     "--sysconfdir=/etc"
     "--localstatedir=/var"
     "--with-systemdsystemunitdir=$(out)/lib/systemd/system"
+    "--enable-uinput" # explicite activation because build env has no uinput
+    "--enable-devinput" # explicite activation because build env has not /dev/input
   ];
 
   installFlags = [

--- a/pkgs/development/libraries/lirc/default.nix
+++ b/pkgs/development/libraries/lirc/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, alsaLib, bash, help2man, pkgconfig, xlibsWrapper
-, python3Packages, libxslt, systemd, libusb, libftdi1 }:
+{ stdenv, fetchurl, alsaLib, bash, help2man, pkgconfig, xlibsWrapper, python3
+, libxslt, systemd, libusb, libftdi1 }:
 
 stdenv.mkDerivation rec {
   name = "lirc-0.9.4d";
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig help2man ];
 
   buildInputs = [ alsaLib xlibsWrapper libxslt systemd libusb libftdi1 ]
-  ++ (with python3Packages; [ python pyyaml ]);
+  ++ (with python3.pkgs; [ python pyyaml ]);
 
   configureFlags = [
     "--sysconfdir=/etc"


### PR DESCRIPTION
* added a bunch of optional libraries to get more IR drivers built
* removed deprecated configure flags
* unneeded make flags
* simplified install flags

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

