### PR TITLE
vte-ng: don't run configure as part of autogen, since it runs w/o args

### DIFF
--- a/pkgs/desktops/gnome-3/core/vte/ng.nix
+++ b/pkgs/desktops/gnome-3/core/vte/ng.nix
@@ -11,7 +11,7 @@ gnome3.vte.overrideAttrs (oldAttrs: rec {
     sha256 = "0i6hfzw9sq8521kz0l7lld2km56r0bfp1hw6kxq3j1msb8z8svcf";
   };
 
-  preConfigure = oldAttrs.preConfigure + "; ./autogen.sh";
+  preConfigure = oldAttrs.preConfigure + "; NOCONFIGURE=1 ./autogen.sh";
 
   nativeBuildInputs = oldAttrs.nativeBuildInputs or []
     ++ [ gtk_doc autoconf automake gettext libtool gperf ];


### PR DESCRIPTION
We could alternatively pass arguments here as well,
but there seems little point in running configure twice.

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/32862#pullrequestreview-84869732

Which suggests we weren't passing arguments as intended, which this PR fixes.

Haven't confirmed fixes build on Darwin, but... should fix the current failure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

