### PR TITLE
gnome3.gnome_online_accounts: enable more backends

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, vala, glib, libxslt, gtk, wrapGAppsHook
-, webkitgtk, json_glib, rest, libsecret, dbus_glib, gnome_common
+, webkitgtk, json_glib, rest, libsecret, dbus_glib, gnome_common, gtk_doc
 , telepathy_glib, intltool, dbus_libs, icu, glib_networking
 , libsoup, docbook_xsl_ns, docbook_xsl, gnome3
 }:
@@ -9,13 +9,17 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-I${dbus_glib.dev}/include/dbus-1.0 -I${dbus_libs.dev}/include/dbus-1.0";
 
-  outputs = [ "out" "man" "dev" ];
+  outputs = [ "out" "man" "dev" "devdoc" ];
+
+  configureFlags = [
+    "--enable-gtk-doc"
+  ];
 
   enableParallelBuilding = true;
 
   nativeBuildInputs = [
     pkgconfig vala gnome_common intltool wrapGAppsHook
-    libxslt docbook_xsl_ns docbook_xsl
+    libxslt docbook_xsl_ns docbook_xsl gtk_doc
   ];
   buildInputs = [
     glib gtk webkitgtk json_glib rest libsecret dbus_glib telepathy_glib glib_networking icu libsoup

--- a/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, vala, glib, libxslt, gtk, wrapGAppsHook
 , webkitgtk, json_glib, rest, libsecret, dbus_glib, gnome_common, gtk_doc
 , telepathy_glib, intltool, dbus_libs, icu, glib_networking
-, libsoup, docbook_xsl_ns, docbook_xsl, gnome3
+, libsoup, docbook_xsl_ns, docbook_xsl, gnome3, gcr, kerberos
 }:
 
 stdenv.mkDerivation rec {
@@ -12,6 +12,10 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "man" "dev" "devdoc" ];
 
   configureFlags = [
+    "--enable-media-server"
+    "--enable-kerberos"
+    "--enable-lastfm"
+    "--enable-todoist"
     "--enable-gtk-doc"
   ];
 
@@ -23,6 +27,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     glib gtk webkitgtk json_glib rest libsecret dbus_glib telepathy_glib glib_networking icu libsoup
+    gcr kerberos
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
@@ -9,12 +9,17 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-I${dbus_glib.dev}/include/dbus-1.0 -I${dbus_libs.dev}/include/dbus-1.0";
 
+  outputs = [ "out" "man" "dev" ];
+
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib libxslt gtk webkitgtk json_glib rest gnome_common wrapGAppsHook
-                  libsecret dbus_glib telepathy_glib glib_networking intltool icu libsoup vala
-                  docbook_xsl_ns docbook_xsl gnome3.defaultIconTheme ];
+  nativeBuildInputs = [
+    pkgconfig vala gnome_common intltool wrapGAppsHook
+    libxslt docbook_xsl_ns docbook_xsl
+  ];
+  buildInputs = [
+    glib gtk webkitgtk json_glib rest libsecret dbus_glib telepathy_glib glib_networking icu libsoup
+  ];
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change
In particular, last.fm.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

