### PR TITLE
cloudflare-warp: init at 2017.12.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -363,6 +363,7 @@
   leonardoce = "Leonardo Cecchi <leonardo.cecchi@gmail.com>";
   lethalman = "Luca Bruno <lucabru@src.gnome.org>";
   lewo = "Antoine Eiche <lewo@abesis.fr>";
+  lezed1 = "Zander Bolgar <lezed1@gmail.com>";
   lheckemann = "Linus Heckemann <git@sphalerite.org>";
   lhvwb = "Nathaniel Baxter <nathaniel.baxter@gmail.com>";
   lihop = "Leroy Hopson <nixos@leroy.geek.nz>";

--- a/pkgs/tools/networking/cloudflare-warp/default.nix
+++ b/pkgs/tools/networking/cloudflare-warp/default.nix
@@ -1,0 +1,52 @@
+{ fetchurl, stdenv }:
+
+assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux";
+
+let
+  version = "2017.12.1";
+in let
+  cloudflare-warp = stdenv.mkDerivation rec {
+    name = "cloudflare-warp-${version}-bin";
+
+    src =
+      if stdenv.system == "i686-linux" then
+        fetchurl {
+          name = "${name}.tgz";
+          url = "https://bin.equinox.io/c/2ovkwS9YHaP/warp-stable-linux-386.tgz";
+          sha256 = "0cvd0jfvw1jcslx07avvsmykbr283n27q790mc0jhwdxqli7qvdl";
+        }
+      else
+        fetchurl {
+          name = "${name}.tgz";
+          url = "https://bin.equinox.io/c/2ovkwS9YHaP/warp-stable-linux-amd64.tgz";
+          sha256 = "0srd0wp87ycg7nzkx1cpyhyz0r2nbz3kccqbnx9wp5ix3gxlsdj7";
+        };
+
+    buildCommand = ''
+      tar xvf ${src}
+      mkdir -p $out/bin
+      mv cloudflare-warp $out/bin/cloudflare-warp
+      patchelf --shrink-rpath $out/bin/cloudflare-warp
+      strip $out/bin/cloudflare-warp
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Exposes applications running on your local web server";
+      longDescription = "Exposes applications running on your local web server, on any network with an Internet connection without adding DNS records, configuring the firewall, configuring the router or opening ports.";
+      homepage = "https://warp.cloudflare.com/";
+      maintainers = with maintainers; [ lezed1 ];
+      license = licenses.unfree;
+    };
+  };
+in stdenv.mkDerivation {
+  name = "cloudflare-warp-${version}";
+
+  phases = [ "installPhase" ];
+  installPhase = ''
+    mkdir -p $out/bin
+    echo $(< $NIX_CC/nix-support/dynamic-linker) ${cloudflare-warp}/bin/cloudflare-warp \"\$@\" > $out/bin/cloudflare-warp
+    chmod +x $out/bin/cloudflare-warp
+  '';
+
+  meta = cloudflare-warp.meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -957,6 +957,8 @@ with pkgs;
 
   clipster = callPackage ../tools/misc/clipster { };
 
+  cloudflare-warp = callPackage ../tools/networking/cloudflare-warp { };
+
   coprthr = callPackage ../development/libraries/coprthr {
     flex = flex_2_5_35;
   };


### PR DESCRIPTION
###### Motivation for this change
`cloudflare-warp` allows you to serve a website behind Cloudflare without opening any port.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

