### PR TITLE
xfce4-13: init

### DIFF
--- a/pkgs/desktops/xfce4-13/automakeAddFlags.sh
+++ b/pkgs/desktops/xfce4-13/automakeAddFlags.sh
@@ -1,0 +1,7 @@
+automakeAddFlags() {
+    local file="$1"
+    local target="$2"
+    local source="$3"
+
+    sed "/$target/a\$($source) \\\\" -i $file
+}

--- a/pkgs/desktops/xfce4-13/default.nix
+++ b/pkgs/desktops/xfce4-13/default.nix
@@ -1,0 +1,80 @@
+{ lib, makeSetupHook, newScope, gnome3, gst_all_1 }:
+
+let
+  inherit (lib) makeScope;
+in
+
+makeScope newScope (self: with self; {
+  mkXfceDerivation = callPackage ./mkXfceDerivation.nix { };
+
+  automakeAddFlags = makeSetupHook { } ./automakeAddFlags.sh;
+
+  exo = callPackage ./exo { };
+
+  garcon = callPackage ./garcon { };
+
+  gigolo = callPackage ./gigolo { };
+
+  libxfce4util = callPackage ./libxfce4util { };
+
+  libxfce4ui = callPackage ./libxfce4ui { };
+
+  mousepad = callPackage ./mousepad {
+    inherit (gnome3) gtksourceview;
+  };
+
+  orage = callPackage ./orage { };
+
+  parole = callPackage ./parole {
+    inherit (gst_all_1) gst-plugins-bad gst-plugins-base gst-plugins-good;
+    gst-plugins-ugly = null;
+  };
+
+  ristretto = callPackage ./ristretto { };
+
+  thunar = callPackage ./thunar { };
+
+  thunar-volman = callPackage ./thunar-volman { };
+
+  tumbler = callPackage ./tumbler { };
+
+  xfburn = callPackage ./xfburn { };
+
+  xfconf = callPackage ./xfconf { };
+
+  xfdesktop = callPackage ./xfdesktop { };
+
+  xfce4-appfinder = callPackage ./xfce4-appfinder { };
+
+  xfce4-dev-tools = callPackage ./xfce4-dev-tools {
+    mkXfceDerivation = mkXfceDerivation.override {
+      xfce4-dev-tools = null;
+    };
+  };
+
+  xfce4-dict = callPackage ./xfce4-dict { };
+
+  xfce4-mixer = callPackage ./xfce4-mixer { };
+
+  xfce4-notifyd = callPackage ./xfce4-notifyd { };
+
+  xfce4-panel = callPackage ./xfce4-panel { };
+
+  xfce4-power-manager = callPackage ./xfce4-power-manager { };
+
+  xfce4-screenshooter = callPackage ./xfce4-screenshooter {
+    inherit (gnome3) libsoup;
+  };
+
+  xfce4-taskmanager = callPackage ./xfce4-taskmanager { };
+
+  xfce4-settings = callPackage ./xfce4-settings { };
+
+  xfce4-terminal = callPackage ./xfce4-terminal {
+    inherit (gnome3) vte;
+  };
+
+  xfce4-volumed-pulse = callPackage ./xfce4-volumed-pulse { };
+
+  xfwm4 = callPackage ./xfwm4 { };
+})

--- a/pkgs/desktops/xfce4-13/exo/default.nix
+++ b/pkgs/desktops/xfce4-13/exo/default.nix
@@ -1,0 +1,23 @@
+{ mkXfceDerivation, docbook_xml_xslt, libxslt, perlPackages, gtk2, gtk3
+, libxfce4ui, libxfce4util }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "exo";
+  version = "0.11.5";
+
+  sha256 = "0zxv7cx1xbjls7q2blv8ir9zwzyq7r189n6q35jwasns7rxj256v";
+
+  nativeBuildInputs = [ libxslt perlPackages.URI ];
+  buildInputs = [ gtk2 gtk3 libxfce4ui libxfce4util ];
+
+  postPatch = ''
+    substituteInPlace docs/reference/Makefile.am \
+      --replace http://docbook.sourceforge.net/release/xsl/current \
+                ${docbook_xml_xslt}/share/xml/docbook-xsl
+  '';
+
+  meta = {
+    description = "Application library for Xfce";
+  };
+}

