### PR TITLE
blsd: init at unstable-2017-07-27

### DIFF
--- a/pkgs/tools/misc/blsd/default.nix
+++ b/pkgs/tools/misc/blsd/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildGoPackage, fetchFromGitHub, pkgconfig, libgit2 }:
+
+buildGoPackage rec {
+  name = "blsd-${version}";
+  version = "2017-07-27";
+
+  goPackagePath = "github.com/junegunn/blsd";
+
+  src = fetchFromGitHub {
+    owner = "junegunn";
+    repo = "blsd";
+    rev = "a2ac619821e502452abdeae9ebab45026893b9e8";
+    sha256 = "0b0q6i4i28cjqgxqmwxbps22gp9rcd3jz562q5wvxrwlpbzlls2h";
+  };
+
+  goDeps = ./deps.nix;
+
+  nativeBuildInputs = [ pkgconfig libgit2 ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/junegunn/blsd;
+    description = "List directories in breadth-first order";
+    license = licenses.mit;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/blsd/deps.nix
+++ b/pkgs/tools/misc/blsd/deps.nix
@@ -1,0 +1,11 @@
+[
+{
+  goPackagePath = "github.com/libgit2/git2go";
+  fetch = {
+    type = "git";
+    url = "https://github.com/libgit2/git2go";
+    rev = "334260d743d713a55ff3c097ec6707f2bb39e9d5";
+    sha256 = "0hfya9z2pg29zbc0s92hj241rnbk7d90jzj34q0dp8b7akz6r1rc";
+  };
+}
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -763,6 +763,10 @@ with pkgs;
 
   blockdiag = pythonPackages.blockdiag;
 
+  blsd = callPackage ../tools/misc/blsd {
+    libgit2 = libgit2_0_25;
+  };
+
   bluez-tools = callPackage ../tools/bluetooth/bluez-tools { };
 
   bmon = callPackage ../tools/misc/bmon { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

