### PR TITLE
Revert "qt5: 5.9.1 -> 5.9.3"

### DIFF
--- a/pkgs/development/libraries/qt-5/5.9/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/default.nix
@@ -6,9 +6,9 @@ Before a major version update, make a copy of this directory. (We like to
 keep the old version around for a short time after major updates.) Add a
 top-level attribute to `top-level/all-packages.nix`.
 
-1. Update the URL in `pkgs/development/libraries/qt-5/$VERSION/fetch.sh`.
+1. Update the URL in `maintainers/scripts/generate-qt.sh`.
 2. From the top of the Nixpkgs tree, run
-   `./maintainers/scripts/fetch-kde-qt.sh > pkgs/development/libraries/qt-5/$VERSION/srcs.nix`.
+   `./maintainers/scripts/generate-qt.sh > pkgs/development/libraries/qt-5/$VERSION/srcs.nix`.
 3. Update `qtCompatVersion` below if the minor version number changes.
 4. Check that the new packages build correctly.
 5. Commit the changes and open a pull request.

--- a/pkgs/development/libraries/qt-5/5.9/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.9/fetch.sh
@@ -1,2 +1,2 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.9/5.9.3/submodules/ \
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.9/5.9.1/submodules/ \
             -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-5/5.9/qtbase.patch
+++ b/pkgs/development/libraries/qt-5/5.9/qtbase.patch
@@ -101,7 +101,7 @@ index bb5083c925..da8e2cb386 100644
  # We are generating cmake files. Most developers of Qt are not aware of cmake,
  # so we require automatic tests to be available. The only module which should
 diff --git a/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in b/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
-index 55c74aad66..0bbc8718eb 100644
+index 17da8b979e..d648ab4058 100644
 --- a/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 +++ b/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 @@ -9,30 +9,6 @@ if (CMAKE_VERSION VERSION_LESS 3.0.0)
@@ -261,10 +261,10 @@ index 55c74aad66..0bbc8718eb 100644
          set_target_properties(Qt5::${Plugin} PROPERTIES
              \"IMPORTED_LOCATION_${Configuration}\" ${imported_location}
 diff --git a/mkspecs/features/mac/default_post.prf b/mkspecs/features/mac/default_post.prf
-index e645ba5803..a0e5c68b7e 100644
+index 395ac34001..a0e5c68b7e 100644
 --- a/mkspecs/features/mac/default_post.prf
 +++ b/mkspecs/features/mac/default_post.prf
-@@ -24,166 +24,3 @@ qt {
+@@ -24,165 +24,3 @@ qt {
          }
      }
  }
@@ -427,18 +427,17 @@ index e645ba5803..a0e5c68b7e 100644
 -}
 -
 -cache(QMAKE_XCODE_DEVELOPER_PATH, stash)
--!isEmpty(QMAKE_XCODE_VERSION): \
--    cache(QMAKE_XCODE_VERSION, stash)
+-cache(QMAKE_XCODE_VERSION, stash)
 -
 -QMAKE_XCODE_LIBRARY_SUFFIX = $$qtPlatformTargetSuffix()
 diff --git a/mkspecs/features/mac/default_pre.prf b/mkspecs/features/mac/default_pre.prf
-index 44636f2288..61ed486a76 100644
+index e21e749ee9..3b01424e67 100644
 --- a/mkspecs/features/mac/default_pre.prf
 +++ b/mkspecs/features/mac/default_pre.prf
-@@ -1,56 +1,3 @@
+@@ -1,51 +1,2 @@
  CONFIG = asset_catalogs rez $$CONFIG
  load(default_pre)
- 
+-
 -isEmpty(QMAKE_XCODE_DEVELOPER_PATH) {
 -    # Get path of Xcode's Developer directory
 -    QMAKE_XCODE_DEVELOPER_PATH = $$system("/usr/bin/xcode-select --print-path 2>/dev/null")
@@ -448,23 +447,18 @@ index 44636f2288..61ed486a76 100644
 -    # Make sure Xcode path is valid
 -    !exists($$QMAKE_XCODE_DEVELOPER_PATH): \
 -        error("Xcode is not installed in $${QMAKE_XCODE_DEVELOPER_PATH}. Please use xcode-select to choose Xcode installation path.")
+-
+-    # Make sure Xcode is set up properly
+-    isEmpty($$list($$system("/usr/bin/xcrun -find xcodebuild 2>/dev/null"))): \
+-        error("Xcode not set up properly. You may need to confirm the license agreement by running /usr/bin/xcodebuild.")
 -}
 -
