### PR TITLE
docker_compose: 1.15.0 -> 1.18.0

### DIFF
--- a/pkgs/development/python-modules/docker/default.nix
+++ b/pkgs/development/python-modules/docker/default.nix
@@ -3,13 +3,13 @@
 , ipaddress, backports_ssl_match_hostname, docker_pycreds
 }:
 buildPythonPackage rec {
-  version = "2.5.1";
+  version = "2.6.1";
   pname = "docker";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://pypi/d/docker/${name}.tar.gz";
-    sha256 = "b876e6909d8d2360e0540364c3a952a62847137f4674f2439320ede16d6db880";
+    sha256 = "09d3nwcqxhc13l9p6rznd1cnnw004nd1vyz5bcgvmmygnckpahbg";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/docker_compose/default.nix
+++ b/pkgs/development/python-modules/docker_compose/default.nix
@@ -6,13 +6,13 @@
 , enum34, functools32
 }:
 buildPythonApplication rec {
-  version = "1.15.0";
+  version = "1.18.0";
   pname = "docker-compose";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0yg58m5kk22kihbra0h40miqnbdmkirjr9y47wns613sdikrymmg";
+    sha256 = "0yfka41raqrg44a3yyvianciv1l8camh0xipfnxqy0c54vzcnc19";
   };
 
   # lots of networking and other fails

--- a/pkgs/development/python-modules/texttable/default.nix
+++ b/pkgs/development/python-modules/texttable/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi
+}:
+buildPythonPackage rec {
+  version = "0.9.0";
+  pname = "texttable";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08353848k7j5rsa6wq4casg7243db76lvval134q2f8w0wvw4wza";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A module to generate a formatted text table, using ASCII characters";
+    homepage = http://foutaise.org/code/;
+    license = licenses.lgpl2;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18376,20 +18376,7 @@ in {
     };
   };
 
-  texttable = self.buildPythonPackage rec {
-    name = "texttable-0.8.4";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/t/texttable/${name}.tar.gz";
-      sha256 = "0bkhs4dx9s6g7fpb969hygq56hyz4ncfamlynw72s0n6nqfbd1w5";
-    };
-
-    meta = {
-      description = "A module to generate a formatted text table, using ASCII characters";
-      homepage = http://foutaise.org/code/;
-      license = licenses.lgpl2;
-    };
-  };
+  texttable = callPackage ../development/python-modules/texttable { };
 
   tiros = callPackage ../development/python-modules/tiros { };
 


### PR DESCRIPTION
Needed to upgrade python dependencies:
docker: 2.5.1 -> 2.6.1
texttable: 0.8.4 -> 0.9.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

