### PR TITLE
nixos/networking: support static resolv.conf

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -290,8 +290,8 @@ in
           ln -s /run/systemd/resolve/resolv.conf /run/resolvconf/interfaces/systemd
         ''}
 
-        # Make sure resolv.conf is up to date if not managed by systemd
-        ${optionalString (!config.services.resolved.enable) ''
+        # Make sure resolv.conf is up to date if not managed manually or by systemd
+        ${optionalString (!config.environment.etc?"resolv.conf") ''
           ${pkgs.openresolv}/bin/resolvconf -u
         ''}
       '';


### PR DESCRIPTION
###### Motivation for this change

This is necessary to support such use as:
```nix
{
  config = {
    environment.etc = {
      "resolv.conf".text = "nameserver 127.0.0.1\n";
    };
}
```
When `/nix/store` is read-only this already works except that `resolvconf` warns that it can not update `/etc/resolv.conf`; when `/nix/store` is writable, without this change `resolvconf` corrupts the store.

When `config.services.resolved.enable = true`, `config.environment.etc."resolv.conf"` is defined, so keeping the old conditional is redundant: https://github.com/NixOS/nixpkgs/blob/f2b690ae2b06f084ffc7fe62d89fbef4ba248879/nixos/modules/config/networking.nix#L250-L253

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I have tested this PR with all combination of settings: `services.resolved.enable = true | false`, `environment.etc = { "resolv.conf" = } | { }`, `services.dnsmasq.enable = true | false`. It does not break anything and works as intended.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
