### PR TITLE
Fix build of opensubdiv

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10239,7 +10239,6 @@ with pkgs;
 
   opensubdiv = callPackage ../development/libraries/opensubdiv {
     cudaSupport = config.cudaSupport or false;
-    cmake = cmake_2_8;
   };
 
   open-wbo = callPackage ../applications/science/logic/open-wbo {};


### PR DESCRIPTION
Fixes #31426

The build failed with the following error:
```
CMake Error at osd_dynamic_gpu_generated_cudaKernel.cu.o.cmake:264 (message):
  Error generating file
  /tmp/nix-build-opensubdiv-3.3.0.drv-0/source/build/opensubdiv/CMakeFiles/osd_dynamic_gpu.dir/osd/./osd_dynamic_gpu_generated_cudaKernel.cu.o
```
We had pinned cmake to cmake_2_8, by simply removing this pinning it builds again.

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