--- a/pkgs/desktops/xfce4-13/exo/gtk3-only.patch
+++ b/pkgs/desktops/xfce4-13/exo/gtk3-only.patch
@@ -1,0 +1,28 @@
+diff -urNZ a/configure.ac.in b/configure.ac.in
+--- a/configure.ac.in	2017-11-20 02:57:40.476664918 +0000
++++ b/configure.ac.in	2017-11-20 03:07:18.999128370 +0000
+@@ -165,11 +165,9 @@
+ dnl ***********************************
+ XDT_CHECK_PACKAGE([GLIB], [glib-2.0], [2.42.0])
+ XDT_CHECK_PACKAGE([GIO], [gio-2.0], [2.42.0])
+-XDT_CHECK_PACKAGE([GTK], [gtk+-2.0], [2.24.0])
+ XDT_CHECK_PACKAGE([GTK3], [gtk+-3.0], [3.20.0])
+ XDT_CHECK_PACKAGE([GTHREAD], [gthread-2.0], [2.42.0])
+ XDT_CHECK_PACKAGE([LIBXFCE4UTIL], [libxfce4util-1.0], [4.10.0])
+-XDT_CHECK_PACKAGE([LIBXFCE4UI], [libxfce4ui-1], [4.12.0])
+ XDT_CHECK_PACKAGE([LIBXFCE4UI2], [libxfce4ui-2], [4.12.0])
+ XDT_CHECK_OPTIONAL_PACKAGE([GIO_UNIX], [gio-unix-2.0], [2.42.0], [gio-unix], [GIO-Unix features])
+ 
+diff -urNZ a/exo/Makefile.am b/exo/Makefile.am
+--- a/exo/Makefile.am	2017-11-20 02:57:34.444785202 +0000
++++ b/exo/Makefile.am	2017-11-20 03:00:49.402897465 +0000
+@@ -117,7 +117,7 @@
+ 
+ libexo_2_includedir = $(includedir)/exo-2/exo
+ 
+-lib_LTLIBRARIES += libexo-2.la
++lib_LTLIBRARIES = libexo-2.la
+ 
+ libexo_2_include_HEADERS =						\
+ 	exo.h								\
+Binary files a/.git/index and b/.git/index differ

--- a/pkgs/desktops/xfce4-13/garcon/12700.patch
+++ b/pkgs/desktops/xfce4-13/garcon/12700.patch
@@ -1,0 +1,37 @@
+From: Yegor Timoshenko <yegortimoshenko@gmail.com>
+Date: Thu, 14 Dec 2017 21:13:02 +0000
+Subject: [PATCH] Decrement allocation counter on item unref (#12700)
+
+diff --git a/garcon/garcon-menu-item-pool.c b/garcon/garcon-menu-item-pool.c
+index 2017180..355e520 100644
+--- a/garcon/garcon-menu-item-pool.c
++++ b/garcon/garcon-menu-item-pool.c
+@@ -191,7 +191,12 @@ garcon_menu_item_pool_filter_exclude (const gchar    *desktop_id,
+   g_return_val_if_fail (GARCON_IS_MENU_ITEM (item), FALSE);
+   g_return_val_if_fail (node != NULL, FALSE);
+
+-  return garcon_menu_node_tree_rule_matches (node, item);
++  gboolean matches = garcon_menu_node_tree_rule_matches (node, item);
++
++  if (matches)
++    garcon_menu_item_increment_allocated (item);
++
++  return matches;
+ }
+
+
+diff --git a/garcon/garcon-menu-item.c b/garcon/garcon-menu-item.c
+index ca8cb63..b44acfe 100644
+--- a/garcon/garcon-menu-item.c
++++ b/garcon/garcon-menu-item.c
+@@ -1908,6 +1908,8 @@ garcon_menu_item_unref (GarconMenuItem *item)
+ {
+   g_return_if_fail (GARCON_IS_MENU_ITEM (item));
+
++  garcon_menu_item_decrement_allocated (item);
++
+   /* Decrement the reference counter */
+   g_object_unref (G_OBJECT (item));
+ }
+--
+2.15.1

--- a/pkgs/desktops/xfce4-13/garcon/13785.patch
+++ b/pkgs/desktops/xfce4-13/garcon/13785.patch
@@ -1,0 +1,75 @@
+From 4387496fe332a50945e7db76bc2196b419656fe3 Mon Sep 17 00:00:00 2001
+From: Stefan Berzl <stefanberzl@gmail.com>
+Date: Mon, 21 Aug 2017 18:39:07 +0300
+Subject: [PATCH] fix: some menu icons are too big (Bug #13785)
+
+Some packages only provide icons in sizes much bigger than the standard
+GTK menu size of 16px.
+
+The clipboard manager qlipper for example provides the following icon:
+/usr/share/icons/hicolor/128x128/apps/qlipper.png
+
+In GTK 3.22.18 the function gtk_image_new_from_icon_name when given
+GTK_ICON_SIZE_MENU as second argument still returns an image with 128x128.
+
+The patch I have supplied uses existing code to scale such an image.
+
+Signed-off-by: Eric Koegel <eric.koegel@gmail.com>
+---
+ garcon-gtk/garcon-gtk-menu.c | 33 +++++++++++++++++++--------------
+ 1 file changed, 19 insertions(+), 14 deletions(-)
+
+diff --git a/garcon-gtk/garcon-gtk-menu.c b/garcon-gtk/garcon-gtk-menu.c
+index 41990f2..f31a1ed 100644
+--- a/garcon-gtk/garcon-gtk-menu.c
++++ b/garcon-gtk/garcon-gtk-menu.c
+@@ -650,7 +650,11 @@ garcon_gtk_menu_load_icon (const gchar *icon_name)
+   gtk_icon_size_lookup (GTK_ICON_SIZE_MENU, &w, &h);
+   size = MIN (w, h);
+ 
+-  if (! gtk_icon_theme_has_icon (icon_theme, icon_name))
++  if (gtk_icon_theme_has_icon (icon_theme, icon_name))
++    {
++	  pixbuf = gtk_icon_theme_load_icon (icon_theme, icon_name, size, 0, NULL);;
++    }
++  else
+     {
+       if (g_path_is_absolute (icon_name))
+         {
+@@ -684,22 +688,23 @@ garcon_gtk_menu_load_icon (const gchar *icon_name)
+               g_free (name);
+             }
+         }
++    }
+ 
+-      /* Turn the pixbuf into a gtk_image */
+-      if (G_LIKELY (pixbuf))
+-        {
+-          /* scale the pixbuf down if it needs it */
+-          GdkPixbuf *tmp = gdk_pixbuf_scale_simple (pixbuf, w, h, GDK_INTERP_BILINEAR);
+-          g_object_unref (pixbuf);
+-          pixbuf = tmp;
++  /* Turn the pixbuf into a gtk_image */
++  if (G_LIKELY (pixbuf))
++    {
++      /* scale the pixbuf down if it needs it */
++      GdkPixbuf *pixbuf_scaled = gdk_pixbuf_scale_simple (pixbuf, w, h, GDK_INTERP_BILINEAR);
++      g_object_unref (G_OBJECT (pixbuf));
+ 
+-          image = gtk_image_new_from_pixbuf (pixbuf);
+-          g_object_unref (G_OBJECT (pixbuf));
+-        }
++      image = gtk_image_new_from_pixbuf (pixbuf_scaled);
++      g_object_unref (G_OBJECT (pixbuf_scaled));
++    }
++  else
++    {
++	  /* display the placeholder at least */
++	  image = gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_MENU);
+     }
+-
+-  if (image == NULL)
+-    image = gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_MENU);
+ 
+   return image;
+ }

