### PR TITLE
pcre2: Patch for CVE-2017-8786

### DIFF
--- a/pkgs/development/libraries/pcre2/default.nix
+++ b/pkgs/development/libraries/pcre2/default.nix
@@ -29,6 +29,13 @@ stdenv.mkDerivation rec {
       stripLen = 2;
       addPrefixes = true;
     })
+    (fetchpatch {
+      name = "CVE-2017-8786.patch";
+      url = "https://vcs.pcre.org/pcre2/code/trunk/src/pcre2test.c?r1=692&r2=697&view=patch";
+      sha256 = "1c629nzrk4il2rfclwyc1a373q58m4q9ys9wr91zhl4skfk7x19b";
+      stripLen = 2;
+      addPrefixes = true;
+    })
   ];
 
   outputs = [ "bin" "dev" "out" "doc" "man" "devdoc" ];


### PR DESCRIPTION
###### Motivation for this change
Part of https://github.com/NixOS/nixpkgs/issues/32117

The issue here is not in the `pcre2` library but in the `pcre2test` cli utility so the impact is very limited.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