--isEmpty(QMAKE_XCODEBUILD_PATH): \
--    QMAKE_XCODEBUILD_PATH = $$system("/usr/bin/xcrun -find xcodebuild 2>/dev/null")
--
--!isEmpty(QMAKE_XCODEBUILD_PATH) {
--    # Make sure Xcode is set up properly
--    !system("/usr/bin/xcrun xcodebuild -license check 2>/dev/null"): \
--        error("Xcode not set up properly. You need to confirm the license agreement by running 'sudo xcrun xcodebuild -license accept'.")
--
--    isEmpty(QMAKE_XCODE_VERSION) {
--        # Extract Xcode version using xcodebuild
--        xcode_version = $$system("/usr/bin/xcrun xcodebuild -version")
--        QMAKE_XCODE_VERSION = $$member(xcode_version, 1)
--        isEmpty(QMAKE_XCODE_VERSION): error("Could not resolve Xcode version.")
--        unset(xcode_version)
--    }
+-isEmpty(QMAKE_XCODE_VERSION) {
+-    # Extract Xcode version using xcodebuild
+-    xcode_version = $$system("/usr/bin/xcodebuild -version")
+-    QMAKE_XCODE_VERSION = $$member(xcode_version, 1)
+-    isEmpty(QMAKE_XCODE_VERSION): error("Could not resolve Xcode version.")
+-    unset(xcode_version)
 -}
 -
 -isEmpty(QMAKE_TARGET_BUNDLE_PREFIX) {
@@ -493,11 +487,11 @@ index 44636f2288..61ed486a76 100644
 -# at build time, depending on the current Xcode SDK and configuration.
 -QMAKE_XCODE_LIBRARY_SUFFIX_SETTING = QT_LIBRARY_SUFFIX
 diff --git a/mkspecs/features/mac/sdk.prf b/mkspecs/features/mac/sdk.prf
-index 3f6dc076ca..8b13789179 100644
+index 68ab7e4053..e69de29bb2 100644
 --- a/mkspecs/features/mac/sdk.prf
 +++ b/mkspecs/features/mac/sdk.prf
-@@ -1,58 +1 @@
- 
+@@ -1,49 +0,0 @@
+-
 -isEmpty(QMAKE_MAC_SDK): \
 -    error("QMAKE_MAC_SDK must be set when using CONFIG += sdk.")
 -
@@ -506,22 +500,13 @@ index 3f6dc076ca..8b13789179 100644
 -
 -defineReplace(xcodeSDKInfo) {
 -    info = $$1
--    equals(info, "Path"): \
--        info = --show-sdk-path
--    equals(info, "PlatformPath"): \
--        info = --show-sdk-platform-path
--    equals(info, "SDKVersion"): \
--        info = --show-sdk-version
 -    sdk = $$2
 -    isEmpty(sdk): \
 -        sdk = $$QMAKE_MAC_SDK
 -
 -    isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}) {
--        QMAKE_MAC_SDK.$${sdk}.$${info} = $$system("/usr/bin/xcrun --sdk $$sdk $$info 2>/dev/null")
--        # --show-sdk-platform-path won't work for Command Line Tools; this is fine
--        # only used by the XCTest backend to testlib
--        isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}):if(!isEmpty(QMAKE_XCODEBUILD_PATH)|!equals(info, "--show-sdk-platform-path")): \
--            error("Could not resolve SDK $$info for \'$$sdk\'")
+-        QMAKE_MAC_SDK.$${sdk}.$${info} = $$system("/usr/bin/xcodebuild -sdk $$sdk -version $$info 2>/dev/null")
+-        isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}): error("Could not resolve SDK $$info for \'$$sdk\'")
 -        cache(QMAKE_MAC_SDK.$${sdk}.$${info}, set stash, QMAKE_MAC_SDK.$${sdk}.$${info})
 -    }
 -
@@ -596,10 +581,10 @@ index d49f4c49c1..097dcd7d39 100644
  target.path = $$instbase/$$TARGETPATH
  INSTALLS += target
 diff --git a/mkspecs/features/qt_app.prf b/mkspecs/features/qt_app.prf
-index 883f8ca215..81db8eb2d4 100644
+index cb84ae0da8..45e16f4302 100644
 --- a/mkspecs/features/qt_app.prf
 +++ b/mkspecs/features/qt_app.prf
