### PR TITLE
hubstaff: 1.2.14 → 1.2.15

### DIFF
--- a/pkgs/applications/misc/hubstaff/default.nix
+++ b/pkgs/applications/misc/hubstaff/default.nix
@@ -4,7 +4,7 @@
 
 let
 
-  version = "1.2.14-36df5e3";
+  version = "1.2.15-590e8bc";
 
   rpath = stdenv.lib.makeLibraryPath
     [ libX11 zlib libSM libICE libXext freetype libXrender fontconfig libXft
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://hubstaff-production.s3.amazonaws.com/downloads/HubstaffClient/Builds/Release/${version}/Hubstaff-${version}.sh";
-    sha256 = "0yzhxk9zppj94llnf8naa6ca61f7c8jaj6b1m25zffnnz37m1sdb";
+    sha256 = "142q8xvwn5gdmpv5x25py2lindr74jqncf8vvw22yb9nj5aqqsi6";
   };
 
   nativeBuildInputs = [ unzip makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Version bump.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

