### PR TITLE
pythonPackages.django_hijack_admin: init at 2.1.5

### DIFF
--- a/pkgs/development/python-modules/django-hijack-admin/default.nix
+++ b/pkgs/development/python-modules/django-hijack-admin/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, python,
+  django_hijack, django_nose }:
+buildPythonPackage rec {
+  pname = "django-hijack-admin";
+  version = "2.1.5";
+  name = "${pname}-${version}";
+
+  # the pypi packages don't include everything required for the tests
+  src = fetchFromGitHub {
+    owner = "arteria";
+    repo = "django-hijack-admin";
+    rev = "v${version}";
+    sha256 = "02j75blvkjiz5mv5wc4jxl27rgmjsrl6l67a3p8342jwazzsm6jg";
+  };
+
+  checkInputs = [ django_nose ];
+  propagatedBuildInputs = [ django_hijack ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} runtests.py hijack_admin
+    runHook postCheck
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Admin integration for django-hijack";
+    homepage = https://github.com/arteria/django-hijack;
+    license = licenses.mit;
+    maintainers = with maintainers; [ lsix ];
+  };
+}

--- a/pkgs/development/python-modules/django-hijack/default.nix
+++ b/pkgs/development/python-modules/django-hijack/default.nix
@@ -3,7 +3,7 @@
 }:
 buildPythonPackage rec {
   pname = "django-hijack";
-  version = "2.1.4";
+  version = "2.1.5";
   name = pname + "-" + version;
 
   # the pypi packages don't include everything required for the tests
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     owner = "arteria";
     repo = "django-hijack";
     rev = "v${version}";
-    sha256 = "1wbm6l8mzpkj4wsj4fyfamzpzi3day2v1cva5j89v4dn4403jq21";
+    sha256 = "1paiyxhc034336xcd9yzf3azpsapsv26j7w2baxiby71z2hhg0sj";
   };
 
   checkInputs = [ django_nose ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7803,6 +7803,8 @@ in {
   # See the Nixpkgs manual for examples on how to override the package set.
   django_hijack = callPackage ../development/python-modules/django-hijack { };
 
+  django_hijack_admin = callPackage ../development/python-modules/django-hijack-admin { };
+
   django_nose = buildPythonPackage rec {
     name = "django-nose-${version}";
     version = "1.4.4";


### PR DESCRIPTION
If there is no objection, I’d like to backport those 2 commits to `release-17.09`.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

