### PR TITLE
mosh: Install bash-completion rule

### DIFF
--- a/pkgs/tools/networking/mosh/default.nix
+++ b/pkgs/tools/networking/mosh/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, zlib, protobuf, ncurses, pkgconfig, IOTty
-, makeWrapper, perl, openssl, autoreconfHook, openssh }:
+, makeWrapper, perl, openssl, autoreconfHook, openssh, bash-completion }:
 
 stdenv.mkDerivation rec {
   name = "mosh-1.3.2";
@@ -10,13 +10,15 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ protobuf ncurses zlib IOTty makeWrapper perl openssl ];
+  buildInputs = [ protobuf ncurses zlib IOTty makeWrapper perl openssl bash-completion ];
 
   patches = [ ./ssh_path.patch ];
   postPatch = ''
     substituteInPlace scripts/mosh.pl \
         --subst-var-by ssh "${openssh}/bin/ssh"
   '';
+
+  configureFlags = [ "--enable-completion" ];
 
   postInstall = ''
       wrapProgram $out/bin/mosh --prefix PERL5LIB : $PERL5LIB


### PR DESCRIPTION
###### Motivation for this change

Mosh comes with a bash-completion rule to complete hostnames from ~/.ssh/known_hosts on `mosh <tab>`. We just need to pass the configure flag to install it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

