### PR TITLE
vala: patch releases for 0.23, 0.28, 0.34, 0.36 and 0.38

### DIFF
--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -31,8 +31,8 @@ in rec {
 
   vala_0_23 = generic {
     major   = "0.23";
-    minor   = "2";
-    sha256  = "0g22ss9qbm3fqhx4fxhsyfmdc5g1hgdw4dz9d37f4489kl0qf8pl";
+    minor   = "3";
+    sha256  = "101xjbc818g4849n9a80c2aai13zakj7mpnd7470xnkvz5jwqq96";
   };
 
   vala_0_26 = generic {
@@ -43,8 +43,8 @@ in rec {
 
   vala_0_28 = generic {
     major   = "0.28";
-    minor   = "0";
-    sha256  = "0zwpzhkhfk3piya14m7p2hl2vaabahprphppfm46ci91z39kp7hd";
+    minor   = "1";
+    sha256  = "0isg327w6rfqqdjja6a8pc3xcdkj7pqrkdhw48bsyxab2fkaw3hw";
   };
 
   vala_0_32 = generic {
@@ -55,14 +55,20 @@ in rec {
 
   vala_0_34 = generic {
     major   = "0.34";
-    minor   = "1";
-    sha256  = "16cjybjw100qps6jg0jdyjh8hndz8a876zmxpybnf30a8vygrk7m";
+    minor   = "13";
+    sha256  = "0ahbnhgwhhjkndmbr1d039ws0g2bb324c60fk6wgx7py5wvmgcd2";
+  };
+
+  vala_0_36 = generic {
+    major   = "0.36";
+    minor   = "8";
+    sha256  = "1nz5a8kcb22ss9idb7k1higwpvghd617xwf40fi0a9ggws614lfz";
   };
 
   vala_0_38 = generic {
     major   = "0.38";
-    minor   = "1";
-    sha256  = "112hl3lkcyakrk8c3qgw12gzn3nxjkvx7bn0jhl5f2m57d7k8d8h";
+    minor   = "4";
+    sha256  = "1sg5gaq3jhgr9vzh2ypiw475167k150wmyglymr7wwqppmikmcrc";
     extraNativeBuildInputs = [ autoconf ] ++ stdenv.lib.optionals stdenv.isDarwin [ libtool expat ];
     extraBuildInputs = [ graphviz ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6415,6 +6415,7 @@ with pkgs;
     vala_0_28
     vala_0_32
     vala_0_34
+    vala_0_36
     vala_0_38
     vala;
 


### PR DESCRIPTION
###### Motivation for this change

A bunch of patch releases have been made as updates to the various versions we package.

It causes a non-insignificant amount of rebuilding...

They build here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

