### PR TITLE
paperwork: 1.2.1 -> 1.2.2

### DIFF
--- a/pkgs/applications/office/paperwork/backend.nix
+++ b/pkgs/applications/office/paperwork/backend.nix
@@ -10,13 +10,13 @@
 
 buildPythonPackage rec {
   pname = "paperwork-backend";
-  version = "1.2.1";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     owner = "openpaperwork";
     repo = "paperwork-backend";
     rev = version;
-    sha256 = "1lrawibm6jnykj1bkrl8196kcxrhndzp7r0brdrb4hs54gql7j5x";
+    sha256 = "1rvf06vphm32601ja1bfkfkfpgjxiv0lh4yxjy31jll0bfnsf7pf";
   };
 
   # Python 2.x is not supported.

--- a/pkgs/applications/office/paperwork/default.nix
+++ b/pkgs/applications/office/paperwork/default.nix
@@ -7,13 +7,13 @@
 python3Packages.buildPythonApplication rec {
   name = "paperwork-${version}";
   # Don't forget to also update paperwork-backend when updating this!
-  version = "1.2.1";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     repo = "paperwork";
     owner = "openpaperwork";
     rev = version;
-    sha256 = "0lqnq74hdjj778j2k0syibwy4i37l8w932gmibs8617s4yi34rxz";
+    sha256 = "1nb5sna2s952xb7c89qccg9qp693pyqj8g7xz16ll16ydfqnzsdk";
   };
 
   # Patch out a few paths that assume that we're using the FHS:


### PR DESCRIPTION
###### Motivation for this change

Paperwork has a new bugfix release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

