### PR TITLE
ocamlPackages.hex: 1.0.0 -> 1.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/hex/default.nix
+++ b/pkgs/development/ocaml-modules/hex/default.nix
@@ -1,21 +1,28 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, cstruct }:
+{ stdenv, fetchurl, ocaml, findlib, jbuilder, cstruct }:
 
-let version = "1.0.0"; in
+if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+then throw "hex is not available for OCaml ${ocaml.version}"
+else
+
+let version = "1.2.0"; in
 
 stdenv.mkDerivation {
-  name = "ocaml-hex-${version}";
+  name = "ocaml${ocaml.version}-hex-${version}";
 
-  src = fetchzip {
-    url = "https://github.com/mirage/ocaml-hex/archive/${version}.tar.gz";
-    sha256 = "0g4cq4bsksga15fa5ln083gkglawknbnhi2s4k8yk0yi5xngvwm4";
+  src = fetchurl {
+    url = "https://github.com/mirage/ocaml-hex/releases/download/v1.2.0/hex-1.2.0.tbz";
+    sha256 = "17hqf7z5afp2z2c55fk5myxkm7cm74259rqm94hcxkqlpdaqhm8h";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  unpackCmd = "tar -xjf $curSrc";
+
+  buildInputs = [ ocaml findlib jbuilder ];
   propagatedBuildInputs = [ cstruct ];
-  configureFlags = "--enable-tests";
+
+  buildPhase = "jbuilder build -p hex";
   doCheck = true;
-  checkTarget = "test";
-  createFindlibDestdir = true;
+  checkPhase = "jbuilder runtest";
+  inherit (jbuilder) installPhase;
 
   meta = {
     description = "Mininal OCaml library providing hexadecimal converters";


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

