### PR TITLE
Powerdns multiple CVE's

### DIFF
--- a/pkgs/servers/dns/pdns-recursor/default.nix
+++ b/pkgs/servers/dns/pdns-recursor/default.nix
@@ -11,11 +11,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "pdns-recursor-${version}";
-  version = "4.0.6";
+  version = "4.0.7";
 
   src = fetchurl {
     url = "https://downloads.powerdns.com/releases/pdns-recursor-${version}.tar.bz2";
-    sha256 = "03fnjiacvhdlkr3a2206mham0p6p24gkawashs5v12r68k32l67j";
+    sha256 = "1rwl5w960ck4lxrjrrh27ipy6d1sf9dsw0dkr46bswicqda1cvcn";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/dns/powerdns/default.nix
+++ b/pkgs/servers/dns/powerdns/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "powerdns-${version}";
-  version = "4.0.4";
+  version = "4.0.5";
 
   src = fetchurl {
     url = "http://downloads.powerdns.com/releases/pdns-${version}.tar.bz2";
-    sha256 = "0qypns1iqlrc5d3iwabrsi1vpb0yffy36chsb1zpqiv9vs4snx6r";
+    sha256 = "097ci4s2c63gl0bil8yh87dsy0sk3fds4w8cpyjh5kns6zazmj2v";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
- 2017-03: Insufficient validation of DNSSEC signatures
(CVE-2017-15090, Recursor >= 4.0.0)
- 2017-04: Missing check on API operations (CVE-2017-15091, Authoritative)
- 2017-05: Cross-Site Scripting in the web interface (CVE-2017-15092,
Recursor >= 4.0.0)
- 2017-06: Configuration file injection in the API (CVE-2017-15093,
Recursor)
- 2017-07: Memory leak in DNSSEC parsing (CVE-2017-15094, Recursor >=
4.0.0)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

