### PR TITLE
cups: 2.2.2 -> 2.2.6

### DIFF
--- a/nixos/tests/printing.nix
+++ b/nixos/tests/printing.nix
@@ -39,7 +39,7 @@ import ./make-test.nix ({pkgs, ... }: {
       $client->waitForUnit("cups.service");
       $client->sleep(10); # wait until cups is fully initialized
       $client->succeed("lpstat -r") =~ /scheduler is running/ or die;
-      $client->succeed("lpstat -H") =~ "/var/run/cups/cups.sock" or die;
+      $client->succeed("lpstat -H") =~ "localhost:631" or die;
       $client->succeed("curl --fail http://localhost:631/");
       $client->succeed("curl --fail http://server:631/");
       $server->fail("curl --fail --connect-timeout 2  http://client:631/");

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, zlib, libjpeg, libpng, libtiff, pam
-, dbus, systemd, acl, gmp, darwin
+{ stdenv, fetchurl, fetchpatch, pkgconfig, removeReferencesTo
+, zlib, libjpeg, libpng, libtiff, pam, dbus, systemd, acl, gmp, darwin
 , libusb ? null, gnutls ? null, avahi ? null, libpaper ? null
 }:
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig removeReferencesTo ];
 
   buildInputs = [ zlib libjpeg libpng libtiff libusb gnutls libpaper ]
     ++ optionals stdenv.isLinux [ avahi pam dbus systemd acl ]
@@ -38,17 +38,9 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ gmp ];
 
   configureFlags = [
-    # Put just lib/* and locale into $lib; this didn't work directly.
-    # lib/cups is moved back to $out in postInstall.
-    # Beware: some parts of cups probably don't fully respect these.
-    "--prefix=$(lib)"
-    "--datadir=$(out)/share"
-    "--localedir=$(lib)/share/locale"
-
     "--localstatedir=/var"
     "--sysconfdir=/etc"
     "--with-rundir=/run"
-    "--with-systemd=\${out}/lib/systemd/system"
     "--enable-raw-printing"
     "--enable-threads"
   ] ++ optionals stdenv.isLinux [
@@ -58,10 +50,24 @@ stdenv.mkDerivation rec {
     ++ optional (gnutls != null) "--enable-ssl"
     ++ optional (avahi != null) "--enable-avahi"
     ++ optional (libpaper != null) "--enable-libpaper"
-    ++ optionals stdenv.isDarwin [
-    "--with-bundledir=$out"
-    "--disable-launchd"
-  ];
+    ++ optional stdenv.isDarwin "--disable-launchd";
+
+  preConfigure = ''
+    configureFlagsArray+=(
+      # Put just lib/* and locale into $lib; this didn't work directly.
+      # lib/cups is moved back to $out in postInstall.
+      # Beware: some parts of cups probably don't fully respect these.
+      "--prefix=$lib"
+      "--datadir=$out/share"
+      "--localedir=$lib/share/locale"
+
+      "--with-systemd=$out/lib/systemd/system"
+
+      ${optionalString stdenv.isDarwin ''
+        "--with-bundledir=$out"
+      ''}
+    )
+  '';
 
   installFlags =
     [ # Don't try to write in /var at build time.
@@ -84,21 +90,26 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   postInstall = ''
-      moveToOutput lib/cups "$out"
+      libexec=${if stdenv.isDarwin then "libexec/cups" else "lib/cups"}
+      moveToOutput $libexec "$out"
+
+      # $lib contains references to $out/share/cups.
+      # CUPS is working without them, so they are not vital.
+      find "$lib" -type f -exec grep -q "$out" {} \; \
+           -printf "removing references from %p\n" \
+           -exec remove-references-to -t "$out" {} +
 
       # Delete obsolete stuff that conflicts with cups-filters.
       rm -rf $out/share/cups/banners $out/share/cups/data/testprint
 
-      # Some outputs in cups-config were unexpanded and some even wrong.
       moveToOutput bin/cups-config "$dev"
-      sed -e "/^cups_serverbin=/s|\$(lib)|$out|" \
-          -e "s|\$(out)|$out|" \
-          -e "s|\$(lib)|$lib|" \
+      sed -e "/^cups_serverbin=/s|$lib|$out|" \
           -i "$dev/bin/cups-config"
 
       # Rename systemd files provided by CUPS
       for f in "$out"/lib/systemd/system/*; do
         substituteInPlace "$f" \
+          --replace "$lib/$libexec" "$out/$libexec" \
           --replace "org.cups.cupsd" "cups" \
           --replace "org.cups." ""
 


### PR DESCRIPTION
###### Motivation for this change

Regular package update but have cupsd use ```Type=notify``` instead of ```Type=simple```.

```nix-build nixos/tests/printing.nix``` passes.

Cc: @jgeerds 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

