### PR TITLE
gitless: init at 0.8.5

### DIFF
--- a/pkgs/applications/version-management/gitless/default.nix
+++ b/pkgs/applications/version-management/gitless/default.nix
@@ -1,0 +1,26 @@
+{ fetchFromGitHub, pythonPackages, stdenv }:
+
+pythonPackages.buildPythonApplication rec {
+  ver = "0.8.5";
+  name = "gitless-${ver}";
+
+  src = fetchFromGitHub {
+    owner = "sdg-mit";
+    repo = "gitless";
+    rev = "v${ver}";
+    sha256 = "1v22i5lardswpqb6vxjgwra3ac8652qyajbijfj18vlkhajz78hq";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ sh pygit2 clint ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = http://gitless.com/;
+    description = "A version control system built on top of Git";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = [ maintainers.cransom ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -603,6 +603,8 @@ with pkgs;
 
   git-fire = callPackage ../tools/misc/git-fire { };
 
+  gitless = callPackage ../applications/version-management/gitless/default.nix { };
+
   grc = callPackage ../tools/misc/grc { };
 
   green-pdfviewer = callPackage ../applications/misc/green-pdfviewer {


### PR DESCRIPTION
###### Motivation for this change

A handy tool that lowers cognitive load of git commands while not conflicting with usage.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

