### PR TITLE
yq: init at 2.3.3

### DIFF
--- a/pkgs/development/tools/yq/default.nix
+++ b/pkgs/development/tools/yq/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, buildPythonApplication, fetchPypi, pyyaml, jq }:
+
+buildPythonApplication rec {
+
+  name = "${pname}-${version}";
+  pname = "yq";
+  version = "2.3.3";
+
+  propagatedBuildInputs = [ pyyaml jq ];
+
+  # ValueError: underlying buffer has been detached
+  doCheck = false;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "14ywdi464z68qclsqzb8r50rzmypknaz74zmpppkahjigfcfppm3";
+  };
+
+  meta = with lib; {
+    description = "Command-line YAML processor - jq wrapper for YAML documents.";
+    homepage = https://pypi.python.org/pypi/yq;
+    license = [ licenses.asl20 ];
+    maintainers = [ maintainers.womfoo ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7779,6 +7779,10 @@ with pkgs;
 
   yodl = callPackage ../development/tools/misc/yodl { };
 
+  yq = callPackage ../development/tools/yq {
+    inherit (python3Packages) buildPythonApplication fetchPypi pyyaml;
+  };
+
   winpdb = callPackage ../development/tools/winpdb { };
 
   grabserial = callPackage ../development/tools/grabserial { };


### PR DESCRIPTION
###### Motivation for this change
new package

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

