### PR TITLE
ocamlPackages.sexplib: 0.9.3 -> 0.10.0

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/default.nix
@@ -6,19 +6,13 @@ rec {
 
   # Jane Street packages, up to ppx_core
 
-  sexplib = janePackage ({
+  sexplib = janePackage {
     name = "sexplib";
     meta.description = "Automated S-expression conversion";
-  } // (if lib.versionAtLeast ocaml.version "4.05"
-    then {
-      version = "0.9.3";
-      hash = "0a2sqh235ja3qwy7b2k3qym2616dz7369a195qwi6ljy3cnh7s53";
-      buildInputs = [ num ];
-    } else {
-      version = "0.9.2";
-      hash = "0szj7gi5ksy7kif5g71rkr6xhxc41xl8hq6s5zz610cjyngzyzjl";
-    }
-  ));
+    version = "0.10.0";
+    hash = "1agw649n0rnf6h4y2dr1zs1970nncxgjmf90848vbxv8y9im4yy2";
+    buildInputs = [ num ];
+  };
 
   base = janePackage {
     name = "base";


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

