### PR TITLE
way-cooler: 0.5.2 -> 0.6.2

### DIFF
--- a/pkgs/applications/window-managers/way-cooler/default.nix
+++ b/pkgs/applications/window-managers/way-cooler/default.nix
@@ -1,27 +1,33 @@
 { stdenv, fetchFromGitHub, rustPlatform, pkgconfig
-, wayland, xwayland, wlc, dbus_libs, dbus_glib, cairo, libxkbcommon }:
+, wayland, xwayland, wlc, dbus_libs, dbus_glib, cairo, libxkbcommon
+, makeWrapper }:
 
 with rustPlatform;
 
 buildRustPackage rec {
   name = "way-cooler-${version}";
-  version = "0.5.2";
+  version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = "way-cooler";
     repo = "way-cooler";
     rev = "v${version}";
-    sha256 = "10s01x54kwjm2c85v57i6g3pvj5w3wpkjblj036mmd865fla1brb";
+    sha256 = "16zswn17c11piby899ciq386m7h7vjvr96f75l35qiswkmwb83kj";
   };
 
-  cargoSha256 = "06qivlybmmc49ksv4232sm1r4hp923xsq4c2ksa4i2azdzc1csdc";
+  cargoSha256 = "1b1mzjicgz1s0gvxq0d54l7r8jnyl0yzmv801n78yl4hwmmf7clv";
 
-  buildInputs = [ wlc dbus_libs dbus_glib cairo libxkbcommon ];
+  buildInputs = [ wlc dbus_libs dbus_glib cairo libxkbcommon wayland makeWrapper ];
 
   nativeBuildInputs = [ pkgconfig ];
 
+  postInstall = ''
+    mkdir -p $out/libexec
+    mv $out/bin/way-cooler $out/libexec
+    makeWrapper $out/libexec/way-cooler $out/bin/way-cooler --prefix LD_LIBRARY_PATH : ${wayland}/lib
+  '';
+
   meta = with stdenv.lib; {
-    broken = true;
     description = "Customizable Wayland compositor (window manager)";
     longDescription = ''
       Way Cooler is a customizable tiling window manager written in Rust


### PR DESCRIPTION
Initially, running way-cooler result in a crash because it
couldn't find libwayland-server.so, this change also addresses
this by wrapping way-cooler to point it to wayland libraries.

###### Motivation for this change

way-cooler 0.5.2 is way outdated

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @miltador 