### PR TITLE
libbitcoin-protocol: init at 3.4.0

### DIFF
--- a/pkgs/tools/misc/libbitcoin/libbitcoin-protocol.nix
+++ b/pkgs/tools/misc/libbitcoin/libbitcoin-protocol.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchurl, pkgconfig, autoreconfHook
+, boost, czmqpp, libbitcoin, secp256k1 }:
+
+let
+  pname = "libbitcoin-protocol";
+  version = "3.4.0";
+
+in stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/libbitcoin/${pname}/archive/v${version}.tar.gz";
+    sha256 = "0pz4cnw5xa603lf61fb5wk6ifcpgjvw4cksg05yjvdci55rwl3g3";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ secp256k1 ];
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--with-tests=no"
+    "--with-boost=${boost.dev}"
+    "--with-boost-libdir=${boost.out}/lib"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Bitcoin Blockchain Query Protocol";
+    homepage = https://libbitcoin.org/;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ asymmetric ];
+
+    license = licenses.agpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14026,6 +14026,8 @@ with pkgs;
 
   libbitcoin-explorer = callPackage ../tools/misc/libbitcoin/libbitcoin-explorer.nix { };
 
+  libbitcoin-protocol = callPackage ../tools/misc/libbitcoin/libbitcoin-protocol.nix { };
+
   go-ethereum = self.altcoins.go-ethereum;
   ethabi = self.altcoins.ethabi;
   ethrun = self.altcoins.ethrun;


### PR DESCRIPTION
###### Motivation for this change

Required by libbitcoin-client.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

