### PR TITLE
calamares: init at 3.1.10

### DIFF
--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -1,57 +1,64 @@
-{ stdenv, fetchurl, cmake, polkit-qt, libyamlcpp, python, boost, parted
-, extra-cmake-modules, kconfig, ki18n, kcoreaddons, solid, utillinux, libatasmart
-, ckbcomp, glibc, tzdata, xkeyboard_config, qtbase, qtsvg, qttools }:
+{ stdenv, fetchurl, boost, cmake, extra-cmake-modules, kparts, kpmcore
+, kservice, libatasmart, libxcb, libyamlcpp, parted, polkit-qt, python, qtbase
+, qtquickcontrols, qtsvg, qttools, qtwebengine, utillinux, glibc, tzdata
+, ckbcomp, xkeyboard_config
+}:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "calamares";
-  version = "1.1.4.2";
+  version = "3.1.10";
 
   # release including submodule
   src = fetchurl {
     url = "https://github.com/${pname}/${pname}/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "1mh0nmzc3i1aqcj79q2s3vpccn0mirlfbj26sfyb0v6gcrvf707d";
+    sha256 = "12phmirx0fgvykvkl8frv5agxqi7n04sxf5bpwjwq12mydq2x7kc";
   };
 
   buildInputs = [
-    cmake qtbase qtsvg qttools libyamlcpp python boost polkit-qt parted
-    extra-cmake-modules kconfig ki18n kcoreaddons solid utillinux libatasmart
+    boost cmake extra-cmake-modules kparts.dev kpmcore.out kservice.dev
+    libatasmart libxcb libyamlcpp parted polkit-qt python qtbase
+    qtquickcontrols qtsvg qttools qtwebengine.dev utillinux
   ];
+
+  enableParallelBuilding = false;
 
   cmakeFlags = [
     "-DPYTHON_LIBRARY=${python}/lib/libpython${python.majorVersion}m.so"
     "-DPYTHON_INCLUDE_DIR=${python}/include/python${python.majorVersion}m"
-    "-DWITH_PARTITIONMANAGER=1"
+    "-DCMAKE_VERBOSE_MAKEFILE=True"
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DWITH_PYTHONQT:BOOL=ON"
   ];
 
+  POLKITQT-1_POLICY_FILES_INSTALL_DIR = "$(out)/share/polkit-1/actions";
+
   patchPhase = ''
-      sed -e "s,/usr/bin/calamares,$out/bin/calamares," \
-          -i calamares.desktop \
-          -i com.github.calamares.calamares.policy
+    sed -e "s,/usr/bin/calamares,$out/bin/calamares," \
+        -i calamares.desktop \
+        -i com.github.calamares.calamares.policy
 
-      sed -e 's,/usr/share/zoneinfo,${tzdata}/share/zoneinfo,' \
-          -i src/modules/locale/timezonewidget/localeconst.h \
-          -i src/modules/locale/SetTimezoneJob.cpp
+    sed -e 's,/usr/share/zoneinfo,${tzdata}/share/zoneinfo,' \
+        -i src/modules/locale/timezonewidget/localeconst.h \
+        -i src/modules/locale/SetTimezoneJob.cpp
 
-      sed -e 's,/usr/share/i18n/locales,${glibc.out}/share/i18n/locales,' \
-          -i src/modules/locale/timezonewidget/localeconst.h
+    sed -e 's,/usr/share/i18n/locales,${glibc.out}/share/i18n/locales,' \
+        -i src/modules/locale/timezonewidget/localeconst.h
 
-      sed -e 's,/usr/share/X11/xkb/rules/base.lst,${xkeyboard_config}/share/X11/xkb/rules/base.lst,' \
-          -i src/modules/keyboard/keyboardwidget/keyboardglobal.h
+    sed -e 's,/usr/share/X11/xkb/rules/base.lst,${xkeyboard_config}/share/X11/xkb/rules/base.lst,' \
+        -i src/modules/keyboard/keyboardwidget/keyboardglobal.h
 
-      sed -e 's,"ckbcomp","${ckbcomp}/bin/ckbcomp",' \
-          -i src/modules/keyboard/keyboardwidget/keyboardpreview.cpp
-  '';
+    sed -e 's,"ckbcomp","${ckbcomp}/bin/ckbcomp",' \
+        -i src/modules/keyboard/keyboardwidget/keyboardpreview.cpp
 
