### PR TITLE
r2-cutter: init at 1.0(.0), radare2 qt gui

### DIFF
--- a/pkgs/development/tools/analysis/cutter/default.nix
+++ b/pkgs/development/tools/analysis/cutter/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, qmake, pkgconfig, qtbase, qtsvg, radare2 }:
+
+
+stdenv.mkDerivation rec {
+  name = "r2-cutter-${version}";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "radareorg";
+    repo = "cutter";
+    rev = "b331dfd083edbbcbd33de83ce7bba17f4d142fe6";
+    sha256 = "0y53fxzxszy785xc7glrqnybnar3560kc3q0ih6nzz4bb7i0ghx1";
+  };
+
+  postUnpack = "export sourceRoot=$sourceRoot/src";
+
+  prePatch = ''
+    substituteInPlace cutter.pro \
+      --replace cutter-small.png cutter_appicon.svg
+    substituteInPlace cutter.desktop \
+      --replace Icon=cutter Icon=cutter_appicon
+  '';
+
+  nativeBuildInputs = [ qmake pkgconfig ];
+  buildInputs = [ qtbase qtsvg radare2 ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A Qt and C++ GUI for radare2 reverse engineering framework";
+    homepage = src.meta.homepage;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7578,6 +7578,7 @@ with pkgs;
     rubyBindings = config.radare.rubyBindings or false;
     luaBindings = config.radare.luaBindings or false;
   };
+  r2-cutter = qt5.callPackage ../development/tools/analysis/cutter { };
 
   ragel = ragelStable;
 


### PR DESCRIPTION
Naming "r2-cutter" since "cutter" already exists,
but AFAIK this naming is not used anywhere else currently.

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

