### PR TITLE
networkmanager_strongswan: fix package

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -241,6 +241,19 @@ in {
           A list of scripts which will be executed in response to  network  events.
         '';
       };
+
+      enableStrongSwan = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable the StrongSwan plugin.
+          </para><para>
+          If you enable this option the
+          <literal>networkmanager_strongswan</literal> plugin will be added to
+          the <option>networking.networkmanager.packages</option> option
+          so you don't need to to that yourself.
+        '';
+      };
     };
   };
 
@@ -339,7 +352,11 @@ in {
 
     security.polkit.extraConfig = polkitConf;
 
-    services.dbus.packages = cfg.packages;
+    networking.networkmanager.packages =
+      mkIf cfg.enableStrongSwan [ pkgs.networkmanager_strongswan ];
+
+    services.dbus.packages =
+      optional cfg.enableStrongSwan pkgs.strongswanNM ++ cfg.packages;
 
     services.udev.packages = cfg.packages;
   };

--- a/pkgs/tools/networking/network-manager/strongswan.nix
+++ b/pkgs/tools/networking/network-manager/strongswan.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, pkgconfig, networkmanager, procps
+{ stdenv, fetchurl, intltool, pkgconfig, networkmanager, strongswanNM, procps
 , gnome3, libgnome_keyring, libsecret }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sed -i "s,nm_libexecdir=.*,nm_libexecdir=$out/libexec," "configure"
   '';
 
-  buildInputs = [ networkmanager libsecret ]
+  buildInputs = [ networkmanager strongswanNM libsecret ]
       ++ (with gnome3; [ gtk libgnome_keyring networkmanagerapplet ]);
 
   nativeBuildInputs = [ intltool pkgconfig ];
@@ -26,9 +26,10 @@ stdenv.mkDerivation rec {
        --replace "/sbin/sysctl" "${procps}/bin/sysctl"
   '';
 
+  configureFlags = [ "--with-charon=${strongswanNM}/libexec/ipsec/charon-nm" ];
+
   meta = {
     description = "NetworkManager's strongswan plugin";
     inherit (networkmanager.meta) platforms;
   };
 }
-

--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -1,7 +1,14 @@
-{ stdenv, fetchurl, gmp, pkgconfig, python, autoreconfHook
-, curl, trousers, sqlite, iptables, libxml2, openresolv
-, ldns, unbound, pcsclite, openssl, systemd, pam
-, enableTNC ? false }:
+{ stdenv, fetchurl
+, pkgconfig, autoreconfHook
+, gmp, python, iptables, ldns, unbound, openssl, pcsclite
+, openresolv
+, systemd, pam
+
+, enableTNC            ? false, curl, trousers, sqlite, libxml2
+, enableNetworkManager ? false, networkmanager
+}:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "strongswan-${version}";
@@ -17,8 +24,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs =
     [ gmp python iptables ldns unbound openssl pcsclite ]
-    ++ stdenv.lib.optionals enableTNC [ curl trousers sqlite libxml2 ]
-    ++ stdenv.lib.optionals stdenv.isLinux [ systemd.dev pam ];
+    ++ optionals enableTNC [ curl trousers sqlite libxml2 ]
+    ++ optionals stdenv.isLinux [ systemd.dev pam ]
+    ++ optionals enableNetworkManager [ networkmanager ];
 
   patches = [
     ./ext_auth-path.patch
@@ -54,9 +62,9 @@ stdenv.mkDerivation rec {
       "--enable-forecast" "--enable-connmark" "--enable-acert"
       "--enable-pkcs11" "--enable-eap-sim-pcsc" "--enable-dnscert" "--enable-unbound"
       "--enable-af-alg" "--enable-xauth-pam" "--enable-chapoly" ]
-    ++ stdenv.lib.optional stdenv.isx86_64 [ "--enable-aesni" "--enable-rdrand" ]
-    ++ stdenv.lib.optional (stdenv.system == "i686-linux") "--enable-padlock"
-    ++ stdenv.lib.optionals enableTNC [
+    ++ optionals stdenv.isx86_64 [ "--enable-aesni" "--enable-rdrand" ]
+    ++ optional (stdenv.system == "i686-linux") "--enable-padlock"
+    ++ optionals enableTNC [
          "--disable-gmp" "--disable-aes" "--disable-md5" "--disable-sha1" "--disable-sha2" "--disable-fips-prf"
          "--enable-curl"
          "--enable-eap-tnc" "--enable-eap-ttls" "--enable-eap-dynamic" "--enable-tnccs-20"
@@ -65,14 +73,15 @@ stdenv.mkDerivation rec {
          "--enable-tnc-ifmap" "--enable-tnc-imc" "--enable-tnc-imv"
          "--with-tss=trousers"
          "--enable-aikgen"
-         "--enable-sqlite" ];
+         "--enable-sqlite" ]
+    ++ optional enableNetworkManager "--enable-nm";
 
   NIX_LDFLAGS = "-lgcc_s" ;
 
   meta = {
     description = "OpenSource IPsec-based VPN Solution";
     homepage = https://www.strongswan.org;
-    license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4605,9 +4605,9 @@ with pkgs;
     preCheck = "export PATH=dist/build/stutter:$PATH";
   });
 
-  strongswan = callPackage ../tools/networking/strongswan { };
-
-  strongswanTNC = callPackage ../tools/networking/strongswan { enableTNC=true; };
+  strongswan    = callPackage ../tools/networking/strongswan { };
+  strongswanTNC = callPackage ../tools/networking/strongswan { enableTNC = true; };
+  strongswanNM  = callPackage ../tools/networking/strongswan { enableNetworkManager = true; };
 
   su = shadow.su;
 


### PR DESCRIPTION
###### Motivation for this change

Fixes: #29873

###### Things done

Added the boolean option:

  `networking.networkmanager.enableStrongSwan`

which enables the `networkmanager_strongswan` plugin and adds `strongswanNM` to the dbus packages.

This was contributed by @wucke13, @eqyiel and @globin.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

