### PR TITLE
pencil: 2.0.21 -> 3.0.4

### DIFF
--- a/pkgs/applications/graphics/pencil/default.nix
+++ b/pkgs/applications/graphics/pencil/default.nix
@@ -1,36 +1,104 @@
-{ stdenv, fetchurl, makeWrapper, xulrunner }:
+{ stdenv, fetchurl, lib, makeWrapper,
+  # build dependencies
+  alsaLib, atk, cairo, cups, dbus, expat, fontconfig,
+  freetype, gdk_pixbuf, glib, gnome2, nspr, nss, xlibs,
+  glibc, udev
+}:
 
 stdenv.mkDerivation rec {
-  version = "2.0.21";
+  version = "3.0.4";
   name = "pencil-${version}";
 
   src = fetchurl {
-    url = "https://github.com/prikhi/pencil/releases/download/v${version}/Pencil-${version}-linux-pkg.tar.gz";
-    sha256 = "0xq3gczqy7gzf1997qxdql5z7qqk1vabr0rzgakmsi4dq2q4d3kq";
+    url    = "http://pencil.evolus.vn/dl/V${version}/Pencil_${version}_amd64.deb";
+    sha256 = "58e2b794c615ea8715d8374f177e19c87f7071e359826ec34a59836d537a62fd";
   };
 
-  buildPhase = "";
+  sourceRoot = ".";
 
-  buildInputs = [ makeWrapper ];
+  unpackCmd = ''
+    ar p "$src" data.tar.xz | tar xJ
+  '';
+
+  buildPhase = ":";
+
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
-    mkdir -p "$out"
-    cp -r usr/* "$out"
-    sed -e "s|/usr/share/evolus-pencil|$out/share/evolus-pencil|" \
-        -i "$out/bin/pencil"
-    sed -e "s|/usr/bin/pencil|$out/bin/pencil|" \
-        -e "s|Icon=.*|Icon=$out/share/evolus-pencil/skin/classic/icon.svg|" \
-        -i "$out/share/applications/pencil.desktop"
+    mkdir -p $out/bin
+    cp -R usr/share opt $out/
 
-    wrapProgram $out/bin/pencil \
-      --prefix PATH ":" ${xulrunner}/bin
+    # fix the path in the desktop file
+    substituteInPlace \
+      $out/share/applications/pencil.desktop \
+      --replace /opt/ $out/opt/
+
+    # symlink the binary to bin/
+    ln -s $out/opt/Pencil/pencil $out/bin/pencil
+  '';
+
+
+  preFixup = let
+    packages = [
+      alsaLib
+      atk
+      cairo
+      cups
+      dbus
+      expat
+      fontconfig
+      freetype
+      gdk_pixbuf
+      glib
+      gnome2.GConf
+      gnome2.gtk
+      gnome2.pango
+      nspr
+      nss
+      xlibs.libX11
+      xlibs.libXScrnSaver
+      xlibs.libXcomposite
+      xlibs.libXcursor
+      xlibs.libXdamage
+      xlibs.libXext
+      xlibs.libXfixes
+      xlibs.libXi
+      xlibs.libXrandr
+      xlibs.libXrender
+      xlibs.libXtst
+      stdenv.cc.cc.lib
+      stdenv.cc.cc
+      glibc
+    ];
+    libPathNative = lib.makeLibraryPath packages;
+    libPath64 = lib.makeSearchPathOutput "lib" "lib64" packages;
+    libPath = "${libPathNative}:${libPath64}";
+  in ''
+    # patch executable
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${libPath}:$out/opt/Pencil" \
+      $out/opt/Pencil/pencil
+
+    # patch libnode
+    patchelf \
+      --set-rpath "${libPath}" \
+      $out/opt/Pencil/libnode.so
+
+    # libffmpeg is for some reason  not executable
+    chmod a+x $out/opt/Pencil/libffmpeg.so
+
+    # fix missing libudev
+    ln -s ${udev}/lib/systemd/libsystemd-shared.so $out/opt/Pencil/libudev.so.1
+    wrapProgram $out/opt/Pencil/pencil \
+      --prefix LD_LIBRARY_PATH : $out/opt/Pencil
   '';
 
   meta = with stdenv.lib; {
     description = "GUI prototyping/mockup tool";
-    homepage = https://github.com/prikhi/pencil;
-    license = licenses.gpl2; # Commercial license is also available
-    maintainers = with maintainers; [ bjornfor prikhi ];
-    platforms = platforms.linux;
+    homepage    = "https://pencil.evolus.vn/";
+    license     = licenses.gpl2; # Commercial license is also available
+    maintainers = with maintainers; [ bjornfor prikhi mrVanDalo ];
+    platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The current pencil version is outdated. You get a message that firefox is to new : 
```
Error: Platform version '56.0.2' is not compatible with
minVersion >= 4.0
maxVersion <= 52.0
```
The new version does not  use firefox anymore, it uses electron.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

