### PR TITLE
pythonPackages.quandl: 3.0.0 -> 3.2.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -284,6 +284,7 @@
   iblech = "Ingo Blechschmidt <iblech@speicherleck.de>";
   igsha = "Igor Sharonov <igor.sharonov@gmail.com>";
   ikervagyok = "Balázs Lengyel <ikervagyok@gmail.com>";
+  ilya-kolpakov = "Ilya Kolpakov <ilya.kolpakov@gmail.com>";
   infinisil = "Silvan Mosberger <infinisil@icloud.com>";
   ironpinguin = "Michele Catalano <michele@catalano.de>";
   ivan-tkatchev = "Ivan Tkatchev <tkatchev@gmail.com>";

--- a/pkgs/development/python-modules/inflection/default.nix
+++ b/pkgs/development/python-modules/inflection/default.nix
@@ -1,21 +1,23 @@
-{ lib, fetchurl, buildPythonPackage, pytest } :
+{ lib, fetchPypi, buildPythonPackage, pytest } :
 
 buildPythonPackage rec {
-   version = "0.3.1";
-   name = "inflection-${version}";
+  pname = "inflection";
+  version = "0.3.1";
 
-   src = fetchurl {
-     url= "mirror://pypi/i/inflection/${name}.tar.gz";
-     sha256 = "1jhnxgnw8y3mbzjssixh6qkc7a3afc4fygajhqrqalnilyvpzshq";
-   };
+  src = fetchPypi {
+   inherit pname version;
+   sha256 = "1jhnxgnw8y3mbzjssixh6qkc7a3afc4fygajhqrqalnilyvpzshq";
+  };
 
-   propagatedBuildInputs = [ pytest ];
+  checkInputs = [ pytest ];
+  # Suppress overly verbose output if tests run successfully
+  checkPhase = ''pytest >/dev/null || pytest'';
 
-   meta = {
-     homepage = https://github.com/jpvanhal/inflection;
-     description = "A port of Ruby on Rails inflector to Python";
-     maintainers = with lib.maintainers; [ NikolaMandic ilya-kolpakov ];
-     license = lib.licenses.mit;
-   };
+  meta = {
+   homepage = https://github.com/jpvanhal/inflection;
+   description = "A port of Ruby on Rails inflector to Python";
+   maintainers = with lib.maintainers; [ NikolaMandic ilya-kolpakov ];
+   license = lib.licenses.mit;
+  };
 }
 

--- a/pkgs/development/python-modules/inflection/default.nix
+++ b/pkgs/development/python-modules/inflection/default.nix
@@ -1,0 +1,21 @@
+{ lib, fetchurl, buildPythonPackage, pytest } :
+
+buildPythonPackage rec {
+   version = "0.3.1";
+   name = "inflection-${version}";
+
+   src = fetchurl {
+     url= "mirror://pypi/i/inflection/${name}.tar.gz";
+     sha256 = "1jhnxgnw8y3mbzjssixh6qkc7a3afc4fygajhqrqalnilyvpzshq";
+   };
+
+   propagatedBuildInputs = [ pytest ];
+
+   meta = {
+     homepage = https://github.com/jpvanhal/inflection;
+     description = "A port of Ruby on Rails inflector to Python";
+     maintainers = with lib.maintainers; [ NikolaMandic ilya-kolpakov ];
+     license = lib.licenses.mit;
+   };
+}
+

