### PR TITLE
werkzeug: 0.12.2 -> 0.13

### DIFF
--- a/pkgs/development/python-modules/werkzeug/default.nix
+++ b/pkgs/development/python-modules/werkzeug/default.nix
@@ -5,11 +5,11 @@
 buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "Werkzeug";
-  version = "0.12.2";
+  version = "0.13";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "09mv4cya3lywkn4mi3qrqmjgwiw99kdk03dk912j8da6ny3pnflh";
+    sha256 = "1lxbwi9qwlqcbp3c5zfg5d52isj57ncwlspv2d0q41d5k3yfaik2";
   };
 
   LC_ALL = "en_US.UTF-8";
@@ -17,9 +17,13 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ itsdangerous ];
   buildInputs = [ pytest requests glibcLocales ];
 
+  checkPhase = ''
+    py.test
+  '';
+
   meta = with stdenv.lib; {
-    homepage = http://werkzeug.pocoo.org/;
-    description = "A WSGI utility library for Python";
+    homepage = https://www.palletsprojects.com/p/werkzeug/;
+    description = "The comprehensive WSGI web application library";
     license = licenses.bsd3;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Updates werkzeug to the latest version.

I was unable to test with `nox-review` because `cherrypy` failed due to an [existing issue](https://hydra.nixos.org/build/66026362) and `nox-review --keep-going` is [currently broken](/madjar/nox/issues/83).
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

