### PR TITLE
fluidsynth: 1.1.6 -> 1.1.8

### DIFF
--- a/pkgs/applications/audio/fluidsynth/default.nix
+++ b/pkgs/applications/audio/fluidsynth/default.nix
@@ -1,34 +1,31 @@
-{ stdenv, fetchurl, alsaLib, glib, libjack2, libsndfile, pkgconfig
-, libpulseaudio, CoreServices, CoreAudio, AudioUnit }:
+{ stdenv, lib, fetchFromGitHub, pkgconfig, cmake
+, alsaLib, glib, libjack2, libsndfile, libpulseaudio
+, AudioUnit, CoreAudio, CoreMIDI, CoreServices
+}:
 
 stdenv.mkDerivation  rec {
   name = "fluidsynth-${version}";
-  version = "1.1.6";
+  version = "1.1.8";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/fluidsynth/${name}.tar.bz2";
-    sha256 = "00gn93bx4cz9bfwf3a8xyj2by7w23nca4zxf09ll53kzpzglg2yj";
+  src = fetchFromGitHub {
+    owner = "FluidSynth";
+    repo = "fluidsynth";
+    rev = "v${version}";
+    sha256 = "12q7hv0zvgylsdj1ipssv5zr7ap2y410dxsd63dz22y05fa2hwwd";
   };
 
-  preBuild = stdenv.lib.optionalString stdenv.isDarwin ''
-    sed -i '40 i\
-    #include <CoreAudio/AudioHardware.h>\
-    #include <CoreAudio/AudioHardwareDeprecated.h>' \
-    src/drivers/fluid_coreaudio.c
-  '';
+  nativeBuildInputs = [ pkgconfig cmake ];
 
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin
-    "-framework CoreAudio -framework CoreServices";
-
-  nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ glib libsndfile ]
-    ++ stdenv.lib.optionals (!stdenv.isDarwin) [ alsaLib libpulseaudio libjack2 ]
-    ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices CoreAudio AudioUnit ];
+    ++ lib.optionals (!stdenv.isDarwin) [ alsaLib libpulseaudio libjack2 ]
+    ++ lib.optionals stdenv.isDarwin [ AudioUnit CoreAudio CoreMIDI CoreServices ];
 
-  meta = with stdenv.lib; {
+  cmakeFlags = lib.optional stdenv.isDarwin "-Denable-framework=off";
+
+  meta = with lib; {
     description = "Real-time software synthesizer based on the SoundFont 2 specifications";
     homepage    = http://www.fluidsynth.org;
-    license     = licenses.lgpl2;
+    license     = licenses.lgpl21Plus;
     maintainers = with maintainers; [ goibhniu lovek323 ];
     platforms   = platforms.unix;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14677,7 +14677,7 @@ with pkgs;
   fldigi = callPackage ../applications/audio/fldigi { };
 
   fluidsynth = callPackage ../applications/audio/fluidsynth {
-     inherit (darwin.apple_sdk.frameworks) CoreServices CoreAudio AudioUnit;
+     inherit (darwin.apple_sdk.frameworks) AudioUnit CoreAudio CoreMIDI CoreServices;
   };
 
   fmit = libsForQt5.callPackage ../applications/audio/fmit { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

