### PR TITLE
 calcurse: 4.2.0 -> 4.3.0 

### DIFF
--- a/pkgs/applications/misc/calcurse/default.nix
+++ b/pkgs/applications/misc/calcurse/default.nix
@@ -2,19 +2,19 @@
 
 stdenv.mkDerivation rec {
   name = "calcurse-${version}";
-  version = "4.2.2";
+  version = "4.3.0";
 
   src = fetchurl {
     url = "http://calcurse.org/files/${name}.tar.gz";
-    sha256 = "0il0y06akdqgy0f9p40m4x6arn66nh7sr1w1i41bszycs7div266";
+    sha256 = "16jzg0nasnxdlz23i121x41pq5kbxmjzk52c5d863rg117fc7v1i";
   };
 
   buildInputs = [ncurses gettext python3 ];
   nativeBuildInputs = [ makeWrapper ];
 
   postInstall = ''
-    makeWrapper ${python3}/bin/python3 $out/bin/calcurse-caldav 
-      '';
+    makeWrapper ${python3}/bin/python3 $out/bin/calcurse-caldav
+  '';
 
   meta = with stdenv.lib; {
     description = "A calendar and scheduling application for the command line";

--- a/pkgs/applications/misc/calcurse/default.nix
+++ b/pkgs/applications/misc/calcurse/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ncurses, gettext, python3, makeWrapper }:
+{ stdenv, fetchurl, ncurses, gettext, python3, python3Packages, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "calcurse-${version}";
@@ -9,11 +9,17 @@ stdenv.mkDerivation rec {
     sha256 = "16jzg0nasnxdlz23i121x41pq5kbxmjzk52c5d863rg117fc7v1i";
   };
 
-  buildInputs = [ncurses gettext python3 ];
+  buildInputs = [ ncurses gettext python3 ];
   nativeBuildInputs = [ makeWrapper ];
 
+  # Build Python environment with httplib2 for calcurse-caldav
+  pythonEnv = python3Packages.python.buildEnv.override {
+    extraLibs = [ python3Packages.httplib2 ];
+  };
+  propogatedBuildInputs = [ pythonEnv ];
+
   postInstall = ''
-    makeWrapper ${python3}/bin/python3 $out/bin/calcurse-caldav
+    substituteInPlace $out/bin/calcurse-caldav --replace /usr/bin/python3 ${pythonEnv}/bin/python3
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

###### Things done
* Update calcurse
* Fix `calcurse-caldav`. It previously just executed `python3`, but now successfully executes with the proper dependencies. I would appreciate feedback on the best way to patch the shebang, this was just the one I figured out

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

