### PR TITLE
apache-directory-studio: init at 2.0.0.v20170904-M13

### DIFF
--- a/pkgs/applications/networking/apache-directory-studio/default.nix
+++ b/pkgs/applications/networking/apache-directory-studio/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl, xorg, jre, makeWrapper }:
+
+let
+  rpath = stdenv.lib.makeLibraryPath (with xorg; [
+    libXtst
+  ]);
+in
+stdenv.mkDerivation rec {
+  name = "apache-directory-studio-${version}";
+  version = "2.0.0.v20170904-M13";
+
+  src =
+    if stdenv.system == "x86_64-linux" then
+      fetchurl {
+        url = "mirror://apache/directory/studio/${version}/ApacheDirectoryStudio-${version}-linux.gtk.x86_64.tar.gz";
+        sha256 = "1jfnm6m0ijk31r30hhrxxnizk742dm317iny041p29v897rma7aq";
+      }
+    else if stdenv.system == "i686-linux" then
+      fetchurl {
+        url = "mirror://apache/directory/studio/${version}/ApacheDirectoryStudio-${version}-linux.gtk.x86.tar.gz";
+        sha256 = "1bxmgram42qyhrqkgp5k8770f5mjjdd4c6xl4gj09smiycm1qa4n";
+      }
+    else throw "Unsupported system: ${stdenv.system}";
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    dest="$out/libexec/ApacheDirectoryStudio"
+    mkdir -p "$dest"
+    cp -r . "$dest"
+
+    mkdir -p "$out/bin"
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        "$dest/ApacheDirectoryStudio"
+    makeWrapper "$dest/ApacheDirectoryStudio" \
+        "$out/bin/ApacheDirectoryStudio" \
+        --prefix PATH : "${jre}/bin" \
+        --prefix LD_LIBRARY_PATH : "${rpath}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Eclipse-based LDAP browser and directory client";
+    homepage = "https://directory.apache.org/studio/";
+    license = licenses.asl20;
+    # Upstream supports macOS and Windows too.
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bjornfor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13972,6 +13972,8 @@ with pkgs;
 
   ao = callPackage ../applications/graphics/ao {};
 
+  apache-directory-studio = callPackage ../applications/networking/apache-directory-studio {};
+
   aqemu = libsForQt5.callPackage ../applications/virtualization/aqemu { };
 
   ardour = callPackage ../applications/audio/ardour {


### PR DESCRIPTION
###### Motivation for this change
I needed to look at LDAP tree at $DAYJOB. This tool was recommended.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`. ----> nox-review currently dies with "fatal: reference is not a tree: e618aad27efc589f804a886b9362d879bdaee451".
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

