### PR TITLE
firefox: enable webrender

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -135,6 +135,9 @@ stdenv.mkDerivation (rec {
     "--with-libclang-path=${llvmPackages.clang-unwrapped}/lib"
     "--with-clang-path=${llvmPackages.clang}/bin/clang"
   ]
+  ++ lib.optionals (stdenv.lib.versionAtLeast version "57") [
+    "--enable-webrender=build"
+  ]
 
   # TorBrowser patches these
   ++ lib.optionals (!isTorBrowserLike) [


### PR DESCRIPTION
###### Motivation for this change

WebRender is the new compositor written in Rust.  It requires a configure flag to be included in the build, but the upstream binaries include it by default.

It will only be used at runtime if the ` layers.acceleration.force-enabled` option is manually set to true (defaults to false).

cc maintainer @edolstra 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

