### PR TITLE
networkmanager: remove restart after suspend from resume

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -333,10 +333,6 @@ in {
       wireless.enable = lib.mkDefault false;
     };
 
-    powerManagement.resumeCommands = ''
-      ${config.systemd.package}/bin/systemctl restart network-manager
-    '';
-
     security.polkit.extraConfig = polkitConf;
 
     services.dbus.packages = cfg.packages;


### PR DESCRIPTION
###### Motivation for this change

In commit ec9dc73 restarting NetworkManager after resume from
suspend/hibernate was introduced.

When I initially switch to NixOS I started noticing a high delay between
wakeup and re-connecting to WiFi & wired networks. The delay increased
from a few seconds (on my previous distro, same software stack) to
almost half a minute with NixOS.

I (locally) applied the change in this commit a few weeks ago and tested
since then. The notebook/mobile device experience has improved a lot.
Reconnects are as before switching to NixOS.

Issue #24401 could be related to this. Since I am not using KDE/plasma5
I can only guess…


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

