### PR TITLE
rhvoice: init at 0.5

### DIFF
--- a/pkgs/applications/audio/rhvoice/default.nix
+++ b/pkgs/applications/audio/rhvoice/default.nix
@@ -2,7 +2,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "rhvoice";
+  name = "rhvoice-${version}";
   #version = "2017-09-24";
   version = "0.5";
 

--- a/pkgs/applications/audio/rhvoice/default.nix
+++ b/pkgs/applications/audio/rhvoice/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, lib, pkgconfig, fetchFromGitHub, scons, python, glibmm, libao
+}:
+
+with lib;
+stdenv.mkDerivation rec {
+  name = "rhvoice";
+  #version = "2017-09-24";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "Olga-Yakovleva";
+    repo = "RHVoice";
+    rev = version;
+    sha256 = "1gk5z1v7g7xg1dvc2qfa0ljgma8s96njg2k70rsnr3s1wsrgvqk7";
+  };
+
+  nativeBuildInputs = [
+    scons pkgconfig
+  ];
+
+  buildInputs = [
+    python glibmm libao
+  ];
+
+  # SConstruct patches
+  # 1. Scons creates an independent environment that assumes standard POSIX paths.
+  #    The patch is needed to push the nix environment.
+  #    - PATH
+  #    - PKG_CONFIG_PATH, to find available (sound) libraries
+  #    - RPATH, to link to the newly built libraries
+  # 2. Some data is being zipped. Zip can't handle files from 1970.
+  #
+  postPatch = ''
+    substituteInPlace SConstruct --replace 'env=Environment(**env_args)' 'env=Environment(**env_args)
+        env.PrependENVPath("PATH", os.environ["PATH"])
+        env["ENV"]["PKG_CONFIG_PATH"]=os.environ["PKG_CONFIG_PATH"]
+            '
+    substituteInPlace SConstruct --replace 'else:
+            env["BUILDDIR"]=BUILDDIR
+    ' 'else:
+            env["BUILDDIR"]=BUILDDIR
+            env["RPATH"]="'$out'/lib"
+    '
+    find "./" '!' -newermt '1980-01-01' -exec touch -d '1980-01-02' '{}' '+'
+  '';
+
+  buildPhase = ''
+    scons prefix=$out
+  '';
+
+  installPhase = ''
+    scons install
+  ''; 
+
+  meta = {
+    description = "A free and open source speech synthesizer for Russian language and others";
+    homepage = https://github.com/Olga-Yakovleva/RHVoice/wiki;
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ berce ];
+    platforms = with platforms; all;
+  };
+}

--- a/pkgs/applications/audio/rhvoice/default.nix
+++ b/pkgs/applications/audio/rhvoice/default.nix
@@ -1,7 +1,6 @@
 { stdenv, lib, pkgconfig, fetchFromGitHub, scons, python, glibmm, libao
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   name = "rhvoice";
   #version = "2017-09-24";
@@ -55,8 +54,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A free and open source speech synthesizer for Russian language and others";
     homepage = https://github.com/Olga-Yakovleva/RHVoice/wiki;
-    license = licenses.lgpl3;
-    maintainers = with maintainers; [ berce ];
-    platforms = with platforms; all;
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ berce ];
+    platforms = with lib.platforms; all;
   };
 }

