### PR TITLE
Elixir: init 1.6-rc.0

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -44,6 +44,11 @@ let
         # BEAM-based languages.
         elixir = elixir_1_5;
 
+        elixir_1_6_rc = lib.callElixir ../interpreters/elixir/1.6.nix {
+                       inherit rebar erlang;
+                       debugInfo = true;
+                     };
+
         elixir_1_5 = lib.callElixir ../interpreters/elixir/1.5.nix {
                        inherit rebar erlang;
                        debugInfo = true;

--- a/pkgs/development/interpreters/elixir/1.6.nix
+++ b/pkgs/development/interpreters/elixir/1.6.nix
@@ -1,0 +1,7 @@
+{ mkDerivation }:
+
+mkDerivation rec {
+  version = "1.6.0-rc.0";
+  sha256 = "1yfyp7y0mfdbh410xsfkq9a7ai2y22mjh2qn2cvpim76s96qjpw6";
+  minimumOTPVersion = "18";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6506,7 +6506,7 @@ with pkgs;
   inherit (beam.interpreters)
     erlang erlangR18 erlangR19 erlangR20
     erlang_odbc erlang_javac erlang_odbc_javac erlang_nox erlang_basho_R16B02
-    elixir elixir_1_5 elixir_1_4 elixir_1_3
+    elixir elixir_1_6_rc elixir_1_5 elixir_1_4 elixir_1_3
     lfe lfe_1_2;
 
   inherit (beam.packages.erlang)

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -52,7 +52,7 @@ rec {
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR19.elixir`.
-    inherit (packages.erlang) elixir elixir_1_5 elixir_1_4 elixir_1_3;
+    inherit (packages.erlang) elixir elixir_1_6_rc elixir_1_5 elixir_1_4 elixir_1_3;
 
     inherit (packages.erlang) lfe lfe_1_2;
   };


### PR DESCRIPTION
###### Motivation for this change

New Elixir version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

