### PR TITLE
mplus-outline-fonts: 062 -> 063

### DIFF
--- a/pkgs/data/fonts/mplus-outline-fonts/default.nix
+++ b/pkgs/data/fonts/mplus-outline-fonts/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchzip }:
 
 let
-  version = "062";
+  version = "063";
 in fetchzip rec {
   name = "mplus-${version}";
 
@@ -13,7 +13,7 @@ in fetchzip rec {
     cp *.ttf $out/share/fonts/truetype
   '';
 
-  sha256 = "0zm1snq5r584rz90yv5lndsqgchdaxq2185vrk7849ch4k5vd23z";
+  sha256 = "0d485l2ihxfk039rrrnfviamlbj13cwky0c752m4ikwvgiqiq94y";
 
   meta = with stdenv.lib; {
     description = "M+ Outline Fonts";


### PR DESCRIPTION
###### Motivation for this change
- Follow upstream (2017-10-25 16:02)

cc @henrytill 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

