### PR TITLE
libva, libva-utils and vaapiIntel: split into v1 and v2

### DIFF
--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -23,7 +23,7 @@ rec {
 
   gst-vaapi = callPackage ./vaapi {
     inherit gst-plugins-base gstreamer gst-plugins-bad;
-    libva = libva-full; # looks also for libva-{x11,wayland}
+    libva = libva-full_1; # looks also for libva-{x11,wayland}
   };
 
   gst-validate = callPackage ./validate { inherit gst-plugins-base; };

--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, libva-full }:
+{ callPackage, libva-full_1 }:
 
 rec {
   gstreamer = callPackage ./core { };

--- a/pkgs/development/libraries/libva-utils/default.nix
+++ b/pkgs/development/libraries/libva-utils/default.nix
@@ -1,29 +1,36 @@
 { stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig
-, libdrm, libva
+, libdrm, libva_1, libva_2
 }:
 
-stdenv.mkDerivation rec {
-  name = "libva-utils-${version}";
-  inherit (libva) version;
+let
+  generic = sha256: vaLib: stdenv.mkDerivation rec {
+    name = "libva-utils-${version}";
+    inherit (vaLib) version;
 
-  src = fetchFromGitHub {
-    owner  = "01org";
-    repo   = "libva-utils";
-    rev    = version;
-    sha256 = "02n51cvp8bzzjk4fargwvgh7z71y8spg24hqgaawbp3p3ahh7xxi";
+    src = fetchFromGitHub {
+      owner  = "01org";
+      repo   = "libva-utils";
+      rev    = version;
+      sha256 = "02n51cvp8bzzjk4fargwvgh7z71y8spg24hqgaawbp3p3ahh7xxi";
+    };
+
+    nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+    buildInputs = [ libdrm vaLib ];
+
+    enableParallelBuilding = true;
+
+    meta = with stdenv.lib; {
+      description = "VAAPI tools: Video Acceleration API";
+      homepage = http://www.freedesktop.org/wiki/Software/vaapi;
+      license = licenses.mit;
+      maintainers = with maintainers; [ garbas ];
+      platforms = platforms.unix;
+    };
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
-
-  buildInputs = [ libdrm libva ];
-
-  enableParallelBuilding = true;
-
-  meta = with stdenv.lib; {
-    description = "VAAPI tools: Video Acceleration API";
-    homepage = http://www.freedesktop.org/wiki/Software/vaapi;
-    license = licenses.mit;
-    maintainers = with maintainers; [ garbas ];
-    platforms = platforms.unix;
-  };
+in {
+  # libva-utils 1.8.3 requires libva 2.0.0+
+  libva-utils_1 = generic "0pxd9v783p9zh8a9zyi6kaknsbjd4s6lxcyaqqlrbkn1n4yq96ai" libva_2;
+  libva-utils_2 = generic "02n51cvp8bzzjk4fargwvgh7z71y8spg24hqgaawbp3p3ahh7xxi" libva_2;
 }

--- a/pkgs/development/libraries/libva-utils/default.nix
+++ b/pkgs/development/libraries/libva-utils/default.nix
@@ -11,7 +11,7 @@ let
       owner  = "01org";
       repo   = "libva-utils";
       rev    = version;
-      sha256 = "02n51cvp8bzzjk4fargwvgh7z71y8spg24hqgaawbp3p3ahh7xxi";
+      inherit sha256;
     };
 
     nativeBuildInputs = [ autoreconfHook pkgconfig ];
@@ -30,7 +30,6 @@ let
   };
 
 in {
-  # libva-utils 1.8.3 requires libva 2.0.0+
-  libva-utils_1 = generic "0pxd9v783p9zh8a9zyi6kaknsbjd4s6lxcyaqqlrbkn1n4yq96ai" libva_2;
+  libva-utils_1 = generic "0pxd9v783p9zh8a9zyi6kaknsbjd4s6lxcyaqqlrbkn1n4yq96ai" libva_1;
   libva-utils_2 = generic "02n51cvp8bzzjk4fargwvgh7z71y8spg24hqgaawbp3p3ahh7xxi" libva_2;
 }

--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -1,43 +1,57 @@
 { stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig
 , libXext, libdrm, libXfixes, wayland, libffi, libX11
 , mesa_noglu
-, minimal ? true, libva
 }:
 
-stdenv.mkDerivation rec {
-  name = "libva-${lib.optionalString (!minimal) "full-"}${version}";
-  version = "2.0.0";
+let
+  v1Version = "1.8.3";
+  v1Sum = "0zqbk02h4jl5v0b141wmi5375k2yplklmm6hv4c75aarlxr7vgms";
 
-  src = fetchFromGitHub {
-    owner  = "01org";
-    repo   = "libva";
-    rev    = version;
-    sha256 = "1x8rlmv5wfqjz3j87byrxb4d9vp5b4lrrin2fx254nwl3aqy15hy";
+  v2Version = "2.0.0";
+  v2Sum = "1x8rlmv5wfqjz3j87byrxb4d9vp5b4lrrin2fx254nwl3aqy15hy";
+
+  generic = version: sha256: minimal: stdenv.mkDerivation rec {
+    name = "libva-${lib.optionalString (!minimal) "full-"}${version}";
+
+    src = fetchFromGitHub {
+      owner  = "01org";
+      repo   = "libva";
+      rev    = version;
+      inherit sha256;
+    };
+
+    outputs = [ "dev" "out" ];
+
+    nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+    buildInputs = [ libdrm ]
+      ++ lib.optionals (!minimal) [ libX11 libXext libXfixes wayland libffi mesa_noglu ];
+    # TODO: share libs between minimal and !minimal - perhaps just symlink them
+
+    enableParallelBuilding = true;
+
+    configureFlags = [
+      "--with-drivers-path=${mesa_noglu.driverLink}/lib/dri"
+    ] ++ lib.optionals (!minimal) [ "--enable-glx" ];
+
+    installFlags = [
+      "dummy_drv_video_ladir=$(out)/lib/dri"
+    ];
+
+    passthru = { inherit version; };
+
+    meta = with stdenv.lib; {
+      description = "VAAPI library: Video Acceleration API";
+      homepage = http://www.freedesktop.org/wiki/Software/vaapi;
+      license = licenses.mit;
+      maintainers = with maintainers; [ garbas ];
+      platforms = platforms.unix;
+    };
   };
 
-  outputs = [ "dev" "out" ];
-
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
-
-  buildInputs = [ libdrm ]
-    ++ lib.optionals (!minimal) [ libva libX11 libXext libXfixes wayland libffi mesa_noglu ];
-  # TODO: share libs between minimal and !minimal - perhaps just symlink them
-
-  enableParallelBuilding = true;
-
-  configureFlags = [
-    "--with-drivers-path=${mesa_noglu.driverLink}/lib/dri"
-  ] ++ lib.optionals (!minimal) [ "--enable-glx" ];
-
-  installFlags = [
-    "dummy_drv_video_ladir=$(out)/lib/dri"
-  ];
-
-  meta = with stdenv.lib; {
-    description = "VAAPI library: Video Acceleration API";
-    homepage = http://www.freedesktop.org/wiki/Software/vaapi;
-    license = licenses.mit;
-    maintainers = with maintainers; [ garbas ];
-    platforms = platforms.unix;
-  };
+in {
+  libva_1      = generic v1Version v1Sum true;
+  libva_2      = generic v2Version v2Sum true;
+  libva-full_1 = generic v1Version v1Sum false;
+  libva-full_2 = generic v2Version v2Sum false;
 }

--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -12,6 +12,7 @@ let
 
   generic = version: sha256: minimal: stdenv.mkDerivation rec {
     name = "libva-${lib.optionalString (!minimal) "full-"}${version}";
+    inherit version;
 
     src = fetchFromGitHub {
       owner  = "01org";
@@ -37,8 +38,6 @@ let
     installFlags = [
       "dummy_drv_video_ladir=$(out)/lib/dri"
     ];
-
-    passthru = { inherit version; };
 
     meta = with stdenv.lib; {
       description = "VAAPI library: Video Acceleration API";

--- a/pkgs/development/libraries/vaapi-intel/default.nix
+++ b/pkgs/development/libraries/vaapi-intel/default.nix
@@ -1,43 +1,49 @@
 { stdenv, fetchFromGitHub, autoreconfHook, gnum4, pkgconfig, python2
-, intel-gpu-tools, libdrm, libva, libX11, mesa_noglu, wayland, libXext
+, intel-gpu-tools, libdrm, libva-full_1, libva-full_2, libX11, mesa_noglu, wayland, libXext
 }:
 
-stdenv.mkDerivation rec {
-  name = "intel-vaapi-driver-${version}";
-  inherit (libva) version;
+let
+  generic = sha256: vaLib: stdenv.mkDerivation rec {
+    name = "intel-vaapi-driver-${version}";
+    inherit (vaLib) version;
 
-  src = fetchFromGitHub {
-    owner  = "01org";
-    repo   = "libva-intel-driver";
-    rev    = version;
-    sha256 = "1832nnva3d33wv52bj59bv62q7a807sdxjqqq0my7l9x7a4qdkzz";
+    src = fetchFromGitHub {
+      owner  = "01org";
+      repo   = "libva-intel-driver";
+      rev    = version;
+      inherit sha256;
+    };
+
+    patchPhase = ''
+      patchShebangs ./src/shaders/gpp.py
+    '';
+
+    preConfigure = ''
+      sed -i -e "s,LIBVA_DRIVERS_PATH=.*,LIBVA_DRIVERS_PATH=$out/lib/dri," configure
+    '';
+
+    configureFlags = [
+      "--enable-drm"
+      "--enable-x11"
+      "--enable-wayland"
+    ];
+
+    nativeBuildInputs = [ autoreconfHook gnum4 pkgconfig python2 ];
+
+    buildInputs = [ vaLib intel-gpu-tools libdrm libX11 libXext mesa_noglu wayland ];
+
+    enableParallelBuilding = true;
+
+    meta = with stdenv.lib; {
+      description = "Intel driver for the VAAPI library";
+      homepage = http://cgit.freedesktop.org/vaapi/intel-driver/;
+      license = licenses.mit;
+      maintainers = with maintainers; [ garbas ];
+      platforms = platforms.unix;
+    };
   };
 
-  patchPhase = ''
-    patchShebangs ./src/shaders/gpp.py
-  '';
-
-  preConfigure = ''
-    sed -i -e "s,LIBVA_DRIVERS_PATH=.*,LIBVA_DRIVERS_PATH=$out/lib/dri," configure
-  '';
-
-  configureFlags = [
-    "--enable-drm"
-    "--enable-x11"
-    "--enable-wayland"
-  ];
-
-  nativeBuildInputs = [ autoreconfHook gnum4 pkgconfig python2 ];
-
-  buildInputs = [ intel-gpu-tools libdrm libva libX11 libXext mesa_noglu wayland ];
-
-  enableParallelBuilding = true;
-
-  meta = with stdenv.lib; {
-    homepage = http://cgit.freedesktop.org/vaapi/intel-driver/;
-    license = licenses.mit;
-    description = "Intel driver for the VAAPI library";
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ garbas ];
-  };
+in {
+  vaapiIntel_1 = generic "0bcdcjzas3090m3nb0by8x26p30mdqfdh0g57yzxbsk22j75v8qp" libva-full_1;
+  vaapiIntel_2 = generic "1832nnva3d33wv52bj59bv62q7a807sdxjqqq0my7l9x7a4qdkzz" libva-full_2;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9833,9 +9833,19 @@ with pkgs;
     withUtils = false;
   });
 
-  libva = callPackage ../development/libraries/libva { };
-  libva-full = libva.override { minimal = false; };
-  libva-utils = callPackage ../development/libraries/libva-utils { };
+  inherit (callPackage ../development/libraries/libva { })
+    libva_1
+    libva-full_1
+    libva_2
+    libva-full_2;
+
+  inherit (callPackage ../development/libraries/libva-utils { })
+    libva-utils_1
+    libva-utils_2;
+
+  libva = libva_2;
+  libva-full = libva-full_2;
+  libva-utils = libva-utils_2;
 
   libvdpau = callPackage ../development/libraries/libvdpau { };
 
@@ -11088,9 +11098,10 @@ with pkgs;
 
   v8_static = lowPrio (self.v8.override { static = true; });
 
-  vaapiIntel = callPackage ../development/libraries/vaapi-intel {
-    libva = libva-full; # also wants libva-{x11,drm,wayland}
-  };
+  inherit (callPackage ../development/libraries/vaapi-intel { })
+    vaapiIntel_1
+    vaapiIntel_2;
+  vaapiIntel = vaapiIntel_2;
 
   vaapiVdpau = callPackage ../development/libraries/vaapi-vdpau {
     libva = libva-full; # needs libva-{x11,glx}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15975,7 +15975,7 @@ with pkgs;
     lua = lua5_1;
     lua5_sockets = lua5_1_sockets;
     youtube-dl = pythonPackages.youtube-dl;
-    libva = libva-full;
+    libva = libva-full_1; # Version > 0.27 should be able to use libva-full (ie v2)
     waylandSupport = stdenv.isLinux;
   };
 


### PR DESCRIPTION
###### Motivation for this change

We need to carry both v1 and v2 of the ```libva``` libraries as not all downstream projects have been updated accordingly.

Further to #32599

Currently building here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

