### PR TITLE
KDE Frameworks 5.41

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.40/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.41/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,611 +3,611 @@
 
 {
   attica = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/attica-5.40.0.tar.xz";
-      sha256 = "1ng76yhljl1ny0wvb7yckiivwqn3llmhk0h4j82zag5965q906iz";
-      name = "attica-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/attica-5.41.0.tar.xz";
+      sha256 = "1l97qhf053z7grl8d77p9zajdvaw3zicllwna9p2vyzbb6n6qyq7";
+      name = "attica-5.41.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/baloo-5.40.0.tar.xz";
-      sha256 = "09hqw8xl34galpiv6rwnq2rrbdp6z9nkx9j71jf87ia22sclz55a";
-      name = "baloo-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/baloo-5.41.0.tar.xz";
+      sha256 = "1kl4xs09r21bi11b5dzjkmc8igh5iv8nvq0gxd00n7qjghpxa399";
+      name = "baloo-5.41.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/bluez-qt-5.40.0.tar.xz";
-      sha256 = "0js212bi7h09bcbd2lr7ic10fy3z09w3v0d0r5210p989qd42a5a";
-      name = "bluez-qt-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/bluez-qt-5.41.0.tar.xz";
+      sha256 = "08wlsmr12n3whqr65zm3l9hmzbaca2jkkhb1wwq5ilqm3gvxxz0n";
+      name = "bluez-qt-5.41.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/breeze-icons-5.40.0.tar.xz";
-      sha256 = "1gdpv6w9a6bhr0dgaldi9pj24a2qvz1ax4jya8i4ck7dl9cgkq96";
-      name = "breeze-icons-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/breeze-icons-5.41.0.tar.xz";
+      sha256 = "1k06ms48cnnwnlrh9wdabsms581jy70nz5narwg1zpzb6clf9p4w";
+      name = "breeze-icons-5.41.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/extra-cmake-modules-5.40.0.tar.xz";
-      sha256 = "02k3dr4w12l9rdgl3l1v3d8zhaf51km4w3p1c3sy8x24r24qir43";
-      name = "extra-cmake-modules-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/extra-cmake-modules-5.41.0.tar.xz";
+      sha256 = "0rwz2rdyxr424z0mra29p8i6gf0b1402ifi94qrq7y4z1fa61bxs";
+      name = "extra-cmake-modules-5.41.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/frameworkintegration-5.40.0.tar.xz";
-      sha256 = "1r480hx18irycaygbxbxsgf1qrk6cdj0ccfi4rqcygxkv52gcxxj";
-      name = "frameworkintegration-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/frameworkintegration-5.41.0.tar.xz";
+      sha256 = "1k67hkzc2jw5im7vc8j64fqsxz5m8fnlq696hm5dh4fbclyckh5s";
+      name = "frameworkintegration-5.41.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kactivities-5.40.0.tar.xz";
-      sha256 = "0c6dgmzs6l33kr4a7aivs8ijf6yw616pz5gmh7sdjw2ny4gxdzab";
-      name = "kactivities-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kactivities-5.41.0.tar.xz";
+      sha256 = "1zxwmizq48kk6pd9y350gzszqi87wjbqni8z4mxa1kmw9lq01xlc";
+      name = "kactivities-5.41.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kactivities-stats-5.40.0.tar.xz";
-      sha256 = "0cdnq2nh3p7baxcag0f1sid5mrmmidfpsd77bb9s0xj11jvs95bx";
-      name = "kactivities-stats-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kactivities-stats-5.41.0.tar.xz";
+      sha256 = "1nm34ln222x6mm4zpmvn8prqk9fr3jxyppn18kwlv0nfw16qmppq";
+      name = "kactivities-stats-5.41.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kapidox-5.40.0.tar.xz";
-      sha256 = "1wvnbmxjxmrm0z1digbfbf5ssf6klzdmzf5lbw7ilf5mkah1bdpy";
-      name = "kapidox-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kapidox-5.41.0.tar.xz";
+      sha256 = "0jdphs536ymaj5f9gh5ycfgq1d41sas6bx4dzzjg13y26w6afyy6";
+      name = "kapidox-5.41.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/karchive-5.40.0.tar.xz";
-      sha256 = "1cbvv6rdrnag2vjbrzdg59csmqi247d594xan7r319qb76ai860y";
-      name = "karchive-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/karchive-5.41.0.tar.xz";
+      sha256 = "0hd7jy9517m53ijvprl9ci97kjx7nd42ga33af71kqx5x030zi23";
+      name = "karchive-5.41.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kauth-5.40.0.tar.xz";
-      sha256 = "072wjhvscyyh2q61knxm8ipqr9r01dzhqd8dihp6c5zmbbpz29ss";
-      name = "kauth-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kauth-5.41.0.tar.xz";
+      sha256 = "1hkaf83p3xwcwkhlfbrdbg7b7nhw0gh0yw4lv8y3vpryn7pcd32l";
+      name = "kauth-5.41.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kbookmarks-5.40.0.tar.xz";
-      sha256 = "1i28pic968llggh24hn84kiq9nhdcv3pn4hbhb0lqb4chrmm322i";
-      name = "kbookmarks-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kbookmarks-5.41.0.tar.xz";
+      sha256 = "173rf85msrp1awmf2zsxwv6jjfkz7yc2pbh4jq0hfcgnqk46s9v0";
+      name = "kbookmarks-5.41.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kcmutils-5.40.0.tar.xz";
-      sha256 = "1pjvjidv9nx8kg5wvkmxanp9y6ins9f43cn933q6g9gczy2hfcbl";
-      name = "kcmutils-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kcmutils-5.41.0.tar.xz";
+      sha256 = "165b5hk0cv769kk9dqqggc6ji6gzln8zns5k6rv12rz825aysnhs";
+      name = "kcmutils-5.41.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kcodecs-5.40.0.tar.xz";
-      sha256 = "0zq9d5006zhp0v31ydc7q0i117l6f8b04l5jgqcl719q1a2hk1x4";
-      name = "kcodecs-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kcodecs-5.41.0.tar.xz";
+      sha256 = "0y96mbp9j083kwkqxk0qgrjyhylp8f7f0ngcqcvhh8s6sgpb8xq9";
+      name = "kcodecs-5.41.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kcompletion-5.40.0.tar.xz";
-      sha256 = "17dzal655xdxdsifk2dmgyj2hja03pcvdqvzpsyq259qbm42cal4";
-      name = "kcompletion-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kcompletion-5.41.0.tar.xz";
+      sha256 = "0b6bh5l4s5q8yi6vls11c8b8dpscykh138kydfi925nxkrms7yv3";
+      name = "kcompletion-5.41.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kconfig-5.40.0.tar.xz";
-      sha256 = "0pr9ammqgbz3gkg6iczp3v9s36cfzzh40kbz2bz29qaxa966b5kb";
-      name = "kconfig-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kconfig-5.41.0.tar.xz";
+      sha256 = "1jch9bpqshigwvc2qs46qa0mclr1hdn0sqlkxbl4b2xb5xj28nzn";
+      name = "kconfig-5.41.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kconfigwidgets-5.40.0.tar.xz";
-      sha256 = "0g5xm3fm3d6a63hbdq1xxiv539z15bhrs36ariq93flc4f912pbz";
-      name = "kconfigwidgets-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kconfigwidgets-5.41.0.tar.xz";
+      sha256 = "1lbpjkhxmpah32ig1wlxkr1v1l3fqicnnvj6lhwpk0bxys8cdnd2";
+      name = "kconfigwidgets-5.41.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kcoreaddons-5.40.0.tar.xz";
-      sha256 = "0n4gvfayaiahvavrx1y3ass6anz30965zm81iczi2749hva9s415";
-      name = "kcoreaddons-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kcoreaddons-5.41.0.tar.xz";
+      sha256 = "1f45x4adql708903x4g27x1wbzvbwd809ibiqa5kiijayaqkjxqf";
+      name = "kcoreaddons-5.41.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kcrash-5.40.0.tar.xz";
-      sha256 = "01h41zz3x0m5hc3zm2v0mifzc42akp5bwxwjzaaryl8pcg8v5lln";
-      name = "kcrash-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kcrash-5.41.0.tar.xz";
+      sha256 = "1jp06hz33mpcy2y93w4j3yqcvkphigiwq6j89mvgi9h21pahpjvy";
+      name = "kcrash-5.41.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kdbusaddons-5.40.0.tar.xz";
-      sha256 = "09zbdy8lzhq6lvd9j9667r90k6p6a882bxans6am1yxx4y0jd9i4";
-      name = "kdbusaddons-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kdbusaddons-5.41.0.tar.xz";
+      sha256 = "02d6zv43vpz5h8si100zlsf5yfgjajsgwldcxblckyjr0qn42xny";
+      name = "kdbusaddons-5.41.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kdeclarative-5.40.0.tar.xz";
-      sha256 = "10yp7g9awv4mdf5zl6ljxplfy50jzmixp45vdqcmcixiq72440d6";
-      name = "kdeclarative-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kdeclarative-5.41.0.tar.xz";
+      sha256 = "1hxfrz4d7xjm63b9kawhf382gz1xykvdi9q4syhkjfbpyacxfjga";
+      name = "kdeclarative-5.41.0.tar.xz";
     };
   };
   kded = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kded-5.40.0.tar.xz";
