### PR TITLE
elementary-gtk-theme: init at 5.1.1

### DIFF
--- a/pkgs/misc/themes/elementary/default.nix
+++ b/pkgs/misc/themes/elementary/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "elementary-gtk-theme-${version}";
+  version = "5.1.1";
+
+  src = fetchFromGitHub {
+    owner = "elementary";
+    repo = "stylesheet";
+    rev = version;
+    sha256 = "1749byc2lbxmprladn9n7k6jh79r8ffgayjn689gmqsrm6czsmh2";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/share/themes/elementary
+    cp -r gtk-* plank $out/share/themes/elementary
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GTK theme designed to be smooth, attractive, fast, and usable";
+    homepage = https://github.com/elementary/stylesheet;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ davidak ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18545,6 +18545,8 @@ with pkgs;
 
   deepin-gtk-theme = callPackage ../misc/themes/deepin { };
 
+  elementary-gtk-theme = callPackage ../misc/themes/elementary { };
+
   albatross = callPackage ../misc/themes/albatross { };
 
   gtk_engines = callPackage ../misc/themes/gtk2/gtk-engines { };


### PR DESCRIPTION
###### Motivation for this change

The master plan is to have a full Pantheon desktop.

Here is it with Xfce, greybird window decorator and `elementary-xfce-icon-theme`.

![screenshot_2017-12-18_01-24-59](https://user-images.githubusercontent.com/91113/34085519-6d52aedc-e392-11e7-8920-aa529658e173.png)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

