### PR TITLE
virtualbox: 5.2.2 -> 5.2.4

### DIFF
--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -109,9 +109,6 @@ let
   } ''
     ${pkgs.parted}/sbin/parted --script /dev/vda mklabel msdos
     ${pkgs.parted}/sbin/parted --script /dev/vda -- mkpart primary ext2 1M -1s
-    . /sys/class/block/vda1/uevent
-    mknod /dev/vda1 b $MAJOR $MINOR
-
     ${pkgs.e2fsprogs}/sbin/mkfs.ext4 /dev/vda1
     ${pkgs.e2fsprogs}/sbin/tune2fs -c 0 -i 0 /dev/vda1
     mkdir /mnt

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -207,7 +207,7 @@ in stdenv.mkDerivation {
   meta = {
     description = "PC emulator";
     homepage = http://www.virtualbox.org/;
-    maintainers = [ lib.maintainers.sander ];
+    maintainers = with maintainers; [ flokli sander ];
     platforms = [ "x86_64-linux" "i686-linux" ];
   };
 }

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -206,6 +206,7 @@ in stdenv.mkDerivation {
 
   meta = {
     description = "PC emulator";
+    license = licenses.gpl2;
     homepage = http://www.virtualbox.org/;
     maintainers = with maintainers; [ flokli sander ];
     platforms = [ "x86_64-linux" "i686-linux" ];

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -20,10 +20,11 @@ let
   python = python2;
   buildType = "release";
   # Manually sha256sum the extensionPack file, must be hex!
-  extpack = "9328548ca8cbc526232c0631cb5a17618c771b07665b362c1e3d89a2425bf799";
-  extpackRev = "119230";
-  main = "05y03fcp013gc500q34bj6hvx1banib41v8l3hcxknzfgwq0rarm";
-  version = "5.2.2";
+  # Do not forget to update the hash in ./guest-additions/default.nix!
+  extpack = "98e9df4f23212c3de827af9d770b391cf2dba8d21f4de597145512c1479302cd";
+  extpackRev = "119785";
+  main = "053xpf0kxrig4jq5djfz9drhkxy1x5a4p9qvgxc0b3hnk6yn1869";
+  version = "5.2.4";
 
   # See https://github.com/NixOS/nixpkgs/issues/672 for details
   extensionPack = requireFile rec {

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "1f0vm20qdjxqsbciwgybxqqpn609gj5dy68an8lpi1wlk93s05w3";
+    sha256 = "0qhsr6vc48ld2p9q3a6n6rfg57rsn163axr3r1m2yqr2snr4pnk0";
   };
 
   KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";


### PR DESCRIPTION
###### Motivation for this change
This bumps virtualbox to version 5.2.4, adds its license and me as a maintainer.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

