### PR TITLE
ccd2iso: init at 0.3

### DIFF
--- a/pkgs/tools/cd-dvd/ccd2iso/default.nix
+++ b/pkgs/tools/cd-dvd/ccd2iso/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "ccd2iso-0.3";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/ccd2iso/${name}.tar.gz";
+    sha256 = "1z000zi7hpr2h9cabj6hzf3n6a6gd6glmm8nn36v4b8i4vzbhx7q";
+  };
+
+  meta = with stdenv.lib; {
+    description = "CloneCD to ISO converter";
+    homepage = https://sourceforge.net/projects/ccd2iso/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ yegortimoshenko ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1393,6 +1393,8 @@ with pkgs;
 
   caudec = callPackage ../applications/audio/caudec { };
 
+  ccd2iso = callPackage ../tools/cd-dvd/ccd2iso { };
+
   ccid = callPackage ../tools/security/ccid { };
 
   ccrypt = callPackage ../tools/security/ccrypt { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

