### PR TITLE
ocamlPackages.cairo2: 0.4.6 -> 0.5

### DIFF
--- a/pkgs/applications/science/logic/acgtk/default.nix
+++ b/pkgs/applications/science/logic/acgtk/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = with ocamlPackages; [
-    ocaml findlib camlp4 ansiterminal biniou bolt ocaml_cairo2 dypgen easy-format ocf yojson
+    ocaml findlib camlp4 ansiterminal biniou bolt cairo2 dypgen easy-format ocf yojson
   ];
 
   patches = [ ./install-emacs-to-site-lisp.patch

--- a/pkgs/development/ocaml-modules/cairo2/default.nix
+++ b/pkgs/development/ocaml-modules/cairo2/default.nix
@@ -6,17 +6,16 @@
 
 let
   inherit (stdenv.lib) optionals;
-  pname = "ocaml-cairo2";
-  version = "0.4.6";
+  version = "0.5";
 in
 
 stdenv.mkDerivation {
 
-  name = "${pname}-${version}";
+  name = "ocaml${ocaml.version}-cairo2-${version}";
 
   src = fetchurl {
-    url = "http://forge.ocamlcore.org/frs/download.php/1279/cairo2-0.4.6.tar.gz";
-    sha256 = "1lc1iv5yz49avbc0wbrw9nrx8dn0c35r7cykivjln1zc2fwscf7w";
+    url = "https://github.com/Chris00/ocaml-cairo/releases/download/${version}/cairo2-${version}.tar.gz";
+    sha256 = "1559df74rzh4v7c9hr6phymq1f5121s83q0xy3r83x4apj74dchj";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -39,7 +38,7 @@ stdenv.mkDerivation {
   installPhase = "ocaml setup.ml -install";
 
   meta = with stdenv.lib; {
-    homepage = http://forge.ocamlcore.org/projects/cairo;
+    homepage = "https://github.com/Chris00/ocaml-cairo";
     description = "Binding to Cairo, a 2D Vector Graphics Library";
     longDescription = ''
       This is a binding to Cairo, a 2D graphics library with support for

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -128,7 +128,7 @@ let
 
     ocaml_cairo = callPackage ../development/ocaml-modules/ocaml-cairo { };
 
-    ocaml_cairo2 = callPackage ../development/ocaml-modules/ocaml-cairo2 { };
+    cairo2 = callPackage ../development/ocaml-modules/cairo2 { };
 
     cil = callPackage ../development/ocaml-modules/cil { };
 


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

