### PR TITLE
garcon: fix issues 10967, 12700 (Xfce)

### DIFF
--- a/pkgs/desktops/xfce/core/garcon-10967.patch
+++ b/pkgs/desktops/xfce/core/garcon-10967.patch
@@ -1,0 +1,14 @@
+diff -urNZ a/garcon-gtk/garcon-gtk-menu.c b/garcon-gtk/garcon-gtk-menu.c
+--- a/garcon-gtk/garcon-gtk-menu.c	2017-11-16 19:22:33.551926068 +0000
++++ b/garcon-gtk/garcon-gtk-menu.c	2017-11-16 19:23:33.055497211 +0000
+@@ -676,6 +676,9 @@
+                   G_CALLBACK (garcon_gtk_menu_deactivate), menu);
+               gtk_widget_show (mi);
+ 
++	      /* submenu are child items, too. */
++	      has_children = TRUE;
++	      
+               if (menu->priv->show_menu_icons)
+                 {
+                   icon_name = garcon_menu_element_get_icon_name (li->data);
+Binary files a/.git/index and b/.git/index differ

--- a/pkgs/desktops/xfce/core/garcon-12700.patch
+++ b/pkgs/desktops/xfce/core/garcon-12700.patch
@@ -1,0 +1,44 @@
+From 222080e6d5fce85eb2a8a5c33df671bd9f21add8 Mon Sep 17 00:00:00 2001
+From: Yegor Timoshenko <yegortimoshenko@gmail.com>
+Date: Thu, 14 Dec 2017 22:04:04 +0000
+Subject: [PATCH] Decrement allocation counter on item unref (#12700)
+
+---
+ garcon/garcon-menu-item-pool.c | 7 ++++++-
+ garcon/garcon-menu-item.c      | 2 ++
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/garcon/garcon-menu-item-pool.c b/garcon/garcon-menu-item-pool.c
+index 2017180..355e520 100644
+--- a/garcon/garcon-menu-item-pool.c
++++ b/garcon/garcon-menu-item-pool.c
+@@ -191,7 +191,12 @@ garcon_menu_item_pool_filter_exclude (const gchar    *desktop_id,
+   g_return_val_if_fail (GARCON_IS_MENU_ITEM (item), FALSE);
+   g_return_val_if_fail (node != NULL, FALSE);
+ 
+-  return garcon_menu_node_tree_rule_matches (node, item);
++  gboolean matches = garcon_menu_node_tree_rule_matches (node, item);
++
++  if (matches)
++    garcon_menu_item_increment_allocated (item);
++
++  return matches;
+ }
+ 
+ 
+diff --git a/garcon/garcon-menu-item.c b/garcon/garcon-menu-item.c
+index 66a86bf..d61c88f 100644
+--- a/garcon/garcon-menu-item.c
++++ b/garcon/garcon-menu-item.c
+@@ -1516,6 +1516,8 @@ garcon_menu_item_unref (GarconMenuItem *item)
+ {
+   g_return_if_fail (GARCON_IS_MENU_ITEM (item));
+ 
++  garcon_menu_item_decrement_allocated (item);
++
+   /* Decrement the reference counter */
+   g_object_unref (G_OBJECT (item));
+ }
+-- 
+2.15.1
+

--- a/pkgs/desktops/xfce/core/garcon.nix
+++ b/pkgs/desktops/xfce/core/garcon.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "out" "dev" ];
+  patches = [ ./garcon-10967.patch ./garcon-12700.patch ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ intltool glib libxfce4util gtk libxfce4ui ];
@@ -24,4 +25,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

I've ran into some bugs with Xfce's application menu. 10967 is fixed in master, while 12700 is not committed (yet). I'm currently running a Xfce session that incorporates these patches.

https://bugzilla.xfce.org/show_bug.cgi?id=10967
https://bugzilla.xfce.org/show_bug.cgi?id=12700

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

