### PR TITLE
python3Packages.git-annex-adapter: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/git-annex-adapter/default.nix
+++ b/pkgs/development/python-modules/git-annex-adapter/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, buildPythonPackage, isPy3k, fetchFromGitHub, fetchurl
+, eject, pygit2, gitMinimal, git-annex }:
+
+buildPythonPackage rec {
+  pname = "git-annex-adapter";
+  version = "0.2.0";
+  name = "${pname}-${version}";
+
+  disabled = (!isPy3k);
+
+  # There is only a wheel on PyPI - build from source instead
+  src = fetchFromGitHub {
+    owner = "alpernebbi";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1sbgp4ivgw4m8nngrlb1f78xdnssh639c1khv4z98753w3sdsxdz";
+  };
+
+  prePatch = ''
+    substituteInPlace git_annex_adapter/process.py \
+      --replace "'git', 'annex'" "'${git-annex}/bin/git-annex'" \
+      --replace "'git-annex'" "'${git-annex}/bin/git-annex'"
+  '';
+
+  # TODO: Remove for next version
+  patches = fetchurl {
+    url = "https://github.com/alpernebbi/git-annex-adapter/commit/9f64c4b99cae7b681820c6c7382e1e40489f4d1e.patch";
+    sha256 = "1hbw8651amjskakvs1wv2msd1wryrq0vpryvbispg5267rs8q7hp";
+  };
+
+  nativeBuildInputs = [
+    eject # `rev` is needed in tests/test_process.py
+  ];
+
+  propagatedBuildInputs = [ pygit2 gitMinimal ];
+
+  buildInputs = [ git-annex ];
+
+  checkPhase = ''
+    python -m unittest
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/alpernebbi/git-annex-adapter;
+    description = "Call git-annex commands from Python";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5449,6 +5449,10 @@ in {
     };
   };
 
+  git-annex-adapter = callPackage ../development/python-modules/git-annex-adapter {
+    inherit (pkgs.gitAndTools) git-annex;
+  };
+
   google-cloud-sdk = callPackage ../tools/admin/google-cloud-sdk { };
   google-cloud-sdk-gce = callPackage ../tools/admin/google-cloud-sdk { with-gce=true; };
 


### PR DESCRIPTION
###### Motivation for this change
See #30411.
Now it also works if neither `git-annex` nor `git` are installed.

`gitMinimal` is required as a propagatedBuildInput. Otherwise, I get the following error:
```
git-annex: git: createProcess: runInteractiveProcess: exec: does not exist (No such file or directory)
```
As discussed in #32011, this is because `git-annex` needs `git` in the path.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

