### PR TITLE
vncdo: init at 0.11.2

### DIFF
--- a/pkgs/tools/admin/vncdo/default.nix
+++ b/pkgs/tools/admin/vncdo/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub
+, pythonPackages
+}:
+pythonPackages.buildPythonPackage rec {
+  pname = "vncdo";
+  version = "0.11.2";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "sibson";
+    repo = "vncdotool";
+    rev = "5c03a82dcb5a3bd9e8f741f8a8d0c1ce082f2834";
+    sha256 = "0k03b09ipsz8vp362x7sx7z68mxgqw9qzvkii2f8j9vx2y79rjsh";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [
+    pillow
+    twisted
+    pexpect
+    nose
+    ptyprocess
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/sibson/vncdotool;
+    description = "A command line VNC client and python library";
+    license = licenses.mit;
+    maintainers = with maintainers; [ elitak ];
+    platforms = with platforms; linux ++ darwin;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5139,6 +5139,8 @@ with pkgs;
 
   vmtouch = callPackage ../tools/misc/vmtouch { };
 
+  vncdo = callPackage ../tools/admin/vncdo { };
+
   volumeicon = callPackage ../tools/audio/volumeicon { };
 
   waf = callPackage ../development/tools/build-managers/waf { };


### PR DESCRIPTION
###### Motivation for this change
Useful utility.

###### Things done
Built and ran.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

