### PR TITLE
airspy: fix installation of udev rules for USB access

### DIFF
--- a/pkgs/applications/misc/airspy/default.nix
+++ b/pkgs/applications/misc/airspy/default.nix
@@ -15,10 +15,14 @@ in
       sha256 = "04kx2p461sqd4q354n1a99zcabg9h29dwcnyhakykq8bpg3mgf1x";
     };
 
+    postPatch = ''
+      substituteInPlace airspy-tools/CMakeLists.txt --replace "/etc/udev/rules.d" "$out/etc/udev/rules.d"
+    '';
+
     nativeBuildInputs = [ cmake pkgconfig ];
     buildInputs = [ libusb ];
 
-    cmakeFlags = [ "-DINSTALL_UDEV_RULES=OFF" ];
+    cmakeFlags = [ "-DINSTALL_UDEV_RULES=ON" ];
 
     meta = with stdenv.lib; {
       homepage = http://github.com/airspy/airspyone_host;


### PR DESCRIPTION
###### Motivation for this change
Integration of the SDR driver with NixOS. Ordinary users require permissions via udev to directly access
USB devices. This change installs the udev rules in the output path of the package and allows
everyone in the 'plugdev' group to gain access to this type of device. This behavior is analog
to other SDR drivers (e.g. hackrf, RTLSDR).
Its udev rules can now be included system wide by adding the package to 'services.udev.packages' in the NixOS configuration.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Tested in a virtualbox with a minimal configuration.nix and a AirSpy R2 device
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

