### PR TITLE
gnucash26: 2.6.12 -> 2.6.18-1

### DIFF
--- a/pkgs/applications/office/gnucash/2.6.nix
+++ b/pkgs/applications/office/gnucash/2.6.nix
@@ -2,7 +2,7 @@
 , intltool, glib, gtk2, libofx, aqbanking, gwenhywfar, libgnomecanvas, goffice
 , webkit, glibcLocales, gsettings_desktop_schemas, makeWrapper, dconf, file
 , gettext, swig, slibGuile, enchant, bzip2, isocodes, libdbi, libdbiDrivers
-, pango, gdk_pixbuf
+, pango, gdk_pixbuf, fetchpatch
 }:
 
 /*
@@ -19,6 +19,14 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/gnucash/${name}.tar.bz2";
     sha256 = "0x84f07p30pwhriamv8ifljgw755cj87rc12jy1xddf47spyj7rp";
   };
+
+  patches = [
+    (fetchpatch {
+     sha256 = "11nlf9j7jm1i37mfcmmnkplxr3nlf257fxd01095vd65i2rn1m8h";
+     name = "fix-brittle-test.patch";
+     url = "https://github.com/Gnucash/gnucash/commit/42ac55e03a1a84739f4a5b7a247c31d91c0adc4a.patch";
+    })
+  ];
 
   buildInputs = [
     # general
@@ -40,7 +48,7 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
 
-  patchPhase = ''
+  postPatch = ''
   patchShebangs ./src
   '';
 

--- a/pkgs/applications/office/gnucash/2.6.nix
+++ b/pkgs/applications/office/gnucash/2.6.nix
@@ -1,8 +1,9 @@
-{ fetchurl, stdenv, pkgconfig, libxml2, libxslt, perl, perlPackages, gconf, guile
-, intltool, glib, gtk2, libofx, aqbanking, gwenhywfar, libgnomecanvas, goffice
-, webkit, glibcLocales, gsettings_desktop_schemas, makeWrapper, dconf, file
+{ fetchurl, fetchpatch, stdenv, intltool, pkgconfig, file, makeWrapper
+, libxml2, libxslt, perl, perlPackages, gconf, guile
+, glib, gtk2, libofx, aqbanking, gwenhywfar, libgnomecanvas, goffice
+, webkit, glibcLocales, gsettings_desktop_schemas, dconf
 , gettext, swig, slibGuile, enchant, bzip2, isocodes, libdbi, libdbiDrivers
-, pango, gdk_pixbuf, fetchpatch
+, pango, gdk_pixbuf
 }:
 
 /*
@@ -28,9 +29,11 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  nativeBuildInputs = [ intltool pkgconfig file makeWrapper ];
+
   buildInputs = [
     # general
-    intltool pkgconfig libxml2 libxslt glibcLocales file gettext swig enchant
+    libxml2 libxslt glibcLocales gettext swig enchant
     bzip2 isocodes
     # glib, gtk...
     glib gtk2 goffice webkit
@@ -44,12 +47,10 @@ stdenv.mkDerivation rec {
     guile slibGuile
     # database backends
     libdbi libdbiDrivers
-    # build
-    makeWrapper
   ];
 
   postPatch = ''
-  patchShebangs ./src
+    patchShebangs ./src
   '';
 
   configureFlags = [

--- a/pkgs/applications/office/gnucash/2.6.nix
+++ b/pkgs/applications/office/gnucash/2.6.nix
@@ -13,11 +13,11 @@ Two cave-ats right now:
 */
 
 stdenv.mkDerivation rec {
-  name = "gnucash-2.6.12";
+  name = "gnucash-2.6.18-1";
 
   src = fetchurl {
     url = "mirror://sourceforge/gnucash/${name}.tar.bz2";
-    sha256 = "0x84f07p30pwhriamv8ifljgw755cj87rc12jy1xddf47spyj7rp";
+    sha256 = "1794qi7lkn1kbnhzk08wawacfcphbln3ngdl3q0qax5drv7hnwv8";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Updated version, as well as a patch that fixes a known-problematic test (per: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=876306) that manifests itself in current builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

