### PR TITLE
vdrsymbols: init at 20100612

### DIFF
--- a/pkgs/data/fonts/vdrsymbols/default.nix
+++ b/pkgs/data/fonts/vdrsymbols/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchzip }:
+
+fetchzip rec {
+  name = "vdrsymbols-20100612";
+
+  url = http://andreas.vdr-developer.org/fonts/download/vdrsymbols-ttf-20100612.tgz;
+
+  sha256 = "0wpxns8zqic98c84j18dr4zmj092v07yq07vwwgzblr0rw9n6gzr";
+
+  postFetch = ''
+    tar xvzf "$downloadedFile"
+    install -Dm444 -t "$out/share/fonts/truetype" */*.ttf
+  '';
+
+  meta = with stdenv.lib; {
+    description = "DejaVu fonts with additional symbols used by VDR";
+    homepage = http://andreas.vdr-developer.org/fonts/;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ck3d ];
+
+    # Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved.
+    # Copyright (c) 2006 by Tavmjong Bah. All Rights Reserved.
+    # DejaVu changes are in public domain
+    # See https://dejavu-fonts.github.io/License.html for details
+    license = licenses.free;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13715,6 +13715,8 @@ with pkgs;
 
   vanilla-dmz = callPackage ../data/icons/vanilla-dmz { };
 
+  vdrsymbols = callPackage ../data/fonts/vdrsymbols { };
+
   vistafonts = callPackage ../data/fonts/vista-fonts { };
 
   vistafonts-chs = callPackage ../data/fonts/vista-fonts-chs { };


### PR DESCRIPTION
###### Motivation for this change
Special font used by VDR

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

