### PR TITLE
atom-beta: 1.23.0-beta0->1.24.0-beta1

### DIFF
--- a/pkgs/applications/editors/atom/beta.nix
+++ b/pkgs/applications/editors/atom/beta.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "atom-beta-${version}";
-  version = "1.23.0-beta0";
+  version = "1.24.0-beta1";
 
   src = fetchurl {
     url = "https://github.com/atom/atom/releases/download/v${version}/atom-amd64.deb";
-    sha256 = "1vfc8jin07kivdmyw88vbzinbjsb6py9n2ggpvy4cccagnvxwj2y";
+    sha256 = "04cyxmk2h8qg9rzs8rm28xsahkkq9d8j14afmp5yx4p26qycdbg5";
     name = "${name}.deb";
   };
 


### PR DESCRIPTION
###### Motivation for this change

A simple version bump; main was updated to 1.23 in 0be3f2cdd8fdad523e756b6899b0119fa43277af, it doesn't make sense to keep 1.23.0-beta0 around, does it?

/cc @NeQuissimus 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note: I have no idea what I'm doing. Seriously. I was just mimicking 0be3f2cdd8fdad523e756b6899b0119fa43277af. I think hash at least is correct (computed via `nix-hash --base32 --type sha256 --flat`). I hope I'm not just needlessly wasting anyone's time.