### PR TITLE
flashplayer: 27.0.0.187 -> 28.0.0.126 [Moderate security fix]

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -94,12 +94,12 @@ let
 
   flash = stdenv.mkDerivation rec {
     name = "flashplayer-ppapi-${version}";
-    version = "27.0.0.187";
+    version = "28.0.0.126";
 
     src = fetchzip {
       url = "https://fpdownload.adobe.com/pub/flashplayer/pdc/"
           + "${version}/flash_player_ppapi_linux.x86_64.tar.gz";
-      sha256 = "102z9aflm0a29klc26jch3wl4y8hdrxzqdqvf5yj0bnibx3hwpsy";
+      sha256 = "10q005jp5vcfqx35jzwp138djv9g7jp83jqbyism40k67ah33i1z";
       stripRoot = false;
     };
 

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
@@ -73,25 +73,25 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-${version}";
-  version = "27.0.0.187";
+  version = "28.0.0.126";
 
   src = fetchurl {
     url =
       if debug then
-        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/27/flash_player_npapi_linux_debug.${arch}.tar.gz"
+        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/28/flash_player_npapi_linux_debug.${arch}.tar.gz"
       else
         "https://fpdownload.adobe.com/get/flashplayer/pdc/${version}/flash_player_npapi_linux.${arch}.tar.gz";
     sha256 =
       if debug then
         if arch == "x86_64" then
-          "1ii97fa1diyggarh1gkg43ia42ws7x84hpjzvrdhxcf6s47lh2ld"
+          "16ivf0j7kr7hak2pxs4mbhw5g0i8ky72mvdkaxpfq42g4mr7qf62"
         else
-          "1gphlgy64ddzn4bbgr2k1kh8xwq9ghf0z0c6zilry0nq33i64xa1"
+          "09dn1zr5bcfvkb46z86p7gr2g9p0a3nj9vvw1qw2fblvbajmznk0"
       else
         if arch == "x86_64" then
-          "1hfcphcvdam62k983rm6r42mnkih4nfwyrnx0v88z3nw14mjr4c3"
+          "0z5p3zimvx8zas649gn2nzp4gfvwc69hklza3d2hpmzb35ckfqbc"
         else
-          "06jb4jd5840w125wd4l35f0b1iqjak07ajy02k9j8srglwi0ffmw";
+          "0kyyjqim7qq0am2hr9ldcbm4sx8dsbgf3916km9gbgg8vjddgxwy";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
@@ -55,19 +55,19 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-standalone-${version}";
-  version = "27.0.0.187";
+  version = "28.0.0.126";
 
   src = fetchurl {
     url =
       if debug then
-        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/27/flash_player_sa_linux_debug.x86_64.tar.gz"
+        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/28/flash_player_sa_linux_debug.x86_64.tar.gz"
       else
-        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/27/flash_player_sa_linux.x86_64.tar.gz";
+        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/28/flash_player_sa_linux.x86_64.tar.gz";
     sha256 =
       if debug then
-        "1857g4yy62pj02pnw7p9bpqazp98jf17yv2xdh1fkqiibzahjc6m"
+        "07692qivf09zh36vlaczwwq93f8p7v1afnsgkry7m9yybxh1753d"
       else
-        "0kywx7c3qb1hfljc14ddzm1cyhvwygbbdfxp1rdhqw8s3b6ns0hw";
+        "14xj55wjp9jvm01n8bwrbwmkhpcrxc44yfqi3jq8f8pzrqi7smck";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

- Moderate security fix.
- Other bug fixes and improvements.

https://helpx.adobe.com/flash-player/release-note/fp_28_air_28_release_notes.html
https://helpx.adobe.com/security/products/flash-player/apsb17-42.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

- Built packages
  - `nix-env -i -f . -A pkgs.flashplayer`
  - `nix-build -I nixpkgs=. -A pkgsi686Linux.flashplayer`
  - `nix-build -I nixpkgs=. -E "(import <nixpkgs> {}).flashplayer.override { debug = true; }"`
  - `nix-build -I nixpkgs=. -E "(import <nixpkgs> {}).pkgsi686Linux.flashplayer.override { debug = true; }"`
  - `nix-build -I nixpkgs=. -A pkgs.flashplayer-standalone`
  - `nix-build -I nixpkgs=. -A pkgs.flashplayer-standalone-debugger`
  - `nix-build -I nixpkgs=. -E "(import <nixpkgs> {}).chromium.override { enablePepperFlash = true; }"`
- Played a video with Firefox and Chromium.
- Checked the version with Firefox, Chromium,  flashplayer-standalone, and flashplayer-standalone-debugger (x86_64) http://www.adobe.com/software/flash/about/

---

