### PR TITLE
adapta-backgrounds: 0.5.1.1 -> 0.5.2.3

### DIFF
--- a/pkgs/data/misc/adapta-backgrounds/default.nix
+++ b/pkgs/data/misc/adapta-backgrounds/default.nix
@@ -2,21 +2,21 @@
 
 stdenv.mkDerivation rec {
   name = "adapta-backgrounds-${version}";
-  version = "0.5.1.1";
+  version = "0.5.2.3";
 
   src = fetchFromGitHub {
     owner = "adapta-project";
     repo = "adapta-backgrounds";
     rev = version;
-    sha256 = "00gwiraq6c9jh1xl5mmmi5fdj9l3r75ii5wk8jnw856qvrajhxyq";
+    sha256 = "0n0ggcxinja81lasmpviqq3l4jiwb05bs8r5aah1im2zvls1g007";
   };
 
   nativeBuildInputs = [ autoreconfHook  ];
 
   meta = with stdenv.lib; {
-    description = "A wallpaper collection for adapta-project";
+    description = "Wallpaper collection for adapta-project";
     homepage = https://github.com/adapta-project/adapta-backgrounds;
-    license = with licenses; [ gpl2 cc-by-sa-30 ];
+    license = with licenses; [ gpl2 cc-by-sa-40 ];
     platforms = platforms.all;
     maintainers = [ maintainers.romildo ];
   };


### PR DESCRIPTION
###### Motivation for this change

Update to version [0.5.2.3](https://github.com/adapta-project/adapta-backgrounds/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).