### PR TITLE
boost166: init at 1.66.0

### DIFF
--- a/pkgs/development/libraries/boost/1.65.nix
+++ b/pkgs/development/libraries/boost/1.65.nix
@@ -9,6 +9,6 @@ callPackage ./generic.nix (args // rec {
     sha256 = "9807a5d16566c57fd74fb522764e0b134a8bbe6b6e8967b83afefd30dcd3be81";
   };
 
-  enableNumpy = true;
+  enableNumpy = args.enableNumpy or true;
 
 })

--- a/pkgs/development/libraries/boost/1.66.nix
+++ b/pkgs/development/libraries/boost/1.66.nix
@@ -9,6 +9,6 @@ callPackage ./generic.nix (args // rec {
     sha256 = "5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9";
   };
 
-  enableNumpy = true;
+  enableNumpy = args.enableNumpy or true;
 
 })

--- a/pkgs/development/libraries/boost/1.66.nix
+++ b/pkgs/development/libraries/boost/1.66.nix
@@ -1,0 +1,14 @@
+{ stdenv, callPackage, fetchurl, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "1.66_0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/boost/boost_1_66_0.tar.bz2";
+    # SHA256 from http://www.boost.org/users/history/version_1_66_0.html
+    sha256 = "5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9";
+  };
+
+  enableNumpy = true;
+
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8009,7 +8009,8 @@ with pkgs;
   boost163 = callPackage ../development/libraries/boost/1.63.nix { };
   boost164 = callPackage ../development/libraries/boost/1.64.nix { };
   boost165 = callPackage ../development/libraries/boost/1.65.nix { };
-  boost16x = boost165;
+  boost166 = callPackage ../development/libraries/boost/1.66.nix { };
+  boost16x = boost166;
   boost = boost16x;
 
   boost_process = callPackage ../development/libraries/boost-process { };


### PR DESCRIPTION
###### Motivation for this change

This pull-request provides version 1_66_0 of boost.

Note that the package enables build of Numpy extension, like #32414

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

