### PR TITLE
recoll: 1.23.1 -> 1.23.5

### DIFF
--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -7,12 +7,12 @@
 assert stdenv.system != "powerpc-linux";
 
 stdenv.mkDerivation rec {
-  ver = "1.23.1";
+  ver = "1.23.5";
   name = "recoll-${ver}";
 
   src = fetchurl {
     url = "http://www.lesbonscomptes.com/recoll/${name}.tar.gz";
-    sha256 = "0si407qm47ndy0l6zv57lqb5za4aiv0lyghnzb211g03szjkfpg8";
+    sha256 = "0ps7ckrv63ydviqkqxs57hn04z53s2jnjnp94n1prs63xx0njswv";
   };
 
   configureFlags = [ "--with-inotify" ];


### PR DESCRIPTION
###### Motivation for this change

1.23.5 is recquired for the firefox webexstension, enabling full text web history search.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

