### PR TITLE
flashtool: mark as broken

### DIFF
--- a/pkgs/development/mobile/flashtool/default.nix
+++ b/pkgs/development/mobile/flashtool/default.nix
@@ -59,5 +59,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.unfreeRedistributableFirmware;
     platforms = stdenv.lib.platforms.linux;
     hydraPlatforms = stdenv.lib.platforms.none;
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The sources are no longer obtainable from the URL specified in the
expression and the package has no maintainers.

/cc @peti who, based on commit history, originally added and maintained the package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

