### PR TITLE
elementary-xfce-icon-theme: init at 2017-11-28

### DIFF
--- a/pkgs/data/icons/elementary-xfce-icon-theme/default.nix
+++ b/pkgs/data/icons/elementary-xfce-icon-theme/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, gtk3, hicolor_icon_theme }:
+
+stdenv.mkDerivation rec {
+  name = "elementary-xfce-icon-theme-${version}";
+  version = "2017-11-28";
+
+  src = fetchFromGitHub {
+    owner = "shimmerproject";
+    repo = "elementary-xfce";
+    rev = "b5cc6f044ed24e388ed2fffed1d02f43ce76f5e6";
+    sha256 = "15n28f2pw8b0y5pi8ydahg31v6hhh7zvpvymi8jaafdc9bn18z3y";
+  };
+
+  # fallback icon theme
+  propagatedBuildInputs = [ hicolor_icon_theme ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -dm 755 $out/share/icons
+    cp -dr --no-preserve='ownership' elementary-xfce{,-dark,-darker,-darkest} $out/share/icons/
+  '';
+
+  postInstall = ''
+    for icons in "$out"/share/icons/*; do
+      "${gtk3.out}/bin/gtk-update-icon-cache" "$icons"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Elementary icons for Xfce and other Gtk+ desktops like Gnome3";
+    homepage = https://github.com/shimmerproject/elementary-xfce;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ davidak ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1051,6 +1051,8 @@ with pkgs;
 
   elementary-icon-theme = callPackage ../data/icons/elementary-icon-theme { };
 
+  elementary-xfce-icon-theme = callPackage ../data/icons/elementary-xfce-icon-theme { };
+
   elm-github-install = callPackage ../tools/package-management/elm-github-install { };
 
   emby = callPackage ../servers/emby { };


### PR DESCRIPTION
###### Motivation for this change

I want to use it with Xfce.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