-  preInstall = ''
-    substituteInPlace cmake_install.cmake --replace "${polkit-qt}" "$out"
+    sed "s,\''${POLKITQT-1_POLICY_FILES_INSTALL_DIR},''${out}/share/polkit-1/actions," \
+        -i CMakeLists.txt
   '';
 
   meta = with stdenv.lib; {
     description = "Distribution-independent installer framework";
     license = licenses.gpl3;
-    maintainers = with stdenv.lib.maintainers; [ tstrobel ];
+    maintainers = with stdenv.lib.maintainers; [ manveru ];
     platforms = platforms.linux;
-    broken = true;
   };
 }

--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchurl, cmake, polkit-qt, libyamlcpp, python, boost, parted
+, extra-cmake-modules, kconfig, ki18n, kcoreaddons, solid, utillinux, libatasmart
+, ckbcomp, glibc, tzdata, xkeyboard_config, qtbase, qtsvg, qttools }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "calamares";
+  version = "1.1.4.2";
+
+  # release including submodule
+  src = fetchurl {
+    url = "https://github.com/${pname}/${pname}/releases/download/v${version}/${name}.tar.gz";
+    sha256 = "1mh0nmzc3i1aqcj79q2s3vpccn0mirlfbj26sfyb0v6gcrvf707d";
+  };
+
+  buildInputs = [
+    cmake qtbase qtsvg qttools libyamlcpp python boost polkit-qt parted
+    extra-cmake-modules kconfig ki18n kcoreaddons solid utillinux libatasmart
+  ];
+
+  cmakeFlags = [
+    "-DPYTHON_LIBRARY=${python}/lib/libpython${python.majorVersion}m.so"
+    "-DPYTHON_INCLUDE_DIR=${python}/include/python${python.majorVersion}m"
+    "-DWITH_PARTITIONMANAGER=1"
+  ];
+
+  patchPhase = ''
+      sed -e "s,/usr/bin/calamares,$out/bin/calamares," \
+          -i calamares.desktop \
+          -i com.github.calamares.calamares.policy
+
+      sed -e 's,/usr/share/zoneinfo,${tzdata}/share/zoneinfo,' \
+          -i src/modules/locale/timezonewidget/localeconst.h \
+          -i src/modules/locale/SetTimezoneJob.cpp
+
+      sed -e 's,/usr/share/i18n/locales,${glibc.out}/share/i18n/locales,' \
+          -i src/modules/locale/timezonewidget/localeconst.h
+
+      sed -e 's,/usr/share/X11/xkb/rules/base.lst,${xkeyboard_config}/share/X11/xkb/rules/base.lst,' \
+          -i src/modules/keyboard/keyboardwidget/keyboardglobal.h
+
+      sed -e 's,"ckbcomp","${ckbcomp}/bin/ckbcomp",' \
+          -i src/modules/keyboard/keyboardwidget/keyboardpreview.cpp
+  '';
+
+  preInstall = ''
+    substituteInPlace cmake_install.cmake --replace "${polkit-qt}" "$out"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Distribution-independent installer framework";
+    license = licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ tstrobel ];
+    platforms = platforms.linux;
+    broken = true;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -856,6 +856,12 @@ with pkgs;
   caddy = callPackage ../servers/caddy { };
   traefik = callPackage ../servers/traefik { };
 
+  calamares = qt5.callPackage ../tools/misc/calamares rec {
+    python = python3;
+    boost = pkgs.boost.override { python=python3; };
+    libyamlcpp = callPackage ../development/libraries/libyaml-cpp { boost=boost; };
+  };
+
   capstone = callPackage ../development/libraries/capstone { };
   unicorn-emu = callPackage ../development/libraries/unicorn-emu { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -856,10 +856,10 @@ with pkgs;
   caddy = callPackage ../servers/caddy { };
   traefik = callPackage ../servers/traefik { };
 
-  calamares = qt5.callPackage ../tools/misc/calamares rec {
+  calamares = libsForQt59.callPackage ../tools/misc/calamares {
     python = python3;
-    boost = pkgs.boost.override { python=python3; };
-    libyamlcpp = callPackage ../development/libraries/libyaml-cpp { boost=boost; };
+    boost = pkgs.boost.override { python = python3; };
+    libyamlcpp = callPackage ../development/libraries/libyaml-cpp { inherit boost; };
   };
 
   capstone = callPackage ../development/libraries/capstone { };


### PR DESCRIPTION
###### Motivation for this change

Was removed in 2016, revived it to base a nixos-installer on top.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

