### PR TITLE
darwin.Libsystem: fix build on 10.13.2

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/system_kernel_symbols
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/system_kernel_symbols
@@ -451,7 +451,6 @@ _host_statistics
 _host_statistics64
 _host_swap_exception_ports
 _host_virtual_physical_table_info
-_host_zone_info
 _i386_get_ldt
 _i386_set_ldt
 _important_boost_assertion_token


### PR DESCRIPTION
###### Motivation for this change

Darwin stdenv does not build on macOS 10.13.2 with the error:
```
Undefined symbols for architecture x86_64:
  "_host_zone_info", referenced from:
     -reexported_symbols_list command line option
ld: symbol(s) not found for architecture x86_64
```

You can check with `nix-build --no-out-link -A darwin.Libsystem --check`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I have checked that this fixes stdenv, but I have not rebuilt everything to see if this breaks anything.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