-      sha256 = "0jf4xahsz86hiv50vs9yhwd2g410d5wjds8mdm5hi8085f7dcf84";
-      name = "kded-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kded-5.41.0.tar.xz";
+      sha256 = "10wmj3nb8vn90h1j0s5kfr8iydk7k853gg9v6hxivm92v6zr6l9g";
+      name = "kded-5.41.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/portingAids/kdelibs4support-5.40.0.tar.xz";
-      sha256 = "1pwmi490hwnijpwjm80zdvbwanlslhnfh8nrlxmiham7ls551mzr";
-      name = "kdelibs4support-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/portingAids/kdelibs4support-5.41.0.tar.xz";
+      sha256 = "1mkp3w8h8cyskbfxcwsl72v87376x66n20ig7b3b6ply36578br4";
+      name = "kdelibs4support-5.41.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kdesignerplugin-5.40.0.tar.xz";
-      sha256 = "00wl4d001ix0ql2hzp818cvhyyr52g06b7zz92qhcyi4x1cf2mqd";
-      name = "kdesignerplugin-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kdesignerplugin-5.41.0.tar.xz";
+      sha256 = "1c1pnjgp9nifynwvsyjp7c45j40i111xnmjp89bb1jk9fv9g2f99";
+      name = "kdesignerplugin-5.41.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kdesu-5.40.0.tar.xz";
-      sha256 = "13dv54c9cw6a2zcn7arrqnda08r3rw2q3nqagrrn013xd3dlrac7";
-      name = "kdesu-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kdesu-5.41.0.tar.xz";
+      sha256 = "126m7by50zzkmk0r778xlkqfbfpihwd6d3wzd4hbqkh9km18l1rb";
+      name = "kdesu-5.41.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kdewebkit-5.40.0.tar.xz";
-      sha256 = "1n7cn3yg8ianfk9ymd7hgf1yr2qcck5pg2mcp2bam0zfk4clbcgf";
-      name = "kdewebkit-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kdewebkit-5.41.0.tar.xz";
+      sha256 = "1rnixlm37x5k4cdwckml2zdmm30k938nklkd7qnbaal230dzvj6d";
+      name = "kdewebkit-5.41.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kdnssd-5.40.0.tar.xz";
-      sha256 = "10la98wshran4my7s50w85ifvdibvbw3mb4007x8znz92x1ikdfj";
-      name = "kdnssd-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kdnssd-5.41.0.tar.xz";
+      sha256 = "042dmh50rxvipb5pqz0csb3y7cvzc2ga2a5qcvd1vw84ii1mmjbh";
+      name = "kdnssd-5.41.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kdoctools-5.40.0.tar.xz";
-      sha256 = "1zzgnqkysdvqc7dkb37gcmxfhwik0bkmd23c4y2av00ra6nzymim";
-      name = "kdoctools-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kdoctools-5.41.0.tar.xz";
+      sha256 = "06v63br6m5nhvsdsynhb7i825yrry94s7zrk20k0xw4yahpvkjcs";
+      name = "kdoctools-5.41.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kemoticons-5.40.0.tar.xz";
-      sha256 = "1jqifvqbj441jif79j5jqrpksyajarill01v625l30kvd584042c";
-      name = "kemoticons-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kemoticons-5.41.0.tar.xz";
+      sha256 = "1lj6c6k8dh2rgj1128ms2xv7dk1v9li5rcy2djqfynqdrvg5iy3g";
+      name = "kemoticons-5.41.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kfilemetadata-5.40.0.tar.xz";
-      sha256 = "1yivydc32y4q6kd1myv529lhcs66j0y388g7qv4zjz4plv6kyxvb";
-      name = "kfilemetadata-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kfilemetadata-5.41.0.tar.xz";
+      sha256 = "0y9ya18bqa8sfi2c10y2q0dkwdry0wfq5s2sb53q0fh2fph7hjvi";
+      name = "kfilemetadata-5.41.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kglobalaccel-5.40.0.tar.xz";
-      sha256 = "1qslksbln3yhhzal88b04zyi4iibffv687gbsm07i4f68pyp0sgn";
-      name = "kglobalaccel-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kglobalaccel-5.41.0.tar.xz";
+      sha256 = "0i8aw0jbsh26asjmhs0lax1yv9qalpr82cd8m0nbyqn2s3f4jyaf";
+      name = "kglobalaccel-5.41.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kguiaddons-5.40.0.tar.xz";
-      sha256 = "02hln4pafph1zny4jnmblydc4wnx66pjj4g6dqxafz6hpvdmncp1";
-      name = "kguiaddons-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kguiaddons-5.41.0.tar.xz";
+      sha256 = "0cva0qy946srqay9nmh97mjv7kf2lr51nipx9qx2jd21d8cvz8p1";
+      name = "kguiaddons-5.41.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/portingAids/khtml-5.40.0.tar.xz";
-      sha256 = "0v73ia4dgpx5d7h3lpl54cy7p3qavgahj5h2x5vah7fb2gysy7z0";
-      name = "khtml-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/portingAids/khtml-5.41.0.tar.xz";
+      sha256 = "0gbs63d7izb8kaf4k8ssp2lkcps9fqk32czjpmzx3fq1gnaczry3";
+      name = "khtml-5.41.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/ki18n-5.40.0.tar.xz";
-      sha256 = "1nv89yi0f2wnb3lc929zfl6bjwznm2q3p449rp3yzp43lx00sym9";
-      name = "ki18n-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/ki18n-5.41.0.tar.xz";
+      sha256 = "12ylqsi7lsxvdcg9a1p9hkd6lpcj971k77zly6vpb4yb3s6z0jqd";
+      name = "ki18n-5.41.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kiconthemes-5.40.0.tar.xz";
-      sha256 = "0i6yjx5fvpbh4hd15wbm69v2qqgxbyfhn1cqp7w7ghgb262b90vx";
-      name = "kiconthemes-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kiconthemes-5.41.0.tar.xz";
+      sha256 = "1ywg7b3vy3p7vmd055a72hmpnwp0l0yvf6cnb6nvmpnp3pm737g1";
+      name = "kiconthemes-5.41.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kidletime-5.40.0.tar.xz";
-      sha256 = "0q6s73vpasfvzxis5br01k2xl8hnxymq8i1k8l60i8b1v46abr99";
-      name = "kidletime-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kidletime-5.41.0.tar.xz";
+      sha256 = "0k4q8ssqfbgfqvjq1rpills16nz4fi92mc754644by3s0czh409w";
+      name = "kidletime-5.41.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kimageformats-5.40.0.tar.xz";
-      sha256 = "1ld47qkb26gzwvr6bmqa16p4rwf3avi4fm15rpmmxjlbc9pm9n51";
-      name = "kimageformats-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kimageformats-5.41.0.tar.xz";
+      sha256 = "11df264s3n192pggdmql2pklnflc8fn9v8zrjpn38f99hs46bq8s";
+      name = "kimageformats-5.41.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kinit-5.40.0.tar.xz";
-      sha256 = "1296dr1iln5g55j75fb1l5b8c1lj32lsccb82qvpaf57h22fp5ya";
-      name = "kinit-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kinit-5.41.0.tar.xz";
+      sha256 = "05jqsnj33gwxp4lc81378kb58idnmcmn84smy3hkqwlakisnwgy9";
+      name = "kinit-5.41.0.tar.xz";
     };
   };
   kio = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kio-5.40.0.tar.xz";