-@@ -33,7 +33,7 @@ host_build:force_bootstrap {
+@@ -29,7 +29,7 @@ host_build:force_bootstrap {
      target.path = $$[QT_HOST_BINS]
  } else {
      !build_pass:qtConfig(debug_and_release): CONFIG += release
@@ -622,7 +607,7 @@ index 1848f00e90..2af93675c5 100644
 +    MODULE_QMAKE_OUTDIR = $$NIX_OUTPUT_OUT
  }
 diff --git a/mkspecs/features/qt_common.prf b/mkspecs/features/qt_common.prf
-index fb96d1b6a0..508ed17d30 100644
+index 1e138730b3..b7ba74dc3f 100644
 --- a/mkspecs/features/qt_common.prf
 +++ b/mkspecs/features/qt_common.prf
 @@ -32,8 +32,8 @@ contains(TEMPLATE, .*lib) {
@@ -676,32 +661,20 @@ index 72dde61a40..f891a2baed 100644
      INSTALLS += inst_qch_docs
  
 diff --git a/mkspecs/features/qt_example_installs.prf b/mkspecs/features/qt_example_installs.prf
-index 668669e4cd..30f7fbac41 100644
+index 0a008374e5..5e7cd92f6f 100644
 --- a/mkspecs/features/qt_example_installs.prf
 +++ b/mkspecs/features/qt_example_installs.prf
-@@ -77,13 +77,13 @@ for(extra, extras): \
- # Just for Qt Creator
- OTHER_FILES += $$sourcefiles
- 
--sourcefiles += \
--    $$_PRO_FILE_ $$RC_FILE $$DEF_FILE \
--    $$SOURCES $$HEADERS $$FORMS $$RESOURCES $$TRANSLATIONS \
--    $$DBUS_ADAPTORS $$DBUS_INTERFACES
--addInstallFiles(sources.files, $$sourcefiles)
--sources.path = $$[QT_INSTALL_EXAMPLES]/$$probase
--INSTALLS += sources
-+    sourcefiles += \
-+        $$_PRO_FILE_ $$RC_FILE $$DEF_FILE \
-+        $$SOURCES $$HEADERS $$FORMS $$RESOURCES $$TRANSLATIONS \
-+        $$DBUS_ADAPTORS $$DBUS_INTERFACES
-+    addInstallFiles(sources.files, $$sourcefiles)
+@@ -73,7 +73,7 @@ probase = $$relative_path($$_PRO_FILE_PWD_, $$dirname(_QMAKE_CONF_)/examples)
+         $$SOURCES $$HEADERS $$FORMS $$RESOURCES $$TRANSLATIONS \
+         $$DBUS_ADAPTORS $$DBUS_INTERFACES
+     addInstallFiles(sources.files, $$sourcefiles)
+-    sources.path = $$[QT_INSTALL_EXAMPLES]/$$probase
 +    sources.path = $$NIX_OUTPUT_DEV/share/examples/$$probase
-+    INSTALLS += sources
+     INSTALLS += sources
  
- check_examples {
-     srcfiles = $$sources.files
+     check_examples {
 diff --git a/mkspecs/features/qt_functions.prf b/mkspecs/features/qt_functions.prf
-index 1903e509c8..ae7b585989 100644
+index c00fdb73f8..5789cd0c06 100644
 --- a/mkspecs/features/qt_functions.prf
 +++ b/mkspecs/features/qt_functions.prf
 @@ -69,7 +69,7 @@ defineTest(qtHaveModule) {
@@ -863,7 +836,7 @@ index 706304cf34..546420f6ad 100644
  set(_qt5_corelib_extra_includes \"$${CMAKE_INSTALL_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
  !!ENDIF
 diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
-index cba279c184..5ae3fd62e5 100644
+index 39e7c71a9c..dced1f2811 100644
 --- a/src/corelib/kernel/qcoreapplication.cpp
 +++ b/src/corelib/kernel/qcoreapplication.cpp
 @@ -2533,6 +2533,15 @@ QStringList QCoreApplication::libraryPaths()
@@ -883,7 +856,7 @@ index cba279c184..5ae3fd62e5 100644
          if (!libPathEnv.isEmpty()) {
              QStringList paths = QFile::decodeName(libPathEnv).split(QDir::listSeparator(), QString::SkipEmptyParts);
 diff --git a/src/corelib/tools/qtimezoneprivate_tz.cpp b/src/corelib/tools/qtimezoneprivate_tz.cpp
-index 4fdc2e36ac..d3ec222543 100644
+index 1714c9802f..fd2ebb1336 100644
 --- a/src/corelib/tools/qtimezoneprivate_tz.cpp
 +++ b/src/corelib/tools/qtimezoneprivate_tz.cpp
 @@ -70,7 +70,11 @@ typedef QHash<QByteArray, QTzTimeZone> QTzTimeZoneHash;
@@ -899,7 +872,7 @@ index 4fdc2e36ac..d3ec222543 100644
      if (!QFile::exists(path))
          path = QStringLiteral("/usr/lib/zoneinfo/zone.tab");
  
-@@ -645,12 +649,16 @@ void QTzTimeZonePrivate::init(const QByteArray &ianaId)
+@@ -643,12 +647,16 @@ void QTzTimeZonePrivate::init(const QByteArray &ianaId)
          if (!tzif.open(QIODevice::ReadOnly))
              return;
      } else {
@@ -994,7 +967,7 @@ index 1da00813ce..0bf877afcb 100644
              return false;
      }
 diff --git a/src/network/kernel/qhostinfo_unix.cpp b/src/network/kernel/qhostinfo_unix.cpp
-index 9a24938284..74962b4ae2 100644
+index cf08a15f96..2310488298 100644
 --- a/src/network/kernel/qhostinfo_unix.cpp
 +++ b/src/network/kernel/qhostinfo_unix.cpp
 @@ -102,7 +102,7 @@ static bool resolveLibraryInternal()
@@ -1051,7 +1024,7 @@ index 341d3bccf2..3368234c26 100644
              scanThread->interfaceName = QString::fromNSString(ifName);
              scanThread->start();
 diff --git a/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp b/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
-index b5a0a5bbeb..6c20305f4d 100644
+index ca9f7af127..a337ad73bf 100644
 --- a/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
 +++ b/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
 @@ -265,12 +265,9 @@ void TableGenerator::initPossibleLocations()
@@ -1069,7 +1042,7 @@ index b5a0a5bbeb..6c20305f4d 100644
  
  QString TableGenerator::findComposeFile()
 diff --git a/src/plugins/platforms/cocoa/qcocoawindow.mm b/src/plugins/platforms/cocoa/qcocoawindow.mm
-index 5cd4beb4f0..84919e6d6a 100644
+index 59b76370ae..b91139ded9 100644
 --- a/src/plugins/platforms/cocoa/qcocoawindow.mm
 +++ b/src/plugins/platforms/cocoa/qcocoawindow.mm
 @@ -320,7 +320,7 @@ static void qt_closePopups()
@@ -1082,7 +1055,7 @@ index 5cd4beb4f0..84919e6d6a 100644
  
  #if QT_MACOS_PLATFORM_SDK_EQUAL_OR_ABOVE(__MAC_10_12)
 diff --git a/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp b/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
-index e2e573f0e1..1c8289f81e 100644
+index 7640a711a9..ef9a14d38b 100644
 --- a/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
 +++ b/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
 @@ -580,7 +580,14 @@ QFunctionPointer QGLXContext::getProcAddress(const char *procName)
@@ -1101,11 +1074,11 @@ index e2e573f0e1..1c8289f81e 100644
  #endif
              }
 diff --git a/src/plugins/platforms/xcb/qxcbcursor.cpp b/src/plugins/platforms/xcb/qxcbcursor.cpp
-index 7c62c2e2b3..fefa40e0f6 100644
+index d257ab1242..75853af4e4 100644
 --- a/src/plugins/platforms/xcb/qxcbcursor.cpp
 +++ b/src/plugins/platforms/xcb/qxcbcursor.cpp
 @@ -311,10 +311,10 @@ QXcbCursor::QXcbCursor(QXcbConnection *conn, QXcbScreen *screen)
- #if QT_CONFIG(xcb_xlib) && QT_CONFIG(library)
+ #if defined(XCB_USE_XLIB) && QT_CONFIG(library)
      static bool function_ptrs_not_initialized = true;
      if (function_ptrs_not_initialized) {
 -        QLibrary xcursorLib(QLatin1String("Xcursor"), 1);

--- a/pkgs/development/libraries/qt-5/5.9/srcs.nix
+++ b/pkgs/development/libraries/qt-5/5.9/srcs.nix
@@ -3,275 +3,275 @@
 
 {
   qt3d = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qt3d-opensource-src-5.9.3.tar.xz";
-      sha256 = "0gr7wvd3p8i2frj9nkfxffxapwqx6i4wh171ymvcsg2qy0r534lp";
-      name = "qt3d-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qt3d-opensource-src-5.9.1.tar.xz";
+      sha256 = "15j9znfnxch1n6fwz9ngi30msdzh0wlpykl53cs8g2fp2awfa7sg";
+      name = "qt3d-opensource-src-5.9.1.tar.xz";
     };
   };
   qtactiveqt = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtactiveqt-opensource-src-5.9.3.tar.xz";
-      sha256 = "16aka3y7a6mhs0yfm7vbq8v5gbh2ifmk4v2hl04iacindq9f5v2r";
-      name = "qtactiveqt-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtactiveqt-opensource-src-5.9.1.tar.xz";
+      sha256 = "07zq60xg7nnlny7qgj6dk1ibg3fzhbdh78gpd0s6x1n822iyislg";
+      name = "qtactiveqt-opensource-src-5.9.1.tar.xz";
     };
   };
   qtandroidextras = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtandroidextras-opensource-src-5.9.3.tar.xz";
-      sha256 = "0f653qmzvr3rjjgipjbcxvp5wq9fbaz1b4bvj7g868s2d9gpqp9n";
-      name = "qtandroidextras-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtandroidextras-opensource-src-5.9.1.tar.xz";
+      sha256 = "0nq879jsa2z1l5q3n0hhiv15mzfm5c6s7zfblcc10sgim90p5mjj";
+      name = "qtandroidextras-opensource-src-5.9.1.tar.xz";
     };
   };
   qtbase = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtbase-opensource-src-5.9.3.tar.xz";
-      sha256 = "10lrkarvs7dpx9rlj7sjcc0pzi42098x8nqnhmydr4bnbq048z4y";
-      name = "qtbase-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtbase-opensource-src-5.9.1.tar.xz";
+      sha256 = "1ikm896jzyfyjv2qv8n3fd81sxb4y24zkygx36865ygzyvlj36mw";
+      name = "qtbase-opensource-src-5.9.1.tar.xz";
     };
   };
   qtcanvas3d = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtcanvas3d-opensource-src-5.9.3.tar.xz";
