### PR TITLE
haskell docs: fix typo

### DIFF
--- a/doc/languages-frameworks/haskell.md
+++ b/doc/languages-frameworks/haskell.md
@@ -48,7 +48,7 @@ trouble with packages like `3dmodels` and `4Blocks`, because these names are
 invalid identifiers in the Nix language. The issue of how to deal with these
 rare corner cases is currently unresolved.)
 
-Haskell packages who's Nix name (second column) begins with a `haskell-` prefix
+Haskell packages whose Nix name (second column) begins with a `haskell-` prefix
 are packages that provide a library whereas packages without that prefix
 provide just executables. Libraries may provide executables too, though: the
 package `haskell-pandoc`, for example, installs both a library and an


### PR DESCRIPTION
###### Motivation for this change
Fixes a simple mistake in the Haskell documentation manual.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

