### PR TITLE
kicad: init unstable at version 2017-12-11

### DIFF
--- a/pkgs/applications/science/electronics/kicad/unstable.nix
+++ b/pkgs/applications/science/electronics/kicad/unstable.nix
@@ -1,28 +1,49 @@
-{ stdenv, fetchFromGitHub, cmake, mesa, wxGTK, zlib, libX11, gettext, glew, glm, cairo, curl, openssl, boost, pkgconfig, doxygen }:
+{ wxGTK, lib, stdenv, fetchFromGitHub, cmake, mesa, zlib
+, libX11, gettext, glew, glm, cairo, curl, openssl, boost, pkgconfig
+, doxygen, pcre, libpthreadstubs, libXdmcp
 
+, oceSupport ? true, opencascade_oce
+, ngspiceSupport ? true, ngspice
+, scriptingSupport ? true, swig, python, wxPython
+}:
+
+with lib;
 stdenv.mkDerivation rec {
   name = "kicad-unstable-${version}";
   version = "2017-12-11";
 
   src = fetchFromGitHub {
-      owner = "KICad";
-      repo = "kicad-source-mirror";
-      rev = "1955f252265c38a313f6c595d6c4c637f38fd316";
-      sha256 = "15cc81h7nh5dk6gj6mc4ylcgdznfriilhb43n1g3xwyq3s8iaibz";
-    };
+    owner = "KICad";
+    repo = "kicad-source-mirror";
+    rev = "1955f252265c38a313f6c595d6c4c637f38fd316";
+    sha256 = "15cc81h7nh5dk6gj6mc4ylcgdznfriilhb43n1g3xwyq3s8iaibz";
+  };
 
-  cmakeFlags = ''
-    -DKICAD_SKIP_BOOST=ON
-  '';
+  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Nightly" ]
+    ++ optionals (oceSupport) [ "-DKICAD_USE_OCE=ON" "-DOCE_DIR=${opencascade_oce}" ]
+    ++ optional (ngspiceSupport) "-DKICAD_SPICE=ON"
+    ++ optionals (scriptingSupport) [
+      "-DKICAD_SCRIPTING=ON"
+      "-DKICAD_SCRIPTING_MODULES=ON"
+      "-DKICAD_SCRIPTING_WXPYTHON=ON"
+      # nix installs wxPython headers in wxPython package, not in wxwidget
+      # as assumed. We explicitely set the header location.
+      "-DCMAKE_CXX_FLAGS=-I${wxPython}/include/wx-3.0"
+    ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake mesa wxGTK zlib libX11 gettext glew glm cairo curl openssl boost doxygen ];
+  nativeBuildInputs = [ cmake doxygen  pkgconfig ];
+  buildInputs = [
+    mesa zlib libX11 wxGTK pcre libXdmcp gettext glew glm libpthreadstubs
+    cairo curl openssl boost
+  ] ++ optional (oceSupport) opencascade_oce
+    ++ optional (ngspiceSupport) ngspice
+    ++ optionals (scriptingSupport) [ swig python wxPython ];
 
   meta = {
     description = "Free Software EDA Suite, Nightly Development Build";
     homepage = http://www.kicad-pcb.org/;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [ berce ];
-    platforms = with stdenv.lib.platforms; linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ berce ];
+    platforms = with platforms; linux;
   };
 }

