### PR TITLE
rpcbind: Patch for CVE-2017-8779

### DIFF
--- a/pkgs/servers/rpcbind/default.nix
+++ b/pkgs/servers/rpcbind/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, libnsl, libtirpc
+{ fetchurl, stdenv, pkgconfig, libnsl, libtirpc, fetchpatch
 , useSystemd ? true, systemd }:
 
 stdenv.mkDerivation rec {
@@ -12,6 +12,11 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./sunrpc.patch
+    (fetchpatch {
+      name = "CVE-2017-8779.patch";
+      url = "https://raw.githubusercontent.com/guidovranken/rpcbomb/e6da9e489aa8ad000b0ad5ac9abc5b4eefc3a769/rpcbind_patch.txt";
+      sha256 = "0w231w8fxihgrn526np078j3vbj3ylvjvxjmfpjvqhga5zg821ab";
+    })
   ];
 
   buildInputs = [ libnsl libtirpc ]


### PR DESCRIPTION
###### Motivation for this change
Part of vulnerability roundup https://github.com/NixOS/nixpkgs/issues/32117

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

