### PR TITLE
nixos/libvirt: avoid dependency on two qemu packages

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -82,6 +82,10 @@ with lib;
     (mkRenamedOptionModule [ "services" "virtualboxHost" "addNetworkInterface" ] [ "virtualisation" "virtualbox" "host" "addNetworkInterface" ])
     (mkRenamedOptionModule [ "services" "virtualboxHost" "enableHardening" ] [ "virtualisation" "virtualbox" "host" "enableHardening" ])
 
+    # libvirtd
+    (mkRemovedOptionModule [ "virtualisation" "libvirtd" "enableKVM" ]
+      "Set the option `virtualisation.libvirtd.qemuPackage' instead.")
+
     # Tarsnap
     (mkRenamedOptionModule [ "services" "tarsnap" "config" ] [ "services" "tarsnap" "archives" ])
 

--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -37,20 +37,13 @@ in {
       '';
     };
 
-    virtualisation.libvirtd.enableKVM = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        This option disables support for non-KVM guests in libvirtd (e.g. aarch64 on x86).
-        KVM is available even if this setting is false.
-      '';
-    };
-
     virtualisation.libvirtd.qemuPackage = mkOption {
       type = types.package;
-      default = if cfg.enableKVM then pkgs.qemu_kvm else pkgs.qemu;
+      default = pkgs.qemu;
       description = ''
-        Qemu package to use with libvirt
+        Qemu package to use with libvirt.
+        `pkgs.qemu` can emulate alien architectures (e.g. aarch64 on x86)
+        `pkgs.qemu_kvm` saves disk space allowing to emulate only host architectures.
       '';
     };
 

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -4,7 +4,7 @@
 , iproute, iptables, readline, lvm2, utillinux, systemd, libpciaccess, gettext
 , libtasn1, ebtables, libgcrypt, yajl, pmutils, libcap_ng, libapparmor
 , dnsmasq, libnl, libpcap, libxslt, xhtml1, numad, numactl, perlPackages
-, curl, libiconv, gmp, xen, zfs, parted, qemu
+, curl, libiconv, gmp, xen, zfs, parted
 }:
 
 with stdenv.lib;
@@ -41,8 +41,6 @@ stdenv.mkDerivation rec {
 
     # the path to qemu-kvm will be stored in VM's .xml and .save files
     # do not use "''${qemu_kvm}/bin/qemu-kvm" to avoid bound VMs to particular qemu derivations
-    substituteInPlace src/qemu/qemu_capabilities.c \
-      --replace '"/usr/libexec/qemu-kvm"' '"/run/libvirt/nix-emulators/${if stdenv.isAarch64 then "qemu-system-aarch64" else "qemu-kvm"}"'
     substituteInPlace src/lxc/lxc_conf.c \
       --replace 'lxc_path,' '"/run/libvirt/nix-emulators/libvirt_lxc",'
   '' + ''
@@ -91,7 +89,7 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/lib/systemd/system/libvirtd.service --replace /bin/kill ${coreutils}/bin/kill
     rm $out/lib/systemd/system/{virtlockd,virtlogd}.*
     wrapProgram $out/sbin/libvirtd \
-      --prefix PATH : ${makeBinPath [ iptables iproute pmutils numad numactl qemu ]}
+      --prefix PATH : /run/libvirt/nix-emulators:${makeBinPath [ iptables iproute pmutils numad numactl ]}
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Currently ```libvirt``` requires two ```qemu``` derivations:
```qemu``` and ```qemu_kvm``` which is just a truncated version  of ```qemu``` (defined as ```qemu.override { hostCpuOnly = true; }```).

This patch exposes an option ```virtualisation.libvirtd.qemuPackage``` which allows to choose which package to use: 
 * ```pkgs.qemu_kvm``` if all your guests have the same CPU as host, or 
 * ```pkgs.qemu``` which allows to emulate alien architectures (for example ```ARMV7L``` on ```X86_64```), or
 * a custom derivation

```virtualisation.libvirtd.enableKVM``` option is vague and could be deprecate in favor of ```virtualisation.libvirtd.qemuPackage```, anyway it does allow to enable/disable kvm.
