### PR TITLE
Add csfml package

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -323,6 +323,7 @@
   joko = "Ioannis Koutras <ioannis.koutras@gmail.com>";
   jonafato = "Jon Banafato <jon@jonafato.com>";
   joncojonathan = "Jonathan Haddock <joncojonathan@gmail.com>";
+  jpdoyle = "Joe Doyle <joethedoyle@gmail.com>";
   jpierre03 = "Jean-Pierre PRUNARET <nix@prunetwork.fr>";
   jpotier = "Martin Potier <jpo.contributes.to.nixos@marvid.fr>";
   jraygauthier = "Raymond Gauthier <jraygauthier@gmail.com>";

--- a/pkgs/development/libraries/csfml/default.nix
+++ b/pkgs/development/libraries/csfml/default.nix
@@ -4,7 +4,7 @@ let
   version = "2.4";
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   name = "csfml-${version}";
   src = fetchurl {
     url = "https://github.com/SFML/CSFML/archive/b5facb85d13bff451a5fd2d088a97472a685576c.tar.gz";

--- a/pkgs/development/libraries/csfml/default.nix
+++ b/pkgs/development/libraries/csfml/default.nix
@@ -7,14 +7,11 @@ in
 stdenv.mkDerivation rec {
   name = "csfml-${version}";
   src = fetchurl {
-    url = "https://github.com/SFML/CSFML/archive/${version}.tar.gz";
-    sha256 = "4e3d9a03afafbd3a507c39457a7619b68616ec79e870b975e09665e924f9c4c6";
+    url = "https://github.com/SFML/CSFML/archive/b5facb85d13bff451a5fd2d088a97472a685576c.tar.gz";
+    sha256 = "22c1fc871b278d96eec3d7d4fa1d49fb06d401689cabe678d51dc5b6be3b9205";
   };
-  #preInstall = "echo 'SFML dir:' '${sfml}'";
   buildInputs = [ cmake sfml ];
-  cmakeFlags = [ "-DCMAKE_MODULE_PATH=${sfml}/share/SFML/cmake/Modules/"
-                 "-DSFML_INSTALL_PKGCONFIG_FILES=yes"
-                 ];
+  cmakeFlags = [ "-DCMAKE_MODULE_PATH=${sfml}/share/SFML/cmake/Modules/" ];
   meta = with stdenv.lib; {
     homepage = http://www.sfml-dev.org/;
     description = "Simple and fast multimedia library";
@@ -24,7 +21,7 @@ stdenv.mkDerivation rec {
       It is written in C++, and has bindings for various languages such as C, .Net, Ruby, Python.
     '';
     license = licenses.zlib;
-    maintainers = [ maintainers.astsmtl ];
+    maintainers = [ maintainers.jpdoyle ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/csfml/default.nix
+++ b/pkgs/development/libraries/csfml/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, cmake, sfml }:
+
+let
+  version = "2.4";
+in
+
+stdenv.mkDerivation rec {
+  name = "csfml-${version}";
+  src = fetchurl {
+    url = "https://github.com/SFML/CSFML/archive/${version}.tar.gz";
+    sha256 = "4e3d9a03afafbd3a507c39457a7619b68616ec79e870b975e09665e924f9c4c6";
+  };
+  #preInstall = "echo 'SFML dir:' '${sfml}'";
+  buildInputs = [ cmake sfml ];
+  cmakeFlags = [ "-DCMAKE_MODULE_PATH=${sfml}/share/SFML/cmake/Modules/"
+                 "-DSFML_INSTALL_PKGCONFIG_FILES=yes"
+                 ];
+  meta = with stdenv.lib; {
+    homepage = http://www.sfml-dev.org/;
+    description = "Simple and fast multimedia library";
+    longDescription = ''
+      SFML is a simple, fast, cross-platform and object-oriented multimedia API.
+      It provides access to windowing, graphics, audio and network.
+      It is written in C++, and has bindings for various languages such as C, .Net, Ruby, Python.
+    '';
+    license = licenses.zlib;
+    maintainers = [ maintainers.astsmtl ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/csfml/default.nix
+++ b/pkgs/development/libraries/csfml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, sfml }:
+{ stdenv, fetchFromGitHub, cmake, sfml }:
 
 let
   version = "2.4";
@@ -6,12 +6,15 @@ in
 
 stdenv.mkDerivation {
   name = "csfml-${version}";
-  src = fetchurl {
-    url = "https://github.com/SFML/CSFML/archive/b5facb85d13bff451a5fd2d088a97472a685576c.tar.gz";
-    sha256 = "22c1fc871b278d96eec3d7d4fa1d49fb06d401689cabe678d51dc5b6be3b9205";
+  src = fetchFromGitHub {
+    owner = "SFML";
+    repo  = "CSFML";
+    rev   = "b5facb85d13bff451a5fd2d088a97472a685576c";
+    sha256 = "1q716gd7c7jlxzwpq5z4rjj5lsrn71ql2djphccdf9jannllqizn";
   };
   buildInputs = [ cmake sfml ];
   cmakeFlags = [ "-DCMAKE_MODULE_PATH=${sfml}/share/SFML/cmake/Modules/" ];
+
   meta = with stdenv.lib; {
     homepage = http://www.sfml-dev.org/;
     description = "Simple and fast multimedia library";
@@ -22,6 +25,7 @@ stdenv.mkDerivation {
     '';
     license = licenses.zlib;
     maintainers = [ maintainers.jpdoyle ];
-    platforms = platforms.linux;
+
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10826,6 +10826,7 @@ with pkgs;
   simp_le = callPackage ../tools/admin/simp_le { };
 
   sfml = callPackage ../development/libraries/sfml { };
+  csfml = callPackage ../development/libraries/csfml { };
 
   shapelib = callPackage ../development/libraries/shapelib { };
 


### PR DESCRIPTION
###### Motivation for this change

I needed this library, and it was not in nixpkgs.

###### Things done

Tested by running `rust-sfml` examples, which depend on `csfml`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

