### PR TITLE
parcellite: wrap to add runtime deps

### DIFF
--- a/pkgs/tools/misc/parcellite/default.nix
+++ b/pkgs/tools/misc/parcellite/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, autoreconfHook
-, gtk2, intltool, pkgconfig }:
+{ stdenv, fetchFromGitHub, autoreconfHook, makeWrapper
+, gtk2, intltool, pkgconfig, which, xdotool }:
 
 stdenv.mkDerivation rec {
   name = "parcellite-${version}";
@@ -12,8 +12,14 @@ stdenv.mkDerivation rec {
     sha256 = "19q4x6x984s6gxk1wpzaxawgvly5vnihivrhmja2kcxhzqrnfhiy";
   };
 
-  nativeBuildInputs = [ autoreconfHook intltool pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook intltool pkgconfig makeWrapper ];
   buildInputs = [ gtk2 ];
+
+  postInstall = ''
+    wrapProgram $out/bin/parcellite \
+      --prefix PATH : "${which}/bin" \
+      --prefix PATH : "${xdotool}/bin"
+  '';
 
   meta = with stdenv.lib; {
     description = "Lightweight GTK+ clipboard manager";


### PR DESCRIPTION
parcellite depends on ability to shell out to `which` and `xdotool` to perform
some of its functions. This ensures that these programs are present in the PATH
when program is being run.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

