### PR TITLE
cryptop: 0.1 -> 0.2

### DIFF
--- a/pkgs/applications/altcoins/cryptop/default.nix
+++ b/pkgs/applications/altcoins/cryptop/default.nix
@@ -1,16 +1,15 @@
-{ lib, python3 }:
+{ lib, buildPythonApplication, fetchPypi, requests, requests-cache }:
 
-python3.pkgs.buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "cryptop";
   version = "0.2.0";
-  name = "${pname}-${version}";
 
-  src = python3.pkgs.fetchPypi {
+  src = fetchPypi {
     inherit pname version;
     sha256 = "0akrrz735vjfrm78plwyg84vabj0x3qficq9xxmy9kr40fhdkzpb";
   };
 
-  propagatedBuildInputs = [ python3.pkgs.requests python3.pkgs.requests-cache ];
+  propagatedBuildInputs = [ requests requests-cache ];
 
   # No tests in archive
   doCheck = false;

--- a/pkgs/applications/altcoins/cryptop/default.nix
+++ b/pkgs/applications/altcoins/cryptop/default.nix
@@ -1,16 +1,16 @@
-{ lib, python2}:
+{ lib, python3 }:
 
-python2.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "cryptop";
-  version = "0.1.0";
+  version = "0.2.0";
   name = "${pname}-${version}";
 
-  src = python2.pkgs.fetchPypi {
+  src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "00glnlyig1aajh30knc5rnfbamwfxpg29js2db6mymjmfka8lbhh";
+    sha256 = "0akrrz735vjfrm78plwyg84vabj0x3qficq9xxmy9kr40fhdkzpb";
   };
 
-  propagatedBuildInputs = [ python2.pkgs.requests ];
+  propagatedBuildInputs = [ python3.pkgs.requests python3.pkgs.requests-cache ];
 
   # No tests in archive
   doCheck = false;

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, boost155, boost162, openssl_1_1_0, haskellPackages, darwin, libsForQt5, miniupnpc_2 }:
+{ callPackage, boost155, boost162, openssl_1_1_0, haskellPackages, darwin, libsForQt5, miniupnpc_2, python3 }:
 
 rec {
 
@@ -19,6 +19,8 @@ rec {
 
   btc1 = callPackage ./btc1.nix { withGui = true; };
   btc1d = callPackage ./btc1.nix { withGui = false; };
+
+  cryptop = python3.pkgs.callPackage ./cryptop { };
 
   dashpay = callPackage ./dashpay.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13910,8 +13910,7 @@ with pkgs;
   altcoins = recurseIntoAttrs ( callPackage ../applications/altcoins { } );
   bitcoin = altcoins.bitcoin;
   bitcoin-xt = altcoins.bitcoin-xt;
-
-  cryptop = callPackage ../applications/altcoins/cryptop { };
+  cryptop = altcoins.cryptop;
 
   libbitcoin = callPackage ../tools/misc/libbitcoin/libbitcoin.nix {
     secp256k1 = secp256k1.override { enableECDH = true; };


### PR DESCRIPTION
Upgrade to new version. According to the upstream documentation, this project is
only tested on python3, so I've upgraded the pkg's interpreter as well.

Tested with nix-build and ./result/bin/cryptop

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

