### PR TITLE
albert: 0.14.7 -> 0.14.14

### DIFF
--- a/pkgs/applications/misc/albert/default.nix
+++ b/pkgs/applications/misc/albert/default.nix
@@ -1,15 +1,15 @@
-{ mkDerivation, lib, fetchFromGitHub, makeWrapper, qtbase, qtdeclarative, qtsvg, qtx11extras, muparser,
-  cmake, python3 }:
+{ mkDerivation, lib, fetchFromGitHub, makeWrapper, qtbase,
+  qtdeclarative, qtsvg, qtx11extras, muparser, cmake, python3 }:
 
 mkDerivation rec {
   name    = "albert-${version}";
-  version = "0.14.7";
+  version = "0.14.14";
 
   src = fetchFromGitHub {
     owner  = "albertlauncher";
     repo   = "albert";
     rev    = "v${version}";
-    sha256 = "1ryjrbrbgignhkvsv4021l4am8ml7g8v4bs5cp5jj288k4p2rf4n";
+    sha256 = "1skh709f4y4p0vqabvvysn6fgws2yq8izbwkib7rfjc357chhmi7";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Update to version 0.14.14

[News](https://packages.debian.org/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).