### PR TITLE
[WIP/RFC] update firefox on 17.09

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -159,10 +159,8 @@ stdenv.mkDerivation (rec {
   ++ flag ffmpegSupport "ffmpeg"
   ++ lib.optional (!ffmpegSupport) "--disable-gstreamer"
   ++ flag webrtcSupport "webrtc"
-  ++ flag geolocationSupport "mozril-geoloc"
   ++ lib.optional googleAPISupport "--with-google-api-keyfile=ga"
   ++ flag crashreporterSupport "crashreporter"
-  ++ flag safeBrowsingSupport "safe-browsing"
   ++ lib.optional drmSupport "--enable-eme=widevine"
 
   ++ (if debugBuild then [ "--enable-debug" "--enable-profiling" ]

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -28,9 +28,11 @@
 # Set to `privacySupport` or `false`.
 
 , webrtcSupport ? !privacySupport
-, googleAPISupport ? !privacySupport
+, geolocationSupport ? !privacySupport
+, googleAPISupport ? geolocationSupport
 , crashreporterSupport ? false
 
+, safeBrowsingSupport ? false
 , drmSupport ? false
 
 ## other
@@ -157,8 +159,10 @@ stdenv.mkDerivation (rec {
   ++ flag ffmpegSupport "ffmpeg"
   ++ lib.optional (!ffmpegSupport) "--disable-gstreamer"
   ++ flag webrtcSupport "webrtc"
+  ++ flag geolocationSupport "mozril-geoloc"
   ++ lib.optional googleAPISupport "--with-google-api-keyfile=ga"
   ++ flag crashreporterSupport "crashreporter"
+  ++ flag safeBrowsingSupport "safe-browsing"
   ++ lib.optional drmSupport "--enable-eme=widevine"
 
   ++ (if debugBuild then [ "--enable-debug" "--enable-profiling" ]

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -126,8 +126,7 @@ stdenv.mkDerivation (rec {
     "--disable-gconf"
     "--enable-default-toolkit=cairo-gtk${if gtk3Support then "3" else "2"}"
   ]
-  ++ lib.optionals (stdenv.lib.versionAtLeast version "56" && !stdenv.hostPlatform.isi686) [
-    # on i686-linux: --with-libclang-path is not available in this configuration
+  ++ lib.optionals (stdenv.lib.versionAtLeast version "56") [
     "--with-libclang-path=${llvmPackages.clang-unwrapped}/lib"
     "--with-clang-path=${llvmPackages.clang}/bin/clang"
   ]

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -28,11 +28,9 @@
 # Set to `privacySupport` or `false`.
 
 , webrtcSupport ? !privacySupport
-, geolocationSupport ? !privacySupport
-, googleAPISupport ? geolocationSupport
+, googleAPISupport ? !privacySupport
 , crashreporterSupport ? false
 
-, safeBrowsingSupport ? false
 , drmSupport ? false
 
 ## other

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -6,10 +6,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "56.0.2";
+    version = "57.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "35f81e8163a254b7e134fc073acbcff63aa1025b9c6392377650a8f2d0a5f0c77211adb0ae3d8ac85f036bb387246934b8847f14a03fceb7fcbc5b3cf94c9392";
+      sha512 = "bd99ff97a2a6f824e6fbd36fd00193903159e309506b1e6945dcbc43a17a95aaa54a05f32131c56872e8860878ba6063008667955550f03aa8c7084f834d14fc";
     };
 
     patches =

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -6,10 +6,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "57.0";
+    version = "57.0.1";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "bd99ff97a2a6f824e6fbd36fd00193903159e309506b1e6945dcbc43a17a95aaa54a05f32131c56872e8860878ba6063008667955550f03aa8c7084f834d14fc";
+      sha512 = "8cbfe0ad2c0f935dbc3a0ac4e855c489c83bf8c4506815dbae6e27f5d6a262ecf19ac82b6e81d52782559834fa14403116ecbf3acc8e3bc56b6c319e68316edd";
     };
 
     patches =

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -6,10 +6,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "57.0.1";
+    version = "57.0.2";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "8cbfe0ad2c0f935dbc3a0ac4e855c489c83bf8c4506815dbae6e27f5d6a262ecf19ac82b6e81d52782559834fa14403116ecbf3acc8e3bc56b6c319e68316edd";
+      sha512 = "e66402c182fae579dc645de1570a2eba4f95953f608de668da07a1ee4f371041cbdb3e01ce6e4708d8fa3b6b3ebe5b79e03e48ced3605f66cb09ac49abf3bbcd";
     };
 
     patches =

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, stdenv, overrideCC, gcc5, fetchurl, fetchFromGitHub, fetchpatch }:
+{ lib, callPackage, stdenv, overrideCC, gcc5, fetchurl, fetchFromGitHub }:
 
 let common = opts: callPackage (import ./common.nix opts); in
 
@@ -13,11 +13,7 @@ rec {
     };
 
     patches =
-      [ ./no-buildconfig.patch ]
-      ++ lib.optional stdenv.isi686 (fetchpatch {
-        url = "https://hg.mozilla.org/mozilla-central/raw-rev/15517c5a5d37";
-        sha256 = "1ba487p3hk4w2w7qqfxgv1y57vp86b8g3xhav2j20qd3j3phbbn7";
-      });
+      [ ./no-buildconfig.patch ];
 
     meta = {
       description = "A web browser built from Firefox source tree";

--- a/pkgs/development/compilers/rust/1.19.0-bin.nix
+++ b/pkgs/development/compilers/rust/1.19.0-bin.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, makeWrapper, buildRustPackage, cacert, zlib, curl }:
+
+let
+  platform =
+    if stdenv.system == "i686-linux"
+    then "i686-unknown-linux-gnu"
+    else if stdenv.system == "x86_64-linux"
+    then "x86_64-unknown-linux-gnu"
+    else if stdenv.system == "i686-darwin"
+    then "i686-apple-darwin"
+    else if stdenv.system == "x86_64-darwin"
+    then "x86_64-apple-darwin"
+    else throw "missing bootstrap url for platform ${stdenv.system}";
+
+  # fetch hashes by patching print-hashes.sh to not use the "$DATE" variable
+  # then running `print-hashes.sh 1.16.0`
+  bootstrapHash =
+    if stdenv.system == "i686-linux"
+    then "657b78f3c1a1b4412e12f7278e20cc318022fa276a58f0d38a0d15b515e39713"
+    else if stdenv.system == "x86_64-linux"
+    then "30ff67884464d32f6bbbde4387e7557db98868e87fb2afbb77c9b7716e3bff09"
+    else if stdenv.system == "i686-darwin"
+    then "bdfd2189245dc5764c9f26bdba1429c2bf9d57477d8e6e3f0ba42ea0dc63edeb"
+    else if stdenv.system == "x86_64-darwin"
+    then "5c668fb60a3ba3e97dc2cb8967fc4bb9422b629155284dcb89f94d116bb17820"
+    else throw "missing bootstrap hash for platform ${stdenv.system}";
+
+  src = fetchurl {
+     url = "https://static.rust-lang.org/dist/rust-${version}-${platform}.tar.gz";
+     sha256 = bootstrapHash;
+  };
+
+  # Note: the version  MUST be one version prior to the version we're
+  # building
+  version = "1.19.0";
+in import ./binaryBuild.nix
+  { inherit stdenv fetchurl makeWrapper cacert zlib buildRustPackage curl;
+    inherit version src platform;
+    versionType = "binary";
+  }

--- a/pkgs/development/libraries/nspr/default.nix
+++ b/pkgs/development/libraries/nspr/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl
 , CoreServices ? null }:
 
-let version = "4.16"; in
+let version = "4.17"; in
 
 stdenv.mkDerivation {
   name = "nspr-${version}";
 
   src = fetchurl {
     url = "mirror://mozilla/nspr/releases/v${version}/src/nspr-${version}.tar.gz";
-    sha256 = "1l9wlnb9y0bzicv448jjl9kssqn044dc2qrkwzp4ll35fvch4ccv";
+    sha256 = "158hdn285dsb5rys8wl1wi32dd1axwhqq0r8fwny4aj157m0l2jr";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -9,11 +9,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "nss-${version}";
-  version = "3.32.1";
+  version = "3.33";
 
   src = fetchurl {
-    url = "mirror://mozilla/security/nss/releases/NSS_3_32_1_RTM/src/${name}.tar.gz";
-    sha256 = "0lj6c94102aa81bnjisnix09zfjly9aa1d6vrzxmcjmzynkrrrad";
+    url = "mirror://mozilla/security/nss/releases/NSS_3_33_RTM/src/${name}.tar.gz";
+    sha256 = "1r44qa4j7sri50mxxbnrpm6fxprwrhv76whi7bfq73j06syxmw4q";
   };
 
   buildInputs = [ perl zlib sqlite ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14497,6 +14497,8 @@ with pkgs;
       python = python2;
       gnused = gnused_422;
       icu = icu59;
+      cargo = rust119bin.cargo;
+      rustc = rust119bin.rustc;
     };
   });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6129,6 +6129,12 @@ with pkgs;
   rustStable = callPackage ../development/compilers/rust {
     inherit (llvmPackages_4) llvm;
   };
+
+  rust119bin = lowPrio (callPackage ../development/compilers/rust/1.19.0-bin.nix {
+     buildRustPackage = callPackage ../build-support/rust {
+       rust = rust119bin;
+     };
+  });
   rustBeta = lowPrio (recurseIntoAttrs (callPackage ../development/compilers/rust/beta.nix {}));
 
   rustNightly = rustBeta;


### PR DESCRIPTION
##### Motivation for this change

Update firefox to the most recent stable release, fixes https://github.com/NixOS/nixpkgs/issues/32655.

https://www.mozilla.org/en-US/firefox/57.0/releasenotes/
https://www.mozilla.org/en-US/firefox/57.0.1/releasenotes/
https://www.mozilla.org/en-US/firefox/57.0.2/releasenotes/

Notably:

> Firefox now exclusively supports extensions built using the WebExtension API, and unsupported legacy extensions will no longer work. Learn more about our efforts to improve the performance and security of extensions

has potential to break many commonly used extensions. OTOH the latest release incorporates a number of security fixes that may be difficult to backport individually on top of current firefox included in 17.09.

Note this uses a binary distribution of rust / cargo as I can't figure out how to bootstrap a recent enough version of cargo without either:

- breaking backward compatibility of `buildRustPackage`
- breaking something else in the process
- breaking i686-linux support

(or a combination of any of the above). My rust packing knowledge is severely lacking though.

This uses rust 1.19.0 but we could perhaps jump straight to 1.22.1 (latest upstream stable release) which should cover minimum required rust version for firefox build for the whole of 17.09 supported lifetime - https://wiki.mozilla.org/Rust_Update_Policy_for_Firefox#Schedule.

I'm also unsure if it makes sense to expose the new rust version attribute as top-level as it's only meant to be consumed by firefox.

I have not yet tested build of all dependent packages as the nss / nspr update required by firefox triggers quite a rebuild and I wanted to check first the overall direction of this PR was acceptable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

