### PR TITLE
sqldeveloper: 17.3.0.271.2323 -> 17.3.1.279.0537

### DIFF
--- a/pkgs/development/tools/database/sqldeveloper/default.nix
+++ b/pkgs/development/tools/database/sqldeveloper/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
       obtain it you need to
 
       - navigate to ${url}
-      - make sure that it says "Version ${version}" above the list of downloads 
+      - make sure that it says "Version ${version}" above the list of downloads
         - if it does not, click on the "Previous Version" link below the downloads
           and repeat until the version is correct. This is necessarry because as the
           time of this writing there exists no permanent link for the current version

--- a/pkgs/development/tools/database/sqldeveloper/default.nix
+++ b/pkgs/development/tools/database/sqldeveloper/default.nix
@@ -1,7 +1,7 @@
 { stdenv, makeWrapper, requireFile, unzip, openjdk }:
 
 stdenv.mkDerivation rec {
-  version = "17.3.0.271.2323";
+  version = "17.3.1.279.0537";
   name = "sqldeveloper-${version}";
 
   src = requireFile rec {
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
         nix-prefetch-url --type sha256 file:///path/to/${name}
     '';
     # obtained by `sha256sum sqldeveloper-${version}-no-jre.zip`
-    sha256 = "06ba5920544bacbea83425548b1b8f69ab3e9bb279076321aece2c0c6d415dad";
+    sha256 = "d9c3c61b12a57d6b0fd6e172bf5716d6e829306d44815bf68ae42eab8a51bea3";
   };
 
   buildInputs = [ makeWrapper unzip ];


### PR DESCRIPTION
###### Motivation for this change
This bumps sqldeveloper to the current version available on the website.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

