### PR TITLE
electron: 1.7.5 -> 1.8.1

### DIFF
--- a/pkgs/development/tools/electron/default.nix
+++ b/pkgs/development/tools/electron/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, libXScrnSaver, makeWrapper, fetchurl, unzip, atomEnv }:
 
 let
-  version = "1.7.5";
+  version = "1.8.1";
   name = "electron-${version}";
 
   meta = with stdenv.lib; {
@@ -9,17 +9,34 @@ let
     homepage = https://github.com/electron/electron;
     license = licenses.mit;
     maintainers = [ maintainers.travisbhartwell ];
-    platforms = [ "x86_64-darwin" "x86_64-linux" ];
+    platforms = [ "x86_64-darwin" "x86_64-linux" "i686-linux" "armv7l-linux" "aarch64-linux" ];
   };
 
   linux = {
     inherit name version meta;
 
-    src = fetchurl {
-      url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-x64.zip";
-      sha256 = "1z1dzk6d2mfyms8lj8g6jn76m52izbd1d7c05k8h88m1syfsgav5";
-      name = "${name}.zip";
-    };
+    src = {
+      i686-linux = fetchurl {
+        url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-ia32.zip";
+        sha256 = "0djqlcs4m9n9354idaqcs4cwskq2m3sf9mzvxpp4wy0a93pk78bw";
+        name = "${name}.zip";
+      };
+      x86_64-linux = fetchurl {
+        url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-x64.zip";
+        sha256 = "0as7bgs050wsc9ywzr7f4i2c9dp1ynddcmiblm2b0hdcvw61k9q2";
+        name = "${name}.zip";
+      };
+      armv7l-linux = fetchurl {
+        url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-armv7l.zip";
+        sha256 = "19x9c12kdr3rj39x4kshv3zi132dpnki7vaqrhadsn23q85n56ig";
+        name = "${name}.zip";
+      };
+      aarch64-linux = fetchurl {
+        url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-arm64.zip";
+        sha256 = "12w1ajj94rqwh4906dzswh3vhs3micn80jvd015qxwss3n4n1lsz";
+        name = "${name}.zip";
+      };
+    }.${stdenv.system};
 
     buildInputs = [ unzip makeWrapper ];
 
@@ -45,18 +62,18 @@ let
 
     src = fetchurl {
       url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-darwin-x64.zip";
-      sha256 = "1d3c3y5j99wbyxlzk1nkry0m1xgxy3mi4a6irvlgyxl729dnwi97";
+      sha256 = "0r0zbiqblwkcrljkljkj7zvfwr078bfgd38lhb1ivbj73fri17ir";
       name = "${name}.zip";
     };
 
     buildInputs = [ unzip ];
 
     buildCommand = ''
-    mkdir -p $out/Applications
-    unzip $src
-    mv Electron.app $out/Applications
-    mkdir -p $out/bin
-    ln -s $out/Applications/Electron.app/Contents/MacOs/Electron $out/bin/electron
+      mkdir -p $out/Applications
+      unzip $src
+      mv Electron.app $out/Applications
+      mkdir -p $out/bin
+      ln -s $out/Applications/Electron.app/Contents/MacOs/Electron $out/bin/electron
     '';
   };
 in


### PR DESCRIPTION
###### Motivation for this change

 - [x] version bump
 - [x] added "i686-linux" "armv7l-linux" "aarch64-linux" (binaries compiled by upstream)
