### PR TITLE
treewide: Use `targetPrefix` instead of `prefix` for platform name prefixes

### DIFF
--- a/pkgs/applications/editors/ed/default.nix
+++ b/pkgs/applications/editors/ed/default.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation rec {
   installFlags = [ "DESTDIR=$(out)" ];
 
   configureFlags = [
-    "--exec-prefix=${stdenv.cc.prefix}"
-    "CC=${stdenv.cc.prefix}cc"
+    "--exec-prefix=${stdenv.cc.targetPrefix}"
+    "CC=${stdenv.cc.targetPrefix}cc"
   ];
 
   meta = {

--- a/pkgs/applications/video/omxplayer/default.nix
+++ b/pkgs/applications/video/omxplayer/default.nix
@@ -49,7 +49,7 @@ let
     crossAttrs = {
       configurePlatforms = [];
       configureFlags = configureFlags ++ [
-        "--cross-prefix=${stdenv.cc.prefix}"
+        "--cross-prefix=${stdenv.cc.targetPrefix}"
         "--enable-cross-compile"
         "--target_os=linux"
         "--arch=${hostPlatform.arch}"

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -117,7 +117,7 @@ let
         -exec sed '1i#line 1 "{}"' -i '{}' \;
     )
   '' + optionalString (hostPlatform.libc == "msvcrt") ''
-    ${stdenv.cc.prefix}ranlib "$out/lib/"*.a
+    ${stdenv.cc.targetPrefix}ranlib "$out/lib/"*.a
   '';
 
 in

--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -438,7 +438,7 @@ stdenv.mkDerivation rec {
   crossAttrs = {
     configurePlatforms = [];
     configureFlags = configureFlags ++ [
-      "--cross-prefix=${stdenv.cc.prefix}"
+      "--cross-prefix=${stdenv.cc.targetPrefix}"
       "--enable-cross-compile"
       "--target_os=${hostPlatform.parsed.kernel.name}"
       "--arch=${hostPlatform.arch}"

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -173,7 +173,7 @@ stdenv.mkDerivation rec {
   crossAttrs = {
     configurePlatforms = [];
     configureFlags = configureFlags ++ [
-      "--cross-prefix=${stdenv.cc.prefix}"
+      "--cross-prefix=${stdenv.cc.targetPrefix}"
       "--enable-cross-compile"
       "--target_os=${hostPlatform.parsed.kernel}"
       "--arch=${hostPlatform.arch}"

--- a/pkgs/development/libraries/libav/default.nix
+++ b/pkgs/development/libraries/libav/default.nix
@@ -110,7 +110,7 @@ let
     crossAttrs = {
       configurePlatforms = [];
       configureFlags = configureFlags ++ [
-        "--cross-prefix=${stdenv.cc.prefix}"
+        "--cross-prefix=${stdenv.cc.targetPrefix}"
         "--enable-cross-compile"
         "--target_os=linux"
         "--arch=${hostPlatform.arch}"

--- a/pkgs/development/libraries/newt/default.nix
+++ b/pkgs/development/libraries/newt/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   '';
 
   crossAttrs = {
-    makeFlags = "CROSS_COMPILE=${stdenv.cc.prefix}";
+    makeFlags = "CROSS_COMPILE=${stdenv.cc.targetPrefix}";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -229,11 +229,11 @@ stdenv.mkDerivation rec {
     '' + optionalString hostPlatform.isMinGW " -xplatform win32-g++-4.6";
     patches = [];
     preConfigure = ''
-      sed -i -e 's/ g++/ ${stdenv.cc.prefix}g++/' \
-        -e 's/ gcc/ ${stdenv.cc.prefix}gcc/' \
-        -e 's/ ar/ ${stdenv.cc.prefix}ar/' \
-        -e 's/ strip/ ${stdenv.cc.prefix}strip/' \
-        -e 's/ windres/ ${stdenv.cc.prefix}windres/' \
+      sed -i -e 's/ g++/ ${stdenv.cc.targetPrefix}g++/' \
+        -e 's/ gcc/ ${stdenv.cc.targetPrefix}gcc/' \
+        -e 's/ ar/ ${stdenv.cc.targetPrefix}ar/' \
+        -e 's/ strip/ ${stdenv.cc.targetPrefix}strip/' \
+        -e 's/ windres/ ${stdenv.cc.targetPrefix}windres/' \
         mkspecs/win32-g++/qmake.conf
     '';
 

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
   ];
 
   makeFlags = [
-    "PREFIX=${stdenv.cc.prefix}"
+    "PREFIX=${stdenv.cc.targetPrefix}"
   ] ++ stdenv.lib.optionals (hostPlatform.libc == "msvcrt") [
     "-f" "win32/Makefile.gcc"
   ] ++ stdenv.lib.optionals (!static) [

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -11,13 +11,13 @@ let
   version = "2.28.1";
   basename = "binutils-${version}";
   inherit (stdenv.lib) optional optionals optionalString;
-  # The prefix prepended to binary names to allow multiple binuntils on the
+  # The targetPrefix prepended to binary names to allow multiple binuntils on the
   # PATH to both be usable.
-  prefix = optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-";
+  targetPrefix = optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-";
 in
 
 stdenv.mkDerivation rec {
-  name = prefix + basename;
+  name = targetPrefix + basename;
 
   src = fetchurl {
     url = "mirror://gnu/binutils/${basename}.tar.bz2";
@@ -81,7 +81,7 @@ stdenv.mkDerivation rec {
     then "-Wno-string-plus-int -Wno-deprecated-declarations"
     else "-static-libgcc";
 
-  # TODO(@Ericson2314): Always pass "--target" and always prefix.
+  # TODO(@Ericson2314): Always pass "--target" and always targetPrefix.
   configurePlatforms =
     # TODO(@Ericson2314): Figure out what's going wrong with Arm
     if hostPlatform == targetPlatform && targetPlatform.isArm
@@ -102,7 +102,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   passthru = {
-    inherit prefix version;
+    inherit targetPrefix version;
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -63,7 +63,7 @@ let
     crossAttrs = {
       makeFlags = [
         "ARCH=${hostPlatform.platform.kernelArch}"
-        "CROSS_COMPILE=${stdenv.cc.prefix}"
+        "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
       ];
     };
 

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -3,24 +3,24 @@
 }:
 
 # Make sure both underlying packages claim to have prepended their binaries
-# with the same prefix.
-assert binutils-raw.prefix == cctools.prefix;
+# with the same targetPrefix.
+assert binutils-raw.targetPrefix == cctools.targetPrefix;
 
 let
-  inherit (binutils-raw) prefix;
+  inherit (binutils-raw) targetPrefix;
   cmds = [
     "ar" "ranlib" "as" "dsymutil" "install_name_tool"
     "ld" "strip" "otool" "lipo" "nm" "strings" "size"
   ];
 in
 
-# TODO loop over prefixed binaries too
+# TODO loop over targetPrefixed binaries too
 stdenv.mkDerivation {
-  name = "${prefix}cctools-binutils-darwin";
+  name = "${targetPrefix}cctools-binutils-darwin";
   buildCommand = ''
     mkdir -p $out/bin $out/include
 
-    ln -s ${binutils-raw.out}/bin/${prefix}c++filt $out/bin/${prefix}c++filt
+    ln -s ${binutils-raw.out}/bin/${targetPrefix}c++filt $out/bin/${targetPrefix}c++filt
 
     # We specifically need:
     # - ld: binutils doesn't provide it on darwin
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
     # - strip: the binutils one seems to break mach-o files
     # - lipo: gcc build assumes it exists
     # - nm: the gnu one doesn't understand many new load commands
-    for i in ${stdenv.lib.concatStringsSep " " (builtins.map (e: prefix + e) cmds)}; do
+    for i in ${stdenv.lib.concatStringsSep " " (builtins.map (e: targetPrefix + e) cmds)}; do
       ln -sf "${cctools}/bin/$i" "$out/bin/$i"
     done
 
@@ -44,6 +44,6 @@ stdenv.mkDerivation {
   '';
 
   passthru = {
-    inherit prefix;
+    inherit targetPrefix;
   };
 }

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -5,9 +5,9 @@
 }:
 
 let
-  # The prefix prepended to binary names to allow multiple binuntils on the
+  # The targetPrefix prepended to binary names to allow multiple binuntils on the
   # PATH to both be usable.
-  prefix = stdenv.lib.optionalString
+  targetPrefix = stdenv.lib.optionalString
     (targetPlatform != hostPlatform)
     "${targetPlatform.config}-";
 in
@@ -19,7 +19,7 @@ assert (!hostPlatform.isDarwin) -> (maloader != null && xctoolchain != null);
 
 let
   baseParams = rec {
-    name = "${prefix}cctools-port-${version}";
+    name = "${targetPrefix}cctools-port-${version}";
     version = "895";
 
     src = fetchFromGitHub {
@@ -49,7 +49,7 @@ let
 
     enableParallelBuilding = true;
 
-    # TODO(@Ericson2314): Always pass "--target" and always prefix.
+    # TODO(@Ericson2314): Always pass "--target" and always targetPrefix.
     configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
     configureFlags = stdenv.lib.optionals (!stdenv.isDarwin) [
       "CXXFLAGS=-I${libcxx}/include/c++/v1"
@@ -113,7 +113,7 @@ let
       '';
 
     passthru = {
-      inherit prefix;
+      inherit targetPrefix;
     };
 
     meta = {

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     CONFIG_DEFAULT_SETFONT_DIR "/etc/kbd"
 
     ${extraConfig}
-    CONFIG_CROSS_COMPILER_PREFIX "${stdenv.cc.prefix}"
+    CONFIG_CROSS_COMPILER_PREFIX "${stdenv.cc.targetPrefix}"
     EOF
 
     make oldconfig
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
   '';
 
   postConfigure = lib.optionalString useMusl ''
-    makeFlagsArray+=("CC=${stdenv.cc.prefix}gcc -isystem ${musl}/include -B${musl}/lib -L${musl}/lib")
+    makeFlagsArray+=("CC=${stdenv.cc.targetPrefix}gcc -isystem ${musl}/include -B${musl}/lib -L${musl}/lib")
   '';
 
   nativeBuildInputs = lib.optional (hostPlatform != buildPlatform) buildPackages.stdenv.cc;

--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
     /* I don't want cross-python or cross-perl -
        I don't know if cross-python even works */
     propagatedBuildInputs = [ elfutils.crossDrv newt.crossDrv ];
-    makeFlags = "CROSS_COMPILE=${stdenv.cc.prefix}";
+    makeFlags = "CROSS_COMPILE=${stdenv.cc.targetPrefix}";
     elfutils = elfutils.crossDrv;
     inherit (kernel.crossDrv) src patches;
   };

--- a/pkgs/os-specific/linux/klibc/default.nix
+++ b/pkgs/os-specific/linux/klibc/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   ] # TODO(@Ericson2314): We now can get the ABI from
     # `hostPlatform.parsed.abi`, is this still a good idea?
     ++ stdenv.lib.optional (hostPlatform.platform.kernelArch == "arm") "CONFIG_AEABI=y"
-    ++ stdenv.lib.optional (hostPlatform != buildPlatform) "CROSS_COMPILE=${stdenv.cc.prefix}";
+    ++ stdenv.lib.optional (hostPlatform != buildPlatform) "CROSS_COMPILE=${stdenv.cc.targetPrefix}";
 
   # Install static binaries as well.
   postInstall = ''

--- a/pkgs/os-specific/linux/mdadm/4.nix
+++ b/pkgs/os-specific/linux/mdadm/4.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     "MANDIR=$(out)/share/man" "RUN_DIR=/dev/.mdadm"
     "STRIP="
   ] ++ stdenv.lib.optionals (hostPlatform != buildPlatform) [
-    "CROSS_COMPILE=${stdenv.cc.prefix}"
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
 
   nativeBuildInputs = [ groff ];

--- a/pkgs/os-specific/linux/mdadm/default.nix
+++ b/pkgs/os-specific/linux/mdadm/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     "MANDIR=$(out)/share/man" "RUN_DIR=/dev/.mdadm"
     "STRIP="
   ] ++ stdenv.lib.optionals (hostPlatform != buildPlatform) [
-    "CROSS_COMPILE=${stdenv.cc.prefix}"
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
 
   nativeBuildInputs = [ groff ];

--- a/pkgs/os-specific/windows/jom/default.nix
+++ b/pkgs/os-specific/windows/jom/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   QTDIR = qt48;
   
   crossAttrs = {
-    # cmakeFlags = "-DWIN32=1 -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_RC_COMPILER=${stdenv.cc.prefix}windres";
+    # cmakeFlags = "-DWIN32=1 -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_RC_COMPILER=${stdenv.cc.targetPrefix}windres";
     QTDIR = qt48.crossDrv;
     preBuild = ''
       export NIX_CROSS_CFLAGS_COMPILE=-fpermissive

--- a/pkgs/tools/networking/htpdate/default.nix
+++ b/pkgs/tools/networking/htpdate/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "INSTALL=install"
-    "STRIP=${stdenv.cc.bintools.prefix}strip"
+    "STRIP=${stdenv.cc.bintools.targetPrefix}strip"
     "prefix=$(out)"
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Certain tools, e.g. compilers, are customarily prefixed with the name of their target platform so that multiple builds can be used at once without clobbering each other on the PATH. I was using identifiers named `prefix` for this purpose, but that conflicts with the standard use of `prefix` to mean the directory where something is installed. To avoid conflict and confusion, I renamed those to `binPrefix`.

###### Things done

No hashes were changed the first time. Then I switched from `binPrefix` to `targetPrefix` at @orivej's suggestion. But it was a safe sed, so this still must be fine.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

