### PR TITLE
pythonPackages.pwntools: disable tests

### DIFF
--- a/pkgs/development/python-modules/pwntools/default.nix
+++ b/pkgs/development/python-modules/pwntools/default.nix
@@ -17,6 +17,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ Mako packaging pysocks pygments ROPGadget capstone paramiko pip psutil pyelftools pypandoc pyserial dateutil requests tox pandoc unicorn intervaltree ];
 
   disabled = isPy3k;
+  doCheck = false; # no setuptools tests for the package
 
   meta = with stdenv.lib; {
     homepage = "http://pwntools.com";


### PR DESCRIPTION
###### Motivation for this change
There aren't any tests to run, and now the package fails to build
because of a crash while looking if there are any tests.

The crash itself seems to happen because TERM isn't set while loading the pwntools terminal handling module, and first started happening at 2017-12-08 according to hydra. I don't know what changed, but it doesn't really matter when the package works and there weren't any tests to begin with.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

