### PR TITLE
polybar: 3.0.5 -> 3.1.0

### DIFF
--- a/pkgs/applications/misc/polybar/default.nix
+++ b/pkgs/applications/misc/polybar/default.nix
@@ -21,11 +21,11 @@ assert i3GapsSupport -> ! i3Support     && jsoncpp != null && i3-gaps != null;
 
 stdenv.mkDerivation rec {
     name = "polybar-${version}";
-    version = "3.0.5";
+    version = "3.1.0";
     src = fetchgit {
       url = "https://github.com/jaagr/polybar";
-      rev = "4e2e2a7a5e0fe81669031ade0f60e1d379b6516d";
-      sha256 = "1iiks9q13pbkgbjhdns18a5zgr6d40ydcm4qn168m73fs6ivf1vn";
+      rev = "bf16a4d415ea7d8845f578544de0c71e56ad314e";
+      sha256 = "1jcvqxl0477j0snvh1rzqsm1dkfsybix2lgrlsgiczdxfknwz8iy";
     };
 
     meta = with stdenv.lib; {
@@ -39,14 +39,6 @@ stdenv.mkDerivation rec {
       maintainers = [ maintainers.afldcr ];
       platforms = platforms.unix;
     };
-    # This patch should be removed with next stable release.
-    patches = [
-      (fetchpatch {
-        name = "polybar-remove-curlbuild.patch";
-        url = "https://github.com/jaagr/polybar/commit/d35abc7620c8f06618b4708d9a969dfa2f309e96.patch";
-        sha256 = "14xr65vsjvd51hzg9linj09w0nnixgn26dh9lqxy25bxachcyzxy";
-      })
-    ];
 
     buildInputs = [
       cairo libXdmcp libpthreadstubs libxcb pcre python2 xcbproto xcbutil


### PR DESCRIPTION
###### Motivation for this change

Upstream released a new version that also contains a fix for compilation with gcc-7 (#31747).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

