### PR TITLE
Erlang CVE-2017-1000385 erlangR{18,19,20}

### DIFF
--- a/pkgs/development/interpreters/erlang/R18.nix
+++ b/pkgs/development/interpreters/erlang/R18.nix
@@ -12,8 +12,8 @@ let
   };
 
 in mkDerivation rec {
-  version = "18.3.4.4";
-  sha256 = "0wilm21yi9m3v6j26vc04hsa58cxca5z4q9yxx71hm81cbm1xbwk";
+  version = "18.3.4.7";
+  sha256 = "1l66vzbb1vidrmf6gr84l34kgrpb9k7z2170bac4c6aviah9r02l";
 
   patches = [
     rmAndPwdPatch

--- a/pkgs/development/interpreters/erlang/R19.nix
+++ b/pkgs/development/interpreters/erlang/R19.nix
@@ -1,8 +1,8 @@
 { mkDerivation, fetchurl, fetchpatch }:
 
 mkDerivation rec {
-  version = "19.3";
-  sha256 = "0pp2hl8jf4iafpnsmf0q7jbm313daqzif6ajqcmjyl87m5pssr86";
+  version = "19.3.6.4";
+  sha256 = "1w0h3wj2h58m3jrfgw56xab2352na3i9ccrbpfs4420dn7igf071";
 
   patches = [
     # macOS 10.13 crypto fix from OTP-20.1.2

--- a/pkgs/development/interpreters/erlang/R20.nix
+++ b/pkgs/development/interpreters/erlang/R20.nix
@@ -1,8 +1,8 @@
 { mkDerivation, fetchurl }:
 
 mkDerivation rec {
-  version = "20.1";
-  sha256 = "13f53lzgq2himg9kax41f66rzv5pjfrb1ln8b54yv9spkqx2hqqi";
+  version = "20.1.7";
+  sha256 = "0sbxl10d76bm7awxb9s07l9815jiwfg78bps07xj2ircxdr08pls";
 
   prePatch = ''
     substituteInPlace configure.in --replace '`sw_vers -productVersion`' '10.10'

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -14,8 +14,6 @@ rec {
     erlang_nox = erlangR19_nox;
 
     # These are standard Erlang versions, using the generic builder.
-    erlangR16 = lib.callErlang ../development/interpreters/erlang/R16.nix {};
-    erlangR16_odbc = erlangR16.override { odbcSupport = true; };
     erlangR17 = lib.callErlang ../development/interpreters/erlang/R17.nix {};
     erlangR17_odbc = erlangR17.override { odbcSupport = true; };
     erlangR17_javac = erlangR17.override { javacSupport = true; };
@@ -75,7 +73,6 @@ rec {
 
     # Packages built with default Erlang version.
     erlang = packagesWith interpreters.erlang;
-    erlangR16 = packagesWith interpreters.erlangR16;
     erlangR17 = packagesWith interpreters.erlangR17;
     erlangR18 = packagesWith interpreters.erlangR18;
     erlangR19 = packagesWith interpreters.erlangR19;


### PR DESCRIPTION
###### Motivation for this change

Closing  CVE-2017-1000385 in erlangR{18,19,20}.

We are also carrying versions of R16, R16-basho & R17 around that are no longer receiving any kinds of updates as far as I can tell.

It should be considered to remove those or at least mark them as unsupported (`meta.broken = true`, …).

CC maintainers: @the-kenny @sjmackenzie @couchemar @gleber 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

