### PR TITLE
pcscd: add plugin for ACS ACR38U smartcard reader

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -80,6 +80,7 @@
   benley = "Benjamin Staffin <benley@gmail.com>";
   bennofs = "Benno Fünfstück <benno.fuenfstueck@gmail.com>";
   benwbooth = "Ben Booth <benwbooth@gmail.com>";
+  berce = "Bert Moens <bert.moens@gmail.com>";
   berdario = "Dario Bertini <berdario@gmail.com>";
   bergey = "Daniel Bergey <bergey@teallabs.org>";
   bhipple = "Benjamin Hipple <bhipple@protonmail.com>";

--- a/pkgs/tools/security/libacr38u/default.nix
+++ b/pkgs/tools/security/libacr38u/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, pkgconfig, pcsclite , libusb }:
+
+stdenv.mkDerivation rec {
+  version = "1.7.11";
+  name = "libacr38u-${version}";
+
+  src = fetchurl {
+    url = "http://http.debian.net/debian/pool/main/a/acr38/acr38_1.7.11.orig.tar.bz2";
+    sha256 = "0lxbq17y51cablx6bcd89klwnyigvkz0rsf9nps1a97ggnllyzkx";
+  };
+
+  doCheck = true;
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ pcsclite libusb ];
+
+  preBuild = ''
+    makeFlagsArray=(usbdropdir="$out/pcsc/drivers");
+  '';
+
+  meta = with stdenv.lib; {
+    description = "ACR38U smartcard reader driver for pcsclite";
+    longDescription = ''
+      A PC/SC IFD handler implementation for the ACS ACR38U
+      smartcard readers. This driver is for the non-CCID version only.
+
+      This package is needed to communicate with the ACR38U smartcard readers through
+      the PC/SC Lite resource manager (pcscd).
+
+      It can be enabled in /etc/nixos/configuration.nix by adding:
+        services.pcscd.enable = true;
+        services.pcscd.plugins = [ libacr38u ];
+
+      The package is based on the debian package libacr38u.
+    '';
+    homepage = http://www.acs.com.hk;
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ berce ];
+    platforms = with platforms; unix;
+  };
+} 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8916,6 +8916,8 @@ with pkgs;
 
   libaccounts-glib = callPackage ../development/libraries/libaccounts-glib { };
 
+  libacr38u = callPackage ../tools/security/libacr38u { };
+
   libagar = callPackage ../development/libraries/libagar { };
   libagar_test = callPackage ../development/libraries/libagar/libagar_test.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Add hardware support for specific smartcard reader hardware.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).