### PR TITLE
sshlatex: 0.7 -> 0.8

### DIFF
--- a/pkgs/tools/typesetting/sshlatex/default.nix
+++ b/pkgs/tools/typesetting/sshlatex/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "sshlatex-${version}";
-  version = "0.7";
+  version = "0.8";
 
   src = fetchFromGitHub {
     owner = "iblech";
     repo = "sshlatex";
     rev = "${version}";
-    sha256 = "02h81i8n3skg9jnlfrisyg5bhqicrn6svq64kp20f70p64s3d7ix";
+    sha256 = "0kaah8is74zba9373xccmsxmnnn6kh0isr4qpg21x3qhdzhlxl7q";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

