### PR TITLE
assimp: 3.3.1 -> 4.1.0

### DIFF
--- a/pkgs/development/libraries/assimp/default.nix
+++ b/pkgs/development/libraries/assimp/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "assimp-${version}";
-  version = "3.3.1";
+  version = "4.1.0";
 
   src = fetchFromGitHub{
     owner = "assimp";
     repo = "assimp";
     rev = "v${version}";
-    sha256 = "13y44fymj13h6alig0nqab91j2qch0yh9gq8yql2zz744ch2s5vc";
+    sha256 = "00g61g3ixmfszzjncpvm8x7gp2livaj4lmhbycjmrw4x3gfqlc4r";
   };
 
   buildInputs = [ cmake boost zlib ];

--- a/pkgs/games/pioneer/default.nix
+++ b/pkgs/games/pioneer/default.nix
@@ -1,38 +1,35 @@
-{ fetchFromGitHub, stdenv, automake, curl, libsigcxx, SDL2
-, SDL2_image, freetype, libvorbis, libpng, assimp, mesa
-, autoconf, pkgconfig }:
+{ fetchFromGitHub, stdenv, autoconf, automake, pkgconfig
+, curl, libsigcxx, SDL2, SDL2_image, freetype, libvorbis, libpng, assimp, mesa
+}:
 
-let
-  version = "20160116";
-  checksum = "07w5yin2xhb0fdlj1aipi64yx6vnr1siahsy0bxvzi06d73ffj6r";
-in
 stdenv.mkDerivation rec {
   name = "pioneer-${version}";
+  version = "20171001";
 
   src = fetchFromGitHub{
     owner = "pioneerspacesim";
     repo = "pioneer";
     rev = version;
-    sha256 = checksum;
+    sha256 = "0yxw1zdvidrwc28vxfi3qpx2nq2dix2d6ylwgzq9ph8kgwv9fl5n";
   };
 
-  buildInputs = [
-    automake curl libsigcxx SDL2 SDL2_image freetype libvorbis
-    libpng assimp mesa autoconf pkgconfig
-  ];
+  nativeBuildInputs = [ autoconf automake pkgconfig ];
+
+  buildInputs = [ curl libsigcxx SDL2 SDL2_image freetype libvorbis libpng assimp mesa ];
 
   NIX_CFLAGS_COMPILE = [
     "-I${SDL2}/include/SDL2"
   ];
-
 
   preConfigure = ''
      export PIONEER_DATA_DIR="$out/share/pioneer/data";
     ./bootstrap
   '';
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
-    description = "Pioneer is a space adventure game set in the Milky Way galaxy at the turn of the 31st century";
+    description = "A space adventure game set in the Milky Way galaxy at the turn of the 31st century";
     homepage = https://pioneerspacesim.net;
     license = with licenses; [
         gpl3 cc-by-sa-30


### PR DESCRIPTION
###### Motivation for this change

This pull-request bumps version of assimp library from 3.3.1 to 4.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

