### PR TITLE
rsync: fix CVE-2017-16548

### DIFF
--- a/pkgs/applications/networking/sync/rsync/base.nix
+++ b/pkgs/applications/networking/sync/rsync/base.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, fetchpatch }:
 
 rec {
   version = "3.1.2";
@@ -7,11 +7,18 @@ rec {
     url = "mirror://samba/rsync/src/rsync-${version}.tar.gz";
     sha256 = "1hm1q04hz15509f0p9bflw4d6jzfvpm1d36dxjwihk1wzakn5ypc";
   };
-  patches = fetchurl {
-    # signed with key 0048 C8B0 26D4 C96F 0E58  9C2F 6C85 9FB1 4B96 A8C5
-    url = "mirror://samba/rsync/rsync-patches-${version}.tar.gz";
-    sha256 = "09i3dcl37p22dp75vlnsvx7bm05ggafnrf1zwhf2kbij4ngvxvpd";
-  };
+  patches = [
+    (fetchurl {
+      # signed with key 0048 C8B0 26D4 C96F 0E58  9C2F 6C85 9FB1 4B96 A8C5
+      url = "mirror://samba/rsync/rsync-patches-${version}.tar.gz";
+      sha256 = "09i3dcl37p22dp75vlnsvx7bm05ggafnrf1zwhf2kbij4ngvxvpd";
+    })
+    (fetchpatch {
+      name = "CVE-2017-16548.patch";
+      url = "https://git.samba.org/rsync.git/?p=rsync.git;a=commitdiff_plain;h=47a63d90e71d3e19e0e96052bb8c6b9cb140ecc1;hp=bc112b0e7feece62ce98708092306639a8a53cce";
+      sha256 = "1dcdnfhbc5gd0ph7pds0xr2v8rpb2a4p7l9c1wml96nhnyww1pg1";
+    })
+  ];
 
   meta = with stdenv.lib; {
     homepage = http://rsync.samba.org/;

--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, libiconv, zlib, popt
+{ stdenv, fetchurl, fetchpatch, perl, libiconv, zlib, popt
 , enableACLs ? true, acl ? null
 , enableCopyDevicesPatch ? false
 }:
@@ -6,7 +6,7 @@
 assert enableACLs -> acl != null;
 
 let
-  base = import ./base.nix { inherit stdenv fetchurl; };
+  base = import ./base.nix { inherit stdenv fetchurl fetchpatch; };
 in
 stdenv.mkDerivation rec {
   name = "rsync-${base.version}";

--- a/pkgs/applications/networking/sync/rsync/rrsync.nix
+++ b/pkgs/applications/networking/sync/rsync/rrsync.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchurl, perl, rsync }:
+{ stdenv, fetchurl, fetchpatch, perl, rsync }:
 
 let
-  base = import ./base.nix { inherit stdenv fetchurl; };
+  base = import ./base.nix { inherit stdenv fetchurl fetchpatch; };
 in
 stdenv.mkDerivation rec {
   name = "rrsync-${base.version}";


### PR DESCRIPTION
###### Motivation for this change

fixes CVE-2017-16548

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

