### PR TITLE
linux-steam-integration: init at 0.7.2

### DIFF
--- a/pkgs/games/linux-steam-integration/default.nix
+++ b/pkgs/games/linux-steam-integration/default.nix
@@ -1,0 +1,80 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, git, gtk, pkgs, gettext,
+  gcc_multi, libressl }:
+
+let
+  version = "0.7.2";
+  steamBinPath = "${stdenv.lib.makeBinPath (with pkgs; [ steam ])}/steam";
+  zenityBinPath = "${stdenv.lib.makeBinPath (with pkgs; [ gnome3.zenity ])}/zenity";
+
+in stdenv.mkDerivation rec {
+  name = "linux-steam-integration-${version}";
+
+  nativeBuildInputs = [ meson ninja pkgconfig git gettext gcc_multi ];
+  buildInputs = [ gtk libressl ];
+
+  src = fetchFromGitHub {
+    owner = "solus-project";
+    repo = "linux-steam-integration";
+    rev = "v${version}";
+    sha256 = "0yn71fvjqi63dxk04jsndb26pgipl0nla10sy94bi7q95pk3sdf6";
+    fetchSubmodules = true;
+  };
+
+  # Patch lib paths (AUDIT_PATH and REDIRECT_PATH) in shim.c
+  # Patch path to lsi-steam in lsi-steam.desktop
+  # Patch path to zenity in lsi.c
+  postPatch = ''
+    sed -i -e "s|/usr/|$out/|g" src/shim/shim.c
+    sed -i -e "s|/usr/|$out/|g" data/lsi-steam.desktop
+    sed -i -e "s|zenity|${zenityBinPath}|g" src/lsi/lsi.c
+  '';
+
+  configurePhase = ''
+    # Configure 64bit things
+    meson build                           \
+      -Dwith-shim=co-exist                \
+      -Dwith-frontend=true                \
+      -Dwith-steam-binary=${steamBinPath} \
+      -Dwith-new-libcxx-abi=true          \
+      -Dwith-libressl-mode=native         \
+      --prefix /                          \
+      --libexecdir lib                    \
+      --libdir lib                        \
+      --bindir bin
+
+    # Configure 32bit things
+    CC="gcc -m32" CXX="g++ -m32" meson build32 \
+      -Dwith-shim=none                         \
+      -Dwith-libressl-mode=native              \
+      --prefix /                               \
+      --libexecdir lib32                       \
+      --libdir lib32
+  '';
+
+  buildPhase = ''
+    # Build 64bit things
+    ninja -C build
+
+    # Build 32bit things
+    ninja -C build32
+  '';
+
+  installPhase = ''
+    DESTDIR="$out" ninja -C build install
+    DESTDIR="$out" ninja -C build32 install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Steam wrapper to improve compability and performance";
+    longDescription = ''
+      Linux Steam Integration is a helper system to make the Steam Client and
+      Steam games run better on Linux. In a nutshell, LSI automatically applies
+      various workarounds to get games working, and fixes long standing bugs in
+      both games and the client
+    '';
+    homepage = https://github.com/solus-project/linux-steam-integration;
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.etu ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18429,6 +18429,10 @@ with pkgs;
     nativeOnly = true;
   }).run;
 
+  linux-steam-integration = callPackage ../games/linux-steam-integration {
+    gtk = pkgs.gtk3;
+  };
+
   stepmania = callPackage ../games/stepmania {
     ffmpeg = ffmpeg_2;
   };


### PR DESCRIPTION
###### Motivation for this change
[Linux Steam Integration](https://github.com/solus-project/linux-steam-integration) is the foundation of the work that the Solus Project have done to get steam to "work better" on their OS. It seems like they solve a lot of problems with their wrappers and things.

Things to solve:
 - [x] 32bit build

Here's the script used by archlinux to see how they build it both as 64 and 32 bit. https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=linux-steam-integration

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

