### PR TITLE
OCRmyPDF: v.5.4.3

### DIFF
--- a/pkgs/applications/graphics/ocrmypdf/default.nix
+++ b/pkgs/applications/graphics/ocrmypdf/default.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  buildPythonApplication,
+  fetchFromGitHub,
+  unpaper,
+  ghostscript,
+  tesseract,
+  qpdf,
+  glibcLocales,
+  pytest,
+  pytest_xdist,
+  pytestcov,
+  setuptools_scm,
+  pytest-helpers-namespace,
+  pytestrunner,
+  ruffus,
+  pillow,
+  reportlab,
+  pypdf2,
+  img2pdf,
+  cffi
+}:
+
+
+
+buildPythonApplication rec {
+  version = "5.4.3";
+  name = "OCRmyPDF-${version}";
+
+  src = fetchFromGitHub {
+    owner = "jbarlow83";
+    repo = "OCRmyPDF";
+    rev = "v${version}";
+    sha256 = "0vnn6g69vkqldbx76llmyz8h9ia7mkxcp290mxdsydy4bjjik6zf";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "ruffus == 2.6.3" "ruffus" \
+      --replace "Pillow == 4.3.0" "Pillow" \
+      --replace "reportlab == 3.4.0" "reportlab" \
+      --replace "PyPDF2 == 1.26.0" "PyPDF2" \
+      --replace "img2pdf == 0.2.4" "img2pdf" \
+      --replace "cffi == 1.11.2" "cffi"
+    substituteInPlace test_requirements.txt \
+      --replace "pytest >= 3.0" "pytest"
+    substituteInPlace ocrmypdf/lib/compile_leptonica.py \
+      --replace "©" "(c)"
+    export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"
+    export LANG=en_US.UTF-8
+    export LC_ALL=en_US.UTF-8
+  '';
+
+  buildInputs = [ glibcLocales setuptools_scm ];
+
+  checkInputs = [  pytest pytest_xdist pytestcov pytest-helpers-namespace pytestrunner ];
+
+  # Issues with leptonica causes it to fail the tests. While this isn't fixed,
+  # only the --deskew option isn't working. All other options work just fine.
+  # https://github.com/jbarlow83/OCRmyPDF/issues/202#issuecomment-346965050
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    ruffus
+    pillow
+    reportlab
+    pypdf2
+    img2pdf
+    cffi
+    unpaper
+    ghostscript
+    tesseract
+    qpdf
+  ];
+
+  meta = with lib; {
+    homepage = https://github.com/jbarlow83/OCRmyPDF;
+    description = "Adds an OCR text layer to scanned PDF files, allowing them to be searched or copy-pasted.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hyper_ch ];
+  };
+}

--- a/pkgs/development/python-modules/img2pdf/default.nix
+++ b/pkgs/development/python-modules/img2pdf/default.nix
@@ -1,0 +1,31 @@
+{
+  stdenv,
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  isPyPy,
+  pillow,
+  pdfrw
+}:
+
+buildPythonPackage rec {
+  pname = "img2pdf";
+  version = "0.2.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1bn9zzsmg4k41wmx1ldmj8a4yfj807p8r0a757lm9yrv7bx702ql";
+  };
+
+  propagatedBuildInputs = [
+    pillow
+    pdfrw
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://gitlab.mister-muffin.de/josch/img2pdf;
+    description = "Losslessly convert raster images to PDF. ";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ hyper_ch ];
+  };
+}

