### PR TITLE
snappy: build both static and shared libs

### DIFF
--- a/pkgs/development/libraries/snappy/default.nix
+++ b/pkgs/development/libraries/snappy/default.nix
@@ -17,13 +17,20 @@ stdenv.mkDerivation rec {
 
   # -DNDEBUG for speed
   configureFlags = [ "CXXFLAGS=-DNDEBUG" ];
-  
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
 
   # SIGILL on darwin
   doCheck = !stdenv.isDarwin;
   checkPhase = ''
     (cd .. && ./build/snappy_unittest)
+  '';
+
+  postInstall = let
+    shared-lib = stdenv.mkDerivation {
+      inherit name src nativeBuildInputs configureFlags;
+      cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+    };
+  in ''
+    cp -dpR ${shared-lib}/* $out
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/snappy/default.nix
+++ b/pkgs/development/libraries/snappy/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
 
   # -DNDEBUG for speed
   configureFlags = [ "CXXFLAGS=-DNDEBUG" ];
+  
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
 
   # SIGILL on darwin
   doCheck = !stdenv.isDarwin;


### PR DESCRIPTION
build lib/libsnappy.so as it was before 1.1.7
