### PR TITLE
qemu: apply patch for CVE-2017-17381

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -67,6 +67,10 @@ stdenv.mkDerivation rec {
            name = "qemu-CVE-2017-15118.patch";
            url = "http://git.qemu.org/?p=qemu.git;a=patch;h=51ae4f8455c9e32c54770c4ebc25bf86a8128183";
            sha256 = "0f9i096dz3h1i8g92y99vak23rjs1shf7prlcxqizsz0fah7wx7h"; })
+         (fetchpatch {
+           name = "qemu-CVE-2017-17381.patch";
+           url = "https://git.kernel.org/pub/scm/virt/kvm/mst/qemu.git/patch/?id=758ead31c7e17bf17a9ef2e0ca1c3e86ab296b43";
+           sha256 = "17yw4bqsbywdrbmrikr94yjnfsg853bf4i3k4y3k169387da2yc5"; })
        ];
 
   hardeningDisable = [ "stackprotector" ];


### PR DESCRIPTION
###### Motivation for this change

More details at [1].

[1] http://www.openwall.com/lists/oss-security/2017/12/05/2


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

