### PR TITLE
container-linux-config-transpiler: 0.4.1 -> 0.5.0

### DIFF
--- a/pkgs/development/tools/container-linux-config-transpiler/default.nix
+++ b/pkgs/development/tools/container-linux-config-transpiler/default.nix
@@ -4,7 +4,7 @@ with lib;
 
 buildGoPackage rec {
   name = "ct-${version}";
-  version = "0.4.1";
+  version = "0.5.0";
 
   goPackagePath = "github.com/coreos/container-linux-config-transpiler";
 
@@ -12,7 +12,7 @@ buildGoPackage rec {
     owner = "coreos";
     repo = "container-linux-config-transpiler";
     rev = "v${version}";
-    sha256="1017xkinja30jcam8p1x2d9q4vkgkfn7gvkad004jkbbmd2216sa";
+    sha256="1gchqvx5a2fhw9bw359azd9zg8d6h50gkzfz21c41vkjln2z6jq6";
   };
 
   buildFlagsArray = ''


### PR DESCRIPTION
###### Motivation for this change

Outdated package.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

