### PR TITLE
linuxsampler: svn-2340 -> 2.1.0

### DIFF
--- a/pkgs/applications/audio/linuxsampler/default.nix
+++ b/pkgs/applications/audio/linuxsampler/default.nix
@@ -1,30 +1,29 @@
-{ stdenv, fetchsvn, alsaLib, asio, autoconf, automake, bison
-, libjack2, libgig, libsndfile, libtool, lv2, pkgconfig }:
+{ stdenv, fetchurl, alsaLib, asio, autoconf, automake, bison
+, libjack2, libgig, libsndfile, libtool, lv2, pkgconfig, liblscp }:
 
 stdenv.mkDerivation rec {
-  name = "linuxsampler-svn-${version}";
-  version = "2340";
+  name = "linuxsampler-${version}";
+  version = "2.1.0";
 
-  src = fetchsvn {
-    url = "https://svn.linuxsampler.org/svn/linuxsampler/trunk";
-    rev = "${version}";
-    sha256 = "0zsrvs9dwwhjx733m45vfi11yjkqv33z8qxn2i9qriq5zs1f0kd7";
+  src = fetchurl {
+    url = "https://download.linuxsampler.org/packages/${name}.tar.bz2";
+    sha256 = "0fdxpw7jjfi058l95131d6d8538h05z7n94l60i6mhp9xbplj2jf";
   };
 
-  patches = ./linuxsampler_lv2_sfz_fix.diff;
+  # patches = ./linuxsampler_lv2_sfz_fix.diff;
 
   # It fails to compile without this option. I'm not sure what the bug
   # is, but everything works OK for me (goibhniu).
-  configureFlags = [ "--disable-nptl-bug-check" ];
+  # configureFlags = [ "--disable-nptl-bug-check" ];
 
   preConfigure = ''
-    sed -e 's/which/type -P/g' -i scripts/generate_parser.sh
-    make -f Makefile.cvs
+    # sed -e 's/which/type -P/g' -i scripts/generate_parser.sh
+    make -f Makefile.svn
   '';
 
-  buildInputs = [ 
+  buildInputs = [
    alsaLib asio autoconf automake bison libjack2 libgig libsndfile
-   libtool lv2 pkgconfig
+   libtool lv2 pkgconfig liblscp
   ];
 
   meta = with stdenv.lib; {
@@ -40,7 +39,7 @@ stdenv.mkDerivation rec {
       prior written permission by the LinuxSampler authors. If you
       have questions on the subject, that are not yet covered by the
       FAQ, please contact us.
-    ''; 
+    '';
     license = licenses.unfree;
     maintainers = [ maintainers.goibhniu ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libgig/default.nix
+++ b/pkgs/development/libraries/libgig/default.nix
@@ -1,13 +1,12 @@
-{ stdenv, fetchsvn, autoconf, automake, libsndfile, libtool, pkgconfig, libuuid }:
+{ stdenv, fetchurl, autoconf, automake, libsndfile, libtool, pkgconfig, libuuid }:
 
 stdenv.mkDerivation rec {
-  name = "libgig-svn-${version}";
-  version = "2334";
+  name = "libgig-${version}";
+  version = "4.1.0";
 
-  src = fetchsvn {
-    url = "https://svn.linuxsampler.org/svn/libgig/trunk";
-    rev = "${version}";
-    sha256 = "0i7sj3zm6banl5avjdxblx0mlbxxzbsbr4x5hsl2fhrdsv5dnxhc";
+  src = fetchurl {
+    url = "http://download.linuxsampler.org/packages/${name}.tar.bz2";
+    sha256 = "02xx6bqxzgkvrawwnzrnxx1ypk244q4kpwfd58266f9ji8kq18h6";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/liblscp/default.nix
+++ b/pkgs/development/libraries/liblscp/default.nix
@@ -1,19 +1,18 @@
-{ stdenv, fetchsvn, autoconf, automake, libtool, pkgconfig }:
+{ stdenv, fetchurl, autoconf, automake, libtool, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "liblscp-svn-${version}";
-  version = "2319";
+  name = "liblscp-${version}";
+  version = "0.5.8";
 
-  src = fetchsvn {
-    url = "https://svn.linuxsampler.org/svn/liblscp/trunk";
-    rev = "${version}";
-    sha256 = "0jgdy9gi9n8x2pqrbll9158vhx8293lnxv8vzl0szcincslgk7hi";
+  src = fetchurl {
+    url = "https://download.linuxsampler.org/packages/${name}.tar.gz";
+    sha256 = "00cfafkw1n80sdjwm9zdsg5vx287wqpgpbajd3zmiz415wzr84dn";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ autoconf automake libtool ];
 
-  preConfigure = "make -f Makefile.svn";
+  # preConfigure = "make -f Makefile.svn";
 
   meta = with stdenv.lib; {
     homepage = http://www.linuxsampler.org;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15637,7 +15637,7 @@ with pkgs;
   };
 
   linuxsampler = callPackage ../applications/audio/linuxsampler {
-    bison = bison2;
+    bison = bison3;
   };
 
   llpp = ocaml-ng.ocamlPackages.callPackage ../applications/misc/llpp { };


### PR DESCRIPTION
libgig: svn-2334 -> 4.1.0
libscp: svn-2319 -> 0.5.8

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

