### PR TITLE
elm-interface-to-json: init at 0.1

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -72,7 +72,7 @@ let
             where foo is a tag for a new version, for example "0.3.1-alpha".
             */
             elm-format = self.callPackage ./packages/elm-format.nix { };
-
+            elm-interface-to-json = self.callPackage ./packages/elm-interface-to-json.nix { };
           };
       in elmPkgs // {
         inherit elmPkgs;

--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -72,7 +72,9 @@ let
             where foo is a tag for a new version, for example "0.3.1-alpha".
             */
             elm-format = self.callPackage ./packages/elm-format.nix { };
-            elm-interface-to-json = self.callPackage ./packages/elm-interface-to-json.nix { };
+            elm-interface-to-json = self.callPackage ./packages/elm-interface-to-json.nix {
+              aeson-pretty = self.aeson-pretty_0_7_2;
+            };
           };
       in elmPkgs // {
         inherit elmPkgs;

--- a/pkgs/development/compilers/elm/packages/elm-interface-to-json.nix
+++ b/pkgs/development/compilers/elm/packages/elm-interface-to-json.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, aeson, aeson-pretty, base, binary, bytestring
+, concatenative, containers, directory, either, elm-compiler
+, filemanip, filepath, indents, optparse-applicative, parsec
+, stdenv, text, transformers, fetchgit
+}:
+mkDerivation {
+  pname = "elm-interface-to-json";
+  version = "0.1.0.0";
+  src = fetchgit {
+    url = "https://github.com/stoeffel/elm-interface-to-json";
+    sha256 = "1izc78w91m7nrc9i2b3lgy3kyjsy4d5mkkblx96ws0bp3dpm5f9k";
+    rev = "9884c1c997a55f11cf7c3d99a8afa72cf2e97323";
+  };
+  isLibrary = false;
+  isExecutable = true;
+  jailbreak = true;
+  executableHaskellDepends = [
+    aeson aeson-pretty base binary bytestring concatenative containers
+    directory either elm-compiler filemanip filepath indents
+    optparse-applicative parsec text transformers
+  ];
+  homepage = "https://github.com/githubuser/elm-interface-to-json#readme";
+  license = stdenv.lib.licenses.bsd3;
+}


### PR DESCRIPTION
###### Motivation for this change

This is needed for elm-test to work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

