### PR TITLE
Preparation for GIMP 2.10

### DIFF
--- a/pkgs/applications/graphics/gimp/2.8.nix
+++ b/pkgs/applications/graphics/gimp/2.8.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, intltool, babl, gegl, gtk2, glib, gdk_pixbuf
 , pango, cairo, freetype, fontconfig, lcms, libpng, libjpeg, poppler, libtiff
 , webkit, libmng, librsvg, libwmf, zlib, libzip, ghostscript, aalib, jasper
-, python2Packages, libart_lgpl, libexif, gettext, xorg
+, python2Packages, libexif, gettext, xorg
 , AppKit, Cocoa, gtk-mac-integration }:
 
 let
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
     [ pkgconfig intltool babl gegl gtk2 glib gdk_pixbuf pango cairo
       freetype fontconfig lcms libpng libjpeg poppler libtiff webkit
       libmng librsvg libwmf zlib libzip ghostscript aalib jasper
-      python pygtk libart_lgpl libexif gettext xorg.libXpm
+      python pygtk libexif gettext xorg.libXpm
       wrapPython
     ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ AppKit Cocoa gtk-mac-integration ];

--- a/pkgs/development/libraries/gegl/3.0.nix
+++ b/pkgs/development/libraries/gegl/3.0.nix
@@ -20,9 +20,11 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   buildInputs = [
-    babl libpng cairo libjpeg librsvg pango gtk bzip2 json_glib
+    libpng cairo libjpeg librsvg pango gtk bzip2
     libraw libwebp gnome3.gexiv2
   ];
+
+  propagatedBuildInputs = [ glib json_glib babl ]; # for gegl-3.0.pc
 
   nativeBuildInputs = [ pkgconfig intltool which autoreconfHook ];
 

--- a/pkgs/development/libraries/libmypaint/default.nix
+++ b/pkgs/development/libraries/libmypaint/default.nix
@@ -1,0 +1,32 @@
+{stdenv, autoconf, automake, fetchFromGitHub, glib, intltool, json_c, libtool, pkgconfig}:
+
+let
+  version = "1.3.0";
+in stdenv.mkDerivation rec {
+  name = "libmypaint-${version}";
+
+  src = fetchFromGitHub {
+    owner = "mypaint";
+    repo = "libmypaint";
+    rev = "v${version}";
+    sha256 = "0b7aynr6ggigwhjkfzi8x3dwz15blj4grkg9hysbgjh6lvzpy9jc";
+  };
+
+  nativeBuildInputs = [ autoconf automake intltool libtool pkgconfig ];
+
+  buildInputs = [ glib ];
+
+  propagatedBuildInputs = [ json_c ]; # for libmypaint.pc
+
+  doCheck = true;
+
+  preConfigure = "./autogen.sh";
+
+  meta = with stdenv.lib; {
+    homepage = http://mypaint.org/;
+    description = "Library for making brushstrokes which is used by MyPaint and other projects";
+    license = licenses.isc;
+    maintainers = with maintainers; [ goibhniu jtojnar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15070,7 +15070,6 @@ with pkgs;
   ghq = gitAndTools.ghq;
 
   gimp_2_8 = callPackage ../applications/graphics/gimp/2.8.nix {
-    inherit (gnome2) libart_lgpl;
     webkit = null;
     lcms = lcms2;
     inherit (darwin.apple_sdk.frameworks) AppKit Cocoa;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9434,6 +9434,8 @@ with pkgs;
 
   libmsgpack = callPackage ../development/libraries/libmsgpack { };
 
+  libmypaint = callPackage ../development/libraries/libmypaint { };
+
   libmysqlconnectorcpp = callPackage ../development/libraries/libmysqlconnectorcpp {
     mysql = mysql57;
   };


### PR DESCRIPTION
###### Motivation for this change
Since a [string freeze](https://www.gimp.org/news/2017/12/21/gimp-2-10-strings-freeze/) occurred recently, 2.10 will be released soon. I have packaged the unstable version in https://github.com/NixOS/nixpkgs/compare/master...jtojnar:gimp-2.10 but these changes make sense on their own.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