-      sha256 = "16rqmh0mdncyyq2vidfpyml94n7vmz7rx71v53salpwr3cihpsih";
-      name = "kio-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kio-5.41.0.tar.xz";
+      sha256 = "17k4pfbhkv1inx5c3wqm388c02cdf3wnqgnhky271v7gb5ww5i4h";
+      name = "kio-5.41.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kirigami2-5.40.0.tar.xz";
-      sha256 = "0a22cwxfrkp0hd5isisaz9bnx2sjixi2cm9l35yvbzdnlmm6qjrb";
-      name = "kirigami2-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kirigami2-5.41.0.tar.xz";
+      sha256 = "04l7b86fs7s80dfrznc2c0zh6phpgirwsinykrzfqg792gmbvx2h";
+      name = "kirigami2-5.41.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kitemmodels-5.40.0.tar.xz";
-      sha256 = "0ij5q0g0cq793znslb7sz6qcrmcdlcx706an8ciznidlwayh9fx9";
-      name = "kitemmodels-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kitemmodels-5.41.0.tar.xz";
+      sha256 = "13kngcj8ifnhbp0jsrjwhw49my8pnw493g11y11cw17hw7sqg55k";
+      name = "kitemmodels-5.41.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kitemviews-5.40.0.tar.xz";
-      sha256 = "0347nx4n5sr0dz2zjzdp7s1ca5gnmcr9d881raj50knsgcwgb3m3";
-      name = "kitemviews-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kitemviews-5.41.0.tar.xz";
+      sha256 = "0147pm5p03w1b71mrr5rssmh2n80q54ghfpbjpq3spjdkjg1f26f";
+      name = "kitemviews-5.41.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kjobwidgets-5.40.0.tar.xz";
-      sha256 = "0m2bfa397mzifgxvpw8hpks95yx5krak0285qk14innr21n62qnk";
-      name = "kjobwidgets-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kjobwidgets-5.41.0.tar.xz";
+      sha256 = "1fbdk6l8rbnyqn0cz2dm9cagn7x89zpy3wczj1cdvnc7k7wg75qv";
+      name = "kjobwidgets-5.41.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/portingAids/kjs-5.40.0.tar.xz";
-      sha256 = "0nkddm9zjjnsmky71112n8ik6f0am52dmhlarcym2i08zy05chdm";
-      name = "kjs-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/portingAids/kjs-5.41.0.tar.xz";
+      sha256 = "1a263cng8i304yh66iq45hwpgnl8ng6wvjrsl11hhqmyv07h2kk0";
+      name = "kjs-5.41.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/portingAids/kjsembed-5.40.0.tar.xz";
-      sha256 = "0fc3454almq5llhwmkhrwpcl2m1nfjyyhvpnmm879yhrbjf7vnid";
-      name = "kjsembed-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/portingAids/kjsembed-5.41.0.tar.xz";
+      sha256 = "1vxbh5rd9rdj3m7sag48c4cns443j479mlfbwxgnpm92z67ka7x7";
+      name = "kjsembed-5.41.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/portingAids/kmediaplayer-5.40.0.tar.xz";
-      sha256 = "13pykc6zvcv6p0k6m9cqf1fx93jb39ilgn1zlvkws7s1jq4ifkpl";
-      name = "kmediaplayer-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/portingAids/kmediaplayer-5.41.0.tar.xz";
+      sha256 = "03420i82p984w6iqdiam2xam7b9khh76pll4ffn0c5k4wf1ba2z4";
+      name = "kmediaplayer-5.41.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/knewstuff-5.40.0.tar.xz";
-      sha256 = "0i4ybzx165js2pl85k8si1waywn4yp47gj16szdx7snlrzvhmq3i";
-      name = "knewstuff-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/knewstuff-5.41.0.tar.xz";
+      sha256 = "0j9qgswiacv7yj8c28q343falaglh5zc4wwcflwy1zvrp59bjcz4";
+      name = "knewstuff-5.41.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/knotifications-5.40.0.tar.xz";
-      sha256 = "013r52a6wl9ayp42mvzrq7s8r5mx73bk1j56zxk3yz45xv6gsm0v";
-      name = "knotifications-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/knotifications-5.41.0.tar.xz";
+      sha256 = "1dsiigmzmhmg3x6y5nf2i9zq3hc4nca2gg2dvl0bz1lm438ddy84";
+      name = "knotifications-5.41.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/knotifyconfig-5.40.0.tar.xz";
-      sha256 = "1c89k1qnbqyq7d9dsccd9645cq7n6vfyn10sh9f7zraqybi75k3k";
-      name = "knotifyconfig-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/knotifyconfig-5.41.0.tar.xz";
+      sha256 = "0hrdjh76php34wkcswnh5rfnkajf0g9n8mpqsdj4djxja39vi6vs";
+      name = "knotifyconfig-5.41.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kpackage-5.40.0.tar.xz";
-      sha256 = "17hhj8x5r3cpb6cx32f1chg6mklxvcwgmw16c3h2sh4p6bgmibmq";
-      name = "kpackage-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kpackage-5.41.0.tar.xz";
+      sha256 = "1663sshy52my9qbrj8ny1a6sipl94l2paxss4k5977fyyax15zdm";
+      name = "kpackage-5.41.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kparts-5.40.0.tar.xz";
-      sha256 = "1vvmgsqwgics6q86c413wx2yk9mgwvj4wm3fk6my0pi3l166djrl";
-      name = "kparts-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kparts-5.41.0.tar.xz";
+      sha256 = "09ddh7n8jj8zisdm90lbmc4xk4axsibhx1cjbpaigzcfcvnj1b71";
+      name = "kparts-5.41.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kpeople-5.40.0.tar.xz";
-      sha256 = "1yfs0k3pwcgkzyf0x568jmmjb5gb757c7qdwmz7g0s3gdnhm1mbr";
-      name = "kpeople-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kpeople-5.41.0.tar.xz";
+      sha256 = "1k72br66mnvkripzdq2wcchlrg6p7mxfqa0rbq0rq3q7npw1zzw5";
+      name = "kpeople-5.41.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kplotting-5.40.0.tar.xz";
-      sha256 = "1hnnvxvz74s7ir5bgqrvd0iv6fl7d18rqi6yjxy5j8b0f8bgrp7i";
-      name = "kplotting-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kplotting-5.41.0.tar.xz";
+      sha256 = "197n2m3q9b588j56m30i12z55nbymbj4wgpgrkbsci7162jjjj1z";
+      name = "kplotting-5.41.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kpty-5.40.0.tar.xz";
-      sha256 = "1r5lddjhr6g3gzwfmcs7mkc585mz4j6ngnn2m5mlgz2cf8bgf277";
-      name = "kpty-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kpty-5.41.0.tar.xz";
+      sha256 = "04xg5pn65nvk1bdh6bfznbsmlra6gzph72i7m28h9idnz143lr12";
+      name = "kpty-5.41.0.tar.xz";
     };
   };
   kross = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/portingAids/kross-5.40.0.tar.xz";
-      sha256 = "1y89sksha028rxdf534kc3ljnccm2zy111lfnb36vq22wzi7198p";
-      name = "kross-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/portingAids/kross-5.41.0.tar.xz";
+      sha256 = "0xsfgwb3ihgby6r6wycxnqkd9d7zrj6w3h9bxw8n4asjfri7lgwi";
+      name = "kross-5.41.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/krunner-5.40.0.tar.xz";
-      sha256 = "19g02k7g2i92fv68gssyqrc1gwlhh924glmzhswp52rkwz4rqf2c";
-      name = "krunner-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/krunner-5.41.0.tar.xz";
+      sha256 = "0vyxijs0vnpa19z7avd1438q1c7s4ka17hbsdq2r0jza3iwkfx83";
+      name = "krunner-5.41.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kservice-5.40.0.tar.xz";
-      sha256 = "0dpd7zpw6x4iqb27a13aazbk9rgbngrdkxz76pq4x32ynzrzzhzc";
-      name = "kservice-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kservice-5.41.0.tar.xz";
+      sha256 = "0k3ch3vbdy9rm82d9n6mf6ir3qm7l2fddp98jy4jmsr0qynqn50q";
+      name = "kservice-5.41.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/ktexteditor-5.40.0.tar.xz";
-      sha256 = "0xlhxgsj1cyvxrhj4d0ydcns1p18x51igh9bda66rp5p3wx8xm5n";
-      name = "ktexteditor-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/ktexteditor-5.41.0.tar.xz";
+      sha256 = "1idvldchfbnvimvcrizigmmam62q7rpam06xprcizywyxq53yw7z";
+      name = "ktexteditor-5.41.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/ktextwidgets-5.40.0.tar.xz";
-      sha256 = "0dm2nka8vyazz10hi55d1imi49ip2lfns1dimwnwbi15j3a14m6r";
-      name = "ktextwidgets-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/ktextwidgets-5.41.0.tar.xz";
+      sha256 = "0m6n4v0njvcaky87f0ga47iwq12hsvghadj8pngjrksankvaj23n";
+      name = "ktextwidgets-5.41.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kunitconversion-5.40.0.tar.xz";
-      sha256 = "1qp0jcds7khbdxbi025ngz62xbw0k35psy204yz95wrmg302hvnw";
-      name = "kunitconversion-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kunitconversion-5.41.0.tar.xz";
+      sha256 = "1kn6lw58b9w6f38mra2hizbnik64ka3gvgqk1xqp0mspqmr498rw";
+      name = "kunitconversion-5.41.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kwallet-5.40.0.tar.xz";
-      sha256 = "0lyx3vdql9n2bwr37wjk6l0k9n2si16gx74vmn1f4r7vqyhij8nd";
-      name = "kwallet-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kwallet-5.41.0.tar.xz";
+      sha256 = "1gdzfp3gbr5qp821pkhaj6v8zg3q21xz6j11frjww8fn5nmp3v3l";
+      name = "kwallet-5.41.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kwayland-5.40.0.tar.xz";
-      sha256 = "00x4df45d80p1nvb0pjbg4y2vmcsghy9hnsr6mwyrhbkdrqdwkid";
-      name = "kwayland-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kwayland-5.41.0.tar.xz";
+      sha256 = "1dw2g6wwj7hhxlgzrjqk39ywpzh6ijwfjnzqjp6s8s5274fvjqbn";
+      name = "kwayland-5.41.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kwidgetsaddons-5.40.0.tar.xz";
-      sha256 = "16h65q1ibmwc5rmwf9jixxrawcd3jvrb5z4z2pcmh8242n1hyhk8";
-      name = "kwidgetsaddons-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kwidgetsaddons-5.41.0.tar.xz";
+      sha256 = "15fm7gni22wb64pski3fn5myrn9z22h077hzzcc34c3af21yh5s5";
+      name = "kwidgetsaddons-5.41.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kwindowsystem-5.40.0.tar.xz";
-      sha256 = "0cw062m9phy7z5yg75yg7qwg2lpz8270mwbmmwcbw9bl6qqkbwzz";
-      name = "kwindowsystem-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kwindowsystem-5.41.0.tar.xz";
+      sha256 = "0x4jz9qkvxs5dlzk860f8vhlczgxg6di614y8ji6afra760nk17l";
+      name = "kwindowsystem-5.41.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kxmlgui-5.40.0.tar.xz";
-      sha256 = "07a7h9l0qwsnlwkh7pf50wmq21939mwynplm2zzzv3hkhfj89v6v";
-      name = "kxmlgui-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kxmlgui-5.41.0.tar.xz";
+      sha256 = "0cgwx3lhnn982gvl2yv5272bs3il05ssfpjlkgmqgnrnz2qxlhlr";
+      name = "kxmlgui-5.41.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/kxmlrpcclient-5.40.0.tar.xz";
-      sha256 = "01zbgnqf2sfjgmx8nn6ljzpvqjg777j2yh2jm55rc4yh15qvvn0l";
-      name = "kxmlrpcclient-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/kxmlrpcclient-5.41.0.tar.xz";
+      sha256 = "0y7n6xk18a6zci36ka426h7ar8r7kkr80jn47mc6jw3qdk4nvri7";
+      name = "kxmlrpcclient-5.41.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/modemmanager-qt-5.40.0.tar.xz";
-      sha256 = "0i0jpcy4c8zak9vv5jzcp4m78vk8mcv27dqi464jh9vaz9z7znfj";
-      name = "modemmanager-qt-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/modemmanager-qt-5.41.0.tar.xz";
+      sha256 = "1bp9mllzgvqr3dsjg9a81yv487whf26vfxiyim8hr42b9j8v8wj0";
+      name = "modemmanager-qt-5.41.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/networkmanager-qt-5.40.0.tar.xz";
-      sha256 = "178rm4c3304fn2h1jbfvf9zji8kkvnzkmnpnk0nkjh9dyqa80jvp";
-      name = "networkmanager-qt-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/networkmanager-qt-5.41.0.tar.xz";
+      sha256 = "0vdrbfwamk5p6mm0i05bxvmrlqxm9c5d373pn7qrm0kzs916xhlv";
+      name = "networkmanager-qt-5.41.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/oxygen-icons5-5.40.0.tar.xz";
-      sha256 = "057v69r3rvrw2qjqmb93k0m29ssgifb4sgm8xbfqx17b5iqms9f3";
-      name = "oxygen-icons5-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/oxygen-icons5-5.41.0.tar.xz";
+      sha256 = "1zpcjfzw4pv73ms8pc1w4fpvxcbpasl2av0g4y6sj7rshzdgrj31";
+      name = "oxygen-icons5-5.41.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/plasma-framework-5.40.0.tar.xz";
-      sha256 = "1mjgy3116pdzvmw43yqhrqz74nyw200yhnnynxk569krgymvalvg";
-      name = "plasma-framework-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/plasma-framework-5.41.0.tar.xz";
+      sha256 = "1risn810pyncfpn01xiqsb5j8pwsnmx60lfajnx7qygny6b69pl4";
+      name = "plasma-framework-5.41.0.tar.xz";
     };
   };
   prison = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/prison-5.40.0.tar.xz";
