### PR TITLE
weechat: default to enabling all plugins

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -667,11 +667,13 @@ cp ${myEmacsConfig} $out/share/emacs/site-lisp/default.el
 <section xml:id="sec-weechat">
 <title>Weechat</title>
 <para>
-Weechat can currently be configured to include your choice of plugins.
-To make use of this functionality, install an expression that overrides its configuration such as
+Weechat can be configured to include your choice of plugins, reducing its
+closure size from the default configuration which includes all available
+plugins.  To make use of this functionality, install an expression that
+overrides its configuration such as
 <programlisting>weechat.override {configure = {availablePlugins, ...}: {
-        plugins = with availablePlugins; [ python perl ];
-    }
+    plugins = with availablePlugins; [ python perl ];
+  }
 }</programlisting>
 </para>
 <para>

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -11,7 +11,7 @@
 , rubySupport ? true, ruby
 , tclSupport ? true, tcl
 , extraBuildInputs ? []
-, configure ? null
+, configure ? { availablePlugins, ... }: { plugins = builtins.attrValues availablePlugins; }
 , runCommand }:
 
 let
@@ -121,9 +121,9 @@ in if configure == null then weechat else
         ln -s $plugin $out/plugins
       done
     '';
-  in writeScriptBin "weechat" ''
+  in (writeScriptBin "weechat" ''
     #!${stdenv.shell}
     export WEECHAT_EXTRA_LIBDIR=${pluginsDir}
     ${lib.concatMapStringsSep "\n" (p: lib.optionalString (p ? extraEnv) p.extraEnv) plugins}
     exec ${weechat}/bin/weechat "$@"
-  ''
+  '') // { unwrapped = weechat; }


### PR DESCRIPTION
###### Motivation for this change
Since a few people have been confused by the absence of python support in the weechat attribute in nixpkgs, provide all plugins by default. Comments on the interface or the principle welcome!

Plain weechat is still accessible as `weechat.unwrapped` or `weechat.override {configure = null;}`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).