### PR TITLE
puredata: 0.47-1 -> 0.48-0

### DIFF
--- a/pkgs/applications/audio/puredata/default.nix
+++ b/pkgs/applications/audio/puredata/default.nix
@@ -1,29 +1,30 @@
 { stdenv, fetchurl, autoreconfHook, gettext, makeWrapper
-, alsaLib, libjack2, tk
+, alsaLib, libjack2, tk, fftw
 }:
 
 stdenv.mkDerivation  rec {
   name = "puredata-${version}";
-  version = "0.47-1";
+  version = "0.48-0";
 
   src = fetchurl {
     url = "http://msp.ucsd.edu/Software/pd-${version}.src.tar.gz";
-    sha256 = "0k5s949kqd7yw97h3m8z81bjz32bis9m4ih8df1z0ymipnafca67";
+    sha256 = "0wy9kl2v00fl27x4mfzhbca415hpaisp6ls8a6mkl01qbw20krny";
   };
-
-  patchPhase = ''
-    rm portaudio/configure.in
-  '';
 
   nativeBuildInputs = [ autoreconfHook gettext makeWrapper ];
 
-  buildInputs = [ alsaLib libjack2 ];
+  buildInputs = [ alsaLib libjack2 fftw ];
 
   configureFlags = ''
     --enable-alsa
     --enable-jack
+    --enable-fftw
     --disable-portaudio
+
   '';
+
+  # https://github.com/pure-data/pure-data/issues/188
+  # --disable-oss
 
   postInstall = ''
     wrapProgram $out/bin/pd --prefix PATH : ${tk}/bin


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

