### PR TITLE
kitty 0.5.0 -> 0.5.1

### DIFF
--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -2,7 +2,7 @@
 
 with python3Packages;
 buildPythonApplication rec {
-  version = "0.5.0";
+  version = "0.5.1";
   name = "kitty-${version}";
   format = "other";
 
@@ -10,7 +10,7 @@ buildPythonApplication rec {
     owner = "kovidgoyal";
     repo = "kitty";
     rev = "v${version}";
-    sha256 = "1w202rsgswagb3kiqbwg4xixcglip2hhz6wj1qx9x2whi4zl1l68";
+    sha256 = "0zs5b1sxi2f1lgpjs1qvd15gz6m1wfpyqskyyr0vmm4ch3rgp5zz";
   };
 
   buildInputs = [ fontconfig glfw ncurses libunistring harfbuzz ];


### PR DESCRIPTION
###### Motivation for this change
Update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