--- a/pkgs/applications/audio/rhvoice/default.nix
+++ b/pkgs/applications/audio/rhvoice/default.nix
@@ -3,7 +3,6 @@
 
 stdenv.mkDerivation rec {
   name = "rhvoice-${version}";
-  #version = "2017-09-24";
   version = "0.5";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/rhvoice/honor_nix_environment.patch
+++ b/pkgs/applications/audio/rhvoice/honor_nix_environment.patch
@@ -1,0 +1,14 @@
+diff --git a/SConstruct b/SConstruct
+index 2421399..ba39254 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -147,6 +147,9 @@ def create_base_env(vars):
+     env_args["package_name"]="RHVoice"
+     env_args["CPPDEFINES"]=[("RHVOICE","1")]
+     env=Environment(**env_args)
++    env.PrependENVPath("PATH", os.environ["PATH"])
++    env["ENV"]["PKG_CONFIG_PATH"]=os.environ["PKG_CONFIG_PATH"]
++    env["RPATH"]=env["libdir"]
+     env["package_version"]=get_version(env["release"])
+     env.Append(CPPDEFINES=("PACKAGE",env.subst(r'\"$package_name\"')))
+     env.Append(CPPDEFINES=("VERSION",env.subst(r'\"$package_version\"')))

--- a/pkgs/development/libraries/speechd/add_rhvoice_module.patch
+++ b/pkgs/development/libraries/speechd/add_rhvoice_module.patch
@@ -1,0 +1,12 @@
+diff --git a/config/speechd.conf b/config/speechd.conf
+index 140de3a..5fdfc32 100644
+--- a/config/speechd.conf
++++ b/config/speechd.conf
+@@ -212,6 +212,7 @@ DefaultVolume 100
+ 
+ #AddModule "espeak"       "sd_espeak"   "espeak.conf"
+ #AddModule "espeak-ng"    "sd_espeak-ng" "espeak-ng.conf"
++AddModule "rhvoice"      "sd_rhvoice"   "RHVoice.conf"
+ #AddModule "festival"     "sd_festival"  "festival.conf"
+ #AddModule "flite"        "sd_flite"     "flite.conf"
+ #AddModule "ivona"	 "sd_ivona"    "ivona.conf"

--- a/pkgs/development/libraries/speechd/default.nix
+++ b/pkgs/development/libraries/speechd/default.nix
@@ -66,14 +66,15 @@ in stdenv.mkDerivation rec {
     # ++ optional withIvona "--with-ivona"
   ;
 
-  patches = [ ./add_rhvoice_module.patch ./set_nix_defaultModule.patch ];
+  patches = [ ./set_nix_defaultModule.patch ]
+    ++ optional withRhvoice [ ./add_rhvoice_module.patch ];
 
   postPatch = ''
-    substituteInPlace config/speechd.conf --replace "nixDefault" "${selectedDefaultModule}"
-    substituteInPlace config/speechd.conf --replace "sd_rhvoice" "${rhvoice}/bin/sd_rhvoice"
-    substituteInPlace config/speechd.conf --replace "RHVoice.conf" "${rhvoice}/etc/RHVoice/RHVoice.conf"
-    ${stdenv.lib.optionalString withPico ''
     substituteInPlace src/modules/pico.c --replace "/usr/share/pico/lang" "${svox}/share/pico/lang"
+    substituteInPlace config/speechd.conf --replace "nixDefault" "${selectedDefaultModule}"
+    ${stdenv.lib.optionalString withRhvoice ''
+      substituteInPlace config/speechd.conf --replace "sd_rhvoice" "${rhvoice}/bin/sd_rhvoice"
+      substituteInPlace config/speechd.conf --replace "RHVoice.conf" "${rhvoice}/etc/RHVoice/RHVoice.conf"
     ''}
   '';
 

--- a/pkgs/development/libraries/speechd/set_nix_defaultModule.patch
+++ b/pkgs/development/libraries/speechd/set_nix_defaultModule.patch
@@ -1,0 +1,18 @@
+diff --git a/config/speechd.conf b/config/speechd.conf
+index 140de3a..5fdfc32 100644
+--- a/config/speechd.conf
++++ b/config/speechd.conf
+@@ -240,12 +241,12 @@ DefaultVolume 100
+ # The DefaultModule selects which output module is the default.  You
+ # must use one of the names of the modules loaded with AddModule.
+ 
+-DefaultModule espeak
++DefaultModule nixDefault
+ 
+ # The LanguageDefaultModule selects which output modules are prefered
+ # for specified languages.
+ 
+-#LanguageDefaultModule "en"  "espeak"
++#LanguageDefaultModule "en"  "nixDefault"
+ #LanguageDefaultModule "cs"  "festival"
+ #LanguageDefaultModule "es"  "festival"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15182,6 +15182,8 @@ with pkgs;
 
   quvi_scripts = callPackage ../applications/video/quvi/scripts.nix { };
 
+  rhvoice = callPackage ../applications/audio/rhvoice { };
+
   svox = callPackage ../applications/audio/svox { };
 
   gkrellm = callPackage ../applications/misc/gkrellm {


### PR DESCRIPTION
###### Motivation for this change

RHVoice is one of the best speech synthesis engines I 've heard, including commercial ones.
It can be tested with `echo "Talk to me" | RHVoice-test`.

###### Things done

- [x] Win the battle against `scons` to gain power over the environment.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).