### PR TITLE
http-prompt: disable tests

### DIFF
--- a/pkgs/tools/networking/http-prompt/default.nix
+++ b/pkgs/tools/networking/http-prompt/default.nix
@@ -20,6 +20,10 @@ pythonPackages.buildPythonApplication rec {
     six
   ];
 
+  checkPhase = ''
+    $out/bin/${name} --version | grep -q "${version}"
+  '';
+
   meta = with stdenv.lib; {
     description = "An interactive command-line HTTP client featuring autocomplete and syntax highlighting";
     homepage = https://github.com/eliangcs/http-prompt;


### PR DESCRIPTION
The http-prompt tests do something with files, which leads to
permission errors during test execution.

For now replace the check with a executable sanity check.  I don't think that the tests ever ran though, so no idea why now