### PR TITLE
google-chrome: meta.platforms "linux" -> "x86_64-linux"

### DIFF
--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -139,6 +139,6 @@ in stdenv.mkDerivation rec {
     homepage = https://www.google.com/chrome/browser/;
     license = licenses.unfree;
     maintainers = [ maintainers.msteen ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
Currently ```google-chrome``` silently installs x86_64 version on aarch64-linux

I have found no aarch64-linux version upstream

Also, i386-linux is broken