### PR TITLE
exim: Fix for CVE-2017-16943 RCE vuln

### DIFF
--- a/pkgs/servers/mail/exim/cve-2017-16943.patch
+++ b/pkgs/servers/mail/exim/cve-2017-16943.patch
@@ -1,0 +1,39 @@
+From 4e6ae6235c68de243b1c2419027472d7659aa2b4 Mon Sep 17 00:00:00 2001
+From: Jeremy Harris <jgh146exb@wizmail.org>
+Date: Fri, 24 Nov 2017 20:22:33 +0000
+Subject: [PATCH] Avoid release of store if there have been later allocations.
+ Bug 2199
+
+---
+ src/receive.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/receive.c b/src/receive.c
+index e7e518a..d9b5001 100644
+--- a/src/receive.c
++++ b/src/receive.c
+@@ -1810,8 +1810,8 @@ for (;;)
+   (and sometimes lunatic messages can have ones that are 100s of K long) we
+   call store_release() for strings that have been copied - if the string is at
+   the start of a block (and therefore the only thing in it, because we aren't
+-  doing any other gets), the block gets freed. We can only do this because we
+-  know there are no other calls to store_get() going on. */
++  doing any other gets), the block gets freed. We can only do this release if
++  there were no allocations since the once that we want to free. */
+
+   if (ptr >= header_size - 4)
+     {
+@@ -1820,9 +1820,10 @@ for (;;)
+     header_size *= 2;
+     if (!store_extend(next->text, oldsize, header_size))
+       {
++      BOOL release_ok = store_last_get[store_pool] == next->text;
+       uschar *newtext = store_get(header_size);
+       memcpy(newtext, next->text, ptr);
+-      store_release(next->text);
++      if (release_ok) store_release(next->text);
+       next->text = newtext;
+       }
+     }
+--
+1.9.1

--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
       url = "https://anonscm.debian.org/git/pkg-exim4/exim4.git/plain/debian/patches/79_CVE-2017-1000369.patch?h=4.89-2%2bdeb9u1";
       sha256 = "0v46zywgkv1rdqhybqqrd0rwkdaj6q1f4x0a3vm9p0wz8vad3023";
     })
+    ./cve-2017-16943.patch
   ];
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
See https://isc.sans.edu/diary/rss/23069 and http://openwall.com/lists/oss-security/2017/11/25/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

