### PR TITLE
make-disk-image: Support creating EFI images

### DIFF
--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -46,7 +46,7 @@ in {
     inherit lib config;
     inherit (cfg) contents format name;
     pkgs = import ../../../.. { inherit (pkgs) system; }; # ensure we use the regular qemu-kvm package
-    partitioned = config.ec2.hvm;
+    partitionTableType = if config.ec2.hvm then "legacy" else "none";
     diskSize = cfg.sizeMB;
     configFile = pkgs.writeText "configuration.nix"
       ''

--- a/nixos/modules/virtualisation/virtualbox-image.nix
+++ b/nixos/modules/virtualisation/virtualbox-image.nix
@@ -25,7 +25,7 @@ in {
       name = "nixos-ova-${config.system.nixosLabel}-${pkgs.stdenv.system}";
 
       inherit pkgs lib config;
-      partitioned = true;
+      partitionTableType = "legacy";
       diskSize = cfg.baseImageSize;
 
       postVM =


### PR DESCRIPTION
This adds EFI support to make-disk-image. That is, for `imageType == "efi"` the image gets a GPT partition table instead of the usual DOS partition table, and a FAT32 ESP partition is created in addition to the root partition.

With a bunch of butchering of amazon-image.nix in https://github.com/NixOS/nixpkgs/compare/master...dezgeg:aarch64-makediskimage I end up with a booting AArch64 image (using EFI GRUB) that can boot in QEMU. Still need to clean up & split those into it's own files but these changes should be ready for review now.

@copumpkin 