### PR TITLE
Update haskell.md

### DIFF
--- a/doc/languages-frameworks/haskell.md
+++ b/doc/languages-frameworks/haskell.md
@@ -777,14 +777,14 @@ to find out the store path of the system's zlib library. Now, you can
     stack --extra-lib-dirs=/nix/store/alsvwzkiw4b7ip38l4nlfjijdvg3fvzn-zlib-1.2.8/lib build
     ```
 
-    Typically, you'll need `--extra-include-dirs` as well. It's possible
-    to add those flag to the project's `stack.yaml` or your user's
-    global `~/.stack/global/stack.yaml` file so that you don't have to
-    specify them manually every time. But again, you're likely better off
-    using Stack's Nix support instead.
+Typically, you'll need `--extra-include-dirs` as well. It's possible
+to add those flag to the project's `stack.yaml` or your user's
+global `~/.stack/global/stack.yaml` file so that you don't have to
+specify them manually every time. But again, you're likely better off
+using Stack's Nix support instead.
 
-    The same thing applies to `cabal configure`, of course, if you're
-    building with `cabal-install` instead of Stack.
+The same thing applies to `cabal configure`, of course, if you're
+building with `cabal-install` instead of Stack.
 
 ### Creating statically linked binaries
 


### PR DESCRIPTION
Unindent prose that was incorrectly being displayed as code.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

