### PR TITLE
Add SOPINE / PINE A64-LTS bootloader

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -573,6 +573,7 @@
   rzetterberg = "Richard Zetterberg <richard.zetterberg@gmail.com>";
   s1lvester = "Markus Silvester <s1lvester@bockhacker.me>";
   samdroid-apps = "Sam Parkinson <sam@sam.today>";
+  samueldr = "Samuel Dionne-Riel <samuel@dionne-riel.com>";
   samuelrivas = "Samuel Rivas <samuelrivas@gmail.com>";
   sander = "Sander van der Burg <s.vanderburg@tudelft.nl>";
   sargon = "Daniel Ehlers <danielehlers@mindeye.net>";

--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -22,7 +22,7 @@ let
 
     name = "arm-trusted-firmware-${platform}-${version}";
 
-    hardeningDisable = [ "all" ];
+    hardeningDisable = [ "stackprotector" ];
 
     makeFlags = ["PLAT=${platform}"];
 

--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -1,0 +1,75 @@
+{ stdenv
+, fetchFromGitHub
+, hostPlatform
+}:
+
+let
+  buildArmTrustedFirmware = { targetPlatforms
+     , platform
+     , filesToInstall
+     , installDir ? "$out"
+     , version ? "1.4"
+     , src ? (fetchFromGitHub {
+         owner = "ARM-software";
+         repo = "arm-trusted-firmware";
+         rev = "v${version}";
+         sha256 = "15m10dfgqkgw6rmzgfg1xzp1si9d5jwzyrcb7cp3y9ckj6mvp3i3";
+       })
+     , extraMeta ? {}
+     , ... } @ args:
+  stdenv.mkDerivation (rec {
+    inherit src;
+
+    name = "arm-trusted-firmware-${platform}-${version}";
+
+    hardeningDisable = [ "all" ];
+
+    makeFlags = ["PLAT=${platform}"];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p ${installDir}
+      cp ${stdenv.lib.concatStringsSep " " filesToInstall} ${installDir}
+
+      runHook postInstall
+    '';
+
+    dontStrip = true;
+
+    meta = with stdenv.lib; {
+      homepage = https://github.com/ARM-software/arm-trusted-firmware;
+      description = "Reference implementation of secure world software for ARMv8-A";
+      license = licenses.bsd3;
+      maintainers = [ maintainers.samueldr ];
+      platforms = targetPlatforms;
+    } // extraMeta;
+  } // args);
+
+in rec {
+  inherit buildArmTrustedFirmware;
+
+  armTrustedFirmwareQemu = buildArmTrustedFirmware rec {
+    platform = "qemu";
+    targetPlatforms = ["aarch64-linux"];
+    filesToInstall = [
+      "build/${platform}/release/bl1.bin"
+      "build/${platform}/release/bl2.bin"
+      "build/${platform}/release/bl31.bin"
+    ];
+  };
+
+  armTrustedFirmwareAllwinner = buildArmTrustedFirmware rec {
+    version = "1.0";
+    src = fetchFromGitHub {
+      owner = "apritzel";
+      repo = "arm-trusted-firmware";
+      # Branch: `allwinner`
+      rev = "91f2402d941036a0db092d5375d0535c270b9121";
+      sha256 = "0lbipkxb01w97r6ah8wdbwxir3013rp249fcqhlzh2gjwhp5l1ys";
+    };
+    platform = "sun50iw1p1";
+    targetPlatforms = ["aarch64-linux"];
+    filesToInstall = ["build/${platform}/release/bl31.bin"];
+  };
+}

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -154,7 +154,6 @@ in rec {
     defconfig = "sopine_baseboard_defconfig";
     targetPlatforms = ["aarch64-linux"];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
-    buildFlags = "DEVICE_TREE=sun50i-a64-sopine-baseboard";
     filesToInstall = ["spl/sunxi-spl.bin" "u-boot.itb"];
   };
 

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchurl, fetchpatch, bc, dtc, python2
+, armTrustedFirmwareAllwinner
 , hostPlatform
 }:
 
@@ -32,6 +33,7 @@ let
         url = https://github.com/dezgeg/u-boot/commit/pythonpath-2017-11.patch;
         sha256 = "162b2lglp307pzxsf9m7nnmzwxqd7xkwp5j85bm6bg1a38ngpl9v";
       })
+      ./sopine-baseboard-dtb-fix.patch
     ];
 
     postPatch = ''
