### PR TITLE
steam: override nss, nspr, fixes #32781 (backport)

### DIFF
--- a/pkgs/games/steam/runtime-wrapped.nix
+++ b/pkgs/games/steam/runtime-wrapped.nix
@@ -5,7 +5,7 @@
 
 assert !(nativeOnly && runtimeOnly);
 
-let 
+let
   runtimePkgs = with pkgs; [
     # Required
     glib
@@ -87,6 +87,8 @@ let
     libva
     vulkan-loader
     gcc.cc
+    nss
+    nspr
   ];
 
   ourRuntime = if runtimeOnly then []


### PR DESCRIPTION
(cherry picked from 16dc6bf5211ca4f6308db17d2a0f31117c2e10be)

See #32783.