### PR TITLE
ocamlPackages.ulex: 1.1 -> 1.2

### DIFF
--- a/pkgs/development/ocaml-modules/ulex/default.nix
+++ b/pkgs/development/ocaml-modules/ulex/default.nix
@@ -1,16 +1,26 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, camlp4 }:
+{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, camlp4 }:
 
 let
   pname = "ulex";
+  param =
+    if stdenv.lib.versionAtLeast ocaml.version "4.02" then {
+      version = "1.2";
+      sha256 = "08yf2x9a52l2y4savjqfjd2xy4pjd1rpla2ylrr9qrz1drpfw4ic";
+    } else {
+      version = "1.1";
+      sha256 = "0cmscxcmcxhlshh4jd0lzw5ffzns12x3bj7h27smbc8waxkwffhl";
+    };
 in
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
-  version = "1.1";
+  name = "ocaml${ocaml.version}-${pname}-${version}";
+  inherit (param) version;
 
-  src = fetchurl {
-    url = "http://www.cduce.org/download/${pname}-${version}.tar.gz";
-    sha256 = "0fjlkwps14adfgxdrbb4yg65fhyimplvjjs1xqj5np197cig67x0";
+  src = fetchFromGitHub {
+    owner = "whitequark";
+    repo = pname;
+    rev = "v${version}";
+    inherit (param) sha256;
   };
 
   createFindlibDestdir = true;
@@ -21,7 +31,7 @@ stdenv.mkDerivation rec {
   buildFlags = "all all.opt";
 
   meta = {
-    homepage = http://www.cduce.org/download.html;
+    inherit (src.meta) homepage;
     description = "A lexer generator for Unicode and OCaml";
     license = stdenv.lib.licenses.mit;
     platforms = ocaml.meta.platforms or [];


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

