### PR TITLE
zsh-command-time: init at 2017-05-09

### DIFF
--- a/pkgs/shells/zsh-command-time/default.nix
+++ b/pkgs/shells/zsh-command-time/default.nix
@@ -8,7 +8,7 @@
 #   '';
 
 stdenv.mkDerivation rec {
-  version = "rev-2111361";
+  version = "2017-05-09";
   name = "zsh-command-time-${version}";
 
   src = fetchFromGitHub {

--- a/pkgs/shells/zsh-command-time/default.nix
+++ b/pkgs/shells/zsh-command-time/default.nix
@@ -18,18 +18,14 @@ stdenv.mkDerivation rec {
     sha256 = "0hr9c7196wy9cg7vkmknszr2h446yvg9pqrq0rf3213kz074dhpg";
   };
 
-  phases = "installPhase";
-
   installPhase = ''
     install -D $src/command-time.plugin.zsh --target-directory=$out/share/zsh-command-time
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Plugin that output time: xx after long commands";
     homepage = https://github.com/popstas/zsh-command-time;
-    license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.mit;
+    platforms = platforms.unix;
   };
 }
-
-

--- a/pkgs/shells/zsh-command-time/default.nix
+++ b/pkgs/shells/zsh-command-time/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub }:
+
+# To make use of this plugin, need to add
+#   programs.zsh.interactiveShellInit = ''
+#     source ${pkgs.zsh-command-time}/share/zsh-command-time/command-time.plugin.zsh
+#     ZSH_COMMAND_TIME_MIN_SECONDS=3
+#     ZSH_COMMAND_TIME_ECHO=1
+#   '';
+
+stdenv.mkDerivation rec {
+  version = "rev-2111361";
+  name = "zsh-command-time-${version}";
+
+  src = fetchFromGitHub {
+    owner = "popstas";
+    repo = "zsh-command-time";
+    rev = "2111361cbc88c542c834fbab7802ae5ae8339824";
+    sha256 = "0hr9c7196wy9cg7vkmknszr2h446yvg9pqrq0rf3213kz074dhpg";
+  };
+
+  phases = "installPhase";
+
+  installPhase = ''
+    install -D $src/command-time.plugin.zsh --target-directory=$out/share/zsh-command-time
+  '';
+
+  meta = {
+    description = "Plugin that output time: xx after long commands";
+    homepage = https://github.com/popstas/zsh-command-time;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.unix;
+  };
+}
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5342,6 +5342,8 @@ with pkgs;
 
   zsh-powerlevel9k = callPackage ../shells/zsh-powerlevel9k { };
 
+  zsh-command-time = callPackage ../shells/zsh-command-time { };
+
   zstd = callPackage ../tools/compression/zstd { };
   zstdmt = callPackage ../tools/compression/zstdmt { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

