### PR TITLE
bepasty: Add `checkInput` for tests

### DIFF
--- a/pkgs/tools/misc/bepasty/default.nix
+++ b/pkgs/tools/misc/bepasty/default.nix
@@ -25,6 +25,11 @@ buildPythonApplication rec {
     sha256 = "0bs79pgrjlnkmjfyj2hllbx3rw757va5w2g2aghi9cydmsl7gyi4";
   };
 
+  checkInputs = [
+    pytest
+    selenium
+  ];
+
   meta = {
     homepage = https://github.com/bepasty/bepasty-server;
     description = "Binary pastebin server";


### PR DESCRIPTION
I added the required `checkInputs` to make the tests pass

Related #32244