### PR TITLE
pam-sshagent: only allow managed SSH keys

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -257,7 +257,7 @@ let
           ${optionalString cfg.logFailures
               "auth required pam_tally.so"}
           ${optionalString (config.security.pam.enableSSHAgentAuth && cfg.sshAgentAuth)
-              "auth sufficient ${pkgs.pam_ssh_agent_auth}/libexec/pam_ssh_agent_auth.so file=~/.ssh/authorized_keys:~/.ssh/authorized_keys2:/etc/ssh/authorized_keys.d/%u"}
+              "auth sufficient ${pkgs.pam_ssh_agent_auth}/libexec/pam_ssh_agent_auth.so file=/etc/ssh/authorized_keys.d/%u"}
           ${optionalString cfg.fprintAuth
               "auth sufficient ${pkgs.fprintd}/lib/security/pam_fprintd.so"}
           ${optionalString cfg.u2fAuth


### PR DESCRIPTION
[Breaking change]

Fixes #31611. If people have self-managed SSH keys in ~/.ssh, they will no longer be able to use those to get sudo access.

Update: This needs to be made configurable first, see the comment below. Basically, enable it if openssh non-managed keys are enabled, and allow overriding?