### PR TITLE
pytorch-0.3 with cuda and cudnn

### DIFF
--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -1,27 +1,34 @@
-{ buildPythonPackage, fetchFromGitHub, lib, numpy, pyyaml, cffi, cmake,
-  git, stdenv }:
+{ buildPythonPackage,
+  cudaSupport ? false, cudatoolkit ? null, cudnn ? null,
+  fetchFromGitHub, lib, numpy, pyyaml, cffi, cmake,
+  git, stdenv,
+  utillinux, which }:
+
+assert cudnn == null || cudatoolkit != null;
+assert !cudaSupport || cudatoolkit != null;
 
 buildPythonPackage rec {
-  version = "0.2.0";
+  version = "0.3.0";
   pname = "pytorch";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner  = "pytorch";
     repo   = "pytorch";
-    rev    = "v${version}";
-    sha256 = "1s3f46ga1f4lfrcj3lpvvhgkdr1pi8i2hjd9xj9qiz3a9vh2sj4n";
+    rev    = "af3964a8725236c78ce969b827fdeee1c5c54110";
+    fetchSubmodules = true;
+    sha256 = "0zbndardq3fpvxfa9qamkms0x7kxla4657lccrpyymydn97n888a";
   };
 
-  checkPhase = ''
-    ${stdenv.shell} test/run_test.sh
-  '';
+  preConfigure = lib.optionalString (cudnn != null) "export CUDNN_INCLUDE_DIR=${cudnn}/include";
 
   buildInputs = [
      cmake
      git
      numpy.blas
-  ];
+     utillinux
+     which
+  ] ++ lib.optionals cudaSupport [cudatoolkit cudnn];
 
   propagatedBuildInputs = [
     cffi
@@ -29,9 +36,11 @@ buildPythonPackage rec {
     pyyaml
   ];
 
-  preConfigure = ''
-    export NO_CUDA=1
+  checkPhase = ''
+    ${stdenv.shell} test/run_test.sh
   '';
+
+  doCheck = false; # for some unknown reason doesn't detect cuda if run from builder user
 
   meta = {
     description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration.";

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     ${stdenv.shell} test/run_test.sh
   '';
 
-  doCheck = false; # for some unknown reason doesn't detect cuda if run from builder user
+  doCheck = !cudaSupport; # for some unknown reason doesn't detect cuda if run from builder user
 
   meta = {
     description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration.";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8469,7 +8469,17 @@ in {
     };
   };
 
-  pytorch = callPackage ../development/python-modules/pytorch { };
+  pytorch = callPackage ../development/python-modules/pytorch {
+    cudaSupport = pkgs.config.cudaSupport or false;
+  };
+
+  pytorchWithCuda = self.pytorch.override {
+    cudaSupport = true;
+  };
+
+  pytorchWithoutCuda = self.pytorch.override {
+    cudaSupport = false;
+  };
 
   python2-pythondialog = buildPythonPackage rec {
     name = "python2-pythondialog-${version}";


### PR DESCRIPTION
###### Motivation for this change
Currently pytorch derivation lacks cuda support. After introducing cudatoolkit9 supporting gcc6 it became easy to add cuda-related flags.

###### Notes
Unfortunately cuda-enabled pytorch tests fail to detect driver if run by nix builder. Still they can be run manually after package installation. Just run unpackPhase and execute the script.
  
Had to provide a fixed commit fix hash for revision, without it getFetchFromGithub doesn't download required submodules.
