### PR TITLE
Curl: Add brotli support

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -8,6 +8,7 @@
 , scpSupport ? false, libssh2 ? null
 , gssSupport ? false, gss ? null
 , c-aresSupport ? false, c-ares ? null
+, brotliSupport ? false, brotli ? null
 }:
 
 assert http2Support -> nghttp2 != null;
@@ -19,6 +20,7 @@ assert !(gnutlsSupport && sslSupport);
 assert gnutlsSupport -> gnutls != null;
 assert scpSupport -> libssh2 != null;
 assert c-aresSupport -> c-ares != null;
+assert brotliSupport -> brotli != null;
 
 stdenv.mkDerivation rec {
   name = "curl-7.57.0";
@@ -47,7 +49,8 @@ stdenv.mkDerivation rec {
     optional c-aresSupport c-ares ++
     optional sslSupport openssl ++
     optional gnutlsSupport gnutls ++
-    optional scpSupport libssh2;
+    optional scpSupport libssh2 ++
+    optional brotliSupport brotli;
 
   # for the second line see https://curl.haxx.se/mail/tracker-2014-03/0087.html
   preConfigure = ''
@@ -64,6 +67,7 @@ stdenv.mkDerivation rec {
       ( if ldapSupport then "--enable-ldap" else "--disable-ldap" )
       ( if ldapSupport then "--enable-ldaps" else "--disable-ldaps" )
       ( if idnSupport then "--with-libidn=${libidn.dev}" else "--without-libidn" )
+      ( if brotliSupport then "--with-brotli" else "--without-brotli" )
     ]
     ++ stdenv.lib.optional c-aresSupport "--enable-ares=${c-ares}"
     ++ stdenv.lib.optional gssSupport "--with-gssapi=${gss}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1639,6 +1639,7 @@ with pkgs;
     idnSupport = true;
     ldapSupport = true;
     gssSupport = true;
+    brotliSupport = true;
   };
 
   curl = callPackage ../tools/networking/curl rec {


### PR DESCRIPTION
Adds `brotli` compression support to curl

Depends on these two PRs:
~~https://github.com/NixOS/nixpkgs/pull/32161~~ (merged!)
~~https://github.com/NixOS/nixpkgs/pull/32123~~ (merged!)

~~When these are merged and the stars are aligned I will rebase this one.~~ (done!)

While I would like to enable `brotli` by default it's a bit tricky because of circular dependencies.

###### Motivation for this change
Adds brotli support to curl

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