-      sha256 = "18drqs6j1dx76224hlrp3xmk1hxq6q8638wpf5vmn6vqw8q304vw";
-      name = "prison-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/prison-5.41.0.tar.xz";
+      sha256 = "0q3r1a3047yxhsd3qfwzwsw261zrfdmsklnyq5d2ayflchcj5vxi";
+      name = "prison-5.41.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/qqc2-desktop-style-5.40.0.tar.xz";
-      sha256 = "0jpdnsq8yf58p4a7qsgvn3pp7ms7q1pgy4rwrlviyjdrlfc1pv49";
-      name = "qqc2-desktop-style-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/qqc2-desktop-style-5.41.0.tar.xz";
+      sha256 = "166cjfaly8fzzchq8pk2s7f5mm63cwmayw3qc0p7amy5d0nykm0w";
+      name = "qqc2-desktop-style-5.41.0.tar.xz";
     };
   };
   solid = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/solid-5.40.0.tar.xz";
-      sha256 = "1kj2rs771hyrbbn8qykbrj5fvdv8g7niajbrf6mydbdvqc96zj8x";
-      name = "solid-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/solid-5.41.0.tar.xz";
+      sha256 = "0i2qxps26rg2x1576m35k4kj018i9jpsnlayzsk4fcj44kvsq9z3";
+      name = "solid-5.41.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/sonnet-5.40.0.tar.xz";
-      sha256 = "1a947kgnx5dp7lv63dwzzlxm331c6h0cycv1lcdfcskan1wsmwk8";
-      name = "sonnet-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/sonnet-5.41.0.tar.xz";
+      sha256 = "1jhpl0ajqlln88fmzbwjxn0illbas4s0hbzwd3w56s9wg8j18s76";
+      name = "sonnet-5.41.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/syntax-highlighting-5.40.0.tar.xz";
-      sha256 = "0xc06nd95q1mqw41pwrgh798jp9p994qylncabimxbcis39x138l";
-      name = "syntax-highlighting-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/syntax-highlighting-5.41.0.tar.xz";
+      sha256 = "0hmcb9f162hyvfb0mfkm69avgrbl146l7lyfzb93z1hk6f2gpxqc";
+      name = "syntax-highlighting-5.41.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.40.0";
+    version = "5.41.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.40/threadweaver-5.40.0.tar.xz";
-      sha256 = "0in3cp75n6nxlc38fr2pycfgh4k0azi70cnyzc8glyf3f2rw8d9g";
-      name = "threadweaver-5.40.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.41/threadweaver-5.41.0.tar.xz";
+      sha256 = "08nlskhdds13wplv4lwy4xshimkhl8jvzkz1h1qks6wggbwxf11m";
+      name = "threadweaver-5.41.0.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/5.9/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/default.nix
@@ -6,9 +6,9 @@ Before a major version update, make a copy of this directory. (We like to
 keep the old version around for a short time after major updates.) Add a
 top-level attribute to `top-level/all-packages.nix`.
 
-1. Update the URL in `maintainers/scripts/generate-qt.sh`.
+1. Update the URL in `pkgs/development/libraries/qt-5/$VERSION/fetch.sh`.
 2. From the top of the Nixpkgs tree, run
-   `./maintainers/scripts/generate-qt.sh > pkgs/development/libraries/qt-5/$VERSION/srcs.nix`.
+   `./maintainers/scripts/fetch-kde-qt.sh > pkgs/development/libraries/qt-5/$VERSION/srcs.nix`.
 3. Update `qtCompatVersion` below if the minor version number changes.
 4. Check that the new packages build correctly.
 5. Commit the changes and open a pull request.

--- a/pkgs/development/libraries/qt-5/5.9/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.9/fetch.sh
@@ -1,2 +1,2 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.9/5.9.1/submodules/ \
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.9/5.9.3/submodules/ \
             -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-5/5.9/qtbase.patch
+++ b/pkgs/development/libraries/qt-5/5.9/qtbase.patch
@@ -101,7 +101,7 @@ index bb5083c925..da8e2cb386 100644
  # We are generating cmake files. Most developers of Qt are not aware of cmake,
  # so we require automatic tests to be available. The only module which should
 diff --git a/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in b/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
-index 17da8b979e..d648ab4058 100644
+index 55c74aad66..0bbc8718eb 100644
 --- a/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 +++ b/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 @@ -9,30 +9,6 @@ if (CMAKE_VERSION VERSION_LESS 3.0.0)
@@ -261,10 +261,10 @@ index 17da8b979e..d648ab4058 100644
          set_target_properties(Qt5::${Plugin} PROPERTIES
              \"IMPORTED_LOCATION_${Configuration}\" ${imported_location}
 diff --git a/mkspecs/features/mac/default_post.prf b/mkspecs/features/mac/default_post.prf
-index 395ac34001..a0e5c68b7e 100644
+index e645ba5803..a0e5c68b7e 100644
 --- a/mkspecs/features/mac/default_post.prf
 +++ b/mkspecs/features/mac/default_post.prf
-@@ -24,165 +24,3 @@ qt {
+@@ -24,166 +24,3 @@ qt {
          }
      }
  }
@@ -427,17 +427,18 @@ index 395ac34001..a0e5c68b7e 100644
 -}
 -
 -cache(QMAKE_XCODE_DEVELOPER_PATH, stash)
--cache(QMAKE_XCODE_VERSION, stash)
+-!isEmpty(QMAKE_XCODE_VERSION): \
+-    cache(QMAKE_XCODE_VERSION, stash)
 -
 -QMAKE_XCODE_LIBRARY_SUFFIX = $$qtPlatformTargetSuffix()
 diff --git a/mkspecs/features/mac/default_pre.prf b/mkspecs/features/mac/default_pre.prf
-index e21e749ee9..3b01424e67 100644
+index 44636f2288..61ed486a76 100644
 --- a/mkspecs/features/mac/default_pre.prf
 +++ b/mkspecs/features/mac/default_pre.prf
-@@ -1,51 +1,2 @@
+@@ -1,56 +1,3 @@
  CONFIG = asset_catalogs rez $$CONFIG
  load(default_pre)
--
+ 
 -isEmpty(QMAKE_XCODE_DEVELOPER_PATH) {
 -    # Get path of Xcode's Developer directory
 -    QMAKE_XCODE_DEVELOPER_PATH = $$system("/usr/bin/xcode-select --print-path 2>/dev/null")
@@ -447,18 +448,23 @@ index e21e749ee9..3b01424e67 100644
 -    # Make sure Xcode path is valid
 -    !exists($$QMAKE_XCODE_DEVELOPER_PATH): \
 -        error("Xcode is not installed in $${QMAKE_XCODE_DEVELOPER_PATH}. Please use xcode-select to choose Xcode installation path.")
--
--    # Make sure Xcode is set up properly
--    isEmpty($$list($$system("/usr/bin/xcrun -find xcodebuild 2>/dev/null"))): \
--        error("Xcode not set up properly. You may need to confirm the license agreement by running /usr/bin/xcodebuild.")
 -}
 -
