### PR TITLE
purescript: fix build by overriding optparse-applicative dependency

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -454,9 +454,9 @@ self: super: {
   threads = dontCheck super.threads;
 
   # https://github.com/NixOS/nixpkgs/issues/32138
-  purescript = super.purescript.overrideScope (self: super: {
+  purescript = super.purescript.override {
     optparse-applicative = self.optparse-applicative_0_14_0_0;
-  });
+  };
 
   # Missing module.
   rematch = dontCheck super.rematch;            # https://github.com/tcrayford/rematch/issues/5

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -453,8 +453,10 @@ self: super: {
   # https://github.com/basvandijk/threads/issues/10
   threads = dontCheck super.threads;
 
-  # https://github.com/purescript/purescript/pull/3041
-  purescript = doJailbreak super.purescript;
+  # https://github.com/NixOS/nixpkgs/issues/32138
+  purescript = super.purescript.overrideScope (self: super: {
+    optparse-applicative = self.optparse-applicative_0_14_0_0;
+  });
 
   # Missing module.
   rematch = dontCheck super.rematch;            # https://github.com/tcrayford/rematch/issues/5


### PR DESCRIPTION
###### Motivation for this change

This PR fixes the build for the haskell `purescript` package. `purescript-0.11.7` depends on `optparse-applicative-0.14.0.0` and fails to build with the previous `optparse-applicative-0.13.*`

Related issue #32138 

Note: I have also removed `doJailbreak` as it no longer seemed necessary.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

