### PR TITLE
ocsigen-i18n: do not strip

### DIFF
--- a/pkgs/development/tools/ocaml/ocsigen-i18n/default.nix
+++ b/pkgs/development/tools/ocaml/ocsigen-i18n/default.nix
@@ -7,9 +7,8 @@ stdenv.mkDerivation rec
 
   buildInputs = with ocamlPackages; [ ocaml findlib ];
 
-  preBuild = ''
-   substituteInPlace Makefile --replace "OCAMLC=ocamlfind ocamlc" "OCAMLC=ocamlfind ocamlopt"
-  '';
+
+  dontStrip = true;
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/development/tools/ocaml/ocsigen-i18n/default.nix
+++ b/pkgs/development/tools/ocaml/ocsigen-i18n/default.nix
@@ -7,6 +7,10 @@ stdenv.mkDerivation rec
 
   buildInputs = with ocamlPackages; [ ocaml findlib ];
 
+  preBuild = ''
+   substituteInPlace Makefile --replace "OCAMLC=ocamlfind ocamlc" "OCAMLC=ocamlfind ocamlopt"
+  '';
+
   installPhase = ''
     mkdir -p $out/bin
     make bindir=$out/bin install


### PR DESCRIPTION
The executables generated by ocamlc were not functional.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

