### PR TITLE
 pythonPackages.dateparser: 0.3.2-pre-2016-01-21 -> 0.6.0 

### DIFF
--- a/pkgs/development/python-modules/dateparser/default.nix
+++ b/pkgs/development/python-modules/dateparser/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, buildPythonPackage, isPy3k
+, nose
+, nose-parameterized
+, mock
+, glibcLocales
+, six
+, jdatetime
+, pyyaml
+, dateutil
+, umalqurra
+, pytz
+, tzlocal
+, regex
+, ruamel_yaml }:
+buildPythonPackage rec {
+  pname = "dateparser";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "scrapinghub";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    sha256 = "0q2vyzvlj46r6pr0s6m1a0md1cpg9nv1n3xw286l4x2cc7fj2g3y";
+  };
+
+  # Upstream Issue: https://github.com/scrapinghub/dateparser/issues/364
+  disabled = isPy3k;
+
+  checkInputs = [ nose nose-parameterized mock glibcLocales ];
+  preCheck =''
+    # skip because of missing convertdate module, which is an extra requirement
+    rm tests/test_jalali.py
+  '';
+
+  propagatedBuildInputs = [ six jdatetime pyyaml dateutil
+            umalqurra pytz tzlocal regex ruamel_yaml ];
+
+  meta = with stdenv.lib;{
+    description = "Date parsing library designed to parse dates from HTML pages";
+    homepage = https://github.com/scrapinghub/dateparser;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4371,33 +4371,7 @@ in {
 
   daphne = callPackage ../development/python-modules/daphne { };
 
-  dateparser = buildPythonPackage rec {
-    name = "dateparser-${version}";
-    version = "0.3.2-pre-2016-01-21"; # Fix assert year 2016 == 2015
-
-    src = pkgs.fetchgit {
-      url = "https://github.com/scrapinghub/dateparser.git";
-      rev = "d20a63f1d1cee5b4bd19c9f745774cfa9f219549";
-      sha256 = "0na7b4hvf7vykrk48482gxiq5xny67rvs8ilamxcxw3y9gfgdjfd";
-    };
-
-    # Does not seem to work on Python 3 because of relative import.
-    # Upstream Travis configuration is wrong and tests only 2.7
-    disabled = isPy3k;
-
-    LC_ALL = "en_US.UTF-8";
-
-    buildInputs = with self; [ nose nose-parameterized mock pkgs.glibcLocales ];
-
-    propagatedBuildInputs = with self; [ six jdatetime pyyaml dateutil umalqurra pytz ];
-
-    meta = {
-      description = "Date parsing library designed to parse dates from HTML pages";
-      homepage = https://pypi.python.org/pypi/dateparser;
-      license = licenses.bsd3;
-      broken = true;
-    };
-  };
+  dateparser = callPackage ../development/python-modules/dateparser { };
 
   # Actual name of package
   python-dateutil = callPackage ../development/python-modules/dateutil { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17544,9 +17544,6 @@ in {
     name = "ruamel.yaml-${version}";
     version = "0.13.7";
 
-    # needs ruamel_ordereddict for python2 support
-    disabled = !isPy3k;
-
     src = pkgs.fetchurl {
       url = "mirror://pypi/r/ruamel.yaml/${name}.tar.gz";
       sha256 = "1vca2552k0kmhr9msg1bbfdvp3p9im17x1a6npaw221vlgg15z7h";
@@ -17555,7 +17552,8 @@ in {
     # Tests cannot load the module to test
     doCheck = false;
 
-    propagatedBuildInputs = with self; [ ruamel_base typing ];
+    propagatedBuildInputs = with self; [ ruamel_base typing ] ++
+    (optional (!isPy3k) self.ruamel_ordereddict);
 
     meta = {
       description = "YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order";


### PR DESCRIPTION
###### Motivation for this change

unbreak pythonPackages.dateparser, bump to latest rev. This PR is part of the testing for https://github.com/makefu/nix-src-updater .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

