### PR TITLE
Dropbox: Backport patches to stable

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -69,7 +69,7 @@ buildFHSUserEnv {
         rm "$installer"
     fi
 
-    exec "$HOME/.dropbox-dist/dropboxd"
+    exec "$HOME/.dropbox-dist/dropboxd" "$@"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -35,7 +35,7 @@ buildFHSUserEnv {
   targetPkgs = pkgs: with pkgs; with xlibs; [
     libICE libSM libX11 libXcomposite libXdamage libXext libXfixes libXrender
     libXxf86vm libxcb xkeyboardconfig
-    curl dbus fontconfig freetype gcc glib gnutar libxml2 libxslt zlib
+    curl dbus fontconfig freetype gcc glib gnutar libxml2 libxslt procps zlib
   ];
 
   extraInstallCommands = ''
@@ -44,12 +44,31 @@ buildFHSUserEnv {
   '';
 
   runScript = writeScript "install-and-start-dropbox" ''
+    set -e
+
+    do_install=
     if ! [ -d "$HOME/.dropbox-dist" ]; then
+        do_install=1
+    else
+        installed_version=$(cat "$HOME/.dropbox-dist/VERSION")
+        latest_version=$(printf "${version}\n$installed_version\n" | sort -V | head -n 1)
+        if [ "x$installed_version" != "x$latest_version" ]; then
+            do_install=1
+        fi
+    fi
+
+    if [ -n "$do_install" ]; then
+        installer=$(mktemp)
         # Dropbox is not installed.
         # Download and unpack the client. If a newer version is available,
         # the client will update itself when run.
-        curl '${installer}' | tar -C "$HOME" -x -z
+        curl '${installer}' >"$installer"
+        pkill dropbox || true
+        rm -fr "$HOME/.dropbox-dist"
+        tar -C "$HOME" -x -z -f "$installer"
+        rm "$installer"
     fi
+
     exec "$HOME/.dropbox-dist/dropboxd"
   '';
 

--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -34,7 +34,7 @@ buildFHSUserEnv {
 
   targetPkgs = pkgs: with pkgs; with xlibs; [
     libICE libSM libX11 libXcomposite libXdamage libXext libXfixes libXrender
-    libXxf86vm libxcb
+    libXxf86vm libxcb xkeyboardconfig
     curl dbus fontconfig freetype gcc glib gnutar libxml2 libxslt zlib
   ];
 

--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -35,7 +35,8 @@ buildFHSUserEnv {
   targetPkgs = pkgs: with pkgs; with xlibs; [
     libICE libSM libX11 libXcomposite libXdamage libXext libXfixes libXrender
     libXxf86vm libxcb xkeyboardconfig
-    curl dbus fontconfig freetype gcc glib gnutar libxml2 libxslt procps zlib
+    curl dbus firefox-bin fontconfig freetype gcc glib gnutar libxml2 libxslt
+    procps zlib
   ];
 
   extraInstallCommands = ''
@@ -44,6 +45,8 @@ buildFHSUserEnv {
   '';
 
   runScript = writeScript "install-and-start-dropbox" ''
+    export BROWSER=firefox
+
     set -e
 
     do_install=


### PR DESCRIPTION
### Testing

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

