### PR TITLE
Add bash to jira PATH: required by health checks.

### DIFF
--- a/nixos/modules/services/web-apps/atlassian/jira.nix
+++ b/nixos/modules/services/web-apps/atlassian/jira.nix
@@ -155,7 +155,7 @@ in
       requires = [ "postgresql.service" ];
       after = [ "postgresql.service" ];
 
-      path = [ cfg.jrePackage ];
+      path = [ cfg.jrePackage pkgs.bash ];
 
       environment = {
         JIRA_USER = cfg.user;


### PR DESCRIPTION
###### Motivation for this change

Otherwise the following warning occurs in the logs of JIRA:
```
2017-12-04 10:22:57,385 HealthCheck:thread-2 WARN ServiceRunner     [c.a.t.healthcheck.impl.DefaultRuntimeHelper] Failed to spawn a process
java.io.IOException: Cannot run program "bash": error=2, No such file or directory
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
        at java.lang.Runtime.exec(Runtime.java:620)
        at java.lang.Runtime.exec(Runtime.java:485)
        at com.atlassian.troubleshooting.healthcheck.impl.DefaultRuntimeHelper.spawnProcessSafely(DefaultRuntimeHelper.java:24)
        at com.atlassian.troubleshooting.healthcheck.impl.FileSystemInfoImpl.getThreadLimit(FileSystemInfoImpl.java:41)
        at com.atlassian.troubleshooting.healthcheck.checks.ThreadLimitHealthCheckCondition.shouldDisplay(ThreadLimitHealthCheckCondition.java:32)
        at java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90)
        at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1357)
        at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126)
        at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:498)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:485)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
        at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
        at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.allMatch(ReferencePipeline.java:454)
        at com.atlassian.troubleshooting.healthcheck.DefaultSupportHealthCheckSupplier.shouldDisplay(DefaultSupportHealthCheckSupplier.java:51)
        at com.atlassian.troubleshooting.healthcheck.DefaultSupportHealthCheckSupplier.asPluginSuppliedSupportHealthCheck(DefaultSupportHealthCheckSupplier.java:127)
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.Iterator.forEachRemaining(Iterator.java:116)
        at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
        at com.atlassian.troubleshooting.healthcheck.DefaultSupportHealthCheckSupplier.healthChecksFrom(DefaultSupportHealthCheckSupplier.java:123)
        at com.atlassian.troubleshooting.healthcheck.DefaultSupportHealthCheckSupplier.getHealthChecks(DefaultSupportHealthCheckSupplier.java:57)
        at com.atlassian.troubleshooting.healthcheck.DefaultSupportHealthCheckSupplier.byInstance(DefaultSupportHealthCheckSupplier.java:88)
        at com.atlassian.troubleshooting.healthcheck.SupportHealthStatusBuilder.getHelpPathUrl(SupportHealthStatusBuilder.java:110)
        at com.atlassian.troubleshooting.healthcheck.SupportHealthStatusBuilder.buildStatus(SupportHealthStatusBuilder.java:135)
        at com.atlassian.troubleshooting.healthcheck.SupportHealthStatusBuilder.ok(SupportHealthStatusBuilder.java:63)
        at com.atlassian.troubleshooting.jira.healthcheck.ApplinksStatusHealthCheck.check(ApplinksStatusHealthCheck.java:46)
        at com.atlassian.troubleshooting.healthcheck.impl.PluginSuppliedSupportHealthCheck.check(PluginSuppliedSupportHealthCheck.java:49)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.IOException: error=2, No such file or directory
        at java.lang.UNIXProcess.forkAndExec(Native Method)
        at java.lang.UNIXProcess.<init>(UNIXProcess.java:247)
        at java.lang.ProcessImpl.start(ProcessImpl.java:134)
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
        ... 37 more
```

###### Things done

[x] tested on NixOS 17.09.

---

Please backport to 17.09.
