### PR TITLE
Fix/lm sensors sensord

### DIFF
--- a/pkgs/os-specific/linux/lm-sensors/default.nix
+++ b/pkgs/os-specific/linux/lm-sensors/default.nix
@@ -1,9 +1,14 @@
-{ stdenv, fetchurl, bison, flex, which, perl }:
+{ sensord ? false,
+  stdenv, fetchurl, bison, flex, which, perl,
+  rrdtool ? null
+}:
+
+assert sensord -> rrdtool != null;
 
 stdenv.mkDerivation rec {
   name = "lm-sensors-${version}";
   version = "3.4.0"; # don't forget to tweak fedoraproject mirror URL hash
-  
+
   src = fetchurl {
     urls = [
       "http://dl.lm-sensors.org/lm-sensors/releases/lm_sensors-${version}.tar.bz2"
@@ -12,10 +17,12 @@ stdenv.mkDerivation rec {
     sha256 = "07q6811l4pp0f7pxr8bk3s97ippb84mx5qdg7v92s9hs10b90mz0";
   };
 
-  buildInputs = [ bison flex which perl ];
+  buildInputs = [ bison flex which perl ]
+   ++ stdenv.lib.optional sensord rrdtool;
 
   preBuild = ''
-    makeFlagsArray=(PREFIX=$out ETCDIR=$out/etc)
+    makeFlagsArray=(PREFIX=$out ETCDIR=$out/etc
+    ${stdenv.lib.optionalString sensord "PROG_EXTRA=sensord"})
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
See  #17040

###### Things done
This patch adds a new variable "sensord". When it's set to true lm-sensors are build with sensord. Rrdtool is added optionally when sensord = true, since it's a dependency for it. By default sensord is false.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

