### PR TITLE
 vivaldi: 1.12.955.38-1 -> 1.13.1008.34-1

### DIFF
--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -14,11 +14,11 @@ stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "vivaldi";
   version = "1.13.1008.34-1";
- 
+
   src = fetchurl {
     url = "https://downloads.vivaldi.com/stable/${product}-stable_${version}_amd64.deb";
     sha256 = "18p5n87n5rkd6dhdsf2lvcyhg6ipn0k4p6a79dy93vsgjmk4bvw2";
-   };
+  };
 
   unpackPhase = ''
     ar vx ${src}

--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -13,12 +13,12 @@
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "vivaldi";
-  version = "1.12.955.38-1";
-
+  version = "1.13.1008.34-1";
+ 
   src = fetchurl {
     url = "https://downloads.vivaldi.com/stable/${product}-stable_${version}_amd64.deb";
-    sha256 = "1bq1ss6vkpr6rw5n0sw9zipxx19vficvxys1lra9symcxk1b4gqw";
-  };
+    sha256 = "18p5n87n5rkd6dhdsf2lvcyhg6ipn0k4p6a79dy93vsgjmk4bvw2";
+   };
 
   unpackPhase = ''
     ar vx ${src}


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

