### PR TITLE
(haskell.packages.ghc802.ghc): (fix llvm dependency)

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -5,7 +5,7 @@ with import ./lib.nix { inherit pkgs; };
 self: super: {
 
   # Suitable LLVM version.
-  llvmPackages = pkgs.llvmPackages_35;
+  llvmPackages = pkgs.llvmPackages_37;
 
   # Disable GHC 8.0.x core libraries.
   array = null;


### PR DESCRIPTION
###### Motivation for this change
The LLVM version associated with GHC 8.0.x is wrong.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

See [Installing & Using the LLVM Back-end](https://ghc.haskell.org/trac/ghc/wiki/Commentary/Compiler/Backends/LLVM/Installing)

Tested against a simple invocation of `ghc --make -fllvm Main.hs`.