### PR TITLE
rkrlv2: b1.0 -> b2.0

### DIFF
--- a/pkgs/applications/audio/rkrlv2/default.nix
+++ b/pkgs/applications/audio/rkrlv2/default.nix
@@ -4,13 +4,13 @@ automake, pkgconfig, lv2, fftw, cmake, xorg, libjack2, libsamplerate, libsndfile
 
 stdenv.mkDerivation rec {
   repo = "rkrlv2";
-  name = "${repo}-b1.0";
+  name = "${repo}-b2.0";
 
   src = fetchFromGitHub {
     owner = "ssj71";
     inherit repo;
-    rev = "a315f5aefe63be7e34663596b8b050410a9b7e72";
-    sha256 = "0kr3rvq7n1bh47qryyarcpiibms601qd8l1vypmm61969l4d4bn8";
+    rev = "beta_2";
+    sha256 = "128jcilbrd1l65c01w2bazsb21x78mng0jjkhi3x9crf1n9qbh2m";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

