### PR TITLE
projectlibre: init at 1.7.0

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -169,6 +169,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName  = "CeCILL-C Free Software License Agreement";
   };
 
+  cpal10 = spdx {
+    spdxId = "CPAL-1.0";
+    fullName = "Common Public Attribution License 1.0";
+  };
+
   cpl10 = spdx {
     spdxId = "CPL-1.0";
     fullName = "Common Public License 1.0";

--- a/pkgs/applications/office/projectlibre/default.nix
+++ b/pkgs/applications/office/projectlibre/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, jre, coreutils, which }:
+
+stdenv.mkDerivation rec {
+  name = "projectlibre-${version}";
+  version = "1.7.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/projectlibre/ProjectLibre/1.7/${name}.tar.gz";
+    sha256 = "0h92h8ybn9z9y1ra2lanaac0504h2gpb77kp09lnja6sjvfsgidb";
+  };
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    mkdir -p "$out/lib/projectlibre"
+    mkdir -p "$out/share/doc/projectlibre"
+
+    cp -R lib \
+        projectlibre.jar \
+        projectlibre.sh \
+        "$out/lib/projectlibre"
+
+    cp -R license "$out/share/doc/projectlibre"
+
+    cat >"$out/bin/projectlibre" << EOF
+    #!${stdenv.shell}
+    # Add PATH at the end so projectlibre can find a browser
+    export "PATH=${jre}/bin:${coreutils}/bin:${which}/bin:\$PATH"
+    exec "$out/lib/projectlibre/projectlibre.sh"
+    EOF
+    chmod +x "$out/bin/projectlibre"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.projectlibre.com/";
+    description = "Open source project management software";
+    license = licenses.cpal10;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bjornfor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15993,6 +15993,8 @@ with pkgs;
 
   polybar = callPackage ../applications/misc/polybar { };
 
+  projectlibre = callPackage ../applications/office/projectlibre { };
+
   ptex = callPackage ../development/libraries/ptex {};
 
   rssguard = libsForQt5.callPackage ../applications/networking/feedreaders/rssguard { };


### PR DESCRIPTION
###### Motivation for this change
I need to work with files created by projectlibre.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

