### PR TITLE
python-bitcoinlib: init at 0.9.0

### DIFF
--- a/pkgs/development/python-modules/bitcoinlib/default.nix
+++ b/pkgs/development/python-modules/bitcoinlib/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchFromGitHub, openssl }:
+
+buildPythonPackage rec {
+  pname = "bitcoinlib";
+  version = "0.9.0";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "petertodd";
+    rev    = "7a8a47ec6b722339de1d0a8144e55b400216f90f";
+    repo   = "python-bitcoinlib";
+    sha256 = "1s1jm2nid7ab7yiwlp1n2v3was9i4q76xmm07wvzpd2zvn5zb91z";
+  };
+
+  postPatch = ''
+    substituteInPlace bitcoin/core/key.py --replace \
+      "ctypes.util.find_library('ssl') or 'libeay32'" \
+      "\"${openssl.out}/lib/libssl.so\""
+  '';
+
+  meta = {
+    homepage = src.meta.homepage;
+    description = "Easy interface to the Bitcoin data structures and protocol";
+    license = with lib.licenses; [ gpl3 ];
+    maintainers = with lib.maintainers; [ jb55 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -185,6 +185,8 @@ in {
 
   bayespy = callPackage ../development/python-modules/bayespy { };
 
+  bitcoinlib = callPackage ../development/python-modules/bitcoinlib { };
+
   bitcoin-price-api = callPackage ../development/python-modules/bitcoin-price-api { };
 
   blivet = callPackage ../development/python-modules/blivet { };


### PR DESCRIPTION
###### Motivation for this change

This adds the python-bitcoinlib library to nixpkgs

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested if library works
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

