### PR TITLE
vulnix: 1.3.4 -> 1.4.0

### DIFF
--- a/pkgs/tools/security/vulnix/default.nix
+++ b/pkgs/tools/security/vulnix/default.nix
@@ -3,11 +3,11 @@
 pythonPackages.buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "vulnix";
-  version = "1.3.4";
+  version = "1.4.0";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "1js1i86pgkkqc9yzp1rck7rmaz79klv4048r9z7v56fam0a6sg05";
+    sha256 = "19kfqxlrigrgwn74x06m70ar2fhyhic5kfmdanjwjcbaxblha3l8";
   };
 
   buildInputs = with pythonPackages; [ flake8 pytest pytestcov ];


### PR DESCRIPTION
###### Motivation for this change

The new vulnix release contains auto-detection of CVE patches.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Ubuntu)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

