### PR TITLE
qesteidutil: 3.12.5.1233 -> 3.12.10

### DIFF
--- a/pkgs/tools/security/qesteidutil/default.nix
+++ b/pkgs/tools/security/qesteidutil/default.nix
@@ -1,21 +1,23 @@
-{ stdenv, fetchurl, cmake, ccid, qttools, qttranslations, pkgconfig, pcsclite
-, hicolor_icon_theme }:
+{ stdenv, fetchFromGitHub, fetchpatch
+, cmake, ccid, qttools, qttranslations
+, pkgconfig, pcsclite, hicolor_icon_theme 
+}:
 
 stdenv.mkDerivation rec {
 
-  version = "3.12.5.1233";
+  version = "3.12.10";
   name = "qesteidutil-${version}";
-  
-  src = fetchurl {
-    url = "https://installer.id.ee/media/ubuntu/pool/main/q/qesteidutil/qesteidutil_${version}.orig.tar.xz";
-    sha256 = "b5f0361af1891cfab6f9113d6b2fab677cc4772fc18b62df7d6e997f13b97857";
-  };
 
-  unpackPhase = ''
-    mkdir src
-    tar xf $src -C src
-    cd src
-  '';
+  src = fetchFromGitHub {
+    owner = "open-eid";
+    repo = "qesteidutil";
+    # TODO: Switch back to this after next release.
+    #rev = "v${version}";
+    # We require the remove breakpad stuff
+    rev = "efdfe4c5521f68f206569e71e292a664bb9f46aa";
+    sha256 = "0zly83sdqsf9lxnfw4ir2a9vmmfba181rhsrz61ga2zzpm2wf0f0";
+    fetchSubmodules = true;
+  };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ cmake ccid qttools pcsclite qttranslations


### PR DESCRIPTION
###### Motivation for this change
Required by nox-review for https://github.com/NixOS/nixpkgs/pull/32100

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

