### PR TITLE
paperkey: 1.4 -> 1.5

### DIFF
--- a/pkgs/tools/security/paperkey/default.nix
+++ b/pkgs/tools/security/paperkey/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "paperkey-${version}";
-  version = "1.4";
+  version = "1.5";
 
   src = fetchurl {
     url = "http://www.jabberwocky.com/software/paperkey/${name}.tar.gz";
-    sha256 = "0vrkryxqbsjcmqalsnxvc3pahg6vvyrn139aj8md29sihgnb0az1";
+    sha256 = "1prd2jaf4zjad3xhv160hmi5n408ssljfg7iz90jxs9w111pjwy4";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

