### PR TITLE
pgtap: 0.97.0 -> 0.98.0, highlight: 3.40 -> 3.41

### DIFF
--- a/pkgs/servers/sql/postgresql/pgtap/default.nix
+++ b/pkgs/servers/sql/postgresql/pgtap/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "pgtap-${version}";
-  version = "0.97.0";
+  version = "0.98.0";
 
   src = fetchFromGitHub {
     owner = "theory";
     repo = "pgtap";
     rev = "v${version}";
-    sha256 = "1vzc8pxzi0rbywmrvx7i5awngsvzcz75i4jl9bk2vqr223chax6f";
+    sha256 = "17r3b409k05pbypmwdwgm1fl669jc6a1391szyxizx784k44a369";
   };
 
   nativeBuildInputs = [ postgresql perl perlPackages.TAPParserSourceHandlerpgTAP which ];

--- a/pkgs/tools/text/highlight/default.nix
+++ b/pkgs/tools/text/highlight/default.nix
@@ -4,13 +4,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "highlight-${version}";
-  version = "3.40";
+  version = "3.41";
 
   src = fetchFromGitHub {
     owner = "andre-simon";
     repo = "highlight";
     rev = "${version}";
-    sha256 = "0bkywhz4y10qcajimdha1ck5mvn7fsrv3yn8nd6rqbva39gbfmfd";
+    sha256 = "163ghkyv3v6v200pskajlsz6sbq3hi31qx7abjcbwc0dajqfngvj";
   };
 
   nativeBuildInputs = [ pkgconfig ] ++ optional stdenv.isDarwin  gcc ;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (I ran the [pgjwt test](https://github.com/NixOS/nixpkgs/blob/5ab47ccfd1e58947f21040ee74d21410c6b5228b/nixos/tests/pgjwt.nix#L4))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

