### PR TITLE
Minor GNOME cleanups

### DIFF
--- a/pkgs/desktops/gnome-2/desktop/gnome-panel/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gnome-panel/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, dbus_glib, dbus, cairo, popt, which, libxml2Python, libxslt, bzip2, python
-, glib, gtk, pango, atk, libXau, libcanberra
+, glib, gtk, pango, atk, libXau, libcanberra_gtk2
 , intltool, ORBit2, libglade, libgnome, libgnomeui, libbonobo, libbonoboui, GConf, gnome_menus, gnome_desktop
 , libwnck, librsvg, libgweather, gnome_doc_utils, libgnomecanvas, libart_lgpl, libtasn1, libtool, xorg }:
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     [ gtk dbus_glib popt libxml2Python libxslt bzip2 python libXau intltool
       ORBit2 libglade libgnome libgnomeui libbonobo libbonoboui GConf
       gnome_menus gnome_desktop libwnck librsvg libgweather gnome_doc_utils
-      libtasn1 libtool libcanberra xorg.libICE xorg.libSM
+      libtasn1 libtool libcanberra_gtk2 xorg.libICE xorg.libSM
     ];
 
   nativeBuildInputs = [ pkgconfig intltool which ];

--- a/pkgs/desktops/gnome-2/desktop/metacity/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/metacity/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, glib, gtk, libXcomposite, libXcursor, libXdamage
-, libcanberra, intltool, GConf, startup_notification, zenity, gnome_doc_utils
+, libcanberra_gtk2, intltool, GConf, startup_notification, zenity, gnome_doc_utils
 , gsettings_desktop_schemas }:
 
 stdenv.mkDerivation {
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs =
-    [ pkgconfig glib gtk libXcomposite libXcursor libXdamage libcanberra
+    [ pkgconfig glib gtk libXcomposite libXcursor libXdamage libcanberra_gtk2
       intltool GConf startup_notification zenity gnome_doc_utils
       gsettings_desktop_schemas
     ];

--- a/pkgs/desktops/gnome-2/platform/libgnome/default.nix
+++ b/pkgs/desktops/gnome-2/platform/libgnome/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, popt, zlib, libcanberra
+{ stdenv, fetchurl, pkgconfig, glib, popt, zlib, libcanberra_gtk2
 , intltool, libbonobo, GConf, gnome_vfs, ORBit2, libtool, libogg
 }:
 
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ popt zlib intltool GConf gnome_vfs libcanberra libtool ];
+  buildInputs = [ popt zlib intltool GConf gnome_vfs libcanberra_gtk2 libtool ];
   propagatedBuildInputs = [ glib libbonobo libogg ];
 }

--- a/pkgs/desktops/gnome-3/apps/gnome-clocks/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-clocks/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl
 , meson, ninja, gettext, pkgconfig, wrapGAppsHook, itstool, desktop_file_utils
