### PR TITLE
faac: 1.29.3 -> 1.29.9.2

### DIFF
--- a/pkgs/development/libraries/faac/default.nix
+++ b/pkgs/development/libraries/faac/default.nix
@@ -8,11 +8,11 @@ assert mp4v2Support -> (mp4v2 != null);
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "faac-${version}";
-  version = "1.29.3";
+  version = "1.29.9.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/faac/${name}.tar.gz";
-    sha256 = "0gssrz2vq52mj8x2hvdqc9bwkp64s4f4g7yj7ac6dwxs8dw8kwnf";
+    sha256 = "0wf781vp7rzmxkx5h0w8j2i4xc63iixxikgbvvkdljbwhffj0pyl";
   };
 
   configureFlags = [ ]
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ]
     ++ optional mp4v2Support mp4v2;
+
+  enableParallelBuilding = true;
 
   meta = {
     description = "Open source MPEG-4 and MPEG-2 AAC encoder";

--- a/pkgs/development/libraries/mp4v2/default.nix
+++ b/pkgs/development/libraries/mp4v2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, lib, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "mp4v2-2.0.0";
@@ -18,10 +18,12 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
+  enableParallelBuilding = true;
+
   meta = {
     homepage = https://code.google.com/archive/p/mp4v2/;
     maintainers = [ ];
-    platforms = stdenv.lib.platforms.linux;
-    license = stdenv.lib.licenses.mpl11;
+    platforms = lib.platforms.unix;
+    license = lib.licenses.mpl11;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

