### PR TITLE
php: add 7.2.0

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -4,7 +4,7 @@
 , mysql, libxml2, readline, zlib, curl, postgresql, gettext
 , openssl, pcre, pkgconfig, sqlite, config, libjpeg, libpng, freetype
 , libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, freetds
-, uwimap, pam, gmp, apacheHttpd, libiconv, systemd }:
+, uwimap, pam, gmp, apacheHttpd, libiconv, systemd, libsodium }:
 
 let
 
@@ -226,6 +226,11 @@ let
         calendar = {
           configureFlags = ["--enable-calendar"];
         };
+
+        sodium = {
+          configureFlags = ["--with-sodium=${libsodium.dev}"];
+          buildInputs = [libsodium];
+        };
       };
 
       cfg = {
@@ -265,6 +270,7 @@ let
         mssqlSupport = (!php7) && (config.php.mssql or (!stdenv.isDarwin));
         ztsSupport = config.php.zts or false;
         calendarSupport = config.php.calendar or true;
+        sodiumSupport = (lib.versionAtLeast version "7.2") && config.php.sodium or true;
       };
 
       hardeningDisable = [ "bindnow" ];
@@ -345,5 +351,10 @@ in {
   php71 = generic {
     version = "7.1.11";
     sha256 = "0ww5493w8w3jlks0xqlfm3v6mm53vpnv5vjy63inkj8zf3gdfikn";
+  };
+
+  php72 = generic {
+    version = "7.2.0";
+    sha256 = "0jn642bm4ah6a5cjavpz8mzw3ddxa270fcwxkj3rg6vb4bjgmzib";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6770,6 +6770,11 @@ with pkgs;
     php = php71;
   });
 
+  php72Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
+    php = php72;
+  });
+
+
   inherit (callPackages ../development/interpreters/php { })
     php56
     php70

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6773,7 +6773,8 @@ with pkgs;
   inherit (callPackages ../development/interpreters/php { })
     php56
     php70
-    php71;
+    php71
+    php72;
 
   php-embed = php71-embed;
 

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -8,6 +8,8 @@ let
     };
   isPhpOlder55 = pkgs.lib.versionOlder php.version "5.5";
   isPhp7 = pkgs.lib.versionAtLeast php.version "7.0";
+  isPhp72 = pkgs.lib.versionAtLeast php.version "7.2";
+  isPhpOlder7 = pkgs.lib.versionOlder php.version "7.0";
 
   apcu = if isPhp7 then apcu51 else apcu40;
 
@@ -179,7 +181,7 @@ let
     buildInputs = [ pkgs.spidermonkey_1_8_5 ];
   };
 
-  xdebug = if isPhp7 then xdebug25 else xdebug23;
+  xdebug = if isPhp72 then xdebug26 else if isPhp7 then xdebug25 else xdebug23;
 
   xdebug23 = assert !isPhp7; buildPecl {
     name = "xdebug-2.3.1";
@@ -190,10 +192,19 @@ let
     checkTarget = "test";
   };
 
-  xdebug25 = buildPecl {
+  xdebug25 = assert !isPhp72; buildPecl {
     name = "xdebug-2.5.0";
 
     sha256 = "03c9y25a3gc3kpav0cdgmhjixcaly6974hx7wgihi0wlchgavmlb";
+
+    doCheck = true;
+    checkTarget = "test";
+  };
+
+  xdebug26 = assert !isPhpOlder7; buildPecl {
+    name = "xdebug-2.6.0beta1";
+
+    sha256 = "0zaj821jbpaqqcbr9a64sa27my9n980pmyy9kxrvvjqq3qg6dpj9";
 
     doCheck = true;
     checkTarget = "test";


### PR DESCRIPTION
###### Motivation for this change
New big release of PHP. Added as alternative.

Don't know if I missed anything important, please point out things so I can update it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---