### PR TITLE
Fixing tests for Google Compute Engine

### DIFF
--- a/pkgs/tools/virtualization/google-compute-engine/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine/default.nix
@@ -7,6 +7,7 @@
 , utillinux
 , boto
 , setuptools
+, mock
 }:
 
 buildPythonApplication rec {
@@ -20,6 +21,8 @@ buildPythonApplication rec {
     rev = version;
     sha256 = "0hlzcrf6yhzan25f4wzy1vbncak9whhqzrzza026ly3sq0smmjpg";
   };
+
+  buildInputs = [ mock ];
 
   postPatch = ''
     for file in $(find google_compute_engine -type f); do


### PR DESCRIPTION
###### Motivation for this change

A new version of the `GoogleCloudPlatform` repository on GitHub broke the `google-compute-engine` derivation (the tests were failing because of a missing package).

This PR fixes it by just adding python package `mock` to the relevant `buildInputs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

