### PR TITLE
multilib-capable clang, multilib tests

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -264,7 +264,7 @@ stdenv.mkDerivation {
       # compile, because it uses "#include_next <limits.h>" to find the
       # limits.h file in ../includes-fixed. To remedy the problem,
       # another -idirafter is necessary to add that directory again.
-      echo "-B${libc_lib}/lib/ -idirafter ${libc_dev}/include -idirafter ${cc}/lib/gcc/*/*/include-fixed" > $out/nix-support/libc-cflags
+      echo "-B${libc_lib}/lib/ -idirafter ${libc_dev}/include ${optionalString isGNU "-idirafter ${cc}/lib/gcc/*/*/include-fixed"}" > $out/nix-support/libc-cflags
 
       echo "-L${libc_lib}/lib" > $out/nix-support/libc-ldflags
 

--- a/pkgs/development/compilers/llvm/multi.nix
+++ b/pkgs/development/compilers/llvm/multi.nix
@@ -1,0 +1,44 @@
+{ runCommand,
+clang,
+gcc64,
+gcc32,
+glibc_multi
+}:
+
+let
+  combine = basegcc: runCommand "combine-gcc-libc" {} ''
+    mkdir -p $out
+    cp -r ${basegcc.cc}/lib $out/lib
+
+    chmod u+rw -R $out/lib
+    cp -r ${basegcc.libc}/lib/* $(ls -d $out/lib/gcc/*/*)
+  '';
+  gcc_multi_sysroot = runCommand "gcc-multi-sysroot" {} ''
+    mkdir -p $out/lib/gcc
+
+    ln -s ${combine gcc64}/lib/gcc/* $out/lib/gcc/
+    ln -s ${combine gcc32}/lib/gcc/* $out/lib/gcc/
+    # XXX: This shouldn't be needed, clang just doesn't look for "i686-unknown"
+    ln -s $out/lib/gcc/i686-unknown-linux-gnu $out/lib/gcc/i686-pc-linux-gnu
+
+
+    # includes
+    ln -s ${glibc_multi.dev}/include $out/
+
+    # dynamic linkers
+    mkdir -p $out/lib/32
+    ln -s ${glibc_multi.out}/lib/ld-linux* $out/lib
+    ln -s ${glibc_multi.out}/lib/32/ld-linux* $out/lib/32/
+  '';
+
+  clangMulti = clang.override {
+    # Only used for providing expected structure re:dynamic linkers, AFAIK
+    # Most of the magic is done by setting the --gcc-toolchain option below
+    libc = gcc_multi_sysroot;
+
+    extraBuildCommands = ''
+      sed -e '$a --gcc-toolchain=${gcc_multi_sysroot}' -i $out/nix-support/libc-cflags
+    '';
+  };
+
+in clangMulti

--- a/pkgs/test/cc-wrapper/multilib.nix
+++ b/pkgs/test/cc-wrapper/multilib.nix
@@ -1,0 +1,37 @@
+{ stdenv }:
+
+stdenv.mkDerivation {
+  name = "cc-multilib-test";
+
+  # XXX: "depend" on cc-wrapper test?
+
+  # TODO: Have tests report pointer size or something; ensure they are what we asked for
+  buildCommand = ''
+    NIX_DEBUG=1 $CC -v
+    NIX_DEBUG=1 $CXX -v
+
+    printf "checking whether compiler builds valid C binaries... " >&2
+    $CC -o cc-check ${./cc-main.c}
+    ./cc-check
+
+    printf "checking whether compiler builds valid 32bit C binaries... " >&2
+    $CC -m32 -o c32-check ${./cc-main.c}
+    ./c32-check
+
+    printf "checking whether compiler builds valid 64bit C binaries... " >&2
+    $CC -m64 -o c64-check ${./cc-main.c}
+    ./c64-check
+
+    printf "checking whether compiler builds valid 32bit C++ binaries... " >&2
+    $CXX -m32 -o cxx32-check ${./cxx-main.cc}
+    ./cxx32-check
+
+    printf "checking whether compiler builds valid 64bit C++ binaries... " >&2
+    $CXX -m64 -o cxx64-check ${./cxx-main.cc}
+    ./cxx64-check
+
+    touch $out
+  '';
+
+  meta.platforms = stdenv.lib.platforms.x86_64;
+}

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -112,6 +112,8 @@ let
               jobs.tests.cc-wrapper-clang-39.x86_64-darwin
               jobs.tests.cc-wrapper-libcxx-39.x86_64-linux
               jobs.tests.cc-wrapper-libcxx-39.x86_64-darwin
+              jobs.tests.cc-multilib-gcc.x86_64-linux
+              jobs.tests.cc-multilib-clang.x86_64-linux
               jobs.tests.stdenv-inputs.x86_64-linux
               jobs.tests.stdenv-inputs.x86_64-darwin
               jobs.tests.macOSSierraShared.x86_64-darwin


### PR DESCRIPTION
###### Motivation for this change

Closes #24136.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

