### PR TITLE
Add syncplay 1.5.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -205,6 +205,7 @@
   elijahcaine = "Elijah Caine <elijahcainemv@gmail.com>";
   elitak = "Eric Litak <elitak@gmail.com>";
   ellis = "Ellis Whitehead <nixos@ellisw.net>";
+  enzime = "Michael Hoang <enzime@users.noreply.github.com>";
   eperuffo = "Emanuele Peruffo <info@emanueleperuffo.com>";
   epitrochoid = "Mabry Cervin <mpcervin@uncg.edu>";
   eqyiel = "Ruben Maher <r@rkm.id.au>";

--- a/pkgs/applications/networking/syncplay/default.nix
+++ b/pkgs/applications/networking/syncplay/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, python2Packages }:
+
+python2Packages.buildPythonApplication rec {
+  name = "syncplay-${version}";
+  version = "1.5.0";
+
+  format = "other";
+
+  src = fetchurl {
+    url = https://github.com/Syncplay/syncplay/archive/v1.5.0.tar.gz;
+    sha256 = "762e6318588e14aa02b1340baa18510e7de87771c62ca5b44d985b6d1289964d";
+  };
+
+  propagatedBuildInputs = with python2Packages; [ pyside twisted ];
+
+  makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+
+  postInstall = ''
+    mkdir -p $out/lib/python2.7/site-packages
+    mv $out/lib/syncplay/syncplay $out/lib/python2.7/site-packages/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://syncplay.pl/;
+    description = "Free software that synchronises media players";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ enzime ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16888,6 +16888,8 @@ with pkgs;
 
   symlinks = callPackage ../tools/system/symlinks { };
 
+  syncplay = callPackage ../applications/networking/syncplay { };
+
   syncthing = callPackage ../applications/networking/syncthing { };
 
   syncthing012 = callPackage ../applications/networking/syncthing012 { };


### PR DESCRIPTION
###### Motivation for this change
Add syncplay application to Nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).