### PR TITLE
ibm-plex: init at 0.5.3

### DIFF
--- a/pkgs/data/fonts/ibm-plex/default.nix
+++ b/pkgs/data/fonts/ibm-plex/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchFromGitHub }:
+
+let version = "0.5.3";
+in fetchFromGitHub rec {
+  name = "ibm-plex-${version}";
+
+  owner = "IBM";
+  repo = "type";
+  rev = "v${version}";
+  sha256 = "1im7sid3qsk4wnm0yhq9h7i50bz46jksqxv60svdfnsrwq0krd1h";
+
+  postFetch = ''
+    tar --strip-components=1 -xzvf $downloadedFile
+    mkdir -p $out/share/fonts/opentype
+    cp fonts/*/desktop/mac/*.otf $out/share/fonts/opentype/
+  '';
+
+  meta = with lib; {
+    description = "IBM Plex Typeface";
+    homepage = https://ibm.github.io/type/;
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13558,6 +13558,8 @@ with pkgs;
 
   hanazono = callPackage ../data/fonts/hanazono { };
 
+  ibm-plex = callPackage ../data/fonts/ibm-plex { };
+
   inconsolata = callPackage ../data/fonts/inconsolata {};
   inconsolata-lgc = callPackage ../data/fonts/inconsolata/lgc.nix {};
 


### PR DESCRIPTION
###### Motivation for this change

Add [IBM Plex](https://ibm.github.io/type/), IBM’s new corporate type family. IBM Plex is open source.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).