### PR TITLE
Update vdirsyncer

### DIFF
--- a/pkgs/development/python-modules/milksnake/default.nix
+++ b/pkgs/development/python-modules/milksnake/default.nix
@@ -1,11 +1,13 @@
-{ lib, buildPythonPackage, fetchurl, cffi }:
+{ lib, buildPythonPackage, fetchPypi, cffi }:
 
 buildPythonPackage rec {
   pname = "milksnake";
   version = "0.1.1";
 
-  src = fetchurl {
-    url = "https://pypi.python.org/packages/04/12/358c2c7a27f06a71d69e44a4b7f62411524c25e6c7284b5a0f757a9ba068/milksnake-0.1.1.zip";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
     sha256 = "12bdyc2kjqpiq8wrbsk7ymcq2xdakri3bsvaqgsyzj33wyzbcwzy";
   };
 
@@ -17,5 +19,6 @@ buildPythonPackage rec {
     description = "A python library that extends setuptools for binary extensions.";
     homepage = https://pypi.python.org/pypi/milksnake/;
     license = licenses.apl;
+    maintainers = with maintainers; [ matthiasbeyer ];
   };
 }

--- a/pkgs/development/python-modules/milksnake/default.nix
+++ b/pkgs/development/python-modules/milksnake/default.nix
@@ -1,0 +1,22 @@
+{ lib, python3Packages, buildPythonPackage, fetchurl }:
+
+buildPythonPackage rec {
+  pname = "milksnake";
+  version = "0.1.1";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://pypi.python.org/packages/04/12/358c2c7a27f06a71d69e44a4b7f62411524c25e6c7284b5a0f757a9ba068/milksnake-0.1.1.zip";
+    sha256 = "12bdyc2kjqpiq8wrbsk7ymcq2xdakri3bsvaqgsyzj33wyzbcwzy";
+  };
+
+  buildInputs = with python3Packages; [
+   cffi
+  ];
+
+  meta = with lib; {
+    description = "A python library that extends setuptools for binary extensions.";
+    homepage = https://pypi.python.org/pypi/milksnake/;
+    license = licenses.apl;
+  };
+}

--- a/pkgs/development/python-modules/milksnake/default.nix
+++ b/pkgs/development/python-modules/milksnake/default.nix
@@ -1,16 +1,15 @@
-{ lib, python3Packages, buildPythonPackage, fetchurl }:
+{ lib, buildPythonPackage, fetchurl, cffi }:
 
 buildPythonPackage rec {
   pname = "milksnake";
   version = "0.1.1";
-  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://pypi.python.org/packages/04/12/358c2c7a27f06a71d69e44a4b7f62411524c25e6c7284b5a0f757a9ba068/milksnake-0.1.1.zip";
     sha256 = "12bdyc2kjqpiq8wrbsk7ymcq2xdakri3bsvaqgsyzj33wyzbcwzy";
   };
 
-  buildInputs = with python3Packages; [
+  propagatedBuildInputs = [
    cffi
   ];
 

--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python3Packages, glibcLocales }:
+{ stdenv, fetchurl, python3Packages, glibcLocales, pkgs }:
 
 # Packaging documentation at:
 # https://github.com/untitaker/vdirsyncer/blob/master/docs/packaging.rst
@@ -6,12 +6,12 @@ let
   pythonPackages = python3Packages;
 in
 pythonPackages.buildPythonApplication rec {
-  version = "0.16.3";
+  version = "0.17.0a1";
   name = "vdirsyncer-${version}";
 
   src = fetchurl {
     url = "mirror://pypi/v/vdirsyncer/${name}.tar.gz";
-    sha256 = "0dpwbfi97ksijqng191659m8k0v215y8ld95w8gb126m4m96qpzw";
+    sha256 = "1gzb37cpn6y7sg0fqcnb62ir9gdq6hvyz85x9pnss1d9xwf07lkn";
   };
 
   propagatedBuildInputs = with pythonPackages; [
@@ -20,6 +20,10 @@ pythonPackages.buildPythonApplication rec {
     requests
     requests_oauthlib # required for google oauth sync
     atomicwrites
+    milksnake
+
+    pkgs.cargo
+    pkgs.rustc
   ];
 
   buildInputs = with pythonPackages; [hypothesis pytest pytest-localserver pytest-subtesthack setuptools_scm ] ++ [ glibcLocales ];

--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python3Packages, glibcLocales, pkgs }:
+{ stdenv, fetchurl, python3Packages, glibcLocales, pkgs, rust, cargo }:
 
 # Packaging documentation at:
 # https://github.com/untitaker/vdirsyncer/blob/master/docs/packaging.rst
@@ -22,8 +22,8 @@ pythonPackages.buildPythonApplication rec {
     atomicwrites
     milksnake
 
-    pkgs.cargo
-    pkgs.rustc
+    cargo
+    rustc
   ];
 
   buildInputs = with pythonPackages; [hypothesis pytest pytest-localserver pytest-subtesthack setuptools_scm ] ++ [ glibcLocales ];

--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python3Packages, glibcLocales, pkgs, rust, cargo }:
+{ stdenv, fetchurl, python3Packages, glibcLocales, rustc, cargo }:
 
 # Packaging documentation at:
 # https://github.com/untitaker/vdirsyncer/blob/master/docs/packaging.rst

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10712,6 +10712,8 @@ in {
     };
   };
 
+  milksnake = callPackage ../development/python-modules/milksnake { };
+
   minimock = buildPythonPackage rec {
     version = "1.2.8";
     name = "minimock-${version}";


### PR DESCRIPTION
###### Motivation for this change

Targets #33050 

###### Things done

`vdirsyncer` requires a new dependency which is written in Rust. Unfortunately, these patches make me build `rustc` from source (so I aborted this) so I cannot test whether packaging works.

I'm not sure how to proceed here.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

