### PR TITLE
lightdm: fix removal of unused user data directories

### DIFF
--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pam, pkgconfig, libxcb, glib, libXdmcp, itstool, libxml2
-, intltool, xlibsWrapper, libxklavier, libgcrypt, libaudit
+, intltool, xlibsWrapper, libxklavier, libgcrypt, libaudit, coreutils
 , qt4 ? null
 , withQt5 ? false, qtbase
 }:
@@ -35,6 +35,11 @@ stdenv.mkDerivation rec {
     "sysconfdir=\${out}/etc"
     "localstatedir=\${TMPDIR}"
   ];
+
+  prePatch = ''
+    substituteInPlace src/shared-data-manager.c \
+      --replace /bin/rm ${coreutils}/bin/rm
+  '';
 
   meta = {
     homepage = https://launchpad.net/lightdm;


### PR DESCRIPTION
###### Motivation for this change

To fix errors such as

    Could not delete unused user data directory /var/lib/lightdm-data/.cache: Failed to execute child process “/bin/rm” (No such file or directory)
    Could not delete unused user data directory /var/lib/lightdm-data/.Xauthority: Failed to execute child process “/bin/rm” (No such file or directory)
    Could not delete unused user data directory /var/lib/lightdm-data/lightdm: Failed to execute child process “/bin/rm” (No such file or directory)

that you can see in `journalctl -u display-manager.service`. I believe this should be backported to 17.09 (where I successfully run this code) as the bug also manifests there.

Maintainer CC: @ocharles @wkennington

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).