### PR TITLE
hhvm: 3.21 -> 3.23.2

### DIFF
--- a/pkgs/development/compilers/hhvm/default.nix
+++ b/pkgs/development/compilers/hhvm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, fetchurl, cmake, pkgconfig, boost, libunwind, libmemcached
+{ stdenv, fetchgit, cmake, pkgconfig, boost, libunwind, libmemcached
 , pcre, libevent, gd, curl, libxml2, icu, flex, bison, openssl, zlib, php
 , expat, libcap, oniguruma, libdwarf, libmcrypt, tbb, gperftools, glog, libkrb5
 , bzip2, openldap, readline, libelf, uwimap, binutils, cyrus_sasl, pam, libpng
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   name    = "hhvm-${version}";
-  version = "3.21";
+  version = "3.23.2";
 
   # use git version since we need submodules
   src = fetchgit {
     url    = "https://github.com/facebook/hhvm.git";
-    rev    = "56483773e2edd9e61782f1901ce40e47959e71b8";
-    sha256 = "0dmdk98nv04m0fv6909gfbsxqlkckn369yi7kadhir0r7vxsj7wa";
+    rev    = "HHVM-${version}";
+    sha256 = "1nic49j8nghx82lgvz0b95r78sqz46qaaqv4nx48p8yrj9ysnd7i";
     fetchSubmodules = true;
   };
 
@@ -29,10 +29,6 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./flexible-array-members-gcc6.patch
-    (fetchurl {
-      url = https://github.com/facebook/hhvm/commit/b506902af2b7c53de6d6c92491c2086472292004.patch;
-      sha256 = "1br7diczqks6b1xjrdsac599fc62m9l17gcx7dvkc0qj54lq7ys4";
-    })
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

I needed features of hhvm 3.23.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

