### PR TITLE
lwan: init -> 0.1

### DIFF
--- a/pkgs/servers/http/lwan/default.nix
+++ b/pkgs/servers/http/lwan/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, pkgconfig, zlib, cmake, jemalloc }:
+
+stdenv.mkDerivation rec {
+  pname = "lwan";
+  version = "0.1";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "lpereira";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1mckryzb06smky0bx2bkqwqzpnq4pb8vlgmmwsvqmwi4mmw9wmi1";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [ jemalloc zlib ];
+
+  meta = with stdenv.lib; {
+    description = "Lightweight high-performance multi-threaded web server";
+    longDescription = "A lightweight and speedy web server with a low memory
+      footprint (~500KiB for 10k idle connections), with minimal system calls and
+      memory allocation.  Lwan contains a hand-crafted HTTP request parser. Files are
+      served using the most efficient way according to their size: no copies between
+      kernel and userland for files larger than 16KiB.  Smaller files are sent using
+      vectored I/O of memory-mapped buffers. Header overhead is considered before
+      compressing small files.  Features include: mustache templating engine and IPv6
+      support.
+    ";
+    homepage = "https://lwan.ws/";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11792,6 +11792,8 @@ with pkgs;
 
   lighttpd = callPackage ../servers/http/lighttpd { };
 
+  lwan = callPackage ../servers/http/lwan { };
+
   mailman = callPackage ../servers/mail/mailman { };
 
   mattermost = callPackage ../servers/mattermost { };


### PR DESCRIPTION
###### Motivation for this change

Adding this interesting lightweight webserver.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

