### PR TITLE
build-support: clean-up fetchSvn

### DIFF
--- a/pkgs/build-support/fetchsvn/builder.sh
+++ b/pkgs/build-support/fetchsvn/builder.sh
@@ -22,11 +22,7 @@ if test -z "$LC_ALL"; then
     export LC_ALL="en_US.UTF-8"
 fi;
 
-# Pipe the "p" character into Subversion to force it to accept the
-# server's certificate.  This is perfectly safe: we don't care
-# whether the server is being spoofed --- only the cryptographic
-# hash of the output matters. Pass in extra p's to handle redirects.
-printf 'p\np\np\n' | svn export --trust-server-cert --non-interactive \
+svn export --trust-server-cert --non-interactive \
     ${ignoreExternals:+--ignore-externals} ${ignoreKeywords:+--ignore-keywords} \
     -r "$rev" "$url" "$out"
 


### PR DESCRIPTION
###### Motivation for this change

Remove old workaround rendered unnecessary by af9db522cf7053797f5d0729698cfafe47aac9be

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

