### PR TITLE
Revert "nixos: doc: implement related packages in the manual"

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -56,7 +56,7 @@ let
       replaceStrings seq stringLength sub substring tail;
     inherit (trivial) id const concat or and boolToString mergeAttrs
       flip mapNullable inNixShell min max importJSON warn info
-      nixpkgsVersion mod compare splitByAndCompare;
+      nixpkgsVersion mod;
 
     inherit (fixedPoints) fix fix' extends composeExtensions
       makeExtensible makeExtensibleWithCustomName;
@@ -71,8 +71,8 @@ let
     inherit (lists) singleton foldr fold foldl foldl' imap0 imap1
       concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range partition zipListsWith zipLists
-      reverseList listDfs toposort sort compareLists take drop sublist
-      last init crossLists unique intersectLists subtractLists
+      reverseList listDfs toposort sort take drop sublist last init
+      crossLists unique intersectLists subtractLists
       mutuallyExclusive;
     inherit (strings) concatStrings concatMapStrings concatImapStrings
       intersperse concatStringsSep concatMapStringsSep

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -385,30 +385,6 @@ rec {
       if len < 2 then list
       else (sort strictLess pivot.left) ++  [ first ] ++  (sort strictLess pivot.right));
 
-  /* Compare two lists element-by-element.
-
-     Example:
-       compareLists compare [] []
-       => 0
-       compareLists compare [] [ "a" ]
-       => -1
-       compareLists compare [ "a" ] []
-       => 1
-       compareLists compare [ "a" "b" ] [ "a" "c" ]
-       => 1
-  */
-  compareLists = cmp: a: b:
-    if a == []
-    then if b == []
-         then 0
-         else -1
-    else if b == []
-         then 1
-         else let rel = cmp (head a) (head b); in
-              if rel == 0
-              then compareLists cmp (tail a) (tail b)
-              else rel;
-
   /* Return the first (at most) N elements of a list.
 
      Example:

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -14,7 +14,6 @@ rec {
     , defaultText ? null # Textual representation of the default, for in the manual.
     , example ? null # Example value used in the manual.
     , description ? null # String describing the option.
-    , relatedPackages ? null # Related packages used in the manual.
     , type ? null # Option type, providing type-checking and value merging.
     , apply ? null # Function that converts the option value to something else.
     , internal ? null # Whether the option is for NixOS developers only.
@@ -77,6 +76,7 @@ rec {
   getValues = map (x: x.value);
   getFiles = map (x: x.file);
 
+
   # Generate documentation template from the list of option declaration like
   # the set generated with filterOptionSets.
   optionAttrSetToDocList = optionAttrSetToDocList' [];
@@ -93,10 +93,9 @@ rec {
           readOnly = opt.readOnly or false;
           type = opt.type.description or null;
         }
-        // optionalAttrs (opt ? example) { example = scrubOptionValue opt.example; }
-        // optionalAttrs (opt ? default) { default = scrubOptionValue opt.default; }
-        // optionalAttrs (opt ? defaultText) { default = opt.defaultText; }
-        // optionalAttrs (opt ? relatedPackages && opt.relatedPackages != null) { inherit (opt) relatedPackages; };
+        // (if opt ? example then { example = scrubOptionValue opt.example; } else {})
+        // (if opt ? default then { default = scrubOptionValue opt.default; } else {})
+        // (if opt ? defaultText then { default = opt.defaultText; } else {});
 
         subOptions =
           let ss = opt.type.getSubOptions opt.loc;

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -81,31 +81,6 @@ rec {
   */
   mod = base: int: base - (int * (builtins.div base int));
 
-  /* C-style comparisons
-
-     a < b  => -1
-     a == b => 0
-     a > b  => 1
-  */
-  compare = a: b:
-    if a < b
-    then -1
-    else if a > b
-         then 1
-         else 0;
-
-  /* Split type into two subtypes by predicate `p`, assume
-
-       forall x y . x < y if p x == true && p y == false
-
-     compare elements of the same subtype with `yes` and `no`
-     comparisons respectively.
-  */
-  splitByAndCompare = p: yes: no: a: b:
-    if p a
-    then if p b then yes a b else -1
-    else if p b then 1 else no a b;
-
   /* Reads a JSON file. */
   importJSON = path:
     builtins.fromJSON (builtins.readFile path);

