### PR TITLE
nix-bash-completions: lazy load aware install

### DIFF
--- a/pkgs/shells/nix-bash-completions/default.nix
+++ b/pkgs/shells/nix-bash-completions/default.nix
@@ -1,19 +1,29 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "0.6";
+  version = "0.6.1";
   name = "nix-bash-completions-${version}";
 
   src = fetchFromGitHub {
     owner = "hedning";
     repo = "nix-bash-completions";
     rev = "v${version}";
-    sha256 = "093rla6wwx51fclh7xm8qlssx70hj0fj23r59qalaaxf7fdzg2hf";
+    sha256 = "10nzdn249f0cw6adgpbpg4x90ysvxm7vs9jjbbwynfh9kngijp64";
   };
 
+  # To enable lazy loading via. bash-completion we need a symlink to the script
+  # from every command name.
   installPhase = ''
-    mkdir -p $out/share/bash-completion/completions
-    cp _nix $out/share/bash-completion/completions
+    commands=$(
+      function complete() { shift 2; echo "$@"; }
+      shopt -s extglob
+      source _nix
+    )
+    install -Dm444 -t $out/share/bash-completion/completions _nix
+    cd $out/share/bash-completion/completions
+    for c in $commands; do
+      ln -s _nix $c
+    done
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
`bash-completion` lazy loads completion scripts by looking up the command name
in the completion directory. As such we need to create a symlink for every
nix command.

The problem had been masked by nixos sourcing all completion scripts on startup, see  #32534.

###### Motivation for this change

Support bash-completion lazy loading properly (This is how bash-completion solves the problem itself: [scp example](https://github.com/scop/bash-completion/blob/master/bash_completion#L2043)).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

