### PR TITLE
Init Centos 7.4 vmTools diskImage

### DIFF
--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1322,6 +1322,19 @@ rec {
       archs = ["noarch" "x86_64"];
       packages = commonCentOSPackages ++ [ "procps-ng" ];
     };
+
+    centos74x86_64 = rec {
+      name = "centos-7.4-x86_64";
+      fullName = "CentOS 7.4 (x86_64)";
+      # N.B. Switch to vault.centos.org when the next release comes out
+      urlPrefix = http://mirror.centos.org/centos-7/7.4.1708/os/x86_64;
+      packagesList = fetchurl {
+        url = "${urlPrefix}/repodata/b686d3a0f337323e656d9387b9a76ce6808b26255fc3a138b1a87d3b1cb95ed5-primary.xml.gz";
+        sha256 = "1mayp4f3nzd8n4wa3hsz4lk8p076djkvk1wkdmjkwcipyfhd71mn";
+      };
+      archs = ["noarch" "x86_64"];
+      packages = commonCentOSPackages ++ [ "procps-ng" ];
+    };
   };
 
 


### PR DESCRIPTION
This commit adds the CentOS 7.4 base image from the CentOS mirror, for use with
building RPMs or evaluating Nix expressions in a CentOS image.

When CentOS 7.5 comes out, I will swap this URL to the permanently vaulted image.

###### Motivation for this change
Would like to get Nix tools building on the latest stable CentOS release for use in enterprise environments.

See related:
https://github.com/NixOS/nixpkgs/pull/31801
https://github.com/NixOS/nix/pull/1141

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
λ brh vm →  nix-build -I nixpkgs=/home/bhipple/src/nixpkgs -K -E 'with import <nixpkgs> { }; pkgs.vmTools.runInLinuxImage (pkgs.runCommand "rel" { diskImage = pkgs.vmTools.diskImages.centos74x86_64; } "cat  /etc/redhat-release" )'
these derivations will be built:
  /nix/store/njqjsdb1n9iaj2fwpbmi0yaz67lwhz8q-rel.drv
building '/nix/store/njqjsdb1n9iaj2fwpbmi0yaz67lwhz8q-rel.drv'...
Formatting '/build/disk-image.qcow2', fmt=qcow2 size=4294967296 backing_file=/nix/store/7la80fwry803z5y8r7564vzln0aynavw-centos-7.4-x86_64/disk-image.qcow2 cluster_size=65536 lazy_refcounts=off refcount_bits=16
loading kernel modules...
[    0.439143] EXT4-fs (vda): couldn't mount as ext3 due to feature incompatibilities
mounting Nix store...
mounting host's temporary directory...
starting stage 2 (/nix/store/awj1ykj7kcijxcq6csinp6ly08amh6q2-vm-run-stage2)
hwclock: Cannot access the Hardware Clock via any known method.
hwclock: Use the --debug option to see the details of our search for an access method.
**CentOS Linux release 7.4.1708 (Core)**
[    0.607279] reboot: Power down
/nix/store/j2vz24k5d0kid261s5w7hhkjkx7zr8kw-rel
```
