### PR TITLE
 firefox: 57.0 -> 57.0.1,  firefox-esr: 52.5.0esr -> 52.5.1esr 

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,955 +1,955 @@
 {
-  version = "57.0";
+  version = "57.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/ach/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/ach/firefox-57.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "dd75abc1ff917398dbb8dd6821f6cff4d925870fb4eb654f18329ceabefc537ae3c908abfdf2f2f836aacdef67ca251645bca2a14c7b39ddd7e57b9eda537503";
+      sha512 = "b98a06b55d43f7a8e8c6acc9ca303bfcb9fc331929199ccff1eafcc9be486ea2848fdca977bebfcd999c81bab7cede0d85edd0f3d3c0147958fda318b4259de0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/af/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/af/firefox-57.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "eab1f1eb0e5931adc06525fbc68960b70b80fc070077c10c7eaf7fbe4be8d4db404aa74e35b83d5c1faac6a78782725cff8328d99f20d2a35f1527eb47c3bce7";
+      sha512 = "e414c270ee2213577dd9049ab711e33f151dd87a3e3345ddd5abd16e413f4b510c6beecce5837908e2221894ad86d1bc3f22c1c5a67a606a8d112a24f0eee089";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/an/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/an/firefox-57.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "384b37825ec8a55d91467a26ff9b14a1c707babb9ef5cd8ad0a73581dfe42ccce5915f3f0fa8e3afe41b870f858b4c27b3ad95a2bb34106b0412a7ee53d606bc";
+      sha512 = "2766735ef82c7a2df8e822a1e433789f6e5708f42f7b4bcea008f7926b7312bc44860fb4c6a90afd1b2ad8de251d49139ecbe05b8900d60a0c58f29caffa62ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/ar/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/ar/firefox-57.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "a6ded39d52ec035cb71b816c6c61b81236f808a95538e578faf1e61ce72fdf4869845e23094351da2d4d2bdb3e01814d864f257730742b807b92cab008a472d6";
+      sha512 = "e3ac3271fa93d8f05a0a953cc127e4d3bcf1f032168c372938b3eeba72fe070bc4d67f0027af690559232b6078337d48b3ec0426d3063df1316f669c9763f1be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/as/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/as/firefox-57.0.1.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "a9e77c4dcb3672f917212baa11417cb5e947a561d4f3e5a2695640183c51b521dd8cae0d269c9cb7df1f608d2e82d620d2dc284c1fccd67fa857612b092c37ef";
+      sha512 = "e41bb2bfb0335355b3d09929df578c3081277cf08d7e1390d47ac88480c966160064eb1d55395845a000e88c5cec32450ea24c8c440a7d6d7ce284c2833964e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/ast/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/ast/firefox-57.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "07ea65e0c973248c4ed63525e24d09868c879f1eebe2530e8511767867e7954ce3bda16492835187013b134cc085a44d5de3205b1272aab65d16d77573274745";
+      sha512 = "2da56588bf6d6cbb54d20a46b95f36ab75edfc98b74bd0bb13cabce7758c396e5c3bb4e0c1fa4400a0248c7415a0848b823b83b8231c9fcd11e66c00ad9608ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/az/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/az/firefox-57.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "2810713aef462af14be0729488bd05e2992f263940dc11bf544eace53b639f63267ba8468c50b0a00748e8498a64bfb3d42110debf92e0aa4968baea47617038";
+      sha512 = "e4e3058c415c65bba21fca8b0fe078782631e4f8c3ff3aad91cd0b461bb76d614fa89880b51dfc698236b397195922138d9b5bc79e81bab4fa689e850514be9d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/be/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/be/firefox-57.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "d8856fea5d7f52ce22ff6bf2af600695494f458214a5d2de254509fac7d4208b816583068fabfd5d2a1460bff9cecd13d1c0ba0880470b4975eca1f7a7a2eeae";
+      sha512 = "3299c58454a9b31a70beb5e2a422ea067d58655eeead6ff9c03edc224a369dc5cd7cf165e9821d6d9cc5a18eb3ddf28829728308cdf7e7345e9d77159b99380f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/bg/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/bg/firefox-57.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "caae904094224b1c0374a07c22240bf06629b81f475c71ad38835c12cd59de016d05690b1744d5e44384db4c1ca86ab8cca4be6101987c34cb5903d920813f72";
+      sha512 = "091410e6edcd21f3cb2858b3b56908cd8c490bcbe4bc97298c0a5a0abf44f88a05968164511302aac866665045e5bb0fd21ff9d26f52f0ffec4a68312aa440d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/bn-BD/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/bn-BD/firefox-57.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "68004a769f2cb81d8f76b66ce713377a83445ca56aa6baf5adfc2617b85ed54cdcd4b410f415b27368c5437f3af5be882cfc701e10ad77938ab7dc2bd9ac87f4";
+      sha512 = "572bc4cb51992645fd6343bb43b1b32ecc10354250bd68952e519e8c5f1c174e9d5edf3d7e1edc5a080de0b479cb6c8871dca8f8536791d999f1de00379cfd77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/bn-IN/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/bn-IN/firefox-57.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "c1cecadd1ba310335cee4fd31a2754c469a8b70725e01e4b33359878cb104a700d6f8c64b8575d09faf843a635a7c26630cc9ed68daf1a9d93a5e075b25a8caa";
+      sha512 = "3f8ee9adc708fdbb30a996f17bcc9e05ca99c0cc65eabcae3c77440d909cee88151269cb9c7bd03117a71371ace7ad09dad0d0c71a6bbb70a366f5a427c5527b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/br/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/br/firefox-57.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "ba39b82ac0872a958d9fe4c9a20bd7e797c6f20ead48bdc379b56a1d227a6fd6d3f2bae9333a133da8bf86973e98af945431e98d8e18941164c0c6ee10923c84";
+      sha512 = "6421a181eb95d6510d4e81d4dde5b5dfa1f52065ea8aae2074978e22310bcd1ee97d1133021022e4cdebe12cc8aad0e440bdc4baa752504e48dd42e77235a572";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/bs/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/bs/firefox-57.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "99e891b6507cfe76700576211e5ca98bec8172c59733102fcc60fcfb036b9e44e44ec8bb50ea568baaad8777aa09b364aed0c419568c3de15d5abaf6e9fba07a";
+      sha512 = "99b45a418aea334c58ef3e6ea520c1b0376a7fb12da2d635b35117052c40b3d603f52165b88ad00b7c647554939dcada70b8771f60c76cada729e1a864b9ad7d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/ca/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/ca/firefox-57.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "87189530b94e49588c323ef388a34f6e3391d31bb7255109d0f25ad256f298576ebf3b3adb436605c1068d6ccb1fd4bd9350d2c48c5ce1a545ad4e28f11d0bdb";
+      sha512 = "845e4de26819bae1cfb327c44c8e15aa5f96e0d3502e8ca9f3820d6a3f92be3c26adc5728d36d14991812e94207abd3e2a59801006defb59a0c362082838efd7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/cak/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/cak/firefox-57.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "91727c8e30bf12faad978cea98ff2b71c600ec6cbd85ffa603b8de7a70d0d93aafa364275061c7960b4d15e9ac729066fd0b600c1518c73dc1c78d13c93595aa";
+      sha512 = "91c595b26f4f8c7505d760b88d2c194a5fcff3f15ef7f5de6bbe69094e6e8144e0d27075eefa7d5c0850e9bde9b76cdcf50e251dd82c7d3ea743e5408886d24c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/cs/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/cs/firefox-57.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "32d9b6e425bac23ca99ce024668995068cf31b2252dd622886bdae395c10a5e4705b9a3bdcf5f72a090fdaf07d4f1f7264f6dcc16be3909d74b51fbc48bac969";
+      sha512 = "c293daccd96a4d5f41ea38e18ce9119624b58ee6f6fb3fd1ec78e78cb440a58010368024bde08a209b65bf7e7f24303c967572f89db0abd9451bcf02d730bc87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/cy/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/cy/firefox-57.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "aa206dec14352a4289612c6a0e8f11ba9daf3c48cd3943413cf9a2528b81bf25addc9392c47922ba806a29fd717e4c9885f6f0335ed0f4c8e6b2c38c4567983b";
+      sha512 = "0f0b41d26323659c412c718bbb6bb493fe71a6d61a52eee17754ae4c7ad462a0cb5f56106854454e82a2521adf5fd65801f15b4eda17664c6ea81a79611ca8e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/da/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/da/firefox-57.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "af047d43a7898c3f2897d6356d60264b3843fa03c1de95d334a346e5c713303f591dda01d2067677cb3e7d2da465ec4cffc195dfcc5f49ee30e354ebdef0e271";
+      sha512 = "799428869a6b1ae2ead7aa8fdc4c2bfdfd596abda537812e28f48847481851f0d5d4fb457ef99ec32791a430c0a1754bb9955eb8be748211ebb1a935adac503b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/de/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/de/firefox-57.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "009ee8f67aac1639437e340f5f6a67b7e881751923af24d45abc0a458ee1186a4dae6a2b049378855e3982aa01de23d063c0090840d55b966130024cae9b8a6b";
+      sha512 = "1f826477c733bfb4b1e7b8e490edc4d17e0ff607217857c089faca68f1e4cfd045cddcb108b4aeb19f64111299e662003ed8db9eb3a842b7ed87238166094c7c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/dsb/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/dsb/firefox-57.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "49ac45a821d203e1915536b0c478fb4fffe905b4efba50361f10eadb824337bc44d4be0e9a83dc6d0e8cbcc24bc69ed8b2609b766b893432dfe14c19d7f0804e";
+      sha512 = "0a6c1a7811aa7796dfa75249336f8b1c10ed6768cc92f573a8684c7b256a9f274cf10b3f466924800c9f78f480eba3744564472a9ad7636e286809d19b39cd57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/el/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/el/firefox-57.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "055946765db4b9b0b028a94a49cfa21174fa4628c1a6d3d9cdee61fc418f7a0c49fb14515ef57ca802ed4ee90618d5fb3bcf2266f368be1e2c02905e3070298c";
+      sha512 = "bcdf4e2c8dba0157eed7fbb27110ee177c129c5c5c54884d064b1c19ddcdcc53e6c8e22165ee13cda3ba7a35d3679a09e019d44738d20a25272ec2a849403010";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/en-GB/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/en-GB/firefox-57.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "e9e017ac8f12032928f16e698f61f7a1d9b7ca274c0c365873e1853cb70189a08f5bb424351d46568a13412851c639b6b355a7e34af53a2ac68f42acfa45fdcb";
+      sha512 = "1987c0598885adcbd292bfca5d79bb107724e5dcda92416e06d01635c54ae55283547a65fa1bc0c0df9534b09c2da9fdee42617c4afc608b1d519064e9d4184c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/en-US/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/en-US/firefox-57.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "53918eb367fa58b4e54496d186f918a6b9f8dba7dbe3b19608a2a49cc6f5abd656998ac5006845d75a900ccffdc8595bbcee7c365792f80c3322fe2a09e1f6fd";
+      sha512 = "44abb10806a486a58aac7d97fc5d2c36bb93a4a2a5350f121b08828ab7a01831162703c3e623d2b550956de287c9dcc6417aaf0e68ea7124c30483a3ab103fd9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/en-ZA/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/en-ZA/firefox-57.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "bd3f538c644c5164f21d7f14bb1d118b1d788b487158aabf085b43a9a10af4df9079ddbad13427d381566f8841198c16f14ec949b8b4c94edb51e5572685993a";
+      sha512 = "efffecd63430f61d94e8e06436ee0831a502849ace4991109c0520fabd053fbc81f16dd63d499c2b225c2dd7a71fdc51d68a1efaa8b90dfa96a65b89165bffd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/eo/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/eo/firefox-57.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "e149060c094d856b98fc6fbe3dcea5ff632f2886e872e753e4416a9461956e1ae62491a052d115c4bae879382915d8df8d15c4b1aa6ccd4aa25464e2a2da8a4c";
+      sha512 = "60f713c6d739c2602c9699b356b645481e347f43a76adaa4836756b03bf536f1d359c7f6e025deeddd457007a44ea5bad9b1ead90af9ab5a2467703cd30a8ade";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/es-AR/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/es-AR/firefox-57.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "34b4d77e53ac80dbead9b4bcc32a6de1a08cadd23efbc203318f3b9c312334efddfa5c0cc15b21fd7c21f64fe74f52e4aeb27f9dc5039599f19faa87143a0cca";
+      sha512 = "e4dc9a067a5cdfad9e1528be6071e67e425fdc7ad0d395d4e86f19db6356bae3191b7d3be32c43ddc7fe3a887a0242e26a6072c7a1bab37020ec49f9f5cca245";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/es-CL/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/es-CL/firefox-57.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "8d379162adce9913f14c4ba9e6bca43fec2e49db6543adde894d1735ed8dc548970a61b2338e088f65a1c9410722bc683436c11f7f62ea46bb8f5a1565b25faf";
+      sha512 = "739670dad0bf99bb4adf2437bd76d87f9099e724edd2ce97a76835b980b5390bd72a3e77aa261e3787846a1e2a046c27dee912386a0ff5d6710ff9d2bf6b2d08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/es-ES/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/es-ES/firefox-57.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "8b3ab31799d6b636bdb8dd78a2e7e3c482169b9e09dc5b8d403e080c41404fe0a803d315b00b4c047adfb7871ba29fd1aa93c600e3b76747bc3091f1613c48c9";
+      sha512 = "5c0a3a5e047792edf0f98d3b3c5a7ce0af0a47df0bdee82a2c20b684d6802c0f33a3f5be436747647acfbbd9984378a7a81f4e82455ca4ac971cdb2a65da3858";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/es-MX/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/es-MX/firefox-57.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "fdd08f2e2fa4cfa2f88edcdb1781f06b87a8deed929eae5fcad733ceca93db5bf750c83d0d5b5e37eb1094ecd68f5958e65fb5f905e2ff401433b3c6ea4ff869";
+      sha512 = "57060bbc7cc53d8b11df426a98fa887197c9a4ff0b3377119ab3ae6b7042428109660e02ff2002476bdea6ef53a8417665e9d5150b3be7ec7bd312895c1fb07a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/et/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/et/firefox-57.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "21f4cd8a7f8964f25013c3d3e2c261489790c9ae54ca765da3199c71c887cce955a710eed744b4f763d123bcaaa86c6bb154b1a6f9c933cb4e799cfced8ae153";
+      sha512 = "eeeacd6e9ba7a698c7644489af9bf39b32a1b1eb99cb5a714e331962b8852f10f4db0bf95554778853c8c56fd1f6fda74d5677e3548252f1c822c531e66f9c13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/eu/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/eu/firefox-57.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "dc8337134ebd464d990ebafb4c04a0a57f84f5a013f7a3dd535be454d0588e62d1df796891593c5e48c4475f4b863cdedccce6548294e1799b8fb8548bf17651";
+      sha512 = "c67ca8a2448e54b1b55c797a08d0d6c1c99709038077ab5497d322a4754dc41dbfce1c46ad26ad9ce8113a608eb7354fba441ecd747beb097c31a00fd7d869ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/fa/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/fa/firefox-57.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "a8464c89ea4d9df863eb02850fb4a27b2dc5f65c5e85849f4ce302d4a7c0531e1bd0b3c1f2a6696ec101c509a8cdc87c91fb1bcbedb0dffe0cab9359e7d584b2";
+      sha512 = "3ab647639452291bc353824322edbf25720b05378769f6ad038f7e2012f148d158e916aef067befcc471c56495061c8e429c07867c704d71e1bda864d60e0adc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/ff/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/ff/firefox-57.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "92fc49c3f38a3bec9608c1a5aac89eda97e970f64a6ee0f90e1cb1e8ac98a4261307b18d3bb906bb66a20adf161118744a297f2072900b11a17e548c31b8baa8";
+      sha512 = "a336ae6bde99dc668f62e3910419e7916f439a7ddaeaeffc650723ac20218dbff7a8929622fff43c1d409c7e54db6047034b53cf937f819fbdac018e3e461a71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/fi/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/fi/firefox-57.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "8c03f59ee65e22299aa04296530f6d21f036ae495862f80c4fa0ec97fe728fe440c723599bf0a66f088050bf40518ff15f62b526c3491c26812ffc72336019a7";
+      sha512 = "8697094c8bffdfde8c921e12617aa1b493962ed1794aaf9d15ea53943244b4aea007fe3a54c28f5e2b611f3d11635f4fb0b7391f6c8a3d23eb8d3c3945b72455";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/fr/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/fr/firefox-57.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "3ae19adc3840c503f762e1625cee9b7b009f8b577f1e498ec1f2b05dac0ca827c957b9ac239a4877e151f8e6f4167111630f0f0bfeb4068c8e892d4ead9f13b5";
+      sha512 = "b1eb6b13b204d9273c14302e5486dff516b00d67b2c40bd8cbd13abf2d8925fd2429adbf650c89c0106dd3d74ef145a073ff69bd587524a373ddf3e0caa072de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/fy-NL/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/fy-NL/firefox-57.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "fc4485f1bcdc129e8199a6e46b8bc4df9a3db3940efde49be569d8d56bd77a932ad69d512d875742e2a2653dfe11c933c83c22303838483ae64e038b947e531c";
+      sha512 = "f900630803facb35837054d2134a1e6bc72fab5fe57e68d8e34c9436f8ce9acf34041f64140d2bed3a6214b7a6eadb3d34d4a91408db729f6e466a89a751850a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/ga-IE/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/ga-IE/firefox-57.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "b306831c247b8db75db2b7faedfc382b0da7d9eb54fe25b1b540b65a1127ac1e672aa56e3c87089d6bbbedc984e2f571611cab0fb2c1d839aa1710ebb2868ec7";
+      sha512 = "2b6afdb01faedd8456a6e76911ee28909cd6e5f0ad9406c540645867c9080fcf0df3f5d41b39d5d28cf329ec9dbb44e2f57044a7c9db6bbfb608cd7ed25b4cb4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/gd/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/gd/firefox-57.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "8d0d4c03ac39fb0b29e328a2cb6a1dec6de0fc9fd956ec5a0c6e431b739e3e98583e42c1bd6a37efe0813fb1d76eb9a881d4e1946ecb98416486e8a6e5d0b181";
+      sha512 = "5a643a7cdbc9a3b97aa78cc6bcf815f78820fe03edc14c8c0cb960a8023a4805ebd44d5a26f64163e265facf3e41b5496c488f4b0735154704747034b11a4913";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/gl/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/gl/firefox-57.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "d7acaba4ea2ee4a22ee64bb918083eb652db21be450fe3415aeb2e4591624b4aff364d37cab51f718c832838a2f775f42cb517e9ef6a81aef6aa283ebae35297";
+      sha512 = "53cb8814f1a1984e4ec19d89cf9a15b5f3438904c0346cf68288cd30a3dcfaae5095f29a38b85fcbf89f65ce6f9dc707c9c289c5619500e6ca0333f7c06045cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/gn/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/gn/firefox-57.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "65c97e250d7dfef68fb5c9479e2a5af25e90bed2608ed4f573591483e1c8db2267c035180064adcc11049a14e6b56b19456cf46a1072ecc9ce054ed0b76c17af";
+      sha512 = "c760e2f00d8f444024c6e8ca6125f1aa348f4207a8d43a2dd2bf03fe014236ad6eb5f781cd5e475acb73390e93f3c6d9ce66add2acd02a42913115d417c6ca34";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/gu-IN/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/gu-IN/firefox-57.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "88780984a9f83da05f7bfeb469442796b78c4c1148fd554bb57c2e55d6c56a49c77412358ada670f857e0b1a2b10dc9021bab84ffff2f7d252679c50fd6ea5a3";
+      sha512 = "911019fe7509cef2f1af15536db0a6fda5570a369c48b778960971f6c85ce5c6957765b2475a3f078e8ef674a8dafe74f44383f2fc77579d436313a408010067";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/he/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/he/firefox-57.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "a412169599e4fbe019932751abb67a538870cc3b4c2398d3d021d6176224a8d699291b4b48e5399156a8de8595077bfffea2bd987916c6bcec24487c4dbc916b";
+      sha512 = "098f14d72c2524f205022ea7b76c36396cd9f7fc64b46a7ffd1d1a8a7511ae89ced577651d69caa4a92e2e800d72243b0516c52e50cf852f34f44a6942eb7e23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/hi-IN/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/hi-IN/firefox-57.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "4956f4086e061bb162b024ea249db8192b1179313aa7735bd42b46483939c4773ab2d3d43ffc056a12500c1873b45a5a6251cd1c89647d375dc605ea8e7b0c1a";
+      sha512 = "7676ec73396ad6c110ed97a23a90f9b2ef9336bf819615bf947e5c46d728fcf8e4073754b5560fd25133092de56be30c9cffcb00765415fcc6e22c4fde621b17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/hr/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/hr/firefox-57.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "e0acfa0d4a1b0a228d8f612a742b71b88d9ef569ee263cf0c47d6e7bde108496f36fc60113a3be27a52d45c07ac3878da2bc1c6a47c1a6ef7efe47eea99090db";
+      sha512 = "6beb75b752cd51ea9dd96358709e982f504d1424ccde6e5ab0a9cca2e1e99282e6ac2e3d5a768c3bcb15f4eff316d32201db23d07321e0824d0de8793c0cb949";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/hsb/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/hsb/firefox-57.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "689592f815ebad0cb2b347ba214c30ececf13e56c48e57dfbbcb16e39cbb09b5689daa5e90fd5adcedc927cc2c5906f313ead51658a2ffb9ccbaeccd503bfb88";
+      sha512 = "8d3cb7c80c4f0b2abdaed55dc7a3053a9425804a9ea325f582c185583166113362dd064a411e48074925855677b4c093d7f45d1b7665ba977c8d4f802aa03881";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/hu/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/hu/firefox-57.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "1cd1aa3a62426fcae8879013937ea1059b172c9b1800be9c7aac7a5d716651f2fae270ed99b61a7794d28ef86fcd79f3712f97446136a2f5b06ec3eca8d6818f";
+      sha512 = "78f278cef9217d9e9a87d404c89279af348558538ba59079db00969e6ad5e38573ce26474c3a53edfa838f023d83ec39c8e0a2c8f6b176b45d439e32b0328a82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/hy-AM/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/hy-AM/firefox-57.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "03709c45ab2771f88ca0ccc2caf3ebf7371d8ef4b52dfb3847f258081ecad6811b4c9885f4f652ad995c41850e322b19078ee5e8019398a015db0dae8ba2e1cf";
+      sha512 = "a59eeb602b1dff769919f0c1f588bcf4c71c487e3c6d68f86dca5a03d9ae63fa5e0cab1ad884f2ffad7a6eca1e8c47d4309a065131b9c0fdae961f585819a22d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/id/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/id/firefox-57.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "1dbb481b7863bfbdb0ec7c85bb8ebbc3766799de8f8fc6b6f073d2601771ffdc523d9206d83db9831e8f62e5ef81af2d96b166269e5bbf0dfea9bcb05ff504c5";
+      sha512 = "e79f42b028fe2c291f9d405564fde0b4b9571b7a3985eac56028c684b455a3c627a596ca7c4820a53a9c1131713e7658990aaaf47c77f7ec6d850c55a033a1ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/is/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/is/firefox-57.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "bd21c60715943ac698d2e1dd062328f63d3f5a706efa7d0f31948fc4293b8d644897b0f62352965944324780dcc5e19a0d582aaf699b2c79b5dbb0530aaddb32";
+      sha512 = "1b505648ba5459e1df251f676c2c55b656f6c879119a8c64a46954d0597cd11b4de8f8f52b9a995ff689573feaeec808300cf9a49379cc2e7184339035958a20";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/it/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/it/firefox-57.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "65d991e4be62df38110f301acacc042a56cbdfeb20d6e5d9d52a7a610a5d0ccbb26d7a79b581c1e654400a4f162c09487afa7a8de313b4f483fabc2d9e2428be";
+      sha512 = "f0a399c409db1e8f787b657ab801db9aa2f47f57e98437177a6a38ece6279371e610a3d83e5311f23d021d3f5a67d0d4bc61c9dee63d20240699410206028731";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/ja/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/ja/firefox-57.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "ed3ba62d9e158a4d8aeeca8a9b2528146c5970c473e4ce9e088a80aede8b98c5e4d822ccf9996868588b08eac51b946aed202a130b38b2cf408a332dfc932c7e";
+      sha512 = "8d77723a2212c38fd1fc0671984f25ba1b8d1fbf877ae4cece67d528a5ba29e0281b7a8c4ab00150b47f21f63651ee5c187819ee14048c76aa728924ae644f36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/ka/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/ka/firefox-57.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "31180f189e68863a54ef6530befd184abae6e6590117ca6a89fcbe8a24a8b8d180d9500bc931ba0b5adb13a7d0173cda9a6b2f7bddea8f7ab3781620c2ca3077";
+      sha512 = "695aadfb2918f3bbd1317d8fc6aa36dd7a938e9bc790a89494a5a49848116836aade5c7df4c845aac6c465c44fdff42c5ad0904c9189caa5ee82009b53840582";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/kab/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/kab/firefox-57.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "55d5de7a1cc6f5133f3031154f25d8e74b253410808acf8020b63a67833a427467d3a4bff74d2cc32bc5f9cbd5c6a1d06d1378281889d4ec78313c3390c8e6d4";
+      sha512 = "baacebdde792367f36d0fb62d3c5d65360704b178ade590089fd46b3972d7e5757f5c18bbf2c810b12cdf7ebaf61e7520f437b4e36f02f010385efd59da9f75b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/kk/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/kk/firefox-57.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "e7c3244cececbda5b36b07ad3e9ba3bf3bd17aa11bf3e39f4ba112f1a9cb51d75819d299fe5e027c29f9e8ad115d1722a0ce318288193379f0b0c7d562f21e5d";
+      sha512 = "544d96b4d18d3f5a86f0e4dbb3bbfaca80a2595c49edaf843dc4120044fd9b0b632ccbd4a0412889c4077913f3afd2e807372b56116a6f73dd7a035080e16e87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/km/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/km/firefox-57.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "c56b3f1b1bbf610abf38f8751da86a092b57e1caf771548b232049041e9bfe252a5204a1e7bd5035444807b4990fc2631b9fec39dc7f25ccd33f93299708c490";
+      sha512 = "fc5f1b62e91eb2ef33f0fab875956cf5d386420d08d56261aa9724ac209c474a233eaa6f30708090de3eae0baa6c5b2577cfd98f94eaf4a044dd2174407d13f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/kn/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/kn/firefox-57.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "5f3e23febcbcf6d71210c4bc77d684c2deaff72f1bbc6bc2d0a5d0f340ecc063dc332464c4b9d8a6e9539723ad44042aeda88bbc872ea7c0bf93b6c5fee5f5d5";
+      sha512 = "1d444fa0eee8493d425c4f18d0b8f935650a9c3e8ba662552e2469e14ddb49e2e42a7ce313c79f5ad857f063cffff1493b76138c6719d075752b55188c60d1f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/ko/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/ko/firefox-57.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "3e129cbf532ebd3cfd3067b666c87118054fb5ff12dbf08f4f2f752c4a36cbe5938fa825fb16d9c1f6b39fbcb44f1a36c0a44f9de9b3a62937c931cd46629782";
+      sha512 = "ad7ebabeaa0ffc5231f2aba35c96a8aa7e05ea085782799807a4c96b01598814d96d1ecdb40984bdfa946a2b0400039b81cb8eb33f42caed80a60a99b931df8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/lij/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/lij/firefox-57.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "71ee2a3fc0fbdfb96010dda366a0fbaf446a7082459c8e221e6e9bc8d6e8ecf94088db26a3605aa59a0205e5e2eec7fb6a246c2728de6f15874e350f35d4b64e";
+      sha512 = "0ad6eafc2fba94d1333688ac3433eb2f08bbd7733f9db9a633af00800a3a27f7f987cfeefd949b26335f617e769450140ec939614f378b1fc6a1a95ca1812b99";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/lt/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/lt/firefox-57.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "f8396adc3ea3e924dc2a74f4a2a0ab6f02f5e6985dd92825746c35834bf9d2375b5d6fcb73e3195e08961a0d71e7a56bfff857e436702bdc57a1fff3ec64f387";
+      sha512 = "0563b0494e7a0ddd506f3d5500127f130dd170643ac77aeb38cb5855c4d9f39f27882bac594054d89346ae9db4bbb1b7d89a56888de9d15fb8649d00991cfc02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/lv/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/lv/firefox-57.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "9a03ee1f41168f427f995134ca83c707e7168fc7106405befac319620c9fb0e8a3754ad8072e8bec5a4bc6ba8fcf250cdeb03f4a776a5e5958b401e88bd1cc27";
+      sha512 = "0bfe9edf3f372cb0c3106e728a123acb76169dff80cbc55b450191c0d07df201698469fe56df92b068d0fe6ac308e302695bc96ac06dba5c9214bf8246e93744";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/mai/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/mai/firefox-57.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "1bea3eb0befe931908b47fe7220a240c245df6d87001d87476c63f40856c9757ba76a8032b184b71792d746adf1e4a126e1cd735a47916c1fad461b3bf6a0cc3";
+      sha512 = "24f332802f6ebde8efb28de1390f9036eb5a226247b8e11ef0b7c06e2d7299cd1b4770837d197a0aa98872985194cb13498c045813d362e32853d990e3f6d27c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/mk/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/mk/firefox-57.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "27fae01181f2c0ca2a2abe3902425c54115dad27d771700ed37d2f7c7e6f1ee23f63c688305eb33475f257605bf3897e9ce080e60be7e4e4aa40883a33fc25da";
+      sha512 = "3cc4da8c95dd51d1a4f996edc6b408e7b3231809d0e7b6fbc1abf7fddad6337d898319e57c2282042ca4968c804e5d7c572f2101a5065fe9a158dd394fd539e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/ml/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/ml/firefox-57.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "52dcbb17a6dcdf25f6791664a3b0cd58c605a768e29cc50cb6b82b1e84b69dfe8aac9ee533492cf85620521cbd9cc9d7883f0a6f98fb42a72e26a6e813bac1b7";
+      sha512 = "f7c19e1b1cc7328f5dc9f2f468ee948c4b8f93515b527f805a981eb55edb0c4554940297eec9b8138f0437fde10624a048a7f24a0195d13d7ffc661d54d2a37d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/mr/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/mr/firefox-57.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "68fbff994395426996d8481598f4dbbd9d1d599b62578622e154393257682624deeab680544d69fc89eb3eec3f5258e1766563267d4ae30eddd874d28be8ac43";
+      sha512 = "144b404bb7b7511008a48ed88ea87bfbed2b2befad7a885c74c0213c0ebc9bbfcf9b5f44607cb6a11c58d9dd033bf7ca2b7f8358896896a47e59245781b80af1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/ms/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/ms/firefox-57.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "5ed20dbb422470379e4a9746c184560143d39e8fa17d60b346080b800f7bd0cc8a9000bc4c07c5e84f9513a08ba7af07a4425b89a403db41c842940f94603a34";
+      sha512 = "68ea8dfdc0dc60085f9c59ba25738f8a28fc1ff7bf5055f6e60706184dbeeab5ab777a9b8278e6cedb8fcfce3ac8542566c9e5f1905021a279e7afc7bfda7e75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/my/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/my/firefox-57.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "f41e5e44178e1744ac26749dc47b091eaab5cd6538fe341bccf9f0fe32f87439007df1fa1625652ed37e4e81da1b74dbf0b6597074442aad9057df1ed143ffec";
+      sha512 = "b74ad06a52d973e906c6e4b96c4fd6ededa3db34bb9dce373178729c77eb53ebc8dd452075ad7ba5f57780dddeaca5bd0021743dcda4f7cc570d8626835dac72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/nb-NO/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/nb-NO/firefox-57.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "f23d6595d69f656fe7c6f2508b16fc0964eed25444d4fe7601f5b2ced86e732ad4cc5e9e8b11744c9cb84652f4447b1138d664815a026e3476c09886493099a8";
+      sha512 = "68a8762950b04f0c24462df6b2b0567742cad591d26e86f5a7656712ed71e04afcb190bb6d190a38734ee3df5f2735ac4713e6e3a7015d0bf4b5226c23039182";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/nl/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/nl/firefox-57.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "ac09484341ec63241a5f36d96fcb3fad70d91a5ee1dd76c1262916f9a6d955800abef91f74f533521db9f79d9f73e81320dc8486cdb740ff52a84dfb42b2f922";
+      sha512 = "1fa33fb50a11a570f5a4207c797f79df28740f9b811c02517240c981518526bcc2614cb65f9c68745648009482e8e40087c5774401c00ead9da37e94c7cbdfd7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/nn-NO/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/nn-NO/firefox-57.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "df79f4edba46642470d7a63bba6095540db649193acb36573edb2e53028919830b68ea3240d3fd6d2ac6f6eea423af806e2935a6158b1f2647f06cd72ebb2c2a";
+      sha512 = "cc15f9bf97d99907f51bb060faea940eb4ac89081d3eea3bfd619a385e9e1dc9e0fc66f354676dc0066b5000a9ec5edb676a9cd5dade0cd88bc7139e62bbf25c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/or/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/or/firefox-57.0.1.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "990c0c81ce39d2295e035b03b704245fc68c79be7a6969fa9f1229eaa1e4a2f8dfd36bbc532b8e8809204320eec793754dac4941dec2be86a1014dc7db3d4f57";
+      sha512 = "0996fae40051db7e587ec4bacae0c30311676e837534d52c2cab793925ec2724038497d2c6005df6c2466bafef507ab6de562f177c99ea4a19f0d3669de173ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/pa-IN/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/pa-IN/firefox-57.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "ee7055df27ffc800d30833468de7fa7013caddf19ed8bfd770ccc456069c8076a9fc307be5e320dae3476bc17aaf9095e0d4c8ab2d306579dc7a2088de0545e1";
+      sha512 = "442e86074d56f595bcdf3d7956a71fcfeba673aeaad9bb441faa4d235922503f2ea89b987731dacd3b1d7747b658e62efd8356f4e005b950d580badf90fadcd8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/pl/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/pl/firefox-57.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "83d698d4a1e4808ec9d5fabd158516e4db9824edbda5f17f85cc0473f033900c86b9a2119bb3533664e29949fa999761bea2f47e61325e37344cb91b86746772";
+      sha512 = "2d3554aa3403fa8b8c7ed972432bc1a78d47c054aafc3acd3c7d78d716bec3851c8d8c17b548053f705c9b62b0cdebbf7514fa6ff18bf6fe744093bdfb525e55";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/pt-BR/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/pt-BR/firefox-57.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "be1e97f4b7c95615598e734f7e09778046e2639b336b404e4b4dfcfc47a2fc9a50f95836dc9b4ebc57a84ca47ae8fe783d352992c6d1dfc256a4eb85fb60bf39";
+      sha512 = "100cf68e95f4b9e67db063a9ff50107fb57e8d6872a1259e85944320bed4604d236ac066d60e8ebda46195207290e251d5a5be88be894bddf6f3b8f0887e52e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/pt-PT/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/pt-PT/firefox-57.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "b3690a9c0e0319273c2f0b2f20eab8b296321e55035f83082cb30581c50030bd4f04ac2d91aaadb9c94bb4c6aa397ee133856c0c322afb884dbe20dcc693c044";
+      sha512 = "b0be537f63a19ffd1afe5f3c08a890b2d7e9799a8dfb3a06e3bab1ea8c36c6bca6d62d83de1774f78073886b63f6dcc51cab1039efbf34a40b48ff195e470bbd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/rm/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/rm/firefox-57.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "2aa88ec2aec0f18a81ba3db642ca2ad7ec4ef522950539a5238a7ddc1779355749f890852dac03678ff2802423584b671c0b10a7d4d3bf67f333a711bd9792e2";
+      sha512 = "973211fc29e85643e4e0657793404e86bf9e0045db8504a547d5ae10f0f0373ebdfac78243342b966dd7e33827e537c13d566cf9b38d9c6ba0a7b65fa22207e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/ro/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/ro/firefox-57.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "011eb6813084b482943237f6ea354400dfd141a17b8415a6c6a65c847b699f1f4f1e3178201014cc787090f88716f3a7d418e080f57df7e4071ed70dc12eed26";
+      sha512 = "dbad9d651eb5ce4140ee2fffb10189c238d055eceadd31ee8321bef86ea4aacbe1ace3e33c72ce4a25b8ea81e8d6bcb1e7703cb076fa746c3c0c6d00feaf83ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/ru/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/ru/firefox-57.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "9ca6f6d611f0ea2f9e866aab1b62a648114ad35baef2624281d7cbd1da70e7eaef5371d37ed4bdaaac06d90ff88a5b68bb0211056aeff12da35d9f0003eda47b";
+      sha512 = "ab0dc0e12f8334ec076379a1831209434a7c232ee8a63442d55d3cb63505fb9760268a4fcfafab9fe802b38a37faebdda67493cbd769521f80208532dcbdc253";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/si/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/si/firefox-57.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "171ea0277b6b96b63aaab0b58eaa401920e7245f60dda6e8b22f7261e788626e6a00f34b6e549def0e09f796a81b98524c1009b4053f11743311717da3dbab2a";
+      sha512 = "28667037738047daf790f0ca029ba4a5edf2a84372f982cb738c31e5a5dcc3c85fa84d952ceb0e07fffe4654623b547889d30ca932cc03529daa9beef21822bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/sk/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/sk/firefox-57.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "402330695a3ba72b1c7b286862b7cdb677799b2eb3d2e2408da0f7e2d1efa1f2fed197d15bf9f18deda19fac01fd91a89d63d535b859b4fc4a1796e7d2457564";
+      sha512 = "651ff7ee6173ce9deba68d9e9327e56933cf32be8e07268e744bc8cb1954d90162b83d20fb2b10d380ab0a78669d9b23216b4a3e23672077b7f222db3f9367db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/sl/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/sl/firefox-57.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "840a062dfd292f27b9aed42682c326e8326294817c44b5269e6ff53bfb7f639f35a100dc031f321f4ba9d90e468eab1483118ea8ded4084cc7df927bd8d2731f";
+      sha512 = "f621e765b44175a447486db5c3934a15274ead2721ad01ce9ad1a502a515954a64f670ba6e245d9f3f168e67e10c3193ab6baf498c1eda187761e4eb9c486aec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/son/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/son/firefox-57.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "d9e8e3490147571c5fa1418e44e9d2739ad3d3efb303cbfe9afe7884af89c4ac185abcd7e2514dad09c880c9a134c1aaea46cfae01b10ff36a2d01e54658aed1";
+      sha512 = "4dec9f2d9581cfd88cc49a3855a0cee3b8ed2db95252c6c872a7a538bb50c4db11e51a55b1e443f7af13035ff18cbc8d7df21d80e9cdb1587a6d5298720bce73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/sq/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/sq/firefox-57.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "996a7e70c32ac0102b087fa11b269f98166a5f53bae4d075db2602e40df40f3c4cbb4b73015c626ee0b856b934dd5da7171a510f297d86995e182632a34f65b5";
+      sha512 = "36fe9146c47098496f433816f4e3928b883d5ca308284b1d70db2998d8f1df28baf50cbd9f071a0e6c7faeda9862037267999ff8fc1194da05bd15ccbe0ab055";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/sr/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/sr/firefox-57.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "5af926ee5e008b4192af127fecbc7f841886aa0bf9742bec3701ea0e954edf36a605191905981ab5ab4d1bc4dc16a27adce74c05adc5fa03295a06c588e1fa4c";
+      sha512 = "ca83d9c745eb6aae3e66b3388c7068e8bd82ca0628d4c9e202cb98732c2986bec50d580371f672c36750b5d13d790a1d44fc9c5fc0ad8602ffe53ec73c5d5554";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/sv-SE/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/sv-SE/firefox-57.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "a2b860bcad1b1ca27b3e086333496c0a3bec5ef12d138765817445cec52f4ca6e5580da5c60f1182676dd577afeee01560b50a15fb8399ec84d97b4c3144c58d";
+      sha512 = "39a802072d0afbc6140b28d6738a9d0e15b949d6a59f48b59a3e028b3bcaef82cbef519580213169ac14cbd85302fc5da10ca224cfc435c6c5f5eb7136f7cbc8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/ta/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/ta/firefox-57.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "8c379738b92b525b9ba166d0b40a76d1ea20d2c756113588e6253adf53c62d4d0d5657162bb71a68c449553d127b6ee9a2e77ace547f29558072fdc2f5b0d779";
+      sha512 = "a76568bd01cd7e03df7cb7dbf6e3ecc0a115d4a91cba5d3278bb9f5ce39141ae272aa5064cd77a8767a8e76ab433973130c80efed6e77ab122cbedac1cbe9e63";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/te/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/te/firefox-57.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "90e36b08e06bfa6740e57e31cdc44e250facb4d85927f74be61beba13261942276add3abafb5b57c72126e7dbfbd82541e38198c605fba7157e9714917b5d854";
+      sha512 = "0a518b4b23bb554b389c96c60e4689905b85dfece7f085abb7205dc25e191526d96b0879b8bd98760424c17ea267108fb87bd8c3e4129f45e3ac5815c9c83f5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/th/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/th/firefox-57.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "698d255326a277ec4dd92f9d91221e04794c9f68c1ff9b6c1b1254afb32220b35505df49bdd66f14fb044b6747295cffe15bd145ed8bf9d8c78cdec69ac86869";
+      sha512 = "85acc9fd795f5d27ec6cfaa73b5a5a8cf76a6955fb35ca3721864f2ad06736d3bc3b24388a4ff861e3c8102561dace4c3f5dedc352a83c1c916d254ac28f74af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/tr/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/tr/firefox-57.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "de399243e17cf1598467532f2cdda5f87569f07956cadfcf72806e1972c0495a0da11b6cd8a3823076658ee5e8b56ae1e6664296b0e06f9d20000001f216605d";
+      sha512 = "b1ab6744adce98723fafc28200ec8e37249cfcd524391cdfde548a6d5f9daec25e60367c49f923cdb6f620edbfcf6d82d49049f865807b76c5d654fd412595ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/uk/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/uk/firefox-57.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "12cf4c40f3f8b2040db20c72fc0a604fe79ca328197ad05bee4b8652ed7769238f15d5ed7d026dc7d51f35c76067d814d873b96efca7a641701099f49963bf30";
+      sha512 = "fd529013373900280e69832f07d3bd91808c30ba10d1b2d2978e0bbfda9963a1a239bbf08ab8ba65c6e9c313ca7abe4adccea778cdff34a5e07d521a96814452";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/ur/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/ur/firefox-57.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "8524c2e24d48645d03b3f6f60c38cb69d16f8d9b665517ef86dd4f1d79d1a83301197784e1e27cfeb9ed0e978c2dd9a5602b3be3c6cf6fdb2e51a0d8f4bde264";
+      sha512 = "c246b71729e6182d2c400bb0389e47c56fb64ad32363f381a28da1648f8d923c79c0305c2d177336c720b8421209565d7744041a503e8959816090ab153b9cf0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/uz/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/uz/firefox-57.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "930df760aea0d9f40414e7d2025c81e3e9752e5d338e0799012b888f10fc5ae2cfc4871a49502bd18ccada0a64c3381c3800bf851bd98d61f8380be2db126eb1";
+      sha512 = "d9b2a157897ade2657f268fefe5a77daecbebb1f4c038405be5945d79a249c54a1f2a4e0b5a035116b10947decc59228adf2c0b1bb5497fd27da91fe967b4883";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/vi/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/vi/firefox-57.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "0e8fdc9ad8aeeda7ab905a81925b8cee9f3aae65516d34f1adfe9e5f8cfe1d392ef98e86cf361503d4d2dc21ea761f878595237039e4adcec2609800ed52152d";
+      sha512 = "18f117aba4161b155ed33baa00f48d41752bc1c0438d6ce1c3b773b4c817adb611b2e0fba25fa5dd957c78df9e97e2af65adad5e63418ca5279e66995a1d7a00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/xh/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/xh/firefox-57.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "e4300974b54297361e3e43a20dc790a1ccf54c23d6cf10eb9d8bc4e43347399d90c7bc1e9eaebc262a882250a38ffe4d0008b69426d2179d50dfbc2970fbcb2a";
+      sha512 = "c4c061b60e73424371a0d7b58e923c2687c6de8c48c5517edd7f0ea84bee8b4d1786cf2141bad0c289619c31e52ee0685708f4279f4de3684e775e8b9a95fb07";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/zh-CN/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/zh-CN/firefox-57.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "1647f1f31d0bae5aba3e2823293abf755cd5108f8bbd9ab28c5d2794644995fd394c0ada3b28a2df3f3903741b5ea863624b099c9a99c8714022813165759093";
+      sha512 = "cb3918d0f69a40eacf8b0cf525b7a58952c73fa6de113a02b7e3941f53579440d97f6888363a15a17673aeffdf16df124661053e2df3b560b97208871750a61e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-x86_64/zh-TW/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-x86_64/zh-TW/firefox-57.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "55ce566e70a1479bc81542b6205724febad35f61a32a11124558af2132881f0cea6b52d590befb2835fca4af6d31d0ee44c8e55ec2809989a247742c062c9241";
+      sha512 = "f9f596bedef10fc958b1d8c99b5120c72da014ca561c6942bc7ae99baed9e59200257f8f1bb9b39613f02b2f7c45ff26009814459fa8834bbf5f11b3c82502f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/ach/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/ach/firefox-57.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "1b9e00b08e50a56c2531656e7deaf3cfbe87928e634459f9c4fb04c8a206457294e16850498cfeee0261a26f4303f863a51bcb025812c8fe1620307f710b1a23";
+      sha512 = "f5b5bb281aa4221e781032b571e36fdf5caf7a713bb7856cb4257532fbe955037b31598854f0cd8ba1485fb28142d5c85755f129cb6ff18b3f33601f32414e5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/af/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/af/firefox-57.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "a0c9190d0864d4424be8ea703aa9f5b8abddcbcaf66a0e38a2a13d991ae34a62e926ddaefceaced72cab6c1c03329ca76279051ab40ebfc9274fef6658bd4336";
+      sha512 = "4658bfe340cea1300fe523574917639cfbfd0d3bd1429b2af30b6894d3924784df35d0d27ff9085f07ea698685206f9c08bd1d7bf1ec84d4b8d136bed679e819";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/an/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/an/firefox-57.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "7c1f7dbed7e600fba0c24e0426c53cce1bad28ab260ffa5461045485f1898483127de4622733e9694dbb06af058ef7abdb77d26e3f7297c856d4fe254eb1b18b";
+      sha512 = "f92b3e572f24b7ab858d55e972a184359569504084e542829d44b4c868789ba372934f00022fd05489242b5c9571d9284d263b7f4276ba24ac04c7e1930d1c22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/ar/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/ar/firefox-57.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "0d945bc6df592e1ba2cbf6183fe40b2feffc4b747312860780a99be3e4fa9cb1dcfeb18f2fe21a3b4a5f4c382040da2b292ffe45a5869366a67dda639e2bb969";
+      sha512 = "0500e6d73b68c248c4cebed4a5df1e44b137b972f03ce67098dc8f46dc5067c7b7572031d0599acc4b840ae0bb9f1f1fd49fb051c16067fc4c267c22b45b3401";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/as/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/as/firefox-57.0.1.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "7a28131e997812f9689ca7afd63c3c72f9ad324e996eaf981e066dd8f125895813a5bc63a97f83345d73e04a7a3e0538163f9d7c878197329bdd2e5684fe679a";
+      sha512 = "d5885e26ca8e6caddcfa33800785e18f1b86ed96310709fba96bb977fdba81216d843cef4f30e0072e011801836ad5d64aec9280006d07088e0dda577f9c508c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/ast/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/ast/firefox-57.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "f0b4e167696f4fa02a1e433914636cbd3d9c3ce4c8c3c61410b54670512d0c7d0c2ead7a1ac880181a6c5b5db262ab5bb14ef10341bcac2eb4b81afa4367bca7";
+      sha512 = "5f05e368129f721783d40f84d096e3dccac2180ddfeba3b5757f5997c1c8b9bb275edc1073394d7bd9cba09df38092239bc88869ce9cb850edd2ec776382f43d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/az/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/az/firefox-57.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "71c2313cd4c7f809e9ca4d999ef5a2f8311ff6d14623c76ac53ed74bbd876c816f5d9cc56145f53b6c2a64d924945038a77ab23047b20e866f9ee3a490cac77a";
+      sha512 = "2c14741b737007757268ab9adf5fe4f2e11640f48aff4c7cd09d8b0880c4e16d2ab67bc19003e36ef91df0fb89e5cedff34223e176cd1068821d43d647817264";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/be/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/be/firefox-57.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "d38d69409618e158cb926c21cff4b30b0e5e6643a4f955e5e16d975d8ed23ee7e5589269603979f9332206d19b676696fb2ebef6cf916789e9f016a2945fc9e0";
+      sha512 = "a4658676505846fa1efb67c2f92d1e2642d0af2508dc85b91c023ed58aeeab4c816967aa6289caf1cd69c05f94a3d21510cee57b818fe48b14a222f34d4abc2c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/bg/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/bg/firefox-57.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "74c9b878c937b29062d8a2f92a89e5e3197e0326a1f629b44739e7d896d753552fb12045b5369881f0106d50d231a56f837fbd2363e2e8f8eb616e61324c1eda";
+      sha512 = "0c47c4a2d6037f21e062451f35d265016ddc0f39d128c662ab265c19d4d310f8788b71b8fffc28797ab61f57bd4db2691454aba90ee726ff15dab5fa2d967719";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/bn-BD/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/bn-BD/firefox-57.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "bd5858cadad888d9392c756eb7c88e4dfbfc42f71459c2a10b992b7be51a08ed22cf5f038ae93b39abf298c47d7063e2dcf91148c080bbb2d56187cfa480dd3f";
+      sha512 = "cc971011f4b7264bad96514eae76bc12bb5be038b69689bb7426f42888f8d3b23ff8307eeaf765a7f31b57ab7edb0a8df21da8dbbeaf90d30677bc7d413f1ac9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/bn-IN/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/bn-IN/firefox-57.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "ee30dbe25537c8376debc9f7d0012034ab05a9034a03b147d242d0d19a2eb31990b8fd68fd14807ec92b3040e469384b191faa002dc8e9956ce4eb8aa79274b3";
+      sha512 = "f8d7ff7faa81392d6b62c1fcd38ccee6221aa953a7aa2f382e6cef5da9e4fc0e5ca71eaac4468ad07211acbeb2a64b174b1a950daa4a266538007d159dea00ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/br/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/br/firefox-57.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "435225909135570713c333887cc0a31667261710ebc05077aa96d11fc6a9506c8524eab15e6ce09b125a57c25447d8f107556c3808fdccc794714a09dc5948c8";
+      sha512 = "2febd7b6a803d5471b840e9e9c7c5fc266ba1c34326153d99ed04f461ab403f75165dfb0133af738fb0d3b40b76aad88915711a2c34ba702ad10351450b197c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/bs/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/bs/firefox-57.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "c702e9f765010f1fd2b17d5790411e7322e78e8b3e86c41f1fa7667e953f805b46a2249e5ce35f3c58dfcd3fb8a93fda6ede6a04284e9d9786bd912c5d5ef71e";
+      sha512 = "2b1875db4da17c2ff8fac8f10fbfa415d1d99e65d9a7082632d385a50185419bdf1e7176e0c97789ae71a3b791a2b8d359a931022f148d8104929fc564335814";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/ca/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/ca/firefox-57.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "89f93e3681627fc3b170e48f8e2e133609a91eab9eb9026a280359a49d650100bdd482ab0e28c89b80b9a751f5fedd29cdea27c332a5d41ca0d4567f81dba828";
+      sha512 = "e18a60d9c53bcf6843a469110694f7dcc1a84cce5b92702266319a21866859c6e518de88eac5f3bbd1df87f386eb9b66e8a377c0e35dc8d88cd796c0acb6f849";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/cak/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/cak/firefox-57.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "91c822ca0be8366e452c8c40558f1f8235a214c6925dc36e6ab7ebfd93ac158be6a71cb424d3f99ea169b27466a44feaa4621af7ed48dd6681f4035948868b27";
+      sha512 = "a87c412478a291383b42e36bd85bb0b9970e6e75648f0a46345b648c30f1177d021b75134ff18aa1a37df7ff2a3fead32e52fb7bab9d6895fed0f66318a8676d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/cs/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/cs/firefox-57.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "a75ed999a18061f53d3ddf7591b6c342d7eafaec68bb14b0144fa790d2919e1c0426cf46e6c1a30be568f9530951f0b42e65ead2a35dfa747d72ce5feb63c5a7";
+      sha512 = "71a32e068c0843bb907789e9ee5c77fa0aaf81f21b92fa63eb7882237c22dffbcf2de60eff8e2b84fe5834dc5ae2234f1ec4d7e4cf3347cd04c64637ba49dc97";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/cy/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/cy/firefox-57.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "7ca858d8db178d7e7d2cebd69ac4bdcddd76da3fd893003fc90d24fdcc41329526b3c2cb5099b1e0adcb078a86e1a4e1841376b907a042547efc7870d15d9fb6";
+      sha512 = "10c1da2f33b568b0ad8e28fc38c9b1684d20a7bd006db6eca9baadf2394351c1b467851b46c0cdade0aea0ed6a185903d95e7711f0839323a11fba85df5486c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/da/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/da/firefox-57.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "1895d076abdb32096a94b8f74a879b9a94b474d6a9f12ccdb5bf6281210529cd2df3b28ae4ec243f79f79a537f50ff2c6e2b99ee847ab799d1c4763942599394";
+      sha512 = "83c329c5b6be5c966beb24f38e99521d0a5be168d027030740778141afcc7850f242645f308dc3cdf1827e7cdf66bc44a7bcb4a0e5feb1eae13e6238875ad75c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/de/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/de/firefox-57.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "bcf7b391d1bf74b9440455461c68736490b63484f842efd9f8e631430e480858c4b3c540f7072a163f56cea32cda75d568de5a957474a90b923b837227a78cd6";
+      sha512 = "4f422bb6f6da9f79e62073ca0fa6a0de79aab7ad9530d9c2aa5c3a2364f8aa62442f10698966c121011dd0c0e67d39d0628969423de3868fa631fb79c9e094a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/dsb/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/dsb/firefox-57.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "1d09a9229db6879710d36b1e7c9e2aa606fe837e69f0107dafb7c1ad18b4c6cfa0540338aaad2c404f739d8060fea7c317a691c695ed57eca8220081ae43534d";
+      sha512 = "54d124b325cd95f6024c2c5c948b37d81a2efbe5aaee68030f0aa116dfcb3d3dae963968c67a33c8a906243ee27d75c9d909cc57e010fb760da1219f04441ae3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/el/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/el/firefox-57.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "767fd415fe7d35ddb7a54925568c334ed693d84208ec2338940e1cce887b80fb552ab51c0b11b2c29e2bcc41a5d8663b761529e5d44e652ad2887fac9778c31e";
+      sha512 = "e98c7c71a0cf3db4bcbe0c69b3427f0f822dff1cdd3e397b7082af2cdd129349c3b37a4c420b7906470bbd0e921453ae517360d39c827218aba99e2562f6c825";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/en-GB/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/en-GB/firefox-57.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "35e7f16f208eaa6d5cb3a3135c566913bdfe7c9e47aa5c68afcf805ba64a368f0fee7791b85e07f151ed7610ec70a78b457d047eaa01e2010210bc6885d5bfeb";
+      sha512 = "331643e1566e6878d448972f9485f2e9df898a830c87fd8fd52b7d8024aaa637a611d8c5145ccb6b1406f283e0d3a88c5c12bd418a9916a2d446e7230b0b9272";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/en-US/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/en-US/firefox-57.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "4d257cc3fba63195c0d74c1ec5c94768dbb29d5f86bb6e9339af4da20bab24000573b33103693cc32f003d974085c4c028f525668cd3e62481b97d2c665d592a";
+      sha512 = "1d0d0c2632338f1a319d86251e54c5e8582082e48429fe5b8e62e663c65cc9439094ce7415f2e4643c0ba3f244b8177685b5f112b244c7232d2585bf7a2b4fd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/en-ZA/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/en-ZA/firefox-57.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "4fde656e27840b0763cadd7c833873b5f012f920ba988953e864a89eaae2fe70482ed32221cbd6e9fff770dd4b6b5d93cfcf5226f70a26c12a3fd66abee232fc";
+      sha512 = "63f3ba0bfea21f7630b93174d399894fb3d4e1683fad0d0e5dad5d078d15fdffc06ed292a07c95244ab509b30496a81ee868ecb4917ea8f925fb590a2e6b3e17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/eo/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/eo/firefox-57.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "2aa40148adc4a0997d370099b2a624b44d4c995aa2d150c8bbbb91b9bef49f5424a572585faa3f0756588b6013e7369d5bcfeb051ce80182fbad175e3cac2905";
+      sha512 = "b1bf24b6ff3cfa938af300a13641dc76910369aa0628b09dadf84817d9f315a0ff1d68b9fd1cfd7be02eec6c31966ae491b856d6c8a5b8088b6c97cb38d2bf0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/es-AR/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/es-AR/firefox-57.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "da078fe38e47025e9130c0512bcbc31410a8e42cc32037e462b7f5ff185029d160e921577e31f52fbd3e43a1962a07133e1fa3f24f950915bd456a752bd8dc0d";
+      sha512 = "678dfe1d784f6caabdc06d1cfe6fd6691335f6f66d30fc3e7320f3f7b3fdcfdd907f2de3963e0b60951fb99983aad135dbdcf70216a093139583ef992499a069";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/es-CL/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/es-CL/firefox-57.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "bac5ec18e2f78fcd67533bd8c3a8483a2234f40a9bcfad66ba7772f9b896d16fd492a229e359ab851db829c37cd72604e209cdc9825670301411e5edf5a0a548";
+      sha512 = "cc507767b5191fba46204e7918318bda7aa6ecd5eab20bc51efdc92910f0b059bc5ddcf7b29aeada82e93188c4ddeeef64ec6d2ec6d8f0e138fb257e10ddfeec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/es-ES/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/es-ES/firefox-57.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "ce8f14d68c9aad9ac5d92bd8793a8a07d7e4e08c4ea57ff11511a50a2b815e5e3844fa0a4ea5353883db071789eb61a011806fdd8c45237dc48d678ffdf2f484";
+      sha512 = "a6404c78d8fcd6a329230e24961feaea347807abeacc5edcb329fe40c99517c355671fb788e121aecfa88cf1796049a4bc843fb35cc4bc12afe30d7c7162d739";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/es-MX/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/es-MX/firefox-57.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "3bb2f44e0a00ce26c527397c639dadb7c9c459e40345359728876eec23084463cb89383e27c97c971dc9a1b0bf2fcea4c1fe4ce37c84d59265e0d7d029cafac9";
+      sha512 = "7ccbb080ffad4b21987172df3e23e1707a52f9d500ee696a0d0bc2efca0821b9c03f5541dcc2414fe9eb578e82f0af8090d3f8e99ef4f325fccc732fc159ac86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/et/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/et/firefox-57.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "948a05c36edf1662ffb6af1ee090b85408a739b330b81ebc4705ae2fe7803da209ea50bd36da79b48691061bc1eef66213e3a15dbbd958a55527c83d3839210a";
+      sha512 = "32ade01760afb5b46428fc11f4ac3cf59211fd2fd3ee5627b02254129527b2a89d380ad92e8b56ddb426bc0306f1c3f4b41ad3a849877da9181814d0a16865c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/eu/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/eu/firefox-57.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "5f994613b3d6f6489c6d9b8fe13a4bcccf93d5663cc493b22d902a0f34bc1a94b7913f3e0e0d5af19b451f44d8a7117da9588c6fb318b610aa306f49804af2a7";
+      sha512 = "6fe9ce65476475b548ad06dc13f6f8e8e845675d4797db0067001498e5bbe167d27538aefcbe740be9587b9d29b7e4cdaef6e0f41856e236b070a5f52d549a30";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/fa/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/fa/firefox-57.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "1fc669a66daef43e94e1534d0d25b55b60099e60c437761c7f623529e4d5d39975de0629ecdf4606fc3dd67ff19092e59b7cd14d13426a0c5fbc143c1bf158d4";
+      sha512 = "462514e0392f8ad90c73c3755033a5035926fa6a151e7a7d31ba6d71ad4e8d050c2ee374ff614ed3d428fcba1074eeaddbfbab98730fc470f0c9653cb4a366a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/ff/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/ff/firefox-57.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "5745915b80c46e983845be25a17ac07db8ffce0b688dfaa5329855ec37839a4f00cbfccdcbc88862d51dd97ca7c54c4405190c1d2fc05426412301b3d576f5bb";
+      sha512 = "a553ae8fbe9c43ff99139bd6720c31e1919861094d8a540696c63804750c8d235caa5cab7cd471f9b80169128e5639ffadaf5e95143c92c3ea9038b317294fc6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/fi/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/fi/firefox-57.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "5ff972e73f132f11684bae62a52ec0439378442b578c96d55a1768e45cb2cfcccbcfecd484cfe1297a956f8c6be8a1f63308ebe3e2c3f7b508c19c5485a14cbb";
+      sha512 = "ce6c5261ebff909d5691072012d4544d43652daaaea6ce38b47cb13fa236681da0e0c527f28cc307c6b9de3f3f76c1688c1d35629aef6469fe41c4ce3bcb2b24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/fr/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/fr/firefox-57.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "f7147fcfd193b58d0e777e3563edbbf44a9f4b299ba5e8cf0cf2c6932a69ed04b5ce35d108049175680ca5fe3e5c32a3916ec32d5b5b647f4a10e12ec1161bd3";
+      sha512 = "8afbc7d3b56184b41877a6f901a6e60d4f8e55f8955fd64bb1f07acaf14f45c0fc0f4c6512c3ae52de37d66b548525bc4be1f2795b9f8e6ada8a267ede0f6bcf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/fy-NL/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/fy-NL/firefox-57.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "4a5bb7f0c8035a4b6a0286f242b65e2a025a55a05fd861da84b6e11c1d33756f3c5e831cb665608e1ba403d7b24e7c3a2b51256c272fcd3b8c5af3b8ec17fc4e";
+      sha512 = "195c6b307c30ba134b4a86b5f241317c39cc846372a0f53be8214f57b192fc24a507ca44fa7606cafe13343e2782f48c97cf16587be64dd49296524b6800abd6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/ga-IE/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/ga-IE/firefox-57.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "d93e6a13384110eb1b8452a9b890ed63ebb96bf1044bda8e0b58ba6c1a19b77ea8e41b4275e4d6d9efa327a6f3d95040336e21e7e6b1109fa2f961409944b40e";
+      sha512 = "cd9521ffe984186097c77f3330b610bd61622f0447568c23bf06fb64ba616c48708c5dba2f7caf4b1b79d0ef7ab3113356e28e1d56d29688bdd09879b417f956";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/gd/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/gd/firefox-57.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "d0a1a5f637e59d25a4014be203142ae31a976eaee97591ab3d7a50593c87e235406ddd2136364948c17ee2de9cd8739cbaae6ed817da45e199f81072cfa1dd30";
+      sha512 = "92e9252c285ab20bd727b9cf8ddf60196997f6b8fb29acc6fb81edaa3ec8d9863f8aef4fcbe7a6b8e7016ef08a0b018b6cb9194c48d487120494bf3192c4599f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/gl/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/gl/firefox-57.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "5cfd266d1e9ece838bbd45d6e4de824e8956325c097c9c91bf22ceeb31d5e2e6f4f6b2f14a1a124b91d2bec054f12f0aa57ef4c4374bd5d1cb759202d6767850";
+      sha512 = "82693a4432cbec96483718c6eb00a45419f223ea9e47432dbf1690249339e2f139cd59a8e77c60acbf2ca45ec77e0218b98195398d3649f46d3087f527ff05fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/gn/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/gn/firefox-57.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "b1fa5b9960eafd78d0a9e1e21f0a25cdb527ea69f088db035ca1da97d3b785a570070b0854b368cf73758437acd3047efcc87e1c7295d8cc34eedc93ff340968";
+      sha512 = "4676bbd543dbd3898345097657192e0eafe679e21f75d5a51bc6edeffbcfbfa85e8e23016e64beac5803c01cea7be8614904bce81bf34848d8717a7410159330";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/gu-IN/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/gu-IN/firefox-57.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "d86f0baadd1dfe89f753fed204cff18867ced55ee0acdb8228d821a8f324da84df2bc79a75a7e50d6be0c3b1c8bcd4e02f8cd2adf66067ce495e0e7b3908fc24";
+      sha512 = "19814fb917e4d0405ea53555f70bfd50d26673a852ab6b4fbc158b8330274445431cba9e49cde1a0b469a32e3a97a1b64faa125f4ac4e962c8120e76a922a587";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/he/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/he/firefox-57.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "da29910b1c43d71a674268ea2f8ca2d5345265a5226dff48292da471d340fa3b1885232ffe93af61148a93b6da04563752598acbdcfabed59534657788909cf8";
+      sha512 = "f8900c98ff45c27f4c66676607ce544b25bc20ed45682e67315a9cbed0260e9e6b8104f8f4d022a5b272ec9c4e6d3fd4775a79e2c264f03bdd1629073c6b7969";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/hi-IN/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/hi-IN/firefox-57.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "f76ad192f1ba83f29f99b0dad313660abf85384803e3d1ee8164d6a917e30b3eec12b64b8a475c27b21134cc394102ac934b283102129947ddb63da3bb8608c2";
+      sha512 = "63bf09e0a984d9cde04cf2a7887668b453b8998931ca4c1b0bbd13ad7dc8106756732c37779e0a1d84d1f842871e63226e196d3d738320f520f8b88ce6999a66";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/hr/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/hr/firefox-57.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "5f58ad50c9c287f3722447f95631c5e80523332c64dc7ec9589a669ae68392abc3a7e8ec7a1f822141cb94101ce437b36b74ccf07b6a9535cc659ac5cffdd101";
+      sha512 = "dce713a45a83b67ba237b04481b66e2a3066b9ae7ab00824df03d2f9769ff14d426c7e3cf723aedb3ac1e1108147707b39680c5328f703e5fc849d8d1e51adcd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/hsb/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/hsb/firefox-57.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "236232af403496442820285b817ea1c0cfd6a48cc9ebf77cefdc4a242e26248e055e5e6dded371e27257d3d1155f2a45fa183311898a8a386308c0d1f2063836";
+      sha512 = "8f6ab7afd6d10b781e0c9a083c72dee3069dfd9c91a500c24f76fc41e9ced3cfeaa47908efdede2d6adbeeecc4ade89a1644c4f5eda79046f1762c35cd2234e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/hu/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/hu/firefox-57.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "e053b499fbf7e4b134f5f1035377e7c639ffc5dcd31fc5df2192733360616b8f7e818e58befb4f597d101d22b2fabc2d550a9b2872205059944b0639270987f9";
+      sha512 = "41149404d276b28a35ba04f19d96ba0c1112f6615207fa8eb65ebf36f0e87115ec2775f374f785f6ad23470cf8f0fd49f1701975bbec218eef2ba9540dc9cd71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/hy-AM/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/hy-AM/firefox-57.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "f6fc4218af3dff916c0117dc6c5fca77fb84ae24d3b39430007f1e1468aba74d2bc6340f3bd48737bac5de0cc76ba01b15875ccaf591691256128e473d495767";
+      sha512 = "4270951b388b5cc34227391f00d4e756a293e3116a9f43827aaf1d27a0b81d255e1fd2021e6fe8b8ba137779eec679bd19e559d767321d0ac2ac6610d06e80a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/id/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/id/firefox-57.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "f78efcda46d3f672fb083329f810f174eb5af1da78f601d76a22ae3fa02ad412a383845368d69938fe8d6b3e4e67a86aa111187fed6ea0d8ff4b40f622ebba63";
+      sha512 = "69348643ae4fcd209155a1c308d1a5eb29786c37b5719d694f977c0e47f77a9696e156ed50e26b8436bc56f3d63e78d3c44287a49d7e48d7521df84a15130d8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/is/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/is/firefox-57.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "9c73ac9d89bd7a45b338b74c8cafac4b27e46bd6bdf8162f21ed7d11e114202b1b5b6789ab1c4a6edca65af257b73ae7a962c9d402e4e59b5ebe08437a3de242";
+      sha512 = "c9a217076b1e52f78846d5898d62c2cb3ba33d4a7d04505b7934a89832cd7ce69fefcbea0f8ee46faa4f1db08c3c3c50a41889f18fedf25cadff76501bdb0ef7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/it/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/it/firefox-57.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "03b905de20e336a49372b51e9e1e977e861359f8e9f515e19151599bf27769cdfe74567e041f3a75b5c8039066686edaad2e2899a3df46513aef64d2963024db";
+      sha512 = "9cb2e8921cbe99b63bf488490e1e3c2e309ad5b5c499cfc08965b23275582491801534af37cd1ec07a6c58aeb8adf730e942a6e363a12e6064e2e6b6b3cfc551";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/ja/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/ja/firefox-57.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "5769e414b18f095b5f1bc446d8fc68bc16467683f44f4711db9b6d6feaf6d60b801b2760fe6d046c062d30ac4ca7e08d633484a79c64cf218c4df8380d7c6abb";
+      sha512 = "d2436d7e024b06f4a16e39a89a99797f0eab66f007334574d7d81ba1d3b4937b3bb9be46a4b5cdd929aac6e1a764e8ed531927a471d0890a5f6ca0755735350f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/ka/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/ka/firefox-57.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "244446f400a8270a1c01a3abe73da8840d28e2660233bc5f5d34a654fe78099d0634d7a927c2b46f2127c5f0131acf5f5b3c8518ff892b0b3832b71af9df016d";
+      sha512 = "69cbf913f02dbf4f2c97ba5fe8ad4eaf744a3b1b3d75d975175b88b9f5cb516af49ffdb54b8102e5f3f1be14980bceb9d15a819ec3544e692b7edb0dfb55669c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/kab/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/kab/firefox-57.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "da679fa35fd7454c820ff5c2fd461f545ecad30cc13891a026244ffdc92867cec7aad71e53a32f98dc06e3679d7571824467b4f6ab70896167cbd762f71113cd";
+      sha512 = "1f8da18abbdabadfff995b37aabcc6b5413d891a089e15a0f23e9d04bbee0c749efb592c633aeed749b78e4b16a63dd91b089aa1a72795d0e28cc89fbfceb357";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/kk/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/kk/firefox-57.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "ff79b1aa99c452e475b61d7e6c773c8471fcd04d8e9fd3eb5427ad1e09db97ffdfede5f706b8c7a5fa82aad2e89341771318a36be55fbe1761bf4dfa4e944295";
+      sha512 = "5316ee63bf10c43ce30e64caf2dab766c63fe6605bb672496689f43c14649638844a9381c632a42af108fac2039c78943cd0cd657d7fb0fdb7b33884a51bc856";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/km/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/km/firefox-57.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "cf073c84edc57468a28fb5a1d7c8efd1a7ba00e09783e6660374423a466aa9260e314d6f94140aaa3d5b42985fcfb1295edd0cb3b093487998eccb516c6f9220";
+      sha512 = "4ed2754dde6d9d6040fc52fe099876f0a26d6ae21aa2ba382187d6d5689bdf5db5217bf40e70d1de566d56ccdf0ea9d1883f44c8c7de497514530bddbcbb12ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/kn/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/kn/firefox-57.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "8e7727b77e6cbcad8c5c87aa12d983b18ebc79dca7b727ce20320a7e384b23281968542eae9ea3207cdcc39d2eaaefaf4c90866071b08f9f944c26e6fd6383d4";
+      sha512 = "2f4ec84174ace361a2d5efbd7ebaf788479d11364d75fffe46b0a9d10f2189893d5eb828064d338e5fdf6993e1a9938ea96a8828a941493b3eb579e339d55601";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/ko/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/ko/firefox-57.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "9f7db828c0c1525d30558b543ac0cc6306ef34d83ed6fd3a25f5899b3fc6e6e2b8355f22b6fcd0f58c8bf7c634243ef878f67c039243b3828be43beff68c7938";
+      sha512 = "b1e8758428a69ea72edfb7fe52f92e0144c541114ac546f1c5295da280ed2454bf755a276dd3b53bb1f75b37a5a13c49813279a92138412acb1cdb571da7aeec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/lij/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/lij/firefox-57.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "9a308c8f7d2000608adf33954ccc2b82b92275563096f801cce4ded8333d786a1c879833f6768b9749dd1d718b33586b84e180971b92ff29387ce53741028381";
+      sha512 = "3eabdd5de44ae2a3063f76a1175287820c417a01b225c0798b4ca6685e4b0dd2515eff7895d1ab3e0b4a071841419c9bdce6102156faa570c48ffa02e5fd00e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/lt/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/lt/firefox-57.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "c1a57ee983fc10155813431845a1ebb46071da4748a44b2bb4578ac6c4e1d743341df5a8ed0c0c02343c360bcd6f50b13b2ab62b760e079830ea0a82d781b0de";
+      sha512 = "7e1d702b92b81d2656734bbd2c2e61db7bd02905b9d276627bf32c908ab5bac1da2888453efbd4282e5b26b2fb0f03c682265081f93c538569c8f47325f2bd1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/lv/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/lv/firefox-57.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "64fd05ef07e08677efff3f57f2c863bb1b070e9dcc088fa7d5217b59fee9db5b9af58086088b488c34734e3a6e53c683d26a8c5755b71e7af17b8a515854edfe";
+      sha512 = "3847065c8573b1f37b584581aef3ba4c6a4666c9d937e36f0f434addfb7a0cbfb36f500afbecbbf061b885d4f5689a647fb0d2e487bd53d4e9bd689bd5cc7aed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/mai/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/mai/firefox-57.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "ca33c7b7f812f6cb8c9b56e969c7f67ade456d9ac6555ffbebd8096e3083d6afd3c1e0bb86ab14ec244c1cb6aa87c55b15d34d06ea0c994867f9e52b38389422";
+      sha512 = "459ed2d8fa1fd6ec45e00af73eb23c53a438f179dda349fc434269d737ec3679812c18804ed306f156b2f8f30ab026a0398817dbf5e8c1339302dac4c9bf0454";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/mk/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/mk/firefox-57.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "ce4e7d7693e0229a83aab9970d1678c621b58dd481d4c6aa4ffe2d478f15d72984968349ad3e4febb38e96c30847631f0bdd7abd8eb09dfcb2d4092e1539ba97";
+      sha512 = "b0c9b7a06eea66f603ed79c36784dc641b2d2791368040522ca464942f6b4a6828dac0c6c098b5251b696d14ef5a8a795fb31d1fa5a5bc6660c77cde452af555";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/ml/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/ml/firefox-57.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "0383725a278add1e0b78c8c75bb7d541967726d90bcf7264118349615e96ab9db83b8b363bc68f1e9fb220078385de4f92f726555c10c8793aa1a190d5869dea";
+      sha512 = "8005d32b1c41b7deb18305c381f64ca02395e30e468cbc7b4d014af4868477aa7c5af5a4f36111e89def0a4e46e78d6be137c573b72b2f5eb27c1cfe109a44cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/mr/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/mr/firefox-57.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "f50849e45b52a34b7cbb02edf3fefdea3c9a9c5a60f8517cbc852cdc5209fe281efd7d182a53e4a793447478d32a79bf529097f1041165d6b1ed37459e4b02bd";
+      sha512 = "3ccf8f3357ff9f559f237c8901f26f8ea54b437bd2a34015a5738af5c97b0cbd882f069ae5c306de3f46d7ccb951f06ed225869ab5d31c82112fdb7da0c2714d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/ms/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/ms/firefox-57.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "f8ec236546a7dede2b502a254c010724c636b69a1f4b7dc73e2684f9d314b1e4d79cab8a0f9ba2a1942c6afbe0b44152c133bb5c94cf8d1f0ef33c08df38a1dc";
+      sha512 = "29102828e4fff49774580d4d0214ffe7fa7e38ba7cd90d09423b0d1ebd175a057221b6d2d374d4c7cc9b2d054ef449e5ca49ce12c971c15179f1f06523c517d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/my/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/my/firefox-57.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "ffae5d1763fa88c57961c3d11c71cb1e3540f109bd553ef0ef86eb5537b3599154943365c7368f4f06a1d5911aec17c52013bc414d899325a5dea8aaa9b92817";
+      sha512 = "b01f3e667887e268fca6f72bb2046461d45fc5f21eb12a760eb61b5ece393de2b4d824000edfe13eb9c680b8f5fb95bcd39b58ba6f3124ac7e179d47f3c221f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/nb-NO/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/nb-NO/firefox-57.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "c8e569886b7470c1856e6b3b6fb756b05d14b21a57dd7337d490d5c7cacec603e9670ca3be8d34b1e8194ef053232d5d758e824a48b66205a5e26698751b0fb2";
+      sha512 = "680273b4636e1bc00ffdefc5c264bb6466cbf6ef577ab382ef5c28cfa731de8b51f7d83ea3695d7e7e01d93041b3b8464ad9442b43aeaa866b29f60761d3e849";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/nl/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/nl/firefox-57.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "d55277a2e99a63e0a2e7343bfb5250ee70443bec1be8629b858ee17e574e0124d37c6d15a03eea58b0f9122ce17042af94498430517cacb0e59058d53f251aaa";
+      sha512 = "a2409928f939401e530f0e1124f0573ea0cb24ccca0046b170cff8353bc3f82fc9c172088760b4e74055984780debd3e0915187d79802192b5c9a2405a8ab198";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/nn-NO/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/nn-NO/firefox-57.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "ed01cae9dd21e46a6fae031994e38980b72fbad6dc521571f5d21d8a23c9a2b4f4606ec92435d2aa2deb441b7f9e15d61f443fc6e557bbbc6b36d4c226f2ace3";
+      sha512 = "f01a149c8a9623bc03dee85e0890019aae858c828c5b4a2609cbd084bc178c15b0aa6677d9d5b2d51edbb75748447a58598e2cb2d6f6ceeed979995a2c1b108a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/or/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/or/firefox-57.0.1.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "2007dcbb344395d80ba05a8a4f87c2f7c19254966cfc08c728ee7363cb763a93c50d616756ab3e601d7a98114e89a6bf97e76e88fbc1ec48decfe028f5aa04b9";
+      sha512 = "55f30387f08e43dd965778de0b18a3cf1584e2ffd5ee732e56c7a53e8092ab25f01dccfc12982d0c8650e32eebac82c50fb0b1e60848d06fce89ea3eb414813c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/pa-IN/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/pa-IN/firefox-57.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "bcf6175628c4ee73746ec8337fe3dd2ab329ed971ee3044684d5ea92bb500b4c708dbed46c97848e56026f00cf26659402cf2f213e106b0b7eece28b87b26ff5";
+      sha512 = "fc32d024176ecfe7e5802fbeb61d5bae7eeefd985336456949f364d98ce80dc0d02e5c60d1dc98d960c455036e2006f8936571e00852b2714ab6c7064eb15e2a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/pl/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/pl/firefox-57.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "b8f51a95786571aabf58cb81e4cd52edabfca23686a481157a11de47adbf14cb39c317c02e9f4ec313bfe282f326d70e531f83735095c51df40ed58ebf068a7f";
+      sha512 = "701b4652eb5f98b43b9cb8c07152f61af51e158eda425712e79f38d64f73a9fa0ece935de0ca0bce383591cbd238ed8d372e7cec732d5c0c4bc8009954f37e6b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/pt-BR/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/pt-BR/firefox-57.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "f53076ea2a933f2c30aa93e222cad9a73d981ff0e7ca9fb98df0f1db97ea4393a1b5a37388549e63ebf7a7f44fcaecace20725ce6c7cbb33626de9c9754ab999";
+      sha512 = "175264c1ef2bfe0f2a87fa2bfe391cd6140fd9602bcfe7c690ed2690f32d4baff8387aff58784f04acb4b08a8199a845026116782311608a89d61d18fb226150";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/pt-PT/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/pt-PT/firefox-57.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "3032b7338b6540086edc86a8c5f1298ad546b77982c02013ba96df564c4c99670db6eefffac8f56f540fee6c3a8887e81fff5de2391cb5b29a8429f72b9ada64";
+      sha512 = "6fea73a5d2b095cfeeaf9e86078ca67273506612224a0d800b4866da7ab79a5ea21ff21ee1131627856453a6536e84b627b6c5bec45b13b414046f4f094d88d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/rm/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/rm/firefox-57.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "7dcc1f088c20687d322f83e6eece96d48fd43a63cfa44816e729e623f161867af3725ee88fe0904ea826640c89f0c84d6f46d7bf847dfef51a671dd2dfc2c044";
+      sha512 = "bec7875fd7151e9175c6d9e0e354c718e61e83893ba050d2555cdd88dc4c6b782c75a3f6b3f92db8bc15bd3fc2a2dbf9007f5d6d33fa9660acbfbc36dfe8f5bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/ro/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/ro/firefox-57.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "b8f6f3f5b10755ec2b13fb68d1add7cbdabe799dca9077036be3750c7f4f753c89c5a0382e45f1b02da5b3842ab095153ec1f48029515f6513d35bb28012be02";
+      sha512 = "95ae533eafc0a3d83127bac3abb4f17e14d25dda534a486e85e0d7750b6bcfca120479cbdda5a7a34b6222f7a4e894c614853c96df4ffb52cb86c170d703d0b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/ru/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/ru/firefox-57.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "7aaec71a4dd8588ad432ccd2f8a44aafe0d5b502f2a15b11e25065c9a04cce5c76e48492f99c6a14ead274d6180564cca3eef7d9bb9e98cee2960d0433cbef71";
+      sha512 = "5a8f11444d2a72c36bd51b0d60911636a34312e7a2ed467eaf4d5cf21992f412ea36f0990634ee7330555d6cfa56139b567d465dee7e696d7b4a394971665b7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/si/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/si/firefox-57.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "6d9032566a45fab13a685258f94bbe9eb937219655924224873635a41fae3d9973f762eeba206b72f3990b5517a96cd984464c86d30618130c1e3429ccd0b00b";
+      sha512 = "0c5dc876dcc8bfa56e9bc7ed5bb629ba7a6d9206fc3586f311b994f2d006ead19bdb0ba015669f547043c9a73202fa9c3c90c9f171f2756f108d45520544b6f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/sk/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/sk/firefox-57.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "6f5359765802799631ca6654a32f74bb27fcb8d81bdc23cfc912805fd10ad9ecd80ac0d24f23e4fc28bcb104891a0846ce7be1a1fd80d7b91e1b3b89f3644c8a";
+      sha512 = "79003a5848287fc6974df32365bb8379b3ad3329d2a3d1d351cc3a61b28229e931b2d53384b5d46961687a928090a6f304b87d80a72cb322d0f39e0bb357f7a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/sl/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/sl/firefox-57.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "d18cb826761333b7fbf1e7d056cfdc4bf2871f39da0ff93d89efc97e808dd79bb8837b9a2656688bd1658737933d60d5cb069d6ce832e72a7d83836887672e7d";
+      sha512 = "989d8be27ea47441bc4b9b42006cb34b99a2b2f4982b4f9758af8725a2955aa472ec19241fdb4adccb2e99f3b0dd245159de2a36286d2b96c44ef60607f51d81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/son/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/son/firefox-57.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "90e86f1cc8b35d28e96f417589d69f2ca016495297d54c74d0243daeeb39b9564cb56e4b66685ba708463284b004b17bb157bd55bde3cc962457d56cdd1dcee0";
+      sha512 = "d4c840680599cdda340b50e91ec348db31e6b896c1fd92587ac938603edcada7973bec0e049a9a1aca73a527867704f51a482e92e3dc5d0d39b74b150b3d772c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/sq/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/sq/firefox-57.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "5c90e9dd76aceaf1ca6995349ab2cae5425764eef75303b3d803544d156b67ce5d353429f3acb15b55d32d5a9f37c6f753dd1a1081cd073ea27b3f88972928ec";
+      sha512 = "eff9704444512c3a9e63f40b71a41ab595d71be6f83ebe678de46a301f55f561b24cd28804416c254cd36c38f03b587da3ac4aefe0d5fad2035437d8159a0580";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/sr/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/sr/firefox-57.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "32cc44f8aeafa861004326dde6ea99690be06c4960436c4eece48353b4de11b1691d347628ee239d7bcebfed14bf1da20180c04ffc5d62096172cbb183e4ad3f";
+      sha512 = "44d9071fc069670459f8cd468474d45d83574ded3a647abea358e65cacebdb89cd26cb903cffe279c6a3d72af9377659433d03c542e13dee3b7e20ecd32b137b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/sv-SE/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/sv-SE/firefox-57.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "c9d0f7eb815474fb866e519a00b6adbe47b6e86b6ee16af3d3d72ba9ea52eac202b3c36aad3245abf25ca88845c65d079a1fba219dd77a5da161a667c06676ed";
+      sha512 = "b9d1654f6a1f9323d0e27bb743bb8e650aabe9978ed9fc818a425377a41cf17b03e3c054945a9cae8e796ad32197f244a5299812cebc602e9bdb67451c234b65";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/ta/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/ta/firefox-57.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "af662b476aa060895e50cb43d49d2b509af24ed3294d5f15d1a5c5d7f00021cc60bfcb77476375e0146f6d247243e2f3701a271a246f08a3ef408cd9cac42753";
+      sha512 = "22e5a751419d5cd332724f09cdea8ab135117b2d7272570622ac8e9b51dfcf61c1a423e78bf4d211d18ce3e4bd652aa6e0b33a02467f011021d23fb0b14179ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/te/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/te/firefox-57.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "e7d7fd6b38d654c72b34b186fea49b7707b2051600d87628a3a8ea02c48bbc810153928bfd556bb88aa9134c1bdac7fdd6f47954519391bc83e478ea5bfedac2";
+      sha512 = "718ca2e72a8beb1a423bba10919faa1a1949e76c3e6aa0a261d7c5a8d611da7c5b73d2a209078f204b8c2f3c9d09c0949260bebe66d52257ee0eafe9b34105f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/th/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/th/firefox-57.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "6bc2827c5de337c7fee9ac97ae31911361661ce107231da80ccc13afba8606944976003bd013ca01adf91c5282dbb956791b47e94363c0f18f25eb40159b2871";
+      sha512 = "fbcbeae74fb96b8dc8116db5c16f3f9cbc8d0dd074f179ec50b00dd6b6e68d977d968b5b308d5c6fa8303d247d5c30f49b0db9d4d6e13567e7818234375399b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/tr/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/tr/firefox-57.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "b03f28b336b1c59ba4a2f5b061f950e9e0491ab6b7173864b3dfb5588d52c397120dc86e9a8beaea47184c6b519ed42380ee6d94d30edd02b8ea8166e9e9f33b";
+      sha512 = "31f12bc63b65b455bd7335482d1b45483e8472874f0ee5c32d686f770d063109adb40d4f0b3e54f7bb45da43828de1844e06818da0b6b5aa514bd304c394df0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/uk/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/uk/firefox-57.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "bf9f67458a280a1ce7c27119680a5b5d37c2aeaef3fc79967a61d0e06b0a688faf3c591d843b8783eac203b60886d298c68d6bf2cd318b982fa91abd98551236";
+      sha512 = "1cb4b91e8e693f2306247164ba049003dd4543ec19afdfb39531626d0ef83793bff85c5e26b4016a608b01699d36e5fbe936d6c974db9222e5fe22361fd13f0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/ur/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/ur/firefox-57.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "069ca0a5ccf90f6a8be96b2db90534473045241abb55be13611ddce7815d37db4cf82fbeab753b3c04a898574a3ca6ecf954e30b860b6d70395c0b24ac9b8a1c";
+      sha512 = "ab777f897db855234c1db88a4d1c3f2a2534b926a0abeb9e55094c99b513ef97f13d36188656ed82015044a4cdd45519e4ad20dc465394108cd2f85ded9c6e19";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/uz/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/uz/firefox-57.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "45b1f0eecf3b6c05be541d764608964db65861f937e94ac011d10befd0e71c7942658a5a02c0a482a22abd164730dffb45b28aa9b8ca4ac87a21a32050b183a2";
+      sha512 = "eb03e3901f5a98b7198c677227830531cce3ab89e1e5e9cfa8a74f344871ec976b14373c337d3113b2a517eb3e80eb91c6239e7e85a2483e5e35d643007a131c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/vi/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/vi/firefox-57.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "4d1c3418dfae7b8929ab117efb1febca6c7569f163ae0d805a27592c00aecdc9f7956aa56c01e898cdc09bffc5d9a55654d5d98712a9ab685ac1f6061c03680e";
+      sha512 = "cb4a7f6ea792e3504d4c6577ee2f616dde7090a020d6bac38bb13a442297ffa279b795ac3aa6cb06c34e739c346dfb1a22fe4a7eaaed832e8c0d387f900dca26";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/xh/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/xh/firefox-57.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "a79e103d319ed72e28b011a658436a3036d1f280b733db2433e36c6c25bd5192a8e44527f591b92e0d6836ec17e23decb9d41ec50623e051484e7fbd20733cc1";
+      sha512 = "6fb867d59393e57f85b597fefafd73d88410b6b8a338882be43c97a8359a6c6fe6542979f280f0b27c50d3c13302be55e16054339bcbb3e2fe0071830bc5ea21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/zh-CN/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/zh-CN/firefox-57.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "d27040490378d8c61d68359715ebfc06bbcce8637936fe399b42c4e38c0935f0bdad34e379c852d00961c22fe97d2b43c0214cc951855acb41cc5c7ef3824e8f";
+      sha512 = "2e055fb920fc33e40cdd0976881cf3187694f5967b87d28ddb385df1913db1f66f2f481c2879919a6fa0cebf893d15a88bc077be8f5a21c07cfdc11cd70aa476";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0/linux-i686/zh-TW/firefox-57.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.1/linux-i686/zh-TW/firefox-57.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "99efd3df2a3dc1a3e4950add00c6768d694b6d349ca7c36c7c7ba5c53650fb553942795923c40c7bc0fadf76e209e9b5f357ab9648f57bc3ae1f30c85878fb65";
+      sha512 = "78bd8081a84d7088b776f0091154e1a88fd5b39e01d8a3380d375a43e94118460c183fad77e801827144dafecffb74fcb4093320205d0143ddc3835652de66b7";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -32,10 +32,10 @@ rec {
 
   firefox-esr = common rec {
     pname = "firefox-esr";
-    version = "52.5.0esr";
+    version = "52.5.1esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "fe724108ba538e590b87a5c1b817471d3cca9b038ba2755642e4d7b8ebb6174322be1fe074f24ef181946f9a027106b50b500d2fa541d8a99ef44905822eda18";
+      sha512 = "37318a9f82fa36fe390b85f536f26be9a6950a5143e74a218477adaffb89c77c1ffe17add4b79b26e320bb3138d418ccbb1371ca11e086d140143ba075947dc0";
     };
 
     patches =

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -6,10 +6,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "57.0";
+    version = "57.0.1";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "bd99ff97a2a6f824e6fbd36fd00193903159e309506b1e6945dcbc43a17a95aaa54a05f32131c56872e8860878ba6063008667955550f03aa8c7084f834d14fc";
+      sha512 = "8cbfe0ad2c0f935dbc3a0ac4e855c489c83bf8c4506815dbae6e27f5d6a262ecf19ac82b6e81d52782559834fa14403116ecbf3acc8e3bc56b6c319e68316edd";
     };
 
     patches =


### PR DESCRIPTION
###### Motivation for this change

- Bug fixes.

https://www.mozilla.org/en-US/firefox/57.0.1/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