--- a/nixos/doc/manual/options-to-docbook.xsl
+++ b/nixos/doc/manual/options-to-docbook.xsl
@@ -70,15 +70,6 @@
                 </para>
               </xsl:if>
 
-              <xsl:if test="attr[@name = 'relatedPackages']">
-                <para>
-                  <emphasis>Related packages:</emphasis>
-                  <xsl:text> </xsl:text>
-                  <xsl:value-of disable-output-escaping="yes"
-                                select="attr[@name = 'relatedPackages']/string/@value" />
-                </para>
-              </xsl:if>
-
               <xsl:if test="count(attr[@name = 'declarations']/list/*) != 0">
                 <para>
                   <emphasis>Declared by:</emphasis>

--- a/nixos/modules/programs/tmux.nix
+++ b/nixos/modules/programs/tmux.nix
@@ -61,12 +61,7 @@ in {
   options = {
     programs.tmux = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whenever to configure <command>tmux</command> system-wide.";
-        relatedPackages = [ "tmux" ];
-      };
+      enable = mkEnableOption "<command>tmux</command> - a <command>screen</command> replacement.";
 
       aggressiveResize = mkOption {
         default = false;

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -207,7 +207,6 @@ with lib;
       "Set the option `services.xserver.displayManager.sddm.package' instead.")
     (mkRemovedOptionModule [ "fonts" "fontconfig" "forceAutohint" ] "")
     (mkRemovedOptionModule [ "fonts" "fontconfig" "renderMonoTTFAsBitmap" ] "")
-    (mkRemovedOptionModule [ "virtualisation" "xen" "qemu" ] "You don't need this option anymore, it will work without it.")
 
     # ZSH
     (mkRenamedOptionModule [ "programs" "zsh" "enableSyntaxHighlighting" ] [ "programs" "zsh" "syntaxHighlighting" "enable" ])
@@ -218,8 +217,5 @@ with lib;
     (mkRenamedOptionModule [ "programs" "zsh" "oh-my-zsh" "theme" ] [ "programs" "zsh" "ohMyZsh" "theme" ])
     (mkRenamedOptionModule [ "programs" "zsh" "oh-my-zsh" "custom" ] [ "programs" "zsh" "ohMyZsh" "custom" ])
     (mkRenamedOptionModule [ "programs" "zsh" "oh-my-zsh" "plugins" ] [ "programs" "zsh" "ohMyZsh" "plugins" ])
-
-    # Xen
-    (mkRenamedOptionModule [ "virtualisation" "xen" "qemu-package" ] [ "virtualisation" "xen" "package-qemu" ])
   ];
 }

--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -35,19 +35,24 @@ in
       description = ''
         The package used for Xen binary.
       '';
-      relatedPackages = [ "xen" "xen-light" ];
     };
 
-    virtualisation.xen.package-qemu = mkOption {
+    virtualisation.xen.qemu = mkOption {
+      type = types.path;
+      defaultText = "\${pkgs.xen}/lib/xen/bin/qemu-system-i386";
+      example = literalExample "''${pkgs.qemu_xen-light}/bin/qemu-system-i386";
+      description = ''
+        The qemu binary to use for Dom-0 backend.
+      '';
+    };
+
+    virtualisation.xen.qemu-package = mkOption {
       type = types.package;
       defaultText = "pkgs.xen";
       example = literalExample "pkgs.qemu_xen-light";
       description = ''
-        The package with qemu binaries for dom0 qemu and xendomains.
+        The package with qemu binaries for xendomains.
       '';
-      relatedPackages = [ "xen"
-                          { name = "qemu_xen-light"; comment = "For use with pkgs.xen-light."; }
-                        ];
     };
 
     virtualisation.xen.bootParams =
@@ -153,7 +158,8 @@ in
     } ];
 
     virtualisation.xen.package = mkDefault pkgs.xen;
