### PR TITLE
cmst: 2017.03.18 -> 2017.09.19

### DIFF
--- a/pkgs/tools/networking/cmst/default.nix
+++ b/pkgs/tools/networking/cmst/default.nix
@@ -1,41 +1,26 @@
-{ stdenv, fetchFromGitHub, qtbase, qmake, makeWrapper, libX11 }:
+{ stdenv, fetchFromGitHub, qmake, qtbase, libX11 }:
 
 stdenv.mkDerivation rec {
   name = "cmst-${version}";
-  version = "2017.03.18";
+  version = "2017.09.19";
 
   src = fetchFromGitHub {
     repo = "cmst";
     owner = "andrew-bibb";
     rev = name;
-    sha256 = "0lsg8ya36df48ij0jawgli3f63hy6mn9zcla48whb1l4r7cih545";
+    sha256 = "14inss0mr9i4q6vfqqfxbjgpjaclp1kh60qlm5xv4cwnvi395rc7";
   };
 
-  nativeBuildInputs = [ makeWrapper qmake ];
+  nativeBuildInputs = [ qmake ];
 
   buildInputs = [ qtbase ];
 
   enableParallelBuilding = true;
 
-  preConfigure = ''
-    substituteInPlace ./cmst.pro \
-      --replace "/usr/share" "$out/share"
-
-    substituteInPlace ./cmst.pri \
-      --replace "/usr/lib" "$out/lib" \
-      --replace "/usr/share" "$out/share"
-
-    substituteInPlace ./apps/cmstapp/cmstapp.pro \
-      --replace "/usr/bin" "$out/bin"
-
-    substituteInPlace ./apps/rootapp/rootapp.pro \
-      --replace "/etc" "$out/etc" \
-      --replace "/usr/share" "$out/share"
-  '';
-
-  postInstall = ''
-    wrapProgram $out/bin/cmst \
-      --prefix "QTCOMPOSE" ":" "${libX11}/share/X11/locale"
+  postPatch = ''
+    for f in $(find . -name \*.cpp -o -name \*.pri -o -name \*.pro); do
+      substituteInPlace $f --replace /etc $out/etc --replace /usr $out
+    done
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Update to version [2017.09.19](https://github.com/andrew-bibb/cmst/releases/tag/cmst-2017.09.19)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).