-, vala,  gtk3, glib, gsound, libcanberra_gtk3
+, vala,  gtk3, glib, gsound
 , gnome3, gdk_pixbuf, geoclue2, libgweather }:
 
 stdenv.mkDerivation rec {
@@ -8,14 +8,13 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  nativeBuildInputs = [ vala meson ninja pkgconfig gettext itstool wrapGAppsHook desktop_file_utils ];
-  buildInputs = [ gtk3 glib libcanberra_gtk3
-                  gnome3.gsettings_desktop_schemas
-                  gdk_pixbuf gnome3.defaultIconTheme
-                  gnome3.gnome_desktop gnome3.geocode_glib geoclue2
-                  libgweather gsound ];
-
-  enableParallelBuilding = true;
+  nativeBuildInputs = [
+    vala meson ninja pkgconfig gettext itstool wrapGAppsHook desktop_file_utils
+  ];
+  buildInputs = [
+    gtk3 glib gnome3.gsettings_desktop_schemas gdk_pixbuf gnome3.defaultIconTheme
+    gnome3.gnome_desktop gnome3.geocode_glib geoclue2 libgweather gsound
+  ];
 
   prePatch = "patchShebangs build-aux/";
 

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -1,44 +1,43 @@
 { fetchurl, stdenv, pkgconfig, gnome3, ibus, intltool, upower, wrapGAppsHook
-, libcanberra_gtk2, libcanberra_gtk3, accountsservice, libpwquality, libpulseaudio
-, gdk_pixbuf, librsvg, libxkbfile, libnotify, libgudev
+, libcanberra_gtk3, accountsservice, libpwquality, libpulseaudio
+, gdk_pixbuf, librsvg, libnotify, libgudev
 , libxml2, polkit, libxslt, libgtop, libsoup, colord, colord-gtk
 , cracklib, python, libkrb5, networkmanagerapplet, networkmanager
-, libwacom, samba, shared_mime_info, tzdata, icu, libtool, udev
+, libwacom, samba, shared_mime_info, tzdata, libtool
 , docbook_xsl, docbook_xsl_ns, modemmanager, clutter, clutter_gtk
 , fontconfig, sound-theme-freedesktop, grilo }:
-
-# http://ftp.gnome.org/pub/GNOME/teams/releng/3.10.2/gnome-suites-core-3.10.2.modules
-# TODO: bluetooth, wacom, printers
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
-  propagatedUserEnvPkgs =
-    [ gnome3.gnome_themes_standard gnome3.libgnomekbd ];
+  propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
 
-  # https://bugzilla.gnome.org/show_bug.cgi?id=752596
-  enableParallelBuilding = false;
+  nativeBuildInputs = [
+    pkgconfig intltool wrapGAppsHook libtool libxslt docbook_xsl docbook_xsl_ns
+    shared_mime_info
+  ];
 
-  buildInputs = with gnome3;
-    [ pkgconfig intltool ibus gtk glib glib_networking upower libcanberra_gtk2 gsettings_desktop_schemas
-      libxml2 gnome_desktop gnome_settings_daemon polkit libxslt libgtop gnome-menus
-      gnome_online_accounts libsoup colord libpulseaudio fontconfig colord-gtk libpwquality
-      accountsservice libkrb5 networkmanagerapplet libwacom samba libnotify libxkbfile
-      shared_mime_info icu libtool docbook_xsl docbook_xsl_ns gnome3.grilo
-      gdk_pixbuf gnome3.defaultIconTheme librsvg clutter clutter_gtk
-      gnome3.vino udev libcanberra_gtk3 libgudev wrapGAppsHook
-      networkmanager modemmanager gnome3.gnome-bluetooth grilo tracker
-      cracklib ];
+  buildInputs = with gnome3; [
+    ibus gtk glib glib_networking upower gsettings_desktop_schemas
+    libxml2 gnome_desktop gnome_settings_daemon polkit libgtop
+    gnome_online_accounts libsoup colord libpulseaudio fontconfig colord-gtk
+    accountsservice libkrb5 networkmanagerapplet libwacom samba libnotify
+    grilo libpwquality cracklib vino libcanberra_gtk3 libgudev
+    gdk_pixbuf defaultIconTheme librsvg clutter clutter_gtk
+    networkmanager modemmanager gnome-bluetooth tracker
+  ];
 
   preBuild = ''
     substituteInPlace panels/datetime/tz.h --replace "/usr/share/zoneinfo/zone.tab" "${tzdata}/share/zoneinfo/zone.tab"
+
+    substituteInPlace panels/region/cc-region-panel.c --replace "gkbd-keyboard-display" "${gnome3.libgnomekbd}/bin/gkbd-keyboard-display"
 
     # hack to make test-endianess happy
     mkdir -p $out/share/locale
     substituteInPlace panels/datetime/test-endianess.c --replace "/usr/share/locale/" "$out/share/locale/"
   '';
 
-  preFixup = with gnome3; ''
+  preFixup = ''
     gappsWrapperArgs+=(
       --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:${sound-theme-freedesktop}/share"
       # Thumbnailers (for setting user profile pictures)
@@ -56,5 +55,4 @@ stdenv.mkDerivation rec {
     maintainers = gnome3.maintainers;
     platforms = platforms.linux;
   };
-
 }

--- a/pkgs/desktops/gnome-3/core/gsound/default.nix
+++ b/pkgs/desktops/gnome-3/core/gsound/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, libcanberra_gtk2, gobjectIntrospection, libtool, gnome3 }:
+{ stdenv, fetchurl, pkgconfig, glib, libcanberra, gobjectIntrospection, libtool, gnome3 }:
 
 let
   majVer = "1.0";
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig gobjectIntrospection libtool gnome3.vala ];
-  buildInputs = [ glib libcanberra_gtk2 ];
+  buildInputs = [ glib libcanberra ];
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Projects/GSound;

