### PR TITLE
gpredict: init at 1.3

### DIFF
--- a/pkgs/applications/science/astronomy/gpredict/default.nix
+++ b/pkgs/applications/science/astronomy/gpredict/default.nix
@@ -25,7 +25,7 @@ in
         well. Gpredict uses the SGP4/SDP4 algorithms, which are compatible with the
         NORAD Keplerian elements.
       '';
-      license = lincenses.gpl2;
+      license = licenses.gpl2;
       platforms = platforms.linux;
       homepage = "https://sourceforge.net/projects/gpredict/";
       maintainers = maintainers.markuskowa;

--- a/pkgs/applications/science/astronomy/gpredict/default.nix
+++ b/pkgs/applications/science/astronomy/gpredict/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, pkgconfig 
+, gtk2-x11, glib, curl, goocanvas, intltool  
+} : 
+
+let
+  version = "1.3";
+in 
+  stdenv.mkDerivation {
+    name = "gpredict-${version}";
+
+    src = fetchurl {
+      url = "https://sourceforge.net/projects/gpredict/files/Gpredict/${version}/gpredict-${version}.tar.gz";
+      sha256 = "18ym71r2f5mwpnjcnrpwrk3py2f6jlqmj8hzp89wbcm1ipnvxxmh";
+    };
+
+    buildInputs = [ curl glib gtk2-x11 goocanvas intltool ];
+    nativeBuildInputs = [ pkgconfig ];
+
+    meta = with stdenv.lib; {
+      description = "Real time satellite tracking and orbit prediction";
+      longDescription = ''
+	      Gpredict is a real time satellite tracking and orbit prediction program
+        written using the Gtk+ widgets. Gpredict is targetted mainly towards ham radio
+        operators but others interested in satellite tracking may find it useful as
+        well. Gpredict uses the SGP4/SDP4 algorithms, which are compatible with the
+        NORAD Keplerian elements.
+      '';
+      license = lincences.gpl2;
+      platforms = platforms.linux;
+      homepage = "https://sourceforge.net/projects/gpredict/";
+      maintainers = maintainers.markuskowa;
+    };
+  }
+

--- a/pkgs/applications/science/astronomy/gpredict/default.nix
+++ b/pkgs/applications/science/astronomy/gpredict/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pkgconfig 
-, gtk2-x11, glib, curl, goocanvas, intltool  
-}: 
+{ stdenv, fetchurl, pkgconfig
+, gtk2-x11, glib, curl, goocanvas, intltool
+}:
 
 let
   version = "1.3";
@@ -13,8 +13,8 @@ stdenv.mkDerivation {
     sha256 = "18ym71r2f5mwpnjcnrpwrk3py2f6jlqmj8hzp89wbcm1ipnvxxmh";
   };
 
-  buildInputs = [ curl glib gtk2-x11 goocanvas intltool ];
-  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ curl glib gtk2-x11 goocanvas ];
+  nativeBuildInputs = [ pkgconfig intltool ];
 
   meta = with stdenv.lib; {
     description = "Real time satellite tracking and orbit prediction";
@@ -28,7 +28,6 @@ stdenv.mkDerivation {
     license = licenses.gpl2;
     platforms = platforms.linux;
     homepage = "https://sourceforge.net/projects/gpredict/";
-    maintainers = maintainers.markuskowa;
+    maintainers = [ maintainers.markuskowa ];
   };
 }
-

--- a/pkgs/applications/science/astronomy/gpredict/default.nix
+++ b/pkgs/applications/science/astronomy/gpredict/default.nix
@@ -25,7 +25,7 @@ in
         well. Gpredict uses the SGP4/SDP4 algorithms, which are compatible with the
         NORAD Keplerian elements.
       '';
-      license = lincences.gpl2;
+      license = lincenses.gpl2;
       platforms = platforms.linux;
       homepage = "https://sourceforge.net/projects/gpredict/";
       maintainers = maintainers.markuskowa;

--- a/pkgs/applications/science/astronomy/gpredict/default.nix
+++ b/pkgs/applications/science/astronomy/gpredict/default.nix
@@ -1,34 +1,34 @@
 { stdenv, fetchurl, pkgconfig 
 , gtk2-x11, glib, curl, goocanvas, intltool  
-} : 
+}: 
 
 let
   version = "1.3";
-in 
-  stdenv.mkDerivation {
-    name = "gpredict-${version}";
+in
+stdenv.mkDerivation {
+  name = "gpredict-${version}";
 
-    src = fetchurl {
-      url = "https://sourceforge.net/projects/gpredict/files/Gpredict/${version}/gpredict-${version}.tar.gz";
-      sha256 = "18ym71r2f5mwpnjcnrpwrk3py2f6jlqmj8hzp89wbcm1ipnvxxmh";
-    };
+  src = fetchurl {
+    url = "https://sourceforge.net/projects/gpredict/files/Gpredict/${version}/gpredict-${version}.tar.gz";
+    sha256 = "18ym71r2f5mwpnjcnrpwrk3py2f6jlqmj8hzp89wbcm1ipnvxxmh";
+  };
 
-    buildInputs = [ curl glib gtk2-x11 goocanvas intltool ];
-    nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ curl glib gtk2-x11 goocanvas intltool ];
+  nativeBuildInputs = [ pkgconfig ];
 
-    meta = with stdenv.lib; {
-      description = "Real time satellite tracking and orbit prediction";
-      longDescription = ''
-	      Gpredict is a real time satellite tracking and orbit prediction program
-        written using the Gtk+ widgets. Gpredict is targetted mainly towards ham radio
-        operators but others interested in satellite tracking may find it useful as
-        well. Gpredict uses the SGP4/SDP4 algorithms, which are compatible with the
-        NORAD Keplerian elements.
-      '';
-      license = licenses.gpl2;
-      platforms = platforms.linux;
-      homepage = "https://sourceforge.net/projects/gpredict/";
-      maintainers = maintainers.markuskowa;
-    };
-  }
+  meta = with stdenv.lib; {
+    description = "Real time satellite tracking and orbit prediction";
+    longDescription = ''
+      Gpredict is a real time satellite tracking and orbit prediction program
+      written using the Gtk+ widgets. Gpredict is targetted mainly towards ham radio
+      operators but others interested in satellite tracking may find it useful as
+      well. Gpredict uses the SGP4/SDP4 algorithms, which are compatible with the
+      NORAD Keplerian elements.
+    '';
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    homepage = "https://sourceforge.net/projects/gpredict/";
+    maintainers = maintainers.markuskowa;
+  };
+}
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2391,6 +2391,8 @@ with pkgs;
 
   gpodder = callPackage ../applications/audio/gpodder { };
 
+  gpredict = callPackage ../applications/science/astronomy/gpredict { };
+
   gptfdisk = callPackage ../tools/system/gptfdisk { };
 
   grafx2 = callPackage ../applications/graphics/grafx2 {};


### PR DESCRIPTION
###### Motivation for this change
Gpredict is program for tracking satellites (with GTK graphical user interface).

###### Things done
GUI tested on x86_64-linux
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

