### PR TITLE
clojure: 1.8.0 -> 1.9.0.273

### DIFF
--- a/pkgs/development/interpreters/clojure/default.nix
+++ b/pkgs/development/interpreters/clojure/default.nix
@@ -1,23 +1,25 @@
-{ stdenv, fetchurl, unzip, ant, jdk, makeWrapper }:
+{ stdenv, fetchurl, jdk, makeWrapper }:
 
-let version = "1.8.0"; in
+let version = "1.9.0.273"; in
 
 stdenv.mkDerivation {
   name = "clojure-${version}";
 
   src = fetchurl {
-    url = "http://repo1.maven.org/maven2/org/clojure/clojure/${version}/clojure-${version}.zip";
-    sha256 = "1nip095fz5c492sw15skril60i1vd21ibg6szin4jcvyy3xr6cym";
+    url = "https://download.clojure.org/install/clojure-tools-${version}.tar.gz";
+    sha256 = "0xmrq3xvr002jgq8m1j0y5ld0rcr49608g3gqxgyxzjqswacglb4";
   };
 
-  buildInputs = [ unzip ant jdk makeWrapper ];
-
-  buildPhase = "ant jar";
+  buildInputs = [ jdk makeWrapper ];
 
   installPhase = ''
-    mkdir -p $out/share/java $out/bin
-    install -t $out/share/java clojure.jar
-    makeWrapper ${jdk.jre}/bin/java $out/bin/clojure --add-flags "-cp $out/share/java/clojure.jar clojure.main"
+    pwd
+    ls -la
+    mkdir -p $out/libexec $out/bin
+    cp -f deps.edn example-deps.edn $out
+    cp -f clojure-tools-${version}.jar $out/libexec
+    sed -i -e "s@PREFIX@$out@g" clojure
+    cp -f clj clojure $out/bin
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Clojure 1.9 have been released. 1.9 release adds native cli tools, which are now used in this package instead of creating a java wrapper with a clojure.jar arguments. See https://clojure.org/guides/deps_and_cli for more details on clojure native cli tools.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

