### PR TITLE
buildkite:  allow configuration and actual use of agent-specific hooks

### DIFF
--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -31,6 +31,14 @@ in
         '';
       };
 
+      hooks-path = mkOption {
+        type = types.str;
+        default = "${pkgs.buildkite-agent}/share/hooks";
+        description = ''
+          Path to the directory storing the hooks.
+        '';
+      };
+
       meta-data = mkOption {
         type = types.str;
         default = "";
@@ -98,10 +106,12 @@ in
             token="${catOrLiteral cfg.token}"
             name="${cfg.name}"
             meta-data="${cfg.meta-data}"
-            hooks-path="${pkgs.buildkite-agent}/share/hooks"
+            hooks-path="${cfg.hooks-path}"
             build-path="/var/lib/buildkite-agent/builds"
             bootstrap-script="${pkgs.buildkite-agent}/share/bootstrap.sh"
             EOF
+
+            chmod +x ${cfg.hooks-path}/* 2>/dev/null || true # Guard against read-only paths.
           '';
 
         serviceConfig =

--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -31,9 +31,10 @@ in
         '';
       };
 
-      hooks-path = mkOption {
+      hooksPath = mkOption {
         type = types.str;
         default = "${pkgs.buildkite-agent}/share/hooks";
+        defaultText = "${pkgs.buildkite-agent}/share/hooks";
         description = ''
           Path to the directory storing the hooks.
         '';
@@ -106,12 +107,10 @@ in
             token="${catOrLiteral cfg.token}"
             name="${cfg.name}"
             meta-data="${cfg.meta-data}"
-            hooks-path="${cfg.hooks-path}"
+            hooks-path="${cfg.hooksPath}"
             build-path="/var/lib/buildkite-agent/builds"
             bootstrap-script="${pkgs.buildkite-agent}/share/bootstrap.sh"
             EOF
-
-            chmod +x ${cfg.hooks-path}/* 2>/dev/null || true # Guard against read-only paths.
           '';
 
         serviceConfig =

--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -32,7 +32,7 @@ in
       };
 
       hooksPath = mkOption {
-        type = types.str;
+        type = types.path;
         default = "${pkgs.buildkite-agent}/share/hooks";
         defaultText = "${pkgs.buildkite-agent}/share/hooks";
         description = ''
@@ -107,7 +107,7 @@ in
             token="${catOrLiteral cfg.token}"
             name="${cfg.name}"
             meta-data="${cfg.meta-data}"
-            hooks-path="${cfg.hooksPath}"
+            hooks-path="${toString cfg.hooksPath}"
             build-path="/var/lib/buildkite-agent/builds"
             bootstrap-script="${pkgs.buildkite-agent}/share/bootstrap.sh"
             EOF


### PR DESCRIPTION
###### Motivation for this change

Allow actually using the agent hooks.  As of now, the directory containing them is hard-configured to point to a fixed location in the Nix store, which is read-only.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

