### PR TITLE
ubootTools: include kwboot

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -7,6 +7,7 @@ let
             , filesToInstall
             , installDir ? "$out"
             , defconfig
+            , extraMakeFlags ? []
             , extraMeta ? {}
             , ... } @ args:
            stdenv.mkDerivation (rec {
@@ -46,7 +47,7 @@ let
 
     hardeningDisable = [ "all" ];
 
-    makeFlags = [ "DTC=dtc" ];
+    makeFlags = [ "DTC=dtc" ] ++ extraMakeFlags;
 
     configurePhase = ''
       make ${defconfig}

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -90,7 +90,15 @@ in rec {
     buildFlags = "tools NO_SDL=1";
     dontStrip = false;
     targetPlatforms = stdenv.lib.platforms.linux;
-    filesToInstall = ["tools/dumpimage" "tools/mkenvimage" "tools/mkimage"];
+    # build tools/kwboot
+    extraMakeFlags = [ "CONFIG_KIRKWOOD=y" ];
+    filesToInstall = [
+      "tools/dumpimage"
+      "tools/fdtgrep"
+      "tools/kwboot"
+      "tools/mkenvimage"
+      "tools/mkimage"
+    ];
   };
 
   ubootA20OlinuxinoLime = buildUBoot rec {


### PR DESCRIPTION
###### Motivation for this change
This introduces `extraMakeFlags`, so we can then build `ubootTools` with additional `makeFlags` (primarily to include `kwboot`)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @dezgeg
