### PR TITLE
gettext: add setup hook populating GETTEXTDATADIRS

### DIFF
--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -48,6 +48,8 @@ stdenv.mkDerivation rec {
   # HACK, see #10874 (and 14664)
   buildInputs = stdenv.lib.optional (!stdenv.isLinux && !hostPlatform.isCygwin) libiconv;
 
+  setupHook = ./gettext-setup-hook.sh;
+
   enableParallelBuilding = true;
 
   meta = {

--- a/pkgs/development/libraries/gettext/gettext-setup-hook.sh
+++ b/pkgs/development/libraries/gettext/gettext-setup-hook.sh
@@ -1,0 +1,7 @@
+gettextDataDirsHook() {
+    if [ -d "$1/share/gettext" ]; then
+        addToSearchPath GETTEXTDATADIRS "$1/share/gettext"
+    fi
+}
+
+envHooks+=(gettextDataDirsHook)


### PR DESCRIPTION
###### Motivation for this change

Fixes #32296: packages expect gettext to be able to find the files they install into `$prefex/share/gettext`, such as `appstream-glib` with its `/nix/store/…-appstream-glib-0.7.2/share/gettext/its/appdata.loc`.

https://www.gnu.org/software/gettext/manual/html_node/Preparing-ITS-Rules.html
https://github.com/autotools-mirror/gettext/blob/981c523ddbd1462970335a1069573ca3bdd3df5e/NEWS#L19

###### Things done

~WIP: needs testing.~

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

