### PR TITLE
terraform: coreos/terraform-provider-ct: init at 0.2.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/providers/data.nix
+++ b/pkgs/applications/networking/cluster/terraform/providers/data.nix
@@ -112,6 +112,13 @@
       version = "1.0.0";
       sha256  = "1008lrvdqn3kk8gwvq094nwknh00b429jmwi0hq4brick7vyvbvz";
     };
+  ct =
+    {
+      owner   = "coreos";
+      repo    = "terraform-provider-ct";
+      version = "0.2.0";
+      sha256  = "147vp5vvp7g0h6z34j7xmj3dvi59ksxhknggab89cf6p1rza4ywq";
+    };
   datadog =
     {
       owner   = "terraform-providers";


### PR DESCRIPTION
###### Motivation for this change

Add Terraform Provider for Container Linux Configs. This is a required plugin for use with [Typhoon - k8s](https://typhoon.psdn.io)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