--isEmpty(QMAKE_XCODE_VERSION) {
--    # Extract Xcode version using xcodebuild
--    xcode_version = $$system("/usr/bin/xcodebuild -version")
--    QMAKE_XCODE_VERSION = $$member(xcode_version, 1)
--    isEmpty(QMAKE_XCODE_VERSION): error("Could not resolve Xcode version.")
--    unset(xcode_version)
+-isEmpty(QMAKE_XCODEBUILD_PATH): \
+-    QMAKE_XCODEBUILD_PATH = $$system("/usr/bin/xcrun -find xcodebuild 2>/dev/null")
+-
+-!isEmpty(QMAKE_XCODEBUILD_PATH) {
+-    # Make sure Xcode is set up properly
+-    !system("/usr/bin/xcrun xcodebuild -license check 2>/dev/null"): \
+-        error("Xcode not set up properly. You need to confirm the license agreement by running 'sudo xcrun xcodebuild -license accept'.")
+-
+-    isEmpty(QMAKE_XCODE_VERSION) {
+-        # Extract Xcode version using xcodebuild
+-        xcode_version = $$system("/usr/bin/xcrun xcodebuild -version")
+-        QMAKE_XCODE_VERSION = $$member(xcode_version, 1)
+-        isEmpty(QMAKE_XCODE_VERSION): error("Could not resolve Xcode version.")
+-        unset(xcode_version)
+-    }
 -}
 -
 -isEmpty(QMAKE_TARGET_BUNDLE_PREFIX) {
@@ -487,11 +493,11 @@ index e21e749ee9..3b01424e67 100644
 -# at build time, depending on the current Xcode SDK and configuration.
 -QMAKE_XCODE_LIBRARY_SUFFIX_SETTING = QT_LIBRARY_SUFFIX
 diff --git a/mkspecs/features/mac/sdk.prf b/mkspecs/features/mac/sdk.prf
-index 68ab7e4053..e69de29bb2 100644
+index 3f6dc076ca..8b13789179 100644
 --- a/mkspecs/features/mac/sdk.prf
 +++ b/mkspecs/features/mac/sdk.prf
-@@ -1,49 +0,0 @@
--
+@@ -1,58 +1 @@
+ 
 -isEmpty(QMAKE_MAC_SDK): \
 -    error("QMAKE_MAC_SDK must be set when using CONFIG += sdk.")
 -
@@ -500,13 +506,22 @@ index 68ab7e4053..e69de29bb2 100644
 -
 -defineReplace(xcodeSDKInfo) {
 -    info = $$1
+-    equals(info, "Path"): \
+-        info = --show-sdk-path
+-    equals(info, "PlatformPath"): \
+-        info = --show-sdk-platform-path
+-    equals(info, "SDKVersion"): \
+-        info = --show-sdk-version
 -    sdk = $$2
 -    isEmpty(sdk): \
 -        sdk = $$QMAKE_MAC_SDK
 -
 -    isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}) {
--        QMAKE_MAC_SDK.$${sdk}.$${info} = $$system("/usr/bin/xcodebuild -sdk $$sdk -version $$info 2>/dev/null")
--        isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}): error("Could not resolve SDK $$info for \'$$sdk\'")
+-        QMAKE_MAC_SDK.$${sdk}.$${info} = $$system("/usr/bin/xcrun --sdk $$sdk $$info 2>/dev/null")
+-        # --show-sdk-platform-path won't work for Command Line Tools; this is fine
+-        # only used by the XCTest backend to testlib
+-        isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}):if(!isEmpty(QMAKE_XCODEBUILD_PATH)|!equals(info, "--show-sdk-platform-path")): \
+-            error("Could not resolve SDK $$info for \'$$sdk\'")
 -        cache(QMAKE_MAC_SDK.$${sdk}.$${info}, set stash, QMAKE_MAC_SDK.$${sdk}.$${info})
 -    }
 -
@@ -581,10 +596,10 @@ index d49f4c49c1..097dcd7d39 100644
  target.path = $$instbase/$$TARGETPATH
  INSTALLS += target
 diff --git a/mkspecs/features/qt_app.prf b/mkspecs/features/qt_app.prf
-index cb84ae0da8..45e16f4302 100644
+index 883f8ca215..81db8eb2d4 100644
 --- a/mkspecs/features/qt_app.prf
 +++ b/mkspecs/features/qt_app.prf
