### PR TITLE
Correct comment in radicale.nix

### DIFF
--- a/nixos/tests/radicale.nix
+++ b/nixos/tests/radicale.nix
@@ -20,7 +20,7 @@ let
       '';
     };
     # WARNING: DON'T DO THIS IN PRODUCTION!
-    # This puts secrets (albeit hashed) directly into the Nix store for ease of testing.
+    # This puts unhashed secrets directly into the Nix store for ease of testing.
     environment.etc."radicale/htpasswd".source = pkgs.runCommand "htpasswd" {} ''
       ${pkgs.apacheHttpd}/bin/htpasswd -bcB "$out" ${user} ${password}
     '';


### PR DESCRIPTION
###### Motivation for this change
The secrets are in fact also stored unhashed, as part of the .drv file
which produces the htpasswd.

###### Things done

No functional changes, so none of this really applies.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

