### PR TITLE
gnome3.gpaste: fix keybindings path

### DIFF
--- a/pkgs/desktops/gnome-3/misc/gpaste/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gpaste/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
                   gtk3 gnome3.gnome_control_center dbus
                   clutter pango appstream-glib systemd gobjectIntrospection ];
 
-  configureFlags = [ "--with-controlcenterdir=$(out)/gnome-control-center/keybindings"
+  configureFlags = [ "--with-controlcenterdir=$(out)/share/gnome-control-center/keybindings"
                      "--with-dbusservicesdir=$(out)/share/dbus-1/services"
                      "--with-systemduserunitdir=$(out)/etc/systemd/user" ];
 


### PR DESCRIPTION
###### Motivation for this change
GNOME Control Center expects the keybindings to be in datadir.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

