### PR TITLE
nodejs: 9.2.0 -> 9.3.0, libuv: 1.16.1 -> 1.18.0

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -2,14 +2,14 @@
 , ApplicationServices, CoreServices }:
 
 stdenv.mkDerivation rec {
-  version = "1.16.1";
+  version = "1.18.0";
   name = "libuv-${version}";
 
   src = fetchFromGitHub {
     owner = "libuv";
     repo = "libuv";
     rev = "v${version}";
-    sha256 = "06p3xy276spqbr9xzbs7qlpdk34qsn87s2qmp6xn4j7v3bnqja7z";
+    sha256 = "0s71c2y4ll3vp463hsdk74q4hr7wprkxc2a4agw3za2hhzcb95pd";
   };
 
   postPatch = let

--- a/pkgs/development/web/nodejs/v9.nix
+++ b/pkgs/development/web/nodejs/v9.nix
@@ -5,7 +5,7 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "9.2.0";
-    sha256 = "1hmvwfbavk2axqz9kin8b5zsld25gznhvlz55h3yl6nwx9iz5jk4";
+    version = "9.3.0";
+    sha256 = "1kap1hi4am5advfp6yb3bd5nhd2wx2j72cjq8qqg7yh95xg0g25j";
     patches = lib.optionals stdenv.isDarwin [ ./no-xcode-v7.patch ];
   }


### PR DESCRIPTION
###### Motivation for this change

Making `nodejs_9_x` up-to-date.

###### Things done

nodejs 9.3.0 didn't compile using libuv 1.16.1, so I've also upgraded libuv. libuv has a lot of dependencies, which I haven't all build yet. A previous PR for nodejs 9 and libuv seemed to be building fine.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (tried using `nix-shell -p nox --run "nox-review wip --against upstream/master"`, but fails due to using Nix 1.12pre4911_b30d1e7). Manually tested the following:
  - [x] neovim
  - [x] nodejs_9_x
  - [ ] pixie
  - [ ] neovim
  - [ ] libwebsockets
  - [ ] cmake
  - [ ] ... others
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

