### PR TITLE
mate-media: init at 1.18

### DIFF
--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -22,6 +22,7 @@ let
     mate-desktop = callPackage ./mate-desktop { };
     mate-icon-theme = callPackage ./mate-icon-theme { };
     mate-icon-theme-faenza = callPackage ./mate-icon-theme-faenza { };
+    mate-media = callPackage ./mate-media { };
     mate-menus = callPackage ./mate-menus { };
     mate-notification-daemon = callPackage ./mate-notification-daemon { };
     mate-panel = callPackage ./mate-panel { };
@@ -56,6 +57,7 @@ let
       engrampa
       eom
       mate-icon-theme-faenza
+      mate-media
       mate-power-manager
       mate-terminal
       pluma

--- a/pkgs/desktops/mate/mate-media/default.nix
+++ b/pkgs/desktops/mate/mate-media/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, pkgconfig, intltool, libtool, libxml2, libcanberra_gtk3, gnome3, mate, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "mate-media-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.18";
+  minor-ver = "0";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "0v19aipqj24367mx82ghkvgnxy1505zd35h50pi30fws36b6plll";
+  };
+
+  buildInputs = [
+    libxml2
+    libcanberra_gtk3
+    gnome3.gtk
+    mate.libmatemixer
+    mate.mate-desktop
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    libtool
+    wrapGAppsHook
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Media tools for MATE";
+    homepage = http://mate-desktop.org;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo maintainers.chpatrick ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

