### PR TITLE
ipv6calc: 0.99.2 -> 1.0.0 (also fixes gcc-7 compilation)

### DIFF
--- a/pkgs/tools/networking/ipv6calc/default.nix
+++ b/pkgs/tools/networking/ipv6calc/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "ipv6calc-${version}";
-  version = "0.99.2";
+  version = "1.0.0";
 
   src = fetchurl {
     url = "ftp://ftp.deepspace6.net/pub/ds6/sources/ipv6calc/${name}.tar.gz";
-    sha256 = "1vs64v8v5g9rskg46baqrzyay86vs7ln3i5r5ippa9l6ildyrvpj";
+    sha256 = "1gcl8mqjdn5j1rcnv2gz2j0i8ayx747hwzjyiazl6j43c5g4bc3l";
   };
 
   buildInputs = [ geoip geolite-legacy getopt ip2location-c openssl ];


### PR DESCRIPTION
###### Motivation for this change

fixing gcc-7 compatibility (#31747)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

