### PR TITLE
nix-bash-completions: 0.5 -> 0.6, nix-zsh-completions: 0.3.5 -> 0.3.6

### DIFF
--- a/pkgs/shells/nix-bash-completions/default.nix
+++ b/pkgs/shells/nix-bash-completions/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "0.5";
+  version = "0.6";
   name = "nix-bash-completions-${version}";
 
   src = fetchFromGitHub {
     owner = "hedning";
     repo = "nix-bash-completions";
     rev = "v${version}";
-    sha256 = "095dbbqssaxf0y85xw73gajif6lzy2aja4scg3plplng3k9zbldz";
+    sha256 = "093rla6wwx51fclh7xm8qlssx70hj0fj23r59qalaaxf7fdzg2hf";
   };
 
   installPhase = ''

--- a/pkgs/shells/nix-zsh-completions/default.nix
+++ b/pkgs/shells/nix-zsh-completions/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub }:
 
 let
-  version = "0.3.5";
+  version = "0.3.6";
 in
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "spwhitt";
     repo = "nix-zsh-completions";
     rev = "${version}";
-    sha256 = "1fp565qbzbbwj99rq3c28gpq8gcnlxb2glj05382zimas1dfd0y9";
+    sha256 = "193yd0c3j62lhy7n7y9l0viwdiymvrfbqcgki69dm2414n3mlh05";
   };
 
   installPhase = ''


### PR DESCRIPTION
Should be safe to backport to 17.09 as there's nothing which depends on these packages. I've tested installation via `nix-env` and haven't seen any regressions.

###### Motivation for this change

The [changelog](https://github.com/hedning/nix-bash-completions/releases/tag/v0.6):

# bash: v0.6, zsh: 0.3.6

The quest for an awesome completion system continues.

The main bulk of changes apply to both ZSH and Bash, with explicit notes otherwise.

## -I/--include <PATH> support

Attribute path completion now takes `-I` and `--include` into account. This makes completion work correctly when doing things like this:
```bash
nix-shell -I nixpkgs=. --packages <tab>
```

When the completion system executes any nix code it will first resolve all URLS in the `NIX_PATH`, and in `-I` input, to a local store path if present. This protects against triggering an intrusive download while completing. `channel:` syntax is correctly translated to its `https://` form and resolved to a cache too.

## --arg and --argstr support

Argument names are now offered as completions using `builtins.functionArgs`. Names already supplied on the command line is excluded from completions. 

Attribute path completion will also take --arg and --argstr into account, which means things like this work:
```bash
nix-instantiate --eval default.nix --argstr bar foo -A <tab>
```
If the content of `default.nix` is `{bar}: {foo = bar;}` then completing will result in `foo`.

## --expr and -E support

Attribute path completion now works for `--expr` input, including argument name completion.

Note, URLs in the expression body is not yet resolved to a local cache so might trigger a download. This should ideally be fixed.

In ZSH `--expr` now behaves properly, allowing completion of options after it has been entered (bash already did the correct thing here).

## Other small fixes and improvements

- Most arguments which expects a `.nix` file will now only offer up those and directories, reducing clutter
- `--file` will now complete more than once, the last one being used to generate attribute matches. In ZSH this allows aliasing `nix-env` to `nix-env -f '<nixpkgs>'` while still getting further `--file` completion which can be used to override the default.
- nix-env now offer `--file` completion together with main operation completion by default. This is a compromise between discover-ability of main operations and the want to specify common options quickly.
- `--add-root` will now off up `/nix/var/nix/gcroots/` by default, if `--indirect` is specified it will give normal directory completion.
- Add missing `--help` and `--version` completion to many commands
- nix-env: `--filter-system` will complete possible systems.
- nix-instantiate: `--find-file` will no longer offer misleading file completion

And a bunch of other small changes and fixes.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