-@@ -29,7 +29,7 @@ host_build:force_bootstrap {
+@@ -33,7 +33,7 @@ host_build:force_bootstrap {
      target.path = $$[QT_HOST_BINS]
  } else {
      !build_pass:qtConfig(debug_and_release): CONFIG += release
@@ -607,7 +622,7 @@ index 1848f00e90..2af93675c5 100644
 +    MODULE_QMAKE_OUTDIR = $$NIX_OUTPUT_OUT
  }
 diff --git a/mkspecs/features/qt_common.prf b/mkspecs/features/qt_common.prf
-index 1e138730b3..b7ba74dc3f 100644
+index fb96d1b6a0..508ed17d30 100644
 --- a/mkspecs/features/qt_common.prf
 +++ b/mkspecs/features/qt_common.prf
 @@ -32,8 +32,8 @@ contains(TEMPLATE, .*lib) {
@@ -661,20 +676,32 @@ index 72dde61a40..f891a2baed 100644
      INSTALLS += inst_qch_docs
  
 diff --git a/mkspecs/features/qt_example_installs.prf b/mkspecs/features/qt_example_installs.prf
-index 0a008374e5..5e7cd92f6f 100644
+index 668669e4cd..30f7fbac41 100644
 --- a/mkspecs/features/qt_example_installs.prf
 +++ b/mkspecs/features/qt_example_installs.prf
-@@ -73,7 +73,7 @@ probase = $$relative_path($$_PRO_FILE_PWD_, $$dirname(_QMAKE_CONF_)/examples)
-         $$SOURCES $$HEADERS $$FORMS $$RESOURCES $$TRANSLATIONS \
-         $$DBUS_ADAPTORS $$DBUS_INTERFACES
-     addInstallFiles(sources.files, $$sourcefiles)
--    sources.path = $$[QT_INSTALL_EXAMPLES]/$$probase
-+    sources.path = $$NIX_OUTPUT_DEV/share/examples/$$probase
-     INSTALLS += sources
+@@ -77,13 +77,13 @@ for(extra, extras): \
+ # Just for Qt Creator
+ OTHER_FILES += $$sourcefiles
  
-     check_examples {
+-sourcefiles += \
+-    $$_PRO_FILE_ $$RC_FILE $$DEF_FILE \
+-    $$SOURCES $$HEADERS $$FORMS $$RESOURCES $$TRANSLATIONS \
+-    $$DBUS_ADAPTORS $$DBUS_INTERFACES
+-addInstallFiles(sources.files, $$sourcefiles)
+-sources.path = $$[QT_INSTALL_EXAMPLES]/$$probase
+-INSTALLS += sources
++    sourcefiles += \
++        $$_PRO_FILE_ $$RC_FILE $$DEF_FILE \
++        $$SOURCES $$HEADERS $$FORMS $$RESOURCES $$TRANSLATIONS \
++        $$DBUS_ADAPTORS $$DBUS_INTERFACES
++    addInstallFiles(sources.files, $$sourcefiles)
++    sources.path = $$NIX_OUTPUT_DEV/share/examples/$$probase
++    INSTALLS += sources
+ 
+ check_examples {
+     srcfiles = $$sources.files
 diff --git a/mkspecs/features/qt_functions.prf b/mkspecs/features/qt_functions.prf
-index c00fdb73f8..5789cd0c06 100644
+index 1903e509c8..ae7b585989 100644
 --- a/mkspecs/features/qt_functions.prf
 +++ b/mkspecs/features/qt_functions.prf
 @@ -69,7 +69,7 @@ defineTest(qtHaveModule) {
@@ -836,7 +863,7 @@ index 706304cf34..546420f6ad 100644
  set(_qt5_corelib_extra_includes \"$${CMAKE_INSTALL_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
  !!ENDIF
 diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
-index 39e7c71a9c..dced1f2811 100644
+index cba279c184..5ae3fd62e5 100644
 --- a/src/corelib/kernel/qcoreapplication.cpp
 +++ b/src/corelib/kernel/qcoreapplication.cpp
 @@ -2533,6 +2533,15 @@ QStringList QCoreApplication::libraryPaths()
@@ -856,7 +883,7 @@ index 39e7c71a9c..dced1f2811 100644
          if (!libPathEnv.isEmpty()) {
              QStringList paths = QFile::decodeName(libPathEnv).split(QDir::listSeparator(), QString::SkipEmptyParts);
 diff --git a/src/corelib/tools/qtimezoneprivate_tz.cpp b/src/corelib/tools/qtimezoneprivate_tz.cpp
-index 1714c9802f..fd2ebb1336 100644
+index 4fdc2e36ac..d3ec222543 100644
 --- a/src/corelib/tools/qtimezoneprivate_tz.cpp
 +++ b/src/corelib/tools/qtimezoneprivate_tz.cpp
 @@ -70,7 +70,11 @@ typedef QHash<QByteArray, QTzTimeZone> QTzTimeZoneHash;
@@ -872,7 +899,7 @@ index 1714c9802f..fd2ebb1336 100644
      if (!QFile::exists(path))
          path = QStringLiteral("/usr/lib/zoneinfo/zone.tab");
  
-@@ -643,12 +647,16 @@ void QTzTimeZonePrivate::init(const QByteArray &ianaId)
+@@ -645,12 +649,16 @@ void QTzTimeZonePrivate::init(const QByteArray &ianaId)
          if (!tzif.open(QIODevice::ReadOnly))
              return;
      } else {
@@ -967,7 +994,7 @@ index 1da00813ce..0bf877afcb 100644
              return false;
      }
 diff --git a/src/network/kernel/qhostinfo_unix.cpp b/src/network/kernel/qhostinfo_unix.cpp
-index cf08a15f96..2310488298 100644
+index 9a24938284..74962b4ae2 100644
 --- a/src/network/kernel/qhostinfo_unix.cpp
 +++ b/src/network/kernel/qhostinfo_unix.cpp
 @@ -102,7 +102,7 @@ static bool resolveLibraryInternal()
@@ -1024,7 +1051,7 @@ index 341d3bccf2..3368234c26 100644
              scanThread->interfaceName = QString::fromNSString(ifName);
              scanThread->start();
 diff --git a/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp b/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
-index ca9f7af127..a337ad73bf 100644
+index b5a0a5bbeb..6c20305f4d 100644
 --- a/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
 +++ b/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
 @@ -265,12 +265,9 @@ void TableGenerator::initPossibleLocations()
@@ -1042,7 +1069,7 @@ index ca9f7af127..a337ad73bf 100644
  
  QString TableGenerator::findComposeFile()
 diff --git a/src/plugins/platforms/cocoa/qcocoawindow.mm b/src/plugins/platforms/cocoa/qcocoawindow.mm
-index 59b76370ae..b91139ded9 100644
+index 5cd4beb4f0..84919e6d6a 100644
 --- a/src/plugins/platforms/cocoa/qcocoawindow.mm
 +++ b/src/plugins/platforms/cocoa/qcocoawindow.mm
 @@ -320,7 +320,7 @@ static void qt_closePopups()
@@ -1055,7 +1082,7 @@ index 59b76370ae..b91139ded9 100644
  
  #if QT_MACOS_PLATFORM_SDK_EQUAL_OR_ABOVE(__MAC_10_12)
 diff --git a/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp b/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
-index 7640a711a9..ef9a14d38b 100644
+index e2e573f0e1..1c8289f81e 100644
 --- a/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
 +++ b/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
 @@ -580,7 +580,14 @@ QFunctionPointer QGLXContext::getProcAddress(const char *procName)
@@ -1074,11 +1101,11 @@ index 7640a711a9..ef9a14d38b 100644
  #endif
              }
 diff --git a/src/plugins/platforms/xcb/qxcbcursor.cpp b/src/plugins/platforms/xcb/qxcbcursor.cpp
-index d257ab1242..75853af4e4 100644
+index 7c62c2e2b3..fefa40e0f6 100644
 --- a/src/plugins/platforms/xcb/qxcbcursor.cpp
 +++ b/src/plugins/platforms/xcb/qxcbcursor.cpp
 @@ -311,10 +311,10 @@ QXcbCursor::QXcbCursor(QXcbConnection *conn, QXcbScreen *screen)
- #if defined(XCB_USE_XLIB) && QT_CONFIG(library)
+ #if QT_CONFIG(xcb_xlib) && QT_CONFIG(library)
      static bool function_ptrs_not_initialized = true;
      if (function_ptrs_not_initialized) {
 -        QLibrary xcursorLib(QLatin1String("Xcursor"), 1);

--- a/pkgs/development/libraries/qt-5/5.9/srcs.nix
+++ b/pkgs/development/libraries/qt-5/5.9/srcs.nix
@@ -3,275 +3,275 @@
 
 {
   qt3d = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qt3d-opensource-src-5.9.1.tar.xz";
-      sha256 = "15j9znfnxch1n6fwz9ngi30msdzh0wlpykl53cs8g2fp2awfa7sg";
-      name = "qt3d-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qt3d-opensource-src-5.9.3.tar.xz";
+      sha256 = "0gr7wvd3p8i2frj9nkfxffxapwqx6i4wh171ymvcsg2qy0r534lp";
+      name = "qt3d-opensource-src-5.9.3.tar.xz";
     };
   };
   qtactiveqt = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtactiveqt-opensource-src-5.9.1.tar.xz";
-      sha256 = "07zq60xg7nnlny7qgj6dk1ibg3fzhbdh78gpd0s6x1n822iyislg";
-      name = "qtactiveqt-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtactiveqt-opensource-src-5.9.3.tar.xz";
+      sha256 = "16aka3y7a6mhs0yfm7vbq8v5gbh2ifmk4v2hl04iacindq9f5v2r";
+      name = "qtactiveqt-opensource-src-5.9.3.tar.xz";
     };
   };
   qtandroidextras = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtandroidextras-opensource-src-5.9.1.tar.xz";
-      sha256 = "0nq879jsa2z1l5q3n0hhiv15mzfm5c6s7zfblcc10sgim90p5mjj";
-      name = "qtandroidextras-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtandroidextras-opensource-src-5.9.3.tar.xz";
+      sha256 = "0f653qmzvr3rjjgipjbcxvp5wq9fbaz1b4bvj7g868s2d9gpqp9n";
+      name = "qtandroidextras-opensource-src-5.9.3.tar.xz";
     };
   };
   qtbase = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtbase-opensource-src-5.9.1.tar.xz";
-      sha256 = "1ikm896jzyfyjv2qv8n3fd81sxb4y24zkygx36865ygzyvlj36mw";
-      name = "qtbase-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtbase-opensource-src-5.9.3.tar.xz";
+      sha256 = "10lrkarvs7dpx9rlj7sjcc0pzi42098x8nqnhmydr4bnbq048z4y";
+      name = "qtbase-opensource-src-5.9.3.tar.xz";
     };
   };
   qtcanvas3d = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtcanvas3d-opensource-src-5.9.1.tar.xz";
-      sha256 = "10fy8wqfw2yhha6lyky5g1a72137aj8pji7mk0wjnggh629z12sb";
-      name = "qtcanvas3d-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtcanvas3d-opensource-src-5.9.3.tar.xz";
+      sha256 = "1g0a606fgal4x17ly0qrj05pb0k8riwh7nj4g3jip05g8iwb2f2y";
+      name = "qtcanvas3d-opensource-src-5.9.3.tar.xz";
     };
   };
   qtcharts = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtcharts-opensource-src-5.9.1.tar.xz";
-      sha256 = "180df5v7i1ki8hc3lgi6jcfdyz7f19pb73dvfkw402wa2gfcna3k";
-      name = "qtcharts-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtcharts-opensource-src-5.9.3.tar.xz";
+      sha256 = "1sb99ncmh84bz0xzq55chgic7jk61awnfvi7ld4gq5ap3nl865zc";
+      name = "qtcharts-opensource-src-5.9.3.tar.xz";
     };
   };
   qtconnectivity = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtconnectivity-opensource-src-5.9.1.tar.xz";
-      sha256 = "1mbzmqix0388iq20a1ljd1pgdq259rm1xzp9kx8gigqpamqqnqs0";
-      name = "qtconnectivity-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtconnectivity-opensource-src-5.9.3.tar.xz";
+      sha256 = "0j86rspn4xgwq1ddc1mpq1kq0ib2c0ag6rsn9ly2xs4iimp1x2g2";
+      name = "qtconnectivity-opensource-src-5.9.3.tar.xz";
     };
   };
   qtdatavis3d = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtdatavis3d-opensource-src-5.9.1.tar.xz";
-      sha256 = "14d1q07winh6n1bkc616dapwfnsfkcjyg5zngdqjdj9mza8ang13";
-      name = "qtdatavis3d-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtdatavis3d-opensource-src-5.9.3.tar.xz";
+      sha256 = "0s636ix44akrjx47gv9qj2ac02q8clnwj3acfr28p6pagm46k7vh";
+      name = "qtdatavis3d-opensource-src-5.9.3.tar.xz";
     };
   };
   qtdeclarative = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtdeclarative-opensource-src-5.9.1.tar.xz";
-      sha256 = "1zwlxrgraxhlsdkwsai3pjbz7f3a6rsnsg2mjrpay6cz3af6rznj";
-      name = "qtdeclarative-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtdeclarative-opensource-src-5.9.3.tar.xz";
+      sha256 = "01wlk17zf47yzx7cc3cp617gj70yadllj2rsfk78879c0v96cpsh";
+      name = "qtdeclarative-opensource-src-5.9.3.tar.xz";
     };
   };
   qtdoc = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtdoc-opensource-src-5.9.1.tar.xz";
-      sha256 = "1d2kk9wzm2261ap87nyf743a4662gll03gz5yh5qi7k620lk372x";
-      name = "qtdoc-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtdoc-opensource-src-5.9.3.tar.xz";
+      sha256 = "0aki592arm3r08y9cq8863jp9zzkvgx7sc48426n30m6q9valsg5";
+      name = "qtdoc-opensource-src-5.9.3.tar.xz";
     };
   };
   qtgamepad = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtgamepad-opensource-src-5.9.1.tar.xz";
-      sha256 = "055w4649zi93q1sl32ngqwgnl2vxw1idnm040s9gjgjb67gi81zi";
-      name = "qtgamepad-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtgamepad-opensource-src-5.9.3.tar.xz";
+      sha256 = "14vari5cq10a0z02559l2m1v78g7ygnyqf1ilkmy2f0kr36wm7y6";
+      name = "qtgamepad-opensource-src-5.9.3.tar.xz";
     };
   };
   qtgraphicaleffects = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtgraphicaleffects-opensource-src-5.9.1.tar.xz";
