### PR TITLE
Add macOS support for KeePassXC package

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -1,6 +1,21 @@
-{ stdenv, fetchFromGitHub, fetchpatch,
-  cmake, libgcrypt, zlib, libmicrohttpd, libXtst, qtbase, qttools, libgpgerror, glibcLocales, libyubikey, yubikey-personalization, libXi, qtx11extras
-, withKeePassHTTP ? true
+{ stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  libgcrypt,
+  zlib,
+  libmicrohttpd,
+  libXtst,
+  qtbase,
+  qttools,
+  libgpgerror,
+  glibcLocales,
+  libyubikey,
+  yubikey-personalization,
+  libXi,
+  qtx11extras,
+  clang,
+  withKeePassHTTP ? true
 }:
 
 with stdenv.lib;
@@ -20,7 +35,20 @@ stdenv.mkDerivation rec {
     "-DWITH_GUI_TESTS=ON"
     "-DWITH_XC_AUTOTYPE=ON"
     "-DWITH_XC_YUBIKEY=ON"
-  ] ++ (optional withKeePassHTTP "-DWITH_XC_HTTP=ON");
+  ]
+  ++ stdenv.lib.optionals stdenv.isDarwin [
+    "-DCMAKE_OSX_ARCHITECTURES=x86_64"
+    "-DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT=14"
+    # We need to trick cmake into thinking the CXX_Compiler is AppleClang 6+.
+    # If cmake thinks it's Clang 4.0.1, it'll throw the following error:
+    # No known features for CXX compiler "Clang" version 4.0.1.
+    "-DCMAKE_CXX_COMPILER_ID='AppleClang'"
+    "-DCMAKE_CXX_COMPILER_VERSION='9.0.0.9000039'"
+    "-DCMAKE_PREFIX_PATH=${qtbase.dev}/lib/cmake"
+    "-DQT_BINARY_DIR=${qttools.bin}/bin"
+    "-DWITH_APP_BUNDLE=OFF"
+  ]
+  ++ (optional withKeePassHTTP "-DWITH_XC_HTTP=ON");
 
   doCheck = true;
   checkPhase = ''
@@ -28,13 +56,28 @@ stdenv.mkDerivation rec {
     make test ARGS+="-E testgui --output-on-failure"
   '';
 
-  buildInputs = [ cmake libgcrypt zlib qtbase qttools libXtst libmicrohttpd libgpgerror glibcLocales libyubikey yubikey-personalization libXi qtx11extras ];
+  buildInputs = [
+    cmake
+    libgcrypt
+    zlib
+    qtbase
+    qttools
+    libXtst
+    libmicrohttpd
+    libgpgerror
+    glibcLocales
+    libyubikey
+    yubikey-personalization
+    libXi
+    qtx11extras
+  ]
+  ++ stdenv.lib.optionals stdenv.isDarwin [ clang ];
 
   meta = {
     description = "Fork of the keepassX password-manager with additional http-interface to allow browser-integration an use with plugins such as PasslFox (https://github.com/pfn/passifox). See also keepassX2.";
     homepage = https://github.com/keepassxreboot/keepassxc;
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ s1lvester jonafato ];
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -74,8 +74,9 @@ stdenv.mkDerivation rec {
   ++ stdenv.lib.optionals stdenv.isDarwin [ clang ];
 
   meta = {
-    description = "Fork of the keepassX password-manager with additional http-interface to allow browser-integration an use with plugins such as PasslFox (https://github.com/pfn/passifox). See also keepassX2.";
-    homepage = https://github.com/keepassxreboot/keepassxc;
+    description = "Password manager to store your passwords safely and auto-type them into your everyday websites and applications";
+    longDescription = "A community fork of KeePassX, which is itself a port of KeePass Password Safe. The goal is to extend and improve KeePassX with new features and bugfixes to provide a feature-rich, fully cross-platform and modern open-source password manager. Accessible via native cross-platform GUI and via CLI. Includes optional http-interface to allow browser-integration with plugins like PassIFox (https://github.com/pfn/passifox).";
+    homepage = https://keepassxc.org/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ s1lvester jonafato ];
     platforms = with stdenv.lib.platforms; linux ++ darwin;


### PR DESCRIPTION
###### Motivation for this change
Make the KeePassXC package work on macOS in addition to Linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