--- a/pkgs/development/python-modules/pdfrw/default.nix
+++ b/pkgs/development/python-modules/pdfrw/default.nix
@@ -1,0 +1,69 @@
+{
+  stdenv,
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchPypi,
+  isPyPy,
+  pytest,
+  unittest2,
+  reportlab,
+  pycrypto,
+  zlib
+}:
+
+let
+
+  static_pdfs = fetchFromGitHub {
+    name = "static_pdfs";
+    owner = "pmaupin";
+    repo = "static_pdfs";
+    rev = "d646009a0e3e71daf13a52ab1029e2230920ebf4";
+    sha256 = "03wff6f73gd4z4wy1yx8b10bqr5gzs2drnzpkjbr767m5b6i62az";
+  };
+
+in
+
+buildPythonPackage rec {
+  pname = "pdfrw";
+  version = "0.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1x1yp63lg3jxpg9igw8lh5rc51q353ifsa1bailb4qb51r54kh0d";
+  };
+
+  postPatch = ''
+    # expected.txt needed, otherwise it'l complain
+    touch expected.txt
+    substituteInPlace tests/update_expected.py \
+      --replace "print src" "print (src)" \
+      --replace 'print "OK"' 'print ("OK")' \
+      --replace "print count, goodcount" "print (count, goodcount)"
+    substituteInPlace tests/test_examples.py \
+      --replace "import expected" "from . import expected"
+    substituteInPlace tests/test_roundtrip.py \
+      --replace "import expected" "from . import expected"
+  '';
+
+  checkInputs = [ pytest unittest2 ];
+
+  checkPhase = ''
+    # Copy over the test pdfs and stuff to the building directory
+    cp -r ${static_pdfs}/* "./tests/static_pdfs"
+    PYTHONPATH="$PYTHONPATH:tests" py.test tests
+  '';
+
+  propagatedBuildInputs = [
+    reportlab
+    pycrypto
+    zlib
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pmaupin/pdfrw;
+    description = "Python library and utility that reads and writes PDF files.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hyper_ch ];
+  };
+}

--- a/pkgs/development/python-modules/pytest_helpers_namespace/default.nix
+++ b/pkgs/development/python-modules/pytest_helpers_namespace/default.nix
@@ -1,0 +1,27 @@
+{
+  stdenv,
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  isPyPy,
+  pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-helpers-namespace";
+  version = "2017.11.11";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ihajp4k8vhc4njq7qsh1b22sy09sdwx5ad53x42lr7xfl76m1jy";
+  };
+
+  checkInputs = [ pytest ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/saltstack/pytest-helpers-namespace;
+    description = "This plugin provides a helpers namespace in pytest.";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hyper_ch ];
+  };
+}

--- a/pkgs/development/python-modules/ruffus/default.nix
+++ b/pkgs/development/python-modules/ruffus/default.nix
@@ -1,0 +1,24 @@
+{
+  stdenv,
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  isPyPy,
+}:
+
+buildPythonPackage rec {
+  pname = "ruffus";
+  version = "2.6.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0qah7rzf9p1l8sj0z19lfyb9dqdwv9a9b4sybv8r2g810bc2i1yp";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://www.ruffus.org.uk/;
+    description = "A Computation Pipeline library for python.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hyper_ch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15909,6 +15909,8 @@ with pkgs;
 
   notion = callPackage ../applications/window-managers/notion { };
 
+  ocrmypdf = python3Packages.callPackage ../applications/graphics/ocrmypdf { };
+
   openshift = callPackage ../applications/networking/cluster/openshift { };
 
   oroborus = callPackage ../applications/window-managers/oroborus {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3933,6 +3933,8 @@ in {
 
   pytest-expect = callPackage ../development/python-modules/pytest-expect { };
 
+  pytest-helpers-namespace = callPackage ../development/python-modules/pytest_helpers_namespace { };
+
   pytest-virtualenv = buildPythonPackage rec {
     name = "${pname}-${version}";
     pname = "pytest-virtualenv";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9711,6 +9711,7 @@ in {
     };
   };
 
+  img2pdf = callPackage ../development/python-modules/img2pdf { };
 
   inflection = buildPythonPackage rec {
      version = "0.3.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14412,6 +14412,8 @@ in {
     };
   };
 
+  pdfrw = callPackage ../development/python-modules/pdfrw { };
+
   pg8000 = buildPythonPackage rec {
     name = "pg8000-1.10.1";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16955,6 +16955,8 @@ in {
     };
   };
 
+  ruffus = callPackage ../development/python-modules/ruffus { };
+
   qscintilla = disabledIf (isPy3k || isPyPy)
     (buildPythonPackage rec {
       # TODO: Qt5 support


### PR DESCRIPTION
###### Motivation for this change

Adding a cli-based ocr tool for scanned pfds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

