### PR TITLE
Mention GNOME-related stuff in changelog

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -40,6 +40,12 @@ has the following highlights: </para>
   </listitem>
 
   <listitem>
+    <para>
+      The GNOME version is now 3.26.
+    </para>
+  </listitem>
+
+  <listitem>
     <para>PHP now defaults to PHP 7.2</para>
   </listitem>
 </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -206,6 +206,14 @@ following incompatible changes:</para>
       overhead of a go package having non-versioned dependencies.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      When using <option>services.xserver.libinput</option> (enabled by default in GNOME),
+      it now handles all input devices, not just touchpads. As a result, you might need to
+      re-evaluate any custom Xorg configuration. In particular,
+      <literal>Option "XkbRules" "base"</literal> may result in broken keyboard layout.
+    </para>
+  </listitem>
 </itemizedlist>
 
 </section>


### PR DESCRIPTION
###### Motivation for this change
* GNOME upgrade
* libinput incompatibility with some Xorg configs (https://github.com/NixOS/nixpkgs/issues/32195)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

