### PR TITLE
stdenv: perform checks only when evaluating .drv and .out

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -36,7 +36,7 @@ rec {
   overrideDerivation = drv: f:
     let
       newDrv = derivation (drv.drvAttrs // (f drv));
-    in addPassthru newDrv (
+    in lib.flip addPassthru newDrv (
       { meta = drv.meta or {};
         passthru = if drv ? passthru then drv.passthru else {};
       }
@@ -157,7 +157,7 @@ rec {
 
   /* Add attributes to each output of a derivation without changing
      the derivation itself. */
-  addPassthru = drv: passthru: extendDerivation true passthru drv;
+  addPassthru = extendDerivation true;
 
   /* Strip a derivation of all non-essential attributes, returning
      only those needed by hydra-eval-jobs. Also strictly evaluate the

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -157,7 +157,8 @@ rec {
 
   /* Add attributes to each output of a derivation without changing
      the derivation itself. */
-  addPassthru = extendDerivation true;
+  addPassthru = lib.warn "`addPassthru` is deprecated, replace with `extendDerivation true`"
+                         (extendDerivation true);
 
   /* Strip a derivation of all non-essential attributes, returning
      only those needed by hydra-eval-jobs. Also strictly evaluate the

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -36,7 +36,7 @@ rec {
   overrideDerivation = drv: f:
     let
       newDrv = derivation (drv.drvAttrs // (f drv));
-    in lib.flip addPassthru newDrv (
+    in lib.flip (extendDerivation true) newDrv (
       { meta = drv.meta or {};
         passthru = if drv ? passthru then drv.passthru else {};
       }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -87,7 +87,8 @@ let
     inherit (stringsWithDeps) textClosureList textClosureMap
       noDepEntry fullDepEntry packEntry stringAfter;
     inherit (customisation) overrideDerivation makeOverridable
-      callPackageWith callPackagesWith addPassthru hydraJob makeScope;
+      callPackageWith callPackagesWith extendDerivation addPassthru
+      hydraJob makeScope;
     inherit (meta) addMetaAttrs dontDistribute setName updateName
       appendToName mapDerivationAttrset lowPrio lowPrioSet hiPrio
       hiPrioSet;

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -134,7 +134,7 @@ let
     passthru = kernel.passthru // (removeAttrs passthru [ "passthru" ]);
   };
 
-  addPassthru' = lib.addPassthru passthru;
+  addPassthru' = lib.extendDerivation true passthru;
 
   nativeDrv = addPassthru' kernel.nativeDrv;
 

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -134,10 +134,12 @@ let
     passthru = kernel.passthru // (removeAttrs passthru [ "passthru" ]);
   };
 
-  nativeDrv = lib.addPassthru kernel.nativeDrv passthru;
+  addPassthru' = lib.addPassthru passthru;
 
-  crossDrv = lib.addPassthru kernel.crossDrv passthru;
+  nativeDrv = addPassthru' kernel.nativeDrv;
+
+  crossDrv = addPassthru' kernel.crossDrv;
 
 in if kernel ? crossDrv
    then nativeDrv // { inherit nativeDrv crossDrv; }
-   else lib.addPassthru kernel passthru
+   else addPassthru' kernel

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -153,6 +153,7 @@ let
 
     # Weirder stuff that doesn't appear in the documentation?
     knownVulnerabilities = listOf str;
+    name = str;
     version = str;
     tag = str;
     updateWalker = bool;

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -159,6 +159,7 @@ let
     executables = listOf str;
     outputsToInstall = listOf str;
     position = str;
+    evaluates = bool;
     repositories = attrsOf str;
     isBuildPythonPackage = platforms;
     schedulingPriority = str;

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -1,6 +1,5 @@
-# Extend a derivation with checks for brokenness, license, etc.  Throw a
-# descriptive error when the check fails; return `derivationArg` otherwise.
-# Note: no dependencies are checked in this step.
+# Checks derivation meta and attrs for problems (like brokenness,
+# licenses, etc).
 
 { lib, config, system, meta, derivationArg, mkDerivationArg }:
 
@@ -196,13 +195,11 @@ let
       { valid = false; reason = "unknown-meta"; errormsg = "has an invalid meta attrset:${lib.concatMapStrings (x: "\n\t - " + x) res}"; }
     else { valid = true; };
 
-  # Throw an error if trying to evaluate an non-valid derivation
-  validityCondition =
-         let v = checkValidity attrs;
-         in if !v.valid
-           then handleEvalIssue (removeAttrs v ["valid"])
-           else true;
+   validity = checkValidity attrs;
 
-in
-  assert validityCondition;
-  derivationArg
+in validity // {
+  # Throw an error if trying to evaluate an non-valid derivation
+  handled = if !validity.valid
+    then handleEvalIssue (removeAttrs validity ["valid"])
+    else true;
+}

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -72,6 +72,9 @@ rec {
       inherit erroneousHardeningFlags hardeningDisable hardeningEnable supportedHardeningFlags;
     })
     else let
+      references = nativeBuildInputs ++ buildInputs
+                ++ propagatedNativeBuildInputs ++ propagatedBuildInputs;
+
       dependencies = map (map lib.chooseDevOutputs) [
         [
           (map (drv: drv.__spliced.buildBuild or drv) depsBuildBuild)
@@ -213,7 +216,10 @@ rec {
           position = pos.file + ":" + toString pos.line;
         # Expose the result of the checks for everyone to see.
         } // {
-          evaluates = validity.valid;
+          evaluates = validity.valid
+                   && (if config.checkMetaRecursively or false
+                       then lib.all (d: d.meta.evaluates or true) references
+                       else true);
         };
 
     in

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -211,6 +211,9 @@ rec {
         # Fill `meta.position` to identify the source location of the package.
         // lib.optionalAttrs (pos != null) {
           position = pos.file + ":" + toString pos.line;
+        # Expose the result of the checks for everyone to see.
+        } // {
+          evaluates = validity.valid;
         };
 
     in

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -194,24 +194,24 @@ rec {
       # but it's not part of the actual derivation, i.e., it's not
       # passed to the builder and is not a dependency.  But since we
       # include it in the result, it *is* available to nix-env for queries.
-      meta = { }
+      meta = {
           # If the packager hasn't specified `outputsToInstall`, choose a default,
           # which is the name of `p.bin or p.out or p`;
           # if he has specified it, it will be overridden below in `// meta`.
           #   Note: This default probably shouldn't be globally configurable.
           #   Services and users should specify outputs explicitly,
           #   unless they are comfortable with this default.
-        // { outputsToInstall =
-          let
-            outs = outputs'; # the value passed to derivation primitive
-            hasOutput = out: builtins.elem out outs;
-          in [( lib.findFirst hasOutput null (["bin" "out"] ++ outs) )];
+          outputsToInstall =
+            let
+              outs = outputs'; # the value passed to derivation primitive
+              hasOutput = out: builtins.elem out outs;
+            in [( lib.findFirst hasOutput null (["bin" "out"] ++ outs) )];
         }
         // attrs.meta or {}
-          # Fill `meta.position` to identify the source location of the package.
-        // lib.optionalAttrs (pos != null)
-          { position = pos.file + ":" + toString pos.line; }
-        ;
+        # Fill `meta.position` to identify the source location of the package.
+        // lib.optionalAttrs (pos != null) {
+          position = pos.file + ":" + toString pos.line;
+        };
 
     in
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -134,9 +134,12 @@ rec {
               (lib.concatLists propagatedDependencies));
         in
         {
-          name = name + lib.optionalString
+          # A hack to make `nix-env -qa` and `nix search` ignore broken packages.
+          # TODO(@oxij): remove this assert when something like NixOS/nix#1771 gets merged into nix.
+          name = assert validity.handled; name + lib.optionalString
             (stdenv.hostPlatform != stdenv.buildPlatform)
             ("-" + stdenv.hostPlatform.config);
+
           builder = attrs.realBuilder or stdenv.shell;
           args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];
           inherit stdenv;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -201,6 +201,10 @@ rec {
       # passed to the builder and is not a dependency.  But since we
       # include it in the result, it *is* available to nix-env for queries.
       meta = {
+          # `name` above includes cross-compilation cruft (and is under assert),
+          # lets have a clean always accessible version here.
+          inherit name;
+
           # If the packager hasn't specified `outputsToInstall`, choose a default,
           # which is the name of `p.bin or p.out or p`;
           # if he has specified it, it will be overridden below in `// meta`.


### PR DESCRIPTION
###### Motivation for this change
I want to have #32424 reverted by #33006 because of the bug uncovered in the discussion of #33006.
This patchset seems to fix the problem.

/cc @vcunat @grahamc 

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Both pass and fail checks evaluate fine.
- [X] No hashes change.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

