### PR TITLE
lbdb: 0.44 -> 0.45.3

### DIFF
--- a/pkgs/tools/misc/lbdb/default.nix
+++ b/pkgs/tools/misc/lbdb/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  version = "0.44";
+  version = "0.45.3";
 in
 with stdenv.lib;
 with perlPackages;
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   name = "lbdb-${version}";
   src = fetchurl {
     url = "http://www.spinnaker.de/debian/lbdb_${version}.tar.gz";
-    sha256 = "0kjz3n2ilrg6yrz8z40714ppdprgwhbgvzcsjzs822l6da4qxna3";
+    sha256 = "01lx1nb5nlhwz663v35gg7crd36c78hnipq4z0dqyb9wjigwwg9k";
   };
 
   buildInputs = [ goobook makeWrapper perl ConvertASN1 NetLDAP AuthenSASL ]
@@ -37,8 +37,9 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://www.spinnaker.de/lbdb/;
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl2;
+    platforms = platforms.all;
     description = "The Little Brother's Database";
+    maintainers = [ maintainers.kaiha ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update lbdb to latest upstream version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

