### PR TITLE
qemu: fix CVE-2017-15118

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -62,7 +62,12 @@ stdenv.mkDerivation rec {
 
   patches = [ ./no-etc-install.patch ]
     ++ optional nixosTestRunner ./force-uid0-on-9p.patch
-    ++ optional pulseSupport ./fix-hda-recording.patch;
+    ++ optional pulseSupport ./fix-hda-recording.patch
+    ++ [ (fetchpatch {
+           name = "qemu-CVE-2017-15118.patch";
+           url = "http://git.qemu.org/?p=qemu.git;a=patch;h=51ae4f8455c9e32c54770c4ebc25bf86a8128183";
+           sha256 = "0f9i096dz3h1i8g92y99vak23rjs1shf7prlcxqizsz0fah7wx7h"; })
+       ];
 
   hardeningDisable = [ "stackprotector" ];
 


### PR DESCRIPTION
###### Motivation for this change
Fix CVE-2017-15118
See https://lists.gnu.org/archive/html/qemu-devel/2017-11/msg05045.html

###### Things done
Qemu built successfully.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

