### PR TITLE
elasticsearch-curator: init at 5.4.1

### DIFF
--- a/pkgs/development/python-modules/elasticsearch-curator/default.nix
+++ b/pkgs/development/python-modules/elasticsearch-curator/default.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, click
+, certifi
+, voluptuous
+, pyyaml
+, elasticsearch
+, nosexcover
+, coverage
+, nose
+, mock
+, funcsigs
+} :
+
+buildPythonPackage rec {
+  pname   = "elasticsearch-curator";
+  version = "5.4.1";
+  name    = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1bhiqa61h6bbrfp0aygwwchr785x281hnwk8qgnjhb8g4r8ppr3s";
+  };
+
+  # The integration tests require a running elasticsearch cluster.
+  postUnpackPhase = ''
+    rm -r test/integration
+  '';
+
+  propagatedBuildInputs = [
+    click
+    certifi
+    voluptuous
+    pyyaml
+    elasticsearch
+  ];
+
+  checkInputs = [
+    nosexcover
+    coverage
+    nose
+    mock
+    funcsigs
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/elastic/curator;
+    description = "Curate, or manage, your Elasticsearch indices and snapshots";
+    license = licenses.asl20;
+    longDescription = ''
+      Elasticsearch Curator helps you curate, or manage, your Elasticsearch
+      indices and snapshots by:
+
+      * Obtaining the full list of indices (or snapshots) from the cluster, as the
+        actionable list
+
+      * Iterate through a list of user-defined filters to progressively remove
+        indices (or snapshots) from this actionable list as needed.
+
+      * Perform various actions on the items which remain in the actionable list.
+    '';
+    maintainers = with maintainers; [ basvandijk ];
+  };
+}

--- a/pkgs/development/python-modules/voluptuous/default.nix
+++ b/pkgs/development/python-modules/voluptuous/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, nose }:
+
+buildPythonPackage rec {
+  pname = "voluptuous";
+  version = "0.10.5";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15i3gaap8ilhpbah1ffc6q415wkvliqxilc6s69a4rinvkw6cx3s";
+  };
+
+  checkInputs = [ nose ];
+
+  meta = with stdenv.lib; {
+    description = "Voluptuous is a Python data validation library";
+    homepage = http://alecthomas.github.io/voluptuous/;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -23290,6 +23290,7 @@ EOF
 
   ephem = callPackage ../development/python-modules/ephem { };
 
+  voluptuous = callPackage ../development/python-modules/voluptuous { };
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14328,26 +14328,6 @@ in {
     };
   };
 
-  pyelasticsearch = buildPythonPackage (rec {
-    name = "pyelasticsearch-1.4";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pyelasticsearch/${name}.tar.gz";
-      sha256 = "18wp6llfjv6hvyhr3f6i8dm9wc5rf46wiqsfxwpvnf6mdrvk6xr7";
-    };
-
-    # Tests require a local instance of elasticsearch
-    doCheck = false;
-    propagatedBuildInputs = with self; [ elasticsearch six simplejson certifi ];
-    buildInputs = with self; [ nose mock ];
-
-    meta = {
-      description = "A clean, future-proof, high-scale API to elasticsearch";
-      homepage = https://pyelasticsearch.readthedocs.org;
-      license = licenses.bsd3;
-    };
-  });
-
   pyelftools = buildPythonPackage rec {
     pname = "pyelftools";
     version = "0.24";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4598,11 +4598,13 @@ in {
   edward = callPackage ../development/python-modules/edward { };
 
   elasticsearch = buildPythonPackage (rec {
-    name = "elasticsearch-1.9.0";
+    pname = "elasticsearch";
+    version = "6.0.0";
+    name = "${pname}-${version}";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/e/elasticsearch/${name}.tar.gz";
-      sha256 = "091s60ziwhyl9kjfm833i86rcpjx46v9h16jkgjgkk5441dln3gb";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "029q603g95fzkh87xkbxxmjfq5s9xkr9y27nfik6d4prsl0zxmlz";
     };
 
     # Check is disabled because running them destroy the content of the local cluster!
@@ -4618,7 +4620,6 @@ in {
       maintainers = with maintainers; [ desiderius ];
     };
   });
-
 
   elasticsearchdsl = buildPythonPackage (rec {
     name = "elasticsearch-dsl-0.0.9";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4643,6 +4643,8 @@ in {
     };
   });
 
+  elasticsearch-curator = callPackage ../development/python-modules/elasticsearch-curator { };
+
   entrypoints = callPackage ../development/python-modules/entrypoints { };
 
   enzyme = callPackage ../development/python-modules/enzyme {};


### PR DESCRIPTION
###### Motivation for this change

This is a handy tool for tending your Elasticsearch indices.

See: https://github.com/elastic/curator

###### Things done

For meeting dependencies I added the `voluptuous` Python library and upgraded the `elasticsearch` Python library from 1.9.0 to 6.0.0.

I tested this by running: 

`curator_cli --host my-elasticsearch-host show_indices`

and observing the expected list of indici.

Note that this is both a Python library as well as a Python CLI script.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

