### PR TITLE
kio: patch for Qt 5.9.3

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kio/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kio/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, copyPathsToStore,
+  mkDerivation, lib, fetchpatch,
   extra-cmake-modules, kdoctools,
   karchive, kbookmarks, kcompletion, kconfig, kconfigwidgets, kcoreaddons,
   kdbusaddons, ki18n, kiconthemes, kitemviews, kjobwidgets, knotifications,
@@ -19,5 +19,19 @@ mkDerivation {
     kbookmarks kcompletion kconfig kcoreaddons kitemviews kjobwidgets kservice
     kxmlgui qtbase solid
   ];
-  patches = (copyPathsToStore (lib.readPathsFromFile ./. ./series));
+  patches =
+    [
+      ./samba-search-path.patch
+      ./kio-debug-module-loader.patch
+
+      # Fix kio-5.40.0 with Qt 5.9.3
+      (fetchpatch {
+        url = "https://cgit.kde.org/kio.git/patch/?id=2353119aae8f03565bc7779ed1d597d266f5afda";
+        sha256 = "19pidf98jm2hx1bga55r4jdjn96xdygasi004s97hpn9bn4nl1hj";
+      })
+      (fetchpatch {
+        url = "https://cgit.kde.org/kio.git/patch/?id=298c0e734efdd8a7b66a531959e3fb5357a6495d";
+        sha256 = "1x6m4ivj5001n63z2hmcz0za00l5am2h5a49fs8w051vnmaf13gz";
+      })
+    ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kio/series
+++ b/pkgs/development/libraries/kde-frameworks/kio/series
@@ -1,2 +1,0 @@
-samba-search-path.patch
-kio-debug-module-loader.patch


### PR DESCRIPTION
kio cannot create folders under Qt 5.9.3 unless we apply these upstream
patches.

### Testing

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

