### PR TITLE
 perl generic builder: recognize #!/usr/bin/env perl

### DIFF
--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -17,10 +17,7 @@ preConfigure() {
             first=$(dd if="$fn" count=2 bs=1 2> /dev/null)
             if test "$first" = "#!"; then
                 echo "patching $fn..."
-                sed < "$fn" > "$fn".tmp \
-                    -e "s|^#\!\(.*/perl.*\)$|#\! \1$perlFlags|"
-                if test -x "$fn"; then chmod +x "$fn".tmp; fi
-                mv "$fn".tmp "$fn"
+                sed -i "$fn" -e "s|^#\!\(.*[ /]perl.*\)$|#\!\1$perlFlags|"
             fi
         fi
     done


### PR DESCRIPTION
###### Motivation for this change

While upgrading biber to 2.7, I noticed that the shebang-patcher in the perl builder only recognizes `/usr/bin/perl`, but not `/usr/bin/env perl`.  I also simplified the sed call with the `-i` in-place option (hope this works on darwin).

This rebuilds all packages that depend on perl modules.  I did not find any problems, but I did not rebuild everything.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

