### PR TITLE
esniper: 2.33.0 -> 2.33.0.2017-11-06

### DIFF
--- a/pkgs/applications/networking/esniper/default.nix
+++ b/pkgs/applications/networking/esniper/default.nix
@@ -1,11 +1,13 @@
-{ stdenv, fetchurl, openssl, curl, coreutils, gawk, bash, which }:
+{ stdenv, fetchFromGitHub, openssl, curl, coreutils, gawk, bash, which }:
 
 stdenv.mkDerivation rec {
-  name = "esniper-2.33.0";
+  name = "esniper-2.33.0.2017-11-06";
 
-  src = fetchurl {
-    url    = "mirror://sourceforge/esniper/${stdenv.lib.replaceStrings ["."] ["-"] name}.tgz";
-    sha256 = "1pck2x7mp7ip0b21v2sjvq86fz12gzw6kig4vvbrghz5xw5b3f69";
+  src = fetchFromGitHub {
+    owner = "yhfudev";
+    repo = "esniper";
+    rev = "c95140d376db3c991300a7462e6c172b0ccf3eb5";
+    sha256 = "1dfb5hmcrvm3yg9ask362c6s5ylxs21szw23dm737a94br37j890";
   };
 
   buildInputs = [ openssl curl ];


### PR DESCRIPTION
###### Motivation for this change
esniper that is from sourceforge is incompatible with latest changes on ebay. This is a fork used by arch that has the problem solved. they haven't upped the version number so this is just the latest checkout from their repo.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X ] NixOS
   - [ ] macOS
   - [ X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ X] Tested execution of all binary files (usually in `./result/bin/`)
- [X ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

