### PR TITLE
android-platform-tools: 26.0.0 -> 26.0.2

### DIFF
--- a/pkgs/development/mobile/androidenv/platform-tools.nix
+++ b/pkgs/development/mobile/androidenv/platform-tools.nix
@@ -1,16 +1,16 @@
 {stdenv, zlib, fetchurl, unzip}:
 
 stdenv.mkDerivation rec {
-  version = "26.0.0";
+  version = "26.0.2";
   name = "android-platform-tools-r${version}";
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
       url = "https://dl.google.com/android/repository/platform-tools_r${version}-linux.zip";
-      sha256 = "02z5fxxdwd6359wmqdag9vvszdq49sm78cvfskqap18xa83q484h";
+      sha256 = "0695npvxljbbh8xwfm65k34fcpyfkzvfkssgnp46wkmnq8w5mcb3";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
       url = "https://dl.google.com/android/repository/platform-tools_r${version}-darwin.zip";
-      sha256 = "13mcyi9l0mmmjr056z1i3rhpb4641iv0a5ky7ij0v8hwsb5r5lwq";
+      sha256 = "0gy7apw9pmnnm41z6ywglw5va4ghmny4j57778may4q7ar751l56";
     }
     else throw "System ${stdenv.system} not supported!";
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     cd $out
     unzip $src
     cd platform-tools
-    
+
     ${stdenv.lib.optionalString (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
       ''
         for i in adb dmtracedump fastboot hprof-conv sqlite3
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
             patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 $i
             patchelf --set-rpath ${stdenv.cc.cc.lib}/lib:`pwd`/lib64 $i
         done
-        
+
         for i in etc1tool
         do
             patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 $i
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
         ln -sf $out/platform-tools/$i $out/bin/$i
     done
   '';
-  
+
   buildInputs = [ unzip ];
 }


### PR DESCRIPTION
###### Motivation for this change
Upgrading to the latest adb and fastboot for newer devices.  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

