### PR TITLE
[WIP] initial code drop for Gurobi solver

### DIFF
--- a/pkgs/development/libraries/gurobi/README.md
+++ b/pkgs/development/libraries/gurobi/README.md
@@ -1,0 +1,5 @@
+The Gurobi Optimizer is a commercial optimization solver for linear programming (LP), quadratic programming (QP), quadratically constrained programming (QCP), mixed integer linear programming (MILP), mixed-integer quadratic programming (MIQP), and mixed-integer quadratically constrained programming (MIQCP).
+
+The solver is free for academic use, and licenses may easily be obtained from Gurobi's [web site](http://www.gurobi.com/registration/academic-license-reg).
+
+You can run `nix-shell gurobi-shell.nix` to try it out, then run `gurobi.sh` and try [to solve an LP](http://www.gurobi.com/documentation/7.0/quickstart_linux/reading_and_optimizing_a_m.html).

--- a/pkgs/development/libraries/gurobi/default.nix
+++ b/pkgs/development/libraries/gurobi/default.nix
@@ -1,0 +1,26 @@
+with import <nixpkgs> {};
+let
+  #TODO generify over platform using hostPlatform, etc.
+  gurobiPlatform = "linux64";
+  version = "7.5.1";
+in  
+stdenv.mkDerivation {
+  pname = "gurobi";
+  version = "$version";
+  name = "gurobi-${version}";
+  description = "A commercial convex and mixed integer optimization solver";
+  src = fetchurl {
+    url = "http://packages.gurobi.com/7.5/gurobi7.5.1_${gurobiPlatform}.tar.gz";
+    sha256 = "7f5c8b0c3d3600ab7a1898f43e238a9d9a32ac1206f2917fb60be9bbb76111b6";
+  };
+  installPhase = ''
+    mkdir -p $out/${gurobiPlatform}
+    cp -R ${gurobiPlatform}/* $out/${gurobiPlatform}
+    patchelf --set-interpreter \
+      ${stdenv.glibc}/lib/ld-linux-x86-64.so.2 $out/${gurobiPlatform}/bin/*
+    patchelf --set-rpath ${stdenv.glibc}/lib $out/${gurobiPlatform}/bin/*
+    mkdir -p $out/bin
+    ln -s $out/${gurobiPlatform}/bin/* $out/bin/
+  '';
+  GUROBI_HOME = "$out/${gurobiPlatform}";
+}

--- a/pkgs/development/libraries/gurobi/gurobi-shell.nix
+++ b/pkgs/development/libraries/gurobi/gurobi-shell.nix
@@ -1,0 +1,17 @@
+# Primarily used to test GUROBI, and as a template for other
+# shells using it.
+
+with import <nixpkgs> {};
+let
+  #TODO inherit gurobiPlatform from package
+  gurobiPlatform = "linux64";
+  myGurobi = (import ./default.nix);
+in stdenv.mkDerivation  {
+  name = "gurobi-shell";
+  buildInputs = [ myGurobi ];
+  shellHook = ''
+   export GUROBI_HOME="${myGurobi.out}/${gurobiPlatform}"
+   export GUROBI_PATH="${myGurobi.out}/${gurobiPlatform}"
+   export GRB_LICENSE_FILE="$HOME/gurobi.lic"
+  '';
+}  

--- a/pkgs/development/libraries/gurobi/gurobi-shell.nix
+++ b/pkgs/development/libraries/gurobi/gurobi-shell.nix
@@ -13,5 +13,6 @@ in stdenv.mkDerivation  {
    export GUROBI_HOME="${myGurobi.out}/${gurobiPlatform}"
    export GUROBI_PATH="${myGurobi.out}/${gurobiPlatform}"
    export GRB_LICENSE_FILE="$HOME/gurobi.lic"
+   export LD_LIBRARY_PATH="${myGurobi.out}/linux64/lib"
   '';
-}  
+}


### PR DESCRIPTION
###### Motivation for this change

We use the Gurobi solver for some of our work; it is easy to obtain an academic license, and is typically far superior to open source solvers.

Once logged in, you can [download for various platforms](http://www.gurobi.com/downloads/gurobi-optimizer) including Mac OS X. I do not have OS X nor do I know enough nix to know how to generify the nix expression for OS X.

###### Things done

I'll try to follow contributing.md more closely once issues are resolved re: OS X and any others that come up, as well as updating Gurobi to the latest version.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

