### PR TITLE
ghc prebuilt: Add 7.8.4, 7.10.3 and 8.2.1, and make consistent style

### DIFF
--- a/pkgs/development/compilers/ghc/6.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/6.10.2-binary.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchurl, perl
 , libedit, ncurses5, gmp
+, enableIntegerSimple ? false
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/compilers/ghc/7.0.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.0.4-binary.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   }.${stdenv.hostPlatform.system}
     or (throw "cannot bootstrap GHC on this platform"));
 
-  buildInputs = [perl];
+  nativeBuildInputs = [ perl ];
 
   postUnpack =
     # GHC has dtrace probes, which causes ld to try to open /usr/lib/libdtrace.dylib
@@ -87,11 +87,11 @@ stdenv.mkDerivation rec {
       done
     '';
 
-  configurePhase = ''
-    ./configure --prefix=$out \
-      --with-gmp-libraries=${gmp.out or gmp}/lib --with-gmp-includes=${gmp.dev or gmp}/include \
-      ${stdenv.lib.optionalString stdenv.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}"}
-  '';
+  configurePlatforms = [ ];
+  configureFlags = [
+    "--with-gmp-libraries=${stdenv.lib.getLib gmp}/lib"
+    "--with-gmp-includes=${stdenv.lib.getDev gmp}/include"
+  ] ++ stdenv.lib.optional stdenv.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}";
 
   # Stripping combined with patchelf breaks the executables (they die
   # with a segfault or the kernel even refuses the execve). (NIXPKGS-85)
