### PR TITLE
amazon-image: use NTP provided by the hypervisor

### DIFF
--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -152,5 +152,8 @@ let cfg = config.ec2; in
     environment.systemPackages = [ pkgs.cryptsetup ];
 
     boot.initrd.supportedFilesystems = [ "unionfs-fuse" ];
+    
+    # EC2 has its own NTP server provided by the hypervisor
+    networking.timeServers = [ "169.254.169.123" ];
   };
 }


### PR DESCRIPTION
See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html for more information.

Fixes #32187

I don't feel strongly on whether to backport to 17.09. @globin @fpletz?

###### Motivation for this change

This allows our AWS AMI to work seamlessly with correct time even when started in a VPC with no internet connectivity.
