### PR TITLE
apt-dater: init at 1.0.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -204,7 +204,6 @@
   elijahcaine = "Elijah Caine <elijahcainemv@gmail.com>";
   elitak = "Eric Litak <elitak@gmail.com>";
   ellis = "Ellis Whitehead <nixos@ellisw.net>";
-  enko = "Tim Schumacher <tim@schumacher.im>";
   eperuffo = "Emanuele Peruffo <info@emanueleperuffo.com>";
   epitrochoid = "Mabry Cervin <mpcervin@uncg.edu>";
   eqyiel = "Ruben Maher <r@rkm.id.au>";

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -204,6 +204,7 @@
   elijahcaine = "Elijah Caine <elijahcainemv@gmail.com>";
   elitak = "Eric Litak <elitak@gmail.com>";
   ellis = "Ellis Whitehead <nixos@ellisw.net>";
+  enko = "Tim Schumacher <tim@schumacher.im>";
   eperuffo = "Emanuele Peruffo <info@emanueleperuffo.com>";
   epitrochoid = "Mabry Cervin <mpcervin@uncg.edu>";
   eqyiel = "Ruben Maher <r@rkm.id.au>";

--- a/pkgs/tools/package-management/apt-dater/default.nix
+++ b/pkgs/tools/package-management/apt-dater/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub
-, automake115x, autoconf, pkgconfig, gettext
+, automake, autoconf, pkgconfig, gettext
 , vim, glib, libxml2, openssl, ncurses, popt, screen
 }:
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pkgconfig automake115x autoconf gettext
+    pkgconfig automake autoconf gettext
   ];
 
   buildInputs = [

--- a/pkgs/tools/package-management/apt-dater/default.nix
+++ b/pkgs/tools/package-management/apt-dater/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "DE-IBH";
     repo = "apt-dater";
-    rev = "v1.0.3";
+    rev = "v${version}";
     sha256 = "1flr6cm72cywmwp5h7pbmmpq057xsi9shkczyplxqaqrb2gns5fl";
   };
 
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       number of remote hosts using SSH. It supports Debian-based managed hosts
       as well as rug (e.g. openSUSE) and yum (e.g. CentOS) based systems.
     '';
-    license = licenses.gpl2;
-    maintainers = with maintainers; [ enko ];
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ c0bw3b ];
   };
 }

