### PR TITLE
qmapshack: 1.9.1 -> 1.10.0

### DIFF
--- a/pkgs/applications/misc/qmapshack/default.nix
+++ b/pkgs/applications/misc/qmapshack/default.nix
@@ -1,14 +1,12 @@
-{ stdenv, fetchFromBitbucket, cmake, qtscript, qtwebkit, gdal, proj, routino, quazip }:
+{ stdenv, fetchurl, cmake, qtscript, qtwebkit, gdal, proj, routino, quazip }:
 
 stdenv.mkDerivation rec {
   name = "qmapshack-${version}";
-  version = "1.9.1";
+  version = "1.10.0";
 
-  src = fetchFromBitbucket {
-    owner = "maproom";
-    repo = "qmapshack";
-    rev = "V%20${version}";
-    sha256 = "1yswdq1s9jjhwb3wfiy3kkiiaqzagw28vjqvl13jxcnmq7y763sr";
+  src = fetchurl {
+    url = "https://bitbucket.org/maproom/qmapshack/downloads/${name}.tar.gz";
+    sha256 = "10qk6c5myw5dhkbw7pcrx3900kiqhs32vy47xl2844nzb4fq2liw";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

