### PR TITLE
clojure: 1.8.0 -> 1.9.0.273, new tools!

### DIFF
--- a/pkgs/build-support/fetchMaven/default.nix
+++ b/pkgs/build-support/fetchMaven/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, maven }: { src, sha256 }:
+
+stdenv.mkDerivation {
+  name = "maven-repo";
+
+  outputHashAlgo = "sha256";
+  outputHash = sha256;
+  outputHashMode = "recursive";
+
+  nativeBuildInputs = [ maven ];
+
+  buildCommand = ''
+    ln -s ${src}/* .
+
+    # Unfortunately, dependency:go-offline phase can't infer dependencies injected
+    # at build time by some Maven plugins, which makes it impossible to fetch all
+    # dependencies without the first build...
+    mvn -Dmaven.repo.local=$out package
+
+    find $out \( -name _remote.repositories -or -name \*.lastUpdated \) -delete
+  '';
+}

--- a/pkgs/development/interpreters/clojure/default.nix
+++ b/pkgs/development/interpreters/clojure/default.nix
@@ -1,51 +1,42 @@
-{ stdenv, fetchurl, jdk, makeWrapper }:
+{ stdenv, fetchFromGitHub, fetchMaven, maven }:
 
-let version = "1.9.0.273"; in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "clojure-${version}";
+  version = "1.9.0.273";
 
-  src = fetchurl {
-    url = "https://download.clojure.org/install/clojure-tools-${version}.tar.gz";
-    sha256 = "0xmrq3xvr002jgq8m1j0y5ld0rcr49608g3gqxgyxzjqswacglb4";
+  src = fetchFromGitHub {
+    owner = "clojure";
+    repo = "brew-install";
+    rev = version;
+    sha256 = "06cfr2jjwvqml19na5220dgyjy4dhkv27l0b2ck02fy5a796vh84";
   };
 
-  buildInputs = [ jdk makeWrapper ];
+  deps = fetchMaven {
+    inherit src;
+    sha256 = "0h80p8jl9w59hc0xrr6lswznh2hi8bjj8h99p2jpjnqfcwdyxrnd";
+  };
+
+  nativeBuildInputs = [ maven ];
+
+  buildPhase = "mvn -o -Dmaven.repo.local=${deps} package";
 
   installPhase = ''
-    pwd
-    ls -la
-    mkdir -p $out/libexec $out/bin
-    cp -f deps.edn example-deps.edn $out
-    cp -f clojure-tools-${version}.jar $out/libexec
-    sed -i -e "s@PREFIX@$out@g" clojure
-    cp -f clj clojure $out/bin
+    local prefix=$out/share/clojure
+    local source=target/classes
+
+    substituteInPlace $source/clojure --replace PREFIX $prefix
+    install -Dt $out/bin $source/{clj,clojure}
+
+    mkdir -p $prefix $prefix/libexec
+    cp target/clojure-tools-${version}.jar $prefix/libexec
+    cp $source/{,example-}deps.edn $prefix
   '';
 
   meta = with stdenv.lib; {
-    description = "A Lisp dialect for the JVM";
-    homepage = https://clojure.org/;
+    description = "The Clojure programming language";
+    homepage = https://clojure.org;
     license = licenses.epl10;
-    longDescription = ''
-      Clojure is a dynamic programming language that targets the Java
-      Virtual Machine. It is designed to be a general-purpose language,
-      combining the approachability and interactive development of a
-      scripting language with an efficient and robust infrastructure for
-      multithreaded programming. Clojure is a compiled language - it
-      compiles directly to JVM bytecode, yet remains completely
-      dynamic. Every feature supported by Clojure is supported at
-      runtime. Clojure provides easy access to the Java frameworks, with
-      optional type hints and type inference, to ensure that calls to Java
-      can avoid reflection.
-
-      Clojure is a dialect of Lisp, and shares with Lisp the code-as-data
-      philosophy and a powerful macro system. Clojure is predominantly a
-      functional programming language, and features a rich set of immutable,
-      persistent data structures. When mutable state is needed, Clojure
-      offers a software transactional memory system and reactive Agent
-      system that ensure clean, correct, multithreaded designs.
-    '';
-    maintainers = with maintainers; [ the-kenny ];
+    maintainers = with maintainers; [ the-kenny yegortimoshenko ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -166,6 +166,8 @@ with pkgs;
 
   mht2htm = callPackage ../tools/misc/mht2htm { };
 
+  fetchMaven = callPackage ../build-support/fetchMaven { };
+
   fetchpatch = callPackage ../build-support/fetchpatch { };
 
   fetchs3 = callPackage ../build-support/fetchs3 { };


### PR DESCRIPTION
###### Motivation for this change

Instead of ad-hoc wrapper around Clojure jar, this uses new Clojure CLI, see: https://clojure.org/guides/deps_and_cli

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

