### PR TITLE
signal-desktop-beta: init at 1.1.0-beta.5

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/beta.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/beta.nix
@@ -1,0 +1,87 @@
+{ stdenv, lib, fetchurl, dpkg, gnome2, atk, cairo, gdk_pixbuf, glib, freetype,
+fontconfig, dbus, libX11, xlibs, libXi, libXcursor, libXdamage, libXrandr,
+libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss,
+nspr, alsaLib, cups, expat, udev
+}:
+let
+  rpath = lib.makeLibraryPath [
+    alsaLib
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk_pixbuf
+    glib
+    gnome2.GConf
+    gnome2.gtk
+    gnome2.pango
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    nspr
+    nss
+    stdenv.cc.cc
+    udev
+    xlibs.libxcb
+  ];
+
+in
+  stdenv.mkDerivation rec {
+    name = "signal-desktop-${version}";
+
+    version = "1.1.0-beta.5";
+
+    src =
+      if stdenv.system == "x86_64-linux" then
+        fetchurl {
+          url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop-beta_${version}_amd64.deb";
+          sha256 = "1kllym2iazp9i5afrh0vmsqqlh5b8i6f929p5yhl8bl4zd17zwpx";
+        }
+      else
+        throw "Signal for Desktop is not currently supported on ${stdenv.system}";
+
+    phases = [ "unpackPhase" "installPhase" ];
+    nativeBuildInputs = [ dpkg ];
+    unpackPhase = "dpkg-deb -x $src .";
+    installPhase = ''
+      mkdir -p $out
+      cp -R opt $out
+      cp -R usr/share $out/share
+
+      chmod -R g-w $out
+
+      # Patch signal
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+               --set-rpath "${rpath}:$out/opt/Signal Beta" \
+               "$out/opt/Signal Beta/signal-desktop-beta"
+
+      # Symlink to bin
+      mkdir -p $out/bin
+      ln -s "$out/opt/Signal Beta/signal-desktop-beta" $out/bin/signal-desktop-beta
+
+      # Fix the desktop link
+      substituteInPlace $out/share/applications/signal-desktop-beta.desktop \
+        --replace "/opt/Signal Beta/signal-desktop-beta" $out/bin/signal-desktop-beta
+    '';
+
+    meta = {
+      description = "Signal Private Messenger for the Desktop (Beta version)";
+      homepage    = https://signal.org/;
+      license     = lib.licenses.gpl3;
+      maintainers = with lib.maintainers; [ ixmatus benley ];
+      platforms   = [
+        "x86_64-linux"
+      ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4451,6 +4451,8 @@ with pkgs;
 
   signal-desktop = callPackage ../applications/networking/instant-messengers/signal-desktop { };
 
+  signal-desktop-beta = callPackage ../applications/networking/instant-messengers/signal-desktop/beta.nix { };
+
   # aka., pgp-tools
   signing-party = callPackage ../tools/security/signing-party { };
 


### PR DESCRIPTION
Signal is a bit like google-chrome, wherein the beta version is independent from the release builds and uses different data locations and binary names.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

