### PR TITLE
speechd: 0.8.5 -> 0.8.8, refactored

### DIFF
--- a/pkgs/applications/audio/espeak-ng/default.nix
+++ b/pkgs/applications/audio/espeak-ng/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   name = "espeak-ng-${version}";
-  version = "2016-08-28";
+  version = "1.49.2";
 
   src = fetchFromGitHub {
     owner = "espeak-ng";
     repo = "espeak-ng";
-    rev = "b784e77c5708b61feed780d8f1113c4c8eb92200";
-    sha256 = "1whix4mv0qvsvifgpwwbdzhv621as3rxpn9ijqc2683h6k8pvcfk";
+    rev = version;
+    sha256 = "17bbl3zi8214iaaj8kjnancjvmvizwybg3sg17qjq4mf5c6xfg2c";
   };
 
   nativeBuildInputs = [ autoconf automake which libtool pkgconfig ronn ];

--- a/pkgs/development/libraries/speechd/default.nix
+++ b/pkgs/development/libraries/speechd/default.nix
@@ -1,29 +1,70 @@
-{ fetchurl, lib, stdenv, intltool, libtool, pkgconfig, glib, dotconf, libsndfile
-, libao, python3Packages
-, withEspeak ? false, espeak
+{ stdenv, pkgconfig, fetchurl, python3Packages
+, intltool, itstool, libtool, texinfo, autoreconfHook
+, glib, dotconf, libsndfile
+, withLibao ? true, libao
+, withPulse ? false, libpulseaudio
+, withAlsa ? false, alsaLib
+, withOss ? false
+, withFlite ? true, flite
+# , withFestival ? false, festival-freebsoft-utils
+, withEspeak ? true, espeak, sonic, pcaudiolib
 , withPico ? true, svox
+# , withIvona ? false, libdumbtts
 }:
 
-stdenv.mkDerivation rec {
+let
+  inherit (stdenv.lib) optional optionals;
+  inherit (python3Packages) python pyxdg wrapPython;
+
+  # speechd hard-codes espeak, even when built without support for it.
+  selectedDefaultModule =
+    if withEspeak then
+      "espeak-ng"
+    else if withPico then
+      "pico"
+    else if withFlite then
+      "flite"
+    else
+      throw "You need to enable at least one output module.";
+in stdenv.mkDerivation rec {
   name = "speech-dispatcher-${version}";
-  version = "0.8.5";
+  version = "0.8.8";
 
   src = fetchurl {
     url = "http://www.freebsoft.org/pub/projects/speechd/${name}.tar.gz";
-    sha256 = "18jlxnhlahyi6njc6l6576hfvmzivjjgfjyd2n7vvrvx9inphjrb";
+    sha256 = "1wvck00w9ixildaq6hlhnf6wa576y02ac96lp6932h3k1n08jaiw";
   };
 
-  buildInputs = [ intltool libtool glib dotconf libsndfile libao python3Packages.python ]
-             ++ lib.optional withEspeak espeak
-             ++ lib.optional withPico svox;
-  nativeBuildInputs = [ pkgconfig python3Packages.wrapPython ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook intltool libtool itstool texinfo wrapPython ];
 
-  hardeningDisable = [ "format" ];
+  buildInputs = [ glib dotconf libsndfile libao libpulseaudio alsaLib python ]
+    ++ optionals withEspeak [ espeak sonic pcaudiolib ]
+    ++ optional withFlite flite
+    ++ optional withPico svox
+    # TODO: add flint/festival support with festival-freebsoft-utils package
+    # ++ optional withFestival festival-freebsoft-utils
+    # TODO: add Ivona support with libdumbtts package
+    # ++ optional withIvona libdumbtts
+  ;
 
-  pythonPath = with python3Packages; [ pyxdg ];
+  pythonPath = [ pyxdg ];
 
-  postPatch = lib.optionalString withPico ''
-    sed -i 's,/usr/share/pico/lang/,${svox}/share/pico/lang/,g' src/modules/pico.c
+  configureFlags = [
+    # Audio method falls back from left to right.
+    "--with-default-audio-method=\"libao,pulse,alsa,oss\""
+  ] ++ optional withPulse "--with-pulse"
+    ++ optional withAlsa "--with-alsa"
+    ++ optional withLibao "--with-libao"
+    ++ optional withOss "--with-oss"
+    ++ optional withEspeak "--with-espeak-ng"
+    ++ optional withPico "--with-pico"
+    # ++ optional withFestival "--with-flint"
+    # ++ optional withIvona "--with-ivona"
+  ;
+
+  postPatch = ''
+    substituteInPlace config/speechd.conf --replace "DefaultModule espeak" "DefaultModule ${selectedDefaultModule}"
+    substituteInPlace src/modules/pico.c --replace "/usr/share/pico/lang" "${svox}/share/pico/lang"
   '';
 
   postInstall = ''
@@ -32,8 +73,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Common interface to speech synthesis";
-    homepage = http://www.freebsoft.org/speechd;
+    homepage = https://devel.freebsoft.org/speechd;
     license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ berce ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Add support for pulseaudio.
Add support for espeak-ng.
Apply best packaging practices I know so far. 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).