### PR TITLE
searx: disable check phase

### DIFF
--- a/pkgs/servers/web-apps/searx/default.nix
+++ b/pkgs/servers/web-apps/searx/default.nix
@@ -29,6 +29,8 @@ pythonPackages.buildPythonApplication rec {
     pyasn1 pyasn1-modules ndg-httpsclient certifi pysocks
   ];
 
+  doCheck = false;
+
   meta = with lib; {
     homepage = https://github.com/asciimoo/searx;
     description = "A privacy-respecting, hackable metasearch engine";


### PR DESCRIPTION
The tests need at least one python packages `splinter` that does not
yet exist in nixpkgs, so I disabled them

Related #32244 