@@ -146,6 +148,14 @@ in rec {
     defconfig = "rpi_3_defconfig";
     targetPlatforms = ["aarch64-linux"];
     filesToInstall = ["u-boot.bin"];
+  };
+
+  ubootSopine = buildUBoot rec {
+    defconfig = "sopine_baseboard_defconfig";
+    targetPlatforms = ["aarch64-linux"];
+    BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
+    buildFlags = "DEVICE_TREE=sun50i-a64-sopine-baseboard";
+    filesToInstall = ["spl/sunxi-spl.bin" "u-boot.itb"];
   };
 
   ubootUtilite = buildUBoot rec {

--- a/pkgs/misc/uboot/sopine-baseboard-dtb-fix.patch
+++ b/pkgs/misc/uboot/sopine-baseboard-dtb-fix.patch
@@ -1,0 +1,69 @@
+diff --git a/arch/arm/dts/sun50i-a64-sopine-baseboard.dts b/arch/arm/dts/sun50i-a64-sopine-baseboard.dts
+new file mode 100644
+index 0000000000..790d14daaa
+--- /dev/null
++++ b/arch/arm/dts/sun50i-a64-sopine-baseboard.dts
+@@ -0,0 +1,50 @@
++/*
++ * Copyright (c) 2016 ARM Ltd.
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This library is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This library is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#include "sun50i-a64-pine64.dts"
++
++/ {
++	model = "Pine64+";
++	compatible = "pine64,pine64-plus", "allwinner,sun50i-a64";
++
++	/* TODO: Camera, Ethernet PHY, touchscreen, etc. */
++};
+diff --git a/configs/sopine_baseboard_defconfig b/configs/sopine_baseboard_defconfig
+index f41e5df317..a1baf81e9e 100644
+--- a/configs/sopine_baseboard_defconfig
++++ b/configs/sopine_baseboard_defconfig
+@@ -8,7 +8,7 @@ CONFIG_DRAM_ZQ=3881949
+ CONFIG_DRAM_ODT_EN=y
+ CONFIG_MMC0_CD_PIN=""
+ CONFIG_MMC_SUNXI_SLOT_EXTRA=2
+-CONFIG_DEFAULT_DEVICE_TREE="sun50i-a64-pine64-plus"
++CONFIG_DEFAULT_DEVICE_TREE="sun50i-a64-sopine-baseboard"
+ # CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
+ CONFIG_SPL=y
+ # CONFIG_CMD_FLASH is not set

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -493,6 +493,13 @@ with pkgs;
 
   arm-frc-linux-gnueabi-gcc = callPackage ../development/compilers/arm-frc-linux-gnueabi-gcc {};
 
+  # Arm Trusted Firmware
+  inherit (callPackage ../misc/arm-trusted-firmware {})
+    buildArmTrustedFirmware
+    armTrustedFirmwareAllwinner
+    armTrustedFirmwareQemu
+    ;
+
   arp-scan = callPackage ../tools/misc/arp-scan { };
 
   inherit (callPackages ../data/fonts/arphic {})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13162,6 +13162,7 @@ with pkgs;
     ubootRaspberryPi2
     ubootRaspberryPi3_32bit
     ubootRaspberryPi3_64bit
+    ubootSopine
     ubootUtilite
     ubootWandboard
     ;


### PR DESCRIPTION
#### Motivation for this change

Adds the necessary packages to build the bootloader for both the [SOPINE](https://www.pine64.org/?page_id=1491) and [PINE A64-LTS](https://www.pine64.org/?page_id=46823) boards.

> Confusingly, the **PINE A64-LTS** is basically 1:1 compatible with SOPINE, but not with other PINE A64 boards. Upstream projects generally use *sopine* as the name for both compatible platforms.

NixOS (upstream Linux) isn't working 100% with these boards, but the upstream u-boot already has support for the boards. Leaving the configuration out isn't really helpful. Whilst Linux isn't working 100%, the stock, untouched, `sd-image-aarch64` image boots, serial works, and USB ethernet makes this board workable enough that this is what I'm using for aarch64 development, preferred over the raspi 3. (The eMMC module makes a big difference in usability over even the faster SD cards.) From there, support should only get better, hopefully.

##### Arm Trusted Firmware

Arm Trusted Firmware is a dependency ([seemingly](http://git.denx.de/?p=u-boot.git;a=blob;f=board/sunxi/README.sunxi64;h=c492f749b8bbe3a7418f29fa4050dee9251c64fb;hb=HEAD#l29)) needed by u-boot.

**I have not tested (used) the QEMU build.** It does build, though. This was added mainly because otherwise I couldn't test the default build instructions, as the Allwinner ATF comes from a fork.

Now, that derivation might frighten or sicken you. I bodged this together, inspired by the u-boot configuration. **Tell me what I should have done instead and I will fix it.** I'm not used to derivations and overriding, this looked like the easiest way to keep everything together while the builds are mostly identical.

##### u-boot

There's nothing fancy in there, except for one patch. That patch is needed only to make u-boot load the right device tree (dtb). This is because in u-boot, pine64-plus is good enough for all the pine64-plus, sopine and the PINE A64-LTS.  Linux, in the other hand, has different DTBs for those platforms. Since u-boot will use the name of the DTB used to build the bootloader to load the DTB for the kernel, this is the simplest way to do it. This should be upstreamed (yes, by me) to u-boot, unless an u-boot expert here tells me there's a more elegant way.

> [Here's the build, if needed](https://stuff.samueldr.com/nixos/uboot-sopine_baseboard_defconfig-2017.11.nixpkgs.20171211.d6d9c235120c1809e7b3c8f775832441c53fcfc6.u-boot-sunxi-with-spl.bin)

#### Things done


- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] ~~macOS~~
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] ~~Tested execution of all binary files (usually in `./result/bin/`)~~
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

* * *

Paging @dezgeg 