### PR TITLE
Enable parallel building for CMake based projects by default

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -251,10 +251,17 @@ genericBuild
 
   <varlistentry>
     <term><varname>enableParallelBuilding</varname></term>
-    <listitem><para>If set, <literal>stdenv</literal> will pass specific
-    flags to <literal>make</literal> and other build tools to enable
-    parallel building with up to <literal>build-cores</literal>
-    workers.</para></listitem>
+    <listitem>
+      <para>If set to <literal>true</literal>, <literal>stdenv</literal> will
+      pass specific flags to <literal>make</literal> and other build tools to
+      enable parallel building with up to <literal>build-cores</literal>
+      workers.</para>
+
+      <para>Unless set to <literal>false</literal>, some build systems with good
+      support for parallel building including <literal>cmake</literal>,
+      <literal>meson</literal>, and <literal>qmake</literal> will set it to
+      <literal>true</literal>.</para>
+    </listitem>
   </varlistentry>
 
   <varlistentry>

--- a/pkgs/applications/altcoins/memorycoin.nix
+++ b/pkgs/applications/altcoins/memorycoin.nix
@@ -31,6 +31,10 @@ stdenv.mkDerivation rec{
     then "install -D bitcoin-qt $out/bin/memorycoin-qt"
     else "install -D bitcoind $out/bin/memorycoind";
 
+  # `make build/version.o`:
+  # make: *** No rule to make target 'build/build.h', needed by 'build/version.o'.  Stop.
+  enableParallelBuilding = false;
+
   meta = {
     description = "Peer-to-peer, CPU-based electronic cash system";
     longDescription= ''

--- a/pkgs/applications/altcoins/primecoin.nix
+++ b/pkgs/applications/altcoins/primecoin.nix
@@ -31,6 +31,10 @@ stdenv.mkDerivation rec{
     then "install -D bitcoin-qt $out/bin/primecoin-qt"
     else "install -D bitcoind $out/bin/primecoind";
 
+  # `make build/version.o`:
+  # make: *** No rule to make target 'build/build.h', needed by 'build/version.o'.  Stop.
+  enableParallelBuilding = false;
+
   meta = {
     description = "A new type cryptocurrency which is proof-of-work based on searching for prime numbers";
     longDescription= ''

--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -14,8 +14,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake makeWrapper ];
 
+  # `make -f src/providers/wms/CMakeFiles/wmsprovider_a.dir/build.make src/providers/wms/CMakeFiles/wmsprovider_a.dir/qgswmssourceselect.cpp.o`:
   # fatal error: ui_qgsdelimitedtextsourceselectbase.h: No such file or directory
-  #enableParallelBuilding = true;
+  enableParallelBuilding = false;
 
   # To handle the lack of 'local' RPATH; required, as they call one of
   # their built binaries requiring their libs, in the build process.

--- a/pkgs/applications/graphics/awesomebump/default.nix
+++ b/pkgs/applications/graphics/awesomebump/default.nix
@@ -15,6 +15,7 @@ let
     name = "qtnproperty";
     inherit src;
     sourceRoot = "AwesomeBump/Sources/utils/QtnProperty";
+    patches = [ ./qtnproperty-parallel-building.patch ];
     buildInputs = [ qtscript qtbase qtdeclarative ];
     nativeBuildInputs = [ qmake flex bison ];
     postInstall = ''
@@ -45,6 +46,10 @@ in stdenv.mkDerivation rec {
     makeWrapper $d/AwesomeBump $out/bin/AwesomeBump \
         --run "cd $d"
   '';
+
+  passthru = {
+    inherit qtnproperty;
+  };
 
   meta = {
     homepage = https://github.com/kmkolasinski/AwesomeBump;

--- a/pkgs/applications/graphics/awesomebump/qtnproperty-parallel-building.patch
+++ b/pkgs/applications/graphics/awesomebump/qtnproperty-parallel-building.patch
@@ -1,0 +1,9 @@
+--- a/PEG/Flex.pri
++++ b/PEG/Flex.pri
+@@ -1,5 +1,6 @@
+ flex.name = Flex ${QMAKE_FILE_IN}
+ flex.input = FLEX_SOURCES
++flex.depends = ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.parser.cpp
+ flex.output = ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.lexer.cpp
+ 
+ win32:flex.commands = win_flex --wincompat -o ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.lexer.cpp ${QMAKE_FILE_IN}

--- a/pkgs/applications/misc/golden-cheetah/default.nix
+++ b/pkgs/applications/misc/golden-cheetah/default.nix
@@ -30,6 +30,10 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  # RCC: Error in 'Resources/application.qrc': Cannot find file 'translations/gc_fr.qm'
+  enableParallelBuilding = false;
+
   meta = {
     description = "Performance software for cyclists, runners and triathletes";
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub
-, vala, cmake, wrapGAppsHook, pkgconfig, gettext
+, vala, cmake, ninja, wrapGAppsHook, pkgconfig, gettext
 , gobjectIntrospection, gnome3, glib, gdk_pixbuf, gtk3, glib_networking
 , xorg, libXdmcp, libxkbcommon
 , libnotify, libsoup
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     vala
     cmake
+    ninja
     pkgconfig
     wrapGAppsHook
   ];

--- a/pkgs/applications/networking/instant-messengers/ricochet/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ricochet/default.nix
@@ -46,6 +46,9 @@ stdenv.mkDerivation rec {
     cp icons/ricochet.png $out/share/pixmaps/ricochet.png
   '';
 
+  # RCC: Error in 'translation/embedded.qrc': Cannot find file 'ricochet_en.qm'
+  enableParallelBuilding = false;
+
   meta = with stdenv.lib; {
     description = "Anonymous peer-to-peer instant messaging";
     homepage = https://ricochet.im;

--- a/pkgs/applications/networking/ostinato/default.nix
+++ b/pkgs/applications/networking/ostinato/default.nix
@@ -54,6 +54,10 @@ stdenv.mkDerivation rec {
     EOF
   '';
 
+  # `cd common; qmake ostproto.pro; make pdmlreader.o`:
+  # pdmlprotocol.h:23:25: fatal error: protocol.pb.h: No such file or directory
+  enableParallelBuilding = false;
+
   meta = with stdenv.lib; {
     description = "A packet traffic generator and analyzer";
     homepage    = http://ostinato.org;

--- a/pkgs/applications/science/logic/stp/default.nix
+++ b/pkgs/applications/science/logic/stp/default.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation rec {
     )
   '';
 
+  # `make -f lib/Interface/CMakeFiles/cppinterface.dir/build.make lib/Interface/CMakeFiles/cppinterface.dir/cpp_interface.cpp.o`:
+  # include/stp/AST/UsefulDefs.h:41:29: fatal error: stp/AST/ASTKind.h: No such file or directory
+  enableParallelBuilding = false;
+
   meta = with stdenv.lib; {
     description = "Simple Theorem Prover";
     maintainers = with maintainers; [ mornfall ];

--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, ccache, cmake, ctags, swig
+{ stdenv, lib, fetchFromGitHub, fetchpatch, ccache, cmake, ctags, swig
 # data, compression
 , bzip2, curl, hdf5, json_c, lzma, lzo, protobuf, snappy
 # maths
@@ -25,6 +25,12 @@ stdenv.mkDerivation rec {
     rev = pname + "_" + version;
     sha256 = "0f2zwzvn5apvwypkfkq371xp7c5bdb4g1fwqfh8c2d57ysjxhmgf";
     fetchSubmodules = true;
+  };
+
+  patches = fetchpatch {
+    name = "Fix-meta-example-parser-bug-in-parallel-builds.patch";
+    url = "https://github.com/shogun-toolbox/shogun/commit/ecd6a8f11ac52748e89d27c7fab7f43c1de39f05.patch";
+    sha256 = "1hrwwrj78sxhwcvgaz7n4kvh5y9snfcc4jf5xpgji5hjymnl311n";
   };
 
   CCACHE_DIR=".ccache";

--- a/pkgs/applications/version-management/guitone/default.nix
+++ b/pkgs/applications/version-management/guitone/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     branch = "net.venge.monotone.guitone";
   };
 
+  patches = [ ./parallel-building.patch ];
+
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ qt4 qmake4Hook graphviz ];
 
@@ -24,6 +26,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Qt4 based GUI for monotone";
     homepage = http://guitone.thomaskeller.biz;
+    downloadPage = https://code.monotone.ca/p/guitone/;
     inherit (qt4.meta) platforms;
   };
 }

--- a/pkgs/applications/version-management/guitone/parallel-building.patch
+++ b/pkgs/applications/version-management/guitone/parallel-building.patch
@@ -1,0 +1,7 @@
+Without this `make tmp/AttributesView.o` fails with
+src/view/dialogs/AddEditAttribute.h:22:35: fatal error: ui_add_edit_attribute.h: No such file or directory
+--- a/guitone.pro
++++ b/guitone.pro
+@@ -215 +215,2 @@ help.commands = @echo Available targets: $${QMAKE_EXTRA_TARGETS}
+ QMAKE_EXTRA_TARGETS += help
++CONFIG += depend_includepath

--- a/pkgs/desktops/gnome-3/core/totem/default.nix
+++ b/pkgs/desktops/gnome-3/core/totem/default.nix
@@ -9,7 +9,9 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  enableParallelBuilding = true;
+  # https://bugzilla.gnome.org/show_bug.cgi?id=784236
+  # https://github.com/mesonbuild/meson/issues/1994
+  enableParallelBuilding = false;
 
   NIX_CFLAGS_COMPILE = "-I${gnome3.glib.dev}/include/gio-unix-2.0";
 

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -70,4 +70,6 @@ stdenv.mkDerivation rec {
     ++ optional (!stdenv.isDarwin) wildmidi;
 
   LDFLAGS = optionalString stdenv.isDarwin "-lintl";
+
+  enableParallelBuilding = true;
 }

--- a/pkgs/development/libraries/qt-4.x/4.8/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-4.x/4.8/qmake-hook.sh
@@ -3,6 +3,11 @@ qmakeConfigurePhase() {
 
     $QMAKE PREFIX=$out $qmakeFlags
 
+    if ! [[ -v enableParallelBuilding ]]; then
+        enableParallelBuilding=1
+        echo "qmake4Hook: enabled parallel building"
+    fi
+
     runHook postConfigure
 }
 

--- a/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
@@ -10,6 +10,11 @@ qmakeConfigurePhase() {
           NIX_OUTPUT_PLUGIN=${!outputBin}/${qtPluginPrefix:?} \
           $qmakeFlags
 
+    if ! [[ -v enableParallelBuilding ]]; then
+        enableParallelBuilding=1
+        echo "qmake: enabled parallel building"
+    fi
+
     runHook postConfigure
 }
 

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -59,6 +59,11 @@ cmakeConfigurePhase() {
 
     cmake ${cmakeDir:-.} $cmakeFlags "${cmakeFlagsArray[@]}"
 
+    if ! [[ -v enableParallelBuilding ]]; then
+        enableParallelBuilding=1
+        echo "cmake: enabled parallel building"
+    fi
+
     runHook postConfigure
 }
 

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -51,6 +51,10 @@ cmakeConfigurePhase() {
     # And build always Release, to ensure optimisation flags
     cmakeFlags="-DCMAKE_BUILD_TYPE=${cmakeBuildType:-Release} -DCMAKE_SKIP_BUILD_RPATH=ON $cmakeFlags"
 
+    if [ "$buildPhase" = ninjaBuildPhase ]; then
+        cmakeFlags="-GNinja $cmakeFlags"
+    fi
+
     echo "cmake flags: $cmakeFlags ${cmakeFlagsArray[@]}"
 
     cmake ${cmakeDir:-.} $cmakeFlags "${cmakeFlagsArray[@]}"

--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -13,6 +13,11 @@ mesonConfigurePhase() {
     meson build $mesonFlags "${mesonFlagsArray[@]}"
     cd build
 
+    if ! [[ -v enableParallelBuilding ]]; then
+        enableParallelBuilding=1
+        echo "meson: enabled parallel building"
+    fi
+
     runHook postConfigure
 }
 

--- a/pkgs/development/tools/build-managers/ninja/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/ninja/setup-hook.sh
@@ -4,9 +4,16 @@ ninjaBuildPhase() {
     if [[ -z "$ninjaFlags" && ! ( -e build.ninja ) ]]; then
         echo "no build.ninja, doing nothing"
     else
+        local buildCores=1
+
+        # Parallel building is enabled by default.
+        if [ "${enableParallelBuilding-1}" ]; then
+            buildCores="$NIX_BUILD_CORES"
+        fi
+
         # shellcheck disable=SC2086
         local flagsArray=( \
-            ${enableParallelBuilding:+-j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES}} \
+            -j"$buildCores" -l"$NIX_BUILD_CORES" \
             $ninjaFlags "${ninjaFlagsArray[@]}" \
             $buildFlags "${buildFlagsArray[@]}")
 

--- a/pkgs/development/tools/misc/editorconfig-core-c/default.nix
+++ b/pkgs/development/tools/misc/editorconfig-core-c/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ pcre ];
   nativeBuildInputs = [ cmake doxygen ];
 
+  # Multiple doxygen can not generate man pages in the same base directory in
+  # parallel: https://bugzilla.gnome.org/show_bug.cgi?id=791153
+  enableParallelBuilding = false;
+
   meta = with stdenv.lib; {
     homepage = http://editorconfig.org/;
     description = "EditorConfig core library written in C";

--- a/pkgs/games/chessx/default.nix
+++ b/pkgs/games/chessx/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig qmake ];
 
   # RCC: Error in 'resources.qrc': Cannot find file 'i18n/chessx_da.qm'
-  #enableParallelBuilding = true;
+  enableParallelBuilding = false;
 
   installPhase = ''
       runHook preInstall

--- a/pkgs/os-specific/linux/conky/default.nix
+++ b/pkgs/os-specific/linux/conky/default.nix
@@ -131,6 +131,10 @@ stdenv.mkDerivation rec {
     ++ optional nvidiaSupport       "-DBUILD_NVIDIA=ON"
     ;
 
+  # `make -f src/CMakeFiles/conky.dir/build.make src/CMakeFiles/conky.dir/conky.cc.o`:
+  # src/conky.cc:137:23: fatal error: defconfig.h: No such file or directory
+  enableParallelBuilding = false;
+
   meta = with stdenv.lib; {
     homepage = http://conky.sourceforge.net/;
     description = "Advanced, highly configurable system monitor based on torsmo";

--- a/pkgs/tools/misc/rockbox-utility/default.nix
+++ b/pkgs/tools/misc/rockbox-utility/default.nix
@@ -39,6 +39,12 @@ stdenv.mkDerivation  rec {
     runHook postInstall
   '';
 
+  # `make build/rcc/qrc_rbutilqt-lang.cpp` fails with
+  #      RCC: Error in 'rbutilqt-lang.qrc': Cannot find file 'lang/rbutil_cs.qm'
+  # Do not add `lrelease rbutilqt.pro` into preConfigure, otherwise `make lrelease`
+  # may clobber the files read by the parallel `make build/rcc/qrc_rbutilqt-lang.cpp`.
+  enableParallelBuilding = false;
+
   meta = with stdenv.lib; {
     description = "Open source firmware for mp3 players";
     homepage = http://www.rockbox.org;


### PR DESCRIPTION
###### Motivation for this change

This obviously benefits small rebuilds. People contributing new packages, updating and fixing bugs in existing packages won't have to wait as much. Reviewers and maintainers of Nixpkgs won't have to ask for `enableParallelBuilding`, push it into pull requests, or bundle it when they commit something that rebuilds packages with parallel building not enabled.

The downside of parallel building with make — unpredictable failures that are difficult to reproduce — is almost mitigated by build systems that automatically generate complete dependencies between build commands.

During the testing of this PR, I have encountered just 4 packages that failed (details are in the commits of the PR):

- `editorconfig-core-c` running doxygen multiple times from the same template with the same output directory has a race on directory creation
- `shogun` running multiple ply.yacc that clobber temporary files of each other
- `dino` using (and recommending) Ninja and writing their cmake scripts in a way not supported by GNU Make generator of CMake
- `totem` relying on a feature missing from Meson

I have reported the first three bugs upstream and disabled parallel building for them. The fourth was already reported both to [Totem](https://bugzilla.gnome.org/show_bug.cgi?id=784236) and [Meson](https://github.com/mesonbuild/meson/issues/1994), with both sides agreeing that this is a bug in Meson, so I have disable parallel building for Meson. @jtojnar, since this seems to affect just one package, could you consider this issue and decide if we should rather enable parallel Meson and disable parallel Totem?

This PR also adds `-GNinja` to cmake when the build phase is `ninjaBuildPhase`, which is an obvious thing to do after #28444 has added the Ninja setup hook.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `pkgs/top-level/release.nix`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