--- a/pkgs/development/python-modules/jsondate/default.nix
+++ b/pkgs/development/python-modules/jsondate/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, buildPythonPackage, six }:
+
+buildPythonPackage rec {
+  version = "0.1.3";
+  pname = "jsondate";
+
+  src = fetchFromGitHub {
+    owner = "ilya-kolpakov";
+    repo = "jsondate";
+    rev = "refs/tags/v${version}";
+    sha256 = "0nhvi48nc0bmad5ncyn6c9yc338krs3xf10bvv55xgz25c5gdgwy";
+    fetchSubmodules = true; # Fetching by tag does not work otherwise
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  meta = {
+    homepage = "https://github.com/ilya-kolpakov/jsondate";
+    description = "JSON with datetime handling";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/quandl/allow-requests-v2.18.patch
+++ b/pkgs/development/python-modules/quandl/allow-requests-v2.18.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+--- a/setup.py
++++ b/setup.py
+@@ -18,7 +18,7 @@ from version import VERSION  # NOQA
+ install_requires = [
+     'pandas >= 0.14',
+     'numpy >= 1.8',
+-    'requests >= 2.7.0, < 2.18',  # Version 2.18 appears to break pulling data.
++    'requests >= 2.7.0', # Works fine
+     'inflection >= 0.3.1',
+     'python-dateutil',
+     'six',

--- a/pkgs/development/python-modules/quandl/default.nix
+++ b/pkgs/development/python-modules/quandl/default.nix
@@ -8,18 +8,16 @@
   pyOpenSSL ? null, ndg-httpsclient ? null, pyasn1 ? null
 }:
 
-let
+buildPythonPackage rec {
+  pname = "quandl";
   version = "3.2.1";
   sha256 = "0vc0pzs2px9yaqkqcmd2m1b2bq1iils8fs0xbl0989hjq791a4jr";
 
-in buildPythonPackage rec {
-  pname = "quandl";
-  inherit version;
-
   patches = [ ./allow-requests-v2.18.patch ];
 
+  # Tests do not work with fetchPypi
   src = fetchFromGitHub {
-    owner = "quandl";
+    owner = pname;
     repo = "quandl-python";
     rev = "refs/tags/v${version}";
     inherit sha256;

--- a/pkgs/development/python-modules/quandl/default.nix
+++ b/pkgs/development/python-modules/quandl/default.nix
@@ -1,0 +1,61 @@
+{
+  lib, fetchFromGitHub, buildPythonPackage, isPy3k,
+  # runtime dependencies
+  pandas, numpy, requests, inflection, python-dateutil, six, more-itertools,
+  # test suite dependencies
+  nose, unittest2, flake8, httpretty, mock, factory_boy, jsondate,
+  # additional runtime dependencies are required on Python 2.x
+  pyOpenSSL ? null, ndg-httpsclient ? null, pyasn1 ? null
+}:
+
+let
+  version = "3.2.1";
+  sha256 = "0vc0pzs2px9yaqkqcmd2m1b2bq1iils8fs0xbl0989hjq791a4jr";
+
+in buildPythonPackage rec {
+  pname = "quandl";
+  inherit version;
+
+  patches = [ ./allow-requests-v2.18.patch ];
+
+  src = fetchFromGitHub {
+    owner = "quandl";
+    repo = "quandl-python";
+    rev = "refs/tags/v${version}";
+    inherit sha256;
+    fetchSubmodules = true; # Fetching by tag does not work otherwise
+  };
+
+  doCheck = true;
+
+  checkInputs = [
+    nose
+    unittest2
+    flake8
+    httpretty
+    mock
+    factory_boy
+    jsondate
+  ];
+
+  propagatedBuildInputs = [
+    pandas
+    numpy
+    requests
+    inflection
+    python-dateutil
+    six
+    more-itertools
+  ] ++ lib.optional (!isPy3k) [
+    pyOpenSSL
+    ndg-httpsclient
+    pyasn1
+  ];
+
+  meta = {
+    homepage = "https://github.com/quandl/quandl-python";
+    description = "Quandl Python client library";
+    maintainers = [ lib.maintainers.ilya-kolpakov ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -24440,6 +24440,7 @@ EOF
 
   inflection = callPackage ../development/python-modules/inflection { };
 
+  quandl = callPackage ../development/python-modules/quandl { };
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9709,25 +9709,6 @@ in {
     };
   };
 
-
-  inflection = buildPythonPackage rec {
-     version = "0.3.1";
-     name = "inflection-${version}";
-
-     src = pkgs.fetchurl {
-       url= "mirror://pypi/i/inflection/${name}.tar.gz";
-       sha256 = "1jhnxgnw8y3mbzjssixh6qkc7a3afc4fygajhqrqalnilyvpzshq";
-     };
-
-     disabled = isPy3k;
-
-     meta = {
-       homepage = https://github.com/jpvanhal/inflection;
-       description = "A port of Ruby on Rails inflector to Python";
-       maintainers = with maintainers; [ NikolaMandic ];
-     };
-  };
-
   influxdb = buildPythonPackage rec {
     name = "influxdb-4.0.0";
 
@@ -24456,6 +24437,9 @@ EOF
   ephem = callPackage ../development/python-modules/ephem { };
 
   jsondate = callPackage ../development/python-modules/jsondate { };
+
+  inflection = callPackage ../development/python-modules/inflection { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -24454,6 +24454,8 @@ EOF
   parse-type = callPackage ../development/python-modules/parse-type { };
 
   ephem = callPackage ../development/python-modules/ephem { };
+
+  jsondate = callPackage ../development/python-modules/jsondate { };
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10046,6 +10046,8 @@ in {
     inherit (self) systemd pytest;
   };
 
+  jsondate = callPackage ../development/python-modules/jsondate { };
+
   jsonnet = buildPythonPackage {
     inherit (pkgs.jsonnet) name src;
     # Python 3 is not yet supported https://github.com/google/jsonnet/pull/335
@@ -24412,8 +24414,6 @@ EOF
   parse-type = callPackage ../development/python-modules/parse-type { };
 
   ephem = callPackage ../development/python-modules/ephem { };
-
-  jsondate = callPackage ../development/python-modules/jsondate { };
 
 });
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -23588,35 +23588,6 @@ EOF
     };
   };
 
-  Quandl = buildPythonPackage rec {
-    version = "3.0.0";
-    name = "Quandl-${version}";
-
-    src = pkgs.fetchurl {
-      url= "mirror://pypi/q/quandl/${name}.tar.gz";
-      sha256 = "d4e698eb39291e0b281975813054101f3dfb379dead10d34d7b536e1aad60584";
-    };
-
-    propagatedBuildInputs = with self; [
-      numpy
-      ndg-httpsclient
-      dateutil
-      inflection
-      more-itertools
-      requests
-      pandas
-    ];
-
-    # No tests in archive
-    doCheck = false;
-
-    meta = {
-      homepage = https://github.com/quandl/quandl-python;
-      description = "A Python library for Quandl’s RESTful API";
-      maintainers = with maintainers; [ NikolaMandic ];
-    };
-  };
-
   queuelib = buildPythonPackage rec {
     name = "queuelib-${version}";
     version = "1.4.2";
@@ -24441,6 +24412,9 @@ EOF
   inflection = callPackage ../development/python-modules/inflection { };
 
   quandl = callPackage ../development/python-modules/quandl { };
+  # alias for an older package which did not support Python 3
+  Quandl = callPackage ../development/python-modules/quandl { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16936,6 +16936,10 @@ in {
     };
   };
 
+  quandl = callPackage ../development/python-modules/quandl { };
+  # alias for an older package which did not support Python 3
+  Quandl = callPackage ../development/python-modules/quandl { };
+
   qscintilla = disabledIf (isPy3k || isPyPy)
     (buildPythonPackage rec {
       # TODO: Qt5 support
@@ -24410,10 +24414,6 @@ EOF
   jsondate = callPackage ../development/python-modules/jsondate { };
 
   inflection = callPackage ../development/python-modules/inflection { };
-
-  quandl = callPackage ../development/python-modules/quandl { };
-  # alias for an older package which did not support Python 3
-  Quandl = callPackage ../development/python-modules/quandl { };
 
 });
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9709,6 +9709,8 @@ in {
     };
   };
 
+  inflection = callPackage ../development/python-modules/inflection { };
+
   influxdb = buildPythonPackage rec {
     name = "influxdb-4.0.0";
 
@@ -24412,8 +24414,6 @@ EOF
   ephem = callPackage ../development/python-modules/ephem { };
 
   jsondate = callPackage ../development/python-modules/jsondate { };
-
-  inflection = callPackage ../development/python-modules/inflection { };
 
 });
 


### PR DESCRIPTION
###### Motivation for this change

1) Update the package to the current version (3.2.1 from 3.0.0)
2) Add Python 3.5 and 3.6 support in addition to 2.7
3) Enable build tests

###### Naming

The old package used was accessible via `Quandl`. I suggest
1) to use`quandl` (lowercase) as default name since it is consistent with
    - upstream ([quandl/quandl-python](https://github.com/quandl/quandl-python))
    - the package itself (`import quandl`)
2) to make the new package accessible as `Quandl` as well.

###### Things done

- [x] Tested using sandboxing 
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change
- [ ] Tested compilation of all pkgs that depend on this change
- [x] Tested the library
- [x] Fits [CONTRIBUTING.md]