### PR TITLE
init devpi-server at 4.3.1, bump devpi-client

### DIFF
--- a/pkgs/development/python-modules/argon2_cffi/default.nix
+++ b/pkgs/development/python-modules/argon2_cffi/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, cffi
+, six
+, hypothesis
+, pytest
+, wheel
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "argon2_cffi";
+  version = "16.3.0";
+  name    = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ap3il3j1pjyprrhpfyhc21izpmhzhfb5s69vlzc65zvd1nj99cr";
+  };
+
+  propagatedBuildInputs = [ cffi six ];
+  checkInputs = [ hypothesis pytest wheel ];
+  checkPhase = ''
+    pytest tests
+  '';
+
+  meta = {
+    description = "Secure Password Hashes for Python";
+    homepage    = https://argon2-cffi.readthedocs.io/;
+  };
+}

--- a/pkgs/development/python-modules/devpi-common/default.nix
+++ b/pkgs/development/python-modules/devpi-common/default.nix
@@ -2,20 +2,18 @@
 
 with pythonPackages;buildPythonPackage rec {
   pname = "devpi-common";
-  version = "3.1.0";
+  version = "3.2.0";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d89634a57981ed43cb5dcd25e00c9454ea111189c5ddc08d945b3d5187ada5fd";
+    sha256 = "0rh119iw5hk41gsvbjr0wixvl1i4f0b1vcnw9ym35rmcp517z0wb";
   };
 
   propagatedBuildInputs = [ requests py ];
   checkInputs = [ pytest ];
 
   checkPhase = ''
-    # Don't know why this test is failing!
-    substituteInPlace testing/test_request.py --replace "test_env" "noop_test_env"
     py.test
   '';
 

--- a/pkgs/development/python-modules/passlib/default.nix
+++ b/pkgs/development/python-modules/passlib/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , nose
 , bcrypt
+, argon2_cffi
 }:
 
 buildPythonPackage rec {
@@ -16,7 +17,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ nose ];
-  propagatedBuildInputs = [ bcrypt ];
+  propagatedBuildInputs = [ bcrypt argon2_cffi ];
 
   meta = {
     description = "A password hashing library for Python";

--- a/pkgs/development/python-modules/pytest-timeout/default.nix
+++ b/pkgs/development/python-modules/pytest-timeout/default.nix
@@ -1,0 +1,27 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, pexpect
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-timeout";
+  version = "1.2.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1kdp6qbh5v1168l99rba5yfzvy05gmzkmkhldgp36p9xcdjd5dv8";
+  };
+  buildInputs = [ pytest ];
+  checkInputs = [ pytest pexpect ];
+  checkPhase = ''pytest -ra'';
+
+  meta = with lib;{
+    description = "py.test plugin to abort hanging tests";
+    homepage = http://bitbucket.org/pytest-dev/pytest-timeout/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ makefu ];
+  };
+}

--- a/pkgs/development/tools/devpi-client/default.nix
+++ b/pkgs/development/tools/devpi-client/default.nix
@@ -1,7 +1,10 @@
 { stdenv
+, lib
 , pythonPackages
 , glibcLocales
 , devpi-server
+, git
+, mercurial
 } :
 
 pythonPackages.buildPythonApplication rec {
@@ -14,19 +17,31 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0w47x3lkafcg9ijlaxllmq4886nsc91w49ck1cd7vn2gafkwjkgr";
   };
 
-  doCheck = true;
-  checkInputs = with pythonPackages; [ pytest webtest mock devpi-server ];
-  checkPhase = "py.test";
+  checkInputs = with pythonPackages; [
+                    pytest webtest mock
+                    devpi-server tox
+                    sphinx wheel git mercurial detox
+                    setuptools
+                    ];
+  checkPhase = ''
+    export PATH=$PATH:$out/bin
+
+    # setuptools do not get propagated into the tox call (cannot import setuptools)
+    rm testing/test_test.py
+
+    # test tries to connect to upstream pypi
+    py.test -k 'not test_pypi_index_attributes' testing
+  '';
 
   LC_ALL = "en_US.UTF-8";
