### PR TITLE
[WIP] ed: fix cross build

### DIFF
--- a/pkgs/applications/editors/ed/default.nix
+++ b/pkgs/applications/editors/ed/default.nix
@@ -2,7 +2,7 @@
 , buildPlatform, hostPlatform
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (rec {
   name = "ed-${version}";
   version = "1.14.2";
 
@@ -36,4 +36,9 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = stdenv.lib.platforms.unix;
   };
-}
+} // stdenv.lib.optionalAttrs (hostPlatform != buildPlatform) {
+  # This may be moved above during a stdenv rebuild.
+  preConfigure = ''
+    configureFlagsArray+=("CC=$CC")
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/pull/32322#issuecomment-350341049

@Ericson2314 Is it correct that there is no `CC` env var during the cross compilation? (I had to use `CC_FOR_BUILD` or `BUILD_CC` instead.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Tested with `nix-build pkgs/top-level/release-cross.nix -A rpi.ed.x86_64-linux`.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).