### PR TITLE
keepassxc: 2.2.2 -> 2.2.4

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -7,17 +7,17 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "keepassxc-${version}";
-  version = "2.2.2";
+  version = "2.2.4";
 
   src = fetchFromGitHub {
     owner = "keepassxreboot";
     repo = "keepassxc";
     rev = "${version}";
-    sha256 = "01pqpa3vzk2q1vrj2lqayr7a3nzpnj176yhnqbrwlm3s9rga4wzn";
+    sha256 = "0q913v2ka6p7jr7c4w9fq8aqh5v6nxqgcv9h7zllk5p0amsf8d80";
   };
 
-  cmakeFlags = [ 
-    "-DWITH_GUI_TESTS=ON" 
+  cmakeFlags = [
+    "-DWITH_GUI_TESTS=ON"
     "-DWITH_XC_AUTOTYPE=ON"
     "-DWITH_XC_YUBIKEY=ON"
   ] ++ (optional withKeePassHTTP "-DWITH_XC_HTTP=ON");


### PR DESCRIPTION
###### Motivation for this change

KeepassXC has a new bugfix release. The changelog is available at https://github.com/keepassxreboot/keepassxc/releases/tag/2.2.4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

