### PR TITLE
mnemosyne: 2.3.2 -> 2.6

### DIFF
--- a/pkgs/games/mnemosyne/default.nix
+++ b/pkgs/games/mnemosyne/default.nix
@@ -1,30 +1,40 @@
 { stdenv
 , fetchurl
-, pythonPackages
+, python
 }:
-let
-  version = "2.3.2";
-in pythonPackages.buildPythonApplication rec {
-  name = "mnemosyne-${version}";
+
+python.pkgs.buildPythonApplication rec {
+  pname = "mnemosyne";
+  version = "2.6";
+
   src = fetchurl {
-    url    = "http://sourceforge.net/projects/mnemosyne-proj/files/mnemosyne/${name}/Mnemosyne-${version}.tar.gz";
-    sha256 = "0jkrw45i4v24p6xyq94z7rz5948h7f5dspgs5mcdaslnlp2accfp";
+    url    = "mirror://sourceforge/project/mnemosyne-proj/mnemosyne/mnemosyne-${version}/Mnemosyne-${version}.tar.gz";
+    sha256 = "0b7b5sk5bfbsg5cyybkv5xw9zw257v3khsn0lwlbxnlhakd0rsg4";
   };
-  propagatedBuildInputs = with pythonPackages; [
-    pyqt4
+
+  propagatedBuildInputs = with python.pkgs; [
+    pyqt5
     matplotlib
     cherrypy
+    cheroot
     webob
+    pillow
   ];
-  preConfigure = ''
+
+  # No tests/ directrory in tarball
+  doCheck = false;
+
+  prePatch = ''
     substituteInPlace setup.py --replace /usr $out
     find . -type f -exec grep -H sys.exec_prefix {} ';' | cut -d: -f1 | xargs sed -i s,sys.exec_prefix,\"$out\",
   '';
+
   postInstall = ''
     mkdir -p $out/share
-    mv $out/lib/python2.7/site-packages/$out/share/locale $out/share
-    rm -r $out/lib/python2.7/site-packages/nix
+    mv $out/${python.sitePackages}/$out/share/locale $out/share
+    rm -r $out/${python.sitePackages}/nix
   '';
+
   meta = {
     homepage = https://mnemosyne-proj.org/;
     description = "Spaced-repetition software";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18489,7 +18489,9 @@ with pkgs;
     libpng = libpng12;
   };
 
-  mnemosyne = callPackage ../games/mnemosyne { };
+  mnemosyne = callPackage ../games/mnemosyne {
+    python = python3;
+  };
 
   mrrescue = callPackage ../games/mrrescue { };
 


### PR DESCRIPTION
###### Motivation for this change
Mnemosyne was broken previously, because tests failed during install.
I updated it, but still something goes very wrong in the checkPhase if I don't disable checks:
```
running build_ext
Traceback (most recent call last):
  File "nix_run_setup.py", line 8, in <module>
    exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
  File "setup.py", line 178, in <module>
    app = py2app_app
  File "/nix/store/vyn106wj077zhv3n7w9c0nwjwq3xja0z-python3.6-bootstrapped-pip-9.0.1/lib/python3.6/site-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/nix/store/nrv3zzw9a42vax72gaif8bjgxgnv9iy1-python3-3.6.3/lib/python3.6/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/nix/store/nrv3zzw9a42vax72gaif8bjgxgnv9iy1-python3-3.6.3/lib/python3.6/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/nix/store/nrv3zzw9a42vax72gaif8bjgxgnv9iy1-python3-3.6.3/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/nix/store/vyn106wj077zhv3n7w9c0nwjwq3xja0z-python3.6-bootstrapped-pip-9.0.1/lib/python3.6/site-packages/setuptools/command/test.py", line 226, in run
    self.run_tests()
  File "/nix/store/vyn106wj077zhv3n7w9c0nwjwq3xja0z-python3.6-bootstrapped-pip-9.0.1/lib/python3.6/site-packages/setuptools/command/test.py", line 248, in run_tests
    exit=False,
  File "/nix/store/nrv3zzw9a42vax72gaif8bjgxgnv9iy1-python3-3.6.3/lib/python3.6/unittest/main.py", line 94, in __init__
    self.parseArgs(argv)
  File "/nix/store/nrv3zzw9a42vax72gaif8bjgxgnv9iy1-python3-3.6.3/lib/python3.6/unittest/main.py", line 118, in parseArgs
    self._do_discovery(argv[2:])
  File "/nix/store/nrv3zzw9a42vax72gaif8bjgxgnv9iy1-python3-3.6.3/lib/python3.6/unittest/main.py", line 229, in _do_discovery
    self.test = loader.discover(self.start, self.pattern, self.top)
  File "/nix/store/nrv3zzw9a42vax72gaif8bjgxgnv9iy1-python3-3.6.3/lib/python3.6/unittest/loader.py", line 341, in discover
    tests = list(self._find_tests(start_dir, pattern))
  File "/nix/store/nrv3zzw9a42vax72gaif8bjgxgnv9iy1-python3-3.6.3/lib/python3.6/unittest/loader.py", line 398, in _find_tests
    full_path, pattern, namespace)
  File "/nix/store/nrv3zzw9a42vax72gaif8bjgxgnv9iy1-python3-3.6.3/lib/python3.6/unittest/loader.py", line 475, in _find_test_path
    tests = self.loadTestsFromModule(package, pattern=pattern)
  File "/nix/store/vyn106wj077zhv3n7w9c0nwjwq3xja0z-python3.6-bootstrapped-pip-9.0.1/lib/python3.6/site-packages/setuptools/command/test.py", line 52, in loadTestsFromModule
    tests.append(self.loadTestsFromName(submodule))
  File "/nix/store/nrv3zzw9a42vax72gaif8bjgxgnv9iy1-python3-3.6.3/lib/python3.6/unittest/loader.py", line 190, in loadTestsFromName
    return self.loadTestsFromModule(obj)
  File "/nix/store/vyn106wj077zhv3n7w9c0nwjwq3xja0z-python3.6-bootstrapped-pip-9.0.1/lib/python3.6/site-packages/setuptools/command/test.py", line 52, in loadTestsFromModule
    tests.append(self.loadTestsFromName(submodule))
  File "/nix/store/nrv3zzw9a42vax72gaif8bjgxgnv9iy1-python3-3.6.3/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/tmp/nix-build-mnemosyne-2.6.drv-0/Mnemosyne-2.6/mnemosyne/pyqt_ui/configuration_wdgt_main.py", line 18, in <module>
    Ui_ConfigurationWdgtMain):
  File "/tmp/nix-build-mnemosyne-2.6.drv-0/Mnemosyne-2.6/mnemosyne/pyqt_ui/configuration_wdgt_main.py", line 20, in ConfigurationWdgtMain
    name = _("General")
TypeError: 'NoneType' object is not callable
```

At least, I'm now able to run the program.
Nevertheless, there also seem to be errors within the program. For example, when starting a server and accessing it via web browser (http://localhost:8513/), some error with a `NoneType` occurs.
I sadly don't have the time to look into these and I've also never made contact with PyQt.

/cc @lverns @domenkozar @peti

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

