### PR TITLE
keyfinder: 2.1 -> 2.2

### DIFF
--- a/pkgs/applications/audio/keyfinder/default.nix
+++ b/pkgs/applications/audio/keyfinder/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "keyfinder-${version}";
-  version = "2.1";
+  version = "2.2";
 
   src = fetchFromGitHub {
-    sha256 = "0j9k90ll4cr8j8dywb6zf1bs9vijlx7m4zsh6w9hxwrr7ymz89hn";
+    sha256 = "0vjszk1h8vj2qycgbffzy6k7amg75jlvlnzwaqhz9nll2pcvw0zl";
     rev = version;
     repo = "is_KeyFinder";
     owner = "ibsh";
@@ -17,7 +17,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace is_KeyFinder.pro \
        --replace "keyfinder.0" "keyfinder" \
-       --replace "-stdlib=libc++" ""
+       --replace "-stdlib=libc++" "" \
+       --replace "\$\$[QT_INSTALL_PREFIX]" "$out"
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
Required by nox-review for https://github.com/NixOS/nixpkgs/pull/32100

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

