### PR TITLE
pkgs.emacs25: backport patch to fix vfork issue

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -36,9 +36,19 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  patches =
-    [ ./clean-env.patch ]
-    ++ lib.optional stdenv.isDarwin ./at-fdcwd.patch;
+  patches = [
+    ./clean-env.patch
+  ] ++ lib.optionals stdenv.isDarwin [
+    ./at-fdcwd.patch
+
+    # Backport of the fix to
+    # https://lists.gnu.org/archive/html/bug-gnu-emacs/2017-04/msg00201.html
+    # Should be removed when switching to Emacs 26.1
+    (fetchurl {
+      url = "https://gist.githubusercontent.com/aaronjensen/f45894ddf431ecbff78b1bcf533d3e6b/raw/6a5cd7f57341aba673234348d8b0d2e776f86719/Emacs-25-OS-X-use-vfork.patch";
+      sha256 = "1nlsxiaynswqhy99jf4mw9x0sndhwcrwy8713kq1l3xqv9dbrzgj";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig ]
     ++ lib.optionals srcRepo [ autoconf automake texinfo ]


### PR DESCRIPTION
Issue described here:
https://lists.gnu.org/archive/html/bug-gnu-emacs/2017-04/msg00201.html

In particular fixes lagging magit, as described here:
https://magit.vc/manual/magit/MacOS-Performance.html

The .patch file is taken from the reference there.

The fix is in Emacs master, so this patch should be removed when switching to
Emacs 26.1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

