### PR TITLE
buildPythonPackage: Make setup hook part of nativeBuildInputs

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -13,7 +13,10 @@
 
 { name ? "${attrs.pname}-${attrs.version}"
 
-# Dependencies for building the package
+# Build-time dependencies for the package
+, nativeBuildInputs ? []
+
+# Run-time dependencies for the package
 , buildInputs ? []
 
 # Dependencies needed for running the checkPhase.
@@ -66,13 +69,15 @@ toPythonModule (python.stdenv.mkDerivation (builtins.removeAttrs attrs [
 
   name = namePrefix + name;
 
-  buildInputs = ([ wrapPython (ensureNewerSourcesHook { year = "1980"; }) ]
-    ++ (lib.optional (lib.hasSuffix "zip" attrs.src.name or "") unzip)
+  nativeBuildInputs = [ (ensureNewerSourcesHook { year = "1980"; }) ]
+    ++ nativeBuildInputs;
+
+  buildInputs = [ wrapPython ]
+    ++ lib.optional (lib.hasSuffix "zip" (attrs.src.name or "")) unzip
     ++ lib.optionals doCheck checkInputs
-    ++ lib.optional catchConflicts setuptools # If we nog longer propagate setuptools
+    ++ lib.optional catchConflicts setuptools # If we no longer propagate setuptools
     ++ buildInputs
-    ++ pythonPath
-  );
+    ++ pythonPath;
 
   # Propagate python and setuptools. We should stop propagating setuptools.
   propagatedBuildInputs = propagatedBuildInputs ++ [ python setuptools ];


### PR DESCRIPTION
###### Motivation for this change

This is better organization in general, but also needed to make python work with #26805.

(The long story is this: The `ensureNewerSourcesHook` needs to run *before* the `pkg/build-support/setup-hooks/set-source-date-epoch-to-latest.sh` setup hook, which is part of stdenv. Nothing currently enforces this very strongly, and with the changes I made in #26805 `buildinputs` have their inputs processed after `defaultNativeBuildInputs`.  `nativeBuildInputs` don't, however, so by properly organizing this, a good thing in any event, we side step the issue. Separately, I do plan on actually enforcing the dependency between the two setup hooks, rather than leaving it up to chance, however,)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @bgamari 
