### PR TITLE
mhwaveedit: fix src url (gna is dead) and use autoreconf for build

### DIFF
--- a/pkgs/applications/audio/mhwaveedit/default.nix
+++ b/pkgs/applications/audio/mhwaveedit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, SDL , alsaLib, gtk2, libjack2, ladspaH
+{ stdenv, fetchurl, makeWrapper, SDL, alsaLib, autoreconfHook, gtk2, libjack2, ladspaH
 , ladspaPlugins, libsamplerate, libsndfile, pkgconfig, libpulseaudio, lame
 , vorbis-tools }:
 
@@ -7,12 +7,18 @@ stdenv.mkDerivation  rec {
   version = "1.4.23";
 
   src = fetchurl {
-    url = "http://download.gna.org/mhwaveedit/${name}.tar.bz2";
-    sha256 = "010rk4mr631s440q9cfgdxx2avgzysr9aq52diwdlbq9cddifli3";
+    url = "https://github.com/magnush/mhwaveedit/archive/v${version}.tar.gz";
+    sha256 = "1lvd54d8kpxwl4gihhznx1b5skhibz4vfxi9k2kwqg808jfgz37l";
   };
 
-  buildInputs = [ SDL alsaLib gtk2 libjack2 ladspaH libsamplerate libsndfile
-     pkgconfig libpulseaudio makeWrapper ];
+  nativeBuildInputs = [ autoreconfHook ];
+
+  preAutoreconf = "(cd docgen && sh gendocs.sh)";
+
+  buildInputs = [
+     SDL alsaLib gtk2 libjack2 ladspaH libsamplerate libsndfile
+     pkgconfig libpulseaudio makeWrapper
+  ];
 
   configureFlags = "--with-default-ladspa-path=${ladspaPlugins}/lib/ladspa";
 


### PR DESCRIPTION
###### Motivation for this change

Since gna died, we've been building from hydra's cached copy of the source. The update switches to using the source from github and fixes the build by generating the configure file using autoreconf.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