-      sha256 = "1g0a606fgal4x17ly0qrj05pb0k8riwh7nj4g3jip05g8iwb2f2y";
-      name = "qtcanvas3d-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtcanvas3d-opensource-src-5.9.1.tar.xz";
+      sha256 = "10fy8wqfw2yhha6lyky5g1a72137aj8pji7mk0wjnggh629z12sb";
+      name = "qtcanvas3d-opensource-src-5.9.1.tar.xz";
     };
   };
   qtcharts = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtcharts-opensource-src-5.9.3.tar.xz";
-      sha256 = "1sb99ncmh84bz0xzq55chgic7jk61awnfvi7ld4gq5ap3nl865zc";
-      name = "qtcharts-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtcharts-opensource-src-5.9.1.tar.xz";
+      sha256 = "180df5v7i1ki8hc3lgi6jcfdyz7f19pb73dvfkw402wa2gfcna3k";
+      name = "qtcharts-opensource-src-5.9.1.tar.xz";
     };
   };
   qtconnectivity = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtconnectivity-opensource-src-5.9.3.tar.xz";
-      sha256 = "0j86rspn4xgwq1ddc1mpq1kq0ib2c0ag6rsn9ly2xs4iimp1x2g2";
-      name = "qtconnectivity-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtconnectivity-opensource-src-5.9.1.tar.xz";
+      sha256 = "1mbzmqix0388iq20a1ljd1pgdq259rm1xzp9kx8gigqpamqqnqs0";
+      name = "qtconnectivity-opensource-src-5.9.1.tar.xz";
     };
   };
   qtdatavis3d = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtdatavis3d-opensource-src-5.9.3.tar.xz";
