### PR TITLE
transgui: 5.0.1-svn-r986 -> 5.0.1-svn-r988

### DIFF
--- a/pkgs/applications/networking/p2p/transgui/default.nix
+++ b/pkgs/applications/networking/p2p/transgui/default.nix
@@ -3,12 +3,12 @@ libX11, glib, gtk2, gdk_pixbuf, pango, atk, cairo, openssl }:
 
 stdenv.mkDerivation rec {
   name = "transgui-5.0.1-svn-r${revision}";
-  revision = "986";
+  revision = "988";
 
   src = fetchsvn {
     url = "https://svn.code.sf.net/p/transgui/code/trunk/";
     rev = revision;
-    sha256 = "0z83hvlhllm6p1z4gkcfi1x3akgn2xkssnfhwp74qynb0n5362pi";
+    sha256 = "1i6ysxs6d2wsmqi6ha10rl3n562brmhizlanhcfad04i53y8pyxf";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -26,6 +26,10 @@ stdenv.mkDerivation rec {
   prePatch = ''
     substituteInPlace restranslator.pas --replace /usr/ $out/
   '';
+
+  patches = [
+    ./r988-compile-fix.patch
+  ];
 
   makeFlags = [
     "FPC=fpc"

--- a/pkgs/applications/networking/p2p/transgui/r988-compile-fix.patch
+++ b/pkgs/applications/networking/p2p/transgui/r988-compile-fix.patch
@@ -1,0 +1,22 @@
+diff --git a/utils.pas b/utils.pas
+index eb8b828..1ff2440 100644
+--- a/utils.pas
++++ b/utils.pas
+@@ -100,7 +100,7 @@ uses
+ {$ifdef CALLSTACK}
+   lineinfo2,
+ {$endif CALLSTACK}
+-  LazFileUtils, LazUtf8, StdCtrls, Graphics;
++  LazFileUtils, LazUtf8, StdCtrls, Graphics, FileUtil;
+ 
+ {$ifdef windows}
+ function FileOpenUTF8(Const FileName : string; Mode : Integer) : THandle;
+@@ -235,7 +235,7 @@ end;
+ 
+ function ParamStrUTF8(Param: Integer): utf8string;
+ begin
+-  Result:=FileUtil.ParamStrUTF8(Param);
++  Result:=ParamStrUTF8(Param);
+ end;
+ 
+ function ParamCount: integer;


### PR DESCRIPTION
###### Motivation for this change

This package was broken in master.

###### Things done

Updated to svn r988 to fix a few compilation errors, manually patched the rest.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

