### PR TITLE
pup: rename attr, go-pup -> pup, clean up, 20160425-e76307d -> 0.4.0, add meta

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -220,6 +220,7 @@ go.stdenv.mkDerivation (
 
   meta = {
     # Add default meta information
+    homepage = "https://${goPackagePath}";
     platforms = go.meta.platforms or lib.platforms.all;
   } // meta // {
     # add an extra maintainer to every package

--- a/pkgs/development/tools/pup/default.nix
+++ b/pkgs/development/tools/pup/default.nix
@@ -1,4 +1,4 @@
-{ buildGoPackage, fetchgit }:
+{ lib, buildGoPackage, fetchgit }:
 
 buildGoPackage rec {
   name = "pup-${version}";
@@ -11,5 +11,11 @@ buildGoPackage rec {
     inherit rev;
     url = "https://${goPackagePath}";
     sha256 = "0mnhw0yph5fvcnrcmj1kfbyw1a4lcg3k9f6y28kf44ihlq8h1dfz";
+  };
+
+  meta = with lib; {
+    description = "Streaming HTML processor/selector";
+    license = licenses.mit;
+    maintainers = with maintainers; [ yegortimoshenko ];
   };
 }

--- a/pkgs/development/tools/pup/default.nix
+++ b/pkgs/development/tools/pup/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, lib, buildGoPackage, fetchgit, fetchhg, fetchbzr, fetchsvn }:
+{ buildGoPackage, fetchgit }:
 
 buildGoPackage rec {
   name = "pup-${version}";
-  version = "20160425-${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "e76307d03d4d2e0f01fb7ab51dee09f2671c3db6";
-  
+  version = "0.4.0";
+  rev = "v${version}";
+
   goPackagePath = "github.com/ericchiang/pup";
 
   src = fetchgit {
     inherit rev;
-    url = "https://github.com/ericchiang/pup";
-    sha256 = "15lwas4cjchlwhrwnd5l4gxcwqdfgazdyh466hava5qzxacqxrm5";
+    url = "https://${goPackagePath}";
+    sha256 = "0mnhw0yph5fvcnrcmj1kfbyw1a4lcg3k9f6y28kf44ihlq8h1dfz";
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -60,6 +60,7 @@ mapAliases (rec {
   gettextWithExpat = gettext; # 2016-02-19
   gdb-multitarget = gdb; # added 2017-11-13
   git-hub = gitAndTools.git-hub; # added 2016-04-29
+  go-pup = pup; # added 2017-12-19
   googleAuthenticator = google-authenticator; # added 2016-10-16
   grantlee5 = libsForQt5.grantlee;  # added 2015-12-19
   gst_ffmpeg = gst-ffmpeg;  # added 2017-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2392,8 +2392,6 @@ with pkgs;
 
   go-mtpfs = callPackage ../tools/filesystems/go-mtpfs { };
 
-  go-pup = callPackage ../development/tools/pup { };
-
   go-sct = callPackage ../tools/X11/go-sct { };
 
   # rename to upower-notify?
@@ -7651,6 +7649,8 @@ with pkgs;
   premake = premake4;
 
   procodile = callPackage ../tools/system/procodile { };
+
+  pup = callPackage ../development/tools/pup { };
 
   qtcreator = libsForQt5.callPackage ../development/qtcreator { };
 


### PR DESCRIPTION
###### Motivation for this change

pup is a very popular tool ([4084 stars on GitHub](https://github.com/ericchiang/pup)) and in my opinion deserves a three-letter attrname and an update to a stable version :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

