### PR TITLE
nixos/gnome3: get keyboard layout(s) from xkb

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -39,6 +39,9 @@ let
        [org.gnome.desktop.screensaver]
        picture-uri='${pkgs.nixos-artwork.wallpapers.gnome-dark}/share/artwork/gnome/Gnome_Dark.png'
 
+       [org.gnome.desktop.input-sources]
+       sources='[]'
+
        ${cfg.extraGSettingsOverrides}
      EOF
 


### PR DESCRIPTION
###### Motivation for this change
GNOME3 defaults to a US keyboard layout, with the user being able to configure this in the Settings dialog. Deleting the default value for keyboard layout makes it instead use the xkb default layout ([source](https://unix.stackexchange.com/a/317057/1863)), which the NixOS manual says to set in configuration.nix (and is presumably where every other desktop environment / window manager gets their choice of keyboard layout from 😒)

GNOME's Wayland compositor still uses xkb, so this change doesn't depend on Xorg

I tried this change on my own system and found that GNOME had preserved the previous default setting for all of my users. I think this is probably ideal - current users see no change (some may not have set layout in configuration.nix, but only in gnome-control-center), whereas for new users the keyboard layout setting in configuration.nix works out-of-the-box (but gnome-control-center can still be used to change keyboard layout if desired)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

