### PR TITLE
release-lib: evaluate nixpkgs on armv6l and armv7l

### DIFF
--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -27,6 +27,8 @@ rec {
     if system == "x86_64-linux" then pkgs_x86_64_linux
     else if system == "i686-linux" then pkgs_i686_linux
     else if system == "aarch64-linux" then pkgs_aarch64_linux
+    else if system == "armv6l-linux" then pkgs_armv6l_linux
+    else if system == "armv7l-linux" then pkgs_armv7l_linux
     else if system == "x86_64-darwin" then pkgs_x86_64_darwin
     else if system == "x86_64-freebsd" then pkgs_x86_64_freebsd
     else if system == "i686-freebsd" then pkgs_i686_freebsd
@@ -37,6 +39,8 @@ rec {
   pkgs_x86_64_linux = allPackages { system = "x86_64-linux"; };
   pkgs_i686_linux = allPackages { system = "i686-linux"; };
   pkgs_aarch64_linux = allPackages { system = "aarch64-linux"; };
+  pkgs_armv6l_linux = allPackages { system = "armv6l-linux"; };
+  pkgs_armv7l_linux = allPackages { system = "armv7l-linux"; };
   pkgs_x86_64_darwin = allPackages { system = "x86_64-darwin"; };
   pkgs_x86_64_freebsd = allPackages { system = "x86_64-freebsd"; };
   pkgs_i686_freebsd = allPackages { system = "i686-freebsd"; };


### PR DESCRIPTION
###### Motivation for this change

I am experimenting with Hydra and armv7l, and I found that release-lib.nix does not evaluate nixpkgs for armv7l. This PR adds support for armv7l as well as armv6l to release-lib.nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

