### PR TITLE
Add types.strMatching

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -219,6 +219,14 @@ rec {
   */
   escapeShellArgs = concatMapStringsSep " " escapeShellArg;
 
+  /* Turn a string into a Nix expression representing that string
+
+     Example:
+       escapeNixString "hello\${}\n"
+       => "\"hello\\\${}\\n\""
+  */
+  escapeNixString = s: escape ["$"] (builtins.toJSON s);
+
   /* Obsolete - use replaceStrings instead. */
   replaceChars = builtins.replaceStrings or (
     del: new: s:

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -174,6 +174,13 @@ rec {
       merge = mergeOneOption;
     };
 
+    strMatching = pattern: mkOptionType {
+      name = "strMatching ${escapeNixString pattern}";
+      description = "string matching the pattern ${pattern}";
+      check = x: str.check x && builtins.match pattern x != null;
+      inherit (str) merge;
+    };
+
     # Merge multiple definitions by concatenating them (with the given
     # separator between the values).
     separatedString = sep: mkOptionType rec {

--- a/nixos/doc/manual/development/option-types.xml
+++ b/nixos/doc/manual/development/option-types.xml
@@ -110,6 +110,12 @@
     <listitem><para>A string. Multiple definitions are concatenated with a 
         collon <literal>":"</literal>.</para></listitem>
   </varlistentry>
+  <varlistentry>
+    <term><varname>types.strMatching</varname></term>
+    <listitem><para>A string matching a specific regular expression. Multiple
+    definitions cannot be merged.  The regular expression is processed using
+    <literal>builtins.match</literal>.</para></listitem>
+  </varlistentry>
 </variablelist>
 
  </section>


### PR DESCRIPTION
###### Motivation for this change

This gives a way for nixos modules to easily check and document requirements for string parameters, when they can be validated by a regular expression.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
   - N/A
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
     - N/A
   - [ ] other Linux distributions
     - N/A
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
   - N/A
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
   - N/A
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
   - N/A
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

