### PR TITLE
gopass: init at 1.6.6

### DIFF
--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, buildGoPackage, fetchFromGitHub, git, gnupg, makeWrapper }:
+
+buildGoPackage rec {
+  version = "1.6.6";
+  name = "gopass-${version}";
+
+  goPackagePath = "github.com/justwatchcom/gopass";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  src = fetchFromGitHub {
+    owner = "justwatchcom";
+    repo = "gopass";
+    rev = "v${version}";
+    sha256 = "0n3isjrjpn2cnlwfdkjdcz5j8n16dhyaw4zyjpmis51nl0bqd3jw";
+  };
+
+  wrapperPath = with stdenv.lib; makeBinPath ([
+    git
+    gnupg
+  ]);
+
+  postFixup = ''
+    wrapProgram $bin/bin/gopass \
+      --prefix PATH : "${wrapperPath}"
+  '';
+
+  meta = with stdenv.lib; {
+    description     = "The slightly more awesome Standard Unix Password Manager for Teams. Written in Go.";
+    homepage        = https://github.com/justwatchcom/gopass;
+    license         = licenses.mit;
+    maintainers     = with maintainers; [ andir ];
+    platforms       = platforms.unix;
+
+    longDescription = ''
+      gopass is a rewrite of the pass password manager in Go with the aim of
+      making it cross-platform and adding additional features. Our target
+      audience are professional developers and sysadmins (and especially teams
+      of those) who are well versed with a command line interface. One explicit
+      goal for this project is to make it more approachable to non-technical
+      users. We go by the UNIX philosophy and try to do one thing and do it
+      well, providing a stellar user experience and a sane, simple interface.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -628,6 +628,8 @@ with pkgs;
 
   pass = callPackage ../tools/security/pass { };
 
+  gopass = callPackage ../tools/security/gopass { };
+
   browserpass = callPackage ../tools/security/browserpass { };
 
   oracle-instantclient = callPackage ../development/libraries/oracle-instantclient { };


### PR DESCRIPTION
###### Motivation for this change

Adding gopass.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

