### PR TITLE
iosevka-bin: init at 1.13.3

### DIFF
--- a/pkgs/data/fonts/iosevka/bin.nix
+++ b/pkgs/data/fonts/iosevka/bin.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchzip }:
+
+let
+  version = "1.13.3";
+in fetchzip rec {
+  name = "iosevka-bin-${version}";
+
+  url = "https://github.com/be5invis/Iosevka/releases/download/v${version}/iosevka-pack-${version}.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.ttc -d $out/share/fonts/iosevka
+  '';
+
+  sha256 = "0103rjxcp2sis42xp7fh7g8i03h5snvs8n78lgsf79g8ssw0p9d4";
+
+  meta = with stdenv.lib; {
+    homepage = https://be5invis.github.io/Iosevka/;
+    downloadPage = "https://github.com/be5invis/Iosevka/releases";
+    description = ''
+      Slender monospace sans-serif and slab-serif typeface inspired by Pragmata
+      Pro, M+ and PF DIN Mono, designed to be the ideal font for programming.
+    '';
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.cstrahan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13450,6 +13450,7 @@ with pkgs;
   iosevka = callPackage ../data/fonts/iosevka {
     nodejs = nodejs-8_x;
   };
+  iosevka-bin = callPackage ../data/fonts/iosevka/bin.nix {};
 
   ipafont = callPackage ../data/fonts/ipafont {};
   ipaexfont = callPackage ../data/fonts/ipaexfont {};


### PR DESCRIPTION
The former fetch-only expression is re-added as iosevka-bin to support platforms
without otfcc where Iosevka cannot be built.

See also: #31835

### Testing

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

