### PR TITLE
opentx: init at 2.2.0

### DIFF
--- a/pkgs/applications/misc/opentx/default.nix
+++ b/pkgs/applications/misc/opentx/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchFromGitHub
+, cmake, gcc-arm-embedded, python
+, qt5, SDL, gmock
+, dfu-util, avrdude
+}:
+
+let
+
+  version = "2.2.1";
+
+in stdenv.mkDerivation {
+
+  name = "opentx-${version}";
+
+  src = fetchFromGitHub {
+    owner = "opentx";
+    repo = "opentx";
+    rev = version;
+    sha256 = "01lnnkrxach21aivnx1k1iqhih02nixh8c4nk6rpw408p13him9g";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = with qt5; [
+    gcc-arm-embedded
+    python python.pkgs.pyqt4
+    qtbase qtmultimedia qttranslations
+    SDL gmock
+  ];
+
+  postPatch = ''
+    sed -i companion/src/burnconfigdialog.cpp -e 's|/usr/.*bin/dfu-util|${dfu-util}/bin/dfu-util|'
+    sed -i companion/src/burnconfigdialog.cpp -e 's|/usr/.*bin/avrdude|${avrdude}/bin/avrdude|'
+  '';
+
+  cmakeFlags = [
+    "-DQT_TRANSLATIONS_DIR=${qt5.qttranslations}/translations"
+    # XXX I would prefer to include these here, though we will need to file a bug upstream to get that changed.
+    #"-DDFU_UTIL_PATH=${dfu-util}/bin/dfu-util"
+    #"-DAVRDUDE_PATH=${avrdude}/bin/avrdude"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "OpenTX Companion transmitter support software";
+    longDescription = ''
+      OpenTX Companion is used for many different tasks like loading OpenTX
+      firmware to the radio, backing up model settings, editing settings and
+      running radio simulators.
+    '';
+    homepage = https://open-tx.org/;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = with maintainers; [ elitak ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16825,6 +16825,8 @@ with pkgs;
 
   openscad = callPackage ../applications/graphics/openscad {};
 
+  opentx = callPackage ../applications/misc/opentx { };
+
   opera = callPackage ../applications/networking/browsers/opera {};
 
   orca = python3Packages.callPackage ../applications/misc/orca {


### PR DESCRIPTION
###### Motivation for this change

Personal; was pretty easy to get working.

###### Things done

Tested fairly briefly. All UI stuff works, dfu-util path, didn't try avrdude path. Writing to sdcard doesnt work without manually mounting the volumes with write access.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

