### PR TITLE
pulsemixer: 1.3.0-license -> 1.4.0

### DIFF
--- a/pkgs/tools/audio/pulsemixer/default.nix
+++ b/pkgs/tools/audio/pulsemixer/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "pulsemixer";
-  version = "1.3.0-license";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "GeorgeFilipkin";
     repo = pname;
     rev = version;
-    sha256 = "186xbzyn35w2j58l68mccj0cnf0wxj93zb7s0r26zj4cppwszn90";
+    sha256 = "0l5zawv36d46sj3k31k5w6imnnxzyn62r83wdhr7fp5mi3ls1h5x";
   };
 
   inherit libpulseaudio;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

