### PR TITLE
lighttpd: add enableLdap option (default false)

### DIFF
--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -1,10 +1,12 @@
 { stdenv, fetchurl, pkgconfig, pcre, libxml2, zlib, attr, bzip2, which, file
 , openssl, enableMagnet ? false, lua5_1 ? null
 , enableMysql ? false, mysql ? null
+, enableLdap ? false, openldap ? null
 }:
 
 assert enableMagnet -> lua5_1 != null;
 assert enableMysql -> mysql != null;
+assert enableLdap -> openldap != null;
 
 stdenv.mkDerivation rec {
   name = "lighttpd-1.4.48";
@@ -17,11 +19,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ pcre libxml2 zlib attr bzip2 which file openssl ]
              ++ stdenv.lib.optional enableMagnet lua5_1
-             ++ stdenv.lib.optional enableMysql mysql.lib;
+             ++ stdenv.lib.optional enableMysql mysql.lib
+             ++ stdenv.lib.optional enableLdap openldap;
 
   configureFlags = [ "--with-openssl" ]
                 ++ stdenv.lib.optional enableMagnet "--with-lua"
-                ++ stdenv.lib.optional enableMysql "--with-mysql";
+                ++ stdenv.lib.optional enableMysql "--with-mysql"
+                ++ stdenv.lib.optional enableLdap "--with-ldap";
 
   preConfigure = ''
     sed -i "s:/usr/bin/file:${file}/bin/file:g" configure


### PR DESCRIPTION
###### Motivation for this change
For end users: Using .override is simpler than .overrideAttrs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

