### PR TITLE
Python: rewrite requiredPythonModules to prevent stack overflows

### DIFF
--- a/pkgs/development/interpreters/python/build-python-package.nix
+++ b/pkgs/development/interpreters/python/build-python-package.nix
@@ -7,7 +7,7 @@
 , setuptools
 , unzip
 , ensureNewerSourcesHook
-, pythonModule
+, toPythonModule
 , namePrefix
 , bootstrapped-pip
 , flit
@@ -19,7 +19,7 @@ let
   wheel-specific = import ./build-python-package-wheel.nix { };
   common = import ./build-python-package-common.nix { inherit python bootstrapped-pip; };
   mkPythonDerivation = import ./mk-python-derivation.nix {
-    inherit lib python wrapPython setuptools unzip ensureNewerSourcesHook pythonModule namePrefix;
+    inherit lib python wrapPython setuptools unzip ensureNewerSourcesHook toPythonModule namePrefix;
   };
 in
 

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -7,7 +7,7 @@
 , unzip
 , ensureNewerSourcesHook
 # Whether the derivation provides a Python module or not.
-, pythonModule
+, toPythonModule
 , namePrefix
 }:
 
@@ -54,7 +54,7 @@ if disabled
 then throw "${name} not supported for interpreter ${python.executable}"
 else
 
-python.stdenv.mkDerivation (builtins.removeAttrs attrs [
+toPythonModule (python.stdenv.mkDerivation (builtins.removeAttrs attrs [
     "disabled" "checkInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts"
   ] // {
 
@@ -84,14 +84,9 @@ python.stdenv.mkDerivation (builtins.removeAttrs attrs [
     ${python.interpreter} ${./catch_conflicts}/catch_conflicts.py
   '' + attrs.postFixup or '''';
 
-  passthru = {
-    inherit python; # The python interpreter
-    inherit pythonModule;
-  } // passthru;
-
   meta = {
     # default to python's platforms
     platforms = python.meta.platforms;
     isBuildPythonPackage = python.meta.platforms;
   } // meta;
-})
+}))

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -127,7 +127,7 @@ in {
 
   recursivePthLoader = callPackage ../development/python-modules/recursive-pth-loader { };
 
-  setuptools = callPackage ../development/python-modules/setuptools { };
+  setuptools = toPythonModule (callPackage ../development/python-modules/setuptools { });
 
   vowpalwabbit = callPackage ../development/python-modules/vowpalwabbit {
     pythonPackages = self;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -87,12 +87,11 @@ let
     in fetcher (builtins.removeAttrs attrs ["format"]) );
 
   # Check whether a derivation provides a Python module.
-  hasPythonModule = drv: (hasAttr "pythonModule" drv) && ( (getAttr "pythonModule" drv) == python);
+  hasPythonModule = drv: drv?pythonModule && drv.pythonModule == python;
 
   # Get list of required Python modules given a list of derivations.
   requiredPythonModules = drvs: let
-    removeNull = list: filter (x: !isNull x) list;
-    modules = filter hasPythonModule (removeNull drvs);
+    modules = filter hasPythonModule drvs;
   in unique ([python] ++ modules ++ concatLists (catAttrs "requiredPythonModules" modules));
 
   # Create a PYTHONPATH from a list of derivations. This function recurses into the items to find derivations


### PR DESCRIPTION
###### Motivation for this change

The version that is currently in staging is causing stack overflows for some people. This version seems to solve that.
https://github.com/NixOS/nixpkgs/commit/859dc02fa3f42bca9b7770eb96f4fd8224cf1576#commitcomment-26177133

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

