### PR TITLE
pycuda: fix boost_python3 link

### DIFF
--- a/pkgs/development/python-modules/pycuda/default.nix
+++ b/pkgs/development/python-modules/pycuda/default.nix
@@ -13,8 +13,7 @@
 , python
 , mkDerivation
 , stdenv
-, pythonOlder
-, isPy35
+, isPy3k
 }:
 let
   compyte = import ./compyte.nix {
@@ -35,7 +34,7 @@ buildPythonPackage rec {
     ${python.interpreter} configure.py --boost-inc-dir=${boost.dev}/include \
                           --boost-lib-dir=${boost}/lib \
                           --no-use-shipped-boost \
-                          --boost-python-libname=boost_python
+                          --boost-python-libname=boost_python${stdenv.lib.optionalString isPy3k "3"}
   '';
 
   postInstall = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6524,7 +6524,6 @@ in {
   pycuda = callPackage ../development/python-modules/pycuda rec {
     cudatoolkit = pkgs.cudatoolkit75;
     inherit (pkgs.stdenv) mkDerivation;
-    inherit pythonOlder;
   };
 
   pyphen = callPackage ../development/python-modules/pyphen {};


### PR DESCRIPTION
Boost python library is now named -lboost_python3 on py3. Without this, link fails on python3.  Still fine on python2. Also removed a couple unused inputs.

###### Motivation for this change

`-lboost_python` not found on python3 pycuda build.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

