### PR TITLE
tetex: patch off-by-one to fix segfault

### DIFF
--- a/pkgs/tools/typesetting/tex/tetex/default.nix
+++ b/pkgs/tools/typesetting/tex/tetex/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     find ./ -name "config.guess" -exec rm {} \; -exec ln -s ${automake}/share/automake-*/config.guess {} \;
   '' else null;
 
-  patches = [ ./environment.patch ./getline.patch ./clang.patch ];
+  patches = [ ./environment.patch ./getline.patch ./clang.patch ./extramembot.patch ];
 
   setupHook = ./setup-hook.sh;
 

--- a/pkgs/tools/typesetting/tex/tetex/extramembot.patch
+++ b/pkgs/tools/typesetting/tex/tetex/extramembot.patch
@@ -1,0 +1,12 @@
+diff -up texlive-2007/texk/web2c/tex.ch.extramembot texlive-2007/texk/web2c/tex.ch
+--- texlive-2007/texk/web2c/tex.ch.extramembot	2006-12-19 02:11:11.000000000 +0100
++++ texlive-2007/texk/web2c/tex.ch	2011-11-30 12:03:32.052795763 +0100
+@@ -365,7 +365,7 @@ for i:=@'177 to @'377 do xchr[i]:=i;
+ {Initialize enc\TeX\ data.}
+ for i:=0 to 255 do mubyte_read[i]:=null;
+ for i:=0 to 255 do mubyte_write[i]:=0;
+-for i:=0 to 128 do mubyte_cswrite[i]:=null;
++for i:=0 to 127 do mubyte_cswrite[i]:=null;
+ mubyte_keep := 0; mubyte_start := false; 
+ write_noexpanding := false; cs_converting := false;
+ special_printing := false; message_printing := false;


### PR DESCRIPTION
Fixes #32264.

Patch based on one from Fedora texlive-2007-66 source rpm.

References:
https://bugzilla.redhat.com/show_bug.cgi?id=754517
http://tug.org/pipermail/tex-k/2011-July/002317.html
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=633011
https://www.mail-archive.com/tetex@dbs.uni-hannover.de/msg00968.html

Redhat discussion suggests this happens when using -Wl,-z,relro
(or other linker flags) that change the default memory layout.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