@@ -101,7 +101,8 @@ stdenv.mkDerivation rec {
   # calls install-strip ...
   dontBuild = true;
 
-  postInstall = ''
+  doInstallCheck = true;
+  installCheckPhase = ''
     # Sanity check, can ghc create executables?
     cd $TMP
     mkdir test-ghc; cd test-ghc

--- a/pkgs/development/compilers/ghc/7.0.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.0.4-binary.nix
@@ -106,15 +106,10 @@ stdenv.mkDerivation rec {
         -exec patchelf --set-rpath "${libPath}" {} \;
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     # not enough room in the object files for the full path to libiconv :(
-    ln -s ${libiconv}/lib/libiconv.dylib $out/bin
-    ln -s ${libiconv}/lib/libiconv.dylib $out/lib/ghc-${version}/libiconv.dylib
-
-    fix () {
-      install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $1
-    }
-
-    for file in ghc-cabal ghc-pwd ghc-stage2 ghc-pkg haddock hsc2hs hpc; do
-      fix $(find "$out" -type f -name $file)
+    for exe in $(find "$out" -type f -executable); do
+      isScript $exe && continue
+      ln -fs ${libiconv}/lib/libiconv.dylib $(dirname $exe)/libiconv.dylib
+      install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $exe
     done
 
     for file in $(find "$out" -name setup-config); do

--- a/pkgs/development/compilers/ghc/7.10.3-binary.nix
+++ b/pkgs/development/compilers/ghc/7.10.3-binary.nix
@@ -87,9 +87,6 @@ stdenv.mkDerivation rec {
 
       sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
       sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
-      for prog in ld ar gcc strip ranlib; do
-        find . -name "setup-config" -exec sed -i "s@/usr/bin/$prog@$(type -p $prog)@g" {} \;
-      done
     '';
 
   configurePlatforms = [ ];
@@ -109,8 +106,12 @@ stdenv.mkDerivation rec {
   # On Linux, use patchelf to modify the executables so that they can
   # find editline/gmp.
   preFixup = stdenv.lib.optionalString stdenv.isLinux ''
-    find "$out" -type f -executable \
-        -exec patchelf --set-rpath "${libPath}" {} \;
+    for p in $(find "$out" -type f -executable); do
+      if isELF "$p"; then
+        echo "Patchelfing $p"
+        patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $p)" $p
+      fi
+    done
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     # not enough room in the object files for the full path to libiconv :(
     for exe in $(find "$out" -type f -executable); do
@@ -126,6 +127,7 @@ stdenv.mkDerivation rec {
 
   doInstallCheck = true;
   installCheckPhase = ''
+    unset ${libEnvVar}
     # Sanity check, can ghc create executables?
     cd $TMP
     mkdir test-ghc; cd test-ghc

--- a/pkgs/development/compilers/ghc/7.10.3-binary.nix
+++ b/pkgs/development/compilers/ghc/7.10.3-binary.nix
@@ -1,0 +1,144 @@
+{ stdenv
+, fetchurl, perl
+, ncurses5, gmp, libiconv
+}:
+
+let
+  libPath = stdenv.lib.makeLibraryPath ([
+    ncurses5 gmp
+  ] ++ stdenv.lib.optional (stdenv.hostPlatform.isDarwin) libiconv);
+
+  libEnvVar = stdenv.lib.optionalString stdenv.hostPlatform.isDarwin "DY"
+    + "LD_LIBRARY_PATH";
+
+in
+
+stdenv.mkDerivation rec {
+  version = "7.10.3";
+
+  name = "ghc-${version}-binary";
+
+  src = fetchurl ({
+    "i686-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}b-i386-deb7-linux.tar.bz2";
+      sha256 = "20b32912fb7e57910a3c908f99a9519b57a4872e1ea0f4f2265b2f7b30e8a3cd";
+    };
+    "x86_64-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}b-x86_64-deb8-linux.tar.bz2";
+      sha256 = "5e163c557e9236cce68be41c984eab0fcdbdc1602e39040ca9ae325e6bdec1c3";
+    };
+    "armv7-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-armv7-deb8-linux.tar.bz2";
+      sha256 = "2913763eef88e4d1843a1e4c34225afb1866310d1a1956c08a4131f4593518f6";
+    };
+    "x86_64-darwin" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}b-x86_64-apple-darwin.tar.bz2";
+      sha256 = "4b537228d49b5ea0f8e8dbcc440a5b3c3cb19a92579d607291cc0041422fa5c3";
+    };
+  }.${stdenv.hostPlatform.system}
+    or (throw "cannot bootstrap GHC on this platform"));
+
+  nativeBuildInputs = [ perl ];
+
+  # Cannot patchelf beforehand due to relative RPATHs that anticipate
+  # the final install location/
+  ${libEnvVar} = libPath;
+
+  postUnpack =
+    # GHC has dtrace probes, which causes ld to try to open /usr/lib/libdtrace.dylib
+    # during linking
+    stdenv.lib.optionalString stdenv.isDarwin ''
+      export NIX_LDFLAGS+=" -no_dtrace_dof"
+    '' +
+
+    # Some scripts used during the build need to have their shebangs patched
+    ''
+      patchShebangs ghc-${version}/utils/
+    '' +
+
+    # Strip is harmful, see also below. It's important that this happens
+    # first. The GHC Cabal build system makes use of strip by default and
+    # has hardcoded paths to /usr/bin/strip in many places. We replace
+    # those below, making them point to our dummy script.
+    ''
+      mkdir "$TMP/bin"
+      for i in strip; do
+        echo '#! ${stdenv.shell}' > "$TMP/bin/$i"
+        chmod +x "$TMP/bin/$i"
+      done
+      PATH="$TMP/bin:$PATH"
+    '' +
+    # We have to patch the GMP paths for the integer-gmp package.
+    ''
+      find . -name integer-gmp.buildinfo \
+          -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${gmp.out}/lib@" {} \;
+    '' + stdenv.lib.optionalString stdenv.isDarwin ''
+      find . -name base.buildinfo \
+          -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${libiconv}/lib@" {} \;
+    '' +
+    # Rename needed libraries and binaries, fix interpreter
+    stdenv.lib.optionalString stdenv.isLinux ''
+      find . -type f -perm -0100 -exec patchelf \
+          --replace-needed libncurses${stdenv.lib.optionalString stdenv.is64bit "w"}.so.5 libncurses.so \
+          --replace-needed libtinfo.so libtinfo.so.5 \
+          --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" {} \;
+
+      paxmark m ./ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
+
+      sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
+      sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
+      for prog in ld ar gcc strip ranlib; do
+        find . -name "setup-config" -exec sed -i "s@/usr/bin/$prog@$(type -p $prog)@g" {} \;
+      done
+    '';
+
+  configurePlatforms = [ ];
+  configureFlags = [
+    "--with-gmp-libraries=${stdenv.lib.getLib gmp}/lib"
+    "--with-gmp-includes=${stdenv.lib.getDev gmp}/include"
+  ] ++ stdenv.lib.optional stdenv.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}";
+
+  # Stripping combined with patchelf breaks the executables (they die
+  # with a segfault or the kernel even refuses the execve). (NIXPKGS-85)
+  dontStrip = true;
+
+  # No building is necessary, but calling make without flags ironically
+  # calls install-strip ...
+  dontBuild = true;
+
+  # On Linux, use patchelf to modify the executables so that they can
+  # find editline/gmp.
+  preFixup = stdenv.lib.optionalString stdenv.isLinux ''
+    find "$out" -type f -executable \
+        -exec patchelf --set-rpath "${libPath}" {} \;
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    # not enough room in the object files for the full path to libiconv :(
+    for exe in $(find "$out" -type f -executable); do
+      isScript $exe && continue
+      ln -fs ${libiconv}/lib/libiconv.dylib $(dirname $exe)/libiconv.dylib
+      install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $exe
+    done
+
+    for file in $(find "$out" -name setup-config); do
+      substituteInPlace $file --replace /usr/bin/ranlib "$(type -P ranlib)"
+    done
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    # Sanity check, can ghc create executables?
+    cd $TMP
+    mkdir test-ghc; cd test-ghc
+    cat > main.hs << EOF
+      {-# LANGUAGE TemplateHaskell #-}
+      module Main where
+      main = putStrLn \$([|"yes"|])
+    EOF
+    $out/bin/ghc --make main.hs || exit 1
+    echo compilation ok
+    [ $(./main) == "yes" ]
+  '';
+
+  meta.license = stdenv.lib.licenses.bsd3;
+  meta.platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin"];
+}

