### PR TITLE
abcmidi: 2017.11.27 -> 2017.12.10

### DIFF
--- a/pkgs/tools/audio/abcmidi/default.nix
+++ b/pkgs/tools/audio/abcmidi/default.nix
@@ -1,16 +1,14 @@
-{ stdenv, fetchurl, unzip }:
+{ stdenv, fetchzip }:
 
 stdenv.mkDerivation rec {
   name = "abcMIDI-${version}";
-  version = "2017.11.27";
+  version = "2017.12.10";
 
   # You can find new releases on http://ifdo.ca/~seymour/runabc/top.html
-  src = fetchurl {
+  src = fetchzip {
     url = "http://ifdo.ca/~seymour/runabc/${name}.zip";
-    sha256 = "095nnyaqnsr3v7hsswpad9g0hxdnr4s6z8yk1bmr3g1j0cfv1xs9";
+    sha256 = "0m6mv6hlpzg14y5vsjicvi6lpmymsi1q4wz8sfliric3n1zb7ygz";
   };
-
-  nativeBuildInputs = [ unzip ];
 
   # There is also a file called "makefile" which seems to be preferred by the standard build phase
   makefile = "Makefile";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

ping @rycee 