### PR TITLE
Bump lhapdf, yoda, rivet

### DIFF
--- a/pkgs/development/libraries/physics/lhapdf/default.nix
+++ b/pkgs/development/libraries/physics/lhapdf/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "lhapdf-${version}";
-  version = "6.2.0";
+  version = "6.2.1";
 
   src = fetchurl {
     url = "http://www.hepforge.org/archive/lhapdf/LHAPDF-${version}.tar.gz";
-    sha256 = "0gfjps7v93n0rrdndkhp22d93y892bf76pnzdhqbish0cigkkxph";
+    sha256 = "0bi02xcmq5as0wf0jn6i3hx0qy0hj61m02sbrbzd1gwjhpccwmvd";
   };
 
   buildInputs = [ python2 ];

--- a/pkgs/development/libraries/physics/rivet/default.nix
+++ b/pkgs/development/libraries/physics/rivet/default.nix
@@ -2,14 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "rivet-${version}";
-  version = "2.5.4";
+  version = "2.6.0";
 
   src = fetchurl {
     url = "http://www.hepforge.org/archive/rivet/Rivet-${version}.tar.bz2";
-    sha256 = "1qi7am60f2l4krd3sbj95mbzfk82lir0wy8z27yr9ncq6qcm48kp";
+    sha256 = "1mvsa3v8d1pl2fj1dcdf8sikzm1yb2jcl0q34fyfsjw2cisxpv5f";
   };
-
-  postPatch = "patchShebangs ./src/Analyses/cat_with_lines";
 
   patches = [
     ./darwin.patch # configure relies on impure sw_vers to -Dunix
@@ -29,6 +27,13 @@ stdenv.mkDerivation rec {
   buildInputs = [ hepmc imagemagick python2 latex makeWrapper ];
   propagatedBuildInputs = [ fastjet ghostscript gsl yoda ];
 
+  preConfigure = ''
+    substituteInPlace bin/rivet-buildplugin.in \
+      --replace '"which"' '"${which}/bin/which"' \
+      --replace 'mycxx=' 'mycxx=${stdenv.cc}/bin/${if stdenv.cc.isClang or false then "clang++" else "g++"}  #' \
+      --replace 'mycxxflags="' "mycxxflags=\"-std=c++11 $NIX_CFLAGS_COMPILE $NIX_CXXSTDLIB_COMPILE $NIX_CFLAGS_LINK "
+  '';
+
   preInstall = ''
     substituteInPlace bin/make-plots \
       --replace '"which"' '"${which}/bin/which"' \
@@ -40,10 +45,6 @@ stdenv.mkDerivation rec {
       --replace '"convert"' '"${imagemagick.out}/bin/convert"'
     substituteInPlace bin/rivet \
       --replace '"less"' '"${less}/bin/less"'
-    substituteInPlace bin/rivet-buildplugin \
-      --replace '"which"' '"${which}/bin/which"' \
-      --replace 'mycxx=' 'mycxx=${stdenv.cc}/bin/${if stdenv.cc.isClang or false then "clang++" else "g++"}  #' \
-      --replace 'mycxxflags="' "mycxxflags=\"-std=c++11 $NIX_CFLAGS_COMPILE $NIX_CXXSTDLIB_COMPILE $NIX_CFLAGS_LINK "
     substituteInPlace bin/rivet-mkhtml \
       --replace '"make-plots"' \"$out/bin/make-plots\" \
       --replace '"rivet-cmphistos"' \"$out/bin/rivet-cmphistos\"

--- a/pkgs/development/libraries/physics/yoda/default.nix
+++ b/pkgs/development/libraries/physics/yoda/default.nix
@@ -1,18 +1,19 @@
-{ stdenv, fetchurl, fetchpatch, python2Packages, root, makeWrapper, withRootSupport ? false }:
+{ stdenv, fetchurl, fetchpatch, python2Packages, root, makeWrapper, zlib, withRootSupport ? false }:
 
 stdenv.mkDerivation rec {
   name = "yoda-${version}";
-  version = "1.6.7";
+  version = "1.7.0";
 
   src = fetchurl {
     url = "http://www.hepforge.org/archive/yoda/YODA-${version}.tar.bz2";
-    sha256 = "05jyv5dypa6d4q1m8wm2qycgq1i0bgzwzzm9qqdj0b43ff2kggra";
+    sha256 = "0fyf6ld1klzlfmr5sl1jxzck4a0h14zfkrff8397rn1fqnqbzmmk";
   };
 
   pythonPath = []; # python wrapper support
 
   buildInputs = with python2Packages; [ python numpy matplotlib makeWrapper ]
     ++ stdenv.lib.optional withRootSupport root;
+  propagatedBuildInputs = [ zlib ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