--- a/pkgs/applications/science/electronics/kicad/unstable.nix
+++ b/pkgs/applications/science/electronics/kicad/unstable.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, cmake, mesa, wxGTK, zlib, libX11, gettext, glew, glm, cairo, curl, openssl, boost, pkgconfig, doxygen }:
+
+stdenv.mkDerivation rec {
+  name = "kicad-unstable-${version}";
+  version = "2017-12-11";
+
+  src = fetchFromGitHub {
+      owner = "KICad";
+      repo = "kicad-source-mirror";
+      rev = "1955f252265c38a313f6c595d6c4c637f38fd316";
+      sha256 = "15cc81h7nh5dk6gj6mc4ylcgdznfriilhb43n1g3xwyq3s8iaibz";
+    };
+
+  cmakeFlags = ''
+    -DKICAD_SKIP_BOOST=ON
+  '';
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ cmake mesa wxGTK zlib libX11 gettext glew glm cairo curl openssl boost doxygen ];
+
+  meta = {
+    description = "Free Software EDA Suite, Nightly Development Build";
+    homepage = http://www.kicad-pcb.org/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ berce ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/applications/science/electronics/kicad/unstable.nix
+++ b/pkgs/applications/science/electronics/kicad/unstable.nix
@@ -19,8 +19,13 @@ stdenv.mkDerivation rec {
     sha256 = "15cc81h7nh5dk6gj6mc4ylcgdznfriilhb43n1g3xwyq3s8iaibz";
   };
 
-  cmakeFlags = [ "-DKICAD_VERSION=${version}" ]
-    ++ optionals (oceSupport) [ "-DKICAD_USE_OCE=ON" "-DOCE_DIR=${opencascade_oce}" ]
+  postPatch = ''
+    substituteInPlace CMakeModules/KiCadVersion.cmake \
+      --replace no-vcs-found ${version}
+  '';
+
+  cmakeFlags =
+    optionals (oceSupport) [ "-DKICAD_USE_OCE=ON" "-DOCE_DIR=${opencascade_oce}" ]
     ++ optional (ngspiceSupport) "-DKICAD_SPICE=ON"
     ++ optionals (scriptingSupport) [
       "-DKICAD_SCRIPTING=ON"

--- a/pkgs/applications/science/electronics/kicad/unstable.nix
+++ b/pkgs/applications/science/electronics/kicad/unstable.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "15cc81h7nh5dk6gj6mc4ylcgdznfriilhb43n1g3xwyq3s8iaibz";
   };
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Nightly" ]
+  cmakeFlags = [ "-DKICAD_VERSION=${version}" ]
     ++ optionals (oceSupport) [ "-DKICAD_USE_OCE=ON" "-DOCE_DIR=${opencascade_oce}" ]
     ++ optional (ngspiceSupport) "-DKICAD_SPICE=ON"
     ++ optionals (scriptingSupport) [

--- a/pkgs/development/python-modules/wxPython/3.0.nix
+++ b/pkgs/development/python-modules/wxPython/3.0.nix
@@ -43,6 +43,9 @@ buildPythonPackage rec {
     # remove wxPython's darwin hack that interference with python-2.7-distutils-C++.patch
     substituteInPlace config.py \
       --replace "distutils.unixccompiler.UnixCCompiler = MyUnixCCompiler" ""
+    # set the WXPREFIX to $out instead of the storepath of wxwidgets
+    substituteInPlace config.py \
+      --replace "WXPREFIX   = getWxConfigValue('--prefix')" "WXPREFIX   = '$out'"
     # this check is supposed to only return false on older systems running non-framework python
     substituteInPlace src/osx_cocoa/_core_wrap.cpp \
       --replace "return wxPyTestDisplayAvailable();" "return true;"
@@ -62,7 +65,7 @@ buildPythonPackage rec {
   buildPhase = "";
 
   installPhase = ''
-    ${python.interpreter} setup.py install WXPORT=${if stdenv.isDarwin then "osx_cocoa" else "gtk2"} NO_HEADERS=1 BUILD_GLCANVAS=${if openglSupport then "1" else "0"} UNICODE=1 --prefix=$out
+    ${python.interpreter} setup.py install WXPORT=${if stdenv.isDarwin then "osx_cocoa" else "gtk2"} NO_HEADERS=0 BUILD_GLCANVAS=${if openglSupport then "1" else "0"} UNICODE=1 --prefix=$out
     wrapPythonPrograms
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19017,6 +19017,11 @@ with pkgs;
     boost = boost160;
   };
 
+  kicad-unstable = callPackage ../applications/science/electronics/kicad/unstable.nix {
+    wxGTK = wxGTK30;
+    boost = boost160;
+  };
+
   ngspice = callPackage ../applications/science/electronics/ngspice { };
 
   pcb = callPackage ../applications/science/electronics/pcb { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19017,7 +19017,7 @@ with pkgs;
     boost = boost160;
   };
 
-  kicad-unstable = callPackage ../applications/science/electronics/kicad/unstable.nix {
+  kicad-unstable = python.pkgs.callPackage ../applications/science/electronics/kicad/unstable.nix {
     wxGTK = wxGTK30;
     boost = boost160;
   };


### PR DESCRIPTION
###### Motivation for this change

Files are not forward compatible, so when cooperating with someone who needs features of the Nightly Development Build, you also need this newer version.
In contrast with the current package for the stable release of KiCad, this package also enables oce, ngspice and scripting support.
This package does not provide the component libraries (schematics, PCB footprints, 3D models). They can be obtained from [KiCad](http://kicad-pcb.org/libraries/download/), unpacked and referenced at runtime.

It is called unstable and not nightly because it doesn't automatically track upstream nightly development builds.

wxPython headers are needed at buildtime. This PR includes  a necessary change to wxPython. That change is also in a separate PR: #32647

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

