### PR TITLE
[WIP] qsynth: 0.4.4 -> 0.5.0

### DIFF
--- a/pkgs/applications/audio/qsynth/default.nix
+++ b/pkgs/applications/audio/qsynth/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation  rec {
   name = "qsynth-${version}";
-  version = "0.4.4";
+  version = "0.5.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/qsynth/${name}.tar.gz";
-    sha256 = "0qhfnikx3xcllkvs60kj6vcf2rwwzh31y41qkk6kwfhzgd219y8f";
+    sha256 = "1sr6vrz8z9r99j9xcix86lgcqldragb2ajmq1bnhr58d99sda584";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
When I do ``nix-env -f $NIXPKGS -iA qsynth`` I get:
``CMake Error: File /tmp/nix-build-qsynth-0.5.0.drv-0/qsynth-0.5.0/src/qsynth.desktop.in does not exist.``.

When I run:
```nix-shell $NIXPKGS -A qsynth
unpackPhase
cd $dir
configurePhase
```
it runs OK

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
