### PR TITLE
xsnow: fix url

### DIFF
--- a/pkgs/games/xsnow/default.nix
+++ b/pkgs/games/xsnow/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   name = "xsnow-${version}";
 
   src = fetchurl {
-    url = "http://dropmix.xs4all.nl/rick/Xsnow/${name}.tar.gz";
+    url = "http://janswaal.home.xs4all.nl/Xsnow/${name}.tar.gz";
     sha256 = "06jnbp88wc9i9dbmy7kggplw4hzlx2bhghxijmlhkjlizgqwimyh";
   };
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "An X-windows application that will let it snow on the root, in between and on windows";
-    homepage = http://dropmix.xs4all.nl/rick/Xsnow/;
+    homepage = http://janswaal.home.xs4all.nl/Xsnow/;
     license = stdenv.lib.licenses.unfree;
     maintainers = [ stdenv.lib.maintainers.robberer ];
   }; 


### PR DESCRIPTION
###### Motivation for this change

The src url was no longer accessible. I picked the updated url from AUR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

