### PR TITLE
mousepad: backport fix of issue 12134, resolves #14862

### DIFF
--- a/pkgs/desktops/xfce/applications/mousepad-12134.patch
+++ b/pkgs/desktops/xfce/applications/mousepad-12134.patch
@@ -1,0 +1,90 @@
+diff -urNZ a/mousepad/mousepad-action-group.c b/mousepad/mousepad-action-group.c
+--- a/mousepad/mousepad-action-group.c	2014-09-01 20:50:07.000000000 +0000
++++ b/mousepad/mousepad-action-group.c	2017-12-18 16:57:46.836538403 +0000
+@@ -302,11 +302,6 @@
+   gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), TRUE);
+   self->locked = FALSE;
+ 
+-  /* update the setting when the active action is changed */
+-  self->locked = TRUE;
+-  MOUSEPAD_SETTING_SET_STRING (COLOR_SCHEME, gtk_source_style_scheme_get_id (scheme));
+-  self->locked = FALSE;
+-
+   g_object_notify (G_OBJECT (self), "active-style-scheme");
+ }
+ 
+@@ -473,6 +468,8 @@
+ mousepad_action_group_style_scheme_action_activate (MousepadActionGroup       *self,
+                                                     MousepadStyleSchemeAction *action)
+ {
++  const gchar *scheme_name = NULL;
++
+   /* only update the active action if we're not already in the process of
+    * setting it and the sender action is actually active */
+   if (! self->locked &&
+@@ -481,7 +478,14 @@
+       GtkSourceStyleScheme *scheme;
+ 
+       scheme = mousepad_style_scheme_action_get_style_scheme (action);
+-      mousepad_action_group_set_active_style_scheme (self, scheme);
++
++      /* update the setting when the active action is changed */
++      if (scheme != NULL)
++        scheme_name = gtk_source_style_scheme_get_id(scheme);
++
++      self->locked = TRUE;
++      MOUSEPAD_SETTING_SET_STRING (COLOR_SCHEME, scheme_name);
++      self->locked = FALSE;
+     }
+ }
+ 
+diff -urNZ a/mousepad/mousepad-window.c b/mousepad/mousepad-window.c
+--- a/mousepad/mousepad-window.c	2014-09-01 20:58:02.000000000 +0000
++++ b/mousepad/mousepad-window.c	2017-12-18 17:07:51.099321408 +0000
+@@ -712,32 +712,6 @@
+ 
+ 
+ static void
+-mousepad_window_action_group_style_scheme_changed (MousepadWindow      *window,
+-                                                   GParamSpec          *pspec,
+-                                                   MousepadActionGroup *group)
+-{
+-  GtkSourceStyleScheme *scheme;
+-  const gchar          *scheme_id;
+-  gint                  npages, i;
+-
+-  /* get the new active language */
+-  scheme = mousepad_action_group_get_active_style_scheme (group);
+-  scheme_id = gtk_source_style_scheme_get_id (scheme);
+-
+-  /* update the color scheme on all the documents */
+-  npages = gtk_notebook_get_n_pages (GTK_NOTEBOOK (window->notebook));
+-  for (i = 0; i < npages; i++)
+-    {
+-      MousepadDocument *document;
+-
+-      document = MOUSEPAD_DOCUMENT (gtk_notebook_get_nth_page (GTK_NOTEBOOK (window->notebook), i));
+-      mousepad_view_set_color_scheme (document->textview, scheme_id);
+-    }
+-}
+-
+-
+-
+-static void
+ mousepad_window_create_style_schemes_menu (MousepadWindow *window)
+ {
+   GtkWidget           *menu, *item;
+@@ -751,13 +725,6 @@
+   gtk_menu_item_set_submenu (GTK_MENU_ITEM (item), menu);
+   gtk_widget_show_all (menu);
+   gtk_widget_show (item);
+-  
+-  /* watch for activations of the style schemes actions */
+-  g_signal_connect_object (window->action_group,
+-                           "notify::active-style-scheme",
+-                           G_CALLBACK (mousepad_window_action_group_style_scheme_changed),
+-                           window,
+-                           G_CONNECT_SWAPPED);
+ }
+ 
+ 

--- a/pkgs/desktops/xfce/applications/mousepad.nix
+++ b/pkgs/desktops/xfce/applications/mousepad.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
   };
   name = "${p_name}-${ver_maj}.${ver_min}";
 
+  patches = [ ./mousepad-12134.patch ];
+
   buildInputs =
     [ pkgconfig intltool libxfce4util
       gtk gtksourceview dbus dbus_glib makeWrapper


### PR DESCRIPTION
###### Motivation for this change

Resolves #14862. This should also be ported to stable.

https://bugzilla.xfce.org/show_bug.cgi?id=12134

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

