### PR TITLE
myrica: init at 2.011.20160403

### DIFF
--- a/pkgs/data/fonts/myrica/default.nix
+++ b/pkgs/data/fonts/myrica/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "myrica-${version}";
+  version = "2.011.20160403";
+
+  src = fetchFromGitHub {
+    owner = "tomokuni";
+    repo = "Myrica";
+    rev = "b737107723bfddd917210f979ccc32ab3eb6dc20";
+    sha256 = "0p95kanf1682d9idq4v9agxlvxh08vhvfid2sjyc63knndsrl7wk";
+  };
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp $src/product/*.TTC $out/share/fonts/truetype
+  '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "187rklcibbkai6m08173ca99qn8v7xpdfdv0izpymmavj85axm12";
+
+  meta = with stdenv.lib; {
+    homepage = https://myrica.estable.jp/;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ mikoim ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13604,6 +13604,8 @@ with pkgs;
 
   mustache-spec = callPackage ../data/documentation/mustache-spec { };
 
+  myrica = callPackage ../data/fonts/myrica { };
+
   nafees = callPackage ../data/fonts/nafees { };
 
   inherit (callPackages ../data/fonts/noto-fonts {})


### PR DESCRIPTION
###### Motivation for this change
Myrica is high-quality Japanese font for programming.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
