### PR TITLE
Fix build of 3 perl packages with ld-is-cc-hook

### DIFF
--- a/pkgs/build-support/setup-hooks/ld-is-cc-hook.sh
+++ b/pkgs/build-support/setup-hooks/ld-is-cc-hook.sh
@@ -1,0 +1,5 @@
+ld-is-cc-hook() {
+    LD=$CC
+}
+
+preConfigureHooks+=(ld-is-cc-hook)

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -95,8 +95,8 @@ rec {
 
 
   # Make a package that just contains a setup hook with the given contents.
-  makeSetupHook = { deps ? [], substitutions ? {} }: script:
-    runCommand "hook" substitutions
+  makeSetupHook = { name ? "hook", deps ? [], substitutions ? {} }: script:
+    runCommand name substitutions
       (''
         mkdir -p $out/nix-support
         cp ${script} $out/nix-support/setup-hook

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -287,6 +287,9 @@ with pkgs;
     inherit url;
   };
 
+  ld-is-cc-hook = makeSetupHook { name = "ld-is-cc-hook"; }
+    ../build-support/setup-hooks/ld-is-cc-hook.sh;
+
   libredirect = callPackage ../build-support/libredirect { };
 
   madonctl = callPackage ../applications/misc/madonctl { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4849,6 +4849,7 @@ let self = _self // overrides; _self = with self; {
       url = "mirror://cpan/authors/id/J/JG/JGMYERS/${name}.tar.gz";
       sha256 = "834d893aa7db6ce3f158afbd0e432d6ed15a276e0940db0a74be13fd9c4bbbf1";
     };
+    nativeBuildInputs = [ pkgs.ld-is-cc-hook ];
     propagatedBuildInputs = [ ModuleBuild ];
     meta = {
       description = "An Encode::Encoding subclass that detects the encoding of data";
@@ -5162,6 +5163,7 @@ let self = _self // overrides; _self = with self; {
       url = "mirror://cpan/modules/by-module/ExtUtils/${name}.tar.gz";
       sha256 = "1a77hxf2pa8ia9na72rijv1yhpn2bjrdsybwk2dj2l938pl3xn0w";
     };
+    nativeBuildInputs = [ pkgs.ld-is-cc-hook ];
     propagatedBuildInputs = [ CaptureTiny ];
   };
 
@@ -8488,6 +8490,7 @@ let self = _self // overrides; _self = with self; {
       url = "mirror://cpan/modules/by-module/Math/${name}.tar.gz";
       sha256 = "0i9wzvig7ayijc9nvh5x5rryk1jrcj1hcvfmlcj449rnnxx24dav";
     };
+    nativeBuildInputs = [ pkgs.ld-is-cc-hook ];
     propagatedBuildInputs = [ ModuleBuildWithXSpp ExtUtilsXSpp ExtUtilsTypemapsDefault TestDeep ];
   };
 


### PR DESCRIPTION
###### Motivation for this change

This is small rebuild targeting `staging` to fix small breakage introduced in #29396.

1. makeSetupHook: make the default name "hook" overridable for occasional convenience while looking at drv paths, such as in the output of nix-build and nix-diff.
2. ld-is-cc-hook: init
This hook sets LD to CC, for use with software that works as if `LD=$CC` when LD is unset, and does not work when LD=ld.
3. perlPackages: use ld-is-cc-hook to fix build after #29396 removed `-L path/to/dir/of/libstdc++.so` from ld flags. See https://github.com/NixOS/nixpkgs/pull/29396#issuecomment-352600129
Module::Build build helper works correctly when LD is unset (taking LD from Perl config to be `cc`).  However, we can not unset LD because this goes contrary to the cross compilation effort, and we can not make it propagate ld-is-cc-hook because it breaks e.g. the build of `libguestfs`. However, #29396 makes LD=ld incompatible with just 3 perl packages; they are individually fixed by this commit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
