### PR TITLE
nixpkgs/manual: fix build with new pandoc

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -23,11 +23,12 @@ pkgs.stdenv.mkDerivation {
 
   buildCommand = let toDocbook = { useChapters ? false, inputFile, outputFile }:
     let
-      extraHeader = ''xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" '';
+      extraHeader = lib.optionalString (!useChapters)
+        ''xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" '';
     in ''
       {
-        pandoc '${inputFile}' -w docbook ${lib.optionalString useChapters "--top-level-division=chapter"} \
-          --smart \
+        pandoc '${inputFile}' -w docbook+smart ${lib.optionalString useChapters "--top-level-division=chapter"} \
+          -f markdown+smart \
           | sed -e 's|<ulink url=|<link xlink:href=|' \
               -e 's|</ulink>|</link>|' \
               -e 's|<sect. id=|<section xml:id=|' \


### PR DESCRIPTION
###### Motivation for this change
Building manual fails with and error because pandoc now handles `--smart` option differently.
Also it seems pandoc now inserts `<xmlns:...>` stuff by itself is some cases, which breaks xmllint.

###### Things done

Updated flags for new pandoc.
Don't insert xmlns attributes where it is not needed.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