--- a/pkgs/development/compilers/ghc/7.10.3-binary.nix
+++ b/pkgs/development/compilers/ghc/7.10.3-binary.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchurl, perl
 , ncurses5, gmp, libiconv
+, enableIntegerSimple ? false
 }:
 
 let

--- a/pkgs/development/compilers/ghc/7.4.2-binary.nix
+++ b/pkgs/development/compilers/ghc/7.4.2-binary.nix
@@ -1,7 +1,17 @@
 { stdenv
-, fetchurl, perl, makeWrapper
+, fetchurl, perl
 , ncurses5, gmp, libiconv
 }:
+
+let
+  libPath = stdenv.lib.makeLibraryPath ([
+    ncurses5 gmp
+  ] ++ stdenv.lib.optional (stdenv.hostPlatform.isDarwin) libiconv);
+
+  libEnvVar = stdenv.lib.optionalString stdenv.hostPlatform.isDarwin "DY"
+    + "LD_LIBRARY_PATH";
+
+in
 
 stdenv.mkDerivation rec {
   version = "7.4.2";
@@ -30,6 +40,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ perl ];
 
+  # Cannot patchelf beforehand due to relative RPATHs that anticipate
+  # the final install location/
+  ${libEnvVar} = libPath;
+
   postUnpack =
     # GHC has dtrace probes, which causes ld to try to open /usr/lib/libdtrace.dylib
     # during linking
