### PR TITLE
haskell: set buildInputs in nix-shell env

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -362,7 +362,8 @@ stdenv.mkDerivation ({
 
     env = stdenv.mkDerivation {
       name = "interactive-${pname}-${version}-environment";
-      nativeBuildInputs = [ ghcEnv systemBuildInputs ];
+      buildInputs = systemBuildInputs;
+      nativeBuildInputs = [ ghcEnv ];
       LANG = "en_US.UTF-8";
       LOCALE_ARCHIVE = optionalString stdenv.isLinux "${glibcLocales}/lib/locale/locale-archive";
       shellHook = ''


### PR DESCRIPTION
### Motivation

`nix-shell` for Haskell projects with foreign library dependencies is broken because GCC cannot find headers or libraries.

systemBuildInputs goes in buildInputs (instead of nativeBuildInputs) so that
NIX_CFLAGS_* is set correctly and gcc works.

### Testing 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] ~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Because Haskell packages use a separate shell environment not derived from the build environment, this should not affect the build of anything in Nixpkgs.