### PR TITLE
nixos/doc/manual/x-windows: update touchpad from synaptics to libinput

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -115,13 +115,14 @@ hardware.opengl.driSupport32Bit = true;
 <para>Support for Synaptics touchpads (found in many laptops such as
 the Dell Latitude series) can be enabled as follows:
 <programlisting>
-services.xserver.synaptics.enable = true;
+services.xserver.libinput.enable = true;
 </programlisting>
 The driver has many options (see <xref linkend="ch-options"/>).  For
-instance, the following enables two-finger scrolling:
+instance, the following disables tap-to-click behavior:
 <programlisting>
-services.xserver.synaptics.twoFingerScroll = true;
+services.xserver.libinput.tapping = false;
 </programlisting>
+Note: the use of <literal>services.xserver.synaptics</literal> is deprecated since NixOS 17.09.
 </para>
 
 </simplesect>


### PR DESCRIPTION
###### Motivation for this change

The release notes for Nixos 17.09 say: "Touchpad support should now be enabled through libinput as synaptics is now deprecated. See the option services.xserver.libinput.enable."
Because a libinput.twoFingerScroll option doesn't exist, I chose an equivalent boolean option as new example libinput.tapping.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

