### PR TITLE
texlive: fix use of xdvi: add hashes and don't orphan it

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -68,8 +68,8 @@ let
       collection-metapost = orig.collection-metapost // {
         deps = orig.collection-metapost.deps // { inherit (tl) metafont; };
       };
-      collection-genericextra = orig.collection-genericextra // {
-        deps = orig.collection-genericextra.deps // { inherit (tl) xdvi; };
+      collection-plaingeneric = orig.collection-plaingeneric // {
+        deps = orig.collection-plaingeneric.deps // { inherit (tl) xdvi; };
       };
     }); # overrides
 

--- a/pkgs/tools/typesetting/tex/texlive/fixedHashes.nix
+++ b/pkgs/tools/typesetting/tex/texlive/fixedHashes.nix
@@ -7582,6 +7582,8 @@
 "unicode-bidi.doc-0.01"="8x4zk0spvhmq3sc8ygvidk03gfzm2875";
 "unisugar-0.92"="wfr974a1y4wzlbw0wwzfr6r0yp9nyasl";
 "unisugar.doc-0.92"="hcnqifbhpj44cwbr8sh4c71phg4i5327";
+"xdvi-22.87.03"="g5irfc0gf7bra3vngv6kdbkhbyicdz84";
+"xdvi.doc-22.87.03"="h2d03izpvnpsii465g3hf299z3ndv4vl";
 "xebaposter-2.51"="glxmnnhjpy8wjab9avncl4v0wmdf0pv7";
 "xebaposter.doc-2.51"="sbpqsj7cqhhhs9gq8jia92hxrdgnhzkk";
 "xechangebar-1.0"="1f2zszj2l5mkqv5zs5bs8g5w4c8rirpv";


### PR DESCRIPTION
Hashes added manually, not using `fixHashes.sh`.

We remove xdvi from collection-basic and put it elsewhere:
previously this was collection-genericextra but that no longer
exist so I suppose it can go in collection-plainextra.
(As mentioned on the issue, might be best to just leave it in basic?)

Fixes #32661.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