@@ -57,14 +71,11 @@ stdenv.mkDerivation rec {
       find . -name base.buildinfo \
           -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${libiconv}/lib@" {} \;
     '' +
-    # On Linux, use patchelf to modify the executables so that they can
-    # find editline/gmp.
+    # Rename needed libraries and binaries, fix interpreter
     stdenv.lib.optionalString stdenv.isLinux ''
-      mkdir -p "$out/lib"
-      ln -sv "${ncurses5.out}/lib/libncurses.so" "$out/lib/libncurses${stdenv.lib.optionalString stdenv.is64bit "w"}.so.5"
-      find . -type f -perm -0100 \
-          -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          --set-rpath "${stdenv.lib.makeLibraryPath [ "$out" gmp ]}" {} \;
+      find . -type f -perm -0100 -exec patchelf \
+          --replace-needed libncurses${stdenv.lib.optionalString stdenv.is64bit "w"}.so.5 libncurses.so \
+          --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" {} \;
 
       paxmark m ./ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
 
@@ -72,23 +83,6 @@ stdenv.mkDerivation rec {
       sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
       for prog in ld ar gcc strip ranlib; do
         find . -name "setup-config" -exec sed -i "s@/usr/bin/$prog@$(type -p $prog)@g" {} \;
-      done
-    '' + stdenv.lib.optionalString stdenv.isDarwin ''
-      # not enough room in the object files for the full path to libiconv :(
-      fix () {
-        install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $1
-      }
-
-      ln -s ${libiconv}/lib/libiconv.dylib ghc-${version}/utils/ghc-pwd/dist-install/build/tmp
-      ln -s ${libiconv}/lib/libiconv.dylib ghc-${version}/utils/hpc/dist-install/build/tmp
-      ln -s ${libiconv}/lib/libiconv.dylib ghc-${version}/ghc/stage2/build/tmp
-
-      for file in ghc-cabal ghc-pwd ghc-stage2 ghc-pkg haddock hsc2hs hpc; do
-        fix $(find . -type f -name $file)
-      done
-
-      for file in $(find . -name setup-config); do
-        substituteInPlace $file --replace /usr/bin/ranlib "$(type -P ranlib)"
       done
     '';
 
@@ -106,12 +100,27 @@ stdenv.mkDerivation rec {
   # calls install-strip ...
   dontBuild = true;
 
-  preInstall = stdenv.lib.optionalString stdenv.isDarwin ''
-    mkdir -p $out/lib/ghc-${version}
-    mkdir -p $out/bin
+  # On Linux, use patchelf to modify the executables so that they can
+  # find editline/gmp.
+  preFixup = stdenv.lib.optionalString stdenv.isLinux ''
+    find "$out" -type f -executable \
+        -exec patchelf --set-rpath "${libPath}" {} \;
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    # not enough room in the object files for the full path to libiconv :(
     ln -s ${libiconv}/lib/libiconv.dylib $out/bin
     ln -s ${libiconv}/lib/libiconv.dylib $out/lib/ghc-${version}/libiconv.dylib
-    ln -s ${libiconv}/lib/libiconv.dylib utils/ghc-cabal/dist-install/build/tmp
+
+    fix () {
+      install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $1
+    }
+
+    for file in ghc-cabal ghc-pwd ghc-stage2 ghc-pkg haddock hsc2hs hpc; do
+      fix $(find "$out" -type f -name $file)
+    done
+
+    for file in $(find "$out" -name setup-config); do
+      substituteInPlace $file --replace /usr/bin/ranlib "$(type -P ranlib)"
+    done
   '';
 
   doInstallCheck = true;

--- a/pkgs/development/compilers/ghc/7.8.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.8.4-binary.nix
@@ -46,6 +46,15 @@ stdenv.mkDerivation rec {
     # during linking
     stdenv.lib.optionalString stdenv.isDarwin ''
       export NIX_LDFLAGS+=" -no_dtrace_dof"
+      # not enough room in the object files for the full path to libiconv :(
+      for exe in $(find . -type f -executable); do
+        isScript $exe && continue
+        ln -fs ${libiconv}/lib/libiconv.dylib $(dirname $exe)/libiconv.dylib
+        install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $exe
+        for file in $(find . -name setup-config); do
+          substituteInPlace $file --replace /usr/bin/ranlib "$(type -P ranlib)"
+        done
+      done
     '' +
 
     # Some scripts used during the build need to have their shebangs patched

--- a/pkgs/development/compilers/ghc/7.8.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.8.4-binary.nix
@@ -1,0 +1,140 @@
+{ stdenv
+, fetchurl, perl
+, ncurses5, gmp, libiconv
+}:
+
+let
+  libPath = stdenv.lib.makeLibraryPath ([
+    ncurses5 gmp
+  ] ++ stdenv.lib.optional (stdenv.hostPlatform.isDarwin) libiconv);
+
+  libEnvVar = stdenv.lib.optionalString stdenv.hostPlatform.isDarwin "DY"
+    + "LD_LIBRARY_PATH";
+
+in
+
+stdenv.mkDerivation rec {
+  version = "7.8.4";
+
+  name = "ghc-${version}-binary";
+
+  src = fetchurl ({
+    "i686-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux-deb7.tar.bz2";
+      sha256 = "5da2cf45986f33319a92a666f1f0149915334a7b64b41892ab94f4557242b406";
+    };
+    "x86_64-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux-deb7.tar.bz2";
+      sha256 = "20b5731d268613bbf6e977dbb192a3a3b7b78d954c35edbfca4fb36b652e24f7";
+    };
+    "x86_64-darwin" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.bz2";
+      sha256 = "dfa161c2a136ee16214a49d5902e2377407c8292dbbdbb14fa0fa6b17220cae6";
+    };
+  }.${stdenv.hostPlatform.system}
+    or (throw "cannot bootstrap GHC on this platform"));
+
+  nativeBuildInputs = [ perl ];
+
+  # Cannot patchelf beforehand due to relative RPATHs that anticipate
+  # the final install location/
+  ${libEnvVar} = libPath;
+
+  postUnpack =
+    # GHC has dtrace probes, which causes ld to try to open /usr/lib/libdtrace.dylib
+    # during linking
+    stdenv.lib.optionalString stdenv.isDarwin ''
+      export NIX_LDFLAGS+=" -no_dtrace_dof"
+    '' +
+
+    # Some scripts used during the build need to have their shebangs patched
+    ''
+      patchShebangs ghc-${version}/utils/
+    '' +
+
+    # Strip is harmful, see also below. It's important that this happens
+    # first. The GHC Cabal build system makes use of strip by default and
+    # has hardcoded paths to /usr/bin/strip in many places. We replace
+    # those below, making them point to our dummy script.
+    ''
+      mkdir "$TMP/bin"
+      for i in strip; do
+        echo '#! ${stdenv.shell}' > "$TMP/bin/$i"
+        chmod +x "$TMP/bin/$i"
+      done
+      PATH="$TMP/bin:$PATH"
+    '' +
+    # We have to patch the GMP paths for the integer-gmp package.
+    ''
+      find . -name integer-gmp.buildinfo \
+          -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${gmp.out}/lib@" {} \;
+    '' + stdenv.lib.optionalString stdenv.isDarwin ''
+      find . -name base.buildinfo \
+          -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${libiconv}/lib@" {} \;
+    '' +
+    # Rename needed libraries and binaries, fix interpreter
+    stdenv.lib.optionalString stdenv.isLinux ''
+      find . -type f -perm -0100 -exec patchelf \
+          --replace-needed libncurses${stdenv.lib.optionalString stdenv.is64bit "w"}.so.5 libncurses.so \
+          --replace-needed libtinfo.so libtinfo.so.5 \
+          --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" {} \;
+
+      paxmark m ./ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
+
+      sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
+      sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
+      for prog in ld ar gcc strip ranlib; do
+        find . -name "setup-config" -exec sed -i "s@/usr/bin/$prog@$(type -p $prog)@g" {} \;
+      done
+    '';
+
+  configurePlatforms = [ ];
+  configureFlags = [
+    "--with-gmp-libraries=${stdenv.lib.getLib gmp}/lib"
+    "--with-gmp-includes=${stdenv.lib.getDev gmp}/include"
+  ] ++ stdenv.lib.optional stdenv.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}";
+
+  # Stripping combined with patchelf breaks the executables (they die
+  # with a segfault or the kernel even refuses the execve). (NIXPKGS-85)
+  dontStrip = true;
+
+  # No building is necessary, but calling make without flags ironically
+  # calls install-strip ...
+  dontBuild = true;
+
+  # On Linux, use patchelf to modify the executables so that they can
+  # find editline/gmp.
+  preFixup = stdenv.lib.optionalString stdenv.isLinux ''
+    find "$out" -type f -executable \
+        -exec patchelf --set-rpath "${libPath}" {} \;
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    # not enough room in the object files for the full path to libiconv :(
+    for exe in $(find "$out" -type f -executable); do
+      isScript $exe && continue
+      ln -fs ${libiconv}/lib/libiconv.dylib $(dirname $exe)/libiconv.dylib
+      install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $exe
+    done
+
+    for file in $(find "$out" -name setup-config); do
+      substituteInPlace $file --replace /usr/bin/ranlib "$(type -P ranlib)"
+    done
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    # Sanity check, can ghc create executables?
+    cd $TMP
+    mkdir test-ghc; cd test-ghc
+    cat > main.hs << EOF
+      {-# LANGUAGE TemplateHaskell #-}
+      module Main where
+      main = putStrLn \$([|"yes"|])
+    EOF
+    $out/bin/ghc --make main.hs || exit 1
+    echo compilation ok
+    [ $(./main) == "yes" ]
+  '';
+
+  meta.license = stdenv.lib.licenses.bsd3;
+  meta.platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin"];
+}

--- a/pkgs/development/compilers/ghc/7.8.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.8.4-binary.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchurl, perl
 , ncurses5, gmp, libiconv
+, enableIntegerSimple ? false
 }:
 
 let

