### PR TITLE
s3-us-west-2.amazonaws.com -> s3.amazonaws.com

### DIFF
--- a/pkgs/applications/networking/mailreaders/nylas-mail-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/nylas-mail-bin/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   src =
     if stdenv.system == "x86_64-linux" then
       fetchurl {
-        url = "https://edgehill.s3-us-west-2.amazonaws.com/${version}-${subVersion}/linux-deb/x64/NylasMail.deb";
+        url = "https://edgehill.s3.amazonaws.com/${version}-${subVersion}/linux-deb/x64/NylasMail.deb";
         sha256 = "40060aa1dc3b5187b8ed4a07b9de3427e3c5a291df98c2c82395647fa2aa4ada";
       }
     else

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -13,7 +13,7 @@ buildGoPackage rec {
   };
 
   srcStatic = fetchurl {
-    url = "https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-${version}.linux-x64.tar.gz";
+    url = "https://grafana-releases.s3.amazonaws.com/release/grafana-${version}.linux-x64.tar.gz";
     sha256 = "01f50w57n7p7if37rhj8zy0y0x84qajbxrrdcfrsbi2qi1kzfz03";
   };
 


### PR DESCRIPTION
###### Motivation for this change

```s3-us-west-2.amazonaws.com``` is not a worldwide available domain.
In particular, it is blocked in Russia:

```
# wget s3-us-west-2.amazonaws.com
--2017-12-19 23:15:33--  http://s3-us-west-2.amazonaws.com/
Resolving s3-us-west-2.amazonaws.com (s3-us-west-2.amazonaws.com)... 54.231.184.176
Connecting to s3-us-west-2.amazonaws.com (s3-us-west-2.amazonaws.com)|54.231.184.176|:80... connected.
HTTP request sent, awaiting response... 307 Temporary Redirect
Location: http://forbidden.yota.ru/ [following]
--2017-12-19 23:15:33--  http://forbidden.yota.ru/
```
