### PR TITLE
ddgr: init at 1.1

### DIFF
--- a/pkgs/applications/misc/ddgr/default.nix
+++ b/pkgs/applications/misc/ddgr/default.nix
@@ -1,0 +1,46 @@
+{stdenv, fetchpatch, fetchFromGitHub, python3Packages}:
+
+stdenv.mkDerivation rec {
+  version = "1.1";
+  name = "ddgr-${version}";
+
+  src = fetchFromGitHub {
+    owner = "jarun";
+    repo = "ddgr";
+    rev = "v${version}";
+    sha256 = "1q66kwip5y0kfkfldm1x54plz85mjyvv1xpxjqrs30r2lr0najgf";
+  };
+
+  buildInputs = [
+    (python3Packages.python.withPackages (ps: with ps; [
+      requests
+    ]))
+  ];
+
+  patches = [
+    (fetchpatch {
+     sha256 = "1rxr3biq0mk4m0m7dsxr70dhz4fg5siil5x5fy9nymcmhvcm1cdc";
+     name = "Fix-zsh-completion.patch";
+     url = "https://github.com/jarun/ddgr/commit/10c1a911a3d5cbf3e96357c932b0211d3165c4b8.patch";
+    })
+  ];
+
+  makeFlags = "PREFIX=$(out)";
+
+  postInstall = ''
+    mkdir -p "$out/share/bash-completion/completions/"
+    cp "auto-completion/bash/ddgr-completion.bash" "$out/share/bash-completion/completions/"
+    mkdir -p "$out/share/fish/vendor_completions.d/"
+    cp "auto-completion/fish/ddgr.fish" "$out/share/fish/vendor_completions.d/"
+    mkdir -p "$out/share/zsh/site-functions/"
+    cp "auto-completion/zsh/_ddgr" "$out/share/zsh/site-functions/"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/jarun/ddgr;
+    description = "Search DuckDuckGo from the terminal";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ markus1189 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14253,6 +14253,8 @@ with pkgs;
 
   dd-agent = callPackage ../tools/networking/dd-agent { };
 
+  ddgr = callPackage ../applications/misc/ddgr { };
+
   deadbeef = callPackage ../applications/audio/deadbeef {
     pulseSupport = config.pulseaudio or true;
   };


### PR DESCRIPTION
###### Motivation for this change
Add the `ddgr` package: https://github.com/jarun/ddgr

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

