### PR TITLE
initial TBS driver

### DIFF
--- a/pkgs/os-specific/linux/tbs/default.nix
+++ b/pkgs/os-specific/linux/tbs/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub, kernel, kmod, perl, patchutils, perlPackages }:
+let
+  media = fetchFromGitHub {
+    owner = "tbsdtv";
+    repo = "linux_media";
+    rev = "14ebbec91f2cd0423aaf859fc6e6d5d986397cd4";
+    sha256 = "1cmqj3kby8sxfcpvslbxywr95529vjxzbn800fdp35lka1fv962h";
+  };
+  build = fetchFromGitHub {
+    owner = "tbsdtv";
+    repo = "media_build";
+    rev = "c340e29a4047e43f7ea7ebf19e1e28c1f2112d05";
+    sha256 = "0hfn1j9qk8lh30z3ywj22qky480nsf8z2iag2bqhrhy4375vjlbl";
+  };
+in stdenv.mkDerivation {
+  name = "tbs-2017-11-05-${kernel.version}";
+
+  srcs = [ media build ];
+  sourceRoot = "${build.name}";
+
+  preConfigure = ''
+    make dir DIR=../${media.name}
+  '';
+
+  postPatch = ''
+    patchShebangs .
+
+    sed -i v4l/Makefile \
+      -i v4l/scripts/make_makefile.pl \
+      -e 's,/sbin/depmod,${kmod}/bin/depmod,g' \
+      -e 's,/sbin/lsmod,${kmod}/bin/lsmod,g'
+
+    sed -i v4l/Makefile \
+      -e 's,^OUTDIR ?= /lib/modules,OUTDIR ?= ${kernel.dev}/lib/modules,' \
+      -e 's,^SRCDIR ?= /lib/modules,SRCDIR ?= ${kernel.dev}/lib/modules,'
+  '';
+
+  buildFlags = [ "VER=${kernel.modDirVersion}" ];
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  hardeningDisable = [ "pic" "format" ];
+  nativeBuildInputs = [ patchutils kmod perl perlPackages.ProcProcessTable ];
+
+  meta = with stdenv.lib; {
+    homepage = https://www.tbsdtv.com/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ ck3d ];
+    priority = 20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13522,6 +13522,8 @@ with pkgs;
 
     broadcom_sta = callPackage ../os-specific/linux/broadcom-sta/default.nix { };
 
+    tbs = callPackage ../os-specific/linux/tbs { };
+
     nvidiabl = callPackage ../os-specific/linux/nvidiabl { };
 
     nvidiaPackages = callPackage ../os-specific/linux/nvidia-x11 { };


### PR DESCRIPTION
###### Motivation for this change
Add driver for TBS devices

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

