### PR TITLE
enpass: fix install to work with firefox webextensions

### DIFF
--- a/pkgs/tools/security/enpass/default.nix
+++ b/pkgs/tools/security/enpass/default.nix
@@ -67,12 +67,13 @@ let
       cp -r usr/* $out
       rm $out/bin/runenpass.sh
       cp $out/bin/EnpassHelper/EnpassHelper{,.untampered}
+      cp $out/bin/EnpassHelper/EnpassNMHost{,.untampered}
 
       sed \
       	-i s@/opt/Enpass/bin/runenpass.sh@$out/bin/Enpass@ \
       	$out/share/applications/enpass.desktop
 
-      for i in $out/bin/{Enpass,EnpassHelper/EnpassHelper}; do
+      for i in $out/bin/{Enpass,EnpassHelper/{EnpassHelper,EnpassNMHost}}; do
         patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $i
       done
 
@@ -85,8 +86,15 @@ let
         --set QT_XKB_CONFIG_ROOT "${xkeyboardconfig}/share/X11/xkb" \
         --set HIDE_TOOLBAR_LINE 0 \
         --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
-        --set NIX_REDIRECTS "$out/bin/EnpassHelper/EnpassHelper=$out/bin/EnpassHelper/EnpassHelper.untampered" \
+        --set NIX_REDIRECTS "$out/bin/EnpassHelper/EnpassHelper=$out/bin/EnpassHelper/EnpassHelper.untampered:$out/bin/EnpassHelper/EnpassNMHost=$out/bin/EnpassHelper/EnpassNMHost.untampered" \
         --prefix PATH : ${lsof}/bin
+
+      makeWrapper $out/bin/EnpassHelper/{EnpassNMHost,runNativeMessaging.sh} \
+        --set LD_LIBRARY_PATH "${libPath}:$out/lib:$out/plugins/sqldrivers" \
+        --set QT_PLUGIN_PATH "$out/plugins" \
+        --set QT_QPA_PLATFORM_PLUGIN_PATH "$out/plugins/platforms" \
+        --set QT_XKB_CONFIG_ROOT "${xkeyboardconfig}/share/X11/xkb" \
+        --set HIDE_TOOLBAR_LINE 0
     '';
   };
   updater = {


### PR DESCRIPTION
With new Firefox 57 and WebExtensions, the new addon uses Firefox'
Native Messaging mechanism to communicate with local programs (here
the main enpass program). This commit activates EnpassNMHost, a binary
that bootstraps communication between the two.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

