### PR TITLE
google-app-engine-go-sdk: 1.9.55 -> 1.9.61

### DIFF
--- a/pkgs/development/tools/google-app-engine-go-sdk/default.nix
+++ b/pkgs/development/tools/google-app-engine-go-sdk/default.nix
@@ -4,17 +4,17 @@ with python27Packages;
 
 stdenv.mkDerivation rec {
   name = "google-app-engine-go-sdk-${version}";
-  version = "1.9.55";
+  version = "1.9.61";
   src =
     if stdenv.system == "x86_64-linux" then
       fetchzip {
         url = "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-${version}.zip";
-        sha256 = "1gwrmqs69h3wbx6z0a7shdr8gn1qiwrkvh3pg6mi7dybwmd1x61h";
+        sha256 = "1i2j9ympl1218akwsmm7yb31v0gibgpzlb657bcravi1irfv1hhs";
       }
     else
       fetchzip {
         url = "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_amd64-${version}.zip";
-        sha256 = "0b8r2fqg9m285ifz0jahd4wasv7cq61nr6p1k664w021r5y5lbvr";
+        sha256 = "0s8sqyc72lnc7dxd4cl559gyfx83x71jjpsld3i3nbp3mwwamczp";
       };
 
   buildInputs = [python27 makeWrapper];
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     cp -r "$src" "$out/share/go_appengine"
 
     # create wrappers with correct env
-    for i in goapp appcfg.py; do
+    for i in goapp go-app-stager *.py; do
       makeWrapper "$out/share/go_appengine/$i" "$out/bin/$i" \
         --prefix PATH : "${python27}/bin" \
         --prefix PYTHONPATH : "$(toPythonPath ${cffi}):$(toPythonPath ${cryptography}):$(toPythonPath ${pyopenssl})"


### PR DESCRIPTION
###### Motivation for this change
I'd like to update GAE/Go SDK.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

