### PR TITLE
procmail: fix CVE-2017-16844

### DIFF
--- a/pkgs/applications/misc/procmail/default.nix
+++ b/pkgs/applications/misc/procmail/default.nix
@@ -3,7 +3,14 @@
 stdenv.mkDerivation {
   name = "procmail-3.22";
 
-  patches = [ ./CVE-2014-3618.patch ];
+  patches = [
+    ./CVE-2014-3618.patch
+    (fetchurl {
+      url = https://sources.debian.org/data/main/p/procmail/3.22-26/debian/patches/30;
+      sha256 = "11zmz1bj0v9pay3ldmyyg7473b80h89gycrhndsgg9q50yhcqaaq";
+      name = "CVE-2017-16844";
+    })
+  ];
 
   # getline is defined differently in glibc now. So rename it.
   # Without the .PHONY target "make install" won't install anything on Darwin.


### PR DESCRIPTION
###### Motivation for this change

[CVE-2017-16844](https://nvd.nist.gov/vuln/detail/CVE-2017-16844)

/cc maintainer @gebner 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