--- a/pkgs/development/compilers/ghc/8.2.1-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.1-binary.nix
@@ -1,0 +1,148 @@
+{ stdenv
+, fetchurl, perl
+, ncurses5, gmp, libiconv
+}:
+
+let
+  libPath = stdenv.lib.makeLibraryPath ([
+    ncurses5 gmp
+  ] ++ stdenv.lib.optional (stdenv.hostPlatform.isDarwin) libiconv);
+
+  libEnvVar = stdenv.lib.optionalString stdenv.hostPlatform.isDarwin "DY"
+    + "LD_LIBRARY_PATH";
+
+in
+
+stdenv.mkDerivation rec {
+  version = "8.2.1";
+
+  name = "ghc-${version}-binary";
+
+  src = fetchurl ({
+    "i686-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-deb8-linux.tar.xz";
+      sha256 = "d86f9c157dd4161a8acb14062c131c8985a4f65fc856603c373502be1d50c95e";
+    };
+    "x86_64-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-deb8-linux.tar.xz";
+      sha256 = "543b81bf610240bd0398111d6c6607a9094dc2d159b564057d46c8a3d1aaa130";
+    };
+    "armv7-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-armv7-deb8-linux.tar.xz";
+      sha256 = "0f0e5e1d4fad3fa1a87ca1fe0d19242f4a94d158b7b8a08f99efefd98b51b019";
+    };
+    "aarch64-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-aarch64-deb8-linux.tar.xz";
+      sha256 = "61dab9c95ef9f9af8bce7338863fda3e42945eb46194b12d922b6d0dc245d0c2";
+    };
+    "x86_64-darwin" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.xz";
+      sha256 = "900c802025fb630060dbd30f9738e5d107a4ca5a50d5c1262cd3e69fe4467188";
+    };
+  }.${stdenv.hostPlatform.system}
+    or (throw "cannot bootstrap GHC on this platform"));
+
+  nativeBuildInputs = [ perl ];
+
+  # Cannot patchelf beforehand due to relative RPATHs that anticipate
+  # the final install location/
+  ${libEnvVar} = libPath;
+
+  postUnpack =
+    # GHC has dtrace probes, which causes ld to try to open /usr/lib/libdtrace.dylib
+    # during linking
+    stdenv.lib.optionalString stdenv.isDarwin ''
+      export NIX_LDFLAGS+=" -no_dtrace_dof"
+    '' +
+
+    # Some scripts used during the build need to have their shebangs patched
+    ''
+      patchShebangs ghc-${version}/utils/
+    '' +
+
+    # Strip is harmful, see also below. It's important that this happens
+    # first. The GHC Cabal build system makes use of strip by default and
+    # has hardcoded paths to /usr/bin/strip in many places. We replace
+    # those below, making them point to our dummy script.
+    ''
+      mkdir "$TMP/bin"
+      for i in strip; do
+        echo '#! ${stdenv.shell}' > "$TMP/bin/$i"
+        chmod +x "$TMP/bin/$i"
+      done
+      PATH="$TMP/bin:$PATH"
+    '' +
+    # We have to patch the GMP paths for the integer-gmp package.
+    ''
+      find . -name integer-gmp.buildinfo \
+          -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${gmp.out}/lib@" {} \;
+    '' + stdenv.lib.optionalString stdenv.isDarwin ''
+      find . -name base.buildinfo \
+          -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${libiconv}/lib@" {} \;
+    '' +
+    # Rename needed libraries and binaries, fix interpreter
+    stdenv.lib.optionalString stdenv.isLinux ''
+      find . -type f -perm -0100 -exec patchelf \
+          --replace-needed libncurses${stdenv.lib.optionalString stdenv.is64bit "w"}.so.5 libncurses.so \
+          --replace-needed libtinfo.so libtinfo.so.5 \
+          --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" {} \;
+
+      paxmark m ./ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
+
+      sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
+      sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
+      for prog in ld ar gcc strip ranlib; do
+        find . -name "setup-config" -exec sed -i "s@/usr/bin/$prog@$(type -p $prog)@g" {} \;
+      done
+    '';
+
+  configurePlatforms = [ ];
+  configureFlags = [
+    "--with-gmp-libraries=${stdenv.lib.getLib gmp}/lib"
+    "--with-gmp-includes=${stdenv.lib.getDev gmp}/include"
+  ] ++ stdenv.lib.optional stdenv.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}";
+
+  # Stripping combined with patchelf breaks the executables (they die
+  # with a segfault or the kernel even refuses the execve). (NIXPKGS-85)
+  dontStrip = true;
+
+  # No building is necessary, but calling make without flags ironically
+  # calls install-strip ...
+  dontBuild = true;
+
+  # On Linux, use patchelf to modify the executables so that they can
+  # find editline/gmp.
+  preFixup = stdenv.lib.optionalString stdenv.isLinux ''
+    find "$out" -type f -executable \
+        -exec patchelf --set-rpath "${libPath}" {} \;
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    # not enough room in the object files for the full path to libiconv :(
+    for exe in $(find "$out" -type f -executable); do
+      isScript $exe && continue
+      ln -fs ${libiconv}/lib/libiconv.dylib $(dirname $exe)/libiconv.dylib
+      install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $exe
+    done
+
+    for file in $(find "$out" -name setup-config); do
+      substituteInPlace $file --replace /usr/bin/ranlib "$(type -P ranlib)"
+    done
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    # Sanity check, can ghc create executables?
+    cd $TMP
+    mkdir test-ghc; cd test-ghc
+    cat > main.hs << EOF
+      {-# LANGUAGE TemplateHaskell #-}
+      module Main where
+      main = putStrLn \$([|"yes"|])
+    EOF
+    $out/bin/ghc --make main.hs || exit 1
+    echo compilation ok
+    [ $(./main) == "yes" ]
+  '';
+
+  meta.license = stdenv.lib.licenses.bsd3;
+  meta.platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin"];
+}

