### PR TITLE
idris-modules: clarify usage of with-packages

### DIFF
--- a/pkgs/development/idris-modules/README.md
+++ b/pkgs/development/idris-modules/README.md
@@ -34,6 +34,12 @@ Mostly for internal use.
 with-packages
 -------------
 
-Bundle idris together with a list of packages. Because idris currently
-only supports a single directory in its library path, you must include
-all desired libraries here, including `prelude` and `base`.
+Bundle idris together with a list of packages. Example usage:
+
+    $ nix-shell -p "idrisPackages.with-packages [ idrisPackages.lightyear ]"
+
+Note that you still have to explicitly make the packages available to
+idris when you run the interpreter, so to make lightyear accessible you
+would start idris with the following command:
+
+    $ idris -p lightyear

--- a/pkgs/development/idris-modules/README.md
+++ b/pkgs/development/idris-modules/README.md
@@ -38,8 +38,8 @@ Bundle idris together with a list of packages. Example usage:
 
     $ nix-shell -p "idrisPackages.with-packages [ idrisPackages.lightyear ]"
 
-Note that you still have to explicitly make the packages available to
-idris when you run the interpreter, so to make lightyear accessible you
-would start idris with the following command:
+Note that it's still necessary to explicitly make the packages available to
+idris when running the interpreter, i.e. to make lightyear accessible,
+start idris with the following command:
 
     $ idris -p lightyear


### PR DESCRIPTION
###### Motivation for this change

It took me a really long time (almost a day) to figure out how to use this, being unfamiliar with the way idris uses packages and with limited experience with nix expressions. The usage turned out to be rather simple but it would help if it's spelled out more. Also, if I actually include prelude and base in the desired libraries I get an error so I think that remark can be removed.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

