### PR TITLE
dmd, ldc, dub: Inherit buildInput and meta from build derivation

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -278,10 +278,12 @@ stdenv.mkDerivation rec {
   inherit phobosUnittests;
   name = "dmd-${version}";
   phases = "installPhase";
+  buildInputs = dmdBuild.buildInputs;
 
   installPhase = ''
     mkdir $out
     cp -r --symbolic-link ${dmdBuild}/* $out/
   '';
+  meta = dmdBuild.meta;
 }
 

--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -249,10 +249,13 @@ stdenv.mkDerivation rec {
   inherit ldcUnittests;
   name = "ldc-${version}";
   phases = "installPhase";
+  buildInputs = ldcBuild.buildInputs;
 
   installPhase = ''
     mkdir $out
     cp -r --symbolic-link ${ldcBuild}/* $out/
   '';
+
+  meta = ldcBuild.meta;
 }
 

--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -87,10 +87,13 @@ stdenv.mkDerivation rec {
   inherit dubUnittests;
   name = "dub-${dubBuild.version}";
   phases = "installPhase";
+  buildInputs = dubBuild.buildInputs;
 
   installPhase = ''
     mkdir $out
     cp -r --symbolic-link ${dubBuild}/* $out/
   '';
+
+  meta = dubBuild.meta;
 }
 


### PR DESCRIPTION
###### Motivation for this change

I think the builds on hydra for dmd, ldc and dub are not working on darwin anymore because of missing meta platforms information.
So I added that and also thought the buildInput needed to be inherited too because the packages should come with those dependencies when installed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

