### PR TITLE
peek: init at 1.2.0

### DIFF
--- a/pkgs/applications/video/peek/default.nix
+++ b/pkgs/applications/video/peek/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, gettext, vala, gtk3, wrapGAppsHook
+, gsettings_desktop_schemas }:
+
+stdenv.mkDerivation rec {
+  name = "peek-${version}";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "phw";
+    repo = "peek";
+    rev = version;
+    sha256 = "04sc6gfrqvnx288rmgsywpjx9l6jcfn2qdbwjcbdvx4wl3gna0qm";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig gettext wrapGAppsHook ];
+  buildInputs = [ vala gtk3 gsettings_desktop_schemas ];
+
+  meta = with stdenv.lib; {
+    homepage    = https://github.com/phw/peek;
+    description = "Simple animated GIF screen recorder with an easy to use interface";
+    license     = licenses.gpl3;
+    maintainers = with maintainers; [ puffnfresh ];
+    platforms   = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16183,6 +16183,8 @@ with pkgs;
     inherit (gst_all_1) gstreamer gst-plugins-base;
   };
 
+  peek = callPackage ../applications/video/peek { };
+
   pflask = callPackage ../os-specific/linux/pflask {};
 
   photoqt = libsForQt5.callPackage ../applications/graphics/photoqt { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

