### PR TITLE
system wide pulseaudio: allow non-root access

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -46,6 +46,7 @@ let
   gid = ids.gids.pulseaudio;
 
   stateDir = "/run/pulse";
+  cookiePath = "${stateDir}/.config/pulse/cookie";
 
   # Create pulse/client.conf even if PulseAudio is disabled so
   # that we can disable the autospawn feature in programs that
@@ -268,8 +269,18 @@ in {
         extraGroups = [ "audio" ];
         description = "PulseAudio system service user";
         home = stateDir;
-        createHome = true;
       };
+
+      users.groups.pulse-access = {};
+
+      # Pulseaudio creates auth files like .esd_auth and cookie in user
+      # read-only mode, but then users are not able to use pulseaudio.
+      system.activationScripts.pulse = ''
+        umask 027
+        mkdir -p $(dirname ${cookiePath})
+        touch "${cookiePath}" "${stateDir}/.esd_auth"
+        chown -R pulse:pulse-access "${stateDir}"
+      '';
 
       users.extraGroups.pulse.gid = gid;
 
@@ -277,7 +288,6 @@ in {
         description = "PulseAudio System-Wide Server";
         wantedBy = [ "sound.target" ];
         before = [ "sound.target" ];
-        environment.PULSE_RUNTIME_PATH = stateDir;
         serviceConfig = {
           Type = "notify";
           ExecStart = "${binaryNoDaemon} --log-level=${cfg.daemon.logLevel} --system -n --file=${myConfigFile}";
@@ -286,7 +296,7 @@ in {
         };
       };
 
-      environment.variables.PULSE_COOKIE = "${stateDir}/.config/pulse/cookie";
+      environment.variables.PULSE_COOKIE = cookiePath;
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change
Accessing system wide pulseaudio is only possible as root.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

