### PR TITLE
abcMIDI: 2017.06.10	-> 2017.11.27

### DIFF
--- a/pkgs/tools/audio/abcmidi/default.nix
+++ b/pkgs/tools/audio/abcmidi/default.nix
@@ -1,15 +1,16 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchurl, unzip }:
 
 stdenv.mkDerivation rec {
   name = "abcMIDI-${version}";
-  version = "2017.06.10";
+  version = "2017.11.27";
 
-  src = fetchFromGitHub {
-    owner = "leesavide";
-    repo = "abcmidi";
-    rev = name;
-    sha256 = "0y92m3mj63vvy79ksq4z5hgkz6w50drg9a4bmbk6jylny0l0bdpy";
+  # You can find new releases on http://ifdo.ca/~seymour/runabc/top.html
+  src = fetchurl {
+    url = "http://ifdo.ca/~seymour/runabc/${name}.zip";
+    sha256 = "095nnyaqnsr3v7hsswpad9g0hxdnr4s6z8yk1bmr3g1j0cfv1xs9";
   };
+
+  nativeBuildInputs = [ unzip ];
 
   # There is also a file called "makefile" which seems to be preferred by the standard build phase
   makefile = "Makefile";
@@ -17,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = http://abc.sourceforge.net/abcMIDI/;
     license = licenses.gpl2Plus;
-    description = "abc <-> MIDI conversion utilities";
+    description = "Utilities for converting between abc and MIDI";
     maintainers = [ maintainers.dotlambda ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The github repo doesn't seem to be updated any longer.

I was also condering renaming the package to lowercase abcmidi because most distros do so:
https://repology.org/metapackage/abcmidi/versions
The only problem I see is that it wouldn't be updated if already installed, if I am correct.
What do you think?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

ping @rycee 