### PR TITLE
cutemaze: init at 1.2.1

### DIFF
--- a/pkgs/games/cutemaze/default.nix
+++ b/pkgs/games/cutemaze/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, qmake, qttools, qtsvg }:
+
+stdenv.mkDerivation rec {
+  name = "cutemaze-${version}";
+  version = "1.2.1";
+
+  src = fetchurl {
+    url = "https://gottcode.org/cutemaze/${name}-src.tar.bz2";
+    sha256 = "841f2a208770c9de6009fed64e24a059a878686c444c4b572c56b564e4cfa66e";
+  };
+
+  nativeBuildInputs = [ qmake qttools ];
+
+  buildInputs = [ qtsvg ];
+
+  meta = with stdenv.lib; {
+    homepage = https://gottcode.org/cutemaze/;
+    description = "Simple, top-down game in which mazes are randomly generated";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dotlambda ];
+    # TODO: add darwin once tested
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/games/cutemaze/default.nix
+++ b/pkgs/games/cutemaze/default.nix
@@ -13,12 +13,16 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ qtsvg ];
 
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications
+    mv CuteMaze.app $out/Applications
+  '';
+
   meta = with stdenv.lib; {
     homepage = https://gottcode.org/cutemaze/;
     description = "Simple, top-down game in which mazes are randomly generated";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ dotlambda ];
-    # TODO: add darwin once tested
-    platforms = with platforms; linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17882,6 +17882,8 @@ with pkgs;
 
   crrcsim = callPackage ../games/crrcsim {};
 
+  cutemaze = libsForQt5.callPackage ../games/cutemaze {};
+
   cuyo = callPackage ../games/cuyo { };
 
   dhewm3 = callPackage ../games/dhewm3 {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