-      sha256 = "0s636ix44akrjx47gv9qj2ac02q8clnwj3acfr28p6pagm46k7vh";
-      name = "qtdatavis3d-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtdatavis3d-opensource-src-5.9.1.tar.xz";
+      sha256 = "14d1q07winh6n1bkc616dapwfnsfkcjyg5zngdqjdj9mza8ang13";
+      name = "qtdatavis3d-opensource-src-5.9.1.tar.xz";
     };
   };
   qtdeclarative = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtdeclarative-opensource-src-5.9.3.tar.xz";
-      sha256 = "01wlk17zf47yzx7cc3cp617gj70yadllj2rsfk78879c0v96cpsh";
-      name = "qtdeclarative-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtdeclarative-opensource-src-5.9.1.tar.xz";
+      sha256 = "1zwlxrgraxhlsdkwsai3pjbz7f3a6rsnsg2mjrpay6cz3af6rznj";
+      name = "qtdeclarative-opensource-src-5.9.1.tar.xz";
     };
   };
   qtdoc = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtdoc-opensource-src-5.9.3.tar.xz";
-      sha256 = "0aki592arm3r08y9cq8863jp9zzkvgx7sc48426n30m6q9valsg5";
-      name = "qtdoc-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtdoc-opensource-src-5.9.1.tar.xz";
+      sha256 = "1d2kk9wzm2261ap87nyf743a4662gll03gz5yh5qi7k620lk372x";
+      name = "qtdoc-opensource-src-5.9.1.tar.xz";
     };
   };
   qtgamepad = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtgamepad-opensource-src-5.9.3.tar.xz";
-      sha256 = "14vari5cq10a0z02559l2m1v78g7ygnyqf1ilkmy2f0kr36wm7y6";
-      name = "qtgamepad-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtgamepad-opensource-src-5.9.1.tar.xz";
+      sha256 = "055w4649zi93q1sl32ngqwgnl2vxw1idnm040s9gjgjb67gi81zi";
+      name = "qtgamepad-opensource-src-5.9.1.tar.xz";
     };
   };
   qtgraphicaleffects = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtgraphicaleffects-opensource-src-5.9.3.tar.xz";
-      sha256 = "1nghl39sqsjamjn6pfmxmgga6z9vwzv2zbgc92amrfxxr2dh42vr";
-      name = "qtgraphicaleffects-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtgraphicaleffects-opensource-src-5.9.1.tar.xz";
+      sha256 = "1zsr3a5dsmpvrb5h4m4h42wqmkvkks3d8mmyrx4k0mfr6s7c71jz";
+      name = "qtgraphicaleffects-opensource-src-5.9.1.tar.xz";
     };
   };
   qtimageformats = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtimageformats-opensource-src-5.9.3.tar.xz";
-      sha256 = "1p95wzm46j49c5br45g0pmlz3n3fl93j1ipzmnpmq9y2pbfhkcyl";
-      name = "qtimageformats-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtimageformats-opensource-src-5.9.1.tar.xz";
+      sha256 = "0iwa3dys5rv706cpxwhmgircv783pmlyl1yrsc5i0rha643y7zkr";
+      name = "qtimageformats-opensource-src-5.9.1.tar.xz";
     };
   };
   qtlocation = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtlocation-opensource-src-5.9.3.tar.xz";
-      sha256 = "1qacqz6l7zljqszblhgzg5y1v4mgki59k45ag7yc2iw7vrf45zc0";
-      name = "qtlocation-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtlocation-opensource-src-5.9.1.tar.xz";
+      sha256 = "058mgvlaml9rkfhkpr1n3avhi12zlva131sqhbwj4lwwyqfkri2b";
+      name = "qtlocation-opensource-src-5.9.1.tar.xz";
     };
   };
   qtmacextras = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtmacextras-opensource-src-5.9.3.tar.xz";
