### PR TITLE
backblaze-b2: 0.6.2 -> 1.1.0

### DIFF
--- a/pkgs/development/tools/backblaze-b2/default.nix
+++ b/pkgs/development/tools/backblaze-b2/default.nix
@@ -1,17 +1,19 @@
-{ fetchFromGitHub, makeWrapper, pythonPackages, stdenv }:
+{ lib, buildPythonApplication, fetchFromGitHub, makeWrapper
+, arrow, futures, logfury, requests, six, tqdm
+}:
 
-pythonPackages.buildPythonApplication rec {
-  name = "backblaze-b2-${version}";
-  version = "0.6.2";
+buildPythonApplication rec {
+  pname = "backblaze-b2";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "Backblaze";
     repo = "B2_Command_Line_Tool";
-    rev = "3a4cd3f0b5309f79f98c2e0d51afc19fb2fe4201";
-    sha256 = "1gl1z7zg3s1xgx45i6b1bvx9iwviiiinl4my00h66qkhrw7ag8p1";
+    rev = "v${version}";
+    sha256 = "0697rcdsmxz51p4b8m8klx2mf5xnx6vx56vcf5jmzidh8mc38a6z";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ futures requests six tqdm ];
+  propagatedBuildInputs = [ arrow futures logfury requests six tqdm ];
 
   checkPhase = ''
     python test_b2_command_line.py test
@@ -27,7 +29,7 @@ pythonPackages.buildPythonApplication rec {
     cp contrib/bash_completion/b2 "$out/etc/bash_completion.d/backblaze-b2"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Command-line tool for accessing the Backblaze B2 storage service";
     homepage = https://github.com/Backblaze/B2_Command_Line_Tool;
     license = licenses.mit;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -703,7 +703,7 @@ with pkgs;
 
   azureus = callPackage ../tools/networking/p2p/azureus { };
 
-  backblaze-b2 = callPackage ../development/tools/backblaze-b2 { };
+  backblaze-b2 = python.pkgs.callPackage ../development/tools/backblaze-b2 { };
 
   backup = callPackage ../tools/backup/backup { };
 


### PR DESCRIPTION
###### Motivation for this change

Introduces a number of bug fixes and a few new features. There is a noted breaking change: "Require --allowEmptySource to sync from empty directory, to help avoid accidental deletion of all files."

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

