### PR TITLE
smenu: init at 0.9.10

### DIFF
--- a/pkgs/tools/misc/smenu/default.nix
+++ b/pkgs/tools/misc/smenu/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, ncurses }:
+
+stdenv.mkDerivation rec {
+  version = "v0.9.10";
+  name = "smenu-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "p-gen";
+    repo   = "smenu";
+    rev    = version;
+    sha256 = "1fh0s5zhx8ps760w0yxjv682lhahz1j63i0gdwvvr5vnvyx6c40d";
+  };
+
+  buildInputs = [ ncurses ];
+
+  meta = with stdenv.lib; {
+    homepage        = https://github.com/p-gen/smenu;
+    description     = "Terminal selection utility";
+    longDescription = ''
+      Terminal utility that allows you to use words coming from the standard
+      input to create a nice selection window just below the cursor. Once done,
+      your selection will be sent to standard output.
+    '';
+    license     = licenses.gpl2;
+    maintainers = [ maintainers.matthiasbeyer ];
+    platforms   = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4503,6 +4503,8 @@ with pkgs;
 
   smbnetfs = callPackage ../tools/filesystems/smbnetfs {};
 
+  smenu = callPackage ../tools/misc/smenu { };
+
   smugline = python3Packages.smugline;
 
   snabb = callPackage ../tools/networking/snabb { } ;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

