### PR TITLE
drat-trim: init at 2017-08-31

### DIFF
--- a/pkgs/applications/science/logic/drat-trim/default.nix
+++ b/pkgs/applications/science/logic/drat-trim/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "drat-trim-2017-08-31";
+
+  src = fetchFromGitHub {
+    owner = "marijnheule";
+    repo = "drat-trim";
+    rev = "37ac8f874826ffa3500a00698910e137498defac";
+    sha256 = "1m9q47dfnvdli1z3kb1jvvbm0dgaw725k1aw6h9w00bggqb91bqh";
+  };
+
+  installPhase = ''
+    install -Dt $out/bin drat-trim
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A proof checker for unSAT proofs";
+    longDescription = ''
+      DRAT-trim is a satisfiability proof checking and trimming
+      utility designed to validate proofs for all known satisfiability
+      solving and preprocessing techniques.  DRAT-trim can also emit
+      trimmed formulas, optimized proofs, and TraceCheck+ dependency
+      graphs.
+
+      DRAT-trim has been used as part of the judging process in the
+      annual SAT Competition in recent years, in order to check
+      competing SAT solvers' work when they claim that a SAT instance
+      is unsatisfiable.
+    '';
+    homepage = https://www.cs.utexas.edu/~marijn/drat-trim/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kini ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18874,6 +18874,8 @@ with pkgs;
   };
   cvc4 = callPackage ../applications/science/logic/cvc4 {};
 
+  drat-trim = callPackage ../applications/science/logic/drat-trim {};
+
   ekrhyper = callPackage ../applications/science/logic/ekrhyper {
     inherit (ocamlPackages_4_02) ocaml;
   };


### PR DESCRIPTION
###### Motivation for this change

DRAT-trim is a tool which can be used to make SAT solvers (such as
glucose and glucose-syrup, which are in nixpkgs) more useful by
checking their work.  It has become well-accepted in the SAT solver
development community and has been used in the annual SAT competitions
for the last few years.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

