### PR TITLE
eolie: init at 0.9.14

### DIFF
--- a/pkgs/applications/networking/browsers/eolie/0001-Extend-the-python-path-rather-than-replacing-it.patch
+++ b/pkgs/applications/networking/browsers/eolie/0001-Extend-the-python-path-rather-than-replacing-it.patch
@@ -1,0 +1,35 @@
+From b51b63b78c9ff1639f5f65ccfdd54681f1cadc1d Mon Sep 17 00:00:00 2001
+From: Sam Parkinson <sam@sam.today>
+Date: Tue, 26 Dec 2017 14:46:27 +1100
+Subject: [PATCH] Extend the python path; rather than replacing it
+
+Some distros (i.e. NixOS) require the special PYTHONPATH, so that
+the web extension has access to the python packages it wants (i.e. gi).
+
+Previously, the PYTHONPATH was replaced with the web extension path;
+meaning it would crash on NixOS.  This instead prepends the web
+extension path to the PYTHONPATH.
+---
+ eolie/application.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/eolie/application.py b/eolie/application.py
+index 3c21542..bed4e55 100644
+--- a/eolie/application.py
++++ b/eolie/application.py
+@@ -340,7 +340,11 @@ class Application(Gtk.Application):
+         self.settings = Settings.new()
+ 
+         # Init extensions
+-        GLib.setenv("PYTHONPATH", self.__extension_dir, True)
++        current_path = GLib.getenv("PYTHONPATH")
++        new_path = self.__extension_dir
++        if current_path:
++            new_path = new_path + ':' + current_path
++        GLib.setenv("PYTHONPATH", new_path, True)
+ 
+         # Create favicon path
+         if not GLib.file_test(self.__FAVICONS_PATH, GLib.FileTest.IS_DIR):
+-- 
+2.15.0
+

--- a/pkgs/applications/networking/browsers/eolie/0001-Remove-post-install-script-handle-in-nix-config-inst.patch
+++ b/pkgs/applications/networking/browsers/eolie/0001-Remove-post-install-script-handle-in-nix-config-inst.patch
@@ -1,0 +1,23 @@
+From a79d2dcd1b6275904193454fb9d68614813929f3 Mon Sep 17 00:00:00 2001
+From: Sam Parkinson <sam@sam.today>
+Date: Mon, 27 Nov 2017 11:17:35 +1100
+Subject: [PATCH] Remove post install script - handle in nix config instead
+
+---
+ meson.build | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index fc45296..2227f1f 100644
+--- a/meson.build
++++ b/meson.build
+@@ -53,5 +53,3 @@ configure_file(
+   configuration: conf,
+   install_dir: bindir
+ )
+-
+-meson.add_install_script('meson_post_install.py')
+-- 
+2.15.0
+
+

--- a/pkgs/applications/networking/browsers/eolie/default.nix
+++ b/pkgs/applications/networking/browsers/eolie/default.nix
@@ -1,0 +1,68 @@
+{ stdenv, fetchgit, intltool, itstool, meson, ninja, pkgconfig, wrapGAppsHook
+, git, glib, glib_networking, gsettings_desktop_schemas, gst_all_1, gtk3
+, gtkspell3, libsecret, python36, python36Packages, webkitgtk }:
+
+stdenv.mkDerivation rec {
+  name = "eolie-${version}";
+  version = "0.9.16";
+
+  src = fetchgit {
+    url = "https://gitlab.gnome.org/gnumdk/eolie";
+    rev = version;
+    sha256 = "0mvhr6hy4nx7xaq9r9qp5rb0y293kjjryw5ykzb473cr3iwzk25b";
+  };
+
+  nativeBuildInputs = [
+    intltool
+    itstool
+    meson
+    ninja
+    pkgconfig
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    git # required to download ad blocking DB
+    glib_networking
+    gsettings_desktop_schemas
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gst-libav
+    gtk3
+    gtkspell3
+    libsecret
+    python36
+    python36Packages.pygobject3
+    python36Packages.pycairo
+    python36Packages.dateutil
+    python36Packages.dbus-python
+    python36Packages.beautifulsoup4
+    python36Packages.pycrypto
+    python36Packages.requests
+    webkitgtk
+  ];
+
+  wrapPrefixVariables = [ "PYTHONPATH" ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    ${glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
+  '';
+
+  patches = [
+    ./0001-Remove-post-install-script-handle-in-nix-config-inst.patch
+    ./0001-Extend-the-python-path-rather-than-replacing-it.patch
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A new GNOME web browser";
+    homepage = https://gitlab.gnome.org/gnumdk/eolie;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.samdroid-apps ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1220,7 +1220,7 @@ with pkgs;
   mpdris2 = callPackage ../tools/audio/mpdris2 { };
 
   nfdump = callPackage ../tools/networking/nfdump { };
-  
+
   nrsc5 = callPackage ../applications/misc/nrsc5 { };
 
   onboard = callPackage ../applications/misc/onboard { };
@@ -14744,6 +14744,8 @@ with pkgs;
   inherit (gnome3) empathy;
 
   enhanced-ctorrent = callPackage ../applications/networking/enhanced-ctorrent { };
+
+  eolie = callPackage ../applications/networking/browsers/eolie { };
 
   epdfview = callPackage ../applications/misc/epdfview { };
 


### PR DESCRIPTION
###### Motivation for this change

Add this cool web browser: https://gnumdk.github.io/eolie-web/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS - N/A
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

