### PR TITLE
pinta: FIX unhandled glib-sharp load exception

### DIFF
--- a/pkgs/applications/graphics/pinta/default.nix
+++ b/pkgs/applications/graphics/pinta/default.nix
@@ -56,9 +56,9 @@ buildDotnetPackage rec {
     '';
 
   makeWrapperArgs = [
-    ''--prefix MONO_GAC_PREFIX ':' "${gtksharp}"''
-    ''--prefix LD_LIBRARY_PATH ':' "${gtksharp}/lib"''
-    ''--prefix LD_LIBRARY_PATH ':' "${gtksharp.gtk.out}/lib"''
+    ''--prefix MONO_GAC_PREFIX : ${gtksharp}''
+    ''--prefix LD_LIBRARY_PATH : ${gtksharp}/lib''
+    ''--prefix LD_LIBRARY_PATH : ${gtksharp.gtk.out}/lib''
   ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

running pinta after https://github.com/NixOS/nixpkgs/pull/31497
results in:

```
Unhandled Exception:
System.IO.FileNotFoundException: Could not load file or assembly 'glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f' or one of its dependencies.
File name: 'glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f'
[ERROR] FATAL UNHANDLED EXCEPTION: System.IO.FileNotFoundException: Could not load file or assembly 'glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f' or one of its dependencies.
File name: 'glib-sharp, Version=2.12.0.0, Culture=neutral,
PublicKeyToken=35e10195dab3c99f'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

