### PR TITLE
liblouis: init at 3.4.0

### DIFF
--- a/pkgs/development/libraries/liblouis/default.nix
+++ b/pkgs/development/libraries/liblouis/default.nix
@@ -1,0 +1,57 @@
+{ fetchFromGitHub, stdenv, autoreconfHook, pkgconfig, gettext, python3
+, texinfo, help2man, libyaml, perl
+}:
+
+let
+  version = "3.4.0";
+in stdenv.mkDerivation rec {
+  name = "liblouis-${version}";
+
+  src = fetchFromGitHub {
+    owner = "liblouis";
+    repo = "liblouis";
+    rev = "v${version}";
+    sha256 = "1b3vf6sq2iffdvj0r2q5g5k198camy3sq2nwfz391brpwivsnayh";
+  };
+
+  outputs = [ "out" "dev" "man" "info" "doc" ];
+
+  nativeBuildInputs = [
+    autoreconfHook pkgconfig gettext python3
+    # Docs, man, info
+    texinfo help2man
+  ];
+
+  buildInputs = [
+    # lou_checkYaml
+    libyaml
+    # maketable.d
+    perl
+  ];
+
+  configureFlags = [
+    # Required by Python bindings
+    "--enable-ucs4"
+  ];
+
+  postPatch = ''
+    patchShebangs tests
+    substituteInPlace python/louis/__init__.py.in --replace "###LIBLOUIS_SONAME###" "$out/lib/liblouis.so"
+  '';
+
+  postInstall = ''
+    pushd python
+    python setup.py install --prefix="$out" --optimize=1
+    popd
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Open-source braille translator and back-translator";
+    homepage = http://liblouis.org/;
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3185,6 +3185,8 @@ with pkgs;
 
   libite = callPackage ../development/libraries/libite { };
 
+  liblouis = callPackage ../development/libraries/liblouis { };
+
   liboauth = callPackage ../development/libraries/liboauth { };
 
   libsidplayfp = callPackage ../development/libraries/libsidplayfp { };


### PR DESCRIPTION
###### Motivation for this change
Optional dependency of [orca](https://github.com/NixOS/nixpkgs/pull/32866)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)

      nix-shell -p liblouis --run "echo 'Quick brown fox' | lou_translate --forward en-us-g2.ctb"

      nix-shell -p liblouis python3 --pure --run "python -c \"import louis; print(louis.translate([b'en-us-g2.ctb'], 'Hello world!', cursorPos=5))\""


- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @berce 