-      sha256 = "0piv3q49vhpjxafdicizcw13am49h0ybfhb37vai0x1wbrlvhdiy";
-      name = "qtmacextras-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtmacextras-opensource-src-5.9.1.tar.xz";
+      sha256 = "0096g9l2hwsiwlzfjkw7rhkdnyvb5gzjzyjjg9kqfnsagbwscv11";
+      name = "qtmacextras-opensource-src-5.9.1.tar.xz";
     };
   };
   qtmultimedia = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtmultimedia-opensource-src-5.9.3.tar.xz";
-      sha256 = "19iqh8xpspzlmpzh05bx5rchlslbfy2pp00xv52496yf9b95i5g7";
-      name = "qtmultimedia-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtmultimedia-opensource-src-5.9.1.tar.xz";
+      sha256 = "1r76zvbv6wwb7lgw9jwlx382iyw34i1amxaypb5bg3j1niqvx3z4";
+      name = "qtmultimedia-opensource-src-5.9.1.tar.xz";
     };
   };
   qtnetworkauth = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtnetworkauth-opensource-src-5.9.3.tar.xz";
-      sha256 = "0fdz5q47xbiij3mi5lzhvxpq4jp9fm929v9kyvcyadz86mp3f8nz";
-      name = "qtnetworkauth-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtnetworkauth-opensource-src-5.9.1.tar.xz";
+      sha256 = "1fgax3p7lqcz29z2n1qxnfpkj3wxq1x9bfx61q6nss1fs74pxzra";
+      name = "qtnetworkauth-opensource-src-5.9.1.tar.xz";
     };
   };
   qtpurchasing = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtpurchasing-opensource-src-5.9.3.tar.xz";
-      sha256 = "00yfdd00frgf7fs9s0vyn1c6c4abxgld5rfgkzms3y6n6lcphs0j";
-      name = "qtpurchasing-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtpurchasing-opensource-src-5.9.1.tar.xz";
+      sha256 = "0b1hlaq6rb7d6b6h8kqd26klcpzf9vcdjrv610kdj0drb00jg3ss";
+      name = "qtpurchasing-opensource-src-5.9.1.tar.xz";
     };
   };
   qtquickcontrols = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtquickcontrols-opensource-src-5.9.3.tar.xz";
-      sha256 = "09p2q3max4xrlw5svbhn11y9cgrvcjsj88xw4c0kq91cgnyyw3ih";
-      name = "qtquickcontrols-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtquickcontrols-opensource-src-5.9.1.tar.xz";
+      sha256 = "0bpc465q822phw3dcbddn70wj1fjlc2hxskkp1z9gl7r23hx03jj";
+      name = "qtquickcontrols-opensource-src-5.9.1.tar.xz";
     };
   };
   qtquickcontrols2 = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtquickcontrols2-opensource-src-5.9.3.tar.xz";
-      sha256 = "0hq888qq8q7dglpyzif64pplqjxfrqjpkvbcx0ycq35darls5ai1";
-      name = "qtquickcontrols2-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtquickcontrols2-opensource-src-5.9.1.tar.xz";
+      sha256 = "1zq86kqz85wm3n84jcxkxw5x1mrhkqzldkigf8xm3l8j24rf0fr0";
+      name = "qtquickcontrols2-opensource-src-5.9.1.tar.xz";
     };
   };
   qtremoteobjects = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtremoteobjects-opensource-src-5.9.3.tar.xz";
-      sha256 = "0z6qd381r6a7gdrsknlkkbhq9mmdqi040kfrvgm6mfa69336f4dk";
-      name = "qtremoteobjects-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtremoteobjects-opensource-src-5.9.1.tar.xz";
+      sha256 = "10kwq0fgmi6zsqhb6s1nkcydpyl8d8flzdpgmyj50c4h2xhg2km0";
+      name = "qtremoteobjects-opensource-src-5.9.1.tar.xz";
     };
   };
   qtscript = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtscript-opensource-src-5.9.3.tar.xz";
-      sha256 = "0rjm6nph1nssfpknp4i682bvk7363y4a2f74060vcm7ib2pzl2xq";
-      name = "qtscript-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtscript-opensource-src-5.9.1.tar.xz";
+      sha256 = "13qq2mjfhqdcvkmzrgxg1gr5kww1ygbwb7r71xxl6rjzbn30hshp";
+      name = "qtscript-opensource-src-5.9.1.tar.xz";
     };
   };
   qtscxml = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtscxml-opensource-src-5.9.3.tar.xz";
-      sha256 = "06x8hs3p7bfgnl6b2fjld4s41acw1rbnxbcgkprgw2fxxnl1zxfq";
-      name = "qtscxml-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtscxml-opensource-src-5.9.1.tar.xz";
+      sha256 = "1m3b6wg5hqasdfc5igpj9bq3czql5kkvvn3rx1ig508kdlh5i5s0";
+      name = "qtscxml-opensource-src-5.9.1.tar.xz";
     };
   };
   qtsensors = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtsensors-opensource-src-5.9.3.tar.xz";
