### PR TITLE
Don't set cxx_stdlib when nativeTools on linux

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -46,7 +46,7 @@ let
   # The wrapper scripts use 'cat' and 'grep', so we may need coreutils.
   coreutils_bin = if nativeTools then "" else getBin coreutils;
 
-  default_cxx_stdlib_compile=optionalString (targetPlatform.isLinux && !(cc.isGNU or false))
+  default_cxx_stdlib_compile = optionalString (targetPlatform.isLinux && !(cc.isGNU or false) && !nativeTools)
     "-isystem $(echo -n ${cc.gcc}/include/c++/*) -isystem $(echo -n ${cc.gcc}/include/c++/*)/$(${cc.gcc}/bin/gcc -dumpmachine)";
 
   dashlessTarget = stdenv.lib.replaceStrings ["-"] ["_"] targetPlatform.config;


### PR DESCRIPTION
There are no gcc paths with nativeTools, and cc isn't set.

When attempting to use nativeTools on linux, an error is produced trying to expand `cc.gcc` to set `default_cxx_stdlib_compile`. I'm guessing this would only happen on obscure unsupported linux architectures. In this case, however, I purposefully want to use nativeTools for a special build, so I'm using:
```
import <nixpkgs> { stdenvStages = import <nixpkgs/pkgs/stdenv/native> };
```
which produces: 
```
value is null while a set was expected, at .../nixpkgs/pkgs/build-support/cc-wrapper/default.nix:50:27
```

If there is a better way to make this work (creating a native tools-based stdenv on linux), that's fine, too.
I realize there are reasons against and risks in doing this, but it is not meant to build a full system.

I don't believe this will break any normal use case, but I'm not entirely sure.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---