### PR TITLE
coqPackages.tlc: init at 20171206

### DIFF
--- a/pkgs/development/coq-modules/tlc/default.nix
+++ b/pkgs/development/coq-modules/tlc/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, coq }:
+
+stdenv.mkDerivation rec {
+  version = "20171206";
+  name = "coq${coq.coq-version}-tlc-${version}";
+
+  src = fetchurl {
+    url = "http://tlc.gforge.inria.fr/releases/tlc-${version}.tar.gz";
+    sha256 = "1wc44qb5zmarafp56gdrbka8gllipqna9cj0a6d99jzb361xg4mf";
+  };
+
+  buildInputs = [ coq ];
+
+  installFlags = "CONTRIB=$(out)/lib/coq/${coq.coq-version}/user-contrib";
+
+  meta = {
+    homepage = "http://www.chargueraud.org/softs/tlc/";
+    description = "A non-constructive library for Coq";
+    license = stdenv.lib.licenses.free;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (coq.meta) platforms;
+  };
+
+  passthru = {
+    compatibleCoqVersions = v: stdenv.lib.versionAtLeast v "8.6";
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -33,6 +33,7 @@ let
       paco = callPackage ../development/coq-modules/paco {};
       QuickChick = callPackage ../development/coq-modules/QuickChick {};
       ssreflect = callPackage ../development/coq-modules/ssreflect { };
+      tlc = callPackage ../development/coq-modules/tlc {};
     };
 
   filterCoqPackages = coq:


### PR DESCRIPTION
TLC is a general purpose Coq library that provides an alternative to Coq's
standard library.

Homepage: http://www.chargueraud.org/softs/tlc/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

