### PR TITLE
minikube: fix wrong path for localkube

### DIFF
--- a/pkgs/applications/networking/cluster/minikube/localkube.patch
+++ b/pkgs/applications/networking/cluster/minikube/localkube.patch
@@ -14,7 +14,7 @@ index 1c4b5000..c9f120d4 100644
 -	if err != nil {
 -		return errors.Wrap(err, "Error updating localkube from uri")
 -	}
-+	localkubeFile = assets.NewBinDataAsset("out/localkube", "/", "localkube", "0777")
++	localkubeFile = assets.NewBinDataAsset("out/localkube", "/usr/local/bin/", "localkube", "0777")
  	copyableFiles = append(copyableFiles, localkubeFile)
 
  	// user added files


### PR DESCRIPTION
###### Motivation for this change

We currently move the `localkube` binary to `/localkube`.  But minikube expects it to be at `/usr/loca/bin/localkube` in the systemd unit

###### Things done

Change the patch, such that it copies the file to the correct destination

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Related issue upstream that will be resolved by this: kubernetes/minikube/issues/2307