### PR TITLE
tlwg: init at 0.6.4

### DIFF
--- a/pkgs/data/fonts/tlwg/default.nix
+++ b/pkgs/data/fonts/tlwg/default.nix
@@ -1,26 +1,26 @@
-{ stdenv, fetchgit, autoconf, automake, git, fontforge }:
+{ stdenv, fetchFromGitHub, autoreconfHook, fontforge }:
 
 stdenv.mkDerivation rec {
   name = "tlwg-${version}";
   version = "0.6.4";
 
-  src = fetchgit {
-   url = "https://github.com/tlwg/fonts-tlwg";
-   rev = "v${version}";
-   sha256 = "1agvarmcy467y1nk670j3vffgx7ihld4z1l2fpyhbybzqwdp708k";
-   leaveDotGit = true;
+  src = fetchFromGitHub {
+    owner = "tlwg";
+    repo = "fonts-tlwg";
+    rev = "v${version}";
+    sha256 = "13bx98ygyyizb15ybdv3856lkxhx1fss8f7aiqmp0lk9zgw4mqyk";
   };
 
-  preConfigure = ''
-    ./autogen.sh
-  '';
+  nativeBuildInputs = [ autoreconfHook ];
 
-  buildInputs = [ autoconf automake fontforge git ];
+  buildInputs = [ fontforge ];
+
+  preAutoreconf = "echo ${version} > VERSION";
 
   meta = with stdenv.lib; {
     description = "A collection of Thai scalable fonts available under free licenses";
     homepage = https://linux.thai.net/projects/fonts-tlwg;
-    license = [ licenses.gpl2 licenses.publicDomain licenses.lppl13c licenses.free ];
+    license = with licenses; [ gpl2 publicDomain lppl13c free ];
     platforms = platforms.unix;
     maintainers = [ maintainers.yrashk ];
   };

--- a/pkgs/data/fonts/tlwg/default.nix
+++ b/pkgs/data/fonts/tlwg/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchgit, autoconf, automake, git, fontforge }:
+
+stdenv.mkDerivation rec {
+  name = "tlwg-${version}";
+  version = "0.6.4";
+
+  src = fetchgit {
+   url = "https://github.com/tlwg/fonts-tlwg";
+   rev = "v${version}";
+   sha256 = "1agvarmcy467y1nk670j3vffgx7ihld4z1l2fpyhbybzqwdp708k";
+   leaveDotGit = true;
+  };
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  buildInputs = [ autoconf automake fontforge git ];
+
+  meta = with stdenv.lib; {
+    description = "A collection of Thai scalable fonts available under free licenses";
+    homepage = https://linux.thai.net/projects/fonts-tlwg;
+    license = [ licenses.gpl2 licenses.publicDomain licenses.lppl13c licenses.free ];
+    platforms = platforms.unix;
+    maintainers = [ maintainers.yrashk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20041,4 +20041,6 @@ with pkgs;
   };
 
   wal-g = callPackage ../tools/backup/wal-g {};
+
+  tlwg = callPackage ../data/fonts/tlwg { };
 }


### PR DESCRIPTION
A collection of Thai scalable fonts available under free licenses

###### Motivation for this change

tlwg not present in nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