--- a/pkgs/development/compilers/ghc/8.2.1-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.1-binary.nix
@@ -91,9 +91,6 @@ stdenv.mkDerivation rec {
 
       sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
       sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
-      for prog in ld ar gcc strip ranlib; do
-        find . -name "setup-config" -exec sed -i "s@/usr/bin/$prog@$(type -p $prog)@g" {} \;
-      done
     '';
 
   configurePlatforms = [ ];
@@ -113,8 +110,12 @@ stdenv.mkDerivation rec {
   # On Linux, use patchelf to modify the executables so that they can
   # find editline/gmp.
   preFixup = stdenv.lib.optionalString stdenv.isLinux ''
-    find "$out" -type f -executable \
-        -exec patchelf --set-rpath "${libPath}" {} \;
+    for p in $(find "$out" -type f -executable); do
+      if isELF "$p"; then
+        echo "Patchelfing $p"
+        patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $p)" $p
+      fi
+    done
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     # not enough room in the object files for the full path to libiconv :(
     for exe in $(find "$out" -type f -executable); do
@@ -130,6 +131,7 @@ stdenv.mkDerivation rec {
 
   doInstallCheck = true;
   installCheckPhase = ''
+    unset ${libEnvVar}
     # Sanity check, can ghc create executables?
     cd $TMP
     mkdir test-ghc; cd test-ghc

--- a/pkgs/development/compilers/ghc/8.2.1-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.1-binary.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchurl, perl
 , ncurses5, gmp, libiconv
+, enableIntegerSimple ? false
 }:
 
 let

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -30,13 +30,18 @@ in rec {
 
   compiler = {
 
-    ghc6102Binary = callPackage ../development/compilers/ghc/6.10.2-binary.nix { gmp = pkgs.gmp4; };
+    ghc6102Binary = callPackage ../development/compilers/ghc/6.10.2-binary.nix {
+      gmp = pkgs.gmp4;
+    };
     ghc704Binary = callPackage ../development/compilers/ghc/7.0.4-binary.nix {
       gmp = pkgs.gmp4;
     };
     ghc742Binary = callPackage ../development/compilers/ghc/7.4.2-binary.nix {
       gmp = pkgs.gmp4;
     };
+    ghc784Binary = callPackage ../development/compilers/ghc/7.8.4-binary.nix { };
+    ghc7103Binary = callPackage ../development/compilers/ghc/7.10.3-binary.nix { };
+    ghc821Binary = callPackage ../development/compilers/ghc/8.2.1-binary.nix { };
 
     ghc6104 = callPackage ../development/compilers/ghc/6.10.4.nix { ghc = compiler.ghc6102Binary; };
     ghc6123 = callPackage ../development/compilers/ghc/6.12.3.nix { ghc = compiler.ghc6102Binary; };


### PR DESCRIPTION
Builds on top of https://github.com/NixOS/nixpkgs/pull/29688 and addresses the blocker to build ghcs on linux.