### PR TITLE
pythonPackages: init camxes at 0.2

### DIFF
--- a/pkgs/development/python-modules/camxes/default.nix
+++ b/pkgs/development/python-modules/camxes/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, jre
+, buildPythonPackage
+, fetchPypi
+, progressbar
+}:
+
+let
+  LEPL = buildPythonPackage rec {
+    pname = "LEPL";
+    version = "5.1.3";
+    name = "${pname}-${version}";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "15qksjl1shj4gp47wf21h79qcs35h9b54pgdmzj0qd88jdq5qwd8";
+    };
+  };
+in buildPythonPackage rec {
+  pname = "camxes";
+  version = "0.2";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1rhj40a60gq7giypxbhnbhlbz9if7ars1ba9vm1ak2izvdzh4mph";
+  };
+
+  postPatch = ''
+    substituteInPlace camxes/__init__.py \
+      --replace "'java'" "'java', '-Xss4m'"
+  '';
+
+  postInstall = ''
+    mkdir -p $out/bin/
+    cp ${./jbo2json.py} $out/bin/jbo2json
+    chmod +x $out/bin/jbo2json
+  '';
+
+  # checkInputs = [ Attest ];
+  propagatedBuildInputs = [ jre LEPL ];
+
+  # checkPhase = ''
+  # '';
+
+  meta = with lib; {
+    description = "Python interface to camxes, the Lojban parser";
+    homepage = https://github.com/dag/python-camxes;
+    license = licenses.bsd;
+    maintainers = with maintainers; [ MostAwesomeDude ];
+  };
+}
+

--- a/pkgs/development/python-modules/camxes/jbo2json.py
+++ b/pkgs/development/python-modules/camxes/jbo2json.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+import camxes, json, sys
+
+def clean(s):
+    return s.replace("\n", " ")
+
+print json.dumps(camxes.parse(clean(sys.stdin.read())).primitive)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -23305,6 +23305,7 @@ EOF
 
   ephem = callPackage ../development/python-modules/ephem { };
 
+  camxes = callPackage ../development/python-modules/camxes { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

I want a working Lojban parser.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

