### PR TITLE
edk2: 2014-12-10 -> 2017-12-05

### DIFF
--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -11,13 +11,13 @@ else
   throw "Unsupported architecture";
 
 edk2 = stdenv.mkDerivation {
-  name = "edk2-2014-12-10";
+  name = "edk2-2017-12-05";
 
   src = fetchFromGitHub {
     owner = "tianocore";
     repo = "edk2";
-    rev = "vUDK2017";
-    sha256 = "0sswa028644yr8fbl8j6rhrdm717fj29h4dys3ygklmjhss90a2g";
+    rev = "f71a70e7a4c93a6143d7bad8ab0220a947679697";
+    sha256 = "0k48xfwxcgcim1bhkggc19hilvsxsf5axvvcpmld0ng1fcfg0cr6";
   };
 
   buildInputs = [ libuuid pythonEnv];
@@ -37,6 +37,7 @@ edk2 = stdenv.mkDerivation {
     description = "Intel EFI development kit";
     homepage = https://sourceforge.net/projects/edk2/;
     license = stdenv.lib.licenses.bsd2;
+    branch = "UDK2017";
     platforms = ["x86_64-linux" "i686-linux"];
   };
 

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, libuuid, python2, iasl }:
+{ stdenv, fetchFromGitHub, fetchpatch, libuuid, python2, iasl }:
 
 let
   pythonEnv = python2.withPackages(ps: [ps.tkinter]);
@@ -20,7 +20,15 @@ edk2 = stdenv.mkDerivation {
     sha256 = "0k48xfwxcgcim1bhkggc19hilvsxsf5axvvcpmld0ng1fcfg0cr6";
   };
 
-  buildInputs = [ libuuid pythonEnv];
+  patches = [
+    (fetchpatch {
+      name = "short-circuit-the-transfer-of-an-empty-S3_CONTEXT.patch";
+      url = "https://github.com/tianocore/edk2/commit/9e2a8e928995c3b1bb664b73fd59785055c6b5f6";
+      sha256 = "0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73";
+    })
+  ];
+
+  buildInputs = [ libuuid pythonEnv ];
 
   makeFlags = "-C BaseTools";
 
@@ -32,6 +40,8 @@ edk2 = stdenv.mkDerivation {
     mv -v EdkCompatibilityPkg $out
     mv -v edksetup.sh $out
   '';
+
+  enableParallelBuilding = true;
 
   meta = {
     description = "Intel EFI development kit";


### PR DESCRIPTION
UDK name was incorrect. Took the opportunity to update to latest version of UDK2017-stable tree.

nox-review completed successfully on this PR

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

