### PR TITLE
pandoc2: fix Haskell dependencies

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -509,6 +509,21 @@ self: super: {
     preConfigure = "sed -i -e 's,time .* < 1.6,time >= 1.5,' -e 's,haddock-library >= 1.1 && < 1.3,haddock-library >= 1.1,' pandoc.cabal";
   });
 
+  # pandoc 2 dependency resolution
+  hslua_0_9_2 = super.hslua_0_9_2.override { lua5_1 = pkgs.lua5_3; };
+  hslua-module-text = super.hslua-module-text.override { hslua = self.hslua_0_9_2; };
+  texmath_0_10 = super.texmath_0_10.override { pandoc-types = self.pandoc-types_1_17_3; };
+  pandoc_2_0_4 = super.pandoc_2_0_4.override {
+    doctemplates = self.doctemplates_0_2_1;
+    pandoc-types = self.pandoc-types_1_17_3;
+    skylighting = self.skylighting_0_4_4_1;
+    texmath = self.texmath_0_10;
+  };
+  pandoc-citeproc_0_12_1 = super.pandoc-citeproc_0_12_1.override {
+    pandoc = self.pandoc_2_0_4;
+    pandoc-types = self.pandoc-types_1_17_3;
+  };
+
   # https://github.com/tych0/xcffib/issues/37
   xcffib = dontCheck super.xcffib;
 


### PR DESCRIPTION
`pandoc2` is broken - the dependencies fail to resolve:

```
nix-shell -p haskellPackages.pandoc_2_0_4
...
Configuring hslua-module-text-0.1.2.1...
Setup: Encountered missing dependencies:
hslua ==0.9.*
```

Hopefully this is the right way to fix this


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---