### PR TITLE
glucose-syrup: Remove unused fetchurl argument

### DIFF
--- a/pkgs/applications/science/logic/glucose/syrup.nix
+++ b/pkgs/applications/science/logic/glucose/syrup.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, glucose }:
+{ stdenv, zlib, glucose }:
 stdenv.mkDerivation rec {
   name = "glucose-syrup-${version}";
   version = glucose.version;


### PR DESCRIPTION
###### Motivation for this change
Trivial cleanup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

