### PR TITLE
dejavu_fonts: make relative symlink

### DIFF
--- a/pkgs/data/fonts/dejavu-fonts/default.nix
+++ b/pkgs/data/fonts/dejavu-fonts/default.nix
@@ -64,11 +64,11 @@ in stdenv.mkDerivation {
   buildCommand = ''
     mkdir -p $out/share/fonts/truetype
     cp ${full-ttf}/share/fonts/truetype/*.ttf $out/share/fonts/truetype/
-    ln -s --force ${minimal}/share/fonts/truetype/DejaVuSans.ttf $out/share/fonts/truetype/DejaVuSans.ttf
+    ln -s --relative --force --target-directory=$out/share/fonts/truetype ${minimal}/share/fonts/truetype/DejaVuSans.ttf
   '';
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "1nf0h15p8yvjx36syq1034i3hix99lm8p54iyjw8dpa19i9jfkmd";
+  outputHash = "15l93xm9mg2ziaxv4nqy2a4jaz54d05xf0hfz1h84bclzb882llh";
   inherit meta;
 
   passthru.minimal = minimal;


### PR DESCRIPTION
###### Motivation for this change

to make hash of fixed-output derivation independent on non-standard $NIX_STORE_DIR

Fixes https://github.com/NixOS/nixpkgs/issues/32909