-  buildInputs = with pythonPackages; [ glibcLocales pkginfo tox check-manifest ];
-  propagatedBuildInputs = with pythonPackages; [ py devpi-common pluggy ];
+  buildInputs = with pythonPackages; [ glibcLocales pkginfo check-manifest ];
+  propagatedBuildInputs = with pythonPackages; [ py devpi-common pluggy setuptools ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://doc.devpi.net;
-    description = "Github-style pypi index server and packaging meta tool";
-    license = stdenv.lib.licenses.mit;
-    maintainers = with stdenv.lib.maintainers; [ lewo makefu ];
-
+    description = "Client for devpi, a pypi index server and packaging meta tool";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lewo makefu ];
   };
+
 }

--- a/pkgs/development/tools/devpi-client/default.nix
+++ b/pkgs/development/tools/devpi-client/default.nix
@@ -1,17 +1,21 @@
-{ stdenv, pythonPackages, glibcLocales} :
+{ stdenv
+, pythonPackages
+, glibcLocales
+, devpi-server
+} :
 
 pythonPackages.buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "devpi-client";
-  version = "3.1.0rc1";
+  version = "3.1.0";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "0kfyva886k9zxmilqb2yviwqzyvs3n36if3s56y4clbvw9hr2lc3";
+    sha256 = "0w47x3lkafcg9ijlaxllmq4886nsc91w49ck1cd7vn2gafkwjkgr";
   };
-  # requires devpi-server which is currently not packaged
+
   doCheck = true;
-  checkInputs = with pythonPackages; [ pytest webtest mock ];
+  checkInputs = with pythonPackages; [ pytest webtest mock devpi-server ];
   checkPhase = "py.test";
 
   LC_ALL = "en_US.UTF-8";

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -1,0 +1,27 @@
+ { stdenv, pythonPackages, glibcLocales, nginx }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "${pname}-${version}";
+  pname = "devpi-server";
+  version = "4.3.1";
+
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "0x6ks2sbpknznxaqlh0gf5hcvhkmgixixq2zs91wgfqxk4vi4s6n";
+  };
+
+  propagatedBuildInputs = with pythonPackages;
+    [ devpi-common execnet itsdangerous pluggy waitress pyramid passlib ];
+  checkInputs = with pythonPackages; [ nginx webtest pytest beautifulsoup4 pytest-timeout pytest-catchlog mock pyyaml ];
+  checkPhase = ''
+    cd test_devpi_server/
+    PATH=$PATH:$out/bin pytest --slow -rfsxX
+  '';
+
+  meta = with stdenv.lib;{
+    homepage = http://doc.devpi.net;
+    description = "Github-style pypi index server and packaging meta tool";
+    license = licenses.mit;
+    maintainers = with maintainers; [ makefu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5535,6 +5535,8 @@ with pkgs;
 
   devpi-client = callPackage ../development/tools/devpi-client {};
 
+  devpi-server = callPackage ../development/tools/devpi-server {};
+
   dotty = callPackage ../development/compilers/scala/dotty.nix { jre = jre8;};
 
   drumstick = callPackage ../development/libraries/drumstick { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3768,6 +3768,8 @@ in {
     };
   };
 
+  pytest-timeout = callPackage ../development/python-modules/pytest-timeout { };
+
   pytest-warnings = callPackage ../development/python-modules/pytest-warnings { };
 
   pytestpep8 = buildPythonPackage rec {
@@ -24463,6 +24465,7 @@ EOF
   parse-type = callPackage ../development/python-modules/parse-type { };
 
   ephem = callPackage ../development/python-modules/ephem { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -162,6 +162,8 @@ in {
 
   ansicolor = callPackage ../development/python-modules/ansicolor { };
 
+  argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };
+
   asana = callPackage ../development/python-modules/asana { };
 
   asn1crypto = callPackage ../development/python-modules/asn1crypto { };


### PR DESCRIPTION
###### Motivation for this change

This PR introduces devpi-server to nixpkgs. For this PR, argon2 needs to be supported by passlib.
With the devpi-server package it is possible to re-enable tests for devpi-client, however a couple of tests needed to be disabled because of issues with tox and setuptools.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

waiting for you, @GrahamcOfBorg ;)

