### PR TITLE
ed: fix docs location. Fixes #32150. Supersedes #32315.

### DIFF
--- a/pkgs/applications/editors/ed/default.nix
+++ b/pkgs/applications/editors/ed/default.nix
@@ -13,16 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ lzip ];
 
-  /* FIXME: Tests currently fail on Darwin:
-
-       building test scripts for ed-1.5...
-       testing ed-1.5...
-       *** Output e1.o of script e1.ed is incorrect ***
-       *** Output r3.o of script r3.ed is incorrect ***
-       make: *** [check] Error 127
-
-    */
-  doCheck = !(hostPlatform.isDarwin || hostPlatform != buildPlatform);
+  doCheck = hostPlatform == buildPlatform;
 
   meta = {
     description = "An implementation of the standard Unix editor";

--- a/pkgs/applications/editors/ed/default.nix
+++ b/pkgs/applications/editors/ed/default.nix
@@ -11,8 +11,6 @@ stdenv.mkDerivation rec {
     sha256 = "1nqhk3n1s1p77g2bjnj55acicsrlyb2yasqxqwpx0w0djfx64ygm";
   };
 
-  unpackCmd = "tar --lzip -xf";
-
   nativeBuildInputs = [ lzip ];
 
   /* FIXME: Tests currently fail on Darwin:

--- a/pkgs/applications/editors/ed/default.nix
+++ b/pkgs/applications/editors/ed/default.nix
@@ -26,13 +26,6 @@ stdenv.mkDerivation rec {
     */
   doCheck = !(hostPlatform.isDarwin || hostPlatform != buildPlatform);
 
-  installFlags = [ "DESTDIR=$(out)" ];
-
-  configureFlags = [
-    "--exec-prefix=${stdenv.cc.targetPrefix}"
-    "CC=${stdenv.cc.targetPrefix}cc"
-  ];
-
   meta = {
     description = "An implementation of the standard Unix editor";
 

--- a/pkgs/tools/compression/lzip/default.nix
+++ b/pkgs/tools/compression/lzip/default.nix
@@ -13,7 +13,10 @@ stdenv.mkDerivation rec {
 
   configureFlags = "CPPFLAGS=-DNDEBUG CFLAGS=-O3 CXXFLAGS=-O3";
 
+  setupHook = ./lzip-setup-hook.sh;
+
   doCheck = true;
+  enableParallelBuilding = true;
 
   meta = {
     homepage = http://www.nongnu.org/lzip/lzip.html;

--- a/pkgs/tools/compression/lzip/lzip-setup-hook.sh
+++ b/pkgs/tools/compression/lzip/lzip-setup-hook.sh
@@ -1,0 +1,5 @@
+lzipUnpackCmdHook() {
+    [[ "$1" = *.tar.lz ]] && tar --lzip -xf "$1"
+}
+
+unpackCmdHooks+=(lzipUnpackCmdHook)


### PR DESCRIPTION
###### Motivation for this change

`DESTDIR` was set manually, but other `installFlags` were missing. Nix could fill the gaps, but that resulted in some wrong directories: man pages ended up in `/nix/store/<hash>-ed/nix/store/<hash>-ed/share/`.
The solution is simple: let nix figure it all out.

#32315 caused mass rebuilding. As suggested by @orivej, I rebased the commit on `staging`.
I now also removed the configureFlags.

Please review the entire default.nix file for further improvements. I 'd be happy to include more 'modernizations' and avoid extra mass rebuilding.

There's no maintainer set. Any volonteers?

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.rg/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---