### PR TITLE
nextcloud: 12.0.3 -> 12.0.4

### DIFF
--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name= "nextcloud-${version}";
-  version = "12.0.3";
+  version = "12.0.4";
 
   src = fetchurl {
     url = "https://download.nextcloud.com/server/releases/${name}.tar.bz2";
-    sha256 = "0wgvvpk7h7psy41a32f0ljh6iasjsqbf4pxi8nhybl46m35srg48";
+    sha256 = "1dh9knqbw6ph2rfrb5rscdraj4375rqddmrifw6adyga9jkn2hb5";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Update to latest nextcloud version.
It seems to resolve the icons not displaying in the interface.

###### Things done

- [x] Tested using my server https://github.com/acelpb/acelpb/commit/6e01302877ef013fa9ae7485dd21dc61247fb33d
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

