### PR TITLE
django: add 2.0 release

### DIFF
--- a/pkgs/development/python-modules/django/2_0.nix
+++ b/pkgs/development/python-modules/django/2_0.nix
@@ -1,0 +1,44 @@
+{ stdenv, buildPythonPackage, fetchPypi, substituteAll,
+  isPy3k,
+  geos, gdal, pytz,
+  withGdal ? false
+}:
+
+buildPythonPackage rec {
+  pname = "Django";
+  name = "${pname}-${version}";
+  version = "2.0";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0iqzqd1jrc4gg5qygxxzbddc8xzk85j0gikk5g9wpy3z98fqa54n";
+  };
+
+  patches = stdenv.lib.optionals withGdal [
+    (substituteAll {
+      src = ./1.10-gis-libs.template.patch;
+      geos = geos;
+      gdal = gdal;
+      extension = stdenv.hostPlatform.extensions.sharedLibrary;
+    })
+  ];
+
+  # patch only $out/bin to avoid problems with starter templates (see #3134)
+  postFixup = ''
+    wrapPythonProgramsIn $out/bin "$out $pythonPath"
+  '';
+
+  propagatedBuildInputs = [ pytz ];
+
+  # too complicated to setup
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A high-level Python Web framework";
+    homepage = https://www.djangoproject.com/;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ georgewhewell ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9081,6 +9081,10 @@ in {
     gdal = self.gdal;
   };
 
+  django_2_0 = callPackage ../development/python-modules/django/2_0.nix {
+    gdal = self.gdal;
+  };
+
   django_1_8 = buildPythonPackage rec {
     name = "Django-${version}";
     version = "1.8.18";


### PR DESCRIPTION
###### Motivation for this change
django 2.0 release not in nixpkgs.

I think we should eventually change `django` attribute to point to 2.0 branch- I didn't put that in this commit since only py3k is supported.

also not sure if we need to keep old versions hanging around in nixpkgs- i think most people manage project dependencies with pypi2nix, so all out-of-tree anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