--- a/pkgs/desktops/xfce4-13/garcon/default.nix
+++ b/pkgs/desktops/xfce4-13/garcon/default.nix
@@ -1,0 +1,12 @@
+{ mkXfceDerivation, gtk2 ? null, gtk3, libxfce4ui, libxfce4util }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "garcon";
+  version = "0.6.1";
+
+  sha256 = "19k8bwn29x7hkg882pxv5xxmrbfagdqgkxg166pwz2k0prab6hl8";
+
+  patches = [ ./12700.patch ./13785.patch ];
+  buildInputs = [ gtk2 gtk3 libxfce4ui libxfce4util ];
+}

--- a/pkgs/desktops/xfce4-13/gigolo/default.nix
+++ b/pkgs/desktops/xfce4-13/gigolo/default.nix
@@ -1,0 +1,11 @@
+{ mkXfceDerivation, gtk2, libX11 }:
+
+mkXfceDerivation rec {
+  category = "apps";
+  pname = "gigolo";
+  version = "0.4.2";
+
+  sha256 = "0qd2jkf3zsvfyd9jn8bfnljja1xfj3ph4wjh3fx10dcwcd791al1";
+
+  buildInputs = [ gtk2 libX11 ];
+}

--- a/pkgs/desktops/xfce4-13/libxfce4ui/default.nix
+++ b/pkgs/desktops/xfce4-13/libxfce4ui/default.nix
@@ -1,0 +1,18 @@
+{ lib, mkXfceDerivation, gobjectIntrospection, gtk2, gtk3
+, libstartup_notification ? null, libxfce4util, xfconf }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "libxfce4ui";
+  version = "4.13.4";
+
+  sha256 = "0m9h3kvkk2nx8pxxmsg9sjnyp6ajwjrz9djjxxvranjsdw3ilydy";
+
+  buildInputs =  [ gobjectIntrospection gtk2 gtk3 libstartup_notification xfconf ];
+  propagatedBuildInputs = [ libxfce4util ];
+
+  meta = with lib; {
+    description = "Widgets library for Xfce";
+    license = licenses.lgpl2Plus;
+  };
+}

--- a/pkgs/desktops/xfce4-13/libxfce4util/default.nix
+++ b/pkgs/desktops/xfce4-13/libxfce4util/default.nix
@@ -1,0 +1,16 @@
+{ lib, mkXfceDerivation, gobjectIntrospection }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "libxfce4util";
+  version = "4.13.1";
+
+  sha256 = "001ls90an2pi9l04g3r6syfa4lhyvjymp0r9djxrkc2q493mcv3d";
+
+  buildInputs = [ gobjectIntrospection ];
+
+  meta = with lib; {
+    description = "Extension library for Xfce";
+    license = licenses.lgpl2Plus;
+  };
+}

