### PR TITLE
Update foo2zjs.

### DIFF
--- a/pkgs/misc/drivers/foo2zjs/default.nix
+++ b/pkgs/misc/drivers/foo2zjs/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, foomatic-filters, bc, unzip, ghostscript, systemd, vim }:
 
 stdenv.mkDerivation rec {
-  name = "foo2zjs-20110210";
+  name = "foo2zjs-20171202";
 
   src = fetchurl {
     url = "http://www.loegria.net/mirrors/foo2zjs/${name}.tar.gz";
-    sha256 = "0vss8gdbbgxr694xw48rys2qflbnb4sp4gdb1v6z4m9ab97hs5yk";
+    sha256 = "b63c65e8e0e7c9fd8d19b9e63f7cd85048eba01a877aac1ca13a6bfc979ea182";
   };
 
   buildInputs = [ foomatic-filters bc unzip ghostscript systemd vim ];


### PR DESCRIPTION
###### Motivation for this change

Support printer Samsung CLX-3185FN.

###### Things done

Update foo2zjs to latest upstream version (2011-02-10 to 2017-12-02).  Configured nixos to use foo2zjs driver, installed printer on localhost:631, printed a test page.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

