### PR TITLE
collectd: 5.7.2 -> 5.8.0

### DIFF
--- a/pkgs/development/libraries/libcollectdclient/default.nix
+++ b/pkgs/development/libraries/libcollectdclient/default.nix
@@ -5,13 +5,16 @@ overrideDerivation collectd (oldAttrs: {
   name = "libcollectdclient-${collectd.version}";
   buildInputs = [ ];
 
-  configureFlags = [
-    "--without-daemon"
+  NIX_CFLAGS_COMPILE = oldAttrs.NIX_CFLAGS_COMPILE ++ [
+    "-Wno-error=unused-function"
   ];
 
-  makeFlags = [
-    "-C src/libcollectdclient/"
+  configureFlags = oldAttrs.configureFlags ++ [
+    "--disable-daemon"
+    "--disable-all-plugins"
   ];
+
+  postInstall = "rm -rf $out/{bin,etc,sbin,share}";
 
 }) // {
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/libsigrok/default.nix
+++ b/pkgs/development/tools/libsigrok/default.nix
@@ -1,37 +1,47 @@
 { stdenv, fetchurl, pkgconfig, libzip, glib, libusb1, libftdi1, check
 , libserialport, librevisa, doxygen, glibmm, python
-, version ? "0.5.0", sha256 ? "197kr5ip98lxn7rv10zs35d1w0j7265s0xvckx0mq2l8kdvqd32c"
 }:
 
-stdenv.mkDerivation rec {
-  inherit version;
-  name = "libsigrok-${version}";
+let
+  common = {version, sha256}: stdenv.mkDerivation rec {
+    inherit version;
+    name = "libsigrok-${version}";
 
-  src = fetchurl {
-    url = "http://sigrok.org/download/source/libsigrok/${name}.tar.gz";
-    inherit sha256;
+    src = fetchurl {
+      url = "http://sigrok.org/download/source/libsigrok/${name}.tar.gz";
+      inherit sha256;
+    };
+
+    firmware = fetchurl {
+      url = "http://sigrok.org/download/binary/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-bin-0.1.3.tar.gz";
+      sha256 = "1qr02ny97navqxr56xq1a227yzf6h09m8jlvc9bnjl0bsk6887bl";
+    };
+
+    nativeBuildInputs = [ pkgconfig ];
+    buildInputs = [ libzip glib libusb1 libftdi1 check libserialport
+      librevisa doxygen glibmm python
+    ];
+
+    postInstall = ''
+      mkdir -p "$out/share/sigrok-firmware/"
+      tar --strip-components=1 -xvf "${firmware}" -C "$out/share/sigrok-firmware/"
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Core library of the sigrok signal analysis software suite";
+      homepage = http://sigrok.org/;
+      license = licenses.gpl3Plus;
+      platforms = platforms.linux;
+      maintainers = [ maintainers.bjornfor ];
+    };
   };
-
-  firmware = fetchurl {
-    url = "http://sigrok.org/download/binary/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-bin-0.1.3.tar.gz";
-    sha256 = "1qr02ny97navqxr56xq1a227yzf6h09m8jlvc9bnjl0bsk6887bl";
+in {
+  libsigrok_0_3 = common {
+    version = "0.3.0";
+    sha256 = "0l3h7zvn3w4c1b9dgvl3hirc4aj1csfkgbk87jkpl7bgl03nk4j3";
   };
-
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libzip glib libusb1 libftdi1 check libserialport
-    librevisa doxygen glibmm python
-  ];
-
-  postInstall = ''
-    mkdir -p "$out/share/sigrok-firmware/"
-    tar --strip-components=1 -xvf "${firmware}" -C "$out/share/sigrok-firmware/"
-  '';
-
-  meta = with stdenv.lib; {
-    description = "Core library of the sigrok signal analysis software suite";
-    homepage = http://sigrok.org/;
-    license = licenses.gpl3Plus;
-    platforms = platforms.linux;
-    maintainers = [ maintainers.bjornfor ];
+  libsigrok_0_5 = common {
+    version = "0.5.0";
+    sha256 = "197kr5ip98lxn7rv10zs35d1w0j7265s0xvckx0mq2l8kdvqd32c";
   };
 }

--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -14,7 +14,7 @@
 , libnotify ? null, gdk_pixbuf ? null
 , liboping ? null
 , libpcap ? null
-, libsigrok ? null
+, libsigrok_0_3 ? null
 , libvirt ? null
 , libxml2 ? null
 , libtool ? null
@@ -25,7 +25,7 @@
 , protobufc ? null
 , python ? null
 , rabbitmq-c ? null
-, riemann ? null
+, riemann_c_client ? null
 , rrdtool ? null
 , udev ? null
 , varnish ? null
@@ -33,18 +33,21 @@
 , net_snmp ? null
 , hiredis ? null
 , libmnl ? null
+, mosquitto ? null
+, rdkafka ? null
+, mongoc ? null
 }:
 stdenv.mkDerivation rec {
-  version = "5.7.2";
+  version = "5.8.0";
   name = "collectd-${version}";
 
   src = fetchurl {
     url = "http://collectd.org/files/${name}.tar.bz2";
-    sha256 = "14p5cc3ys3qfg71xzxfvmxdmz5l4brpbhlmw1fwdda392lia084x";
+    sha256 = "1j8mxgfq8039js2bscphd6cnriy35hk4jrxfjz5k6mghpdvg8vxh";
   };
 
-  # on 5.7.2: lvm2app.h:21:2: error: #warning "liblvm2app is deprecated, use D-Bus API instead." [-Werror=cpp]
-  NIX_CFLAGS_COMPILE = "-Wno-error=cpp";
+  # on 5.8.0: lvm2app.h:21:2: error: #warning "liblvm2app is deprecated, use D-Bus API instead." [-Werror=cpp]
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=cpp" ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
@@ -52,19 +55,16 @@ stdenv.mkDerivation rec {
     cyrus_sasl libnotify gdk_pixbuf liboping libpcap libvirt
     libxml2 libmysql postgresql protobufc rrdtool
     varnish yajl jdk libtool python hiredis libmicrohttpd
+    riemann_c_client mosquitto rdkafka mongoc
   ] ++ stdenv.lib.optionals stdenv.isLinux [
-    iptables libatasmart libcredis libmodbus libsigrok
+    iptables libatasmart libcredis libmodbus libsigrok_0_3
     lm_sensors lvm2 rabbitmq-c udev net_snmp libmnl
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.IOKit
     darwin.apple_sdk.frameworks.ApplicationServices
   ];
 
-  # for some reason libsigrok isn't auto-detected
-  configureFlags =
-    [ "--localstatedir=/var" ] ++
-    stdenv.lib.optional (stdenv.isLinux && libsigrok != null) "--with-libsigrok" ++
-    stdenv.lib.optional (python != null) "--with-python=${python}/bin/python";
+  configureFlags = [ "--localstatedir=/var" ];
 
   # do not create directories in /var during installPhase
   postConfigure = ''
@@ -76,6 +76,8 @@ stdenv.mkDerivation rec {
       mv $out/share/collectd/java $out/share/
     fi
   '';
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Daemon which collects system performance statistics periodically";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1504,7 +1504,6 @@ with pkgs;
 
   collectd = callPackage ../tools/system/collectd {
     libmysql = mysql.lib;
-    libsigrok = libsigrok-0-3-0; # not compatible with >= 0.4.0 yet
   };
 
   collectd-data = callPackage ../tools/system/collectd/data.nix { };
@@ -7270,12 +7269,10 @@ with pkgs;
 
   libstdcxx5 = callPackage ../development/libraries/libstdc++5 { };
 
-  libsigrok = callPackage ../development/tools/libsigrok { };
-  # old version:
-  libsigrok-0-3-0 = libsigrok.override {
-    version = "0.3.0";
-    sha256 = "0l3h7zvn3w4c1b9dgvl3hirc4aj1csfkgbk87jkpl7bgl03nk4j3";
-  };
+  inherit (callPackages ../development/tools/libsigrok { })
+    libsigrok_0_3
+    libsigrok_0_5;
+  libsigrok = libsigrok_0_5;
 
   libsigrokdecode = callPackage ../development/tools/libsigrokdecode { };
 


### PR DESCRIPTION
###### Motivation for this change

New version is aware about new versions of the softwares ```collectd``` can monitor (for example Varnish 5.2.x)

Fixes #32061

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

