### PR TITLE
Use wrapGAppsHook for parcellite also add dependencies

### DIFF
--- a/pkgs/tools/misc/parcellite/default.nix
+++ b/pkgs/tools/misc/parcellite/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook
-, gtk2, intltool, pkgconfig }:
+, gtk2, hicolor_icon_theme, intltool, pkgconfig, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "parcellite-${version}";
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "19q4x6x984s6gxk1wpzaxawgvly5vnihivrhmja2kcxhzqrnfhiy";
   };
 
-  nativeBuildInputs = [ autoreconfHook intltool pkgconfig ];
-  buildInputs = [ gtk2 ];
+  nativeBuildInputs = [ autoreconfHook intltool pkgconfig wrapGAppsHook ];
+  buildInputs = [ gtk2 hicolor_icon_theme ];
 
   meta = with stdenv.lib; {
     description = "Lightweight GTK+ clipboard manager";

--- a/pkgs/tools/misc/parcellite/default.nix
+++ b/pkgs/tools/misc/parcellite/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, autoreconfHook
-, gtk2, hicolor_icon_theme, intltool, pkgconfig, wrapGAppsHook }:
+, gtk2, hicolor_icon_theme, intltool, pkgconfig
+, which, wrapGAppsHook, xdotool }:
 
 stdenv.mkDerivation rec {
   name = "parcellite-${version}";
@@ -14,6 +15,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook intltool pkgconfig wrapGAppsHook ];
   buildInputs = [ gtk2 hicolor_icon_theme ];
+
+  preFixup = ''
+    # Need which and xdotool on path to fix auto-pasting.
+    gappsWrapperArgs+=(--prefix PATH : "${which}/bin:${xdotool}/bin")
+  '';
 
   meta = with stdenv.lib; {
     description = "Lightweight GTK+ clipboard manager";


### PR DESCRIPTION
###### Motivation for this change

To improve the out-of-box user experience for Parcellite.

CC @gleber

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).