-      sha256 = "1hfsih5iy4fi6mnpw2shf1lzx9hxcdc1arspad1mark17l5s4pmr";
-      name = "qtsensors-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtsensors-opensource-src-5.9.1.tar.xz";
+      sha256 = "1772x7r6y9xv2sv0w2dfz2yhagsq5bpa9kdpzg0qikccmabr7was";
+      name = "qtsensors-opensource-src-5.9.1.tar.xz";
     };
   };
   qtserialbus = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtserialbus-opensource-src-5.9.3.tar.xz";
-      sha256 = "0f39qh05mp54frpn5sy9k5vfw5zb2gg72qaqz81mwlck2xg78qpg";
-      name = "qtserialbus-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtserialbus-opensource-src-5.9.1.tar.xz";
+      sha256 = "1hzk377c3zl4dm5hxwvpxg2w096m160448y9df6v6l8xpzpzxafa";
+      name = "qtserialbus-opensource-src-5.9.1.tar.xz";
     };
   };
   qtserialport = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtserialport-opensource-src-5.9.3.tar.xz";
-      sha256 = "1pxb679cx77vk39ik7j0k91a57wqa63d4g4riw3r2gpcay8kxpac";
-      name = "qtserialport-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtserialport-opensource-src-5.9.1.tar.xz";
+      sha256 = "0sbsc7n701kxl16r247a907zg2afmbx1xlml5jkc6a9956zqbzp1";
+      name = "qtserialport-opensource-src-5.9.1.tar.xz";
     };
   };
   qtspeech = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtspeech-opensource-src-5.9.3.tar.xz";
-      sha256 = "1c4rpf3by620fx8lrvmc38r60cikqczqh2rfcm7ixz3x8cj60lh1";
-      name = "qtspeech-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtspeech-opensource-src-5.9.1.tar.xz";
+      sha256 = "00daxkf8iwf6n9rhkkv3isv5qa8wijwzb0zy1f6zlm3vcc8fz75c";
+      name = "qtspeech-opensource-src-5.9.1.tar.xz";
     };
   };
   qtsvg = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtsvg-opensource-src-5.9.3.tar.xz";
-      sha256 = "1wjx9ymk2h19l9kk76jh87bnhhj955f9a93akvwwzfwg1jk2hrnz";
-      name = "qtsvg-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtsvg-opensource-src-5.9.1.tar.xz";
+      sha256 = "1rg2q4snh2g4n93zmk995swwkl0ab1jr9ka9xpj56ddifkw99wlr";
+      name = "qtsvg-opensource-src-5.9.1.tar.xz";
     };
   };
   qttools = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qttools-opensource-src-5.9.3.tar.xz";
-      sha256 = "1zw4j8ymwcpn7dx1dlbxpmx5lfp26rag7pysap1xry9m7vg3hb24";
-      name = "qttools-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qttools-opensource-src-5.9.1.tar.xz";
+      sha256 = "1s50kh3sg5wc5gqhwwznnibh7jcnfginnmkv66w62mm74k7mdsy4";
+      name = "qttools-opensource-src-5.9.1.tar.xz";
     };
   };
   qttranslations = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qttranslations-opensource-src-5.9.3.tar.xz";
-      sha256 = "1ncvj1qlcgrm0zqdlq2bkb0hc8dyisz8m7bszxyx4kyxg7n5gb20";
-      name = "qttranslations-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qttranslations-opensource-src-5.9.1.tar.xz";
+      sha256 = "0sdjiqli15fmkbqvhhgjfavff906sg56jx5xf8bg6xzd2j5544ja";
+      name = "qttranslations-opensource-src-5.9.1.tar.xz";
     };
   };
   qtvirtualkeyboard = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtvirtualkeyboard-opensource-src-5.9.3.tar.xz";
-      sha256 = "1zrj4pjy98dskzycjswbkm4m2j6k1j4150h0w7vdrw1681s3ycdr";
-      name = "qtvirtualkeyboard-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtvirtualkeyboard-opensource-src-5.9.1.tar.xz";
+      sha256 = "0k79sqa8bg6gkbsk16320gnila1iiwpnl3vx03rysm5bqdnnlx3b";
+      name = "qtvirtualkeyboard-opensource-src-5.9.1.tar.xz";
     };
   };
   qtwayland = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtwayland-opensource-src-5.9.3.tar.xz";
-      sha256 = "0vazcmpqdka3llmyg7m99lw0ngrydmw74p9nd04544xdn128r3ih";
-      name = "qtwayland-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwayland-opensource-src-5.9.1.tar.xz";
+      sha256 = "1yizvbmh26mx1ffq0qaci02g2wihy68ld0y7r3z8nx3v5acb236g";
+      name = "qtwayland-opensource-src-5.9.1.tar.xz";
     };
   };
   qtwebchannel = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtwebchannel-opensource-src-5.9.3.tar.xz";
