### PR TITLE
nixos-container: Fix `destroy` terminating before it's done. Fixes #32545

### DIFF
--- a/pkgs/tools/virtualization/nixos-container/nixos-container.pl
+++ b/pkgs/tools/virtualization/nixos-container/nixos-container.pl
@@ -7,6 +7,7 @@ use File::Slurp;
 use Fcntl ':flock';
 use Getopt::Long qw(:config gnu_getopt);
 use Cwd 'abs_path';
+use Time::HiRes;
 
 my $nsenter = "@utillinux@/bin/nsenter";
 my $su = "@su@";
@@ -214,27 +215,36 @@ if (!-e $confFile) {
     die "$0: container ‘$containerName’ does not exist\n" ;
 }
 
-sub isContainerRunning {
-    my $status = `systemctl show 'container\@$containerName'`;
-    return $status =~ /ActiveState=active/;
-}
-
-sub terminateContainer {
-    system("machinectl", "terminate", $containerName) == 0
-        or die "$0: failed to terminate container\n";
-}
-
-sub stopContainer {
-    system("systemctl", "stop", "container\@$containerName") == 0
-        or die "$0: failed to stop container\n";
-}
-
 # Return the PID of the init process of the container.
 sub getLeader {
     my $s = `machinectl show "$containerName" -p Leader`;
     chomp $s;
     $s =~ /^Leader=(\d+)$/ or die "unable to get container's main PID\n";
     return int($1);
+}
+
+sub isContainerRunning {
+    my $status = `systemctl show 'container\@$containerName'`;
+    return $status =~ /ActiveState=active/;
+}
+
+sub terminateContainer {
+    my $leader = getLeader;
+    system("machinectl", "terminate", $containerName) == 0
+        or die "$0: failed to terminate container\n";
+    # Wait for the leader process to exit
+    # TODO: As for any use of PIDs for process control where the process is
+    #       not a direct child of ours, this can go wrong when the pid gets
+    #       recycled after a PID overflow.
+    #       Relying entirely on some form of UUID provided by machinectl
+    #       instead of PIDs would remove this risk.
+    #       See https://github.com/NixOS/nixpkgs/pull/32992#discussion_r158586048
+    while ( kill 0, $leader ) { Time::HiRes::sleep(0.1) }
+}
+
+sub stopContainer {
+    system("systemctl", "stop", "container\@$containerName") == 0
+        or die "$0: failed to stop container\n";
 }
 
 # Run a command in the container.


### PR DESCRIPTION
nixos-container: Fix `destroy` terminating before it's done. Fixes #32545

This also fixes the race condition found in #32551.

And it fixes nixops's repeated destroy/deploy being broken
(https://github.com/NixOS/nixops/issues/809).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

