### PR TITLE
welle-io: init at 1.0-rc1

### DIFF
--- a/pkgs/applications/misc/welle-io/default.nix
+++ b/pkgs/applications/misc/welle-io/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, buildEnv, fetchFromGitHub, cmake, pkgconfig
+, qtbase, qtcharts, qtmultimedia, qtquickcontrols, qtquickcontrols2
+, faad2, rtl-sdr, libusb, fftwSinglePrec }:
+let
+
+  version = "1.0-rc1";
+
+in stdenv.mkDerivation {
+
+  name = "welle-io-${version}";
+
+  src = fetchFromGitHub {
+    owner = "AlbrechtL";
+    repo = "welle.io";
+    rev = "V${version}";
+    sha256 = "1xi59rmk3rdqqxxxrm2pbllrlsql46vxs95l1pkfx7bp8f7n7rsv";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [
+    faad2
+    fftwSinglePrec
+    libusb
+    qtbase
+    qtcharts
+    qtmultimedia
+    qtquickcontrols
+    qtquickcontrols2
+    rtl-sdr
+  ];
+
+  cmakeFlags = [
+    "-DRTLSDR=true"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A DAB/DAB+ Software Radio";
+    homepage = http://www.welle.io/;
+    maintainers = with maintainers; [ ck3d ];
+    license = licenses.gpl2;
+    platforms = with platforms; linux ++ darwin;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14916,6 +14916,8 @@ with pkgs;
 
   wavrsocvt = callPackage ../applications/misc/audio/wavrsocvt { };
 
+  welle-io = libsForQt5.callPackage ../applications/misc/welle-io { };
+
   wireshark-cli = callPackage ../applications/networking/sniffers/wireshark {
     withQt = false;
     withGtk = false;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

