### PR TITLE
pqiv: add dependencies needed to enable all backends

### DIFF
--- a/pkgs/applications/graphics/pqiv/default.nix
+++ b/pkgs/applications/graphics/pqiv/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub, getopt, which, pkgconfig, gtk3 } :
+{ stdenv, fetchFromGitHub, getopt, which, pkgconfig, gtk3,
+ffmpeg, imagemagick, libarchive, libspectre, libwebp, poppler
+}:
 
 stdenv.mkDerivation (rec {
   name = "pqiv-${version}";
@@ -12,7 +14,10 @@ stdenv.mkDerivation (rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ getopt which gtk3 ];
+  buildInputs = [
+    getopt which gtk3
+    ffmpeg imagemagick libarchive libspectre libwebp poppler
+  ];
 
   prePatch = "patchShebangs .";
 


### PR DESCRIPTION

###### Motivation for this change

Support more formats by default! :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