-    virtualisation.xen.package-qemu = mkDefault pkgs.xen;
+    virtualisation.xen.qemu = mkDefault "${pkgs.xen}/lib/xen/bin/qemu-system-i386";
+    virtualisation.xen.qemu-package = mkDefault pkgs.xen;
     virtualisation.xen.stored = mkDefault "${cfg.package}/bin/oxenstored";
 
     environment.systemPackages = [ cfg.package ];
@@ -333,8 +339,7 @@ in
       after = [ "xen-console.service" ];
       requires = [ "xen-store.service" ];
       serviceConfig.ExecStart = ''
-        ${cfg.package-qemu}/${cfg.package-qemu.qemu-system-i386} \
-           -xen-attach -xen-domid 0 -name dom0 -M xenpv \
+        ${cfg.qemu} -xen-attach -xen-domid 0 -name dom0 -M xenpv \
            -nographic -monitor /dev/null -serial /dev/null -parallel /dev/null
         '';
     };
@@ -443,7 +448,7 @@ in
       before = [ "dhcpd.service" ];
       restartIfChanged = false;
       serviceConfig.RemainAfterExit = "yes";
-      path = [ cfg.package cfg.package-qemu ];
+      path = [ cfg.package cfg.qemu-package ];
       environment.XENDOM_CONFIG = "${cfg.package}/etc/sysconfig/xendomains";
       preStart = "mkdir -p /var/lock/subsys -m 755";
       serviceConfig.ExecStart = "${cfg.package}/etc/init.d/xendomains start";

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -101,10 +101,6 @@ stdenv.mkDerivation rec {
     else if stdenv.isAarch64 then ''makeWrapper $out/bin/qemu-system-aarch64 $out/bin/qemu-kvm --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"''
     else "";
 
-  passthru = {
-    qemu-system-i386 = "bin/qemu-system-i386";
-  };
-
   meta = with stdenv.lib; {
     homepage = http://www.qemu.org/;
     description = "A generic and open source machine emulator and virtualizer";

--- a/pkgs/applications/virtualization/xen/4.5.nix
+++ b/pkgs/applications/virtualization/xen/4.5.nix
@@ -248,10 +248,4 @@ callPackage (import ./generic.nix (rec {
       -i tools/libxl/libxl_device.c
   '';
 
-  passthru = {
-    qemu-system-i386 = if withInternalQemu
-      then "lib/xen/bin/qemu-system-i386"
-      else throw "this xen has no qemu builtin";
-  };
-
 })) ({ ocamlPackages = ocamlPackages_4_02; } // args)

--- a/pkgs/applications/virtualization/xen/4.8.nix
+++ b/pkgs/applications/virtualization/xen/4.8.nix
@@ -176,10 +176,4 @@ callPackage (import ./generic.nix (rec {
       -i tools/libxl/libxl_device.c
   '';
 
-  passthru = {
-    qemu-system-i386 = if withInternalQemu
-      then "lib/xen/bin/qemu-system-i386"
-      else throw "this xen has no qemu builtin";
-  };
-
 })) args


### PR DESCRIPTION
Reverts NixOS/nixpkgs#32424

I'm not sure why exactly, but this is causing problems after merging that ofborg didn't catch prior to merging:


```
$ HOME=/homeless-shelter NIX_PATH=nixpkgs=$(pwd) nix-instantiate ./nixos/release.nix -A manual --option restrict-eval true --option build-timeout 1800 --argstr system x86_64-linux --show-trace
...
Package ‘xen-4.5.5’ in /home/grahamc/projects/nixpkgs/pkgs/applications/virtualization/xen/generic.nix:226 is not supported on ‘aarch64-linux’, refusing to evaluate.

a) For `nixos-rebuild` you can set
  { nixpkgs.config.allowBroken = true; }
in configuration.nix to override this.

b) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
  { allowBroken = true; }
to ~/.config/nixpkgs/config.nix.
```

@oxij I like the work and didn't want to revert it, but it wasn't clear to me how to fix it. Can you try again?