### PR TITLE
tzdata: export TZDIR for dependent packages

### DIFF
--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -41,6 +41,8 @@ stdenv.mkDerivation rec {
       cp tzfile.h "$dev/include/tzfile.h"
     '';
 
+  setupHook = ./tzdata-setup-hook.sh;
+
   meta = {
     homepage = http://www.iana.org/time-zones;
     description = "Database of current and historical time zones";

--- a/pkgs/data/misc/tzdata/tzdata-setup-hook.sh
+++ b/pkgs/data/misc/tzdata/tzdata-setup-hook.sh
@@ -1,0 +1,6 @@
+tzdataHook() {
+    export TZDIR=@out@/share/zoneinfo
+}
+
+envHooks+=(tzdataHook)
+crossEnvHooks+=(tzdataHook)


### PR DESCRIPTION
###### Motivation for this change

See https://github.com/NixOS/nix/issues/1709. This is primarily intended for `nix-shell -p tzdata` and `nix-shell -A depends.on.tzdata`, but it may be used by actual builds as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).