### PR TITLE
oraclejdk8: fix armv7l hashes

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -4,7 +4,7 @@ import ./jdk-linux-base.nix {
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
   sha256_i686 = "0w1snn9hxwvdnk77frhdzbsm6v30v99dy5zmpy8ij7yxd57z6ql0";
   sha256_x86_64 = "0zq2dxbxmshz080yskhc8y2wbqi0y0kl9girxjbb4rwk837010n7";
-  sha256_armv7l = "10r3nyssx8piyjaspravwgj2bnq4537041pn0lz4fk5b3473kgfb";
+  sha256_armv7l = "0fdkvg1al7g9lqbq10rlw400aqr0xxi2a802319sw5n0zipkrjic";
   sha256_aarch64 = "1xva22cjjpwa95h7x3xzyymn1bgxp1q67j5j304kn6cqah4k31j1";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -4,7 +4,7 @@ import ./jdk-linux-base.nix {
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
   sha256_i686 = "0gjc7kcfx40f43z1w1qsn1fqxdz8d46wml2g11qgm55ishhv2q7w";
   sha256_x86_64 = "1gv1348hrgna9l3sssv3g9jzs37y1lkx05xq83chav9z1hs3p2r1";
-  sha256_armv7l = "10r3nyssx8piyjaspravwgj2bnq4537041pn0lz4fk5b3473kgfb";
+  sha256_armv7l = "1w0hwslsd3z0kvb3z7gmbh20xsyiz73vglmdqz2108y7alim7arm";
   sha256_aarch64 = "13qpxa8nxsnikmm7h6ysnsdqg5vl8j7hzfa8kgh20z8a17fhj9kk";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;


### PR DESCRIPTION
###### Motivation for this change

fix armv7l hashes, they was not updated with version bump https://github.com/nixos/nixpkgs/commit/08075d57e853a6b6ba71e64d4da5295e1c6aed4f