--- a/pkgs/desktops/xfce4-13/mkXfceDerivation.nix
+++ b/pkgs/desktops/xfce4-13/mkXfceDerivation.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchgit, pkgconfig, xfce4-dev-tools ? null }:
+
+{ category, pname, sha256 ? null, version, ... } @ args:
+
+let
+  inherit (builtins) filter getAttr head isList;
+  inherit (stdenv.lib) attrNames concatLists recursiveUpdate zipAttrsWithNames;
+
+  filterAttrNames = f: attrs:
+    filter (n: f (getAttr n attrs)) (attrNames attrs);
+
+  concatAttrLists = attrsets:
+    zipAttrsWithNames (filterAttrNames isList (head attrsets)) (_: concatLists) attrsets;
+
+  template = rec {
+    name = "${pname}-${version}";
+
+    nativeBuildInputs = [ pkgconfig xfce4-dev-tools ];
+    configureFlags = [ "--enable-maintainer-mode" ];
+
+    src = fetchgit {
+      url = "git://git.xfce.org/${category}/${pname}";
+      rev = name;
+      inherit sha256;
+    };
+
+    enableParallelBuilding = true;
+    outputs = [ "out" "dev" ];
+
+    meta = with stdenv.lib; {
+      homepage = "https://git.xfce.org/${category}/${pname}/about";
+      license = licenses.gpl2; # some libraries are under LGPLv2+
+      platforms = platforms.linux;
+    };
+  };
+
+  publicArgs = removeAttrs args [ "category" "pname" "sha256" ];
+in
+
+stdenv.mkDerivation (recursiveUpdate template publicArgs // concatAttrLists [ template args ])

--- a/pkgs/desktops/xfce4-13/mousepad/default.nix
+++ b/pkgs/desktops/xfce4-13/mousepad/default.nix
@@ -1,0 +1,12 @@
+{ mkXfceDerivation, exo, wrapGAppsHook, dbus_glib ? null, gtk3, gtksourceview }:
+
+mkXfceDerivation rec {
+  category = "apps";
+  pname = "mousepad";
+  version = "0.4.0";
+
+  sha256 = "0mm90iq2yd3d0qbgsjyk3yj25k0gm3p34jazl640vixk84v20lyw";
+
+  nativeBuildInputs = [ exo wrapGAppsHook ];
+  buildInputs = [ dbus_glib gtk3 gtksourceview ];
+}

--- a/pkgs/desktops/xfce4-13/orage/default.nix
+++ b/pkgs/desktops/xfce4-13/orage/default.nix
@@ -1,0 +1,18 @@
+{ lib, mkXfceDerivation, dbus_glib ? null, gtk2, libical, libnotify ? null
+, popt ? null, libxfce4ui ? null, xfce4-panel ? null, withPanelPlugin ? true }:
+
+assert withPanelPlugin -> libxfce4ui != null && xfce4-panel != null;
+
+let
+  inherit (lib) optionals;
+in
+
+mkXfceDerivation rec {
+  category = "apps";
+  pname = "orage";
+  version = "4.12.1";
+
+  sha256 = "04z6y1vfaz1im1zq1zr7cf8pjibjhj9zkyanbp7vn30q520yxa0m";
+  buildInputs = [ dbus_glib gtk2 libical libnotify popt ]
+    ++ optionals withPanelPlugin [ libxfce4ui xfce4-panel ];
+}

--- a/pkgs/desktops/xfce4-13/parole/default.nix
+++ b/pkgs/desktops/xfce4-13/parole/default.nix
@@ -1,0 +1,36 @@
+{ mkXfceDerivation, makeWrapper, wrapGAppsHook, dbus, dbus_glib
+, gst-plugins-bad ? null, gst-plugins-base, gst-plugins-good
+, gst-plugins-ugly ? null, gtk3, libnotify, libxfce4ui, libxfce4util
+, taglib ? null, xfconf }:
+
+# Doesn't seem to find H.264 codec even though built with gst-plugins-bad.
+
+mkXfceDerivation rec {
+  category = "apps";
+  pname = "parole";
+  version = "0.9.2";
+
+  sha256 = "07i9d7xn2ys3z71sxvr53idq4ivy94pqgxvr0k78crva39ls08s5";
+
+  postPatch = ''
+    substituteInPlace src/plugins/mpris2/Makefile.am \
+      --replace GST_BASE_CFLAGS GST_VIDEO_CFLAGS
+  '';
+
+  nativeBuildInputs = [ makeWrapper wrapGAppsHook ];
+
+  buildInputs = [
+    dbus
+    dbus_glib
+    gst-plugins-bad
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-ugly
+    gtk3
+    libnotify
+    libxfce4ui
+    libxfce4util
+    taglib
+    xfconf
+  ];
+}

--- a/pkgs/desktops/xfce4-13/ristretto/default.nix
+++ b/pkgs/desktops/xfce4-13/ristretto/default.nix
@@ -1,0 +1,18 @@
+{ mkXfceDerivation, automakeAddFlags, exo, dbus_glib, gtk2, libexif
+, libxfce4ui, libxfce4util, xfconf }:
+
+mkXfceDerivation rec {
+  category = "apps";
+  pname = "ristretto";
+  version = "0.8.2";
+
+  postPatch = ''
+    automakeAddFlags src/Makefile.am ristretto_CFLAGS DBUS_GLIB_CFLAGS
+    automakeAddFlags src/Makefile.am ristretto_LDADD DBUS_GLIB_LIBS
+  '';
+
+  nativeBuildInputs = [ automakeAddFlags exo ];
+  buildInputs = [ dbus_glib gtk2 libexif libxfce4ui libxfce4util xfconf ];
+
+  sha256 = "0ra50452ldk91pvhcpl3f3rhdssw3djfr6cm0hc29v8r58am0wni";
+}

--- a/pkgs/desktops/xfce4-13/thunar-volman/default.nix
+++ b/pkgs/desktops/xfce4-13/thunar-volman/default.nix
@@ -1,0 +1,11 @@
+{ mkXfceDerivation, exo, gtk3, libgudev, libxfce4ui, libxfce4util, xfconf }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "thunar-volman";
+  version = "0.9.0";
+
+  buildInputs = [ exo gtk3 libgudev libxfce4ui libxfce4util xfconf ];
+
+  sha256 = "08aqbp3i0z6frj7z3laz9nj641iakrcr7vh2dxb057ky24gj61i7";
+}

