### PR TITLE
adapta-backgrounds: 0.4.0.6 -> 0.5.1.1

### DIFF
--- a/pkgs/data/misc/adapta-backgrounds/default.nix
+++ b/pkgs/data/misc/adapta-backgrounds/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "adapta-backgrounds-${version}";
-  version = "0.4.0.6";
+  version = "0.5.1.1";
 
   src = fetchFromGitHub {
     owner = "adapta-project";
     repo = "adapta-backgrounds";
     rev = version;
-    sha256 = "1yqxrwhjl6g92wm52kalbns41i2l5g45qbd4185b22crhbrn5x79";
+    sha256 = "00gwiraq6c9jh1xl5mmmi5fdj9l3r75ii5wk8jnw856qvrajhxyq";
   };
 
   nativeBuildInputs = [ autoreconfHook  ];


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).