### PR TITLE
ocamlPackages.ocurl: 0.7.8 -> 0.8.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocurl/default.nix
+++ b/pkgs/development/ocaml-modules/ocurl/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, ocaml, findlib, fetchurl, curl, ncurses }:
+{ stdenv, pkgconfig, ocaml, findlib, fetchurl, curl, ncurses }:
 
 stdenv.mkDerivation rec {
-  name = "ocurl-0.7.8";
+  name = "ocurl-0.8.0";
   src = fetchurl {
-    url = "https://forge.ocamlcore.org/frs/download.php/1463/${name}.tar.bz2";
-    sha256 = "0yn7f3g5wva8nqxh76adpq9rihggc405jkqysfghzwnf3yymyqrr";
+    url = "http://ygrek.org.ua/p/release/ocurl/${name}.tar.gz";
+    sha256 = "0292knvm9g038br0dc03lcsnbjqycyiqha256dp4bxkz3vmmz4wr";
   };
 
-  buildInputs = [ ocaml findlib ncurses ];
+  buildInputs = [ pkgconfig ocaml findlib ncurses ];
   propagatedBuildInputs = [ curl ];
   createFindlibDestdir = true;
   meta = {
     description = "OCaml bindings to libcurl";
-    license = stdenv.lib.licenses.bsd3;
-    homepage = http://ocurl.forge.ocamlcore.org/;
+    license = stdenv.lib.licenses.mit;
+    homepage = "http://ygrek.org.ua/p/ocurl/";
     maintainers = with stdenv.lib.maintainers; [ bennofs ];
     platforms = ocaml.meta.platforms or [];
   };


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

