### PR TITLE
firefoxPackages: tor-browser: 52.3.0esr-7.0.1 -> 52.5.0esr-7.0-1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -29,9 +29,11 @@
 # Set to `privacySupport` or `false`.
 
 , webrtcSupport ? !privacySupport
-, googleAPISupport ? !privacySupport
+, geolocationSupport ? !privacySupport
+, googleAPISupport ? geolocationSupport
 , crashreporterSupport ? false
 
+, safeBrowsingSupport ? false
 , drmSupport ? false
 
 ## other
@@ -159,8 +161,10 @@ stdenv.mkDerivation (rec {
   ++ flag gssSupport "negotiateauth"
   ++ lib.optional (!ffmpegSupport) "--disable-gstreamer"
   ++ flag webrtcSupport "webrtc"
+  ++ flag geolocationSupport "mozril-geoloc"
   ++ lib.optional googleAPISupport "--with-google-api-keyfile=ga"
   ++ flag crashreporterSupport "crashreporter"
+  ++ flag safeBrowsingSupport "safe-browsing"
   ++ lib.optional drmSupport "--enable-eme=widevine"
 
   ++ (if debugBuild then [ "--enable-debug" "--enable-profiling" ]

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -143,7 +143,7 @@ stdenv.mkDerivation (rec {
   ]
 
   # and wants these
-  ++ lib.optionals isTorBrowserLike [
+  ++ lib.optionals isTorBrowserLike ([
     "--with-tor-browser-version=${version}"
     "--enable-signmar"
     "--enable-verify-mar"
@@ -153,7 +153,9 @@ stdenv.mkDerivation (rec {
     # possibilities on other platforms.
     # Lets save some space instead.
     "--with-system-nspr"
-  ]
+  ] ++ flag geolocationSupport "mozril-geoloc"
+    ++ flag safeBrowsingSupport "safe-browsing"
+  )
 
   ++ flag alsaSupport "alsa"
   ++ flag pulseaudioSupport "pulseaudio"
@@ -161,10 +163,8 @@ stdenv.mkDerivation (rec {
   ++ flag gssSupport "negotiateauth"
   ++ lib.optional (!ffmpegSupport) "--disable-gstreamer"
   ++ flag webrtcSupport "webrtc"
-  ++ flag geolocationSupport "mozril-geoloc"
   ++ lib.optional googleAPISupport "--with-google-api-keyfile=ga"
   ++ flag crashreporterSupport "crashreporter"
-  ++ flag safeBrowsingSupport "safe-browsing"
   ++ lib.optional drmSupport "--enable-eme=widevine"
 
   ++ (if debugBuild then [ "--enable-debug" "--enable-profiling" ]

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -109,7 +109,7 @@ in rec {
     src = fetchFromGitHub {
       owner = "SLNOS";
       repo = "tor-browser";
-      # branch "tor-browser-45.8.0esr-6.5-2"
+      # branch "tor-browser-45.8.0esr-6.5-2-slnos"
       rev = "e4140ea01b9906934f0347e95f860cec207ea824";
       sha256 = "0a1qk3a9a3xxrl56bp4zbknbchv5x17k1w5kgcf4j3vklcv6av60";
     };
@@ -128,8 +128,9 @@ in rec {
     src = fetchFromGitHub {
       owner = "SLNOS";
       repo  = "tor-browser";
-      rev   = "tor-browser-52.3.0esr-7.0-1-slnos";
-      sha256 = "0szbf8gjbl4dnrb4igy4mq5858i1y6ki4skhdw63iqqdd8w9v4yv";
+      # branch "tor-browser-52.5.0esr-7.0-1-slnos";
+      rev   = "830ff8d622ef20345d83f386174f790b0fc2440d";
+      sha256 = "169mjkr0bp80yv9nzza7kay7y2k03lpnx71h4ybcv9ygxgzdgax5";
     };
 
     patches =


### PR DESCRIPTION
###### Motivation for this change
Overfermented SLNOS patchset.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

