### PR TITLE
ffmpeg-3.4: apply fix CVE CVE-2017-16840

### DIFF
--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, perl, texinfo, yasm
+{ stdenv, fetchurl, fetchpatch, pkgconfig, perl, texinfo, yasm
 , hostPlatform
 /*
  *  Licensing options (yes some are listed twice, filters and such are not listed)
@@ -238,7 +238,16 @@ stdenv.mkDerivation rec {
     sha256 = "1vzvpx8ixy8m44f8qwp833hv253hpghybgzbc4n8b3div3j0dvmf";
   };
 
-  patchPhase = ''patchShebangs .
+  patches = [
+    (fetchurl {
+      name = "CVE-2017-16840.patch";
+      url = "http://git.videolan.org/?p=ffmpeg.git;a=patch;h=a94cb36ab2ad99d3a1331c9f91831ef593d94f74";
+      sha256 = "0zx0vh110hrykk7j863j04bx6igm2q8dlkv25mf5g4rbxafpqig3";
+    })
+  ];
+
+  prePatch = ''
+    patchShebangs .
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     sed -i 's/#ifndef __MAC_10_11/#if 1/' ./libavcodec/audiotoolboxdec.c
   '' + stdenv.lib.optionalString (frei0r != null) ''

--- a/pkgs/development/libraries/ffmpeg/3.4.nix
+++ b/pkgs/development/libraries/ffmpeg/3.4.nix
@@ -1,4 +1,4 @@
-{ stdenv, callPackage
+{ stdenv, callPackage, fetchpatch
 # Darwin frameworks
 , Cocoa, CoreMedia
 , ...
@@ -9,4 +9,13 @@ callPackage ./generic.nix (args // rec {
   branch = "3.4";
   sha256 = "0pn8g3ab937ahslqd41crk0g4j4fh7kwimsrlfc0rl0pc3z132ax";
   darwinFrameworks = [ Cocoa CoreMedia ];
+
+  patches = [
+    (fetchpatch{
+      name = "CVE-2017-16840.patch";
+      url = "http://git.videolan.org/?p=ffmpeg.git;a=patch;h=a94cb36ab2ad99d3a1331c9f91831ef593d94f74";
+      sha256 = "1rjr9lc71cyy43wsa2zxb9ygya292h9jflvr5wk61nf0vp97gjg3";
+    })
+  ];
+
 })


### PR DESCRIPTION
Details at [1].

[1] http://git.videolan.org/?p=ffmpeg.git;a=commit;h=a94cb36ab2ad99d3a1331c9f91831ef593d94f74

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

