### PR TITLE
nextcloud-client: 2.3.2 -> 2.3.3

### DIFF
--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -3,12 +3,12 @@
 
 stdenv.mkDerivation rec {
   name = "nextcloud-client-${version}";
-  version = "2.3.2";
+  version = "2.3.3";
 
   src = fetchgit {
     url = "git://github.com/nextcloud/client_theming.git";
-    rev = "1ee750d1aeaaefc899629e85c311594603e9ac1b";
-    sha256 = "0dxyng8a7cg78z8yngiqypsb44lf5c6vkabvkfch0cl0cqmarc1a";
+    rev = "ab40efe1e1475efddd636c09251d8917627261da";
+    sha256 = "19a1kqydgx47sa1a917j46zlbc5g9nynsanasyad9c8sqi0qvyip";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Updates the Nextcloud desktop client (a themed version of the ownCloud desktop client) to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

