### PR TITLE
drake-factual: init at 1.0.3

### DIFF
--- a/pkgs/development/tools/build-managers/drake-factual/default.nix
+++ b/pkgs/development/tools/build-managers/drake-factual/default.nix
@@ -34,11 +34,11 @@ stdenv.mkDerivation rec {
 
   phases = [ "unpackPhase" "patchPhase" "configurePhase" "buildPhase" "checkPhase"];
 
-  meta = with stdenv; {
+  meta = with stdenv.lib; {
     description = "a simple-to-use, extensible, text-based data workflow tool that organizes command execution around data and its dependencies";
     homepage = https://github.com/Factual/drake;
-    license = licenses.epl;
-    platforms = lib.platforms.linux;
+    license = licenses.epl10;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ rybern ];
   };
 }

--- a/pkgs/development/tools/build-managers/drake-factual/default.nix
+++ b/pkgs/development/tools/build-managers/drake-factual/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, leiningen, jdk, which, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "drake";
+  numVersion = "1.0.3";
+  version = "v${numVersion}";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "Factual";
+    rev = version;
+    sha256 = "0sm8ghw9x7ba05q6c2gx1my46xigw0a0djjdlrqni2jj3pf0v27w";
+  };
+
+  buildInputs = [ leiningen ];
+  propagatedBuildInputs = [ jdk which ];
+
+  patchPhase = ''
+    sed -i -e "1d" bin/drake
+  '';
+
+  buildPhase = ''
+    chmod +x bin/drake
+    sed -ie '/:main drake.core/a \ \ :local-repo ".m2"' project.clj
+    bin/drake --version
+    mkdir $out
+    mkdir $out/target
+    mkdir $out/bin
+    export DRAKE_HOME=$out
+    mv bin/drake $out/bin
+    mv target/drake-${numVersion}.jar $out/target
+  '';
+
+  phases = [ "unpackPhase" "patchPhase" "configurePhase" "buildPhase" "checkPhase"];
+
+  meta = with stdenv; {
+    description = "a simple-to-use, extensible, text-based data workflow tool that organizes command execution around data and its dependencies";
+    homepage = https://github.com/Factual/drake;
+    license = licenses.epl;
+    platforms = lib.platforms.linux;
+    maintainers = with maintainers; [ rybern ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7238,6 +7238,8 @@ with pkgs;
 
   drake = callPackage ../development/tools/build-managers/drake { };
 
+  drake-factual = callPackage ../development/tools/build-managers/drake-factual { };
+
   drush = callPackage ../development/tools/misc/drush { };
 
   editorconfig-core-c = callPackage ../development/tools/misc/editorconfig-core-c { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

