### PR TITLE
nodePackages: Added instructions to README about packages with binary addons

### DIFF
--- a/pkgs/development/node-packages/README.md
+++ b/pkgs/development/node-packages/README.md
@@ -17,6 +17,23 @@ is that a new package should be added to the collection for the latest stable LT
 release (which is currently 6.x), unless there is an explicit reason to support
 a different release.
 
+If your package uses native addons, you need to examine what kind of native
+build system it uses. Here are some examples:
+
+* `node-gyp`
+* `node-gyp-builder`
+* `node-pre-gyp`
+
+After you have identified the correct system, you need to override your package
+expression while adding in build system as a build input. For example, `dat`
+requires `node-gyp-build`, so we override its expression in `default-v6.nix`:
+
+```nix
+dat = nodePackages.dat.override (oldAttrs: {
+  buildInputs = oldAttrs.buildInputs ++ [ nodePackages.node-gyp-build ];
+});
+```
+
 To add a package from NPM to nixpkgs:
 
  1. Modify `pkgs/development/node-packages/node-packages-v6.json` to add, update


### PR DESCRIPTION
This adds a little note about how to contribute to nodePackages when your package has a binary add on.