### PR TITLE
libcomps: init at 0.1.8

### DIFF
--- a/pkgs/development/libraries/libcomps/0001-Python-respect-CMAKE_INSTALL_PREFIX.patch
+++ b/pkgs/development/libraries/libcomps/0001-Python-respect-CMAKE_INSTALL_PREFIX.patch
@@ -1,0 +1,51 @@
+From de8384017bf83798b2578ec588aee7c38c826bae Mon Sep 17 00:00:00 2001
+From: Frederik Rietdijk <fridh@fridh.nl>
+Date: Tue, 5 Dec 2017 16:50:40 +0100
+Subject: [PATCH] Python: respect CMAKE_INSTALL_PREFIX
+
+While packaging I noticed it tried to put the modules in the wrong
+folder.
+---
+ libcomps/src/python/src/python2/CMakeLists.txt | 7 ++++++-
+ libcomps/src/python/src/python3/CMakeLists.txt | 7 ++++++-
+ 2 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/libcomps/src/python/src/python2/CMakeLists.txt b/libcomps/src/python/src/python2/CMakeLists.txt
+index 3ad9e18..a9326fa 100644
+--- a/libcomps/src/python/src/python2/CMakeLists.txt
++++ b/libcomps/src/python/src/python2/CMakeLists.txt
+@@ -1,7 +1,12 @@
+ find_package (PythonLibs 2.6)
+ find_package (PythonInterp 2.6 REQUIRED)
+ 
+-execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from distutils import sysconfig; stdout.write(sysconfig.get_python_lib(True))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
++EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "
++from sys import stdout
++from distutils import sysconfig
++path=sysconfig.get_python_lib(True, prefix='${CMAKE_INSTALL_PREFIX}')
++stdout.write(path)"
++OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
+ 
+ include_directories(${PYTHON_INCLUDE_PATH})
+ include_directories(${LIBCOMPS_INCLUDE_PATH})
+diff --git a/libcomps/src/python/src/python3/CMakeLists.txt b/libcomps/src/python/src/python3/CMakeLists.txt
+index 7fafa9f..e359092 100644
+--- a/libcomps/src/python/src/python3/CMakeLists.txt
++++ b/libcomps/src/python/src/python3/CMakeLists.txt
+@@ -2,7 +2,12 @@ find_package (PythonLibs 3.0)
+ find_package (PythonInterp 3.0)
+ #add_custom_target(py3-copy)
+ 
+-execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from distutils import sysconfig; stdout.write(sysconfig.get_python_lib(True))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
++EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "
++from sys import stdout
++from distutils import sysconfig
++path=sysconfig.get_python_lib(True, prefix='${CMAKE_INSTALL_PREFIX}')
++stdout.write(path)"
++OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
+ 
+ include_directories(${PYTHON_INCLUDE_PATH})
+ include_directories(${LIBCOMPS_INCLUDE_PATH})
+-- 
+2.15.0
+

--- a/pkgs/development/libraries/libcomps/default.nix
+++ b/pkgs/development/libraries/libcomps/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, pkgconfig
+, libxml2
+, expat
+, python
+, check
+}:
+
+let
+  pname = "libcomps";
+  version = "0.1.8";
+in stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "rpm-software-management";
+    repo   = pname;
+    rev    = name;
+    sha256 = "0nn9q8hpjcwwrnyf0j6mfkw7rvd7ynbndy18nscn108aqr7nv81l";
+  };
+
+  patches = [
+    ./0001-Python-respect-CMAKE_INSTALL_PREFIX.patch
+  ];
+
+  patchFlags = ["-p2"]; # Because of sourceRoot
+
+  sourceRoot = "${src.name}/${pname}";
+
+  cmakeFlags="-DPYTHON_DESIRED=${stdenv.lib.substring 0 1 python.pythonVersion}";
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [ libxml2 expat python check ];
+
+  meta = with stdenv.lib; {
+    description = "Libcomps is alternative for yum.comps library";
+    homepage = https://github.com/rpm-software-management/libcomps;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9014,6 +9014,8 @@ with pkgs;
 
   libchipcard = callPackage ../development/libraries/aqbanking/libchipcard.nix { };
 
+  libcomps = callPackage ../development/libraries/libcomps { };
+
   libcrafter = callPackage ../development/libraries/libcrafter { };
 
   libcrossguid = callPackage ../development/libraries/libcrossguid { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10404,6 +10404,10 @@ in {
     cudaSupport = pkgs.config.cudaSupport or false;
   };
 
+  libcomps = toPythonModule (pkgs.libcomps.override {
+    inherit python;
+  });
+
   librepo = toPythonModule (pkgs.librepo.override {
     inherit python;
   });


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

