### PR TITLE
gcal: init at 4.1

### DIFF
--- a/pkgs/applications/misc/gcal/default.nix
+++ b/pkgs/applications/misc/gcal/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, pkgconfig, ncurses  }:
+
+stdenv.mkDerivation rec {
+  name = "gcal-${version}";
+  version = "4.1";
+
+  src = fetchurl {
+    url = "mirror://gnu/gcal/${name}.tar.xz";
+    sha256 = "1av11zkfirbixn05hyq4xvilin0ncddfjqzc4zd9pviyp506rdci";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ ncurses ];
+
+  meta = {
+    description = "Program for calculating and printing calendars";
+    longDescription = ''
+      Gcal is the GNU version of the trusty old cal(1). Gcal is a
+      program for calculating and printing calendars. Gcal displays
+      hybrid and proleptic Julian and Gregorian calendar sheets.  It
+      also displays holiday lists for many countries around the globe.
+    '';
+    homepage = https://www.gnu.org/software/gcal/;
+    license = stdenv.lib.licenses.gpl3Plus;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14694,6 +14694,8 @@ with pkgs;
 
   ganttproject-bin = callPackage ../applications/misc/ganttproject-bin { };
 
+  gcal = callPackage ../applications/misc/gcal { };
+
   geany = callPackage ../applications/editors/geany { };
   geany-with-vte = callPackage ../applications/editors/geany/with-vte.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Add [GCal](https://www.gnu.org/software/gcal/) package.

> Gcal is a program for calculating and printing calendars. Gcal displays hybrid and proleptic Julian and Gregorian calendar sheets, respectively for one month, three months, or a whole year. It also displays eternal holiday lists for many countries around the globe, and features a very powerful creation of fixed date liststhat can be used for reminding purposes. Gcal can calculate various astronomical data and times of the Sun and the Moon for pleasure at any location, precisely enough for most civil purposes. Gcal supports some other calendar systems, for example, the Chinese and Japanese calendars, the Hebrew calendar, and the civil Islamic calendar, too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).