### PR TITLE
ansible: 2.4.1.0 -> 2.4.2.0

### DIFF
--- a/pkgs/tools/admin/ansible/2.4.nix
+++ b/pkgs/tools/admin/ansible/2.4.nix
@@ -6,12 +6,12 @@
 
 pythonPackages.buildPythonPackage rec {
   pname = "ansible";
-  version = "2.4.1.0";
+  version = "2.4.2.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "http://releases.ansible.com/ansible/${name}.tar.gz";
-    sha256 = "0spv0kjaicwss4q52s727b6grdizcxpa0bbsfg26pgf5kjrayqfs";
+    sha256 = "0n3n9py4s3aykiii31xq8g4wmd6693jvby0424pjrg0bna01apri";
   };
 
   prePatch = ''


### PR DESCRIPTION
###### Motivation for this change

Bump to the latest upstream release version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] **n/a** ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

