### PR TITLE
telepathy-morse: init at 0.1.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-qt/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-qt/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake, qtbase, qtdeclarative, openssl, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "telegram-qt-unstable-${version}";
+  version = "2017-11-12";
+
+  src = fetchFromGitHub {
+    owner = "Kaffeine";
+    repo = "telegram-qt";
+    rev = "71c722f05983883b30f9f6ae7aa8e39d0b514c10";
+    sha256 = "1d21pi67a6347117w9pqqrzgyahhxmp3ri4yacn7dny2pb4pwqmb";
+  };
+
+  buildInputs = [ qtbase qtdeclarative openssl zlib ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = " Qt-based library for Telegram network";
+    homepage = src.meta.homepage;
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.jtojnar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/telepathy/morse/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/morse/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake, qtbase, telepathy, telegram }:
+
+stdenv.mkDerivation rec {
+  name = "telepathy-morse-unstable-${version}";
+  version = "2017-04-14";
+
+  src = fetchFromGitHub {
+    owner = "TelepathyIM";
+    repo = "telepathy-morse";
+    rev = "bf8b134556a20d2d7f1ace03f1f45e2a63bacb6f";
+    sha256 = "07j77il0jim7p2azgpj9vxjhll9qq83c9r0rbkfh0gg9zydp1s51";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qtbase telepathy telegram ];
+
+  meta = with stdenv.lib; {
+    description = "Telepathy Connection Manager for the Telegram network";
+    homepage = src.meta.homepage;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.jtojnar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17046,6 +17046,8 @@ with pkgs;
 
   telepathy_mission_control = callPackage ../applications/networking/instant-messengers/telepathy/mission-control { };
 
+  telepathy_morse = libsForQt5.callPackage ../applications/networking/instant-messengers/telepathy/morse { };
+
   telepathy_salut = callPackage ../applications/networking/instant-messengers/telepathy/salut {};
 
   telepathy_idle = callPackage ../applications/networking/instant-messengers/telepathy/idle {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10641,6 +10641,8 @@ with pkgs;
 
     telepathy = callPackage ../development/libraries/telepathy/qt { };
 
+    telegram = callPackage ../applications/networking/instant-messengers/telegram/telegram-qt { };
+
     vlc = lowPrio (callPackage ../applications/video/vlc {
       qt4 = null;
       withQt5 = true;


### PR DESCRIPTION
###### Motivation for this change
Using Telegram through something more fitting than the official client.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

