### PR TITLE
wordpress: 4.7.6 -> 4.7.8

### DIFF
--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -2,8 +2,8 @@
 { fetchFromGitHub, lib } : fetchFromGitHub {
   owner = "WordPress";
   repo = "WordPress";
-  rev = "4.7.6";
-  sha256 = "0da44nqb6ny0r2z9m93zvigxzjz1k1ggxfc1320yy3f77ini82jr";
+  rev = "4.7.8";
+  sha256 = "1fm82xba6scmivjds8jplr31z6xd5n456kjdl50l87rps0anqjbm";
   meta = {
     homepage = https://wordpress.org;
     description = "WordPress is open source software you can use to create a beautiful website, blog, or app.";


### PR DESCRIPTION
###### Motivation for this change

This is for release-17.09.

New security and maintenance release is available for 4.7.x release series.

https://codex.wordpress.org/Version_4.7.7
https://codex.wordpress.org/Version_4.7.8

(somehow I missed 4.7.7 when doing previous package update :-()

/cc @basvandijk 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