-      sha256 = "1zsr3a5dsmpvrb5h4m4h42wqmkvkks3d8mmyrx4k0mfr6s7c71jz";
-      name = "qtgraphicaleffects-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtgraphicaleffects-opensource-src-5.9.3.tar.xz";
+      sha256 = "1nghl39sqsjamjn6pfmxmgga6z9vwzv2zbgc92amrfxxr2dh42vr";
+      name = "qtgraphicaleffects-opensource-src-5.9.3.tar.xz";
     };
   };
   qtimageformats = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtimageformats-opensource-src-5.9.1.tar.xz";
-      sha256 = "0iwa3dys5rv706cpxwhmgircv783pmlyl1yrsc5i0rha643y7zkr";
-      name = "qtimageformats-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtimageformats-opensource-src-5.9.3.tar.xz";
+      sha256 = "1p95wzm46j49c5br45g0pmlz3n3fl93j1ipzmnpmq9y2pbfhkcyl";
+      name = "qtimageformats-opensource-src-5.9.3.tar.xz";
     };
   };
   qtlocation = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtlocation-opensource-src-5.9.1.tar.xz";
-      sha256 = "058mgvlaml9rkfhkpr1n3avhi12zlva131sqhbwj4lwwyqfkri2b";
-      name = "qtlocation-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtlocation-opensource-src-5.9.3.tar.xz";
+      sha256 = "1qacqz6l7zljqszblhgzg5y1v4mgki59k45ag7yc2iw7vrf45zc0";
+      name = "qtlocation-opensource-src-5.9.3.tar.xz";
     };
   };
   qtmacextras = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtmacextras-opensource-src-5.9.1.tar.xz";
-      sha256 = "0096g9l2hwsiwlzfjkw7rhkdnyvb5gzjzyjjg9kqfnsagbwscv11";
-      name = "qtmacextras-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtmacextras-opensource-src-5.9.3.tar.xz";
+      sha256 = "0piv3q49vhpjxafdicizcw13am49h0ybfhb37vai0x1wbrlvhdiy";
+      name = "qtmacextras-opensource-src-5.9.3.tar.xz";
     };
   };
   qtmultimedia = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtmultimedia-opensource-src-5.9.1.tar.xz";
-      sha256 = "1r76zvbv6wwb7lgw9jwlx382iyw34i1amxaypb5bg3j1niqvx3z4";
-      name = "qtmultimedia-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtmultimedia-opensource-src-5.9.3.tar.xz";
+      sha256 = "19iqh8xpspzlmpzh05bx5rchlslbfy2pp00xv52496yf9b95i5g7";
+      name = "qtmultimedia-opensource-src-5.9.3.tar.xz";
     };
   };
   qtnetworkauth = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtnetworkauth-opensource-src-5.9.1.tar.xz";
-      sha256 = "1fgax3p7lqcz29z2n1qxnfpkj3wxq1x9bfx61q6nss1fs74pxzra";
-      name = "qtnetworkauth-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtnetworkauth-opensource-src-5.9.3.tar.xz";
+      sha256 = "0fdz5q47xbiij3mi5lzhvxpq4jp9fm929v9kyvcyadz86mp3f8nz";
+      name = "qtnetworkauth-opensource-src-5.9.3.tar.xz";
     };
   };
   qtpurchasing = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtpurchasing-opensource-src-5.9.1.tar.xz";
-      sha256 = "0b1hlaq6rb7d6b6h8kqd26klcpzf9vcdjrv610kdj0drb00jg3ss";
-      name = "qtpurchasing-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtpurchasing-opensource-src-5.9.3.tar.xz";
+      sha256 = "00yfdd00frgf7fs9s0vyn1c6c4abxgld5rfgkzms3y6n6lcphs0j";
+      name = "qtpurchasing-opensource-src-5.9.3.tar.xz";
     };
   };
   qtquickcontrols = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtquickcontrols-opensource-src-5.9.1.tar.xz";
-      sha256 = "0bpc465q822phw3dcbddn70wj1fjlc2hxskkp1z9gl7r23hx03jj";
-      name = "qtquickcontrols-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtquickcontrols-opensource-src-5.9.3.tar.xz";
+      sha256 = "09p2q3max4xrlw5svbhn11y9cgrvcjsj88xw4c0kq91cgnyyw3ih";
+      name = "qtquickcontrols-opensource-src-5.9.3.tar.xz";
     };
   };
   qtquickcontrols2 = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtquickcontrols2-opensource-src-5.9.1.tar.xz";
-      sha256 = "1zq86kqz85wm3n84jcxkxw5x1mrhkqzldkigf8xm3l8j24rf0fr0";
-      name = "qtquickcontrols2-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtquickcontrols2-opensource-src-5.9.3.tar.xz";
+      sha256 = "0hq888qq8q7dglpyzif64pplqjxfrqjpkvbcx0ycq35darls5ai1";
+      name = "qtquickcontrols2-opensource-src-5.9.3.tar.xz";
     };
   };
   qtremoteobjects = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtremoteobjects-opensource-src-5.9.1.tar.xz";
-      sha256 = "10kwq0fgmi6zsqhb6s1nkcydpyl8d8flzdpgmyj50c4h2xhg2km0";
-      name = "qtremoteobjects-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtremoteobjects-opensource-src-5.9.3.tar.xz";
+      sha256 = "0z6qd381r6a7gdrsknlkkbhq9mmdqi040kfrvgm6mfa69336f4dk";
+      name = "qtremoteobjects-opensource-src-5.9.3.tar.xz";
     };
   };
   qtscript = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtscript-opensource-src-5.9.1.tar.xz";
-      sha256 = "13qq2mjfhqdcvkmzrgxg1gr5kww1ygbwb7r71xxl6rjzbn30hshp";
-      name = "qtscript-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtscript-opensource-src-5.9.3.tar.xz";
+      sha256 = "0rjm6nph1nssfpknp4i682bvk7363y4a2f74060vcm7ib2pzl2xq";
+      name = "qtscript-opensource-src-5.9.3.tar.xz";
     };
   };
   qtscxml = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtscxml-opensource-src-5.9.1.tar.xz";
-      sha256 = "1m3b6wg5hqasdfc5igpj9bq3czql5kkvvn3rx1ig508kdlh5i5s0";
-      name = "qtscxml-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtscxml-opensource-src-5.9.3.tar.xz";
+      sha256 = "06x8hs3p7bfgnl6b2fjld4s41acw1rbnxbcgkprgw2fxxnl1zxfq";
+      name = "qtscxml-opensource-src-5.9.3.tar.xz";
     };
   };
   qtsensors = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtsensors-opensource-src-5.9.1.tar.xz";
-      sha256 = "1772x7r6y9xv2sv0w2dfz2yhagsq5bpa9kdpzg0qikccmabr7was";
-      name = "qtsensors-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtsensors-opensource-src-5.9.3.tar.xz";
+      sha256 = "1hfsih5iy4fi6mnpw2shf1lzx9hxcdc1arspad1mark17l5s4pmr";
+      name = "qtsensors-opensource-src-5.9.3.tar.xz";
     };
   };
   qtserialbus = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtserialbus-opensource-src-5.9.1.tar.xz";
-      sha256 = "1hzk377c3zl4dm5hxwvpxg2w096m160448y9df6v6l8xpzpzxafa";
-      name = "qtserialbus-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtserialbus-opensource-src-5.9.3.tar.xz";
+      sha256 = "0f39qh05mp54frpn5sy9k5vfw5zb2gg72qaqz81mwlck2xg78qpg";
+      name = "qtserialbus-opensource-src-5.9.3.tar.xz";
     };
   };
   qtserialport = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtserialport-opensource-src-5.9.1.tar.xz";
-      sha256 = "0sbsc7n701kxl16r247a907zg2afmbx1xlml5jkc6a9956zqbzp1";
-      name = "qtserialport-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtserialport-opensource-src-5.9.3.tar.xz";
+      sha256 = "1pxb679cx77vk39ik7j0k91a57wqa63d4g4riw3r2gpcay8kxpac";
+      name = "qtserialport-opensource-src-5.9.3.tar.xz";
     };
   };
   qtspeech = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtspeech-opensource-src-5.9.1.tar.xz";
-      sha256 = "00daxkf8iwf6n9rhkkv3isv5qa8wijwzb0zy1f6zlm3vcc8fz75c";
-      name = "qtspeech-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtspeech-opensource-src-5.9.3.tar.xz";
+      sha256 = "1c4rpf3by620fx8lrvmc38r60cikqczqh2rfcm7ixz3x8cj60lh1";
+      name = "qtspeech-opensource-src-5.9.3.tar.xz";
     };
   };
   qtsvg = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtsvg-opensource-src-5.9.1.tar.xz";
-      sha256 = "1rg2q4snh2g4n93zmk995swwkl0ab1jr9ka9xpj56ddifkw99wlr";
-      name = "qtsvg-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtsvg-opensource-src-5.9.3.tar.xz";
+      sha256 = "1wjx9ymk2h19l9kk76jh87bnhhj955f9a93akvwwzfwg1jk2hrnz";
+      name = "qtsvg-opensource-src-5.9.3.tar.xz";
     };
   };
   qttools = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qttools-opensource-src-5.9.1.tar.xz";