--- a/pkgs/desktops/xfce4-13/thunar/default.nix
+++ b/pkgs/desktops/xfce4-13/thunar/default.nix
@@ -1,0 +1,30 @@
+{ mkXfceDerivation, docbook_xml_xslt, exo, gdk_pixbuf, gtk3, libgudev ? null
+, libnotify ? null, libX11, libxfce4ui, libxfce4util, libxslt, xfconf }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "thunar";
+  version = "1.7.0";
+
+  sha256 = "1s262hii524a5hb15pb8xbrrrhyi5fj3837zgbscg3rdnsm52igw";
+
+  postPatch = ''
+    substituteInPlace docs/Makefile.am \
+      --replace http://docbook.sourceforge.net/release/xsl/current \
+                ${docbook_xml_xslt}/share/xml/docbook-xsl
+  '';
+
+  nativeBuildInputs = [ libxslt ];
+
+  buildInputs = [
+    exo
+    gdk_pixbuf
+    gtk3
+    libgudev
+    libnotify
+    libX11
+    libxfce4ui
+    libxfce4util
+    xfconf
+  ];
+}

--- a/pkgs/desktops/xfce4-13/tumbler/default.nix
+++ b/pkgs/desktops/xfce4-13/tumbler/default.nix
@@ -1,0 +1,14 @@
+{ mkXfceDerivation, gdk_pixbuf ? null, ffmpegthumbnailer ? null, libgsf ? null
+, poppler ? null }:
+
+# TODO: add libopenraw
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "tumbler";
+  version = "0.2.0";
+
+  sha256 = "0jr6rhgc57yqb3iwp7y49yf5ig541liaz6xpvjl45ki34j091iaj";
+
+  buildInputs = [ gdk_pixbuf ffmpegthumbnailer libgsf poppler ];
+}

--- a/pkgs/desktops/xfce4-13/xfburn/default.nix
+++ b/pkgs/desktops/xfce4-13/xfburn/default.nix
@@ -1,0 +1,18 @@
+{ mkXfceDerivation, docbook_xml_xslt, exo, gtk2, libburn, libICE, libisofs, libSM, libxfce4ui, libxslt }:
+
+mkXfceDerivation rec {
+  category = "apps";
+  pname = "xfburn";
+  version = "0.5.5";
+
+  postPatch = ''
+    substituteInPlace docs/Makefile.am \
+      --replace http://docbook.sourceforge.net/release/xsl/current \
+                ${docbook_xml_xslt}/share/xml/docbook-xsl
+  '';
+
+  sha256 = "1lmv48vqrlap1a2ha72g16vqly18zvcwj8y3f3f00l10pmn52bkp";
+
+  nativeBuildInputs = [ libxslt ];
+  buildInputs = [ exo gtk2 libburn libICE libisofs libSM libxfce4ui ];
+}

--- a/pkgs/desktops/xfce4-13/xfce4-appfinder/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-appfinder/default.nix
@@ -1,0 +1,12 @@
+{ mkXfceDerivation, exo, garcon, gtk3, libxfce4util, libxfce4ui, xfconf }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "xfce4-appfinder";
+  version = "4.13.0";
+
+  sha256 = "13xsshzw04gx5rhalx4r0khjb0dbq26fv6n20biyiai1ykznyryy";
+
+  nativeBuildInputs = [ exo ];
+  buildInputs = [ garcon gtk3 libxfce4ui libxfce4util xfconf ];
+}

