### PR TITLE
lynis: init at 2.5.7

### DIFF
--- a/pkgs/tools/security/lynis/default.nix
+++ b/pkgs/tools/security/lynis/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, makeWrapper, fetchFromGitHub, gawk, perl }:
+
+stdenv.mkDerivation rec {
+  pname = "lynis";
+  version = "2.5.7";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "CISOfy";
+    repo = "${pname}";
+    rev = "${version}";
+    sha256 = "19rfkiri73bi43i4yxpqrxjzpqn5rfrkq2picja5filjv14hbyly";
+  };
+
+  nativeBuildInputs = [ makeWrapper perl ];
+
+  postPatch = ''
+    grep -rl '/usr/local/lynis' ./ | xargs sed -i "s@/usr/local/lynis@$out/share/lynis@g"
+    # Don't use predefined binary paths. See https://github.com/CISOfy/lynis/issues/468
+    perl -i -p0e 's/BIN_PATHS="[^"]*"/BIN_PATHS=\$\(echo \$PATH\ | sed "s\/:\/ \/g")/sm;' include/consts
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/lynis
+    cp -r include db default.prf $out/share/lynis/
+    mkdir -p $out/bin
+    cp -a lynis $out/bin
+    wrapProgram "$out/bin/lynis" --prefix PATH : ${stdenv.lib.makeBinPath [ gawk ]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Security auditing tool for Linux, macOS, and UNIX-based systems";
+    homepage = "https://cisofy.com/lynis/";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.ryneeverett ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1171,6 +1171,8 @@ with pkgs;
 
   iio-sensor-proxy = callPackage ../os-specific/linux/iio-sensor-proxy { };
 
+  lynis = callPackage ../tools/security/lynis { };
+
   mathics = pythonPackages.mathics;
 
   masscan = callPackage ../tools/security/masscan { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

