### PR TITLE
rtags: 2.15 -> 2.16

### DIFF
--- a/pkgs/development/tools/rtags/default.nix
+++ b/pkgs/development/tools/rtags/default.nix
@@ -2,19 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "rtags-${version}";
-  version = "2.15";
+  version = "2.16";
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ llvmPackages.llvm openssl emacs ]
     ++ lib.optionals stdenv.cc.isGNU [ llvmPackages.clang-unwrapped ]
     ++ lib.optionals stdenv.isDarwin [ apple_sdk.libs.xpc apple_sdk.frameworks.CoreServices ];
 
-
   src = fetchgit {
     rev = "refs/tags/v${version}";
     fetchSubmodules = true;
     url = "https://github.com/andersbakken/rtags.git";
-    sha256 = "12nnyav2q1ddkz9wm0aclhn7r74xj4ibrb0x05k7mcf694bg79c0";
+    sha256 = "15qmwkajw2zzfnw9hnv08p0asa6prg88nvqlxmv56c0dyhldjpkm";
     # unicode file names lead to different checksums on HFS+ vs. other
     # filesystems because of unicode normalisation
     postFetch = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

