### PR TITLE
git-annex-metadata-gui: init at 0.2.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -51,6 +51,10 @@ rec {
   git-annex = pkgs.haskellPackages.git-annex;
   gitAnnex = git-annex;
 
+  git-annex-metadata-gui = libsForQt5.callPackage ./git-annex-metadata-gui {
+    inherit (python3Packages) buildPythonApplication pyqt5 git-annex-adapter;
+  };
+
   git-annex-remote-b2 = callPackage ./git-annex-remote-b2 { };
 
   git-annex-remote-rclone = callPackage ./git-annex-remote-rclone { };

--- a/pkgs/applications/version-management/git-and-tools/git-annex-metadata-gui/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-annex-metadata-gui/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonApplication, fetchFromGitHub, pyqt5, git-annex-adapter }:
+
+buildPythonApplication rec {
+  name = "git-annex-metadata-gui-${version}";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "alpernebbi";
+    repo = "git-annex-metadata-gui";
+    rev = "v${version}";
+    sha256 = "03kch67k0q9lcs817906g864wwabkn208aiqvbiyqp1qbg99skam";
+  };
+
+  prePatch = ''
+    substituteInPlace setup.py --replace "'PyQt5', " ""
+  '';
+
+  propagatedBuildInputs = [ pyqt5 git-annex-adapter ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/alpernebbi/git-annex-metadata-gui;
+    description = "Graphical interface for git-annex metadata commands";
+    maintainers = with maintainers; [ dotlambda ];
+    license = licenses.gpl3Plus;
+    platforms = with platforms; linux;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

