### PR TITLE
redis-desktop-manager: 0.8.3 -> 0.9.0-alpha5

### DIFF
--- a/pkgs/applications/misc/redis-desktop-manager/default.nix
+++ b/pkgs/applications/misc/redis-desktop-manager/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, fetchgit, pkgconfig , libssh2
+{ stdenv, lib, fetchgit, fetchpatch, pkgconfig, libssh2
 , qtbase, qtdeclarative, qtgraphicaleffects, qtimageformats, qtquickcontrols
-, qtsvg, qttools, qtquick1
+, qtsvg, qttools, qtquick1, qtcharts
 , qmake
 }:
 
@@ -15,29 +15,34 @@ in
 
 stdenv.mkDerivation rec {
   name = "redis-desktop-manager-${version}";
-  version = "0.8.3";
+  version = "0.9.0-alpha5";
 
   src = fetchgit {
     url = "https://github.com/uglide/RedisDesktopManager.git";
     fetchSubmodules = true;
     rev = "refs/tags/${version}";
-    sha256 = "0a7xa39qp1q32zkypw32mm3wi8wbhxhvrm6l3xsa3k1jzih7hzxr";
+    sha256 = "1grw4zng0ff0lvplzzld133hlz6zjn5f5hl3z6z7kc1nq5642yr9";
   };
 
   nativeBuildInputs = [ pkgconfig qmake ];
   buildInputs = [
     libssh2 qtbase qtdeclarative qtgraphicaleffects qtimageformats
-    qtquick1 qtquickcontrols qtsvg qttools
+    qtquick1 qtquickcontrols qtsvg qttools qtcharts
   ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/google/breakpad/commit/bddcc58860f522a0d4cbaa7e9d04058caee0db9d.patch";
+      sha256 = "1bcamjkmif62rb0lbp111r0ppf4raqw664m5by7vr3pdkcjbbilq";
+    })
+  ];
+
+  patchFlags = "-d 3rdparty/gbreakpad -p1";
 
   dontUseQmakeConfigure = true;
 
   buildPhase = ''
     srcdir=$PWD
-
-    substituteInPlace src/resources/qml/ValueTabs.qml \
-      --replace "import QtQuick.Controls 1.4" \
-                "import QtQuick.Controls 1.2"
 
     cat <<EOF > src/version.h
 #ifndef RDM_VERSION

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19523,7 +19523,7 @@ with pkgs;
     pcre = pcre-cpp;
   });
 
-  redis-desktop-manager = libsForQt56.callPackage ../applications/misc/redis-desktop-manager { };
+  redis-desktop-manager = libsForQt59.callPackage ../applications/misc/redis-desktop-manager { };
 
   robo3t = callPackage ../applications/misc/robo3t { };
 


### PR DESCRIPTION
###### Motivation for this change
Required by `nox-review` for https://github.com/NixOS/nixpkgs/pull/32100

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

