### PR TITLE
lftp: 4.8.2 -> 4.8.3 (17.09 backport)

### DIFF
--- a/pkgs/tools/networking/lftp/default.nix
+++ b/pkgs/tools/networking/lftp/default.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation rec {
   name = "lftp-${version}";
-  version = "4.8.2";
+  version = "4.8.3";
 
   src = fetchurl {
     urls = [
-      "https://lftp.tech/ftp/${name}.tar.bz2"
-      "ftp://ftp.st.ryukoku.ac.jp/pub/network/ftp/lftp/${name}.tar.bz2"
-      "http://lftp.yar.ru/ftp/old/${name}.tar.bz2"
+      "https://lftp.tech/ftp/${name}.tar.xz"
+      "https://ftp.st.ryukoku.ac.jp/pub/network/ftp/lftp/${name}.tar.xz"
+      "http://lftp.yar.ru/ftp/${name}.tar.xz"
       ];
-    sha256 = "0a4sp9khqgny1md0b2c9vvg4c7sz0g31w3sfdslxw7dsvijin3mn";
+    sha256 = "12y77jlfs4x4zvcah92mw2h2sb4j0bvbaxkh3wwsm8gs392ywyny";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A file transfer program supporting a number of network protocols";
-    homepage = http://lftp.tech/;
+    homepage = https://lftp.tech/;
     license = licenses.gpl3;
     platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];


### PR DESCRIPTION
###### Motivation for this change
As @c0bw3b mentioned in #31542 version 4.8.3 fixes some issues. As I am currently encountering them on 17.09  I would like to get this into 17.09.

The PR applies cleanly on the current release-17.09 branch and seem to be working fine on all my hosts.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