-      sha256 = "1s50kh3sg5wc5gqhwwznnibh7jcnfginnmkv66w62mm74k7mdsy4";
-      name = "qttools-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qttools-opensource-src-5.9.3.tar.xz";
+      sha256 = "1zw4j8ymwcpn7dx1dlbxpmx5lfp26rag7pysap1xry9m7vg3hb24";
+      name = "qttools-opensource-src-5.9.3.tar.xz";
     };
   };
   qttranslations = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qttranslations-opensource-src-5.9.1.tar.xz";
-      sha256 = "0sdjiqli15fmkbqvhhgjfavff906sg56jx5xf8bg6xzd2j5544ja";
-      name = "qttranslations-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qttranslations-opensource-src-5.9.3.tar.xz";
+      sha256 = "1ncvj1qlcgrm0zqdlq2bkb0hc8dyisz8m7bszxyx4kyxg7n5gb20";
+      name = "qttranslations-opensource-src-5.9.3.tar.xz";
     };
   };
   qtvirtualkeyboard = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtvirtualkeyboard-opensource-src-5.9.1.tar.xz";
-      sha256 = "0k79sqa8bg6gkbsk16320gnila1iiwpnl3vx03rysm5bqdnnlx3b";
-      name = "qtvirtualkeyboard-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtvirtualkeyboard-opensource-src-5.9.3.tar.xz";
+      sha256 = "1zrj4pjy98dskzycjswbkm4m2j6k1j4150h0w7vdrw1681s3ycdr";
+      name = "qtvirtualkeyboard-opensource-src-5.9.3.tar.xz";
     };
   };
   qtwayland = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwayland-opensource-src-5.9.1.tar.xz";
-      sha256 = "1yizvbmh26mx1ffq0qaci02g2wihy68ld0y7r3z8nx3v5acb236g";
-      name = "qtwayland-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtwayland-opensource-src-5.9.3.tar.xz";
+      sha256 = "0vazcmpqdka3llmyg7m99lw0ngrydmw74p9nd04544xdn128r3ih";
+      name = "qtwayland-opensource-src-5.9.3.tar.xz";
     };
   };
   qtwebchannel = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwebchannel-opensource-src-5.9.1.tar.xz";
-      sha256 = "003h09mla82f2znb8jjigx13ivc68ikgv7w04594yy7qdmd5yhl0";
-      name = "qtwebchannel-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtwebchannel-opensource-src-5.9.3.tar.xz";
+      sha256 = "0n438mk01sh2bbqakc1m3s65qqmi75m4n4hymad8wcgijfr9a9v3";
+      name = "qtwebchannel-opensource-src-5.9.3.tar.xz";
     };
   };
   qtwebengine = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwebengine-opensource-src-5.9.1.tar.xz";
-      sha256 = "00b4d18m54pbxa1hm6ijh2mrd4wmrs7lkplys8b4liw8j7mpx8zn";
-      name = "qtwebengine-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtwebengine-opensource-src-5.9.3.tar.xz";
+      sha256 = "0dqxawc9vfffz6ygdn5mdpl79rrqfx18jy2d1w81q9w7zm113bj5";
+      name = "qtwebengine-opensource-src-5.9.3.tar.xz";
     };
   };
   qtwebkit = {
@@ -291,43 +291,43 @@
     };
   };
   qtwebsockets = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwebsockets-opensource-src-5.9.1.tar.xz";
-      sha256 = "0r1lya2jj3wfci82zfn0vk6vr8sk9k7xiphnkb0panhb8di769q1";
-      name = "qtwebsockets-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtwebsockets-opensource-src-5.9.3.tar.xz";
+      sha256 = "1phic630ah85ajxp6iqrw9bpg0y8s88y45ygkc1wcasmbgzrs1nf";
+      name = "qtwebsockets-opensource-src-5.9.3.tar.xz";
     };
   };
   qtwebview = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwebview-opensource-src-5.9.1.tar.xz";
-      sha256 = "0qmxrh4y3i9n8x6yhrlnahcn75cc2xwlc8mi4g8n2d83c3x7pxyn";
-      name = "qtwebview-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtwebview-opensource-src-5.9.3.tar.xz";
+      sha256 = "1i99fy86gydpfsfc4my5d9vxjywfrzbqxk66cb3yf2ac57j66mpf";
+      name = "qtwebview-opensource-src-5.9.3.tar.xz";
     };
   };
   qtwinextras = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtwinextras-opensource-src-5.9.1.tar.xz";
-      sha256 = "1x7f944f3g2ml3mm594qv6jlvl5dzzsxq86yinp7av0lhnyrxk0s";
-      name = "qtwinextras-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtwinextras-opensource-src-5.9.3.tar.xz";
+      sha256 = "1lj4qa51ymhpvk0bdp6xf6b3n1k39kihns5lvp6xq1w2mljn6phl";
+      name = "qtwinextras-opensource-src-5.9.3.tar.xz";
     };
   };
   qtx11extras = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtx11extras-opensource-src-5.9.1.tar.xz";
-      sha256 = "00fn3bps48gjyw0pdqvvl9scknxdpmacby6hvdrdccc3jll0wgd6";
-      name = "qtx11extras-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtx11extras-opensource-src-5.9.3.tar.xz";
+      sha256 = "1gpjgca4xvyy0r743kh2ys128r14fh6j8bdphnmmi5v2pf6bzq74";
+      name = "qtx11extras-opensource-src-5.9.3.tar.xz";
     };
   };
   qtxmlpatterns = {
-    version = "5.9.1";
+    version = "5.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.9/5.9.1/submodules/qtxmlpatterns-opensource-src-5.9.1.tar.xz";
-      sha256 = "094wwap2fsl23cys6rxh2ciw0gxbbiqbshnn4qs1n6xdjrj6i15m";
-      name = "qtxmlpatterns-opensource-src-5.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.9/5.9.3/submodules/qtxmlpatterns-opensource-src-5.9.3.tar.xz";
+      sha256 = "1fphhqr3v3vzjp2vbv16bc1vs879wn7aqlabgcpkhqx92ak6d76g";
+      name = "qtxmlpatterns-opensource-src-5.9.3.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -3,7 +3,7 @@
   src, patches, version, qtCompatVersion,
 
   coreutils, bison, flex, gdb, gperf, lndir, patchelf, perl, pkgconfig, python2,
-  ruby,
+  ruby, which,
   # darwin support
   darwin, libiconv, libcxx,
 
@@ -84,7 +84,7 @@ stdenv.mkDerivation {
     ++ lib.optional (postgresql != null) postgresql;
 
   nativeBuildInputs =
-    [ bison flex gperf lndir perl pkgconfig python2 ]
+    [ bison flex gperf lndir perl pkgconfig python2 which ]
     ++ lib.optional (!stdenv.isDarwin) patchelf;
 
   propagatedNativeBuildInputs = [ lndir ];

--- a/pkgs/development/libraries/taglib/default.nix
+++ b/pkgs/development/libraries/taglib/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, zlib, cmake}:
 
 stdenv.mkDerivation rec {
-  name = "taglib-1.10";
+  name = "taglib-1.11.1";
 
   src = fetchurl {
-    url = "http://taglib.github.io/releases/${name}.tar.gz";
-    sha256 = "1alv6vp72p0x9i9yscmz2a71anjwqy53y9pbcbqxvc1c0i82vhr4";
+    url = "http://taglib.org/releases/${name}.tar.gz";
+    sha256 = "0ssjcdjv4qf9liph5ry1kngam1y7zp8fzr9xv4wzzrma22kabldn";
   };
 
   cmakeFlags = "-DWITH_ASF=ON -DWITH_MP4=ON";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   meta = {
-    homepage = http://developer.kde.org/~wheeler/taglib.html;
+    homepage = http://taglib.org/;
     repositories.git = git://github.com/taglib/taglib.git;
 
     description = "A library for reading and editing the meta-data of several popular audio formats";

--- a/pkgs/development/libraries/taglib/default.nix
+++ b/pkgs/development/libraries/taglib/default.nix
@@ -8,17 +8,23 @@ stdenv.mkDerivation rec {
     sha256 = "0ssjcdjv4qf9liph5ry1kngam1y7zp8fzr9xv4wzzrma22kabldn";
   };
 
-  cmakeFlags = "-DWITH_ASF=ON -DWITH_MP4=ON";
+  cmakeFlags = [ "-DWITH_ASF=ON" "-DWITH_MP4=ON" ];
 
   buildInputs = [ zlib ];
   nativeBuildInputs = [ cmake ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://taglib.org/;
     repositories.git = git://github.com/taglib/taglib.git;
-
-    description = "A library for reading and editing the meta-data of several popular audio formats";
+    shortDescription = "A library for reading and editing audio file metadata.";
+    description = ''
+      TagLib is a library for reading and editing the meta-data of several
+      popular audio formats. Currently it supports both ID3v1 and ID3v2 for MP3
+      files, Ogg Vorbis comments and ID3 tags and Vorbis comments in FLAC, MPC,
+      Speex, WavPack, TrueAudio, WAV, AIFF, MP4 and ASF files.
+    '';
+    license = with licenses; [ lgpl3 mpl11 ];
     inherit (cmake.meta) platforms;
-    maintainers = [ ];
+    maintainers = with maintainers; [ ttuegel ];
   };
 }


### PR DESCRIPTION
### Motivation

Regular update to KDE Frameworks, bringing compatibility with Qt 5.9.3.


### Testing

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

