### PR TITLE
wxPython: enable headers

### DIFF
--- a/pkgs/development/python-modules/wxPython/3.0.nix
+++ b/pkgs/development/python-modules/wxPython/3.0.nix
@@ -43,6 +43,9 @@ buildPythonPackage rec {
     # remove wxPython's darwin hack that interference with python-2.7-distutils-C++.patch
     substituteInPlace config.py \
       --replace "distutils.unixccompiler.UnixCCompiler = MyUnixCCompiler" ""
+    # set the WXPREFIX to $out instead of the storepath of wxwidgets
+    substituteInPlace config.py \
+      --replace "WXPREFIX   = getWxConfigValue('--prefix')" "WXPREFIX   = '$out'"
     # this check is supposed to only return false on older systems running non-framework python
     substituteInPlace src/osx_cocoa/_core_wrap.cpp \
       --replace "return wxPyTestDisplayAvailable();" "return true;"
@@ -62,7 +65,7 @@ buildPythonPackage rec {
   buildPhase = "";
 
   installPhase = ''
-    ${python.interpreter} setup.py install WXPORT=${if stdenv.isDarwin then "osx_cocoa" else "gtk2"} NO_HEADERS=1 BUILD_GLCANVAS=${if openglSupport then "1" else "0"} UNICODE=1 --prefix=$out
+    ${python.interpreter} setup.py install WXPORT=${if stdenv.isDarwin then "osx_cocoa" else "gtk2"} NO_HEADERS=0 BUILD_GLCANVAS=${if openglSupport then "1" else "0"} UNICODE=1 --prefix=$out
     wrapPythonPrograms
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Kicad needs wxPython headers at compile time if scripting is enabled.
wxPython headers were disabled, probably because they caused a build error: the header files were being copied to the store path of wxwidgets, but access was denied.
With this PR, the header files stay in the wxPython store path.

To point the builder of another derivation to the wxPython header files, some tweaking is needed. E.g. for kicad: cmakeFlags = [ "-DCMAKE_CXX_FLAGS=-I${wxPython}/include/wx-3.0" ]

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

