### PR TITLE
firmware-linux-nonfree: update

### DIFF
--- a/pkgs/os-specific/linux/firmware/firmware-linux-nonfree/default.nix
+++ b/pkgs/os-specific/linux/firmware/firmware-linux-nonfree/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "firmware-linux-nonfree-${version}";
-  version = "2017-10-09-${src.iwlRev}";
+  version = "2017-10-13-${src.iwlRev}";
 
   # The src runCommand automates the process of building a merged repository of both
   #
-  # http://git.kernel.org/cgit/linux/kernel/git/firmware/linux-firmware.git/
-  # http://git.kernel.org/cgit/linux/kernel/git/iwlwifi/linux-firmware.git/
+  # https://git.kernel.org/cgit/linux/kernel/git/firmware/linux-firmware.git/
+  # https://git.kernel.org/cgit/linux/kernel/git/iwlwifi/linux-firmware.git/
   #
   # This gives us up to date iwlwifi firmware as well as
   # the usual set of firmware. firmware/linux-firmware usually lags kernel releases
@@ -17,15 +17,21 @@ stdenv.mkDerivation rec {
   # update version to the more recent commit date
 
   src = runCommand "firmware-linux-nonfree-src-merged-${version}" {
-    # When updating this, you need to let it run with a wrong hash, in order to find out the desired hash
-    baseRev = "bf04291309d3169c0ad3b8db52564235bbd08e30";
-    iwlRev = "iwlwifi-fw-2017-11-03";
+    shallowSince = "2017-10-01";
+    baseRev = "85313b4aa4ef0c2ce41bbd0ffdb9b03363256f28";
+    iwlRev = "iwlwifi-fw-2017-11-15";
 
+    # When updating this, you need to let it run with a wrong hash, in order to find out the desired hash
     # randomly mutate the hash to break out of fixed hash, when updating
-    outputHash = "11izv1vpq9ixlqdss19lzs5q289d7jxr5kgf6iymk4alxznffd8z";
+    outputHash = "0kpg1xmx5mjnqxv5n21yvvq4sl59yjpwjv9ficd054544q1v2jly";
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
+
+    # Doing the download on a remote machine just duplicates network
+    # traffic, so don't do that.
+    preferLocalBuild = true;
+
     buildInputs = [ git gnupg ];
     NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
   } ''
@@ -33,12 +39,12 @@ stdenv.mkDerivation rec {
       cd src
       git config user.email "build-daemon@nixos.org"
       git config user.name "Nixos Build Daemon $name"
-      git remote add base git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
-      git remote add iwl git://git.kernel.org/pub/scm/linux/kernel/git/iwlwifi/linux-firmware.git
-      git fetch base $baseRev
-      git checkout -b work FETCH_HEAD
-      git fetch iwl $iwlRev
-      git merge FETCH_HEAD)
+      git remote add base https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
+      git remote add iwl https://git.kernel.org/pub/scm/linux/kernel/git/iwlwifi/linux-firmware.git
+      git fetch --shallow-since=$shallowSince base
+      git fetch --shallow-since=$shallowSince iwl
+      git checkout -b work $baseRev
+      git merge $iwlRev)
     rm -rf src/.git
     cp -a src $out
   '';


### PR DESCRIPTION
###### Motivation for this change
The old expression didn't work for me. Update is just a happy coincidence.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