-      sha256 = "0n438mk01sh2bbqakc1m3s65qqmi75m4n4hymad8wcgijfr9a9v3";
-      name = "qtwebchannel-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwebchannel-opensource-src-5.9.1.tar.xz";
+      sha256 = "003h09mla82f2znb8jjigx13ivc68ikgv7w04594yy7qdmd5yhl0";
+      name = "qtwebchannel-opensource-src-5.9.1.tar.xz";
     };
   };
   qtwebengine = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtwebengine-opensource-src-5.9.3.tar.xz";
-      sha256 = "0dqxawc9vfffz6ygdn5mdpl79rrqfx18jy2d1w81q9w7zm113bj5";
-      name = "qtwebengine-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwebengine-opensource-src-5.9.1.tar.xz";
+      sha256 = "00b4d18m54pbxa1hm6ijh2mrd4wmrs7lkplys8b4liw8j7mpx8zn";
+      name = "qtwebengine-opensource-src-5.9.1.tar.xz";
     };
   };
   qtwebkit = {
@@ -291,43 +291,43 @@
     };
   };
   qtwebsockets = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtwebsockets-opensource-src-5.9.3.tar.xz";
-      sha256 = "1phic630ah85ajxp6iqrw9bpg0y8s88y45ygkc1wcasmbgzrs1nf";
-      name = "qtwebsockets-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwebsockets-opensource-src-5.9.1.tar.xz";
+      sha256 = "0r1lya2jj3wfci82zfn0vk6vr8sk9k7xiphnkb0panhb8di769q1";
+      name = "qtwebsockets-opensource-src-5.9.1.tar.xz";
     };
   };
   qtwebview = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtwebview-opensource-src-5.9.3.tar.xz";
-      sha256 = "1i99fy86gydpfsfc4my5d9vxjywfrzbqxk66cb3yf2ac57j66mpf";
-      name = "qtwebview-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwebview-opensource-src-5.9.1.tar.xz";
+      sha256 = "0qmxrh4y3i9n8x6yhrlnahcn75cc2xwlc8mi4g8n2d83c3x7pxyn";
+      name = "qtwebview-opensource-src-5.9.1.tar.xz";
     };
   };
   qtwinextras = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtwinextras-opensource-src-5.9.3.tar.xz";
-      sha256 = "1lj4qa51ymhpvk0bdp6xf6b3n1k39kihns5lvp6xq1w2mljn6phl";
-      name = "qtwinextras-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwinextras-opensource-src-5.9.1.tar.xz";
+      sha256 = "1x7f944f3g2ml3mm594qv6jlvl5dzzsxq86yinp7av0lhnyrxk0s";
+      name = "qtwinextras-opensource-src-5.9.1.tar.xz";
     };
   };
   qtx11extras = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtx11extras-opensource-src-5.9.3.tar.xz";
-      sha256 = "1gpjgca4xvyy0r743kh2ys128r14fh6j8bdphnmmi5v2pf6bzq74";
-      name = "qtx11extras-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtx11extras-opensource-src-5.9.1.tar.xz";
+      sha256 = "00fn3bps48gjyw0pdqvvl9scknxdpmacby6hvdrdccc3jll0wgd6";
+      name = "qtx11extras-opensource-src-5.9.1.tar.xz";
     };
   };
   qtxmlpatterns = {
-    version = "5.9.3";
+    version = "5.9.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtxmlpatterns-opensource-src-5.9.3.tar.xz";
-      sha256 = "1fphhqr3v3vzjp2vbv16bc1vs879wn7aqlabgcpkhqx92ak6d76g";
-      name = "qtxmlpatterns-opensource-src-5.9.3.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtxmlpatterns-opensource-src-5.9.1.tar.xz";
+      sha256 = "094wwap2fsl23cys6rxh2ciw0gxbbiqbshnn4qs1n6xdjrj6i15m";
+      name = "qtxmlpatterns-opensource-src-5.9.1.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -3,7 +3,7 @@
   src, patches, version, qtCompatVersion,
 
   coreutils, bison, flex, gdb, gperf, lndir, patchelf, perl, pkgconfig, python2,
-  ruby, which,
+  ruby,
   # darwin support
   darwin, libiconv, libcxx,
 
@@ -84,7 +84,7 @@ stdenv.mkDerivation {
     ++ lib.optional (postgresql != null) postgresql;
 
   nativeBuildInputs =
-    [ bison flex gperf lndir perl pkgconfig python2 which ]
+    [ bison flex gperf lndir perl pkgconfig python2 ]
     ++ lib.optional (!stdenv.isDarwin) patchelf;
 
   propagatedNativeBuildInputs = [ lndir ];


### PR DESCRIPTION
###### Motivation for this change

KDE frameworks 5.40 are not compatible with Qt 5.9.3: #32253. We should wait for a version that does not require cherry picking upstream patches because we may miss some, and updating Qt is not urgent.

This reverts commit bd71d3aef7a61f1c01e14fa5c0ec7f6f6a7dc56e (#32100).

###### Things done

Tested switching to the resulting configuration with the KDE desktop.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).