### PR TITLE
vst-sdk: vstsdk366_27_06_2016_build_61 -> vstsdk368_08_11_2017_build_121

### DIFF
--- a/pkgs/applications/audio/airwave/default.nix
+++ b/pkgs/applications/audio/airwave/default.nix
@@ -16,11 +16,11 @@ let
   stdenv_multi = overrideCC stdenv gcc_multi;
 
   vst-sdk = stdenv.mkDerivation rec {
-    name = "vstsdk366_27_06_2016_build_61";
+    name = "vstsdk368_08_11_2017_build_121";
     src = requireFile {
       name = "${name}.zip";
       url = "http://www.steinberg.net/en/company/developers.html";
-      sha256 = "05gsr13bpi2hhp34rvhllsvmn44rqvmjdpg9fsgfzgylfkz0kiki";
+      sha256 = "e0f235d8826d70f1ae0ae5929cd198acae1ecff74612fde5c60cbfb45c2f4a70";
     };
     nativeBuildInputs = [ unzip ];
     installPhase = "cp -r . $out";
@@ -64,7 +64,7 @@ stdenv_multi.mkDerivation {
   # Cf. https://github.com/phantom-code/airwave/issues/57
   hardeningDisable = [ "format" ];
 
-  cmakeFlags = "-DVSTSDK_PATH=${vst-sdk}";
+  cmakeFlags = "-DVSTSDK_PATH=${vst-sdk}/VST2_SDK";
 
   postInstall = ''
     mv $out/bin $out/libexec


### PR DESCRIPTION
###### Motivation for this change
Update to latest vst-sdk.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

