### PR TITLE
awscli: 1.11.185 -> 1.14.6

### DIFF
--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -12,11 +12,11 @@
 buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "botocore";
-  version = "1.7.43";
+  version = "1.8.10";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0wyyj7sk7dh9v7i1g5jc5maqdadvbs4khi7srz0095cywkjqpysc";
+    sha256 = "16dznd0mxxs8imsl228vx5s9bz9v7ggajs496jy21n5a19cadkch";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/s3transfer/default.nix
+++ b/pkgs/development/python-modules/s3transfer/default.nix
@@ -14,11 +14,11 @@
 
 buildPythonPackage rec {
   pname = "s3transfer";
-  version = "0.1.11";
+  version = "0.1.12";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0yfrfnf404cxzn3iswibqjxklsl0b1lwgqiml6pwiqj79a7zbwbn";
+    sha256 = "07hjj1cy62sc3rh5lhna9mhylp7h7aak4v6mf6809q4nc8j1p28h";
   };
 
   foo = 1;

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -27,12 +27,12 @@ let
 in buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "awscli";
-  version = "1.11.185";
+  version = "1.14.6";
   namePrefix = "";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "18rskl6sla456z4hkq2gmmm03fqc4rqw5pfiqdyc7a2v9kljv4ah";
+    sha256 = "1lhv8vb3bkjfjg4jm3hgfjssxgqy50gb6vbkh4lxiy8cn3y2dxp1";
   };
 
   # No tests included

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1993,13 +1993,13 @@ in {
 
   boto3 = buildPythonPackage rec {
     name = "boto3-${version}";
-    version = "1.4.7";
+    version = "1.4.8";
 
     src = pkgs.fetchFromGitHub {
       owner = "boto";
       repo  = "boto3";
       rev   = version;
-      sha256 = "0ca08xkkx6py08gqgn1aci9pklidwivxbvpwjv7623jr21avakdi";
+      sha256 = "11ysd7a9l5y98q7b7az56phsj2m7w90abf4jabwrknp2c43sq9bi";
     };
 
     propagatedBuildInputs = [ self.botocore self.jmespath self.s3transfer ] ++


### PR DESCRIPTION
###### Motivation for this change

Stay up to date with upstream.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

