### PR TITLE
mydumper: init at 0.9.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -289,6 +289,7 @@
   ironpinguin = "Michele Catalano <michele@catalano.de>";
   ivan-tkatchev = "Ivan Tkatchev <tkatchev@gmail.com>";
   ixmatus = "Parnell Springmeyer <parnell@digitalmentat.com>";
+  izorkin = "Yurii Izorkin <Izorkin@gmail.com>";
   j-keck = "Jürgen Keck <jhyphenkeck@gmail.com>";
   jagajaga = "Arseniy Seroka <ars.seroka@gmail.com>";
   jammerful = "jammerful <jammerful@gmail.com>";

--- a/pkgs/tools/backup/mydumper/default.nix
+++ b/pkgs/tools/backup/mydumper/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
+, glib, zlib, pcre, mariadb, libressl, }:
+
+stdenv.mkDerivation rec {
+  version = "0.9.3";
+  name = "mydumper-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "maxbube";
+    repo   = "mydumper";
+    rev    = "v${version}";
+    sha256 = "139v6707sxyslg7n1fii8b1ybdq50hbqhc8zf6p1cr3h2hhl6ns9";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [ glib zlib pcre mariadb.client.dev libressl ];
+
+  meta = with stdenv.lib; {
+    description = ''High-perfomance MySQL backup tool'';
+    homepage = https://github.com/maxbube/mydumper;
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ izorkin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3486,6 +3486,8 @@ with pkgs;
 
   mycli = callPackage ../tools/admin/mycli { };
 
+  mydumper = callPackage ../tools/backup/mydumper { };
+
   mysql2pgsql = callPackage ../tools/misc/mysql2pgsql { };
 
   mysqltuner = callPackage ../tools/misc/mysqltuner { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

