### PR TITLE
Added ROCK kernel which is required by AMDs ROCm project

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-4.11-kfd.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.11-kfd.nix
@@ -1,4 +1,4 @@
-{ stdenv, hostPlatform, fetchgit, perl, buildLinux, ... } @ args:
+{ stdenv, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
 let
   ver = "4.11.0";
@@ -6,11 +6,14 @@ let
 in
 import ./generic.nix (args // rec {
   version = "${ver}-${revision}";
+  modDirVersion = "${ver}";
   extraMeta.branch = "4.11";
 
-  src = fetchgit {
-    url = "https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver.git";
+  src = fetchFromGitHub {
+    owner = "RadeonOpenCompute";
+    repo = "ROCK-Kernel-Driver";
+    # url = "https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver.git";
     rev = "roc-1.6.x";
-    sha256 = "0fwnmba25ww5q4asfz3mqdmbrhfdfgid388701h4xy20pwpjndsy";
+    sha256 = "1gl883j1lzysvh4qnls75k72x2g4kzmx36rm5d6zfknk3mrk2b4d";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-4.11-kfd.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.11-kfd.nix
@@ -1,0 +1,16 @@
+{ stdenv, hostPlatform, fetchgit, perl, buildLinux, ... } @ args:
+
+let
+  ver = "4.11.0";
+  revision = "kfd-roc-1.6.x";
+in
+import ./generic.nix (args // rec {
+  version = "${ver}-${revision}";
+  extraMeta.branch = "4.11";
+
+  src = fetchgit {
+    url = "https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver.git";
+    rev = "roc-1.6.x";
+    sha256 = "0fwnmba25ww5q4asfz3mqdmbrhfdfgid388701h4xy20pwpjndsy";
+  };
+} // (args.argsOverride or {}))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12550,6 +12550,19 @@ with pkgs;
     ];
   };
 
+  linux_4_11_kfd = callPackage ../os-specific/linux/kernel/linux-4.11-kfd.nix {
+    kernelPatches =
+      [ kernelPatches.bridge_stp_helper
+        kernelPatches.cpu-cgroup-v2."4.9"
+        kernelPatches.modinst_arg_list_too_long
+      ]
+      ++ lib.optionals ((platform.kernelArch or null) == "mips")
+      [ kernelPatches.mips_fpureg_emu
+        kernelPatches.mips_fpu_sigill
+        kernelPatches.mips_ext3_n32
+      ];
+  };
+
   linux_4_4 = callPackage ../os-specific/linux/kernel/linux-4.4.nix {
     kernelPatches =
       [ kernelPatches.bridge_stp_helper
@@ -12803,6 +12816,7 @@ with pkgs;
   linuxPackages_rpi = linuxPackagesFor pkgs.linux_rpi;
   linuxPackages_4_4 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_4);
   linuxPackages_4_9 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_9);
+  linuxPackages_4_11_kfd = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_11_kfd);
   linuxPackages_4_13 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_13);
   linuxPackages_4_14 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_14);
   # Don't forget to update linuxPackages_latest!


### PR DESCRIPTION
Make the ROCm OpenCL and ecosystem work.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---