--- a/pkgs/desktops/xfce4-13/xfce4-dev-tools/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-dev-tools/default.nix
@@ -1,0 +1,31 @@
+{ mkXfceDerivation, autoreconfHook, autoconf, automake, glib, gtk_doc, intltool, libtool }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "xfce4-dev-tools";
+  version = "4.12.0";
+
+  sha256 = "0bbmlmw2dpm10q2wv3vy592i0vx7b5h1qnd35j0fdzxqb8x2hbw2";
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  propagatedNativeBuildInputs = [
+    autoconf
+    automake
+    glib
+    gtk_doc
+    intltool
+    libtool
+  ];
+
+  preAutoreconf = ''
+    substitute configure.ac.in configure.ac \
+      --subst-var-by REVISION UNKNOWN
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  meta = {
+    description = "Autoconf macros and scripts to augment app build systems";
+  };
+}

--- a/pkgs/desktops/xfce4-13/xfce4-dev-tools/setup-hook.sh
+++ b/pkgs/desktops/xfce4-13/xfce4-dev-tools/setup-hook.sh
@@ -1,0 +1,12 @@
+xdtEnvHook() {
+    addToSearchPath ACLOCAL_PATH $1/share/xfce4/dev-tools/m4macros
+}
+
+envHooks+=(xdtEnvHook)
+
+xdtAutogenPhase() {
+    mkdir -p m4
+    NOCONFIGURE=1 xdt-autogen
+}
+
+preConfigurePhases+=(xdtAutogenPhase)

--- a/pkgs/desktops/xfce4-13/xfce4-dict/configure-gio.patch
+++ b/pkgs/desktops/xfce4-13/xfce4-dict/configure-gio.patch
@@ -1,0 +1,11 @@
+diff -urNZ a/configure.ac.in b/configure.ac.in
+--- a/configure.ac.in	2017-12-16 19:46:13.784914017 +0000
++++ b/configure.ac.in	2017-12-16 19:46:38.612477052 +0000
+@@ -53,6 +53,7 @@
+ dnl ***********************************
+ dnl *** Check for required packages ***
+ dnl ***********************************
++XDT_CHECK_PACKAGE([GIO], [gio-unix-2.0], [2.32.0])
+ XDT_CHECK_PACKAGE([GTHREAD], [gthread-2.0], [2.24.0])
+ XDT_CHECK_PACKAGE([GTK], [gtk+-3.0], [3.20.0])
+ XDT_CHECK_PACKAGE([LIBXFCE4UI], [libxfce4ui-2], [4.12.0])

--- a/pkgs/desktops/xfce4-13/xfce4-dict/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-dict/default.nix
@@ -1,0 +1,19 @@
+{ mkXfceDerivation, automakeAddFlags, gtk3, libxfce4ui, libxfce4util, xfce4-panel }:
+
+mkXfceDerivation rec {
+  category = "apps";
+  pname = "xfce4-dict";
+  version = "0.8.0";
+
+  sha256 = "1r1k9cgl7zkn3q4mjf7qjql6vlxkb2m0spgj9p646mw7bnhbf9wr";
+
+  patches = [ ./configure-gio.patch ];
+
+  nativeBuildInputs = [ automakeAddFlags ];
+
+  postPatch = ''
+    automakeAddFlags lib/Makefile.am libdict_la_CFLAGS GIO_CFLAGS
+  '';
+
+  buildInputs = [ gtk3 libxfce4ui libxfce4util xfce4-panel ];
+}

--- a/pkgs/desktops/xfce4-13/xfce4-mixer/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-mixer/default.nix
@@ -1,0 +1,30 @@
+{ mkXfceDerivation, automakeAddFlags, dbus_glib, gst-plugins-base, gtk2
+, libICE, libSM, libunique, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+
+mkXfceDerivation rec {
+  category = "apps";
+  pname = "xfce4-mixer";
+  version = "4.11.0";
+
+  sha256 = "1kiz5ysn4rqkjfzz4dvbsfj64kqqayg7bqakcys3rw28g2q5qyys";
+
+  nativeBuildInputs = [ automakeAddFlags ];
+
+  postPatch = ''
+    automakeAddFlags panel-plugin/Makefile.am libmixer_la_CFLAGS DBUS_GLIB_CFLAGS
+    automakeAddFlags xfce4-mixer/Makefile.am xfce4_mixer_CFLAGS DBUS_GLIB_CFLAGS
+  '';
+
+  buildInputs = [
+    dbus_glib
+    gst-plugins-base
+    gtk2
+    libICE
+    libSM
+    libunique
+    libxfce4ui
+    libxfce4util
+    xfce4-panel
+    xfconf
+  ];
+}

--- a/pkgs/desktops/xfce4-13/xfce4-notifyd/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-notifyd/default.nix
@@ -1,0 +1,13 @@
+{ mkXfceDerivation, dbus_glib, exo, gtk3, libnotify, libxfce4ui, libxfce4util
+, xfce4-panel, xfconf }:
+
+mkXfceDerivation rec {
+  category = "apps";
+  pname = "xfce4-notifyd";
+  version = "0.4.1";
+
+  sha256 = "12mqi0q1hcjm16f4pndq7l58h2n0nq160r5fqx8ns320i83nh94k";
+
+  nativeBuildInputs = [ dbus_glib exo ];
+  buildInputs = [ gtk3 libnotify libxfce4ui libxfce4util xfce4-panel xfconf ];
+}

--- a/pkgs/desktops/xfce4-13/xfce4-panel/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-panel/default.nix
@@ -1,0 +1,15 @@
+{ mkXfceDerivation, exo, garcon, gtk2, gtk3, libxfce4ui, libxfce4util, libwnck3, xfconf }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "xfce4-panel";
+  version = "4.13.2";
+
+  sha256 = "194pihmg7af4x81nia2fy3h7rls306a7c0bqny9ycqikvi6nmdmn";
+
+  buildInputs = [ exo garcon gtk2 gtk3 libxfce4ui libxfce4util libwnck3 xfconf ];
+
+  meta =  {
+    description = "Xfce's panel";
+  };
+}

