### PR TITLE
digikam: Fix empty album problem with Qt 5.9.3

### DIFF
--- a/pkgs/applications/graphics/digikam/default.nix
+++ b/pkgs/applications/graphics/digikam/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchurl, cmake, doxygen, extra-cmake-modules, wrapGAppsHook
+{ mkDerivation, lib, fetchurl, cmake, doxygen, extra-cmake-modules, wrapGAppsHook, fetchpatch
 
 # For `digitaglinktree`
 , perl, sqlite
@@ -113,6 +113,16 @@ mkDerivation rec {
       --replace "/usr/bin/perl" "${perl}/bin/perl" \
       --replace "/usr/bin/sqlite3" "${sqlite}/bin/sqlite3"
   '';
+
+  patches = [
+    # fix Qt-5.9.3 empty album problem
+    (fetchpatch {
+      url = "https://cgit.kde.org/digikam.git/patch/?id=855ba5b7d4bc6337234720a72ea824ddd3b32e5b";
+      sha256 = "0zk8p182piy6xn9v0mhwawya9ciq596vql1qc3lgnx371a97mmni";
+    })
+  ];
+
+  patchFlags = "-d core -p1";
 
   meta = with lib; {
     description = "Photo Management Program";


### PR DESCRIPTION
###### Motivation for this change
That patch solves a bug with Qt 5.9.3 and digikam albums.

Qt 5.9.3: https://github.com/NixOS/nixpkgs/pull/32100

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

