### PR TITLE
easyrpg-player: init at 0.5.3

### DIFF
--- a/pkgs/development/libraries/liblcf/default.nix
+++ b/pkgs/development/libraries/liblcf/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, expat, icu }:
+
+stdenv.mkDerivation rec {
+  name = "liblcf-${version}";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "EasyRPG";
+    repo = "liblcf";
+    rev = version;
+    sha256 = "1y3pbl3jxan9f0cb1rxkibqjc0h23jm3jlwlv0xxn2pgw8l0fk34";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ expat icu ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/EasyRPG/liblcf;
+    license = licenses.mit;
+    maintainers = with maintainers; [ yegortimoshenko ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/easyrpg-player/default.nix
+++ b/pkgs/games/easyrpg-player/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, cmake, doxygen ? null, pkgconfig, freetype ? null, harfbuzz ? null
+, liblcf, libpng, libsndfile ? null, libxmp ? null, libvorbis ? null, mpg123 ? null
+, opusfile ? null, pixman, SDL2, speexdsp ? null, wildmidi ? null, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "easyrpg-player-${version}";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "EasyRPG";
+    repo = "Player";
+    rev = version;
+    sha256 = "1cn3g08ap6cf812s8p3ilf31q7y7y4knp1s0gk45mqcz215cpd8q";
+  };
+
+  nativeBuildInputs = [ cmake doxygen pkgconfig ];
+
+  buildInputs = [
+    freetype
+    harfbuzz
+    liblcf
+    libpng
+    libsndfile
+    libxmp
+    libvorbis
+    mpg123
+    opusfile
+    SDL2
+    pixman
+    speexdsp
+    wildmidi
+    zlib
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://easyrpg.org/;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ yegortimoshenko ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18008,6 +18008,8 @@ with pkgs;
 
   d2x_rebirth = callPackage ../games/d2x-rebirth { };
 
+  easyrpg-player = callPackage ../games/easyrpg-player { };
+
   eboard = callPackage ../games/eboard { };
 
   eduke32 = callPackage ../games/eduke32 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9415,6 +9415,8 @@ with pkgs;
 
   liblastfm = callPackage ../development/libraries/liblastfm { };
 
+  liblcf = callPackage ../development/libraries/liblcf { };
+
   liblqr1 = callPackage ../development/libraries/liblqr-1 { };
 
   liblockfile = callPackage ../development/libraries/liblockfile { };


### PR DESCRIPTION
###### Motivation for this change

Playing RPG Maker 2000 games, like OFF: http://offgame.wikia.com/wiki/Downloads

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

