### PR TITLE
libamqpcpp: init at 2.7.4

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -422,6 +422,7 @@
   mirdhyn = "Merlin Gaillard <mirdhyn@gmail.com>";
   mirrexagon = "Andrew Abbott <mirrexagon@mirrexagon.com>";
   mjanczyk = "Marcin Janczyk <m@dragonvr.pl>";
+  mjp = "Mike Playle <mike@mythik.co.uk>"; # github = "MikePlayle";
   mlieberman85 = "Michael Lieberman <mlieberman85@gmail.com>";
   modulistic = "Pablo Costa <modulistic@gmail.com>";
   mog = "Matthew O'Gorman <mog-lists@rldn.net>";

--- a/pkgs/development/libraries/libamqpcpp/default.nix
+++ b/pkgs/development/libraries/libamqpcpp/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "libamqpcpp-${version}";
+  version = "2.7.4";
+
+  src = fetchFromGitHub {
+    owner = "CopernicaMarketingSoftware";
+    repo = "AMQP-CPP";
+    rev = "v${version}";
+    sha256 = "0m010bz0axawcpv4d1p1vx7c6r8lg27w2s2vjqpbpg99w35n6c8k";
+  };
+
+  patches = [ ./libamqpcpp-darwin.patch ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Library for communicating with a RabbitMQ server";
+    homepage = https://github.com/CopernicaMarketingSoftware/AMQP-CPP;
+    license = licenses.asl20;
+    maintainers = [ maintainers.mjp ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/libamqpcpp/libamqpcpp-darwin.patch
+++ b/pkgs/development/libraries/libamqpcpp/libamqpcpp-darwin.patch
@@ -1,0 +1,13 @@
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -0,0 +1 @@
++CXX ?= g++
+@@ -43 +44 @@ ${SHARED_LIB}: ${SHARED_OBJECTS}
+-	${LD} ${LD_FLAGS} -Wl,${SONAMEPARAMETER},lib$(LIBRARY_NAME).so.$(SONAME) -o $@ ${SHARED_OBJECTS}
++	${CXX} ${LD_FLAGS} -Wl,${SONAMEPARAMETER},lib$(LIBRARY_NAME).so.$(SONAME) -o $@ ${SHARED_OBJECTS}
+@@ -52 +53 @@ ${SHARED_OBJECTS}:
+-	${CPP} ${CPPFLAGS} -fpic -o $@ ${@:%.o=%.cpp}
++	${CXX} ${CPPFLAGS} -fpic -o $@ ${@:%.o=%.cpp}
+@@ -55 +56 @@ ${STATIC_OBJECTS}:
+-	${CPP} ${CPPFLAGS} -o $@ ${@:%.s.o=%.cpp}
++	${CXX} ${CPPFLAGS} -o $@ ${@:%.s.o=%.cpp}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8918,6 +8918,8 @@ with pkgs;
 
   libabw = callPackage ../development/libraries/libabw { };
 
+  libamqpcpp = callPackage ../development/libraries/libamqpcpp { };
+
   libantlr3c = callPackage ../development/libraries/libantlr3c {};
 
   libappindicator-gtk2 = callPackage ../development/libraries/libappindicator { gtkVersion = "2"; };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

