### PR TITLE
termite: add patch to fix handling nix urls

### DIFF
--- a/pkgs/applications/misc/termite/default.nix
+++ b/pkgs/applications/misc/termite/default.nix
@@ -13,6 +13,9 @@ let
       sha256 = "02cn70ygl93ghhkhs3xdxn5b1yadc255v3yp8cmhhyzsv5027hvj";
     };
 
+    # https://github.com/thestinger/termite/pull/516
+    patches = [ ./url_regexp_trailing.patch ];
+
     postPatch = "sed '1i#include <math.h>' -i termite.cc";
 
     makeFlags = [ "VERSION=v${version}" "PREFIX=" "DESTDIR=$(out)" ];

--- a/pkgs/applications/misc/termite/url_regexp_trailing.patch
+++ b/pkgs/applications/misc/termite/url_regexp_trailing.patch
@@ -1,0 +1,27 @@
+Based on https://github.com/thestinger/termite/pull/516
+Modified to apply to v13
+
+From 65a454ffa8e681f3f14729cba7c42e1570a85e8a Mon Sep 17 00:00:00 2001
+From: Paul Baecher <pbaecher@gmail.com>
+Date: Thu, 7 Sep 2017 22:58:51 +0200
+Subject: [PATCH] Do not match punctuation at the end of URLs
+
+Punctuation at the end of URLs is most likely part of natural language
+or markup (for example in Markdown). Do not match it as part of the URL.
+---
+ url_regex.hh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/url_regex.hh b/url_regex.hh
+index 2ec6be8..3039b53 100644
+--- a/url_regex.hh
++++ b/url_regex.hh
+@@ -9,7 +9,7 @@
+ #define PORT            "(?:\\:[[:digit:]]{1,5})?"
+ #define SCHEME          "(?:[[:alpha:]][+-.[:alnum:]]*:)"
+ #define USERPASS        USERCHARS_CLASS "+(?:\\:" PASSCHARS_CLASS "+)?"
+-#define URLPATH         "(?:/[[:alnum:]\\Q-_.!~*'();/?:@&=+$,#%\\E]*)?"
++#define URLPATH         "(?:/[[:alnum:]\\Q-_.!~*'();/?:@&=+$,#%\\E]*(?<![\\Q.,:;()!?\\E]))?"
+ 
+ const char * const url_regex = SCHEME "//(?:" USERPASS "\\@)?" HOST PORT URLPATH;
+ 


### PR DESCRIPTION
(Builds on #32860 since patch is slightly different on v13 vs v12)

###### Motivation for this change

Nix-provided terminal shouldn't break on URL patterns commonly used in `*.nix` files!
This PR includes a patch addressing this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Anecdotally: I've been using termite patched in this manner for months (tracking git, more or less) and I haven't experienced any problems.