### PR TITLE
ocaml-modules.cstruct: fix homepage eval

### DIFF
--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -1,28 +1,28 @@
 { stdenv, fetchurl, ocaml, jbuilder, findlib, sexplib, ocplib-endian }:
 
 stdenv.mkDerivation rec {
-	name = "ocaml${ocaml.version}-cstruct-${version}";
-	version = "3.0.2";
-	src = fetchurl {
-		url = "https://github.com/mirage/ocaml-cstruct/releases/download/v${version}/cstruct-${version}.tbz";
-		sha256 = "03caxcyzfjmbnnwa15zy9s1ckkl4sc834d1qkgi4jcs3zqchvd8z";
-	};
+  name = "ocaml${ocaml.version}-cstruct-${version}";
+  version = "3.0.2";
+  src = fetchurl {
+    url = "https://github.com/mirage/ocaml-cstruct/releases/download/v${version}/cstruct-${version}.tbz";
+    sha256 = "03caxcyzfjmbnnwa15zy9s1ckkl4sc834d1qkgi4jcs3zqchvd8z";
+  };
 
-	unpackCmd = "tar -xjf $curSrc";
+  unpackCmd = "tar -xjf $curSrc";
 
-	buildInputs = [ ocaml jbuilder findlib ];
+  buildInputs = [ ocaml jbuilder findlib ];
 
-	propagatedBuildInputs = [ sexplib ocplib-endian ];
+  propagatedBuildInputs = [ sexplib ocplib-endian ];
 
-	buildPhase = "jbuilder build -p cstruct";
+  buildPhase = "jbuilder build -p cstruct";
 
-	inherit (jbuilder) installPhase;
+  inherit (jbuilder) installPhase;
 
-	meta = {
-		description = "Access C-like structures directly from OCaml";
-		license = stdenv.lib.licenses.isc;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
-		inherit (src.meta) homepage;
-		inherit (ocaml.meta) platforms;
-	};
+  meta = {
+    description = "Access C-like structures directly from OCaml";
+    license = stdenv.lib.licenses.isc;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    homepage = "https://github.com/mirage/ocaml-cstruct";
+    inherit (ocaml.meta) platforms;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

