### PR TITLE
tuntox: init at 0.0.8

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -306,6 +306,7 @@
       ceph = 288;
       duplicati = 289;
       monetdb = 290;
+      tuntox = 291;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -580,6 +581,7 @@
       ceph = 288;
       duplicati = 289;
       monetdb = 290;
+      tuntox = 291;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -576,6 +576,7 @@
   ./services/networking/tftpd.nix
   ./services/networking/tox-bootstrapd.nix
   ./services/networking/toxvpn.nix
+  ./services/networking/tuntox.nix
   ./services/networking/tvheadend.nix
   ./services/networking/unbound.nix
   ./services/networking/unifi.nix

--- a/nixos/modules/services/networking/tuntox.nix
+++ b/nixos/modules/services/networking/tuntox.nix
@@ -1,0 +1,108 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.tuntox.server;
+  hostsWhitelistFile = pkgs.writeText "tuntox-hosts-whitelist" ''
+    ${toString cfg.hostsWhitelist}
+  '';
+  persistentIdDirectory = "/var/lib/tuntox";
+in
+{
+  options = {
+    services.tuntox.server = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "If enabled, start the Tuntox Service.";
+      };
+
+      relayPort = mkOption {
+        type = types.nullOr types.string;
+        default = null;
+        description = "Set TCP relay port (0 disables TCP relaying)";
+      };
+
+      portRange = mkOption {
+        type = types.nullOr types.string;
+        default = null;
+        description = "Set Tox UDP port range (<literal>port:port</literal>)";
+      };
+
+      persistentId = mkOption {
+        type = types.bool;
+        default = false;
+        description = "If enabled, persist the tox id between runs";
+      };
+
+      hostsWhitelist = mkOption {
+        type = types.listOf (types.separatedString "\n");
+        default = [];
+        description = "Only allow connections to the specified <literal>hostname:port</literal> pairs";
+      };
+
+      idWhitelist = mkOption {
+        type = types.listOf (types.separatedString " ");
+        default = [];
+        description = "Whitelisted Tox IDs. If empty, id whitelisting will be disabled";
+      };
+
+      secret = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Shared secret used for connection authentication";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    warnings =
+      if cfg.secret == null && cfg.idWhitelist == []
+      then [ ''Tuntox is insecure without either <literal>secret</literal>
+               or <literal>idWhitelist</literal> non-empty (preferably both).'' ]
+      else [];
+
+    users.extraUsers.tuntox = {
+      description     = "Tuntox Service user";
+      createHome      = false;
+      isSystemUser    = true;
+      uid             = config.ids.uids.tuntox;
+    };
+
+    systemd.services.tuntox = {
+      description = "Tuntox Tunnel Service";
+      wantedBy    = [ "multi-user.target" ];
+      after       = [ "network.target "];
+
+      serviceConfig = {
+        Type      = "simple";
+        Restart   = "on-failure";
+        User      = "tuntox";
+        Group     = "tuntox";
+        ExecStart =
+          ''
+            ${pkgs.tuntox}/bin/tuntox \
+              -C /var/lib/tuntox \
+              ${optionalString (cfg.relayPort != null) "-t ${cfg.relayPort}"} \
+              ${optionalString (cfg.portRange != null) "-u ${cfg.portRange}"} \
+              ${optionalString (cfg.hostsWhitelist != []) "-f ${hostsWhitelistFile}"} \
+              ${toString (map (toxId: "-i ${toxId}") cfg.idWhitelist)}
+          '';
+        PermissionsStartOnly = true;
+        ProtectSystem = "strict";
+      } // optionalAttrs cfg.persistentId {
+        ReadWriteDirectories = persistentIdDirectory;
+      } // optionalAttrs (cfg.secret != null) {
+        Environment = "TUNTOX_SHARED_SECRET=${cfg.secret}";
+      };
+
+      preStart = ''
+        mkdir -p ${persistentIdDirectory}
+        chown -R tuntox ${persistentIdDirectory}
+        chmod -R ${if cfg.persistentId then "700" else "000"} ${persistentIdDirectory}
+      '';
+    };
+  };
+}

--- a/pkgs/tools/networking/tuntox/default.nix
+++ b/pkgs/tools/networking/tuntox/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, libtoxcore, libsodium, libevent }:
+
+stdenv.mkDerivation rec {
+  name = "tuntox-${version}";
+  version = "0.0.8";
+
+  nativeBuildInputs = [
+    pkgconfig
+  ];
+
+  buildInputs = [
+    libtoxcore
+    libsodium
+    libevent
+  ];
+
+  src = fetchFromGitHub {
+    owner = "gjedeer";
+    repo = "tuntox";
+    rev = "${version}";
+    sha256 = "1vm34w6jxg5vhzk2lzpmv6s0182l4ic8ic9kq6x2l84m78i0wjm9";
+  };
+
+  makeFlags = "tuntox_nostatic";
+
+  installPhase = ''
+    install -m755 -D tuntox_nostatic "$out/bin/tuntox"
+    install -m755 -D scripts/tokssh "$out/bin/tokssh"
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Tunnel TCP connections over the Tox protocol";
+    longDescription = ''
+      Tuntox is a program which forwards TCP connections over the Tox protocol.
+      This allows low-latency access to distant machines behind a NAT you can't
+      control or with a dynamic IP address.
+    '';
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ fgaz ];
+    homepage = https://github.com/gjedeer/tuntox;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1420,6 +1420,8 @@ with pkgs;
     hiredis = null;
   };
 
+  tuntox = callPackage ../tools/networking/tuntox { } ;
+
   mar1d = callPackage ../games/mar1d { } ;
 
   mcrypt = callPackage ../tools/misc/mcrypt { };


### PR DESCRIPTION
###### Motivation for this change

Add the [tuntox](https://github.com/gjedeer/tuntox) package and a systemd service to set up a server with it. I may also add a tuntox client service in the future, so the server is under the `tuntox.server` namespace

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
  - **This causes the PreStart script to fail!** Any idea why? Maybe I shouldn't create that directory that way, but I couldn't find alternatives.. or maybe `/var` isn't the right place?
    ```
    tuntox.service: Failed at step NAMESPACE spawning /nix/store/wa0c5wzs92ngv7qbsbi0c3dvlxwk2fs0-unit-script/bin/tuntox-pre-start: No such file or directory
    ```
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

