### PR TITLE
renderdoc: Fixes build with missing SWIG_PACKAGE

### DIFF
--- a/pkgs/applications/graphics/renderdoc/custom_swig.patch
+++ b/pkgs/applications/graphics/renderdoc/custom_swig.patch
@@ -1,0 +1,32 @@
+diff --git a/qrenderdoc/CMakeLists.txt b/qrenderdoc/CMakeLists.txt
+index 2df9ffa5..66bafaba 100644
+--- a/qrenderdoc/CMakeLists.txt
++++ b/qrenderdoc/CMakeLists.txt
+@@ -65,16 +65,6 @@ include(ExternalProject)
+ # Need bison for swig
+ find_package(BISON)
+ 
+-# Compile our custom SWIG that will do scoped/strong enum classes
+-ExternalProject_Add(custom_swig
+-    # using an URL to a zip directly so we don't clone the history etc
+-    URL ${RENDERDOC_SWIG_PACKAGE}
+-    BUILD_IN_SOURCE 1
+-    CONFIGURE_COMMAND ./autogen.sh > /dev/null 2>&1
+-    COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ./configure --with-pcre=yes --prefix=${CMAKE_BINARY_DIR} > /dev/null
+-    BUILD_COMMAND $(MAKE) > /dev/null 2>&1
+-    INSTALL_COMMAND $(MAKE) install > /dev/null 2>&1)
+-
+ # Lastly find PySide 2, optionally, for Qt5 Python bindings
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
+ 
+@@ -186,9 +176,8 @@ foreach(in ${swig_interfaces})
+     get_filename_component(swig_file ${in} NAME_WE)
+ 
+     add_custom_command(OUTPUT ${swig_file}_python.cxx ${swig_file}.py
+-            COMMAND ${CMAKE_BINARY_DIR}/bin/swig -v -Wextra -Werror -O -c++ -python -modern -modernargs -enumclass -fastunpack -py3 -builtin -I${CMAKE_CURRENT_SOURCE_DIR} -I${CMAKE_SOURCE_DIR}/renderdoc/api/replay -outdir ${CMAKE_CURRENT_BINARY_DIR} -o ${CMAKE_CURRENT_BINARY_DIR}/${swig_file}_python.cxx ${CMAKE_CURRENT_SOURCE_DIR}/${in}
++	    COMMAND $ENV{NIXOS_CUSTOM_SWIG} -v -Wextra -Werror -O -c++ -python -modern -modernargs -enumclass -fastunpack -py3 -builtin -I${CMAKE_CURRENT_SOURCE_DIR} -I${CMAKE_SOURCE_DIR}/renderdoc/api/replay -outdir ${CMAKE_CURRENT_BINARY_DIR} -o ${CMAKE_CURRENT_BINARY_DIR}/${swig_file}_python.cxx ${CMAKE_CURRENT_SOURCE_DIR}/${in}
+             DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${in}
+-            DEPENDS custom_swig
+             DEPENDS ${RDOC_REPLAY_FILES}
+             DEPENDS ${QRD_INTERFACE_FILES})
+ 

--- a/pkgs/applications/graphics/renderdoc/default.nix
+++ b/pkgs/applications/graphics/renderdoc/default.nix
@@ -1,8 +1,26 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig
 , qtbase, qtx11extras, qtsvg, makeWrapper, python3, bison
-, autoconf, automake, pcre, vulkan-loader, xorg
+, pcre, vulkan-loader, xorg, autoreconfHook
 }:
 
+let
+  custom_swig = stdenv.mkDerivation {
+    name = "renderdoc-custom-swig";
+    src = fetchFromGitHub {
+      owner = "baldurk";
+      repo = "swig";
+      rev = "renderdoc-modified-1";
+      sha256 = "1whymd3vamwnp4jqfc9asls3dw9wsdi21xhm1d2a4vx9nql8if1x";
+    };
+
+    nativeBuildInputs = [ autoreconfHook pcre ];
+
+    autoreconfPhase = ''
+      patchShebangs autogen.sh
+      ./autogen.sh
+    '';
+  };
+in
 stdenv.mkDerivation rec {
   name = "renderdoc-${version}";
   version = "0.91";
@@ -17,7 +35,8 @@ stdenv.mkDerivation rec {
   buildInputs = [
     qtbase qtsvg xorg.libpthreadstubs xorg.libXdmcp qtx11extras vulkan-loader
   ];
-  nativeBuildInputs = [ cmake makeWrapper pkgconfig python3 bison autoconf automake pcre ];
+
+  nativeBuildInputs = [ cmake makeWrapper pkgconfig python3 bison ];
 
   cmakeFlags = [
     "-DBUILD_VERSION_HASH=${src.rev}"
@@ -28,6 +47,7 @@ stdenv.mkDerivation rec {
     # TODO: use this instead of preConfigure once placeholders land
     #"-DVULKAN_LAYER_FOLDER=${placeholder out}/share/vulkan/implicit_layer.d/"
   ];
+
   preConfigure = ''
     cmakeFlags+=" -DVULKAN_LAYER_FOLDER=$out/share/vulkan/implicit_layer.d/"
   '';
@@ -41,7 +61,13 @@ stdenv.mkDerivation rec {
     ln -s $out/bin/.bin/renderdoccmd $out/bin/renderdoccmd
     wrapProgram $out/bin/renderdoccmd --suffix LD_LIBRARY_PATH : $out/lib --suffix LD_LIBRARY_PATH : ${vulkan-loader}/lib
   '';
+
+  # Set path to custom swig binary
+  NIXOS_CUSTOM_SWIG = "${custom_swig}/bin/swig";
+
   enableParallelBuilding = true;
+
+  patches = [ ./custom_swig.patch ];
 
   meta = with stdenv.lib; {
     description = "A single-frame graphics debugger";


### PR DESCRIPTION
###### Motivation for this change
Required by nox-review for https://github.com/NixOS/nixpkgs/pull/32100

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

