### PR TITLE
bind: explicitly disable lmdb

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
     "--without-gssapi"
     "--without-idn"
     "--without-idnlib"
+    "--without-lmdb"
     "--without-pkcs11"
     "--without-purify"
     "--without-python"


### PR DESCRIPTION
bind's configure autodetects lmdb by default, so it should be disabled already, but avoid finding a
broken system version.

###### Motivation for this change

Configure fails on unsandboxed centos7 with lmdb installed. 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

