### PR TITLE
zilla-slab: init at 1.002

### DIFF
--- a/pkgs/data/fonts/zilla-slab/default.nix
+++ b/pkgs/data/fonts/zilla-slab/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchzip }:
+
+let
+  version = "1.002";
+  hash = "1b1ys28hyjcl4qwbnsyi6527nj01g3d6id9jl23fv6f8fjm4ph0f";
+in fetchzip {
+  name = "zilla-slab-${version}";
+
+  url = "https://github.com/mozilla/zilla-slab/releases/download/v${version}/Zilla-Slab-Fonts-v${version}.zip";
+  postFetch = ''
+    unzip $downloadedFile
+    mkdir -p $out/share/fonts/truetype
+    cp -v zilla-slab/ttf/*.ttf $out/share/fonts/truetype/
+  '';
+  sha256 = hash;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mozilla/zilla-slab;
+    description = "Zilla Slab fonts";
+    longDescription = ''
+      Zilla Slab is Mozilla's core typeface, used
+      for the Mozilla wordmark, headlines and
+      throughout their designs. A contemporary
+      slab serif, based on Typotheque's Tesla, it
+      is constructed with smooth curves and true
+      italics, which gives text an unexpectedly
+      sophisticated industrial look and a friendly
+      approachability in all weights.
+    '';
+    license = licenses.ofl;
+    maintainers = with maintainers; [ caugner ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13751,6 +13751,8 @@ with pkgs;
 
   zeal = libsForQt5.callPackage ../data/documentation/zeal { };
 
+  zilla-slab = callPackage ../data/fonts/zilla-slab { };
+
 
   ### APPLICATIONS
 


### PR DESCRIPTION
###### Motivation for this change

Adds Mozilla's core typeface.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

