### PR TITLE
protobuf: restore version 2.5.0

### DIFF
--- a/pkgs/development/libraries/protobuf/2.5.nix
+++ b/pkgs/development/libraries/protobuf/2.5.nix
@@ -1,0 +1,10 @@
+{ callPackage, fetchurl, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "2.5.0";
+  # make sure you test also -A pythonPackages.protobuf
+  src = fetchurl {
+    url = "http://protobuf.googlecode.com/files/${version}.tar.bz2";
+    sha256 = "0xxn9gxhvsgzz2sgmihzf6pf75clr05mqj6218camwrwajpcbgqk";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10426,6 +10426,7 @@ with pkgs;
   protobuf = callPackage ../development/libraries/protobuf/3.4.nix { };
 
   protobuf3_1 = callPackage ../development/libraries/protobuf/3.1.nix { };
+  protobuf2_5 = callPackage ../development/libraries/protobuf/2.5.nix { };
 
   protobufc = callPackage ../development/libraries/protobufc/1.3.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Old ```protobuf``` versions were removed in https://github.com/NixOS/nixpkgs/pull/29134
Although ```protobuf-2.5.0``` is so legendary a version that some software (mostly from the Java world, for example, Hadoop, even the recent hadoop-3.0.0) needs exactly ```protobuf-2.5.0``` and not a newer version.
@abbradar 