### PR TITLE
remove network-uri-json from dont-distribute-packages

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6881,7 +6881,6 @@ dont-distribute-packages:
   network-stream:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   network-topic-models:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   network-transport-amqp:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  network-uri-json:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   network-uri-static:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   network-voicetext:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   network-wai-router:                           [ i686-linux, x86_64-linux, x86_64-darwin ]


### PR DESCRIPTION
###### Motivation for this change

I've fixed the build issues with network-uri-json and uploaded the new
package to hackage.  This should be successful going forward.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

