### PR TITLE
neovim: add viAlias argument

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -9,6 +9,7 @@
 
 , withPyGUI ? false
 , vimAlias ? false
+, viAlias ? false
 , configure ? null
 }:
 
@@ -174,7 +175,9 @@ let
     };
   };
 
-in if (vimAlias == false && configure == null) then neovim else stdenv.mkDerivation {
+in if (vimAlias == false && viAlias == false && configure == null)
+      then neovim
+      else stdenv.mkDerivation {
   name = "neovim-${neovim.version}-configured";
   inherit (neovim) version meta;
 
@@ -187,6 +190,8 @@ in if (vimAlias == false && configure == null) then neovim else stdenv.mkDerivat
     done
   '' + optionalString vimAlias ''
     ln -s $out/bin/nvim $out/bin/vim
+  '' + optionalString viAlias ''
+    ln -s $out/bin/nvim $out/bin/vi
   '' + optionalString (configure != null) ''
     wrapProgram $out/bin/nvim --add-flags "-u ${vimUtils.vimrcFile configure}"
   '';


### PR DESCRIPTION
The argument viAlias mimicks the behavior of vimAlias: when set to true, it
creates a symbolic link from $out/bin/vi to $out/bin/nvim.

###### Motivation for this change

It is likely that the user that sets vimAlias to true does not have vim installed. In this case, using viAlias allows them to get a "vi" back.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

