### PR TITLE
Move pluggy to separate module

### DIFF
--- a/pkgs/development/python-modules/pluggy/default.nix
+++ b/pkgs/development/python-modules/pluggy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest, six, doCheck ? true }:
+{ stdenv, buildPythonPackage, fetchPypi, pytest, six }:
 buildPythonPackage rec {
   pname = "pluggy";
   version = "0.6.0";

--- a/pkgs/development/python-modules/pluggy/default.nix
+++ b/pkgs/development/python-modules/pluggy/default.nix
@@ -2,18 +2,18 @@
 buildPythonPackage rec {
   pname = "pluggy";
   version = "0.6.0";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff";
   };
 
-  checkInputs = stdenv.lib.optionals doCheck [ pytest ];
+  checkInputs = [ pytest ];
 
   checkPhase = ''
     pytest testing/
   '';
+
 
   meta = with stdenv.lib; {
     description = "A minimalist production ready plugin system";

--- a/pkgs/development/python-modules/pluggy/default.nix
+++ b/pkgs/development/python-modules/pluggy/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest, six, doCheck ? true }:
+buildPythonPackage rec {
+  pname = "pluggy";
+  version = "0.6.0";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff";
+  };
+
+  checkInputs = stdenv.lib.optionals doCheck [ pytest ];
+
+  checkPhase = ''
+    pytest testing/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A minimalist production ready plugin system";
+    homepage = "https://pluggy.readthedocs.io/en/latest/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jgeerds ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -230,8 +230,6 @@ in {
 
   intelhex = callPackage ../development/python-modules/intelhex { };
 
-  lmtpd = callPackage ../development/python-modules/lmtpd { };
-
   mpi4py = callPackage ../development/python-modules/mpi4py {
     mpi = pkgs.openmpi;
   };
@@ -345,8 +343,6 @@ in {
   pyzufall = callPackage ../development/python-modules/pyzufall { };
 
   rhpl = disabledIf isPy3k (callPackage ../development/python-modules/rhpl {});
-
-  salmon = callPackage ../development/python-modules/salmon { };
 
   simpleeval = callPackage ../development/python-modules/simpleeval { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -230,6 +230,8 @@ in {
 
   intelhex = callPackage ../development/python-modules/intelhex { };
 
+  lmtpd = callPackage ../development/python-modules/lmtpd { };
+
   mpi4py = callPackage ../development/python-modules/mpi4py {
     mpi = pkgs.openmpi;
   };
@@ -343,6 +345,8 @@ in {
   pyzufall = callPackage ../development/python-modules/pyzufall { };
 
   rhpl = disabledIf isPy3k (callPackage ../development/python-modules/rhpl {});
+
+  salmon = callPackage ../development/python-modules/salmon { };
 
   simpleeval = callPackage ../development/python-modules/simpleeval { };
 
@@ -3589,6 +3593,8 @@ in {
       platforms   = platforms.all;
     };
   };
+
+  pluggy = callPackage ../development/python-modules/pluggy { };
 
   pytest = self.pytest_32;
 
@@ -23084,23 +23090,6 @@ EOF
       homepage = "http://python-otr.pentabarf.de/";
       license = licenses.lgpl3Plus;
       maintainers = with maintainers; [ globin ];
-    };
-  };
-
-  pluggy = buildPythonPackage rec {
-    name = "pluggy-${version}";
-    version = "0.3.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pluggy/${name}.tar.gz";
-      sha256 = "18qfzfm40bgx672lkg8q9x5hdh76n7vax99aank7vh2nw21wg70m";
-    };
-
-    meta = {
-      description = "Plugin and hook calling mechanisms for Python";
-      homepage = "https://pypi.python.org/pypi/pluggy";
-      license = licenses.mit;
-      maintainers = with maintainers; [ jgeerds ];
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

This commit moves pluggy (which was long forgotten) to a separate
module. Pytest introduces pluggy as a dependency. To be able to
react easier to that and to keep it updated more frequently via
`update-python-libraries.sh` it is moved to a separate module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`) (ran an interactive python with the newly built pluggy)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

