### PR TITLE
dblatex: 0.3.7 -> 0.3.10, also fix for new texlive

### DIFF
--- a/pkgs/tools/typesetting/tex/dblatex/default.nix
+++ b/pkgs/tools/typesetting/tex/dblatex/default.nix
@@ -21,11 +21,11 @@ assert enableAllFeatures ->
   ghostscript != null;
 
 stdenv.mkDerivation rec {
-  name = "dblatex-0.3.7";
+  name = "dblatex-0.3.10";
 
   src = fetchurl {
     url = "mirror://sourceforge/dblatex/${name}.tar.bz2";
-    sha256 = "0bkjgrn03dy5c7438s429wnv6z5ynxkr4pbhp2z49kynskgkzkjr";
+    sha256 = "1yicd861rqz78i2khl35j7nvc0ccv4jx4hzqrbhll17082vrdmkg";
   };
 
   buildInputs = [ python2 libxslt tex ]


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

