### PR TITLE
nix-info: apply SC1117 suggested fix

### DIFF
--- a/pkgs/tools/nix/info/info.sh
+++ b/pkgs/tools/nix/info/info.sh
@@ -143,7 +143,7 @@ fact() {
             printf ", "
         fi
     else
-        printf " - %s: \`%s\`\n" "$name" "$value"
+        printf " - %s: \`%s\`\\n" "$name" "$value"
     fi
 
     if [ "$last" -eq 0 ]; then


### PR DESCRIPTION
###### Motivation for this change
It seems like this a `nix-info` build failure is blocking the `unstable` channels.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

