### PR TITLE
darwin stdenv: Make stdenv.cc, not stdenv itself, bring in libcxx

### DIFF
--- a/pkgs/development/compilers/llvm/3.7/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/default.nix
@@ -44,15 +44,11 @@ let
     stdenv = stdenv.override (drv: {
       allowedRequisites = null;
       cc = self.clang;
-      # Don't include the libc++ and libc++abi from the original stdenv.
-      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
     });
 
     libcxxStdenv = stdenv.override (drv: {
       allowedRequisites = null;
       cc = self.libcxxClang;
-      # Don't include the libc++ and libc++abi from the original stdenv.
-      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
     });
 
     lldb = callPackage ./lldb.nix {};

--- a/pkgs/development/compilers/llvm/3.8/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/default.nix
@@ -41,15 +41,11 @@ let
     stdenv = stdenv.override (drv: {
       allowedRequisites = null;
       cc = self.clang;
-      # Don't include the libc++ and libc++abi from the original stdenv.
-      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
     });
 
     libcxxStdenv = stdenv.override (drv: {
       allowedRequisites = null;
       cc = self.libcxxClang;
-      # Don't include the libc++ and libc++abi from the original stdenv.
-      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
     });
 
     lldb = callPackage ./lldb.nix {};

--- a/pkgs/development/compilers/llvm/3.9/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/default.nix
@@ -41,15 +41,11 @@ let
     stdenv = stdenv.override (drv: {
       allowedRequisites = null;
       cc = self.clang;
-      # Don't include the libc++ and libc++abi from the original stdenv.
-      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
     });
 
     libcxxStdenv = stdenv.override (drv: {
       allowedRequisites = null;
       cc = self.libcxxClang;
-      # Don't include the libc++ and libc++abi from the original stdenv.
-      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
     });
 
     lldb = callPackage ./lldb.nix {};

--- a/pkgs/development/compilers/llvm/4/default.nix
+++ b/pkgs/development/compilers/llvm/4/default.nix
@@ -56,15 +56,11 @@ let
     stdenv = stdenv.override (drv: {
       allowedRequisites = null;
       cc = self.clang;
-      # Don't include the libc++ and libc++abi from the original stdenv.
-      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
     });
 
     libcxxStdenv = stdenv.override (drv: {
       allowedRequisites = null;
       cc = self.libcxxClang;
-      # Don't include the libc++ and libc++abi from the original stdenv.
-      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
     });
 
     lld = callPackage ./lld.nix {};

--- a/pkgs/development/compilers/llvm/5/default.nix
+++ b/pkgs/development/compilers/llvm/5/default.nix
@@ -56,15 +56,11 @@ let
     stdenv = stdenv.override (drv: {
       allowedRequisites = null;
       cc = self.clang;
-      # Don't include the libc++ and libc++abi from the original stdenv.
-      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
     });
 
     libcxxStdenv = stdenv.override (drv: {
       allowedRequisites = null;
       cc = self.libcxxClang;
-      # Don't include the libc++ and libc++abi from the original stdenv.
-      extraBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.CF;
     });
 
     lld = callPackage ./lld.nix {};


### PR DESCRIPTION
###### Motivation for this change

`stdenvNoCC` should not inject any C++ standard library, just as it doesn't inject any C standard library. `stdenv` still does, but only indirectly through `stdenv.cc`. Wrapped clangs can be simplified now that they don't need to worry about clobbering CoreFoundation when replacing the C++ standard library implementation.

This generally-good cleanup should assist with debugging some C++ failures in #26805.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

