### PR TITLE
uwimap pollution of `include/`

### DIFF
--- a/pkgs/build-support/build-pecl.nix
+++ b/pkgs/build-support/build-pecl.nix
@@ -22,6 +22,4 @@ stdenv.mkDerivation (args // {
   makeFlags = [ "EXTENSION_DIR=$(out)/lib/php/extensions" ] ++ makeFlags;
 
   autoreconfPhase = "phpize";
-
-  preConfigure = "touch unix.h";
 })

--- a/pkgs/servers/prayer/default.nix
+++ b/pkgs/servers/prayer/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
       ${ssl} \
       -e 's/CCLIENT_LIBS=.*/CCLIENT_LIBS=-lc-client/' \
       -e 's,^PREFIX .*,PREFIX='$out, \
+      -e 's,^CCLIENT_DIR=.*,CCLIENT_DIR=${uwimap}/include/c-client,' \
       Config
     sed -i -e s,/usr/bin/perl,${perl}/bin/perl, \
       templates/src/*.pl

--- a/pkgs/servers/uwsgi/default.nix
+++ b/pkgs/servers/uwsgi/default.nix
@@ -33,7 +33,6 @@ let pythonPlugin = pkg : lib.nameValuePair "python${if pkg ? isPy2 then "2" else
                   (lib.nameValuePair "php" {
                     # usage: https://uwsgi-docs.readthedocs.io/en/latest/PHP.html#running-php-apps-with-nginx
                     path = "plugins/php";
-                    preBuild = "touch unix.h";
                     inputs = [ php-embed ] ++ php-embed.buildInputs;
                   })
                 ];

--- a/pkgs/tools/networking/uwimap/default.nix
+++ b/pkgs/tools/networking/uwimap/default.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation {
     "-I${openssl.dev}/include/openssl";
 
   installPhase = ''
-    mkdir -p $out/bin $out/lib $out/include
-    cp c-client/*.h c-client/linkage.c $out/include
+    mkdir -p $out/bin $out/lib $out/include/c-client
+    cp c-client/*.h osdep/unix/*.h c-client/linkage.c c-client/auths.c $out/include/c-client/
     cp c-client/c-client.a $out/lib/libc-client.a
     cp mailutil/mailutil imapd/imapd dmail/dmail mlock/mlock mtest/mtest tmail/tmail \
       tools/{an,ua} $out/bin


### PR DESCRIPTION
###### Motivation for this change

Initially I just wanted to upgrade weechat from version 1.9.8 to 2.0. Since weechat now supports PHP as a script language I added PHP support to our Weechat derivation.
While testing my changes I noticed that weechat wouldn't find a mysterious `<unix.h>` file. Digging a bit deeper that file originated from `uwimap` (which is a dependency of PHP's imap plugin). 

In 2015 someone noticed this and "fixed" it in 8c125c0c7448086cb4bd8dafd1f798d8697fcd78.

This PR now tries to correct the situation without the hack that was introduced.

Inspired by the way Debian installs the uwimap headers I moved them to `include/c-client` which seems to be the correct path for them.

I built PHP multiple times with the changes in this set I just didn't have the time / power to recompile everything that might potentially depend on PHP (yet).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

