### PR TITLE
zfs/spl bump to 0.7.4 to fix incompatibility with 4.14

### DIFF
--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -66,10 +66,8 @@ in
   assert buildKernel -> kernel != null;
 {
     splStable = common {
-      version = "0.7.3";
-      sha256 = "0j8mb9ky3pjz9hnz5w6fajpzajl15jq3p0xvxb6lhpqj3rjzsqxb";
-
-      broken = kernel != null && stdenv.lib.versionAtLeast kernel.version "4.14";
+      version = "0.7.4";
+      sha256 = "0vmakqi3zm8ka5cglif45ll2m6ynq7r55mhk8d1rzjkgi191cddh";
     };
 
     splUnstable = common {

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -140,9 +140,9 @@ in {
     incompatibleKernelVersion = null;
 
     # this package should point to the latest release.
-    version = "0.7.3";
+    version = "0.7.4";
 
-    sha256 = "1bbajrwfilnmfhn1n69gvsaznyc4q29wi7nkwc0p9r4dli37w28b";
+    sha256 = "1djm97nlipn0fch1vcvpw94bnfvg9ylv9i2hp46dzaxhdh7bm265";
 
     extraPatches = [
       (fetchpatch {


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/31640

###### Things done
On this:
* Ran nix-build nixos/tests/installer.nix -A zfsroot

On a private cherry-pick against release-17.09:
* Booted my machine set to 4.14.3
* Ran nix-build nixos/tests/installer.nix -A zfsroot (which isn't really exciting as the default kernel on release-17.09 is 4.9)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

