### PR TITLE
fcitx-skk: init at 0.1.4

### DIFF
--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-skk/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-skk/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, fcitx, libskk, skk-dicts }:
+
+stdenv.mkDerivation rec {
+  name = "fcitx-skk-${version}";
+  version = "0.1.4";
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = "fcitx-skk";
+    rev = "f66d0f56a40ff833edbfa68a4be4eaa2e93d0e3d";
+    sha256 = "1yl2syqrk212h26vzzkwl19fyp71inqmsli9411h4n2hbcp6m916";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ fcitx libskk skk-dicts ];
+
+  cmakeFlags = [ "-DSKK_DEFAULT_PATH=${skk-dicts}/share/SKK-JISYO.combined"
+                 "-DENABLE_QT=FALSE"
+               ];
+  preInstall = ''
+    substituteInPlace src/cmake_install.cmake \
+      --replace ${fcitx} $out
+    substituteInPlace po/cmake_install.cmake \
+      --replace ${fcitx} $out
+    substituteInPlace data/cmake_install.cmake \
+      --replace ${fcitx} $out
+  '';
+
+  meta = with stdenv.lib; {
+    isFcitxEngine = true;
+    description   = "A SKK style input method engine for fcitx";
+    longDescription = ''
+      Fcitx-skk is an input method engine for fcitx. It is based on libskk and thus
+      provides basic features of SKK Japanese input method such as kana-to-kanji conversion,
+      new word registration, completion, numeric conversion, abbrev mode, kuten input,
+      hankaku-katakana input, and re-conversion.
+    '';
+    license       = licenses.gpl3Plus;
+    platforms     = platforms.linux;
+    maintainers   = with maintainers; [ yuriaisaka ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2030,6 +2030,8 @@ with pkgs;
     cloudpinyin = callPackage ../tools/inputmethods/fcitx-engines/fcitx-cloudpinyin { };
 
     libpinyin = callPackage ../tools/inputmethods/fcitx-engines/fcitx-libpinyin { };
+
+    skk = callPackage ../tools/inputmethods/fcitx-engines/fcitx-skk { };
   };
 
   fcitx-configtool = callPackage ../tools/inputmethods/fcitx/fcitx-configtool.nix { };


### PR DESCRIPTION
###### Motivation for this change

(This is a sequel to the pull requests `skktools`: init at 1.3.3 #30778, `skk-dicts`: init at 2017-10-26 #30960 and `libskk`: init at 1.0.2 #32108.)

`fcitx-skk` is a `fcitx` engine that implements the kana-to-kanji conversion logic for the SKK Japanese input method.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

