### PR TITLE
airspy: init at 1.0.9

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -390,6 +390,7 @@
   manveru = "Michael Fellinger <m.fellinger@gmail.com>";
   marcweber = "Marc Weber <marco-oweber@gmx.de>";
   markus1189 = "Markus Hauck <markus1189@gmail.com>";
+  markuskowa = "Markus Kowalewski <markus.kowalewski@gmail.com>";
   markWot = "Markus Wotringer <markus@wotringer.de>";
   martijnvermaat = "Martijn Vermaat <martijn@vermaat.name>";
   martingms = "Martin Gammelsæter <martin@mg.am>";

--- a/pkgs/applications/misc/airspy/default.nix
+++ b/pkgs/applications/misc/airspy/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub
+, cmake , pkgconfig, libusb
+}:
+
+let
+  version = "1.0.9";
+in  
+  stdenv.mkDerivation {
+    name = "airspy-${version}";
+
+    src = fetchFromGitHub {
+      owner = "airspy";
+      repo = "airspyone_host";
+      rev = "v${version}";
+      sha256 = "04kx2p461sqd4q354n1a99zcabg9h29dwcnyhakykq8bpg3mgf1x";
+    };
+
+    nativeBuildInputs = [ cmake pkgconfig ];
+    buildInputs = [ libusb ];
+ 
+    cmakeFlags = [ "-DINSTALL_UDEV_RULES=OFF" ];
+   
+    meta = with stdenv.lib; {
+      homepage = http://github.com/airspy/airspyone_host;
+      description = "Host tools and driver library for the AirSpy SDR";
+      license = licenses.free;
+      platforms = platforms.linux;
+      maintainer = with maintainers; [ markuskowa ];
+    };
+  }
+

--- a/pkgs/applications/misc/gnuradio-osmosdr/default.nix
+++ b/pkgs/applications/misc/gnuradio-osmosdr/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, cmake, pkgconfig, boost, gnuradio, rtl-sdr, uhd
-, makeWrapper, hackrf
+, makeWrapper, hackrf, airspy
 , pythonSupport ? true, python, swig
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    cmake boost gnuradio rtl-sdr uhd makeWrapper hackrf
+    cmake boost gnuradio rtl-sdr uhd makeWrapper hackrf airspy
   ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
 
   postInstall = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -430,6 +430,8 @@ with pkgs;
 
   airsonic = callPackage ../servers/misc/airsonic { };
 
+  airspy = callPackage ../applications/misc/airspy { };
+
   aj-snapshot  = callPackage ../applications/audio/aj-snapshot { };
 
   albert = libsForQt5.callPackage ../applications/misc/albert {};


### PR DESCRIPTION
###### Motivation for this change
USB driver library for the AirSpy software defined radio (SDR) and its host tools.
This packages is needed by e.g. gnuradio-osmosdr to use this SDR device
with the gnuradio framework.

###### Things done
Tested against an airspy R2 device.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

