### PR TITLE
hl1110 : init at 3.0.1-1

### DIFF
--- a/pkgs/misc/cups/drivers/hl1110/default.nix
+++ b/pkgs/misc/cups/drivers/hl1110/default.nix
@@ -1,0 +1,73 @@
+{stdenv, fetchurl, cups, dpkg, gnused, makeWrapper, ghostscript, file, a2ps, coreutils, gawk, patchelf}:
+
+let
+  version = "3.0.1-1";
+cupsdeb = fetchurl {
+  url = "http://download.brother.com/welcome/dlf100421/hl1110cupswrapper-${version}.i386.deb";
+  sha256 = "a87880f4ece764a724411b5b24d15d1b912f6ffc6ecbfd9fac4cd5eda13d2eb7";
+};
+srcdir = "hl1110cupswrapper-GPL_src-${version}";
+cupssrc = fetchurl {
+  url = "http://download.brother.com/welcome/dlf100422/${srcdir}.tar.gz";
+  sha256 = "be1dce6a4608cb253b0b382db30bf5885da46b010e8eb595b15c435e2487761c";
+};
+lprdeb = fetchurl {
+  url = "http://download.brother.com/welcome/dlf100419/hl1110lpr-${version}.i386.deb";
+  sha256 = "5af241782a0d500d7f47e06ea43d61127f4019b5b1c6e68b4c1cb4521a742c22";
+};
+  in
+stdenv.mkDerivation {
+  name = "cups-brother-hl1110";
+
+  srcs = [ lprdeb cupssrc cupsdeb ];
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ cups ghostscript dpkg a2ps ];
+  unpackPhase = ''
+    tar -xvf ${cupssrc}
+    '';
+  buildPhase = ''
+    gcc -Wall ${srcdir}/brcupsconfig/brcupsconfig.c -o brcupsconfig4
+    '';
+  installPhase = ''
+    # install lpr
+    dpkg-deb -x ${lprdeb} $out
+
+    substituteInPlace $out/opt/brother/Printers/HL1110/lpd/filter_HL1110 \
+    --replace /opt "$out/opt" \
+
+    sed -i '/GHOST_SCRIPT=/c\GHOST_SCRIPT=gs' $out/opt/brother/Printers/HL1110/lpd/psconvert2
+
+    patchelf --set-interpreter ${stdenv.glibc.out}/lib/ld-linux.so.2 $out/opt/brother/Printers/HL1110/lpd/brprintconflsr3
+    patchelf --set-interpreter ${stdenv.glibc.out}/lib/ld-linux.so.2 $out/opt/brother/Printers/HL1110/lpd/rawtobr3
+    patchelf --set-interpreter ${stdenv.glibc.out}/lib/ld-linux.so.2 $out/opt/brother/Printers/HL1110/inf/braddprinter
+
+    wrapProgram $out/opt/brother/Printers/HL1110/lpd/psconvert2 \
+    --prefix PATH ":" ${ stdenv.lib.makeBinPath [ gnused coreutils gawk ] }
+
+    wrapProgram $out/opt/brother/Printers/HL1110/lpd/filter_HL1110 \
+    --prefix PATH ":" ${ stdenv.lib.makeBinPath [ ghostscript a2ps file gnused coreutils ] }
+
+
+    dpkg-deb -x ${cupsdeb} $out
+
+    substituteInPlace $out/opt/brother/Printers/HL1110/cupswrapper/brother_lpdwrapper_HL1110 --replace /opt "$out/opt"
+
+    mkdir -p $out/lib/cups/filter
+    ln -s $out/opt/brother/Printers/HL1110/cupswrapper/brother_lpdwrapper_HL1110 $out/lib/cups/filter/brother_lpdwrapper_HL1110
+    ln -s $out/opt/brother/Printers/HL1110/cupswrapper/brother-HL1110-cups-en.ppd $out/lib/cups/filter/brother-HL1110-cups-en.ppd
+    cp brcupsconfig4 $out/opt/brother/Printers/HL1110/cupswrapper/
+    ln -s $out/opt/brother/Printers/HL1110/cupswrapper/brcupsconfig4 $out/lib/cups/filter/brcupsconfig4
+
+    wrapProgram $out/opt/brother/Printers/HL1110/cupswrapper/brother_lpdwrapper_HL1110 \
+    --prefix PATH ":" ${ stdenv.lib.makeBinPath [ gnused coreutils gawk ] }
+
+    '';
+
+  meta = {
+    homepage = http://www.brother.com/;
+    description = "Brother HL1110 printer driver";
+    license = stdenv.lib.licenses.unfree;
+    platforms = stdenv.lib.platforms.linux;
+    downloadPage = "http://support.brother.com/g/b/downloadlist.aspx?c=eu_ot&lang=en&prod=hl1110_us_eu_as&os=128#SelectLanguageType-561_0_1";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19453,6 +19453,8 @@ with pkgs;
 
   cups-bjnp = callPackage ../misc/cups/drivers/cups-bjnp { };
 
+  cups-brother-hl1110 = callPackage_i686 ../misc/cups/drivers/hl1110 { };
+
   # this driver ships with pre-compiled 32-bit binary libraries
   cnijfilter_2_80 = callPackage_i686 ../misc/cups/drivers/cnijfilter_2_80 { };
 


### PR DESCRIPTION
This commit adds a driver to cups for the Brother HL1110 printer.

###### Things done

This package is based on  'mfcj470dw-cupswrapper' and 'mfcj470dwlpr', and merged into a single nix file. I've decided to do this because this way because it requires less patching to the scripts and other source files.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

