### PR TITLE
mono: re-enable parallel building

### DIFF
--- a/pkgs/development/compilers/mono/generic-cmake.nix
+++ b/pkgs/development/compilers/mono/generic-cmake.nix
@@ -45,8 +45,7 @@ stdenv.mkDerivation rec {
   # The file /nix/store/xxx-mono-2.4.2.1/lib/mscorlib.dll is an invalid CIL image
   dontStrip = true;
 
-  # Parallel building doesn't work, as shows http://hydra.nixos.org/build/2983601
-  enableParallelBuilding = false;
+  enableParallelBuilding = true;
 
   # We want pkg-config to take priority over the dlls in the Mono framework and the GAC
   # because we control pkg-config

--- a/pkgs/development/compilers/mono/generic.nix
+++ b/pkgs/development/compilers/mono/generic.nix
@@ -40,8 +40,7 @@ stdenv.mkDerivation rec {
   # The file /nix/store/xxx-mono-2.4.2.1/lib/mscorlib.dll is an invalid CIL image
   dontStrip = true;
 
-  # Parallel building doesn't work, as shows http://hydra.nixos.org/build/2983601
-  enableParallelBuilding = false;
+  enableParallelBuilding = true;
 
   # We want pkg-config to take priority over the dlls in the Mono framework and the GAC
   # because we control pkg-config


### PR DESCRIPTION
###### Motivation for this change

Shorter build times for mono packages. The commit that originally disabled parallel builds is from 2012 for an older version of mono and according to upstream the issues have been since resolved - https://bugzilla.xamarin.com/show_bug.cgi?id=2018.

/cc maintainers @viric @thoughtpolice @obadz @vrthra

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

