### PR TITLE
radare2: 2.0.1 -> 2.1.0

### DIFF
--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -13,23 +13,15 @@ let
   inherit (stdenv.lib) optional;
 in
 stdenv.mkDerivation rec {
-  version = "2.0.1";
+  version = "2.1.0";
   name = "radare2-${version}";
 
   src = fetchFromGitHub {
     owner = "radare";
     repo = "radare2";
     rev = version;
-    sha256 = "031ndvinsypagpkdszxjq0hj91ijq9zx4dzk53sz7il7s3zn65c7";
+    sha256 = "1mny0iw2dgszvvx0yb0z5vlygz4f3jblzi9byybczm8wdqs1vhb1";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2017-15385.patch";
-      url = https://github.com/radare/radare2/commit/21a6f570ba33fa9f52f1bba87f07acc4e8c178f4.patch;
-      sha256 = "19qg5j9yr5r62nrq2b6mscxsz0wyyfah2z5jz8dvj9kqxq186d43";
-    })
-  ];
 
   postPatch = let
     cs_ver = "3.0.4"; # version from $sourceRoot/shlr/Makefile
@@ -50,13 +42,6 @@ stdenv.mkDerivation rec {
     ++ optional rubyBindings [ruby]
     ++ optional pythonBindings [python]
     ++ optional luaBindings [lua];
-
-  postInstall = ''
-    # replace symlinks pointing into the build directory with the files they point to
-    rm $out/bin/{r2-docker,r2-indent}
-    cp sys/r2-docker.sh $out/bin/r2-docker
-    cp sys/indent.sh    $out/bin/r2-indent
-  '';
 
   meta = {
     description = "unix-like reverse engineering framework and commandline tools";


### PR DESCRIPTION
* drop patch, now included
* drop r2-docker/r2-indent fixups, no longer installed
  (see https://github.com/radare/radare2/commit/a09d6dae925ab381ed9eeb9d11ad595b1a83e4c5)

###### Motivation for this change

Package update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