--- a/pkgs/tools/package-management/apt-dater/default.nix
+++ b/pkgs/tools/package-management/apt-dater/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub
-, automake, autoconf, pkgconfig, gettext
+, autoreconfHook, pkgconfig, gettext
 , vim, glib, libxml2, openssl, ncurses, popt, screen
 }:
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pkgconfig automake autoconf gettext
+    pkgconfig autoreconfHook gettext
   ];
 
   buildInputs = [

--- a/pkgs/tools/package-management/apt-dater/default.nix
+++ b/pkgs/tools/package-management/apt-dater/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl
+{ stdenv, fetchFromGitHub
 , automake115x, autoconf, pkgconfig, gettext
 , vim, glib, libxml2, openssl, ncurses, popt, screen
 }:
@@ -7,9 +7,11 @@ stdenv.mkDerivation rec {
   name = "apt-dater-${version}";
   version = "1.0.3";
 
-  src = fetchurl {
-    url = "https://github.com/DE-IBH/apt-dater/archive/v${version}.tar.gz";
-    sha256 = "891b15e4dd37c7b35540811bbe444e5f2a8d79b1c04644730b99069eabf1e10f";
+  src = fetchFromGitHub {
+    owner = "DE-IBH";
+    repo = "apt-dater";
+    rev = "v1.0.3";
+    sha256 = "1flr6cm72cywmwp5h7pbmmpq057xsi9shkczyplxqaqrb2gns5fl";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/package-management/apt-dater/default.nix
+++ b/pkgs/tools/package-management/apt-dater/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, automake115x, autoconf, vim, glib, clang, libxml2, fetchurl, openssl, ncurses, pkgconfig, popt, screen, gettext }:
+{ stdenv, fetchurl
+, automake115x, autoconf, pkgconfig, gettext
+, vim, glib, libxml2, openssl, ncurses, popt, screen
+}:
 
 stdenv.mkDerivation rec {
   name = "apt-dater-${version}";
@@ -9,24 +12,36 @@ stdenv.mkDerivation rec {
     sha256 = "891b15e4dd37c7b35540811bbe444e5f2a8d79b1c04644730b99069eabf1e10f";
   };
 
-  buildInputs = [ clang libxml2 pkgconfig ncurses automake115x autoconf vim glib popt screen gettext ];
+  nativeBuildInputs = [
+    pkgconfig automake115x autoconf gettext
+  ];
+
+  buildInputs = [
+    libxml2 ncurses vim glib popt screen
+  ];
 
   configureFlags = [ "--disable-history" ];
 
   prePatch = ''
-    substituteInPlace etc/Makefile.am --replace 02770 0770
+    substituteInPlace etc/Makefile.am \
+      --replace 02770 0770
   '';
 
   postPatch = ''
-    substituteInPlace configure.ac --replace "/usr/bin/screen" "${screen}/bin/screen"
+    substituteInPlace configure.ac \
+      --replace "/usr/bin/screen" "${screen}/bin/screen"
   '';
 
   doCheck = true;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/DE-IBH/apt-dater;
-    description = "terminal-based remote package update manager";
-    longDescription = "apt-dater provides an ncurses frontend for managing package updates on a large number of remote hosts using SSH. It supports Debian-based managed hosts as well as rug (e.g. openSUSE) and yum (e.g. CentOS) based systems.";
+    description = "Terminal-based remote package update manager";
+    longDescription = ''
+      Provides an ncurses frontend for managing package updates on a large
+      number of remote hosts using SSH. It supports Debian-based managed hosts
+      as well as rug (e.g. openSUSE) and yum (e.g. CentOS) based systems.
+    '';
     license = licenses.gpl2;
     maintainers = with maintainers; [ enko ];
   };

--- a/pkgs/tools/package-management/apt-dater/default.nix
+++ b/pkgs/tools/package-management/apt-dater/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, automake115x, autoconf, vim, glib, clang, libxml2, fetchurl, openssl, ncurses, pkgconfig, popt, screen, gettext }:
+
+stdenv.mkDerivation rec {
+  name = "apt-dater-${version}";
+  version = "1.0.3";
+
+  src = fetchurl {
+    url = "https://github.com/DE-IBH/apt-dater/archive/v${version}.tar.gz";
+    sha256 = "891b15e4dd37c7b35540811bbe444e5f2a8d79b1c04644730b99069eabf1e10f";
+  };
+
+  buildInputs = [ clang libxml2 pkgconfig ncurses automake115x autoconf vim glib popt screen gettext ];
+
+  configureFlags = [ "--disable-history" ];
+
+  prePatch = ''
+    substituteInPlace etc/Makefile.am --replace 02770 0770
+  '';
+
+  postPatch = ''
+    substituteInPlace configure.ac --replace "/usr/bin/screen" "${screen}/bin/screen"
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/DE-IBH/apt-dater;
+    description = "terminal-based remote package update manager";
+    longDescription = "apt-dater provides an ncurses frontend for managing package updates on a large number of remote hosts using SSH. It supports Debian-based managed hosts as well as rug (e.g. openSUSE) and yum (e.g. CentOS) based systems.";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ enko ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -563,6 +563,8 @@ with pkgs;
     stdenv = overrideCC stdenv gcc5;
   };
 
+  apt-dater = callPackage ../tools/package-management/apt-dater { };
+
   autorevision = callPackage ../tools/misc/autorevision { };
 
   bcachefs-tools = callPackage ../tools/filesystems/bcachefs-tools { };


### PR DESCRIPTION
###### Motivation for this change

I'm personaly using this nix package all the time and dont want it to get lost if my machine might breaks and I thought others might need this too.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

