### PR TITLE
nixos/boot: tmpOnTmpfs -> tmpfsOnTmp

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -217,5 +217,7 @@ with lib;
     (mkRenamedOptionModule [ "programs" "zsh" "oh-my-zsh" "theme" ] [ "programs" "zsh" "ohMyZsh" "theme" ])
     (mkRenamedOptionModule [ "programs" "zsh" "oh-my-zsh" "custom" ] [ "programs" "zsh" "ohMyZsh" "custom" ])
     (mkRenamedOptionModule [ "programs" "zsh" "oh-my-zsh" "plugins" ] [ "programs" "zsh" "ohMyZsh" "plugins" ])
+
+    (mkRenamedOptionModule [ "boot" "tmpOnTmpfs" ] [ "boot" "tmpfsOnTmp" ])
   ];
 }

--- a/nixos/modules/system/boot/tmp.nix
+++ b/nixos/modules/system/boot/tmp.nix
@@ -16,7 +16,7 @@ with lib;
       '';
     };
 
-    boot.tmpOnTmpfs = mkOption {
+    boot.tmpfsOnTmp = mkOption {
       type = types.bool;
       default = false;
       description = ''
@@ -30,7 +30,7 @@ with lib;
 
   config = {
 
-    systemd.additionalUpstreamSystemUnits = optional config.boot.tmpOnTmpfs "tmp.mount";
+    systemd.additionalUpstreamSystemUnits = optional config.boot.tmpfsOnTmp "tmp.mount";
 
     systemd.tmpfiles.rules = optional config.boot.cleanTmpDir "D! /tmp 1777 root root";
 

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -462,7 +462,7 @@ in
             options = [ "trans=virtio" "version=9p2000.L" "cache=loose" ];
             neededForBoot = true;
           };
-        "/tmp" = mkIf config.boot.tmpOnTmpfs
+        "/tmp" = mkIf config.boot.tmpfsOnTmp
           { device = "tmpfs";
             fsType = "tmpfs";
             neededForBoot = true;


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/17494#issuecomment-238195977

I also think that would be a better name.

###### Things done

Ran `nixos-rebuild -I nixpkgs=... switch` to make sure that I would get a warning when `boot.tmpOnTmpfs` is used:

```
trace: warning: The option `boot.tmpOnTmpfs' defined in `/etc/nixos/configuration.nix' has been renamed to `boot.tmpfsOnTmp'.
```