### PR TITLE
Orca: init 3.26.0

### DIFF
--- a/pkgs/applications/misc/orca/default.nix
+++ b/pkgs/applications/misc/orca/default.nix
@@ -1,0 +1,67 @@
+{ stdenv, lib, pkgconfig, fetchurl, buildPythonApplication
+, autoreconfHook, wrapGAppsHook
+, intltool, yelp_tools, itstool, libxmlxx3
+, python, pygobject3, gtk3, gnome3, substituteAll
+, at_spi2_atk, at_spi2_core, pyatspi, dbus, dbus-python, pyxdg
+, xkbcomp, gsettings_desktop_schemas, liblouis
+, speechd, brltty, setproctitle, gst_all_1, gst-python
+}:
+
+with lib;
+let
+  version = "3.26.0";
+  majorVersion = builtins.concatStringsSep "." (take 2 (splitString "." version));
+in buildPythonApplication rec {
+  name = "orca-${version}";
+
+  format = "other";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/orca/${majorVersion}/${name}.tar.xz";
+    sha256 = "0xk5k9cbswymma60nrfj00dl97wypx59c107fb1hwi75gm0i07a7";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      xkbcomp = "${xkbcomp}/bin/xkbcomp";
+    })
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook wrapGAppsHook pkgconfig libxmlxx3
+    intltool yelp_tools itstool
+  ];
+
+  propagatedBuildInputs = [
+    pygobject3 pyatspi dbus-python pyxdg brltty liblouis speechd gst-python setproctitle
+  ];
+
+  buildInputs = [
+    python gtk3 at_spi2_atk at_spi2_core dbus gsettings_desktop_schemas
+    gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
+  ];
+
+  # Run intltoolize to create po/Makefile.in.in
+  preConfigure = ''
+    intltoolize
+  '';
+
+  meta = {
+    homepage = https://wiki.gnome.org/Projects/Orca;
+    description = "Screen reader";
+    longDescription = ''
+      A free, open source, flexible and extensible screen reader that provides
+      access to the graphical desktop via speech and refreshable braille.
+      It works with applications and toolkits that support the Assistive
+      Technology Service Provider Interface (AT-SPI). That includes the GNOME
+      Gtk+ toolkit, the Java platform's Swing toolkit, LibreOffice, Gecko, and
+      WebKitGtk. AT-SPI support for the KDE Qt toolkit is being pursued.
+
+      Needs `services.gnome3.at-spi2-core.enable = true;` in `configuration.nix`.
+    '';
+    maintainers = with maintainers; [ berce ] ++ gnome3.maintainers;
+    license = licenses.lgpl21;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/orca/fix-paths.patch
+++ b/pkgs/applications/misc/orca/fix-paths.patch
@@ -1,0 +1,29 @@
+--- a/src/orca/orca.py
++++ b/src/orca/orca.py
+@@ -239,7 +239,7 @@
+ 
+ def _setXmodmap(xkbmap):
+     """Set the keyboard map using xkbcomp."""
+-    p = subprocess.Popen(['xkbcomp', '-w0', '-', os.environ['DISPLAY']],
++    p = subprocess.Popen(['@xkbcomp@', '-w0', '-', os.environ['DISPLAY']],
+         stdin=subprocess.PIPE, stdout=None, stderr=None)
+     p.communicate(xkbmap)
+ 
+@@ -297,7 +297,7 @@
+     """
+ 
+     global _originalXmodmap
+-    _originalXmodmap = subprocess.check_output(['xkbcomp', os.environ['DISPLAY'], '-'])
++    _originalXmodmap = subprocess.check_output(['@xkbcomp@', os.environ['DISPLAY'], '-'])
+ 
+ def _restoreXmodmap(keyList=[]):
+     """Restore the original xmodmap values for the keys in keyList.
+@@ -309,7 +309,7 @@
+ 
+     global _capsLockCleared
+     _capsLockCleared = False
+-    p = subprocess.Popen(['xkbcomp', '-w0', '-', os.environ['DISPLAY']],
++    p = subprocess.Popen(['@xkbcomp@', '-w0', '-', os.environ['DISPLAY']],
+         stdin=subprocess.PIPE, stdout=None, stderr=None)
+     p.communicate(_originalXmodmap)
+ 

--- a/pkgs/tools/misc/brltty/default.nix
+++ b/pkgs/tools/misc/brltty/default.nix
@@ -1,35 +1,37 @@
-{ stdenv, fetchurl, pkgconfig, alsaSupport, alsaLib ? null, bluez, systemdSupport, systemd ? null }:
+{ stdenv, fetchurl, pkgconfig, python3, alsaSupport, alsaLib ? null, bluez, systemdSupport, systemd ? null }:
 
 assert alsaSupport -> alsaLib != null;
 assert systemdSupport -> systemd != null;
 
 stdenv.mkDerivation rec {
   name = "brltty-5.5";
-  
+
   src = fetchurl {
     url = "http://brltty.com/archive/${name}.tar.gz";
     sha256 = "0slrqanwj9cm7ql0rpb296xq676zrc1sjyr13lh5lygp4b8qfpci";
   };
-  
-  nativeBuildInputs = [ pkgconfig ];
+
+  nativeBuildInputs = [ pkgconfig python3.pkgs.cython ];
   buildInputs = [ bluez ]
     ++ stdenv.lib.optional alsaSupport alsaLib
     ++ stdenv.lib.optional systemdSupport systemd;
-  
+
   meta = {
     description = "Access software for a blind person using a braille display";
     longDescription = ''
       BRLTTY is a background process (daemon) which provides access to the Linux/Unix
       console (when in text mode) for a blind person using a refreshable braille display.
       It drives the braille display, and provides complete screen review functionality.
-      Some speech capability has also been incorporated. 
+      Some speech capability has also been incorporated.
     '';
     homepage = http://www.brltty.com/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.bramd ];
     platforms = stdenv.lib.platforms.all;
   };
-  
+
+  makeFlags = [ "PYTHON_PREFIX=$(out)" ];
+
   preConfigurePhases = [ "preConfigure" ];
 
   preConfigure = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16308,6 +16308,10 @@ with pkgs;
 
   opera = callPackage ../applications/networking/browsers/opera {};
 
+  orca = python3Packages.callPackage ../applications/misc/orca {
+    inherit (gnome3) yelp_tools;
+  };
+
   osmctools = callPackage ../applications/misc/osmctools { };
 
   vivaldi = callPackage ../applications/networking/browsers/vivaldi {};


### PR DESCRIPTION
###### Motivation for this change

Also visually impaired people should be able to enjoy the magic of nix.
Orca is part of Gnome.

It builds, some parts run.
~~The main issue is with `gst-python` now. I 'd like some help to fix this.~~

Braille won't be supported until `brlapi` ~~and `liblouis`~~ becomes available.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

