### PR TITLE
notary: init at 0.5.1

### DIFF
--- a/pkgs/tools/security/notary/default.nix
+++ b/pkgs/tools/security/notary/default.nix
@@ -1,44 +1,55 @@
-{ stdenv, fetchgit, buildGoPackage, git, libtool }:
+{ stdenv, fetchFromGitHub, buildGoPackage, git, libtool }:
 
 buildGoPackage rec {
   name = "notary-${version}";
   version = "0.5.1";
   gitcommit = "9211198";
 
-  src = fetchgit {
-    url = "https://github.com/theupdateframework/notary";
-    rev = "refs/tags/v${version}";
-    sha256 = "1iybkwvl7021g7kklqybrip8d7hsvvqggpb19yx9kjjisasi2dw6";
-    leaveDotGit = true;
+  src = fetchFromGitHub {
+    owner = "theupdateframework";
+    repo = "notary";
+    rev = "v${version}";
+    sha256 = "0z9nsb1mrl0q5j02jkyzbc6xqsm83qzacsckypsxcrijhw935rs5";
   };
 
-  buildInputs = [ git libtool ];
+  buildInputs = [ libtool ];
 
   goPackagePath = "github.com/docker/notary";
+
   buildPhase = ''
     cd go/src/github.com/docker/notary
-    make GITCOMMIT=${gitcommit} client
+    make GITCOMMIT=${gitcommit} GITUNTRACKEDCHANGES= client
   '';
 
   installPhase = ''
-    mkdir -p $bin/bin
-    cp bin/notary $bin/bin/notary
+    install -D bin/notary $bin/bin/notary
   '';
 
   meta = with stdenv.lib; {
-      description = " Notary is a project that allows anyone to have trust over arbitrary collections of data";
-      longDescription = ''
-        The Notary project comprises a server and a client for running and interacting with trusted collections. See the service architecture documentation for more information.
+    description = " Notary is a project that allows anyone to have trust over arbitrary collections of data";
+    longDescription = ''
+      The Notary project comprises a server and a client for running and
+      interacting with trusted collections. See the service architecture
+      documentation for more information.
 
-        Notary aims to make the internet more secure by making it easy for people to publish and verify content. We often rely on TLS to secure our communications with a web server which is inherently flawed, as any compromise of the server enables malicious content to be substituted for the legitimate content.
+      Notary aims to make the internet more secure by making it easy for people
+      to publish and verify content. We often rely on TLS to secure our
+      communications with a web server which is inherently flawed, as any
+      compromise of the server enables malicious content to be substituted for
+      the legitimate content.
 
-        With Notary, publishers can sign their content offline using keys kept highly secure. Once the publisher is ready to make the content available, they can push their signed trusted collection to a Notary Server.
+      With Notary, publishers can sign their content offline using keys kept
+      highly secure. Once the publisher is ready to make the content available,
+      they can push their signed trusted collection to a Notary Server.
 
-        Consumers, having acquired the publisher's public key through a secure channel, can then communicate with any notary server or (insecure) mirror, relying only on the publisher's key to determine the validity and integrity of the received content.
-      '';
-      license = licenses.asl20;
-      homepage = https://github.com/theupdateframework/notary;
-      maintainers = with maintainers; [ vdemeester ];
-      platforms = with platforms; unix;
+      Consumers, having acquired the publisher's public key through a secure
+      channel, can then communicate with any notary server or (insecure) mirror,
+      relying only on the publisher's key to determine the validity and
+      integrity of the received content.
+    '';
+    license = licenses.asl20;
+    homepage = https://github.com/theupdateframework/notary;
+    maintainers = with maintainers; [ vdemeester ];
+    platforms = with platforms; unix;
   };
 }

--- a/pkgs/tools/security/notary/default.nix
+++ b/pkgs/tools/security/notary/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchgit, buildGoPackage, git, libtool }:
+
+buildGoPackage rec {
+  name = "notary-${version}";
+  version = "0.5.1";
+  gitcommit = "9211198";
+
+  src = fetchgit {
+    url = "https://github.com/theupdateframework/notary";
+    rev = "refs/tags/v${version}";
+    sha256 = "1iybkwvl7021g7kklqybrip8d7hsvvqggpb19yx9kjjisasi2dw6";
+    leaveDotGit = true;
+  };
+
+  buildInputs = [ git libtool ];
+
+  goPackagePath = "github.com/docker/notary";
+  buildPhase = ''
+    cd go/src/github.com/docker/notary
+    make GITCOMMIT=${gitcommit} client
+  '';
+
+  installPhase = ''
+    mkdir -p $bin/bin
+    cp bin/notary $bin/bin/notary
+  '';
+
+  meta = with stdenv.lib; {
+      description = " Notary is a project that allows anyone to have trust over arbitrary collections of data";
+      longDescription = ''
+        The Notary project comprises a server and a client for running and interacting with trusted collections. See the service architecture documentation for more information.
+
+        Notary aims to make the internet more secure by making it easy for people to publish and verify content. We often rely on TLS to secure our communications with a web server which is inherently flawed, as any compromise of the server enables malicious content to be substituted for the legitimate content.
+
+        With Notary, publishers can sign their content offline using keys kept highly secure. Once the publisher is ready to make the content available, they can push their signed trusted collection to a Notary Server.
+
+        Consumers, having acquired the publisher's public key through a secure channel, can then communicate with any notary server or (insecure) mirror, relying only on the publisher's key to determine the validity and integrity of the received content.
+      '';
+      license = licenses.asl20;
+      homepage = https://github.com/theupdateframework/notary;
+      maintainers = with maintainers; [ vdemeester ];
+      platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3707,6 +3707,8 @@ with pkgs;
 
   nnn = callPackage ../applications/misc/nnn { };
 
+  notary = callPackage ../tools/security/notary { };
+
   notify-osd = callPackage ../applications/misc/notify-osd { };
 
   nox = callPackage ../tools/package-management/nox {


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

 Notary is a project that allows anyone to have trust over arbitrary collections of data. It is used for docker content trust but definitely can be used on its own.

https://github.com/theupdateframework/notary

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

