### PR TITLE
chicken: 4.11.0 -> 4.13.0

### DIFF
--- a/pkgs/development/compilers/chicken/default.nix
+++ b/pkgs/development/compilers/chicken/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, makeWrapper, bootstrap-chicken ? null }:
 
 let
-  version = "4.11.0";
+  version = "4.13.0";
   platform = with stdenv;
     if isDarwin then "macosx"
     else if isCygwin then "cygwin"
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://code.call-cc.org/releases/${version}/chicken-${version}.tar.gz";
-    sha256 = "12ddyiikqknpr8h6llsxbg2fz75xnayvcnsvr1cwv8xnjn7jpp73";
+    sha256 = "0hvckhi5gfny3mlva6d7y9pmx7cbwvq0r7mk11k3sdiik9hlkmdd";
   };
 
   setupHook = lib.ifEnable (bootstrap-chicken != null) ./setup-hook.sh;

--- a/pkgs/tools/backup/ugarit-manifest-maker/eggs.nix
+++ b/pkgs/tools/backup/ugarit-manifest-maker/eggs.nix
@@ -294,12 +294,12 @@ rec {
   };
 
   ssql = eggDerivation {
-    name = "ssql-0.2.2";
+    name = "ssql-0.2.4";
 
     src = fetchegg {
       name = "ssql";
-      version = "0.2.2";
-      sha256 = "10557ymy0fgvqqazsg2jsbqvng0b91jqcjfgsxkrq8xs3klyd5mf";
+      version = "0.2.4";
+      sha256 = "0qhnghhx1wrvav4s7l780mspwlh8s6kzq4bl0cslwp1km90fx9bk";
     };
 
     buildInputs = [

--- a/pkgs/tools/backup/ugarit/eggs.nix
+++ b/pkgs/tools/backup/ugarit/eggs.nix
@@ -294,12 +294,12 @@ rec {
   };
 
   ssql = eggDerivation {
-    name = "ssql-0.2.2";
+    name = "ssql-0.2.4";
 
     src = fetchegg {
       name = "ssql";
-      version = "0.2.2";
-      sha256 = "10557ymy0fgvqqazsg2jsbqvng0b91jqcjfgsxkrq8xs3klyd5mf";
+      version = "0.2.4";
+      sha256 = "0qhnghhx1wrvav4s7l780mspwlh8s6kzq4bl0cslwp1km90fx9bk";
     };
 
     buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

<https://lists.nongnu.org/archive/html/chicken-announce/2017-12/msg00005.html>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

See commit message for details about the chicken-ssql version bump.