### PR TITLE
iwd-unstable: 2017-09-22 -> 2017-12-14

### DIFF
--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -1,19 +1,36 @@
-{ stdenv, fetchgit, autoreconfHook, readline }:
+{ stdenv, fetchgit, autoreconfHook, readline, python3Packages }:
 
 let
   ell = fetchgit {
      url = https://git.kernel.org/pub/scm/libs/ell/ell.git;
-     rev = "e0dbdfbd5992bd3e78029b83930b9020e74cdaa5";
-     sha256 = "031m1vvcrhggnyvvqyrqpzldi2amsbvhdfcxrypzqz58vysk69vm";
+     rev = "8192131685be0f27d6f51b14b78ef93fa7f3c692";
+     sha256 = "1k74qz3w0l4zq8llrxc4p62xy0c0n33f260vy3d14wx5rhvf0544";
   };
 in stdenv.mkDerivation rec {
-  name = "iwd-unstable-2017-09-22";
+  name = "iwd-unstable-2017-12-14";
 
   src = fetchgit {
     url = https://git.kernel.org/pub/scm/network/wireless/iwd.git;
-    rev = "31631e1935337910c7bc0c3eb215f579143c1fe0";
-    sha256 = "0xl8ali5hy7ragdc4palm857y0prcg32294hv3vv28r9r4x4llcm";
+    rev = "cf3372235c4592ca7366b27548abc4e89a982414";
+    sha256 = "0dg28j919w1v8sqr6jdj12c233rsjzd2jzkcpag1hx2h3g35hnlz";
   };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    python3Packages.wrapPython
+  ];
+
+  buildInputs = [
+    readline
+    python3Packages.python
+  ];
+  
+  pythonPath = [
+    python3Packages.dbus-python
+    python3Packages.pygobject3
+  ];
+
+  enableParallelBuilding = true;
 
   configureFlags = [
     "--with-dbusconfdir=$(out)/etc/"
@@ -21,15 +38,24 @@ in stdenv.mkDerivation rec {
 
   postUnpack = ''
     ln -s ${ell} ell
+    patchShebangs .
   '';
 
-  nativeBuildInputs = [ autoreconfHook ];
+  postInstall = ''
+    cp -a test/* $out/bin/
+    mkdir -p $out/share
+    cp -a doc $out/share/
+    cp -a README AUTHORS TODO $out/share/doc/
+  '';
 
-  buildInputs = [ readline ];
+  preFixup = ''
+    wrapPythonPrograms
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://git.kernel.org/pub/scm/network/wireless/iwd.git;
     description = "Wireless daemon for Linux";
+    license = licenses.lgpl21;
     platforms = platforms.linux;
     maintainers = [ maintainers.mic92 ];
   };


### PR DESCRIPTION
###### Motivation for this change

- Update to the latest commit
- Package distributed tools and docs
- Add license

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).