### PR TITLE
snpeff: 4.3p -> 4.3t

### DIFF
--- a/pkgs/applications/science/biology/snpeff/default.nix
+++ b/pkgs/applications/science/biology/snpeff/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "snpeff-${version}";
-  version = "4.3p";
+  version = "4.3t";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/snpeff/snpEff_v4_3p_core.zip";
-    sha256 = "1xb3k0yxd634znw2q083ligm2ww4p6v64041r9sdy3930lhjvxb1";
+    url = "mirror://sourceforge/project/snpeff/snpEff_v4_3t_core.zip";
+    sha256 = "0i12mv93bfv8xjwc3rs2x73d6hkvi7kgbbbx3ry984l3ly4p6nnm";
   };
 
   buildInputs = [ unzip jre makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Update snpEff to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

