### PR TITLE
ed: Fix output directories by not setting DESTDIR. Fixes #32150

### DIFF
--- a/pkgs/applications/editors/ed/default.nix
+++ b/pkgs/applications/editors/ed/default.nix
@@ -26,8 +26,6 @@ stdenv.mkDerivation rec {
     */
   doCheck = !(hostPlatform.isDarwin || hostPlatform != buildPlatform);
 
-  installFlags = [ "DESTDIR=$(out)" ];
-
   configureFlags = [
     "--exec-prefix=${stdenv.cc.targetPrefix}"
     "CC=${stdenv.cc.targetPrefix}cc"


### PR DESCRIPTION
###### Motivation for this change

`DESTDIR` was set manually, but other `configureFlags` were missing. Nix could fill the gaps, but that resulted in some wrong directories: man pages ended up in `/nix/store/<hash>-ed/nix/store/<hash>-ed/share/`.
The solution is simple: let nix figure it all out.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

