### PR TITLE
cataclysm-dda-git: update to latest and add arguments

### DIFF
--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -2,14 +2,14 @@
 SDL2_mixer, freetype, gettext }:
 
 stdenv.mkDerivation rec {
-  version = "2017-07-12";
+  version = "2017-12-09";
   name = "cataclysm-dda-git-${version}";
 
   src = fetchFromGitHub {
     owner = "CleverRaven";
     repo = "Cataclysm-DDA";
-    rev = "2d7aa8c";
-    sha256 = "0xx7si4k5ivyb5gv98fzlcghrg3w0dfblri547x7x4is7fj5ffjd";
+    rev = "24e92956db5587809750283873c242cc0796d7e6";
+    sha256 = "1a7kdmx76na4g65zra01qaq98lxp9j2dl9ddv09r0p5yxaizw68z";
   };
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Update the git version of cataclysm-dda-git and add the revision and sha256 as an argument to make it overridable via e.g. an overlay.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

