### PR TITLE
antigen: 2.2.1 -> 2.2.2

### DIFF
--- a/pkgs/shells/antigen/default.nix
+++ b/pkgs/shells/antigen/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "2.2.1";
+  version = "2.2.2";
   name = "antigen-${version}";
 
   src = fetchurl {
     url = "https://github.com/zsh-users/antigen/releases/download/v${version}/antigen.zsh";
-    sha256 = "0s32280ak0gd0rr66g5dj6r5px0si8w47bcxlqfpaijg7i8xk1i7";
+    sha256 = "0635dvnsqh7dpqdwx5qq3kx7m1cx2038zln6y9ycnbi3i0ilgj9z";
   };
+
   phases = "installPhase";
 
   installPhase = ''
     outdir=$out/share/antigen
-
     mkdir -p $outdir
     cp $src $outdir/antigen.zsh
   '';


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

