### PR TITLE
Enh/boost with numpy extension

### DIFF
--- a/pkgs/development/libraries/boost/1.65.nix
+++ b/pkgs/development/libraries/boost/1.65.nix
@@ -9,4 +9,6 @@ callPackage ./generic.nix (args // rec {
     sha256 = "9807a5d16566c57fd74fb522764e0b134a8bbe6b6e8967b83afefd30dcd3be81";
   };
 
+  enableNumpy = true;
+
 })

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -10,7 +10,7 @@
 , enablePIC ? false
 , enableExceptions ? false
 , enablePython ? hostPlatform == buildPlatform
-, enableNumpy ? true
+, enableNumpy ? false
 , taggedLayout ? ((enableRelease && enableDebug) || (enableSingleThreaded && enableMultiThreaded) || (enableShared && enableStatic))
 , patches ? null
 , mpi ? null

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -10,7 +10,7 @@
 , enablePIC ? false
 , enableExceptions ? false
 , enablePython ? hostPlatform == buildPlatform
-, enableNumpy ? false, numpy ? null
+, enableNumpy ? true
 , taggedLayout ? ((enableRelease && enableDebug) || (enableSingleThreaded && enableMultiThreaded) || (enableShared && enableStatic))
 , patches ? null
 , mpi ? null
@@ -156,7 +156,7 @@ stdenv.mkDerivation {
     ++ optional (hostPlatform == buildPlatform) icu
     ++ optional stdenv.isDarwin fixDarwinDylibNames
     ++ optional enablePython python
-    ++ optional enableNumpy numpy;
+    ++ optional enableNumpy python.pkgs.numpy;
 
   configureScript = "./bootstrap.sh";
   configureFlags = commonConfigureFlags


### PR DESCRIPTION
###### Motivation for this change

Build Boost numpy Python by default.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

