### PR TITLE
Add pythonPackages.salmon and dependencies

### DIFF
--- a/pkgs/development/python-modules/lmtpd/default.nix
+++ b/pkgs/development/python-modules/lmtpd/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "lmtpd";
+  version = "6.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "192d1j9lj9i6f4llwg51817am4jj8pjvlqmkx03spmsay6f832bm";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/moggers87/lmtpd;
+    description = "LMTP counterpart to smtpd in the Python standard library";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/salmon/default.nix
+++ b/pkgs/development/python-modules/salmon/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, pythonOlder, nose, dns
+,  chardet, lmtpd, pythondaemon, six, jinja2, mock }:
+
+buildPythonPackage rec {
+  pname = "salmon";
+  # NOTE: The latest release version 2 is over 3 years old. So let's use some
+  # recent commit from master. There will be a new release at some point, then
+  # one can change this to use PyPI. See:
+  # https://github.com/moggers87/salmon/issues/52
+  version = "bec795cdab744be4f103d8e35584dfee622ddab2";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "moggers87";
+    repo = "salmon";
+    rev = version;
+    sha256 = "0nx8pyxy7n42nsqqvhd85ycm1i5wlacsi7lwb4rrs9d416bpd300";
+  };
+
+  checkInputs = [ nose jinja2 mock ];
+  propagatedBuildInputs = [ chardet dns lmtpd pythondaemon six ];
+
+  meta = with stdenv.lib; {
+    homepage = http://salmon-mail.readthedocs.org/;
+    description = "Pythonic mail application server";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -192,6 +192,8 @@ in {
 
   intelhex = callPackage ../development/python-modules/intelhex { };
 
+  lmtpd = callPackage ../development/python-modules/lmtpd { };
+
   mpi4py = callPackage ../development/python-modules/mpi4py {
     mpi = pkgs.openmpi;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -306,6 +306,8 @@ in {
 
   rhpl = if !isPy3k then callPackage ../development/python-modules/rhpl {} else throw "rhpl not supported for interpreter ${python.executable}";
 
+  salmon = callPackage ../development/python-modules/salmon { };
+
   simpleeval = callPackage ../development/python-modules/simpleeval { };
 
   sip = callPackage ../development/python-modules/sip { };


### PR DESCRIPTION
###### Motivation for this change

Add Python package salmon and its dependencies.

I wasn't able to run the tests for dnspython successfully. I got the following errors: https://github.com/rthalley/dnspython/issues/289. If anyone has ideas how to fix those, I could try to fix. For now, I just skipped the tests (although not all tests failed).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

