### PR TITLE
swagger-codegen: Init at 2.2.1

### DIFF
--- a/pkgs/tools/networking/swagger-codegen/default.nix
+++ b/pkgs/tools/networking/swagger-codegen/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, jre, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  version = "2.2.1";
+  pname = "swagger-codegen";
+  name = "${pname}-${version}";
+
+  jarfilename = "${pname}-cli-${version}.jar";
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  src = fetchurl {
+    url = "https://oss.sonatype.org/content/repositories/releases/io/swagger/${pname}-cli/${version}/${jarfilename}";
+    sha256 = "1pwxkl3r93c8hsif9xm0h1hmbjrxz1q7hr5qn5n0sni1x3c3k0d1";
+  };
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    install -D "$src" "$out/share/java/${jarfilename}"
+
+    makeWrapper ${jre}/bin/java $out/bin/swagger-codegen \
+      --add-flags "-jar $out/share/java/${jarfilename}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Allows generation of API client libraries (SDK generation), server stubs and documentation automatically given an OpenAPI Spec";
+    homepage = https://github.com/swagger-api/swagger-codegen;
+    license = licenses.asl20;
+    maintainers = [ maintainers.jraygauthier ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4612,6 +4612,8 @@ with pkgs;
 
   surfraw = callPackage ../tools/networking/surfraw { };
 
+  swagger-codegen = callPackage ../tools/networking/swagger-codegen { };
+
   swec = callPackage ../tools/networking/swec {
     inherit (perlPackages) LWP URI HTMLParser HTTPServerSimple Parent;
   };


### PR DESCRIPTION
###### Motivation for this change

A missing essential in web dev. Currently using it in combination with `servant-swagger`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

