### PR TITLE
xen: apply patches for XSA-246 & XSA-247 (CVE-2017-{17044,17045}) & XSA-248, XSA-249, XSA-250, XSA-251

### DIFF
--- a/pkgs/applications/virtualization/xen/4.5.nix
+++ b/pkgs/applications/virtualization/xen/4.5.nix
@@ -230,6 +230,8 @@ callPackage (import ./generic.nix (rec {
     XSA_243_45
     XSA_244_45
     XSA_245
+    XSA_246_45
+    XSA_247_45
   ];
 
   # Fix build on Glibc 2.24.

--- a/pkgs/applications/virtualization/xen/4.5.nix
+++ b/pkgs/applications/virtualization/xen/4.5.nix
@@ -232,6 +232,10 @@ callPackage (import ./generic.nix (rec {
     XSA_245
     XSA_246_45
     XSA_247_45
+    XSA_248_45
+    XSA_249
+    XSA_250_45
+    XSA_251_45
   ];
 
   # Fix build on Glibc 2.24.

--- a/pkgs/applications/virtualization/xen/4.8.nix
+++ b/pkgs/applications/virtualization/xen/4.8.nix
@@ -160,6 +160,10 @@ callPackage (import ./generic.nix (rec {
     XSA_245
     XSA_246
     XSA_247_48
+    XSA_248_48
+    XSA_249
+    XSA_250
+    XSA_251_48
   ];
 
   # Fix build on Glibc 2.24.

--- a/pkgs/applications/virtualization/xen/4.8.nix
+++ b/pkgs/applications/virtualization/xen/4.8.nix
@@ -158,6 +158,8 @@ callPackage (import ./generic.nix (rec {
     XSA_243_48
     XSA_244
     XSA_245
+    XSA_246
+    XSA_247_48
   ];
 
   # Fix build on Glibc 2.24.

--- a/pkgs/applications/virtualization/xen/xsa-patches.nix
+++ b/pkgs/applications/virtualization/xen/xsa-patches.nix
@@ -811,4 +811,57 @@ in rec {
       sha256 = "0vjjybxbcm4xl26wbqvcqfiyvvlayswm4f98i1fr5a9abmljn5sb";
     })
   ];
+
+	# 4.5
+  XSA_248_45 = [
+    (xsaPatch {
+      name = "248-4.5";
+      sha256 = "0csxg6h492ddsa210b45av28iqf7cn2dfdqk4zx10zwf1pv2shyn";
+    })
+  ];
+
+  # 4.8
+  XSA_248_48 = [
+    (xsaPatch {
+      name = "248-4.8";
+      sha256 = "1ycw29q22ymxg18kxpr5p7vhpmp8klssbp5gq77hspxzz2mb96q1";
+    })
+  ];
+
+  # 4.5 .. 4.9
+  XSA_249 = [
+   (xsaPatch {
+      name = "249";
+      sha256 = "0v6ngzqhkz7yv4n83xlpxfbkr2qyg5b1cds7ikkinm86hiqy6agl";
+    })
+  ];
+  # 4.5
+  XSA_250_45 = [
+   (xsaPatch {
+      name = "250-4.5";
+      sha256 = "0pqldl6qnl834gvfp90z247q9xcjh3835s2iffnajz7jhjb2145d";
+    })
+  ];
+  # 4.8 ...
+  XSA_250 = [
+   (xsaPatch {
+      name = "250";
+      sha256 = "1wpigg8kmha57sspqqln3ih9nbczsw6rx3v72mc62lh62qvwd7x8";
+    })
+  ];
+  # 4.5
+  XSA_251_45 = [
+   (xsaPatch {
+      name = "251-4.5";
+      sha256 = "0lc94cx271z09r0mhxaypyd9d4740051p28idf5calx5228dqjgm";
+    })
+  ];
+  # 4.8
+  XSA_251_48 = [
+   (xsaPatch {
+      name = "251-4.8";
+      sha256 = "079wi0j6iydid2zj7k584w2c393kgh588w7sjz2nn4039qn8k9mq";
+    })
+  ];
+
 }

--- a/pkgs/applications/virtualization/xen/xsa-patches.nix
+++ b/pkgs/applications/virtualization/xen/xsa-patches.nix
@@ -771,4 +771,44 @@ in rec {
       sha256 = "1k6z5r7wnrswsczn2j3a1mc4nvxqm4ydj6n6rvgqizk2pszdkqg8";
     })
   ];
+
+  # 4.5 - 4.7
+  XSA_246_45 = [
+    (xsaPatch {
+      name = "246-4.7";
+      sha256 = "13rad4k8z3bq15d67dhgy96kdbrjiq9sy8px0jskbpx9ygjdahkn";
+    })
+  ];
+
+  # 4.8 - 4.9
+  XSA_246 = [
+    (xsaPatch {
+      name = "246-4.9";
+      sha256 = "0z68vm0z5zvv9gm06pxs9kxq2q9fdbl0l0cm71ggzdplg1vw0snz";
+    })
+  ];
+
+  # 4.8
+  XSA_247_48 = [
+    (xsaPatch {
+      name = "247-4.8/0001-p2m-Always-check-to-see-if-removing-a-p2m-entry-actu";
+      sha256 = "0kvjrk90n69s721c2qj2df5raml3pjk6bg80aig353p620w6s3xh";
+    })
+    (xsaPatch {
+      name = "247-4.8/0002-p2m-Check-return-value-of-p2m_set_entry-when-decreas";
+      sha256 = "1s9kv6h6dd8psi5qf5l5gpk9qhq8blckwhl76cjbldcgi6imb3nr";
+    })
+  ];
+
+  # 4.5
+  XSA_247_45 = [
+    (xsaPatch {
+      name = "247-4.5/0001-p2m-Always-check-to-see-if-removing-a-p2m-entry-actu";
+      sha256 = "0h1mp5s9si8aw2gipds317f27h9pi7bgnhj0bcmw11p0ch98sg1m";
+    })
+    (xsaPatch {
+      name = "247-4.5/0002-p2m-Check-return-value-of-p2m_set_entry-when-decreas";
+      sha256 = "0vjjybxbcm4xl26wbqvcqfiyvvlayswm4f98i1fr5a9abmljn5sb";
+    })
+  ];
 }


### PR DESCRIPTION
###### Motivation for this change

Close open XEN (HVM) vulnerabilities.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