--- a/pkgs/desktops/gnome-3/core/libgnomekbd/default.nix
+++ b/pkgs/desktops/gnome-3/core/libgnomekbd/default.nix
@@ -3,8 +3,8 @@
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ file intltool glib gtk3 libxklavier makeWrapper ];
+  nativeBuildInputs = [ pkgconfig file intltool makeWrapper ];
+  buildInputs = [ glib gtk3 libxklavier ];
 
   preFixup = ''
     wrapProgram $out/bin/gkbd-keyboard-display \

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -1,13 +1,10 @@
 { fetchurl, stdenv, pkgconfig, gnome3, intltool, gobjectIntrospection, upower, cairo
-, pango, cogl, clutter, libstartup_notification, libcanberra_gtk2, zenity, libcanberra_gtk3
-, libtool, makeWrapper, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libudev, libinput
+, pango, cogl, clutter, libstartup_notification, zenity, libcanberra_gtk3
+, libtool, makeWrapper, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
 , libgudev, libwacom, xwayland, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
-
-  # fatal error: gio/gunixfdlist.h: No such file or directory
-  NIX_CFLAGS_COMPILE = "-I${gnome3.glib.dev}/include/gio-unix-2.0 -Wno-error=format -Wno-error=sign-compare";
 
   configureFlags = [
     "--with-x"
@@ -28,12 +25,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig intltool libtool makeWrapper ];
 
-  buildInputs = with gnome3;
-    [ glib gobjectIntrospection gtk gsettings_desktop_schemas upower
-      gnome_desktop cairo pango cogl clutter zenity libstartup_notification libcanberra_gtk2
-      gnome3.geocode_glib libudev libinput libgudev libwacom
-      libcanberra_gtk3 zenity xkeyboard_config libxkbfile
-      libxkbcommon ];
+  buildInputs = with gnome3; [
+    glib gobjectIntrospection gtk gsettings_desktop_schemas upower
+    gnome_desktop cairo pango cogl clutter zenity libstartup_notification
+    gnome3.geocode_glib libinput libgudev libwacom
+    libcanberra_gtk3 zenity xkeyboard_config libxkbfile
+    libxkbcommon
+  ];
 
   preFixup = ''
     wrapProgram "$out/bin/mutter" \
@@ -45,6 +43,6 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     platforms = platforms.linux;
     maintainers = gnome3.maintainers;
+    license = licenses.gpl2;
   };
-
 }

--- a/pkgs/desktops/gnome-3/misc/pomodoro/default.nix
+++ b/pkgs/desktops/gnome-3/misc/pomodoro/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoconf-archive, appstream-glib, intltool, pkgconfig, libtool, wrapGAppsHook,
-  dbus_glib, libcanberra_gtk2, gst_all_1, vala, gnome3, gtk3, libxml2,
+  dbus_glib, libcanberra, gst_all_1, vala, gnome3, gtk3, libxml2, autoreconfHook,
   glib, gobjectIntrospection, libpeas
 }:
 
@@ -14,24 +14,21 @@ stdenv.mkDerivation rec {
     sha256 = "0fiql99nhj168wbfhvzrhfcm4c4569gikd2zaf10vzszdqjahrl1";
   };
 
-  configureScript = "./autogen.sh";
-
   nativeBuildInputs = [
-    autoconf-archive libtool intltool appstream-glib
+    autoreconfHook vala autoconf-archive libtool intltool appstream-glib
     wrapGAppsHook pkgconfig libxml2
   ];
 
   buildInputs = [
     glib gobjectIntrospection libpeas
-    dbus_glib libcanberra_gtk2 vala gst_all_1.gstreamer
+    dbus_glib libcanberra gst_all_1.gstreamer
     gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
     gnome3.gsettings_desktop_schemas
-    gnome3.gnome_common gnome3.gnome_shell gtk3
-    gnome3.defaultIconTheme
+    gnome3.gnome_shell gtk3 gnome3.defaultIconTheme
   ];
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/codito/gnome-shell-pomodoro;
+    homepage = http://gnomepomodoro.org/;
     description = "A time management utility for GNOME based on the pomodoro technique";
     longDescription = ''
       This GNOME utility helps to manage time according to Pomodoro Technique.

