### PR TITLE
arp-scan: 1.9 -> 1.9.5

### DIFF
--- a/pkgs/tools/misc/arp-scan/default.nix
+++ b/pkgs/tools/misc/arp-scan/default.nix
@@ -1,13 +1,17 @@
-{ stdenv, fetchurl, libpcap }:
+{ stdenv, fetchFromGitHub, autoreconfHook, libpcap }:
 
 stdenv.mkDerivation rec {
-  name = "arp-scan-1.9";
+  name = "arp-scan-${version}";
+  version = "1.9.5";
 
-  src = fetchurl {
-    url = "http://www.nta-monitor.com/files/arp-scan/${name}.tar.gz";
-    sha256 = "14nqjzbmnlx2nac7lwa93y5m5iqk3layakyxyvfmvs283k3qm46f";
+  src = fetchFromGitHub {
+    owner = "royhills";
+    repo = "arp-scan";
+    rev = "4de863c2627a05177eda7159692a588f9f520cd1";
+    sha256 = "15zpfdybk2kh98shqs8qqd0f9nyi2ch2wcyv729rfj7yp0hif5mb";
   };
 
+  nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ libpcap ];
 
   meta = with stdenv.lib; {
@@ -19,6 +23,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.nta-monitor.com/wiki/index.php/Arp-scan_Documentation;
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = [ maintainers.bjornfor ];
+    maintainers = with maintainers; [ bjornfor mikoim ];
   };
 }

--- a/pkgs/tools/misc/arp-scan/default.nix
+++ b/pkgs/tools/misc/arp-scan/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, libpcap }:
+{ stdenv, fetchFromGitHub, autoreconfHook, libpcap, makeWrapper, perlPackages }:
 
 stdenv.mkDerivation rec {
   name = "arp-scan-${version}";
@@ -11,8 +11,21 @@ stdenv.mkDerivation rec {
     sha256 = "15zpfdybk2kh98shqs8qqd0f9nyi2ch2wcyv729rfj7yp0hif5mb";
   };
 
+  perlModules = with perlPackages; [
+    HTTPDate
+    HTTPMessage
+    LWPUserAgent
+    URI
+  ];
+
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ libpcap ];
+  buildInputs = [ libpcap makeWrapper ];
+
+  postInstall = ''
+    for name in get-{oui,iab}; do
+      wrapProgram "$out/bin/$name" --set PERL5LIB "${stdenv.lib.makePerlPath perlModules }"
+    done;
+  '';
 
   meta = with stdenv.lib; {
     description = "ARP scanning and fingerprinting tool";


### PR DESCRIPTION
###### Motivation for this change
- Change upstream to GitHub
There is no release in recent years but development is undergoing on GitHub by the original author.
- Add missing dependency
`get-oui` and `get-iab` need some Perl modules, but they are lacked.

cc @bjornfor 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

