### PR TITLE
ladspa-sdk: change back mirror to original site

### DIFF
--- a/pkgs/applications/audio/ladspa-sdk/default.nix
+++ b/pkgs/applications/audio/ladspa-sdk/default.nix
@@ -3,7 +3,7 @@ stdenv.mkDerivation rec {
   name = "ladspa-sdk-${version}";
   version = "1.13";
   src = fetchurl {
-    url = "http://http.debian.net/debian/pool/main/l/ladspa-sdk/ladspa-sdk_${version}.orig.tar.gz";
+    url = "http://www.ladspa.org/download/ladspa_sdk_${version}.tgz";
     sha256 = "0srh5n2l63354bc0srcrv58rzjkn4gv8qjqzg8dnq3rs4m7kzvdm";
   };
 

--- a/pkgs/applications/audio/ladspa-sdk/ladspah.nix
+++ b/pkgs/applications/audio/ladspa-sdk/ladspah.nix
@@ -3,7 +3,7 @@ stdenv.mkDerivation rec {
   name = "ladspa.h-${version}";
   version = "1.13";
   src = fetchurl {
-    url = "http://http.debian.net/debian/pool/main/l/ladspa-sdk/ladspa-sdk_${version}.orig.tar.gz";
+    url = "http://www.ladspa.org/download/ladspa_sdk_${version}.tgz";
     sha256 = "0srh5n2l63354bc0srcrv58rzjkn4gv8qjqzg8dnq3rs4m7kzvdm";
   };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

