### PR TITLE
libdbusmenu: 12.10.12 -> 16.04.0; network-manager-applet: enable appindicator support

### DIFF
--- a/pkgs/development/libraries/libdbusmenu/default.nix
+++ b/pkgs/development/libraries/libdbusmenu/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, lib, file
 , pkgconfig, intltool
 , glib, dbus_glib, json_glib
-, gobjectIntrospection, vala_0_23, gnome_doc_utils
+, gobjectIntrospection, vala_0_38, gnome_doc_utils
 , gtkVersion ? null, gtk2 ? null, gtk3 ? null }:
 
 with lib;
@@ -10,19 +10,19 @@ stdenv.mkDerivation rec {
   name = let postfix = if gtkVersion == null then "glib" else "gtk${gtkVersion}";
           in "libdbusmenu-${postfix}-${version}";
   version = "${versionMajor}.${versionMinor}";
-  versionMajor = "12.10";
-  versionMinor = "2";
+  versionMajor = "16.04";
+  versionMinor = "0";
 
   src = fetchurl {
     url = "${meta.homepage}/${versionMajor}/${version}/+download/libdbusmenu-${version}.tar.gz";
-    sha256 = "9d6ad4a0b918b342ad2ee9230cce8a095eb601cb0cee6ddc1122d0481f9d04c9";
+    sha256 = "12l7z8dhl917iy9h02sxmpclnhkdjryn08r8i4sr8l3lrlm4mk5r";
   };
 
   nativeBuildInputs = [ pkgconfig intltool ];
 
   buildInputs = [
     glib dbus_glib json_glib
-    gobjectIntrospection vala_0_23 gnome_doc_utils
+    gobjectIntrospection vala_0_38 gnome_doc_utils
   ] ++ optional (gtkVersion != null) (if gtkVersion == "2" then gtk2 else gtk3);
 
   postPatch = ''
@@ -49,10 +49,11 @@ stdenv.mkDerivation rec {
   installFlags = [
     "sysconfdir=\${out}/etc"
     "localstatedir=\${TMPDIR}"
+    "typelibdir=\${out}/lib/girepository-1.0"
   ];
 
   meta = {
-    description = "A library for passing menu structures across DBus";
+    description = "Library for passing menu structures across DBus";
     homepage = https://launchpad.net/dbusmenu;
     license = with licenses; [ gpl3 lgpl21 lgpl3 ];
     platforms = platforms.linux;

--- a/pkgs/tools/networking/network-manager-applet/default.nix
+++ b/pkgs/tools/networking/network-manager-applet/default.nix
@@ -2,7 +2,7 @@
 , libnotify, libsecret, polkit, isocodes, modemmanager
 , mobile_broadband_provider_info, glib_networking, gsettings_desktop_schemas
 , udev, libgudev, hicolor_icon_theme, jansson, wrapGAppsHook, webkitgtk
-, withGnome ? false }:
+, libindicator-gtk3, libappindicator-gtk3, withGnome ? false }:
 
 stdenv.mkDerivation rec {
   name    = "${pname}-${major}.${minor}";
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--sysconfdir=/etc"
     "--without-selinux"
+    "--with-appindicator"
   ];
 
   outputs = [ "out" "dev" ];
@@ -26,6 +27,7 @@ stdenv.mkDerivation rec {
     gnome3.gtk libglade networkmanager libnotify libsecret gsettings_desktop_schemas
     polkit isocodes udev libgudev gnome3.libgnome_keyring
     modemmanager jansson glib_networking
+    libindicator-gtk3 libappindicator-gtk3
   ] ++ stdenv.lib.optional withGnome webkitgtk;
 
   nativeBuildInputs = [ intltool pkgconfig wrapGAppsHook ];


### PR DESCRIPTION
###### Motivation for this change

- Updates `libdbusmenu` to 16.04.0
- Enables `appindicator` support in `network-manager-applet`.

Some desktops (like Enlightenment and Pluma) does not support the old `xembed` standard anymore for the notification tray. The `appindicator` interface should be used instead in this cases.

To use it just start the applet with the following command:
```
$ nm-applet --indicator
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).