### PR TITLE
gnuplot_full: init with support for lua/tikz/tex

### DIFF
--- a/pkgs/test/gnuplot/default.nix
+++ b/pkgs/test/gnuplot/default.nix
@@ -1,0 +1,30 @@
+{ runCommand, texlive, gnuplot_full }:
+
+let
+  ## For now, only test the tikz terminal since that requires setup-hook to work
+
+  tex = texlive.combine { inherit (texlive) scheme-small; };
+
+  tikz-plot = runCommand "tikz-plot" { nativeBuildInputs = [ gnuplot_full ]; } ''
+    gnuplot > $out <<EOF
+      set term tikz
+      plot sin(x)
+    EOF
+  '';
+
+  # Ensure gnuplot's tikz files are found and can be successfully used:
+  tikz-pdf = runCommand "tikz-pdf" { nativeBuildInputs = [ tex gnuplot_full ]; } ''
+    cat > doc.tex << EOF
+      \documentclass{article}
+      \usepackage{gnuplot-lua-tikz}
+      \begin{document}
+      \input{${tikz-plot}}
+      \end{document}
+    EOF
+    pdflatex doc.tex
+    pdflatex doc.tex
+
+    mv doc.pdf $out
+  '';
+
+in tikz-pdf

--- a/pkgs/tools/graphics/gnuplot/default.nix
+++ b/pkgs/tools/graphics/gnuplot/default.nix
@@ -48,6 +48,10 @@ stdenv.mkDerivation rec {
     (if aquaterm then "--with-aquaterm" else "--without-aquaterm")
   ];
 
+  preConfigure = lib.optionalString withTeXLive ''
+    configureFlagsArray+=(--with-texdir=$out/share/texmf-nix/tex/latex/gnuplot)
+  '';
+
   postInstall = lib.optionalString withX ''
     wrapProgram $out/bin/gnuplot \
        --prefix PATH : '${gnused}/bin' \
@@ -57,6 +61,9 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+
+  # Set TEXINPUTS to include us
+  setupHook = lib.optionalString (withTeXLive) ./setup-hook.sh;
 
   meta = with lib; {
     homepage = http://www.gnuplot.info/;

--- a/pkgs/tools/graphics/gnuplot/setup-hook.sh
+++ b/pkgs/tools/graphics/gnuplot/setup-hook.sh
@@ -1,0 +1,7 @@
+addTeXMFPath () {
+    if test -d "$1/share/texmf-nix"; then
+        export TEXINPUTS="${TEXINPUTS}${TEXINPUTS:+:}$1/share/texmf-nix//:"
+    fi
+}
+
+envHooks+=(addTeXMFPath)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2375,6 +2375,7 @@ with pkgs;
   gnuplot = libsForQt5.callPackage ../tools/graphics/gnuplot { };
 
   gnuplot_qt = gnuplot.override { withQt = true; };
+  gnuplot_full = gnuplot.override { withTeXLive = true; withLua = true; withQt = true; };
 
   # must have AquaTerm installed separately
   gnuplot_aquaterm = gnuplot.override { aquaterm = true; };
@@ -20105,6 +20106,8 @@ with pkgs;
     cc-multilib-clang = callPackage ../test/cc-wrapper/multilib.nix { stdenv = clangMultiStdenv; };
 
     macOSSierraShared = callPackage ../test/macos-sierra-shared {};
+
+    gnuplot = callPackage ../test/gnuplot { };
   };
 
   duti = callPackage ../os-specific/darwin/duti {};

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -117,6 +117,7 @@ let
               jobs.tests.stdenv-inputs.x86_64-linux
               jobs.tests.stdenv-inputs.x86_64-darwin
               jobs.tests.macOSSierraShared.x86_64-darwin
+              jobs.tests.gnuplot.x86_64-linux
             ] ++ lib.collect lib.isDerivation jobs.stdenvBootstrapTools;
         };
 


### PR DESCRIPTION
###### Motivation for this change

#32941 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Test included that both demonstrates how to use gnuplot_full with tikz terminal, as well as verifying it continues to work moving forward.