--- a/pkgs/desktops/xfce4-13/xfce4-power-manager/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-power-manager/default.nix
@@ -1,0 +1,19 @@
+{ mkXfceDerivation, automakeAddFlags, exo, gtk3, libnotify
+, libxfce4ui, libxfce4util, upower, xfconf }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "xfce4-power-manager";
+  version = "1.6.0";
+
+  sha256 = "1sh6ydn44j1yki8f020ljayp1fjcigkywcvjp38fsk7j25ni2wrp";
+
+  nativeBuildInputs = [ automakeAddFlags exo ];
+  buildInputs = [ gtk3 libnotify libxfce4ui libxfce4util upower xfconf ];
+
+  postPatch = ''
+    substituteInPlace configure.ac.in --replace gio-2.0 gio-unix-2.0
+    automakeAddFlags src/Makefile.am xfce4_power_manager_CFLAGS GIO_CFLAGS
+    automakeAddFlags src/Makefile.am xfce4_power_manager_settings_CFLAGS GIO_CFLAGS
+  '';
+}

--- a/pkgs/desktops/xfce4-13/xfce4-screenshooter/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-screenshooter/default.nix
@@ -1,0 +1,11 @@
+{ mkXfceDerivation, exo, gtk3, libsoup, libxfce4ui, libxfce4util, xfce4-panel }:
+
+mkXfceDerivation rec {
+  category = "apps";
+  pname = "xfce4-screenshooter";
+  version = "1.9.1";
+
+  sha256 = "1q13hvaz3ykrbgbbqb1186mhri8r9hkmpaayjwhnkvjm7jfyhbin";
+
+  buildInputs = [ exo gtk3 libsoup libxfce4ui libxfce4util xfce4-panel ];
+}

--- a/pkgs/desktops/xfce4-13/xfce4-settings/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-settings/default.nix
@@ -1,0 +1,39 @@
+{ mkXfceDerivation, automakeAddFlags, dbus_glib, exo, garcon, gtk3
+, libnotify ? null, libxfce4ui, libxfce4util, libxklavier ? null
+, upower ? null, xfconf, xf86inputlibinput ? null }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "xfce4-settings";
+  version = "4.13.1";
+
+  sha256 = "010vcgy3qiqykk174jhf50a8q3x4a5qq2lf6b0wcbyzv7aikydrw";
+
+  postPatch = ''
+    automakeAddFlags xfce4-settings-editor/Makefile.am xfce4_settings_editor_CFLAGS DBUS_GLIB_CFLAGS
+    for f in $(find . -name \*.c); do
+      substituteInPlace $f --replace \"libinput-properties.h\" '<xorg/libinput-properties.h>'
+    done
+  '';
+
+  nativeBuildInputs = [ automakeAddFlags ];
+
+  buildInputs = [
+    dbus_glib
+    exo
+    garcon
+    gtk3
+    libnotify
+    libxfce4ui
+    libxfce4util
+    libxklavier
+    upower
+    xfconf
+    xf86inputlibinput
+  ];
+
+  configureFlags = [
+    "--enable-pluggable-dialogs"
+    "--enable-sound-settings"
+  ];
+}

--- a/pkgs/desktops/xfce4-13/xfce4-taskmanager/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-taskmanager/default.nix
@@ -1,0 +1,18 @@
+{ lib, mkXfceDerivation, exo, gtk2, gtk3 ? null, libwnck3 ? null, libXmu }:
+
+let
+  inherit (lib) enableFeature;
+in
+
+mkXfceDerivation rec {
+  category = "apps";
+  pname = "xfce4-taskmanager";
+  version = "1.2.0";
+
+  sha256 = "1lx66lhzfzhysymcbzfq9nrafyfmwdb79lli9kvhz6m12dhz6j18";
+
+  nativeBuildInputs = [ exo ];
+  buildInputs = [ gtk2 gtk3 libwnck3 libXmu ];
+
+  configureFlags = [ (enableFeature (gtk3 != null) "gtk3") ];
+}

