### PR TITLE
ModSecurity lib: init 3.0.0-2017-11-17

### DIFF
--- a/pkgs/tools/security/libmodsecurity/default.nix
+++ b/pkgs/tools/security/libmodsecurity/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+, doxygen, perl, valgrind
+, curl, geoip, libxml2, lmdb, lua, pcre, yajl }:
+
+stdenv.mkDerivation rec {
+  name = "libmodsecurity-${version}";
+  version = "3.0.0-2017-11-17";
+
+  src = fetchFromGitHub {
+    owner = "SpiderLabs";
+    repo = "ModSecurity";
+    fetchSubmodules = true;
+    rev = "81e1cdced3c0266d4b02a68e5f99c30a9c992303";
+    sha256 = "120bpvjq6ws2lv4vw98rx2s0c9yn0pfhlaphlgfv2rxqm3q7yhrr";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ doxygen perl valgrind curl geoip libxml2 lmdb lua pcre yajl];
+
+  configureFlags = [
+    "--enable-static"
+    "--with-curl=${curl.dev}"
+    "--with-libxml=${libxml2.dev}"
+    "--with-pcre=${pcre.dev}"
+    "--with-yajl=${yajl}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = ''
+      Libmodsecurity is one component of the ModSecurity v3 project.
+    '';
+    longDescription = ''
+      Libmodsecurity is one component of the ModSecurity v3 project. The
+      library codebase serves as an interface to ModSecurity Connectors taking
+      in web traffic and applying traditional ModSecurity processing. In
+      general, it provides the capability to load/interpret rules written in
+      the ModSecurity SecRules format and apply them to HTTP content provided
+      by your application via Connectors.
+    '';
+    homepage = https://modsecurity.org/;
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ izorkin ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11719,6 +11719,8 @@ with pkgs;
     modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders nginxModules.shibboleth ];
   };
 
+  libmodsecurity = callPackage ../tools/security/libmodsecurity { };
+
   ngircd = callPackage ../servers/irc/ngircd { };
 
   nix-binary-cache = callPackage ../servers/http/nix-binary-cache {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

