### PR TITLE
thefuck: 3.18 -> 3.25

### DIFF
--- a/pkgs/tools/misc/thefuck/default.nix
+++ b/pkgs/tools/misc/thefuck/default.nix
@@ -1,22 +1,32 @@
-{ fetchurl, stdenv, pkgs, ... }:
+{ stdenv, fetchFromGitHub, buildPythonApplication
+, colorama, decorator, psutil, pyte, six
+, pytest, pytest-mock
+}:
 
-pkgs.pythonPackages.buildPythonPackage rec {
-  name = "${pname}-${version}";
+buildPythonApplication rec {
   pname = "thefuck";
-  version = "3.18";
+  version = "3.25";
 
-  src = fetchurl {
-    url = "https://github.com/nvbn/${pname}/archive/${version}.tar.gz";
-    sha256 = "1xsvkqh89rgxq5w03mnlcfkn9y39nfwhb2pjabjspcc2mi2mq5y6";
+  src = fetchFromGitHub {
+    owner = "nvbn";
+    repo = "${pname}";
+    rev = version;
+    sha256 = "090mg809aac932lgqmjxm4za53lg3bjprj562sp189k47xs4wijv";
   };
 
-  propagatedBuildInputs = with pkgs.pythonPackages; [
-    psutil
-    colorama
-    six
-    decorator
-    pathlib2
-  ];
+  propagatedBuildInputs = [ colorama decorator psutil pyte six ];
+
+  checkInputs = [ pytest pytest-mock ];
+
+  checkPhase = ''
+    export HOME=$TMPDIR
+    export LANG=en_US.UTF-8
+    export XDG_CACHE_HOME=$TMPDIR/cache
+    export XDG_CONFIG_HOME=$TMPDIR/config
+    py.test
+  '';
+
+  doCheck = false; # The above is only enough for tests to pass outside the sandbox.
 
   meta = with stdenv.lib; {
     homepage = https://github.com/nvbn/thefuck;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4716,7 +4716,7 @@ with pkgs;
 
   thc-hydra = callPackage ../tools/security/thc-hydra { };
 
-  thefuck = callPackage ../tools/misc/thefuck { };
+  thefuck = python3Packages.callPackage ../tools/misc/thefuck { };
 
   thin-provisioning-tools = callPackage ../tools/misc/thin-provisioning-tools {  };
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #32670.

Switching to Python 3 because the upstream claims that this is required.

I was not able to make tests pass in the sandbox, even though they do not need anything special. They seem to ignore the environment variables set in the checkPhase.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).