### PR TITLE
Trezor GPG Agent

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22403,6 +22403,12 @@ EOF
       mnemonic semver unidecode pyqt5 pkgs.which
     ];
 
+    postFixup = ''
+      # fix for qt pinentry in non-tty environments such as systemd services
+      wrapProgram $out/bin/trezor-gpg-agent \
+        --set QT_QPA_PLATFORM_PLUGIN_PATH "${pkgs.qt59.qtbase.bin}/lib/qt-5.9/plugins/platforms/"
+    '';
+
     meta = {
       description = "Using Trezor as hardware SSH agent";
       homepage = https://github.com/romanz/trezor-agent;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22388,16 +22388,19 @@ EOF
   trezor_agent = buildPythonPackage rec{
     name = "${pname}-${version}";
     pname = "trezor_agent";
-    version = "0.9.0";
+    version = "0.9.2";
 
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "1i5cdamlf3c0ym600pjklij74p8ifj9cv7xrpnrfl1b8nkadswbz";
-    };
+    src = "${pkgs.fetchFromGitHub {
+      repo = "trezor-agent";
+      owner = "romanz";
+      rev = "v${version}";
+
+      sha256 = "1wrmf76016ksx394l1xknnqn08sc5pid5ihri619cd83zsxpkfvk";
+    }}/agents/trezor";
 
     propagatedBuildInputs = with self; [
       trezor libagent ecdsa ed25519
-      mnemonic keepkey semver
+      mnemonic semver unidecode pyqt5 pkgs.which
     ];
 
     meta = {


### PR DESCRIPTION
###### Motivation for this change

This adds an option to enable trezor-agent, a GPG agent that enables GPG encrypting and signing with a Trezor hardware wallet.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

