### PR TITLE
qt48: match whitespace in context of patch to better apply on @dtzWill's tree and maybe future nixpkgs too

### DIFF
--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -128,7 +128,7 @@ stdenv.mkDerivation rec {
 
   postConfigure = ''
     echo "applying patch ${./parallel-build.patch}"
-    patch -p1 < ${./parallel-build.patch}
+    patch -p1 -i ${./parallel-build.patch}
   '';
 
   prefixKey = "-prefix ";

--- a/pkgs/development/libraries/qt-4.x/4.8/parallel-build.patch
+++ b/pkgs/development/libraries/qt-4.x/4.8/parallel-build.patch
@@ -1,6 +1,6 @@
 --- a/tools/designer/src/lib/Makefile
 +++ b/tools/designer/src/lib/Makefile
 @@ -7167,2 +7167,3 @@ compiler_moc_header_clean:
-                .uic/release-shared/ui_qtgradientviewdialog.h \
-+               .uic/release-shared/ui_qtgradientview.h \
-                ../../../shared/qtgradienteditor/qtgradientviewdialog.h
+ 		.uic/release-shared/ui_qtgradientviewdialog.h \
++		.uic/release-shared/ui_qtgradientview.h \
+ 		../../../shared/qtgradienteditor/qtgradientviewdialog.h


### PR DESCRIPTION
Patch may work as-is but silently does the wrong thing in my build,
eventually failing with make complaining about tabs vs spaces
due to the added line being inserted in the wrong place :(.

On a whim/hunch I tried fixing the use of tabs in the patch
to match the context and it seems to do the right thing.

###### Motivation for this change

Maybe tabs were originally used in the patch but overzealous whitespace git settings interfered along the way? Dunno.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
