### PR TITLE
warzone2100: 3.2.2 -> 3.2.3

### DIFF
--- a/pkgs/games/warzone2100/default.nix
+++ b/pkgs/games/warzone2100/default.nix
@@ -12,12 +12,12 @@ let
 in
 
 stdenv.mkDerivation rec {
-  version = "3.2.2";
+  version = "3.2.3";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/${pname}/releases/${version}/${name}.tar.xz";
-    sha256 = "064xfxwkqpvqyy7kz46cwi71mxmimxi4wgjly9g51wwxkvz8snmg";
+    sha256 = "10kmpr4cby95zwqsl1zwx95d9achli6khq7flv6xmrq30a39xazw";
   };
 
   buildInputs = [ qtbase qtscript SDL2 libtheora openal glew physfs fribidi ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @astsmtl (mantainer)