### PR TITLE
lumail: 2.9 -> 3.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/lumail/default.nix
+++ b/pkgs/applications/networking/mailreaders/lumail/default.nix
@@ -2,14 +2,14 @@
 , perl, perlPackages }:
 
 let
-  version = "2.9";
+  version = "3.1";
 in
 stdenv.mkDerivation {
   name = "lumail-${version}";
 
   src = fetchurl {
     url = "https://lumail.org/download/lumail-${version}.tar.gz";
-    sha256 = "1rni5lbic36v4cd1r0l28542x0hlmfqkl6nac79gln491in2l2sc";
+    sha256 = "0vj7p7f02m3w8wb74ilajcwznc4ai4h2ikkz9ildy0c00aqsi5w4";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/networking/mailreaders/lumail/default.nix
+++ b/pkgs/applications/networking/mailreaders/lumail/default.nix
@@ -1,8 +1,28 @@
 { stdenv, fetchurl, pkgconfig, lua5_2, file, ncurses, gmime, pcre-cpp
-, perl, perlPackages }:
+, perl, perlPackages
+, debugBuild ? false
+, alternativeGlobalConfigFilePath ? null
+}:
 
 let
-  version = "3.1";
+  version    = "3.1";
+  binaryName = if debugBuild then "lumail2-debug" else "lumail2";
+  alternativeConfig = builtins.toFile "lumail2.lua"
+    (builtins.readFile alternativeGlobalConfigFilePath);
+
+  globalConfig = if isNull alternativeGlobalConfigFilePath then ''
+    mkdir -p $out/etc/lumail2
+    cp global.config.lua $out/etc/lumail2.lua
+    for n in ./lib/*.lua; do
+      cp "$n" $out/etc/lumail2/
+    done
+  '' else ''
+    ln -s ${alternativeConfig} $out/etc/lumail2.lua
+  '';
+
+  getPath  = type : "${lua}/lib/?.${type};";
+  luaPath  = getPath "lua";
+  luaCPath = getPath "so";
 in
 stdenv.mkDerivation {
   name = "lumail-${version}";
@@ -12,7 +32,9 @@ stdenv.mkDerivation {
     sha256 = "0vj7p7f02m3w8wb74ilajcwznc4ai4h2ikkz9ildy0c00aqsi5w4";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ pkgconfig makeWrapper ];
   buildInputs = [
     lua5_2 file ncurses gmime pcre-cpp
     perl perlPackages.JSON perlPackages.NetIMAPClient
@@ -29,15 +51,25 @@ stdenv.mkDerivation {
     sed -e "s|^#\!\(.*/perl.*\)$|#\!\1$perlFlags|" -i perl.d/imap-proxy
   '';
 
+  buildFlags = if debugBuild then "lumail2-debug" else "";
+
+  installPhase = ''
+    mkdir -p $out/bin || true
+    install -m755 ${binaryName} $out/bin/
+  ''
+  + globalConfig
+  + ''
+    wrapProgram $out/bin/${binaryName} \
+        --prefix LUA_PATH : "${luaPath}" \
+        --prefix LUA_CPATH : "${luaCPath}"
+  '';
+
   makeFlags = [
     "LVER=lua"
     "PREFIX=$(out)"
     "SYSCONFDIR=$(out)/etc"
+    "LUMAIL_LIBS=$(out)/etc/lumail2"
   ];
-
-  postInstall = ''
-    cp lumail2.user.lua $out/etc/lumail2/
-  '';
 
   meta = with stdenv.lib; {
     description = "Console-based email client";

--- a/pkgs/applications/networking/mailreaders/lumail/default.nix
+++ b/pkgs/applications/networking/mailreaders/lumail/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, lua5_2, file, ncurses, gmime, pcre-cpp
-, perl, perlPackages
+{ stdenv, fetchurl, pkgconfig, lua, file, ncurses, gmime, pcre-cpp
+, perl, perlPackages, makeWrapper
 , debugBuild ? false
 , alternativeGlobalConfigFilePath ? null
 }:
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];
   buildInputs = [
-    lua5_2 file ncurses gmime pcre-cpp
+    lua file ncurses gmime pcre-cpp
     perl perlPackages.JSON perlPackages.NetIMAPClient
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16440,7 +16440,9 @@ with pkgs;
 
   looking-glass-client = callPackage ../applications/virtualization/looking-glass-client { };
 
-  lumail = callPackage ../applications/networking/mailreaders/lumail { };
+  lumail = callPackage ../applications/networking/mailreaders/lumail {
+    lua = lua5_1;
+  };
 
   lv2bm = callPackage ../applications/audio/lv2bm { };
 


### PR DESCRIPTION
###### Motivation for this change

Wanna try out lumail

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This fails for me with

```
installing
install flags: install SHELL=/nix/store/sxwh6a4v8xdlvg4jf3vl2jh9l5760hsc-bash-4.4-p12/bin/bash LVER=lua PREFIX=\$\(out\) SYSCONFDIR=\$\(out\)/etc gsettingsschemadir=/nix/store/c697qr96a0cbyli667jy3khhglsdvmj4-lumail-3.1/share/gsettings-schemas/lumail-3.1/glib-2.0/schemas/
rm /etc/lumail2/perl.d/delete-message || true
rm: cannot remove '/etc/lumail2/perl.d/delete-message': No such file or directory
rm /etc/lumail2/perl.d/get-folders    || true
rm: cannot remove '/etc/lumail2/perl.d/get-folders': No such file or directory
rm /etc/lumail2/perl.d/get-messages   || true
rm: cannot remove '/etc/lumail2/perl.d/get-messages': No such file or directory
rm /etc/lumail2/perl.d/save-message   || true
rm: cannot remove '/etc/lumail2/perl.d/save-message': No such file or directory
rm /etc/lumail2/perl.d/set-flags      || true
rm: cannot remove '/etc/lumail2/perl.d/set-flags': No such file or directory
rm /etc/lumail2/perl.d/imap-proxy     || true
rm: cannot remove '/etc/lumail2/perl.d/imap-proxy': No such file or directory
rm /etc/lumail2/perl.d/Lumail.pm      || true
rm: cannot remove '/etc/lumail2/perl.d/Lumail.pm': No such file or directory
rmdir /etc/lumail2/perl.d             || true
rmdir: failed to remove '/etc/lumail2/perl.d': No such file or directory
mkdir -p /usr/share/lumail || true
mkdir: cannot create directory '/usr': Permission denied
install -m755 perl.d/imap-proxy /usr/share/lumail/
install: target '/usr/share/lumail/' is not a directory: No such file or directory
make: *** [Makefile:243: install_imap] Error 1
builder for ‘/nix/store/ipd27jim2a0gcc2rc6yhbg77zsw35xcn-lumail-3.1.drv’ failed with exit code 2
```

I assume that the `makeFlags` do not properly work. Neither `DESTDIR` nor `PREFIX` is overriden, as the log suggests.
