### PR TITLE
fish: 2.6.0 -> 2.7.0

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -35,11 +35,11 @@ let
     #     source both, but source the more global configuration files earlier
     #     than the more local ones, so that more local configurations inherit
     #     from but override the more global locations.
-    
+
     if test -f /etc/fish/config.fish
       source /etc/fish/config.fish
     end
-    
+
     #                                                                             #
     ############### ↑ Nix hook for sourcing /etc/fish/config.fish ↑ ###############
   '';
@@ -88,13 +88,15 @@ let
 
   fish = stdenv.mkDerivation rec {
     name = "fish-${version}";
-    version = "2.6.0";
+    version = "2.7.0";
 
     etcConfigAppendix = builtins.toFile "etc-config.appendix.fish" etcConfigAppendixText;
 
     src = fetchurl {
-      url = "http://fishshell.com/files/${version}/${name}.tar.gz";
-      sha256 = "1yzx73kg5ng5ivhi68756sl5hpb8869110l9fwim6gn7f7bbprby";
+      # There are differences between the release tarball and the tarball github packages from the tag
+      # Hence we cannot use fetchFromGithub
+      url = "https://github.com/fish-shell/fish-shell/releases/download/${version}/${name}.tar.gz";
+      sha256 = "1jvvm27hp46w0cia14lfz6161dkz8b935j1m7j38i7rgx75bfxis";
     };
 
     buildInputs = [ ncurses libiconv pcre2 ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @ocharles 