### PR TITLE
cacert: add hook that sets SSL_CERT_FILE

### DIFF
--- a/pkgs/build-support/fetchbower/default.nix
+++ b/pkgs/build-support/fetchbower/default.nix
@@ -11,7 +11,6 @@ let
 
   fetchbower = name: version: target: outputHash: stdenv.mkDerivation {
     name = "${cleanName name}-${bowerVersion version}";
-    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
     buildCommand = ''
       fetch-bower --quiet --out=$PWD/out "${name}" "${target}" "${version}"
       # In some cases, the result of fetchBower is different depending
@@ -23,7 +22,7 @@ let
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
     inherit outputHash;
-    buildInputs = [ bower2nix ];
+    buildInputs = [ cacert bower2nix ];
   };
 
 in fetchbower

--- a/pkgs/build-support/fetchdarcs/default.nix
+++ b/pkgs/build-support/fetchdarcs/default.nix
@@ -7,9 +7,8 @@ if md5 != "" then
 else
 stdenv.mkDerivation {
   name = "fetchdarcs";
-  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
   builder = ./builder.sh;
-  buildInputs = [darcs];
+  buildInputs = [cacert darcs];
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";

--- a/pkgs/build-support/fetchgx/default.nix
+++ b/pkgs/build-support/fetchgx/default.nix
@@ -6,15 +6,13 @@ stdenv.mkDerivation {
   name = "${name}-gxdeps";
   inherit src;
 
-  buildInputs = [ go gx gx-go ];
+  buildInputs = [ cacert go gx gx-go ];
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
   outputHash = sha256;
 
   phases = [ "unpackPhase" "buildPhase" "installPhase" ];
-
-  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
   buildPhase = ''
     export GOPATH=$(pwd)/vendor

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -32,7 +32,7 @@ in stdenv.mkDerivation (args // {
 
   patchRegistryDeps = ./patch-registry-deps;
 
-  buildInputs = [ git rust.cargo rust.rustc ] ++ buildInputs;
+  buildInputs = [ cacert git rust.cargo rust.rustc ] ++ buildInputs;
 
   configurePhase = args.configurePhase or ''
     runHook preConfigure
@@ -60,7 +60,6 @@ in stdenv.mkDerivation (args // {
     unset cargoDepsCopy
 
     export RUST_LOG=${logLevel}
-    export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
   '' + (args.postUnpack or "");
 
   buildPhase = with builtins; args.buildPhase or ''

--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -19,7 +19,6 @@ stdenv.mkDerivation {
         exit 1
     fi
 
-    export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
     export CARGO_HOME=$(mktemp -d cargo-home.XXX)
 
     cargo vendor

--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -52,6 +52,8 @@ stdenv.mkDerivation rec {
     cp -v ca-bundle.crt $out/etc/ssl/certs
   '';
 
+  setupHook = ./setup-hook.sh;
+
   meta = {
     homepage = https://curl.haxx.se/docs/caextract.html;
     description = "A bundle of X.509 certificates of public Certificate Authorities (CA)";

--- a/pkgs/data/misc/cacert/setup-hook.sh
+++ b/pkgs/data/misc/cacert/setup-hook.sh
@@ -1,0 +1,6 @@
+cacertHook() {
+    export SSL_CERT_FILE=@out@/etc/ssl/certs/ca-bundle.crt
+}
+
+envHooks+=(cacertHook)
+crossEnvHooks+=(cacertHook)

--- a/pkgs/development/compilers/go/1.7.nix
+++ b/pkgs/development/compilers/go/1.7.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   # perl is used for testing go vet
   nativeBuildInputs = [ perl which pkgconfig patch ];
-  buildInputs = [ pcre ];
+  buildInputs = [ cacert pcre ];
   propagatedBuildInputs = optionals stdenv.isDarwin [ Security Foundation ];
 
   hardeningDisable = [ "all" ];
@@ -115,8 +115,6 @@ stdenv.mkDerivation rec {
         sha256 = "1ny5l3f8a9dpjjrnjnsplb66308a0x13sa0wwr4j6yrkc8j4qxqi";
       })
     ];
-
-  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
   GOOS = if stdenv.isDarwin then "darwin" else "linux";
   GOARCH = if stdenv.isDarwin then "amd64"

--- a/pkgs/development/compilers/go/1.8.nix
+++ b/pkgs/development/compilers/go/1.8.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   # perl is used for testing go vet
   nativeBuildInputs = [ perl which pkgconfig patch makeWrapper ]
     ++ optionals stdenv.isLinux [ procps ];
-  buildInputs = [ pcre ]
+  buildInputs = [ cacert pcre ]
     ++ optionals stdenv.isLinux [ stdenv.glibc.out stdenv.glibc.static ];
   propagatedBuildInputs = optionals stdenv.isDarwin [ Security Foundation ];
 
@@ -121,8 +121,6 @@ stdenv.mkDerivation rec {
     echo "substitute hardcoded dsymutil with ${llvm}/bin/llvm-dsymutil"
     substituteInPlace "src/cmd/link/internal/ld/lib.go" --replace dsymutil ${llvm}/bin/llvm-dsymutil
   '';
-
-  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
   GOOS = if stdenv.isDarwin then "darwin" else "linux";
   GOARCH = if stdenv.isDarwin then "amd64"

--- a/pkgs/development/compilers/go/1.9.nix
+++ b/pkgs/development/compilers/go/1.9.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   # perl is used for testing go vet
   nativeBuildInputs = [ perl which pkgconfig patch makeWrapper ]
     ++ optionals stdenv.isLinux [ procps ];
-  buildInputs = [ pcre ]
+  buildInputs = [ cacert pcre ]
     ++ optionals stdenv.isLinux [ stdenv.glibc.out stdenv.glibc.static ];
   propagatedBuildInputs = optionals stdenv.isDarwin [ Security Foundation ];
 
@@ -127,8 +127,6 @@ stdenv.mkDerivation rec {
     echo "substitute hardcoded dsymutil with ${llvm}/bin/llvm-dsymutil"
     substituteInPlace "src/cmd/link/internal/ld/lib.go" --replace dsymutil ${llvm}/bin/llvm-dsymutil
   '';
-
-  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
   GOOS = if stdenv.isDarwin then "darwin" else "linux";
   GOARCH = if stdenv.isDarwin then "amd64"

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
   passthru.rustc = rustc;
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ file curl python openssl cmake zlib makeWrapper libgit2 ]
+  buildInputs = [ cacert file curl python openssl cmake zlib makeWrapper libgit2 ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation libiconv ];
 
   LIBGIT2_SYS_USE_PKG_CONFIG=1;
@@ -48,8 +48,6 @@ rustPlatform.buildRustPackage rec {
   '';
 
   checkPhase = ''
-    # Export SSL_CERT_FILE as without it one test fails with SSL verification error
-    export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
     # Disable cross compilation tests
     export CFG_DISABLE_CROSS_TESTS=1
     cargo test

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -3,7 +3,7 @@
 { R, pkgs, overrides }:
 
 let
-  inherit (pkgs) fetchurl stdenv lib;
+  inherit (pkgs) cacert fetchurl stdenv lib;
 
   buildRPackage = pkgs.callPackage ./generic-builder.nix {
     inherit R;
@@ -912,9 +912,7 @@ let
     });
 
     geojsonio = old.geojsonio.overrideDerivation (attrs: {
-      preConfigure = ''
-        export SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
-        '';
+      buildInputs = [ cacert ] ++ attrs.buildInputs;
     });
 
     rstan = old.rstan.overrideDerivation (attrs: {

--- a/pkgs/os-specific/linux/firmware/firmware-linux-nonfree/default.nix
+++ b/pkgs/os-specific/linux/firmware/firmware-linux-nonfree/default.nix
@@ -32,8 +32,7 @@ stdenv.mkDerivation rec {
     # traffic, so don't do that.
     preferLocalBuild = true;
 
-    buildInputs = [ git gnupg ];
-    NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+    buildInputs = [ cacert git gnupg ];
   } ''
     git init src && (
       cd src


### PR DESCRIPTION
###### Motivation for this change

Fixes #32981

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---