### PR TITLE
type-of-html should build now

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8330,7 +8330,6 @@ dont-distribute-packages:
   type-level-bst:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-level-natural-number-induction:          [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-level-natural-number-operations:         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  type-of-html:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-ord-spine-cereal:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-ord:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-prelude:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]


### PR DESCRIPTION
- [x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS