### PR TITLE
xfce.xfdesktop: appending bug fix

### DIFF
--- a/pkgs/desktops/xfce/core/xfdesktop.nix
+++ b/pkgs/desktops/xfce/core/xfdesktop.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk, libxfce4util, libxfce4ui
+{ stdenv, fetchurl, fetchpatch, pkgconfig, intltool, gtk, libxfce4util, libxfce4ui
 , libwnck, xfconf, libglade, xfce4panel, thunar, exo, garcon, libnotify
 , hicolor_icon_theme }:
 let

--- a/pkgs/desktops/xfce/core/xfdesktop.nix
+++ b/pkgs/desktops/xfce/core/xfdesktop.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   patches =
     [
-      (fetchurl {
+      (fetchpatch {
       url = https://git.xfce.org/xfce/xfdesktop/patch?id=157f5b55cfc3629d595ef38984278de5915aac27;
       sha256 = "07yvhci0yccbxnqymh2cf49j8yc0jsw147mnjzw9iy4kghj2rqxj";})
     ];

--- a/pkgs/desktops/xfce/core/xfdesktop.nix
+++ b/pkgs/desktops/xfce/core/xfdesktop.nix
@@ -19,6 +19,13 @@ stdenv.mkDerivation rec {
       libglade xfce4panel thunar exo garcon libnotify hicolor_icon_theme
     ];
 
+  patches =
+    [
+      (fetchurl {
+      url = https://git.xfce.org/users/eric/xfdesktop/patch/?id=cc311b61b82b7510a3a6cb0952d3a331e3551e05;
+      sha256 = "0wil8533v0hag5b6vn5qjx7nlw9h643idzbkjdxd910483la94vz";})
+    ];
+
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
@@ -29,4 +36,3 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.eelco ];
   };
 }
-

--- a/pkgs/desktops/xfce/core/xfdesktop.nix
+++ b/pkgs/desktops/xfce/core/xfdesktop.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
   patches =
     [
       (fetchurl {
-      url = https://git.xfce.org/users/eric/xfdesktop/patch/?id=cc311b61b82b7510a3a6cb0952d3a331e3551e05;
-      sha256 = "0wil8533v0hag5b6vn5qjx7nlw9h643idzbkjdxd910483la94vz";})
+      url = https://git.xfce.org/xfce/xfdesktop/patch?id=157f5b55cfc3629d595ef38984278de5915aac27;
+      sha256 = "07yvhci0yccbxnqymh2cf49j8yc0jsw147mnjzw9iy4kghj2rqxj";})
     ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Contains Bug#12832 fix which solves issue with gtk 2.24.31 regression - grayed out folders in wallpaper choose dialog

https://bugzilla.xfce.org/show_bug.cgi?id=12832

Patch source:
https://git.xfce.org/xfce/xfdesktop/commit?id=157f5b55cfc3629d595ef38984278de5915aac27

###### Motivation for this change

Unable to change wallpapers folder in wallpaper choose dialog.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

