### PR TITLE
U-Boot: Adds Orange Pi PC build

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -118,6 +118,12 @@ in rec {
     filesToInstall = ["u-boot-dtb.bin"];
   };
 
+  ubootOrangePiPc = buildUBoot rec {
+    defconfig = "orangepi_pc_defconfig";
+    targetPlatforms = ["armv7l-linux"];
+    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+  };
+
   ubootPcduino3Nano = buildUBoot rec {
     defconfig = "Linksprite_pcDuino3_Nano_defconfig";
     targetPlatforms = ["armv7l-linux"];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13150,6 +13150,7 @@ with pkgs;
     ubootBeagleboneBlack
     ubootJetsonTK1
     ubootOdroidXU3
+    ubootOrangePiPc
     ubootPcduino3Nano
     ubootRaspberryPi
     ubootRaspberryPi2


### PR DESCRIPTION
###### Motivation for this change

Simply adds [Orange Pi PC](http://www.orangepi.org/orangepipc/) build to u-boot. Nothing fancy, it's all supported upstream by u-boot.

For Linux, the upstreaming of most important parts is already done, the ethernet is coming soon (4.15), so no custom kernel is needed in NixOS. (See #29569 for a 4.13/4.14 kernel with ethernet support.) [Using @dezgeg's ARMv7 installation instructions will work for this board](https://nixos.wiki/wiki/NixOS_on_ARM). u-boot can be installed using the usual sunxi offsets (`bs=1024 seek=8`)

> [Here's the build, if needed](https://stuff.samueldr.com/nixos/uboot-orangepi_pc_defconfig-2017.11.nixpkgs.20171211.1545c3163bc6cf3cd0e81fee73dbf9baf29e5b0b.u-boot-sunxi-with-spl.bin)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Paging @dezgeg 