### PR TITLE
radicale: add pytz to closure

### DIFF
--- a/pkgs/servers/radicale/default.nix
+++ b/pkgs/servers/radicale/default.nix
@@ -21,6 +21,7 @@ python3Packages.buildPythonApplication {
   propagatedBuildInputs = with python3Packages; [
     vobject
     passlib
+    pytz
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
I have run the tests (`nix-build nixos/tests/radicale.nix`), I assume an exit code of 0 means everything OK. 

###### Motivation for this change

Without pytz I got error messages like this in the journal:

`  Dec 09 00:00:00 x radicale[8868]: ERROR:root:No module named 'pytz'`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

