### PR TITLE
pgbouncer: init at 1.7.2

### DIFF
--- a/pkgs/servers/sql/pgbouncer/default.nix
+++ b/pkgs/servers/sql/pgbouncer/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, openssl, libevent }:
+
+stdenv.mkDerivation rec {
+  name = "pgbouncer-${version}";
+  version = "1.7.2";
+
+  src = fetchurl {
+    url = "https://pgbouncer.github.io/downloads/files/${version}/${name}.tar.gz";
+    sha256 = "de36b318fe4a2f20a5f60d1c5ea62c1ca331f6813d2c484866ecb59265a160ba";
+  };
+
+  buildInputs = [ libevent openssl ];
+
+  meta = with stdenv.lib; {
+    homepage = https://pgbouncer.github.io;
+    description = "Lightweight connection pooler for PostgreSQL";
+    license = licenses.isc;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11960,6 +11960,8 @@ with pkgs;
 
   vmfs-tools = callPackage ../tools/filesystems/vmfs-tools { };
 
+  pgbouncer = callPackage ../servers/sql/pgbouncer/default.nix { };
+
   pgpool93 = pgpool.override { postgresql = postgresql93; };
   pgpool94 = pgpool.override { postgresql = postgresql94; };
 


### PR DESCRIPTION
###### Motivation for this change

PgBouncer is a lightweight connection pooler for PostgreSQL, similar to pgpool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

