### PR TITLE
dropbox: fix version sort order

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -54,7 +54,7 @@ buildFHSUserEnv {
         do_install=1
     else
         installed_version=$(cat "$HOME/.dropbox-dist/VERSION")
-        latest_version=$(printf "${version}\n$installed_version\n" | sort -V | head -n 1)
+        latest_version=$(printf "${version}\n$installed_version\n" | sort -rV | head -n 1)
         if [ "x$installed_version" != "x$latest_version" ]; then
             do_install=1
         fi


### PR DESCRIPTION
This makes the startup wrapper work as intended instead of deleting, re-downloading, and downgrading Dropbox after each time it updates itself.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

