### PR TITLE
recoverjpeg: init at 2.6.1

### DIFF
--- a/pkgs/tools/misc/recoverjpeg/default.nix
+++ b/pkgs/tools/misc/recoverjpeg/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, makeWrapper, python2, exif, imagemagick }:
+
+stdenv.mkDerivation rec {
+  name = "recoverjpeg-${version}";
+  version = "2.6.1";
+
+  src = fetchurl {
+    url = "https://www.rfc1149.net/download/recoverjpeg/${name}.tar.gz";
+    sha256 = "00zi23l4nq9nfjg1zzbpsfxf1s47r5w713aws90w13fd19jqn0rj";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ python2 ];
+
+  postFixup = ''
+    wrapProgram $out/bin/sort-pictures \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ exif imagemagick ]}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://rfc1149.net/devel/recoverjpeg.html;
+    description = "Recover lost JPEGs and MOV files on a bogus memory card or disk";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ dotlambda ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4274,6 +4274,8 @@ with pkgs;
 
   reckon = callPackage ../tools/text/reckon { };
 
+  recoverjpeg = callPackage ../tools/misc/recoverjpeg { };
+
   reposurgeon = callPackage ../applications/version-management/reposurgeon { };
 
   reptyr = callPackage ../os-specific/linux/reptyr {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