--- a/pkgs/development/libraries/webkitgtk/2.18.nix
+++ b/pkgs/development/libraries/webkitgtk/2.18.nix
@@ -1,13 +1,16 @@
 { stdenv, fetchurl, perl, python2, ruby, bison, gperf, cmake
 , pkgconfig, gettext, gobjectIntrospection, libnotify, gnutls
-, gtk2, gtk3, wayland, libwebp, enchant, xlibs, libxkbcommon, epoxy, at_spi2_core
+, gtk3, wayland, libwebp, enchant, xlibs, libxkbcommon, epoxy, at_spi2_core
 , libxml2, libsoup, libsecret, libxslt, harfbuzz, libpthreadstubs, pcre, nettle, libtasn1, p11_kit
 , libidn, libedit, readline, mesa, libintlOrEmpty
 , enableGeoLocation ? true, geoclue2, sqlite
+, enableGtk2Plugins ? false, gtk2 ? null
 , gst-plugins-base, gst-plugins-bad
 }:
 
 assert enableGeoLocation -> geoclue2 != null;
+assert enableGtk2Plugins -> gtk2 != null;
+assert stdenv.isDarwin -> !enableGtk2Plugins;
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -16,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Web content rendering engine, GTK+ port";
-    homepage = http://webkitgtk.org/;
+    homepage = https://webkitgtk.org/;
     license = licenses.bsd2;
     platforms = with platforms; linux ++ darwin;
     hydraPlatforms = [];
@@ -59,13 +62,12 @@ stdenv.mkDerivation rec {
   "-DPORT=GTK"
   "-DUSE_LIBHYPHEN=0"
   ]
+  ++ optional (!enableGtk2Plugins) "-DENABLE_PLUGIN_PROCESS_GTK2=OFF"
   ++ optional stdenv.isLinux "-DENABLE_GLES2=ON"
   ++ optionals stdenv.isDarwin [
   "-DUSE_SYSTEM_MALLOC=ON"
   "-DUSE_ACCELERATE=0"
   "-DENABLE_INTROSPECTION=ON"
-  "-DENABLE_MINIBROWSER=OFF"
-  "-DENABLE_PLUGIN_PROCESS_GTK2=OFF"
   "-DENABLE_MINIBROWSER=OFF"
   "-DENABLE_VIDEO=ON"
   "-DENABLE_QUARTZ_TARGET=ON"
@@ -85,10 +87,11 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = libintlOrEmpty ++ [
-    gtk2 libwebp enchant libnotify gnutls pcre nettle libidn
+    libwebp enchant libnotify gnutls pcre nettle libidn
     libxml2 libsecret libxslt harfbuzz libpthreadstubs libtasn1 p11_kit
     sqlite gst-plugins-base gst-plugins-bad libxkbcommon epoxy at_spi2_core
   ] ++ optional enableGeoLocation geoclue2
+    ++ optional enableGtk2Plugins gtk2
     ++ (with xlibs; [ libXdmcp libXt libXtst ])
     ++ optionals stdenv.isDarwin [ libedit readline mesa ]
     ++ optional stdenv.isLinux wayland;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9002,13 +9002,12 @@ with pkgs;
     inherit (xlibs) libX11 libXext;
   };
 
-  libcanberra_gtk3 = callPackage ../development/libraries/libcanberra {
-    gtk = pkgs.gtk3;
-  };
+  libcanberra = callPackage ../development/libraries/libcanberra { };
+  libcanberra_gtk3 = pkgs.libcanberra.override { gtk = pkgs.gtk3; };
   libcanberra_gtk2 = pkgs.libcanberra_gtk3.override { gtk = pkgs.gtk2; };
 
   libcanberra_kde = if (config.kde_runtime.libcanberraWithoutGTK or true)
-    then pkgs.libcanberra_gtk2.override { gtk = null; }
+    then pkgs.libcanberra
     else pkgs.libcanberra_gtk2;
 
   libcec = callPackage ../development/libraries/libcec { };
@@ -18446,14 +18445,13 @@ with pkgs;
   } // {
     inherit (pkgs)
       # GTK Libs
-      glib glibmm atk atkmm cairo pango pangomm gdk_pixbuf gtkmm2
+      glib glibmm atk atkmm cairo pango pangomm gdk_pixbuf gtkmm2 libcanberra_gtk2
 
       # Included for backwards compatibility
       libsoup libwnck gtk_doc gnome_doc_utils;
 
     gtk = self.gtk2;
     gtkmm = self.gtkmm2;
-    libcanberra = self.libcanberra_gtk2;
   });
 
   gnome3 = recurseIntoAttrs (callPackage ../desktops/gnome-3 { });


### PR DESCRIPTION
###### Motivation for this change
- Created libcanberra without GTK since libraries usually do not need the GTK modules.
- Dropped some unnecessary dependencies.
- More clean-ups.
- Try to drop some gtk2 dependencies #18559

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

