### PR TITLE
k2pdfopt: Patch openjpeg version into mupdf as in #31852.

### DIFF
--- a/pkgs/applications/misc/k2pdfopt/load-jpx.patch
+++ b/pkgs/applications/misc/k2pdfopt/load-jpx.patch
@@ -1,0 +1,29 @@
+--- a/source/fitz/load-jpx.c
++++ b/source/fitz/load-jpx.c
+@@ -484,12 +484,16 @@
+ /* Without the definition of OPJ_STATIC, compilation fails on windows
+  * due to the use of __stdcall. We believe it is required on some
+  * linux toolchains too. */
++#ifdef __cplusplus
++extern "C"
++{
+ #define OPJ_STATIC
+ #ifndef _MSC_VER
+ #define OPJ_HAVE_STDINT_H
+ #endif
++#endif
+ 
+-#include <openjpeg.h>
++#include <openjpeg-__OPENJPEG__VERSION__/openjpeg.h>
+ 
+ /* OpenJPEG does not provide a safe mechanism to intercept
+  * allocations. In the latest version all allocations go
+@@ -971,4 +975,8 @@
+ 	fz_drop_pixmap(ctx, img);
+ }
+ 
++#ifdef __cplusplus
++}
++#endif
++
+ #endif /* HAVE_LURATECH */


### PR DESCRIPTION
###### Motivation for this change
k2pdfopt package mupdf for its own use. openjpeg's version bump broke it. See #31852.  At the moment k2pdfopt doesn't build under release-17.09. Please cherry-pick.

(I don't understand why k2pdfopt/default.nix repackages so many libs.)

###### Things done
Adjust patch for load-jpx.c to fit mupdf 1.10a.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

