### PR TITLE
ocamlPackages.mlgmpidl: 1.2.4 -> 1.2.6

### DIFF
--- a/pkgs/development/ocaml-modules/mlgmpidl/default.nix
+++ b/pkgs/development/ocaml-modules/mlgmpidl/default.nix
@@ -1,19 +1,20 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, camlidl, gmp, mpfr }:
+{ stdenv, fetchFromGitHub, perl, ocaml, findlib, camlidl, gmp, mpfr }:
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-mlgmpidl-${version}";
-  version = "1.2.4";
+  version = "1.2.6";
   src = fetchFromGitHub {
     owner = "nberth";
     repo = "mlgmpidl";
     rev = version;
-    sha256 = "09f9rk2bavhb7cdwjpibjf8bcjk59z85ac9dr8nvks1s842dp65s";
+    sha256 = "1lq3yy10v3rvlchbl5kl75l9f8frgj6g9f1n14kj5qlxm5xsrvks";
   };
 
-  buildInputs = [ gmp mpfr ocaml findlib camlidl ];
+  buildInputs = [ perl gmp mpfr ocaml findlib camlidl ];
 
   configurePhase = ''
-    cp Makefile.config.model Makefile.config
+    echo CAML_PREFIX = ${ocaml} > Makefile.config
+    cat Makefile.config.model >> Makefile.config
     sed -i Makefile.config \
       -e 's|^MLGMPIDL_PREFIX.*$|MLGMPIDL_PREFIX = $out|' \
       -e 's|^GMP_PREFIX.*$|GMP_PREFIX = ${gmp.dev}|' \


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