--- a/pkgs/desktops/xfce4-13/xfce4-terminal/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-terminal/default.nix
@@ -1,0 +1,15 @@
+{ mkXfceDerivation, gtk3, libxfce4ui, vte }:
+
+mkXfceDerivation rec {
+  category = "apps";
+  pname = "xfce4-terminal";
+  version = "0.8.6";
+
+  sha256 = "1a0b2ih552zhbbx1fc5ad80nafvkc5my3gw89as4mvycnhyd5inj";
+
+  buildInputs = [ gtk3 libxfce4ui vte ];
+
+  meta = {
+    description = "A modern terminal emulator";
+  };
+}

--- a/pkgs/desktops/xfce4-13/xfce4-volumed-pulse/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-volumed-pulse/default.nix
@@ -1,0 +1,15 @@
+{ lib, mkXfceDerivation, gtk2, libnotify ? null, libpulseaudio, keybinder, xfconf }:
+
+mkXfceDerivation rec {
+  category = "apps";
+  pname = "xfce4-volumed-pulse";
+  version = "0.2.2";
+
+  sha256 = "0ccb98b433lx5fgdqd3nqqppg4sldr5p1is6pnx85h9wyxx5svhp";
+
+  buildInputs = [ gtk2 libnotify libpulseaudio keybinder xfconf ];
+
+  meta = with lib; {
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/desktops/xfce4-13/xfconf/default.nix
+++ b/pkgs/desktops/xfce4-13/xfconf/default.nix
@@ -1,0 +1,11 @@
+{ mkXfceDerivation, libxfce4util }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "xfconf";
+  version = "4.13.4";
+
+  sha256 = "1bm4q06rwlmkmcy6qnwm6l70w6749iqfrmsrgj3y1jb2sacc3pd4";
+
+  buildInputs = [ libxfce4util ];
+}

--- a/pkgs/desktops/xfce4-13/xfdesktop/default.nix
+++ b/pkgs/desktops/xfce4-13/xfdesktop/default.nix
@@ -1,0 +1,22 @@
+{ mkXfceDerivation, exo, gtk3, libxfce4ui, libxfce4util, libwnck3, xfconf }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "xfdesktop";
+  version = "4.13.1";
+
+  sha256 = "0idc8j44apflvdasnvj7ld0fa8mxlwpndfqzbh97w54s8972gf6g";
+
+  buildInputs = [
+    exo
+    gtk3
+    libxfce4ui
+    libxfce4util
+    libwnck3
+    xfconf
+  ];
+
+  meta = {
+    description = "Xfce's desktop manager";
+  };
+}

--- a/pkgs/desktops/xfce4-13/xfwm4/default.nix
+++ b/pkgs/desktops/xfce4-13/xfwm4/default.nix
@@ -1,0 +1,27 @@
+{ mkXfceDerivation, exo, dbus_glib, epoxy ? null, gtk2, libICE, libSM
+, libstartup_notification ? null, libxfce4ui, libxfce4util, libwnck
+, libXpresent ? null, xfconf }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "xfwm4";
+  version = "4.13.0";
+
+  sha256 = "19ikyls4xawsbz07qdz60g5yl2jbvpb90sfy5zql7ghypd69cgn9";
+
+  nativeBuildInputs = [ exo ];
+
+  buildInputs = [
+    dbus_glib
+    epoxy
+    gtk2
+    libICE
+    libSM
+    libstartup_notification
+    libxfce4ui
+    libxfce4util
+    libwnck
+    libXpresent
+    xfconf
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18643,7 +18643,10 @@ with pkgs;
   };
 
   xfce = xfce4-12;
+  xfceUnstable = xfce4-13;
+
   xfce4-12 = recurseIntoAttrs (callPackage ../desktops/xfce { });
+  xfce4-13 = recurseIntoAttrs (callPackage ../desktops/xfce4-13 { });
 
   xrandr-invert-colors = callPackage ../applications/misc/xrandr-invert-colors { };
 


### PR DESCRIPTION
###### Motivation for this change

Prepare for upcoming Xfce 4.14 release. Most, but not all, components have been switched to GTK+ 3.

This is a clean-room packaging effort and differs from currently packaged Xfce in some ways:

* build entirely from source, using `xfce4-dev-tools`, source from Git
* package latest versions rather than Xfce 4.12 branch
* mark optional dependencies as such
* abstract away common parts via `mkXfceDerivation`
* attribute names match upstream names
* overridable scope (created via `makeScope`)

There are quite a few Autoconf fixes that had to be made, mostly related to their dbus_glib -> gdbus switch. I've talked with Xfce devs and plan to upstream these fixes before the release.

Everything works, except:

* `xfce4-volumed` is missing (but not `xfce4-volumed-pulse`): release is not tagged
* Doesn't include `xfce4-panel` plugins, yet
* Thunar doesn't seem to work, yet (needs to be wrapped)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

