### PR TITLE
ipe: 7.1.10 -> 7.2.7

### DIFF
--- a/pkgs/applications/graphics/ipe/default.nix
+++ b/pkgs/applications/graphics/ipe/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "ipe-7.1.10";
+  name = "ipe-7.2.7";
 
   src = fetchurl {
-    url = "https://dl.bintray.com/otfried/generic/ipe/7.1/${name}-src.tar.gz";
-    sha256 = "0kwk8l2jasb4fdixaca08g661d0sdmx2jkk3ch7pxh0f4xkdxkkz";
+    url = "https://dl.bintray.com/otfried/generic/ipe/7.2/${name}-src.tar.gz";
+    sha256 = "08lzqhagvr8l69hxghyw9akf5dixbily7hj2gxhzzrp334k3yvfn";
   };
 
   # changes taken from Gentoo portage
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
       wrapProgram "$prog" --prefix PATH : "${texlive}/bin"
     done
   '';
+
+  patches = [ ./xlocale.patch ];
 
   #TODO: make .desktop entry
 

--- a/pkgs/applications/graphics/ipe/xlocale.patch
+++ b/pkgs/applications/graphics/ipe/xlocale.patch
@@ -1,0 +1,10 @@
+--- ipe-7.2.7/src/ipelib/ipeplatform.cpp     2016-12-09 15:09:04.000000000 +0100
++++ ipe-7.2.7/src/ipelib/ipeplatform.cpp     2017-11-23 17:13:11.152395834 +0100
+@@ -38,7 +38,6 @@
+ #include <gdiplus.h>
+ #else
+ #include <sys/wait.h>
+-#include <xlocale.h>
+ #include <dirent.h>
+ #endif
+ #ifdef __APPLE__


### PR DESCRIPTION
###### Motivation for this change
Required by nox-review for https://github.com/NixOS/nixpkgs/pull/32100

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

