### PR TITLE
libsoundio: Fix build on darwin

### DIFF
--- a/pkgs/development/libraries/libsoundio/default.nix
+++ b/pkgs/development/libraries/libsoundio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, alsaLib, libjack2, libpulseaudio }:
+{ stdenv, fetchFromGitHub, cmake, alsaLib, libjack2, libpulseaudio, AudioUnit }:
 
 stdenv.mkDerivation rec {
   version = "1.1.0";
@@ -11,7 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "0mw197l4bci1cjc2z877gxwsvk8r43dr7qiwci2hwl2cjlcnqr2p";
   };
 
-  buildInputs = [ cmake alsaLib libjack2 libpulseaudio ];
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ libjack2 libpulseaudio ]
+    ++ stdenv.lib.optional stdenv.isLinux alsaLib
+    ++ stdenv.lib.optional stdenv.isDarwin AudioUnit;
+
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-Wno-strict-prototypes";
 
   meta = with stdenv.lib; {
     description = "Cross platform audio input and output";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9287,7 +9287,9 @@ with pkgs;
 
   libserialport = callPackage ../development/libraries/libserialport { };
 
-  libsoundio = callPackage ../development/libraries/libsoundio { };
+  libsoundio = callPackage ../development/libraries/libsoundio {
+    inherit (darwin.apple_sdk.frameworks) AudioUnit;
+  };
 
   libgtop = callPackage ../development/libraries/libgtop {};
 


### PR DESCRIPTION
###### Motivation for this change
I've fixed the libsoundio build on darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

