### PR TITLE
libvirt: remove xen dependency on aarch64

### DIFF
--- a/pkgs/applications/virtualization/virt-viewer/default.nix
+++ b/pkgs/applications/virtualization/virt-viewer/default.nix
@@ -25,8 +25,12 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib libxml2 gtk3 gtkvnc gmp libgcrypt gnupg cyrus_sasl shared_mime_info
     libvirt yajl gsettings_desktop_schemas makeWrapper libvirt-glib
-    libcap_ng numactl libapparmor xen
-  ] ++ optionals spiceSupport [ spice_gtk spice_protocol libcap gdbm ];
+    libcap_ng numactl libapparmor
+  ] ++ optionals stdenv.isx86_64 [
+    xen
+  ] ++ optionals spiceSupport [
+    spice_gtk spice_protocol libcap gdbm
+  ];
 
   postInstall = ''
     for f in "$out"/bin/*; do

--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -16,7 +16,9 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     libvirt glib libxml2 intltool libtool yajl nettle libgcrypt
-    python pygobject2 gobjectIntrospection libcap_ng numactl xen libapparmor
+    python pygobject2 gobjectIntrospection libcap_ng numactl libapparmor
+  ] ++ stdenv.lib.optionals stdenv.isx86_64 [
+    xen
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -27,9 +27,11 @@ stdenv.mkDerivation rec {
     libxslt xhtml1 perlPackages.XMLXPath curl libpcap
   ] ++ optionals stdenv.isLinux [
     libpciaccess devicemapper lvm2 utillinux systemd libnl numad zfs
-    libapparmor libcap_ng numactl xen attr parted
+    libapparmor libcap_ng numactl attr parted
+  ] ++ optionals (stdenv.isLinux && stdenv.isx86_64) [
+    xen
   ] ++ optionals stdenv.isDarwin [
-     libiconv gmp
+    libiconv gmp
   ];
 
   preConfigure = optionalString stdenv.isLinux ''


### PR DESCRIPTION
###### Motivation for this change

```libvirt``` works on ```aarch64-linux``` if compiled without ```xen```
