### PR TITLE
cnijfilter2: specify --datadir for cnijlgmon3

### DIFF
--- a/pkgs/misc/cups/drivers/cnijfilter2/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter2/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
         --replace /usr/include/libusb-1.0 \
                   ${libusb.dev}/include/libusb-1.0
       ./autogen.sh --prefix=$out --enable-progpath=$out/bin \
+                   --datadir=$out/share \
                    --enable-libdir=/var/cache/cups
       make
     )


### PR DESCRIPTION
If --datadir is not given, it uses '${datarootdir}/cnijlgmon3',
with the unsubstituted variable.

###### Motivation for this change

I have a Canon MG5620 printer which could not print using the cnijfilter2 cups driver. I found that the cnijlgmon3 program was looking for its resource file in the literal `${datarootdir}/cnijlgmon3` directory, which doesn't exist, instead of `$out/share/cnijlgmon3` where the file exists.

By supplying an appropriate `--datadir` argument during the build, `cnijlgmon3` finds its resource file, and I can print.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

