### PR TITLE
coqPackages.contribs: recurse into the nested set

### DIFF
--- a/pkgs/development/coq-modules/contribs/default.nix
+++ b/pkgs/development/coq-modules/contribs/default.nix
@@ -189,10 +189,10 @@ let mkContrib = repo: revs: param:
     sha256 = "1ddwzg12pbzpnz3njin4zhpph92kscrbsn3bzds26yj8fp76zc33";
   };
 
-  containers = mkContrib "containers" [ ] {
-    version = "v8.6.0-10-g2432994";
-    rev = "2432994b4a0a63f28b21aad23d0c3c90c7630890";
-    sha256 = "1q0i20qag2c8jh6jw63s09d8nr6m1zaz4hqblg5mmmp5zh6fllk6";
+  containers = mkContrib "containers" [ "8.6" ] {
+    version = "8.6.0";
+    rev = "fa1fec7";
+    sha256 = "1ns0swlr8hzb1zc7fsyd3vws1vbq0vvfxcf0lszqnca9c9hfkfy4";
   };
 
   continuations = mkContrib "continuations" [ ] {

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, newScope
+{ lib, callPackage, newScope, recurseIntoAttrs
 , gnumake3
 , ocamlPackages_3_12_1
 , ocamlPackages_4_02
@@ -9,6 +9,9 @@ let
     let callPackage = newScope self ; in rec {
       inherit callPackage coq;
       coqPackages = self;
+
+      contribs = recurseIntoAttrs
+        (callPackage ../development/coq-modules/contribs {});
 
       autosubst = callPackage ../development/coq-modules/autosubst {};
       bignums = if lib.versionAtLeast coq.coq-version "8.6"
@@ -33,11 +36,10 @@ let
       paco = callPackage ../development/coq-modules/paco {};
       QuickChick = callPackage ../development/coq-modules/QuickChick {};
       ssreflect = callPackage ../development/coq-modules/ssreflect { };
-      contribs = callPackage ../development/coq-modules/contribs { };
     };
 
   filterCoqPackages = coq:
-    lib.filterAttrs
+    lib.filterAttrsRecursive
     (_: p:
       let pred = p.compatibleCoqVersions or (_: true);
       in pred coq.coq-version


### PR DESCRIPTION
###### Motivation for this change

The attribute `compatibleCoqVersions` is set but not used, unless a recursive filtering is used.

Therefore, there are currently a lot of broken packages (e.g., `coqPackages.contribs.continuations`).

The revision for `containers` is also fixed: released version, that builds with 8.6.

@jwiegley Thanks for contributing the whole set of contribs to nixpkgs. Going through a pull-request could have helped finding and fixing this issue before merging a lot of broken stuff to master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

