### PR TITLE
slurm: 17.02.6 -> 17.02.9 for CVE-2017-15566

### DIFF
--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "slurm-${version}";
-  version = "17.02.6";
+  version = "17.02.9";
 
   src = fetchurl {
-    url = "https://www.schedmd.com/downloads/latest/slurm-17.02.6.tar.bz2";
-    sha256 = "1sp4xg15jc569r6dh61svgk2fmy3ndcgr5358yryajslf1w14mzh";
+    url = "https://download.schedmd.com/slurm/${name}.tar.bz2";
+    sha256 = "0w8v7fzbn7b3f9kg6lcj2jpkzln3vcv9s2cz37xbdifz0m2p1x7s";
   };
 
   outputs = [ "out" "dev" ];
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     rm -f $out/lib/*.la $out/lib/slurm/*.la
   '';
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = http://www.schedmd.com/;


### PR DESCRIPTION
###### Motivation for this change

Older version downloads of slurm have been removed. This patch version includes only minor changes from previous. (There is a newer 17.11 series as well, but it's a larger change.) Tested built clients in live slurm env.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

