### PR TITLE
Backport Steam fix to 17.09

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -36,6 +36,20 @@ let
       ++ lib.optional withPrimus primus
       ++ extraPkgs pkgs;
 
+  ldPath = map (x: "/steamrt/${steam-runtime-wrapped.arch}/" + x) steam-runtime-wrapped.libs
+           ++ lib.optionals (steam-runtime-wrapped-i686 != null) (map (x: "/steamrt/${steam-runtime-wrapped-i686.arch}/" + x) steam-runtime-wrapped-i686.libs);
+
+  runSh = writeScript "run.sh" ''
+    #!${stdenv.shell}
+    runtime_paths="${lib.concatStringsSep ":" ldPath}"
+    if [ "$1" == "--print-steam-runtime-library-paths" ]; then
+      echo "$runtime_paths"
+      exit 0
+    fi
+    export LD_LIBRARY_PATH="$runtime_paths:$LD_LIBRARY_PATH"
+    exec "$@"
+  '';
+
 in buildFHSUserEnv rec {
   name = "steam";
 
@@ -73,6 +87,7 @@ in buildFHSUserEnv rec {
     ${lib.optionalString (steam-runtime-i686 != null) ''
       ln -s ../lib32/steam-runtime steamrt/${steam-runtime-i686.arch}
     ''}
+    ln -s ${runSh} steamrt/run.sh
   '';
 
   extraInstallCommands = ''
@@ -95,19 +110,16 @@ in buildFHSUserEnv rec {
     targetPkgs = commonTargetPkgs;
     inherit multiPkgs extraBuildCommands;
 
-    runScript =
-      let ldPath = map (x: "/steamrt/${steam-runtime.arch}/" + x) steam-runtime.libs
-                 ++ lib.optionals (steam-runtime-i686 != null) (map (x: "/steamrt/${steam-runtime-i686.arch}/" + x) steam-runtime-i686.libs);
-      in writeScript "steam-run" ''
-        #!${stdenv.shell}
-        run="$1"
-        if [ "$run" = "" ]; then
-          echo "Usage: steam-run command-to-run args..." >&2
-          exit 1
-        fi
-        shift
-        export LD_LIBRARY_PATH=${lib.concatStringsSep ":" ldPath}:$LD_LIBRARY_PATH
-        exec "$run" "$@"
-      '';
+    runScript = writeScript "steam-run" ''
+      #!${stdenv.shell}
+      run="$1"
+      if [ "$run" = "" ]; then
+        echo "Usage: steam-run command-to-run args..." >&2
+        exit 1
+      fi
+      shift
+      export LD_LIBRARY_PATH=${lib.concatStringsSep ":" ldPath}:$LD_LIBRARY_PATH
+      exec "$run" "$@"
+    '';
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This is needed for Steam which expects run.sh to print runtime library paths.

Fixes #32687. Original commit: https://github.com/NixOS/nixpkgs/commit/459e4b78db754872dfbd741e9f136d8998ffcaff

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

