### PR TITLE
konversation: 1.7.2 -> 1.7.4

### DIFF
--- a/pkgs/applications/networking/irc/konversation/default.nix
+++ b/pkgs/applications/networking/irc/konversation/default.nix
@@ -29,13 +29,13 @@
 
 let
   pname = "konversation";
-  version = "1.7.2";
+  version = "1.7.4";
 in mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
-    sha256 = "0616h59bsw5c3y8lij56v3fhv9by0rwdfcaa83yfxqg4rs26xyaz";
+    sha256 = "0y4rj4fcl1wsi3y1fhnzad9nf4llwrnipfm9mfm55kqnx1zmpvqp";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

New upstream release is available, includes a fix for [CVE-2017-15923](https://nvd.nist.gov/vuln/detail/CVE-2017-15923).

/cc maintainer @FRidh 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

