### PR TITLE
solvespace2x: init at 2.x

### DIFF
--- a/pkgs/applications/graphics/solvespace/2.x.nix
+++ b/pkgs/applications/graphics/solvespace/2.x.nix
@@ -6,9 +6,10 @@ stdenv.mkDerivation rec {
   name = "solvespace-2.x";
   rev = "b1d87bf284b32e875c8edba592113e691ea10bcd";
   src = fetchgit {
-    url = https://github.com/solvespace/solvespace;
+    url = https://github.com/solvespace/solvespace.git;
     inherit rev;
     fetchSubmodules = true;
+    sha256 = "160qam04pfrwkh9qskfmjkj01wrjwhl09xi6jjxi009yqg3cff9l";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/solvespace/2.x.nix
+++ b/pkgs/applications/graphics/solvespace/2.x.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchgit, cmake, pkgconfig, zlib, libpng, cairo, freetype
+, json_c, fontconfig, gtkmm2, pangomm, glew, mesa_glu, xlibs, pcre
+, wrapGAppsHook
+}:
+stdenv.mkDerivation rec {
+  name = "solvespace-2.x";
+  rev = "b1d87bf284b32e875c8edba592113e691ea10bcd";
+  src = fetchgit {
+    url = https://github.com/solvespace/solvespace;
+    inherit rev;
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    pkgconfig cmake wrapGAppsHook
+  ];
+  buildInputs = [
+    zlib libpng cairo freetype
+    json_c fontconfig gtkmm2 pangomm glew mesa_glu
+    xlibs.libpthreadstubs xlibs.libXdmcp pcre
+  ];
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    patch CMakeLists.txt <<EOF
+    @@ -20,9 +20,9 @@
+     # NOTE TO PACKAGERS: The embedded git commit hash is critical for rapid bug triage when the builds
+     # can come from a variety of sources. If you are mirroring the sources or otherwise build when
+     # the .git directory is not present, please comment the following line:
+    -include(GetGitCommitHash)
+    +# include(GetGitCommitHash)
+     # and instead uncomment the following, adding the complete git hash of the checkout you are using:
+    -# set(GIT_COMMIT_HASH 0000000000000000000000000000000000000000)
+    +set(GIT_COMMIT_HASH $rev)
+    EOF
+  '';
+
+  postInstall = ''
+    substituteInPlace $out/share/applications/solvespace.desktop \
+      --replace /usr/bin/ $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A parametric 3d CAD program";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.edef ];
+    platforms = platforms.linux;
+    homepage = http://solvespace.com;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4519,6 +4519,7 @@ with pkgs;
   solr = callPackage ../servers/search/solr { };
 
   solvespace = callPackage ../applications/graphics/solvespace { };
+  solvespace2x = callPackage ../applications/graphics/solvespace/2.x.nix { };
 
   sonarr = callPackage ../servers/sonarr { };
 


### PR DESCRIPTION
###### Motivation for this change
default.nix can't build live prog on two my Nix system
build from 2.x branch solvespace make live prog ver 2.3 on two my Nix system

###### Things done?


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

