### PR TITLE
 thunderbird: 52.5.0 -> 52.5.2  [Security fix]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,595 +1,595 @@
 {
-  version = "52.5.0";
+  version = "52.5.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ar/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ar/thunderbird-52.5.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "e848c7a44222be7bc637dc2d0356028e67c4093f48e4eb9c66e0c02731f41b2e1f2d09cd7765ee984137fcef4d498aac8cfee39b31c0fe5187347107b2cd12a3";
+      sha512 = "637ca11b07a86b806ea274cf3cd9a47dc2d23a2700203c1ddfb25bac15bb4ed1eb4749f630021dd0f33f00c43539954d9fecc192d3582e752940ade0930422ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ast/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ast/thunderbird-52.5.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "a9f8888ab021e696c8460d75ba1f843f8b31555f3f6f95e9af7f9c6d910ea1c3d68bab3d5adc6c0f70e6d8d9227db4176a7db762d28c1ff19addc95e0a756826";
+      sha512 = "78c6da93f60134c9b033f270d04b983713dd84ba6af8cd1c0529471dbd3c860085491bc54f0fd37a8373dd5164b064653d9ae6ab12f7748a9722aa61472ed7cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/be/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/be/thunderbird-52.5.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "4d903b23dcaf17d41c6b9f3d7a3ec936ecc01f19b93ecba88a5fe826f715b606064a6e2737611697c072e887f3776cf10ddba7e26a66dc4b91c3658129171580";
+      sha512 = "7081fddbc88cdd0280bb35c7f16c33f8935d639d91e2ed4258e344565ea6f27d1ed8f2b5daa5d2e861e92357ba65c4c4b05260fab83f0bfaf6e2fa44ab081fbb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/bg/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/bg/thunderbird-52.5.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "6d34b3c3e907a16125f26f5f6365b5c3f2127ccf725753e94495b5dafedf3c506e71017d2b4699b755f8940ad0ea4241d6cfc00e958d4642c928c68a7e278fdb";
+      sha512 = "d5d21dfea54ac7c75c515cd95f0140a21451a3b2c533cc95f0a519a13b950e01c6f1d17e2fdae3610b46fef7450e1d816158a71ae37e8813d8b9dbbde2fbb4e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/bn-BD/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/bn-BD/thunderbird-52.5.2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "74106efb92c5ba792a3f10dc0ea19d2fc38012f1f761c0e9b9753f8b067e2771a9c4691df55197a9b5e23024f73688bbc26d24357f0eef95b8b305bccad5d9f1";
+      sha512 = "c59b5b7381ce8fc65018bd70dce55488b12915d2c9fab7421433d7836cde95a409c2f5206323581bcf7af08b90e7ce8eb3c55b0a4f660734d3e159077ba60374";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/br/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/br/thunderbird-52.5.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "2477afe645f7c0e0005a4817a42d24075dfabfce2724446bcd4fce50b72b7408895261544537be0e3dbdf8323e1af07215ca277c9e69261d575cdf4fc1f242ca";
+      sha512 = "f3d5bea008f0849dc8834d51b6ba0529c2f803e5b059582076baf016fd9a02288d57851e1073c1df3f79f4fdb0f72ca8c707d25f75109d6b33ed60353180e80c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ca/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ca/thunderbird-52.5.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "810c5295bcde18217b77e2f147a70a5e94798b92c40d659c47f3f113624f049b788ba9fdcdc22608cc57719e8236372636e6ca46ce7fde309b70fc05e3036f47";
+      sha512 = "64d024e4c696cffd4d97566411f7412ae16e98f169101bd36e87efb027555bc163f38ea1898b29a772fe31e1667dd69cc5eb19a96e04982b01b0de3975654292";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/cs/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/cs/thunderbird-52.5.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "f8e033ed566d6b076213e33c489fcfcab520a0e1c3ce5c89c78c7443b360e55136e90b518428527a682854a24cb9b303a6c3475a59950d9546c1becd5db2a46a";
+      sha512 = "ecd78ba038a9133d8ecd0184ae44af661efd38d08e53184cb26b221d50101df38bc7833a0cd7c76d55a185288f055f5ac630b1da525a9008d878b4c5a3d9166c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/cy/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/cy/thunderbird-52.5.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "27ade0c53cee3fe125420eb7fdeb5b013771d34af735bacd59af6681836d81acddda3b3b9cefe3f8a05b70703c040d6692732c427db13e5dd971848c078ae7ab";
+      sha512 = "1aaef9550bb3e3e5a49ad220344a9b8e20db885e06eea182f87dc8ddeaac62b0cd2b94f58524b0c6d3afea054cea0d75cc96f80732e390cc47848da16cad3fba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/da/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/da/thunderbird-52.5.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "11de17a749643d35bcee49ebb1aa62caeb6806fd0025125363f228593979e873fbf8a927bc451c2e4a5332f431937c00601ff380d74e48bed60cfea5399b891b";
+      sha512 = "fa501b4febbeefc90ff9ecf4c2dc4468c6fd2dd04559ac886d8e58ea3d4eaf003cb4577197b5b5c391f602b83defe158b8e3405b36edf2a6e48e48719849deeb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/de/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/de/thunderbird-52.5.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "3d2408f523d55471f0bcdcb3a05e66381d390f56987b448a40118b1f0e3fb66cba8ed64cb3178694873f5ee0c7f5a74303ffa288eddf7192a4f519d537ecb65d";
+      sha512 = "e4c87e3736dcfbe4e8fcce8a101030844cacfe2c20209de4a21cce247b8e80de3e4646c9a84c36d6d73199ea5926c2777a678b8f2b83521078c0c3a10a752b32";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/dsb/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/dsb/thunderbird-52.5.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "d1f560111bd8d8eac360ed39b0ac741ca10c480ec528cad48e9bf6544d17e12fe2f41d4abe4caa3549b448fd1fb55416ed84fa864dd60fe0cabd91766e754992";
+      sha512 = "eb169f9d2e9836b83edfd8ef8f7af867ac27831bb5aadf5a75f6e652b507dd7c34ca135c278f95d8f967406732d296af3d42a18fa9e91c8ed18216da77824e11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/el/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/el/thunderbird-52.5.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "22c3270759d095c4672694c0885d3960d87cb9f53eedcf7c030f8a38f204d4809914b3fe1cd144f32555508eded73999907c64df2d9ae9494c69ce879180278f";
+      sha512 = "dfd0160965fbebdffc217ed171bbb308902e1b0e89d91abe8167d7d26db991a8ce2b40b3161d623441102b2b6379a774b6af4a19bb39c27c59d76840351900b1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/en-GB/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/en-GB/thunderbird-52.5.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "3e778e8f60101d2371ce7eb369c3f80c26fdc8164f5fcc78b8f65f2986288388e06d1413387b493ae479bd95b3af7fdd76f88365aa5803c4e9e3bb23e4f3aa59";
+      sha512 = "8c8506a8fe62e6ca55b1d99d8db9ec5fd224fa87ff63f9eae49656001f94124312110a414769d5d396574aa0e1f69a8f0a5298d6ad86146ba40912ebe68393a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/en-US/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/en-US/thunderbird-52.5.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "d4eb0d90d621b28cc706bca0f6884361b7fd53cb02dd9ecccfc3f6027634353cc8f4c911824ebe6bf1d7bbfb06318258daad32fd47687f2f3b930c90da4b8830";
+      sha512 = "73e15c04a11190e8968bc64226ae4c677fa00ab460fe3497aab861c92c07ff6a3814673a7773ffc4e735491ac338e9d190e0c7cd626416c2508826000e1df002";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/es-AR/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/es-AR/thunderbird-52.5.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "0088b0380aa533e4c2818e0b384f5edafeaa3c84256e81eefd0dff95f27adc32c8a22b3368576d13aa1276674f519333b5c3f4a825fcc38da1abd0751c48f996";
+      sha512 = "6b42efb1bd21fb9c9df67496a09fdba958145d56b185d10187256e45b8891dcf725cecbf1868c7cdba515397085f616328c111301ab1cce584158a17ae47b944";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/es-ES/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/es-ES/thunderbird-52.5.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "251cf4cba82dbc10bc38039348894843b8f5c76875be72ce5ea1cb26cf26939055350e61a86e8ed9f63964bb95e99aac5442389c87588829e45e9ef41709ac7b";
+      sha512 = "c1eaa597f18102f93b7621d50b5ebb54f9007ad01b5ce543e3f53cae88a42ce06c7d2332fb0e6b080ac2209403dfe06ce24a17f09c7ae3d5ace8d5e85e1ce603";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/et/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/et/thunderbird-52.5.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "609bfd8fd7f8dc17b52173de9916133e0cd52e41e66a488ee2bd1aea5078cb9e08084c10d0b20be36204bfc3f785574500e2bbf9a81f307394b169068ef3ff07";
+      sha512 = "b0386ef97662e21806c15342b68b2224ed3b41a8f1648f1b9869b527eb8b60951f9453a5abbc74e94905799953af5a7289b25c80fc370772368f39a048ef89bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/eu/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/eu/thunderbird-52.5.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "ebbc42c9d491f0f0e9ac5528d58c5d8604a913d77fb3d4548cb0127e356817c729c1ce87fd7874ae6f688268ab64b8b898611780b5c6b11707b455f529ab5f65";
+      sha512 = "d7070db2bac9aabbf5b020f60080d3beb9b1ecb4df73fb541f387435eb9ea80e2297c76a79910af0858ea42882298cfdd5c5016bd2049fdbe91dfe1f4bdb8b70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/fi/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/fi/thunderbird-52.5.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "807b4fe85c2b751e815dd4ac19b0e80199f391f7a8fe7e7f5c1f7f75e896620ddc7b758aae076bd44f9cd7774b2020640f858e139db57b508919d78caa77d913";
+      sha512 = "2dc49e7ebb96cafb37b600490bbf49a40393ed00cd4889e1bda6331e9dbf377a4cd53cb6cd98e7fb2e7cdf0da75e69e38e9f3894ab289f3ba0894f499e4f83b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/fr/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/fr/thunderbird-52.5.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "d2d6e92815ed9176a2743578c32ac82150d4097eee6bf31356a9bc1cc1ba649c86008d301654e291bf0bf5ae2d81c13d941c4203aaa9dd3c4110d36a34f28140";
+      sha512 = "2ece29dfad71788ee5bf98afa262edc3b9bfaf57a2ea07d669c1003b09c5a5fbefcdb028d4842c53e17c1a63cce16f9296e574b834631cd485d0737cb13b174c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/fy-NL/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/fy-NL/thunderbird-52.5.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "bb5e34f15d63abecc4b68a74cf818def59caa2de47c9ab71458ca79839fd29f3fc2476b5e38a95d5d5252acb03595f0e065bcba5eaba6ff2eba29be66607f417";
+      sha512 = "a84eab825c051666d606fff131542c71bcad7f204db19dc10d54166b499869e43951c9799d05b194f66ff40d5f307957c2d27de17da6ecac48ac24621da7287a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ga-IE/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ga-IE/thunderbird-52.5.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "e6f84323e42ad5a0df546307ba0a87be57d1ead7b7a807ffed4cb977b5b4c19c91ce8058794da07fb1ce678e4f8e59838454deb9a19232a5cd7d60c6cbbce74c";
+      sha512 = "181fcdb0bae1a2aed16ba61523ec90f89b884d907796e1d1c37c722f68b89dbbabf977446022af6c7050e3e26d995e33891880e875f28247653225479847acfb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/gd/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/gd/thunderbird-52.5.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "1e28be9ff5c3ccefc320e020dbe574f9d5f8319eaa79e441ab7f1283557eca01501a2e0f4aca6af6e58157b4c1686422d70a258010657803ceb272b900ad3e3a";
+      sha512 = "cc91084f593788da76815f185e2b9a877409537cdf52566000953a008bcb2783c09cd8893cba9f387b731fd636b1d8e7b7208832623d1222b5fef72db8cb4541";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/gl/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/gl/thunderbird-52.5.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "db2d76733fb97558d05b3ccb963ad82ab6886d1db32923bb73e4a62bbd80353fb7d7cbe4e1a82fc9095d582e467fe9a045d82be0aeb319fddcdc88c530733381";
+      sha512 = "6491bf74093139c86a5809d02582b6d055ebdb3cbf29a1a24ff7529a6e8c2bb89e26c27e7f65bb588c379566741510d6f8372f7f2a11004350cc7e907a3a6d8d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/he/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/he/thunderbird-52.5.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "1b4640496d3a1acc7b8a146c8642f25dbc5dcccb7a164fb49a0ddad41e5a43d571936111154838b149bcee091205f0212926618ba5f233aaee051d5def345889";
+      sha512 = "4235dfe0f51f55dcb905453aadc01baec3b8033384e5085072abb600c71f777699df4b556233ffa9b07f5d62442aefbce6f1eef2a9d557b24b48d797cf03b026";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/hr/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/hr/thunderbird-52.5.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "5d4e361e7597b4dd0a896e38e31cf737dc1d51e87c09490a298147e4f0f395989567de2edff69f862fccc860dd0c18b24d2f91356736294c71429d22f47eab4d";
+      sha512 = "4236d464d704ba9c4c60323dd3518a37f71d24cd441404b6ae7a0e97ff17c839e2eff48d100211cf5ce9d3759336e7a0c29abe5f8390facedd769804adb8b956";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/hsb/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/hsb/thunderbird-52.5.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "40b51097b472a36078a7de4ed35446baf9a3a5806a92f13d49cb0024ca154e511195e6b470959b6084ba689c4475224acb81010f417618686a4e99efc624754d";
+      sha512 = "876a6c45e62c1025bf29ad3c626e3d2cbbc7d9d660e8e862b0fb586b73ed42a0bb58611dc69af727571c93f31dca450dd9156ba78b23b9a4a2116e561a8e3763";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/hu/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/hu/thunderbird-52.5.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "01a11e4e59c527e43d13c5c12dd95665bea7aad105d9ee9988e94671e394b7a55c2e85154e1bfb200d9290373de32d7c33ad1364e6cf2c189d8c9d8b52fb813a";
+      sha512 = "7bf7604f08e452f33154ba91cdef8aeda9905470f526f403dd76e19d1010f822cf2f3fb7c5f0525299bd0401139df1a12631f796d603e0ec3af4aa8df73ed0f2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/hy-AM/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/hy-AM/thunderbird-52.5.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "bc3c78d1d3da660c66b64930d295f3e79467684d178c831ae4f2eceb9d9c7753e5f1b60453fca674346da5e6eaf3c835df7340f0cdeb0e9040be546aa69d0cfc";
+      sha512 = "bd62aedb2c800265fc34c884f1605caa0040794cc49479189dfa4a959d49397ef023efaac0937c9573ef7a114cee16504b5a65f8f8f3f3d4d222f4a173707bfa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/id/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/id/thunderbird-52.5.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "d377473cce2365f60aa5a65680daa2569716f3c331d20427f3d9002a72b42c0356e112f943db228a026f0d8cd5319168a9f718f3144b4c0a93ea3209c9003680";
+      sha512 = "1dd761bc1bdd865b5ebb494c00dede5e616a1bf7fbe6d7cf88d4f5362eb75435ae162d2e027fb7928783fe255179de00d28a29ab3d90350f75be7a1e4ad428a9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/is/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/is/thunderbird-52.5.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "bf41f55ef16c9ec322d732174a1076e5ab6a5db12f861891bb0ad1becf2b630b7504155505789e9ff7778b6c708642da55630aa20c0c18ccf11734572f62bab4";
+      sha512 = "12dbca26babd51739fc6505fdd36ad32b5827e1c3e439f3ae4c2c8e0f165528e693af537bec8630146c6c6bbc55b75d7c5bdd3bd84b5255cbf756d627beac2ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/it/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/it/thunderbird-52.5.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "eef60e791ffabfae57c4e9f4094a39c8cb5c61ad4a8296aa111c6ff4e14f05bd86d4f9e682859ba6ae4e8d0c10001403d21bf8fa54e7c5688ca9e0ff06b4d2fb";
+      sha512 = "9c9b77c70429436b1cb0030c92109343eba9357f58873c13399e9e64f44807e06fc0c429e0748ce9a11f68baf643bec7cf313fe79cbfd35e548ad579b0e6e108";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ja/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ja/thunderbird-52.5.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "43dfc61aebfd6b80651900b1bd066e3c731e06854bb375d2eba206733d4bffb42f9b0116fbea0853f2aa440a6873cbe9e188ed528cff25c8634d7afb59e9d3c2";
+      sha512 = "2f785ddcb2e16ee1970cb582852ce52e1f3f7cbd58e8f714a18a387019b510cddfa1927f593b61ccc4b662b6e65f3fe20135eed451ba07a1df45b5979743b20d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/kab/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/kab/thunderbird-52.5.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "e75c653e6dcaa6a3116aba962afc6196c29e9194235b726e3ba0b4fe050129512f6d67358a2ce9e2b6879f6f52c6ada583af10b70cddde7ee0b8fa72edacc40d";
+      sha512 = "1bbd7b2c79cce7b74614e6f09cd7235d58def667f74bf3276ec928df4f0084704654224f100f227cdb350f839a13e474cbc98e4614ae45cf00969b2706291076";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ko/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ko/thunderbird-52.5.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "52e29e6b2996a59dc4ffeee6f7a35f7a491e1d44af370ab1537d0a45c8d9ab8b1bf972a24f1f2efbcb6fa1d8e9b7b15c7b0c00d5aaf24546fe7860c7a6f97afb";
+      sha512 = "e176558707cda5570b020aa0fc3620deae7edc6e7e363e1ba4b51d6cad9f4a9e74a35be5f419fcc0e18dca31b6c887a62112f99b4a60d9026b8dc5f87de45f74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/lt/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/lt/thunderbird-52.5.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "d935c882dd6a9a3ad5a6c5609047a6e3c2c4146b198e8c28657ad166d7b6ad826e6db0e4c88944214521f0cda0907281b50a6088432b574d1ee13e5c504c939a";
+      sha512 = "f431c57a74e0f8498a9a1ad36e6528d09dccf8b03aaf9e7ab66ddd503bbd78ddd15176a5e6c2358eeb616ee023f78414c30b67fd39c4c2f15f4e377df81759cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/nb-NO/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/nb-NO/thunderbird-52.5.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "bd607e451f2601483aa4d59cf6225318a3bf1b2066d0f6b76c64025de0b20a8c8d8211f95b953440505248905d5b4dac569cdc610fe4d9d658a6ecc124966b82";
+      sha512 = "5bfae55863550e32ea6581d0c24ae5374e2365d9e5e8f05f91856d0fd2760b761d183b12c9809668730efbba63e6c23408431f4616f6a7cc52ee465ccb939aba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/nl/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/nl/thunderbird-52.5.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "4767403a33047512f301617dfdc779f92e001114a06f31244e5b9a648ed4a7a96c6fa16194a803682417d151f2f9d61da241065f15cdd2e5953eb5ef41220093";
+      sha512 = "fd7d35c0205610d868fb0676f3a8aaf328b1906dd1b174124e254ec8b08e5173741853938707dc99b10b4417df4a7010e20cb8a1038bf8f3258dee593cf788bb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/nn-NO/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/nn-NO/thunderbird-52.5.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "f2fd66bc8a520f90fb65e5f737ea25e44f5e3270429cfcf878e4b128f1facfc3bd29282586aa6ba73478de04cb796322436d14580d86fb5861072b6722e2ef87";
+      sha512 = "1070fbd6c51d68e560fa0eeab66f2baa39d11752018d20d23a3577b12b504355f5729d0d961ffd20256521f54eda69d03fb8efef70f8254685e28b0164201354";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/pa-IN/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/pa-IN/thunderbird-52.5.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "8e4c38febf02e61b874f931b0cf03221781ed9543f9b7a392ca9122f101622c20135f0fd94e5ee7696d0741a9910e1d1031fad3c825941d54da1f56a2533b61f";
+      sha512 = "12293c8258f02403c8db220c73cf76b24315268324f2c6ac41dba7d77d9653cd1a21771a4994f7c6dc0db9948a601008e347d908c05dc59b7cf6ddcf95b2e86b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/pl/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/pl/thunderbird-52.5.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "3e6fda867feb132f37913a8b2bda2ff2736f4d804e274f01c306d387b3c48fe30aa04b6f85eb4a7fb444036bdd4b3fcd4f68cbb53244d85b5064aa36c3588cde";
+      sha512 = "331b81876aeb162e1f4e838cb00712e971310285febfa669bf7c6d245c1e8353be941b6d1236423e0d835feacaabf859077da1918cf2652f6b79de30c4beaa30";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/pt-BR/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/pt-BR/thunderbird-52.5.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "662e0616d12fcb7dcfcb98a4e07228509ae7ad731c93d2c90a7bb7ebc3bd0f9636563a70977db14733c832220258eede361526b01132dd02a4e44b16acc6a5e6";
+      sha512 = "d69fdae2048b738133fd07c6aa0ab6c264e555a3bc3a899d09fd7fe49435511fd544f3ef04e079c4efd320bc2abfa813f85a5f2a9e477af56aa47495466103b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/pt-PT/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/pt-PT/thunderbird-52.5.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "8037be03b26263f3a1e69c4971cb70db50f95356c97e3252f76f080f5a7961c1b2ac5aea09d2e142994c5fc91c91ab8db738e5a104795e8506a06c997977930a";
+      sha512 = "fa3286336d47b2216b0ec0c5fb6cba2421cb0cc81d1f815515c637a063b8de167cccfc3dd30b02636ae88e74efb34f8fde1b198924fe864b1fdc08d95b7f0f3d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/rm/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/rm/thunderbird-52.5.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "93a76b870c15b61a1135e405f76897a86674e1fad2dfa9b3a71cab83f99c9369b7363a395e813536492a25133548f227f5254795cd20de78f127c969fa3ff5aa";
+      sha512 = "b4affea897ac5af177c1fb6e4919f94f5f20860c3f492584c79664d803b7c2d092a96f1a3afe6b3212f689901a52d0ca74abab4910ba291280d52ecef2cf9a33";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ro/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ro/thunderbird-52.5.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "4a535aac1f6666d20c7aee65ee974bd545cd4aba56fd0ea2655d89a532b60bcbb174b8046792365041b431d3d3099e0c273c5ce83f1e1f3599a476028b482f37";
+      sha512 = "3cdcf374f33961484962a6294ad8fd654b006f3472ce6550936a8c00a28943088c9c61049fba278cd304381003b46903a5514ac340b5a85a959edfe17242eb4e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ru/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ru/thunderbird-52.5.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "ec56cb45428ce24497ad398716f99f49d6a5787a042855dd5839e5185d43763ea87b89090bf15c571841aa0526f5b4b0fec8958bd673a39ccf33ad5f2937b33a";
+      sha512 = "aa1d54fe356ef15d852a9ce3f269deee411d4815f4108c93c832def784c1afa104193e62fd9b47977d20ecfcf3057c05d76f39cc3abeb0341102b7e6e6639763";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/si/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/si/thunderbird-52.5.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "e1b19b27571cc833de579d1460d27629042529480546cf3de11a39608b8d599ffd19451ae3df96390009e95b87521f17e5843bc77251c923823d3b0529167f17";
+      sha512 = "543710116d67afb86e316dd17bf9a74a07ee5e3772381d9f0495af4d42075e96b6ff888ce0c3ce68ec779dc051f3ecb6105d51a6e4459cb4907a604662c933b7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/sk/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/sk/thunderbird-52.5.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "d20d0649426fbcc812b536d368ec5785b32def01b91d67776d5776a7fb45d9c723e1c455d20eedc7825370b03e484634ea42fb55dab5b3c860167cbeb8596c7b";
+      sha512 = "3ae5ab97172ff0f4d3eaea7a69fa54d9bcf639a8032ee2c5a3fcda2d8b30072d3386c54ef7e8c9bf5417a6030966c1097d69d41dd8c5355e82d048b783aef461";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/sl/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/sl/thunderbird-52.5.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "c37ecb24cc9bfe2d31459590d0882fd9cf196e822a18105b61150db4049bd52c31bad2a05ebfb710bf1d1d879a22b3e6fdca08ec81663e1c1735a4a2d157b4b2";
+      sha512 = "9f3e0724e837608cf4a64a2505af732e4cdf61928bd5dd1237e27d5222147a8ec52870e88c73653de8518e9ab81af4fb8916b067c780b1af25b8f6c208a10684";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/sq/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/sq/thunderbird-52.5.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "0ed120ba3b39f884784269a6098242b8e1298bb4287749b901c2702d06c6824f762942bfe05a0dc1966c19e883239b09312139ee7eeb2cb22995d47aa2d124cc";
+      sha512 = "0f2e10a8b9cae1185079af8e37ca9622d9ed29b6bb38377cc2db7523dded8da4969798941ab1e99cc70b36bf2fa59549567cf5c1e1cc40ee0131350d60f8239f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/sr/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/sr/thunderbird-52.5.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "5e83710d06507a40705ae5177e4749c31aed4e932efc0c51f8da6a4b30d598328601f8a53b9fc0dc35cadcc130bb637771454d9cf55e8dec2b934287213e17f8";
+      sha512 = "1f32b2705e4939c5e57f7a6a3eac29ccacbd90bb93361007b208a0eb1aea4f279b50fa17ffb86571cc2aa793742d3ff62caf28047b69c95ce358b6ec2cd24268";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/sv-SE/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/sv-SE/thunderbird-52.5.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "4cbb20b1d818f0238cb0d5235ea82a1984b8dd632467ca91e3f3f4e8ba58de904603d1135c8a7ea359188f1b01a6ffe8d654a2d0a73b4af1f3862011d697f755";
+      sha512 = "887176e1d4d9cb385ce0261a45f22bb67a87a125da737403c6965a6dd57ec7f0763b1245ea0d04b79aff5f41cd1ded3a06dc4ee301a17c01a9417ea2d515dcb0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/ta-LK/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ta-LK/thunderbird-52.5.2.tar.bz2";
       locale = "ta-LK";
       arch = "linux-x86_64";
-      sha512 = "3c2397e9b9e8abbbef10af15cd35ba086336daa5c317ba60d4489786b3ae4fee89457f2b34c0b42ea550000e8536ca3fee94032848b11dbb2c4cb6fe489efe6c";
+      sha512 = "fb981e6175b1f8fe79b65f2c324e376a89c7378074a6ead4cf3444516fd8d566591f942133642830caeef1f342ceb169d2e558171a5675ffc96a82deeca585a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/tr/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/tr/thunderbird-52.5.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "9360797bca24f5477120d93665f9b4aa1614463558b6646e2813b31fac5b5bf84d5e88a752696c28fb51613c288482e3d88197ded2310b66515582b11f81aeb0";
+      sha512 = "2ce313b74b8512eea958c2c3e303829a3d7452a48efc07afbfbe9ea783c6099e75693b679cddb65802fef5a47f98526b7ceaf4c1e7fdebf9357c91d5a306bd70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/uk/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/uk/thunderbird-52.5.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "ee521d20fd5e7cc3f803f74ef5a9ecc4c1df8b149668489b28cc212ad2d5c765bda838904ad726b92b5e0e2eb35c2ba6fd4f48ac7c700e41e896e0e976fe2028";
+      sha512 = "dcf852d0c584c3959fe0f7ff72cdd45fa8497aa1ca44ca036e849c3395da470a52376343f4b6e37a343e2f2919245a52e63bb5dfb5651bbf749c72c35a8918b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/vi/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/vi/thunderbird-52.5.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "3d7b7cd1f83e80290f460829b49b6893a73871456cd10ab22da482381ece0ac14fac3e5c0e2fdf1e61d463b7c211c33ec8d98120fc0bc17d2052bbbcd4e16af8";
+      sha512 = "2b3c262c1955045bbda194715f4e9fce97872054ca8cc6f7bca3c1c6da303ccda4715336c846d47bc204fadca003ba9f4efdb6798e55c9e928ca822544bfe152";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/zh-CN/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/zh-CN/thunderbird-52.5.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "c0f9902bacbb659f5f012f30b6190d4e3e53baa7e4473cf231da0b7c509beb98e49f0e4fd1ca3ed9917c54279609ce5fba1c51b80b12aeafedb82a83218856d2";
+      sha512 = "74e7d7f4039d38f6af9590303d173d7293046f897e5b23acf8ff16c7b1ecfc50d0e8896550ee371f19e73518432d137779cba26bad913e8deb9e4af1b0637edc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-x86_64/zh-TW/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/zh-TW/thunderbird-52.5.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "64dbbbe05b3ade46901686fa4733cc7c25570d1f02b378a2b2855b75905e687db9f97db852bb53e2baaa1010a0ff365bbd90060eb7cec7db745faf014c5e5564";
+      sha512 = "914af708ab185b76a67e8a2a4c85c14f41bdc05bfbef66c56a8b28820e4eeb866dcb6d60b1b4b61d924af9a6ccfa9ec6a10afd6ffb74794487472d508807b417";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ar/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ar/thunderbird-52.5.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "1e6449d23bb937d07fd28049ef4e36b64c1f36edf3f4def640dfa6412d354ec6acd5b1642e0b266f18334f3ab7806a9cbb016946c0a36ec4222cfcae39339bcf";
+      sha512 = "b749fdc34c15b48bcc0b99af41ac0357fff3a9c4bf774de536caf1fa65b33dfc69a4a14a4cb0c06a82d41e222362cccafb9ff8f4ca64c128cf0a031c1161d74f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ast/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ast/thunderbird-52.5.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "38f0fddb28d8a894798e9811599e706e60ff80131b22568e3dc70ff7f43388acd6de5ee4485587c59fdba8f790b393f4f16cef6bcdd86b928f3fa1bfff7297e8";
+      sha512 = "f3ddb2b95237e8c505286328369c9f7613e5cb22ede50f8842e936c158aa6cbdb053de6c0f4ef0a9256b394b5510c1733ce0f8cc8423370581ec54b871f59b56";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/be/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/be/thunderbird-52.5.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "0966c3fdbf73a51d2c7776918abba4b77392dfe2308aee36970cffcbbc3e1de537625c0b5881a85eea74817b33055278d976af719773579885b3294746a3ae50";
+      sha512 = "d41e1bcb8460015876d784eccb37aabfeaa8a283f408e6606d84175f3e6b1e7428b8d277d30b250192cede4cb6bf2746945cf6fd4afa698fcb1b4230ee0f6d5b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/bg/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/bg/thunderbird-52.5.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "a0a792063a3eaad2d15f4b726c9ed170f59f99b1ba9c966fdcd6471865dcf2f25284ab5e4e28641a66fa8ddcb019f8b8f521d69f5ed5e8d1ebc2729abd9be8b0";
+      sha512 = "e07885f88953dab1a940d21142fc04c7b8b2f807fc424f69b99f90d4a8f5ed034fc00de92d76dd4fb858c669cf6c3e9cb82f93ac3a264ba71f7b644e99849fef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/bn-BD/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/bn-BD/thunderbird-52.5.2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "ea583cbba8a0080a5529fb91988a0ee1c7aada1447b616e1ae43b6eff86dde87768cb4fe90fdede8454ad5240d266bc5e6ba9f1e5e05f2ad82cd3ef68ba374d3";
+      sha512 = "2cdab1cc1066ab51d8fd0787115568cf70f3d584d2fd5e3908eee0f64037ce61a80a3f19ae31dc8cabca8f05cee51221917c717ea535a5a8085dd3410fa56422";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/br/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/br/thunderbird-52.5.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "18060c8473e82554ff793ba495ba6760c7d7d8c2ccf8fdafbb41589c57474baa0a88808d154a29f6359c657bec40d9d164e53066d44bead78d4661b229522783";
+      sha512 = "0db76f3544b14360bdee64186b9f828dce717d72d23ab59d4568cf079dd1db138e5b79eb500bae6d0043550bb906a0558f07e3b5ac98d0ff67705578d04ebefb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ca/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ca/thunderbird-52.5.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "f63dc5e923d8e60470fa4e4bc5adb8ef629a82dcca84a87a6e742e9d34a8709cd0946a85bf5822b19b5ff5c1c34b6e290439f3e3418e4ab86844a0ff54c2632a";
+      sha512 = "6229309d3e81f374f4f04071843e3a1e7e18ad8316359ba6badd0509284ef59c16085af9a52956a5a2f438bd9cf8c88400e15fb99bcb75001f08fb72c285b3ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/cs/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/cs/thunderbird-52.5.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "72e1a77e10105a757c51542bb236d10c417f96f58c3875b63112c71848ce023c8754971bcd34dc5d2a48719070939d3733df9dbe4d2218e7bae7e89049d067cd";
+      sha512 = "12a2df8d37d02076acf6cd2bc86bbc71e38e157e121b1729096c880481a82d23a0c1c8f1c8b1ff53193aefa1eebc64ffa49bebf38dcdee5fdbdf429bff5d9993";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/cy/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/cy/thunderbird-52.5.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "4901eb53235ac29cdf685dbee78db301abc1f088ea9df585e388814c8f48d81aa0daf816f927b0c7d6df7985d8dd1e64c0c1cc26026f3ad9625251a72b666692";
+      sha512 = "7c71ae8ce62dd271e0202b4e25b52ab9291ff83b920465b9a96c36d55c520ee87a5a348ab9d0ffd495744b787d424741ecf9e89ae4879281d0a6f2cb3742ae2b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/da/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/da/thunderbird-52.5.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "0f061a7ad1e3b113d7b954487d661b4ca57a0ae861770c44081257a069e324388ba506b27ef0123a240cd949edb4ae60f500712c0addeed146cb922c76bbdc32";
+      sha512 = "36861c719370036033286139f5e93d750eb8712afea42df7cc7f8bbfb9a00dde999e3ac4e38bc48b64a343a8091483163914cd362e9e30e0f9a98c6cf6a1783a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/de/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/de/thunderbird-52.5.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "12ecdd09f77035ece4161c97cf4ae8bffab6a7eb46c7b9a2f7323dbcbdcf4f3d1bfcf5fab4d40b2887fbf64b541c0d5bac54f1b8f73ce7e31bfa201e955077c0";
+      sha512 = "8571075c5435ab4763ac1c0f3904ca39b5ad1363390fd78eec9b73115caccb3eb3cc9f2e1a8c4119469ed5cc99d648fc905a8fb4d51c0bd10dc9ecb0338ad59b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/dsb/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/dsb/thunderbird-52.5.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "54fe7ff647565d5b82843d879ce3f791b2962bb034ec2ec2d5ea85cea3019ddae49f9f45384751d1a2d0f879aff4203a61687a4432ebdb948fd30569b6ddd7be";
+      sha512 = "1b873aa804d253786b37a8bd1e85884f12c48292c3703d9c04a9d370e8fff73b0d865495a65de7fe690e34f835220ea88810194385ef50f3b285e8237f3761bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/el/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/el/thunderbird-52.5.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "d667a2d4f3782c30b308cfa6dd13ad321f6b7108d95f05c68dabe085228de28439f8e851920205404e48849829e65a07601ddcc553f3c73b08e233175805f046";
+      sha512 = "8f6327796a1e937e0d43f2af23f25292ee3a56b9d173bcbad1bf1d7cd60ca464570ef4a9d8255d2f3897dc862680073146a6509944014d0abeb21395da8c0201";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/en-GB/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/en-GB/thunderbird-52.5.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "ed7d40db832e9abf89d0d1e497f1b276dec7836e494b616eee8db1557cddd33f6f700bc9f17db0324f7a3b191ea425a7701b7e2b10630c21ab07f3c709039312";
+      sha512 = "e27a9c743a1d439e3cda7f2924c01044c797f88bd4b90723face80a472c8e0854c747472e5cb72dfe10ab1018188044681e1ae633ea55f4a11aae6f62a3a891b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/en-US/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/en-US/thunderbird-52.5.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "9ffe74492c2fe29523a34b02ab869f9660aa1c33b16e45a026c4404e714b9cb6a5d2b24e73c7ac2f52e22f21e6e88e9a7686edbeb2c0876594054b17222d9ad5";
+      sha512 = "b20aeac366bbfe257e709133fafa59bc8fd784d33926a167adf24d2c90d2cf5adfb68815e2000de4837be7cf73258d890cef555be82112aaeaef2bcc244f634f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/es-AR/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/es-AR/thunderbird-52.5.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "9f154f4fcb465925d445cbaecad4495d12d6381f0afd502973c4869890dfcd77366fa90bba835016729343947e064772163529528bfa76d52fc87bba5e9af1d0";
+      sha512 = "a3547d8ea9675970dfe9dc40e1b763558fbb204b8d0940156b97212f2a5af00ca82ea2493f77fe896e257d7e0cb1ce7a1fe05a4c23aaa09222da43cc9b823e88";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/es-ES/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/es-ES/thunderbird-52.5.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "4dc72ba78d8de913ab2b3a76920e0f4e3bb75cd880c3a8a55af72cc38334906e5786b24feb0db7d1e12db845f995c28e3342b5bb1bd4600c70de6b9fba012194";
+      sha512 = "2ad8177608038799c2ea653ea056c599949972a51493a27a34d4aa0769814106cebc8eac3521c7d6186432fadbf8e17e7b9e5221bdd1bf70de4fa80de163e964";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/et/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/et/thunderbird-52.5.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "64279f558880cd6f6653e9387b479f08dcff440a23dc9a7bda664f09ca641cea05a268bea7cb7ee6495910fc67f1294f78bb163d09d70df06f335486d46d7ee9";
+      sha512 = "a68d4606e943a4b5841853b1c2d5165f5c97405690d467c0548ef0169fe472e76088c0387f9adabcd5837a3fba72287398453c4e149343bc9130348b5d62c682";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/eu/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/eu/thunderbird-52.5.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "90185fb2a72b648af46b83470b2c57ab8784baad2c75c32920a5e6e1d5e03b5fd3a5ffad04cd52ea73a942c4ccc9b02d71ef7ca4887d3d089ba8f13745087b79";
+      sha512 = "dfc826d722b7ff331df35b6fc9b82eae9714f8f8e75c1fe3119a3b449a5b2817a8641e939ddf32b4b6605406a7cfeb57de24493b5a4d0cf9992a3dc30f2558cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/fi/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/fi/thunderbird-52.5.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "3d8fbda9afd0bb82db6baba04d06682c5083a8a05cb941552c5ae2abfa0fd7e9ea9e020423877f3141922485a69c1af5d48235dda29fb4b583c1f4435a747f59";
+      sha512 = "2676d22c662a5d7b4b3eb32a71b032e76bb609b39a89381054b254ad7a966625af2166b2a5edd9c09ad8d9728933203c99a3c60e03c2fb031b748e94c16eba77";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/fr/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/fr/thunderbird-52.5.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "669723deede608bb8239ee5a04dcccfccf3680e32da494d28fe5380714b012a322caca38eb3b6ccb3c136a3a9742f917a5614f1183ee08b80d760fa5cb19493a";
+      sha512 = "b6ec3f6f2abb0f1ae8de3167e03d9d254959a93881b4cb8202db5880bade5569a53f1b5aaeaec10fb6fcfe453fcbe7cf0c090947c546ec62ae0f858dc0b251d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/fy-NL/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/fy-NL/thunderbird-52.5.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "c35371dc26545e5f1b30a1c866538380e8d6cd21456e1415260cfdcde3c37f6f301f1a5ebfcba4d6a5612ed3809f7a27e5a5470fd5f5b7146b923ab15a5046a7";
+      sha512 = "c0e2618f223f5b58d80283b23c38ce703d5fa019444dc2168d1ca88149780e458ed9c5414931457a0a3e7733407eb07b1fd38f3b40c381db2f012c5a1eec7eaf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ga-IE/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ga-IE/thunderbird-52.5.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "1f5eaa4928e7b56ad27937b6a49f90fc5739149dfa8119563eb6153cd1d850243ce3a15e42d6e5a7a7c306401c97424b5ebbb6bbc7d20102aab09723c91925a5";
+      sha512 = "fb6e815a5690382f1608d20cecb596012677616cfe3de11ba8aacdf32c59314a5e61ade11151965fa4c5f310445700f9fe89e14734f8876ebad4dcde9f46535a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/gd/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/gd/thunderbird-52.5.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "61c1f4d9769981149a5961c096d9826e737ed356582b90d09efc437c38f93d9897ee84489f33e3fdc20787dd9d437ed58a5592bc5f586748d3e5897ddda38b20";
+      sha512 = "3edf7e424f7a21540225d6e30543bb39f395564a3effd5064f3471f7922c19e275fc7b20e1df929a93eb375e0b37937f5beb239003300bff0af8af0d2f7b203d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/gl/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/gl/thunderbird-52.5.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "cd23d74ddd303be4d86e4c63d5d2186ce3d0237caa62b0a48987b63c63322898f591e4b2c7a5fa5d219c49cb28070fde5cd933050dc0c0e6b9aefdd5f03e5b1d";
+      sha512 = "7afea0817603271e8ddfa01374102f8856fa1d090fb3a98ff9e3ef477aeb019f3860e68c6ea72659ea0b65c54967c68bfa0d84a040d7677469ece8460fbf93c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/he/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/he/thunderbird-52.5.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "58d98ff08576c3cd3d5a8637b8ba8dbab1b7e61942f4dd772ca48e3fb447a2dbcefe2cb9ed8cd3e86ffd0d9f8ba33366dbe01d744a825bf513861ea870d69ecc";
+      sha512 = "546484c47f925bfb92bab962735cef6a74336d6b282881afce1054caaee559360e2df1d497d857a12ae76b99ce765ac985adf48d17f9a759b262f8b134e9adf0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/hr/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/hr/thunderbird-52.5.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "770a4a095993a9a84266b15e461645c4446ba6370092f1d0984d2ebcf836d24538276f63f9513dcaa537a4f016bb699169dafb14a68450f1e13050679800c5b3";
+      sha512 = "552ebbc20522633fdd27117a941a0541bc3195b4a650612e6bf9f5e341f09c39efe1a58dcb9b0bf3ebb4797c7cf49e7d8a8d7922d2f3cb83284f9a3dca7e6b68";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/hsb/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/hsb/thunderbird-52.5.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "35f0a061f152d871636723b4690d3a3ff7172abb5adf0644b02e44fd23583e9a9d8ea68890a5313d74d190a6d293798b5ae8969a38b1166cd942a3d17b0246f6";
+      sha512 = "f92450010bfb1d1620bd4819103d89f0d58af567231219ff106dbd48550e04af2900b362b93bd199482aaeb72a0ac88344e3767d754d6934d401cca13af4b718";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/hu/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/hu/thunderbird-52.5.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "a4e9dd6ad2295cde7d7e5bfa8efee3c68123ae11d7535f0c076e29b18b952320ef39e4c92e8ad4aa66f63d8490b5737ee849e425378db04df8c794bb64f5393e";
+      sha512 = "6a4d10925475f3fc499f49894f6c79de88bd394c9b3359efb326e55aa3e1af9b7d6ee2c853908bedd95e113d697ae3b25e612dff72d81d01addb1fbc39c6ea36";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/hy-AM/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/hy-AM/thunderbird-52.5.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "8006eedb925424458cc9e084b367d4b8f16f78a6245159c61f13b75455404adf13eba353b4141cc555d82d4d6060deae9f97633884ba6d3b18d88af8bf93c4c7";
+      sha512 = "ecf982393bfc9c826dd74ea6c0452788c34958f031636c4f70bf12388e966a3630cde159f3751540b3b917e52f0b64a2cd572d211ef3b61d97725a80f51b4f5e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/id/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/id/thunderbird-52.5.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "df166f9e33adadd2e38290d1ea92a035c9cd0d910c1b246906ed38181c8db12bba29e69b4a909594a79b8b3eccc23131f34236afb40d6746793cdbda3a195bcd";
+      sha512 = "a4d735acd212827ceea6205125e8d38f292b0994a5375738857b12531aaa947539033fe3be3e198eae82b77647d243227200a9fafb4ff2729bf4b0028868295f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/is/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/is/thunderbird-52.5.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "1a05df69389d95d9920e133e085a0d3a05eb917b1b28c24fe9d8cdce316e19319fe08aa7a3fec304153fa0f59a0b8a630f9c44fa1d9c0310de03fc102172dbc4";
+      sha512 = "8d4b0a3eef192d42ecc9c65eb692b5c35ead5c1a7ef17f575e96e06f8990a76607b31abafbb03cabbdd4385eefcb09bb0477c7a6cff1b5fc3a60bc9fb1d0518e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/it/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/it/thunderbird-52.5.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "c446fa3e15e9eb72aff880f928f5c8a0b2b0c96632c243db4f5c377bd2dab56ccfb569a8500e9778ac5a4459ca634dc6d2ec1ec0f05aaa2980d3f45109fa2ffa";
+      sha512 = "4f2d5c1bd7cc404bb8ab6097bc3dd40424a745f8a6cbc0e73722a28d68a582150acbdab83e02b89811c6617e63a2d56f5f02f6fc463092e8e959a91552a6f3d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ja/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ja/thunderbird-52.5.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "c7699f90c49fc4bca1580c749ccc446a95cb9f1a5a48cfee3b2a566ba13e073a4e405ba7b17ebff704f719639e323332f533db19f7c82007300322330f2b3983";
+      sha512 = "78445e5bb7211d7319609edb30e063c3584ed8c92eb4fb2953520720125306c28905e2248eb5825d6bc09399d38e35f37be57707e64edd3aae555b4ea748205f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/kab/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/kab/thunderbird-52.5.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "5c098954ce0e642c76c3597d419bcd5f286d62af96ccf2726bd00cefe12036708217cc6829c39cd669a21ed0cdfd8a6d511b8a55e8dafefa8c3940040e99d9a6";
+      sha512 = "7ad9d0213a2cd6297cf899f311ea3b8a7493f8596c352c351aa5aae3c7b0639c787dfda9d63adde7b2d920277c09d987b690506c762e24da16d86f985cb8f846";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ko/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ko/thunderbird-52.5.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "0a435742a13454634ef563b704d1618ce492a997814466ece1066e244160494e2092588b5cbbe5d1a7076b89c895b5f1a3288a377b547d454eb411960e3faeb4";
+      sha512 = "a76a8acadbf082a7fbaecae8798fbb3fec4d03515db2f0a7d2d10d15ef468c128329e79f68e9b0075c4a7767bf56de5d3f1f5521cfa7beaad2fa2026fecb43f2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/lt/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/lt/thunderbird-52.5.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "0ffbe8a40179cdce48423c70ce871ebbce066932cf9ab21560ba3107d2794198a7c8f5d5d3fefa58627beac4faa2ed398a09c429a47b261153f3045fe5779883";
+      sha512 = "cd8911a16d2662f5b80b76b04013113a8e9a231d25404afebe29852b5335d587a1dd22aaa74727c1b74ae5b26ffbd0f4723fc86ecef5c43397485a5199d65b71";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/nb-NO/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/nb-NO/thunderbird-52.5.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "d44ece21a5ce26df33d7ea04f56cf2a21dc67bb053212a71a2a30dbabb7894bc9cd5b8a07f86906c882fda29603d2c8ff16d675c8e8bef8ec362be8c824624a9";
+      sha512 = "3a82189796c1bbbe4633ef7beb054cd5f324504173678aae2763714b4ca25b04bce479eb63d89abe920c89ce7a4159eefa5e27b6e5959d2bea01a4cd53e13e58";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/nl/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/nl/thunderbird-52.5.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "8c2489dd4d860fc657893986f268746512cef54943b19f7c129013e5a6a8db8f4a8fb0ef22b1cfdc41306bbd63d1c81131989af7161d310cabe2427e21ab4702";
+      sha512 = "63e40217f5abea50375c0fc0060cab6c6291acb25d468edde8a14751c0693f0e9d751cbdee339a2c141269edad6c4ac87ec37f440257b5a78492bc43e66a9cd6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/nn-NO/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/nn-NO/thunderbird-52.5.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "57270f4645bc1d82f3602a49aad11bb6261a2be39200b3284ee65082df363b5870b1cacbaeb3802a83f6ef1554a4d6a2c6e6b2720aa2b9d29b7a86208d676f6a";
+      sha512 = "bfa15dfb0606ca225ec370426b983a17c614dc850b665e40ba648504f5d9bf556a2f31ec20533fe739ff94f57f3eb5486f422972c7ed8c08d8cd7c8a023f9937";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/pa-IN/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/pa-IN/thunderbird-52.5.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "7a7464cbf08e418c56c979abba5ef7120f1202073ab630ef4ce070aa1b55520597dda0b0f31e7afc50e14c8c4fe0f33759a2278035d5db5f21edacb6d521672c";
+      sha512 = "6989775d3e36ec43aeccf3db32627d3f1be13021943a088385313fc7111d4288b8daa32ec37a9679353d68a9f15761fac2f7a4eb7dc1a60e3d15598296b11f82";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/pl/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/pl/thunderbird-52.5.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "ae0b8da805a3b055bbb64a3c0f1d3562f44fae08751026b8300c130f4a2629a1a17857d2be2468c9e2ddb2a082155d35a26b7b1f0c99369b2031a90b34aa2443";
+      sha512 = "05d252299552f987641be34e5f3462d56b08b01a66637b2d039d1a39f2fdb1b9b986ecd353bc69290bd64b5858b2e7fb7c928209cdbb98b27fca479ec8f959b4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/pt-BR/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/pt-BR/thunderbird-52.5.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "f61d66c71c2144aba0781f82370318fcff0637d4bb28cda3703f099718691f13bbbc51eaa4252ef1fbd1dbe821032597e41adb80b1abec89a2bc50df043f5099";
+      sha512 = "b40deb4d5239e335f2c2e65d676cb6528c3320ee28bc9d83dd53bae2a486bcce2921726309754cc0bc155d3f8a0f56d69aa98e782bb4b8375cfcebfee5f58320";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/pt-PT/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/pt-PT/thunderbird-52.5.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "ad0d63ab9389e3c4cf6985835dc4277d3ac5cf79e09457331f87629c8f9a58e95ce7b68c2eec8973ab445cc8f8c50c0b01b78ebd0ada042f4fa6a2d2bc838241";
+      sha512 = "0afa965096f5a79b79b3e49af1758dc200ceb8161192a97d260313f9582f1c8b7a1d4e54e093cca6b9c92a9458dd38ba0493fdd1d6567f0505a90fc9bd97f09a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/rm/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/rm/thunderbird-52.5.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "5e5f96598101695ad0d16a7f3aea38c42d875b3d7b7e2eb529786f16cc008ca8b20bfcb24d2b975cdd2e114d00c1d17f8901f19fa84263f64506d9d75568e6be";
+      sha512 = "c9babc6d6e85936a251d4f7214991a06a3b92c6ae207a8012fe14cffb277a6b2468213a4ba94672a360bfdf9f4b817b8663cc15ceeafb79a63cbac13310e1aca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ro/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ro/thunderbird-52.5.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "82a0324bc4724460d5aafa194a78d611c1d11cc347446d5c2203e9fb40a45f6c7ffb0e17aa87b603af8b3ae5847fa91cac529ae878a6981c9c754ea91b8b6b52";
+      sha512 = "86f303e7878cb988ee1773e6de2ea6b433028d4bfd40d9388384b14b5343b1de9b6b5084f92f1c95b4110ecc7fda669ed98d50dbb6266a775f4e058d5083e24a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ru/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ru/thunderbird-52.5.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "508d949263abd425ff805f417cfa60736d391e1dc99b53dca2243c4c93487ad2889ac6a9bd8beed59b4e09bc82ba31b9c5cbc9fe084ee3b5fde74baaa2720a7e";
+      sha512 = "d262ad2a73ab34bdecf6d180840922bfe16fdd4dc7097ccd900712d99ca915da648f2a196accbf6ff9946d9fc48c674e9eb0f0bafdfc94cd6f9069139cf0f036";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/si/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/si/thunderbird-52.5.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "e9869c86acbba32bab6b536f2542b498e9de0a306558b3115ffaf143f83c5a5010ead37573ed7ce9565c42b6306d98b4f92da866ba62f5c4042dd537f66e377e";
+      sha512 = "6b39cd9501b2dc44d033efe9524c5865cad8fdfd8224a51fb04679227e5306d67d05a9acaf4f5810cd67e6d10b1afc69ff80e63a7926616c35c79ecc3f02d93b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/sk/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/sk/thunderbird-52.5.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "1297d9a8ed5d062790766ee5cb66a1c3b67526326440b5d3f27b712440c0e3525ab2231774e02436bfad4b8ccf1006e5a16d2fce4be26bf2c757427228f7fed7";
+      sha512 = "356c86279387b023540fba86f73376b1be12413887f8ea2c3b706ccc268aad282d77b7eb863e58d6f15f66516dd4bd8f56a8f413815753dfd6496f81ee842aea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/sl/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/sl/thunderbird-52.5.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "734d57ba493e160547953debc20b1d5565c31b0e6e5b486344f5da65aa4cbc77fa7790f49f4ad6322a633232fbcca2f21bdeae7f4abb2aa8cf13e5741519d706";
+      sha512 = "86d035a6b7108fab33582eb665afce9063e3d55b0c468b81569503cdde7ffe169de227024e94a60dd45e39073eaa3c3f313bf061c0ba492b66f75f79941c6100";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/sq/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/sq/thunderbird-52.5.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "e7a21ce516318f46d467f987dd244174ed2533bdeeeba41c2fff3a838ebb78047febabe6f3e86ab57bcc12f0b1418fb7ac195ca044a7c84eda404e152690b554";
+      sha512 = "f2dd5958774c81710aa59d7c9cf8543c86d82cd21da16b13ad1580cb2680df5caf973cf28a505fb994ad809264deeceea8806641fa27b9df5a7f26c725030515";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/sr/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/sr/thunderbird-52.5.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "132fbcd2a7890ac413dbc3b1651a02227b741a8a31e2406780f36415fd47ed75503968a93414ec31384f28ecf1e14753f0e1bb2988468d973dfac9ab45787519";
+      sha512 = "47a96a821fb825b6624262bbc0138027b842a9a69985af8903a7bfd435f6cbd3211e382899f3cc989cf716759aad927a8be22b2500f42f75362cfad09dbe67fe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/sv-SE/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/sv-SE/thunderbird-52.5.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "6e07841987bba5fcd69f790fc8a292ad7a3d71bcd802d16081145f243a71d49c8c57c5b6ad60ebfe1a550d62b1c9713843a83066893a397889f925e8b88904ef";
+      sha512 = "978c8c41034137361663f2b12818477baac0e795e4c1ca7f7a013a8e1bb68534ef2a8a9d73e31c1ded7461bc5dc6298fc628dc6190b3657ce415f9687a3ed85e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/ta-LK/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ta-LK/thunderbird-52.5.2.tar.bz2";
       locale = "ta-LK";
       arch = "linux-i686";
-      sha512 = "978b1ba5f77271906ea67b37637b31a9c1da0f97453ea4e140adff8558ee2b01fe32f3018a48b141198cd0ad9f9d927ce213100be3f3310b020bfb3ff8b1d69c";
+      sha512 = "970405c59d2589e49c53f0ab37e959c6f3b94bac41929ac6d5776c7b78b91bc0f8a6c1acee1557338b76bb8fc2a9f62f179a0ad10a0a8c984254d39577402556";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/tr/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/tr/thunderbird-52.5.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "2531185c167e66b77c6b7f968927a64a9e8de56580fd82c7b2408bfac71523738610b740650644eeee4c485dbf532a8da92367bdc574733d0df0d749613bd6b4";
+      sha512 = "cec76a997708b5339d5e49baea40125226f4bd708fa57f43f7812e2c7be686515986b90ab6ee525dadcaccbd9b9ea2c961e1a645b2c9634062e3e0c9c00ce2dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/uk/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/uk/thunderbird-52.5.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "3f9eed73e2e85528deef2f2ffcbc166d2a836d363693f6ece98adeabe872a6aaa77facd16efd918fac9eefebed68ff35c59750d7116545a6540c9e1aede45c51";
+      sha512 = "be710c5a5d28b34136ad72456ab9893d7c31dc0f3eea8cfc38d70169c37df5c96fb3aa18b72555e081115d0791f3a634325da191ac004ffc6a38d1412e140e95";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/vi/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/vi/thunderbird-52.5.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "fa776aca6c434491925e6fcd1802f047fcdcc2ae817805ffae0c873e17f1ad233836954544d85ac378ab28fb607c9cbc5b1808a12bbfa1d9337c8e47de4eddd7";
+      sha512 = "7d1f59f1fd78609700b6d6246087b88c5190139c79e7e60f2eaba91908ff0afbac0bce0e2a60594cda0800cf68ab0b5568702e0cfcfd1718e4cf46a88f20bc01";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/zh-CN/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/zh-CN/thunderbird-52.5.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "ddc20a6b05b48d6bcbc59c585b4a2365cee6d526ddef29e3dd04d38c8632c5c7ddda9eab24f2850dd2614bb7acc6e982ae4673c2b51c679eb5afd48047bf6fca";
+      sha512 = "5763d93646a83b8a88e8c4b1c1c72101831f72323b600d576619330e2cf77ac7a9dc668aef5ef59188e0f467db900d1d8f3c2ef299f422f83de51f53519c70be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.0/linux-i686/zh-TW/thunderbird-52.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/zh-TW/thunderbird-52.5.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "aa527aeaa6b10d785e3fa3a8052c5dfa70f9aae2601119aed7dfd60e8af30f03cc1b4d93f749c36be4e54bbce6071fe66fb1937fa392b8391ca695e55ffe68ab";
+      sha512 = "cd593b08ed5f31dd89b44e9b79b1db324c51facf63e9d9c0c2ad847b9cc13a0548e831a87078c9c0ae910512c4855e6f3ae22d1c40189e082ff6ff26224c35b4";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -22,11 +22,11 @@ let
   wrapperTool = if enableGTK3 then wrapGAppsHook else makeWrapper;
 in stdenv.mkDerivation rec {
   name = "thunderbird-${version}";
-  version = "52.5.0";
+  version = "52.5.2";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "b9b599e5853887bd518e5a57f6fd04751bb78f553f97b260cd9ba7268c4cff307be40b81b00f1320f5a5156e5c67115595b2d389f931c265d0c3448f56fb8319";
+    sha512 = "d626d3d37959539b15b5d2ae4a580fcc160380974bfc1a69a1fc8ff2435932e90a69fa386d5ecb6721d9154603c6b7d063e3368f6f995fea057eb593c06ef4ff";
   };
 
   # New sed no longer tolerates this mistake.


### PR DESCRIPTION
###### Motivation for this change

- Security fix

https://www.mozilla.org/en-US/thunderbird/52.5.2/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

