### PR TITLE
More GNOME clean-ups

### DIFF
--- a/pkgs/desktops/gnome-3/apps/glade/default.nix
+++ b/pkgs/desktops/gnome-3/apps/glade/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, intltool, fetchurl, python
+{ stdenv, intltool, fetchurl, python3
 , pkgconfig, gtk3, glib, gobjectIntrospection
 , wrapGAppsHook, itstool, libxml2, docbook_xsl
 , gnome3, gdk_pixbuf, libxslt }:
@@ -9,9 +9,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig intltool itstool wrapGAppsHook docbook_xsl libxslt gobjectIntrospection
   ];
-  buildInputs = [ gtk3 glib libxml2 python
-                  gnome3.gsettings_desktop_schemas
-                  gdk_pixbuf gnome3.defaultIconTheme ];
+  buildInputs = [
+    gtk3 glib libxml2 python3 python3.pkgs.pygobject3
+    gnome3.gsettings_desktop_schemas
+    gdk_pixbuf gnome3.defaultIconTheme
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, gnome3, python, dconf
+{ fetchurl, stdenv, pkgconfig, gnome3, python3, dconf
 , intltool, libsoup, libxml2, libsecret, icu, sqlite
 , p11_kit, db, nspr, nss, libical, gperf, makeWrapper, valaSupport ? true
 , vala, cmake, kerberos, openldap, webkitgtk, libaccounts-glib, json_glib }:
@@ -6,21 +6,25 @@
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
-  nativeBuildInputs = [ cmake pkgconfig intltool python gperf makeWrapper ];
-  buildInputs = with gnome3;
-    [ glib libsoup libxml2 gtk gnome_online_accounts
-      (stdenv.lib.getLib dconf) gcr p11_kit libgweather libgdata
-      icu sqlite gsettings_desktop_schemas kerberos openldap webkitgtk
-      libaccounts-glib json_glib ]
-    ++ stdenv.lib.optional valaSupport vala;
+  nativeBuildInputs = [
+    cmake pkgconfig intltool python3 gperf makeWrapper
+  ] ++ stdenv.lib.optional valaSupport vala;
+  buildInputs = with gnome3; [
+    glib libsoup libxml2 gtk gnome_online_accounts
+    gcr p11_kit libgweather libgdata libaccounts-glib json_glib
+    icu sqlite kerberos openldap webkitgtk
+  ];
 
   propagatedBuildInputs = [ libsecret nss nspr libical db ];
 
   # uoa irrelevant for now
-  cmakeFlags = [ "-DENABLE_UOA=OFF" ]
-                   ++ stdenv.lib.optionals valaSupport [
-                     "-DENABLE_VALA_BINDINGS=ON" "-DENABLE_INTROSPECTION=ON"
-                     "-DCMAKE_SKIP_BUILD_RPATH=OFF" ];
+  cmakeFlags = [
+    "-DENABLE_UOA=OFF"
+  ] ++ stdenv.lib.optionals valaSupport [
+    "-DENABLE_VALA_BINDINGS=ON"
+    "-DENABLE_INTROSPECTION=ON"
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
+  ];
 
   enableParallelBuilding = true;
 
@@ -33,8 +37,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    platforms = platforms.linux;
+    license = licenses.lgpl2;
     maintainers = gnome3.maintainers;
+    platforms = platforms.linux;
   };
-
 }

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -2,7 +2,7 @@
 , libcanberra_gtk3, accountsservice, libpwquality, libpulseaudio
 , gdk_pixbuf, librsvg, libnotify, libgudev
 , libxml2, polkit, libxslt, libgtop, libsoup, colord, colord-gtk
-, cracklib, python, libkrb5, networkmanagerapplet, networkmanager
+, cracklib, libkrb5, networkmanagerapplet, networkmanager
 , libwacom, samba, shared_mime_info, tzdata, libtool
 , docbook_xsl, docbook_xsl_ns, modemmanager, clutter, clutter_gtk
 , fontconfig, sound-theme-freedesktop, grilo }:

--- a/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, python, libxml2Python, libxslt, which, libX11, gnome3, gtk3, glib
-, intltool, gnome_doc_utils, libxkbfile, xkeyboard_config, isocodes, itstool, wayland
+{ stdenv, fetchurl, pkgconfig, libxslt, which, libX11, gnome3, gtk3, glib
+, intltool, gnome_doc_utils, xkeyboard_config, isocodes, itstool, wayland
 , libseccomp, bubblewrap, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
@@ -13,9 +13,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig which itstool intltool libxslt gnome_doc_utils gobjectIntrospection
   ];
