### PR TITLE
libva: 1.7.3 -> 2.0.0

### DIFF
--- a/pkgs/development/libraries/libva-utils/default.nix
+++ b/pkgs/development/libraries/libva-utils/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig
+, libdrm, libva
+}:
+
+stdenv.mkDerivation rec {
+  name = "libva-utils-${version}";
+  inherit (libva) version;
+
+  src = fetchFromGitHub {
+    owner  = "01org";
+    repo   = "libva-utils";
+    rev    = version;
+    sha256 = "02n51cvp8bzzjk4fargwvgh7z71y8spg24hqgaawbp3p3ahh7xxi";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ libdrm libva ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "VAAPI tools: Video Acceleration API";
+    homepage = http://www.freedesktop.org/wiki/Software/vaapi;
+    license = licenses.mit;
+    maintainers = with maintainers; [ garbas ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -1,36 +1,43 @@
-{ stdenv, lib, fetchurl, libX11, pkgconfig, libXext, libdrm, libXfixes, wayland, libffi
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig
+, libXext, libdrm, libXfixes, wayland, libffi, libX11
 , mesa_noglu
 , minimal ? true, libva
 }:
 
 stdenv.mkDerivation rec {
-  name = "libva-${version}";
-  version = "1.7.3";
+  name = "libva-${lib.optionalString (!minimal) "full-"}${version}";
+  version = "2.0.0";
 
-  src = fetchurl {
-    url = "http://www.freedesktop.org/software/vaapi/releases/libva/${name}.tar.bz2";
-    sha256 = "1ndrf136rlw03xag7j1xpmf9015d1h0dpnv6v587jnh6k2a17g12";
+  src = fetchFromGitHub {
+    owner  = "01org";
+    repo   = "libva";
+    rev    = version;
+    sha256 = "1x8rlmv5wfqjz3j87byrxb4d9vp5b4lrrin2fx254nwl3aqy15hy";
   };
 
-  outputs = [ "bin" "dev" "out" ];
+  outputs = [ "dev" "out" ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   buildInputs = [ libdrm ]
     ++ lib.optionals (!minimal) [ libva libX11 libXext libXfixes wayland libffi mesa_noglu ];
   # TODO: share libs between minimal and !minimal - perhaps just symlink them
 
-  configureFlags =
-    [ "--with-drivers-path=${mesa_noglu.driverLink}/lib/dri" ] ++
-    lib.optionals (!minimal) [ "--enable-glx" ];
+  enableParallelBuilding = true;
 
-  installFlags = [ "dummy_drv_video_ladir=$(out)/lib/dri" ];
+  configureFlags = [
+    "--with-drivers-path=${mesa_noglu.driverLink}/lib/dri"
+  ] ++ lib.optionals (!minimal) [ "--enable-glx" ];
+
+  installFlags = [
+    "dummy_drv_video_ladir=$(out)/lib/dri"
+  ];
 
   meta = with stdenv.lib; {
+    description = "VAAPI library: Video Acceleration API";
     homepage = http://www.freedesktop.org/wiki/Software/vaapi;
     license = licenses.mit;
-    description = "VAAPI library: Video Acceleration API";
-    platforms = platforms.unix;
     maintainers = with maintainers; [ garbas ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/vaapi-intel/default.nix
+++ b/pkgs/development/libraries/vaapi-intel/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, fetchurl, gnum4, pkgconfig, python2
+{ stdenv, fetchFromGitHub, autoreconfHook, gnum4, pkgconfig, python2
 , intel-gpu-tools, libdrm, libva, libX11, mesa_noglu, wayland, libXext
 }:
 
 stdenv.mkDerivation rec {
   name = "intel-vaapi-driver-${version}";
-  version = "1.8.2";
+  inherit (libva) version;
 
-  src = fetchurl {
-    url = "http://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${name}.tar.bz2";
-    sha256 = "00mpcvininwr5c4wyhp16s4bddg7vclxxjm2sfq5h7lifjcxyv46";
+  src = fetchFromGitHub {
+    owner  = "01org";
+    repo   = "libva-intel-driver";
+    rev    = version;
+    sha256 = "1832nnva3d33wv52bj59bv62q7a807sdxjqqq0my7l9x7a4qdkzz";
   };
 
   patchPhase = ''
@@ -25,9 +27,11 @@ stdenv.mkDerivation rec {
     "--enable-wayland"
   ];
 
-  nativeBuildInputs = [ gnum4 pkgconfig python2 ];
+  nativeBuildInputs = [ autoreconfHook gnum4 pkgconfig python2 ];
 
   buildInputs = [ intel-gpu-tools libdrm libva libX11 libXext mesa_noglu wayland ];
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = http://cgit.freedesktop.org/vaapi/intel-driver/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9747,6 +9747,7 @@ with pkgs;
 
   libva = callPackage ../development/libraries/libva { };
   libva-full = libva.override { minimal = false; };
+  libva-utils = callPackage ../development/libraries/libva-utils { };
 
   libvdpau = callPackage ../development/libraries/libvdpau { };
 


### PR DESCRIPTION
###### Motivation for this change

The ```vaapi-intel``` driver is released in accordance with ```libva``` releases, so this PR sets up the dependency.

Additionally, the tools previously part of ```libva``` are now a separate ```libva-utils```.

This triggers a lot of rebuilding so I haven't tried it out here yet.

Cc: @garbas 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

