### PR TITLE
scalafmt: 0.6.8 -> 1.3.0

### DIFF
--- a/pkgs/development/tools/scalafmt/default.nix
+++ b/pkgs/development/tools/scalafmt/default.nix
@@ -1,29 +1,36 @@
-{ stdenv, fetchurl, unzip, jre }:
+{ stdenv, jdk, jre, coursier, makeWrapper }:
 
-stdenv.mkDerivation rec {
-  version = "0.6.8";
+let
   baseName = "scalafmt";
+  version = "1.3.0";
+  deps = stdenv.mkDerivation {
+    name = "${baseName}-${version}-deps";
+    buildCommand = ''
+      export COURSIER_CACHE=$(pwd)
+      mkdir -p $out/share/java
+      cp $(${coursier}/bin/coursier fetch com.geirsson:scalafmt-cli_2.12:${version}) $out/share/java/
+    '';
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash     = "0q1vw6drpdrfifbm3266igpml0phdk6pl0gd3b5amysigx83m251";
+  };
+in
+stdenv.mkDerivation rec {
   name = "${baseName}-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/scalameta/scalafmt/releases/download/v${version}/${baseName}.tar.gz";
-    sha256 = "1iaanrxk5lhxx1zj9gbxzgqbnyy1azfrab984mga7di5z1hs02s2";
-  };
+  buildInputs = [ jdk makeWrapper deps ];
 
-  unpackPhase = "tar xvzf $src";
+  doCheck = true;
+
+  phases = [ "installPhase" "checkPhase" ];
 
   installPhase = ''
-    mkdir -p "$out/bin"
-    mkdir -p "$out/lib"
+    makeWrapper ${jre}/bin/java $out/bin/${baseName} \
+      --add-flags "-cp $CLASSPATH org.scalafmt.cli.Cli"
+  '';
 
-    cp cli/target/scala-2.11/scalafmt.jar "$out/lib/${name}.jar"
-
-    cat > "$out/bin/${baseName}" << EOF
-    #!${stdenv.shell}
-    exec ${jre}/bin/java -jar "$out/lib/${name}.jar" "\$@"
-    EOF
-
-    chmod a+x "$out/bin/${baseName}"
+  checkPhase = ''
+    $out/bin/${baseName} --version | grep -q "${version}"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Scalafmt does no longer (already pretty long :D) package a fat-jar, which required a larger change to fetch all `jar` dependencies via nix, before we could use the newer versions.

I finally came around to creating a script that automates the creation of a file `support.nix` which lists all of them and fetches them using `fetchMavenArtifact`: https://gist.github.com/markus1189/e48f8bbaa63b1272d39d74c498116003.

With that I updated the the build to version 1.3.0.

Question: I saw that it should be enough to add the `fetchMavenArtifact` results to the buildInputs, but it seems like they never got added to the `CLASSPATH` (as tested via `echo $CLASSPATH` inside the builder).  That's why I added them manually in the `makeWrapper`, but if there is an easier way let me know.

/cc @olafurpg FYI :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
### 24 Pull Requests (https://24pullrequests.com) ###
![https://24pullrequests.com](https://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png
)