-  buildInputs = [ python libxml2Python libX11 bubblewrap
-                  xkeyboard_config isocodes wayland
-                  gtk3 glib libxkbfile libseccomp ];
+  buildInputs = [
+    libX11 bubblewrap xkeyboard_config isocodes wayland
+    gtk3 glib libseccomp
+  ];
 
   propagatedBuildInputs = [ gnome3.gsettings_desktop_schemas ];
 
@@ -29,6 +30,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    description = "Library with common API for various GNOME modules";
+    license = with licenses; [ gpl2 lgpl2 ];
     platforms = platforms.linux;
     maintainers = gnome3.maintainers;
   };

--- a/pkgs/desktops/gnome-3/core/gnome-keyring/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-keyring/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, dbus, libgcrypt, libtasn1, pam, python, glib, libxslt
+{ stdenv, fetchurl, pkgconfig, dbus, libgcrypt, libtasn1, pam, python2, glib, libxslt
 , intltool, pango, gcr, gdk_pixbuf, atk, p11_kit, wrapGAppsHook
-, docbook_xsl_ns, docbook_xsl, gnome3 }:
+, docbook_xsl, docbook_xml_dtd_42, gnome3 }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
@@ -8,21 +8,41 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   buildInputs = with gnome3; [
-    dbus libgcrypt pam python gtk3 gconf libgnome_keyring
+    dbus libgcrypt pam gtk3 gconf libgnome_keyring
     pango gcr gdk_pixbuf atk p11_kit
   ];
 
+  # In 3.20.1, tests do not support Python 3
+  checkInputs = [ dbus python2 ];
+
   propagatedBuildInputs = [ glib libtasn1 libxslt ];
 
-  nativeBuildInputs = [ pkgconfig intltool docbook_xsl_ns docbook_xsl wrapGAppsHook ];
+  nativeBuildInputs = [
+    pkgconfig intltool docbook_xsl docbook_xml_dtd_42 wrapGAppsHook
+  ] ++ stdenv.lib.optionals doCheck checkInputs;
 
   configureFlags = [
     "--with-pkcs11-config=$$out/etc/pkcs11/" # installation directories
     "--with-pkcs11-modules=$$out/lib/pkcs11/"
   ];
 
+  postPatch = ''
+    patchShebangs build
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    export HOME=$(mktemp -d)
+    dbus-run-session \
+      --config-file=${dbus.daemon}/share/dbus-1/session.conf \
+      make check
+  '';
+
   meta = with stdenv.lib; {
-    platforms = platforms.linux;
+    description = "Collection of components in GNOME that store secrets, passwords, keys, certificates and make them available to applications";
+    homepage = https://wiki.gnome.org/Projects/GnomeKeyring;
+    license = licenses.gpl2;
     maintainers = gnome3.maintainers;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/gnome-3/devtools/anjuta/default.nix
+++ b/pkgs/desktops/gnome-3/devtools/anjuta/default.nix
@@ -1,14 +1,19 @@
 { stdenv, fetchurl, pkgconfig, gnome3, gtk3, flex, bison, libxml2, intltool,
-  itstool, python2, makeWrapper }:
+  itstool, python3, ncurses, makeWrapper }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ flex bison gtk3 libxml2 gnome3.gjs gnome3.gdl
-    gnome3.libgda gnome3.gtksourceview intltool itstool python2 makeWrapper
+  nativeBuildInputs = [
+    pkgconfig intltool itstool python3 makeWrapper
+    # Required by python3
+    ncurses
+  ];
+  buildInputs = [
+    flex bison gtk3 libxml2 gnome3.gjs gnome3.gdl
+    gnome3.libgda gnome3.gtksourceview
     gnome3.gsettings_desktop_schemas
   ];
 
@@ -22,6 +27,7 @@ stdenv.mkDerivation rec {
     description = "Software development studio";
     homepage = http://anjuta.org/;
     license = licenses.gpl2;
+    maintainers = with maintainers; [];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Convert the remaining packages using Python 2. gnome-keyring still requires it for tests, though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

