### PR TITLE
connman: enable support for Wireless daemon for Linux (iwd)

### DIFF
--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
     "--enable-datafiles"
     "--enable-pptp"
     "--with-pptp=${pptp}/sbin/pptp"
+    "--enable-iwd"
   ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

From the [README](https://git.kernel.org/pub/scm/network/connman/connman.git/tree/README#n134):

> --enable-iwd
> 
> 		Enable support for Wireless daemon for Linux
> 
> 		The IWD project does not have initial release so far,
> 		therefore by default IWD support is not enabled.
> 
> 		It is safe to enable this option along WiFi support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).