### PR TITLE
libpcap: increase maximum snapshot length for dbus

### DIFF
--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -26,6 +26,15 @@ stdenv.mkDerivation rec {
       url    = "https://sources.debian.net/data/main/libp/libpcap/1.8.1-3/debian/patches/disable-remote.diff";
       sha256 = "0dvjax9c0spvq8cdjnkbnm65wlzaml259yragf95kzg611vszfmj";
     })
+    # See https://github.com/wjt/bustle/commit/f62cf6bfa662af4ae39effbbd4891bc619e3b4e9
+    (fetchpatch {
+      url    = "https://github.com/the-tcpdump-group/libpcap/commit/2be9c29d45fb1fab8e9549342a30c160b7dea3e1.patch";
+      sha256 = "1g8mh942vr0abn48g0bdvi4gmhq1bz0l80276603y7064qhy3wq5";
+    })
+    (fetchpatch {
+      url    = "https://github.com/the-tcpdump-group/libpcap/commit/1a6b088a88886eac782008f37a7219a32b86da45.patch";
+      sha256 = "1n5ylm7ch3i1lh4y2q16b0vabgym8g8mqiqxpqcdkjdn05c1wflr";
+    })
   ];
 
   preInstall = ''mkdir -p $out/bin'';


### PR DESCRIPTION
###### Motivation for this change
DBus packet size can be bigger than the size allowed by libpcap, which breaks applications like bustle.

The issue was fixed upstream so we are backporting the commits.

https://github.com/wjt/bustle/issues/4

###### Things done

I confirmed that this fixed the bustle issue.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

