### PR TITLE
SkypeExport: init at 1.4.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/SkypeExport/default.nix
+++ b/pkgs/applications/networking/instant-messengers/SkypeExport/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, cmake, boost }:
+
+stdenv.mkDerivation rec {
+  name = "SkypeExport-${version}";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "Temptin";
+    repo = "SkypeExport";
+    rev = "v${version}";
+    sha256 = "1ilkh0s3dz5cp83wwgmscnfmnyck5qcwqg1yxp9zv6s356dxnbak";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost ];
+
+  preConfigure = "cd src/SkypeExport/_gccbuild/linux";
+  installPhase = "install -Dt $out/bin SkypeExport";
+
+  meta = with stdenv.lib; {
+    description = "Export Skype history to HTML";
+    homepage = https://github.com/Temptin/SkypeExport;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ yegortimoshenko ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16686,6 +16686,8 @@ with pkgs;
 
   skype_call_recorder = callPackage ../applications/networking/instant-messengers/skype-call-recorder { };
 
+  SkypeExport = callPackage ../applications/networking/instant-messengers/SkypeExport { };
+
   slmenu = callPackage ../applications/misc/slmenu {};
 
   slop = callPackage ../tools/misc/slop {};


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This may be controversial due to the fact that I use the same case in the attribute name (and the directory name) as the author uses in the executable's name and the project's name.