### PR TITLE
libskk: init at 1.0.2

### DIFF
--- a/pkgs/development/libraries/libskk/default.nix
+++ b/pkgs/development/libraries/libskk/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl, fetchFromGitHub,
+  libtool, intltool, pkgconfig,
+  vala, gnome_common, gobjectIntrospection,
+  libgee_0_8, json_glib, skk-dicts }:
+
+stdenv.mkDerivation rec {
+  name = "libskk-${version}";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "ueno";
+    repo = "libskk";
+    rev = "6a232e75de6d5dbe543ab17c9b85dc7560093509";
+    sha256 = "1xa9akf95jyi4laiw1llnjdpfq5skhidm7dnkd0i0ds6npzzqnxc";
+  };
+
+  buildInputs = [ skk-dicts ];
+  nativeBuildInputs = [ vala gnome_common gobjectIntrospection libtool intltool pkgconfig ];
+  propagatedBuildInputs = [ libgee_0_8 json_glib ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  # link SKK-JISYO.L from skkdicts for the bundled tool `skk`
+  preInstall = ''
+    dictDir=$out/share/skk
+    mkdir -p $dictDir
+    ln -s ${skk-dicts}/share/SKK-JISYO.L $dictDir/
+  '';
+
+  meta = {
+    description = "A library to deal with Japanese kana-to-kanji conversion method";
+    longDescription = ''
+      Libskk is a library that implements basic features of SKK including:
+      new word registration, completion, numeric conversion, abbrev mode, kuten input,
+      hankaku-katakana input, Lisp expression evaluation (concat only), and re-conversion.
+      It also supports various typing rules including: romaji-to-kana, AZIK, TUT-Code, and NICOLA,
+      as well as various dictionary types including: file dictionary (such as SKK-JISYO.[SML]),
+      user dictionary, skkserv, and CDB format dictionary.
+    '';
+    homepage = https://github.com/ueno/libskk;
+    license = stdenv.lib.licenses.gpl3Plus;
+    maintainers = with stdenv.lib.maintainers; [ yuriaisaka ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1494,6 +1494,8 @@ with pkgs;
 
   libpinyin = callPackage ../development/libraries/libpinyin { };
 
+  libskk = callPackage ../development/libraries/libskk { gnome_common = gnome3.gnome_common; };
+
   m17n_db = callPackage ../tools/inputmethods/m17n-db { };
 
   m17n_lib = callPackage ../tools/inputmethods/m17n-lib { };


### PR DESCRIPTION
###### Motivation for this change

(This is a sequel to the pull requests `skktools: init at 1.3.3 #30778` and `skk-dicts: init at 2017-10-26 #30960`.)

`libskk` is a library that implements the kana-to-kanji conversion logic for the SKK Japanese input method. 

The motivation for having `libskk` in nixpkgs comes from the desire to have
`fcitx-skk` in `fcitx-engines`, which depends on `libskk`. Further pull requests are planned for fcitx-skk (a fcitx engine).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md)
---

