### PR TITLE
stm32flash: 1.0 -> 0.5

### DIFF
--- a/pkgs/development/tools/misc/stm32flash/default.nix
+++ b/pkgs/development/tools/misc/stm32flash/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, unzip }:
 
 stdenv.mkDerivation {
-  name = "stm32flash-1.0";
+  name = "stm32flash-0.5";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/stm32flash/stm32flash.tar.gz";
-    sha256 = "04k631g9lzvp9xr4sw51xpq1g542np61s1l8fpwx9rbsc8m5l0i6";
+    url = mirror://sourceforge/stm32flash/stm32flash-0.5.tar.gz;
+    sha256 = "01p396daqw3zh6nijffbfbwyqza33bi2k4q3m5yjzs02xwi99alp";
   };
 
   buildFlags = [ "CC=cc" ];
@@ -21,6 +21,6 @@ stdenv.mkDerivation {
     homepage = https://sourceforge.net/projects/stm32flash/;
     license = stdenv.lib.licenses.gpl2;
     platforms = platforms.all; # Should work on all platforms
-    maintainers = [ maintainers.the-kenny ];
+    maintainers = with maintainers; [ the-kenny elitak ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
This version is newer. 1.0 was given as a placeholder, I presume, because that sourcetree wasn't versioned.
 
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

