### PR TITLE
 color_coded: init at 2017-10-30 

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -4,6 +4,7 @@
 , xkb_switch, rustracerd, fzf, skim
 , python3, boost, icu, ncurses
 , ycmd, makeWrapper, rake
+, lua51Packages, zlib, llvm_39
 , pythonPackages, python3Packages
 , substituteAll
 , languagetool
@@ -1425,6 +1426,34 @@ rec {
     };
     dependencies = [];
 
+  };
+
+  color_coded = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "color_coded-2017-10-30";
+    src = fetchgit {
+      url = "https://github.com/jeaye/color_coded";
+      rev = "b450a19bdaaced760ad4c78558043d77bf3ed902";
+      sha256 = "1sq68c2hx4q95ibdxkywbdksc6lcmmb206acy0704957m8sc8n1f";
+    };
+    dependencies = [];
+    nativeBuildInputs = [ cmake ];
+    buildInputs = [
+      lua51Packages.lua
+      ncurses
+      zlib
+      llvm_39
+    ];
+    buildPhase = ''
+      patchShebangs .
+      sed -i "s/add_dependencies(\S\+ \S\+_track_api)//" CMakeLists.txt
+
+      cmake -DDOWNLOAD_CLANG=0 \
+            -DLLVM_CONFIG=${llvm_39}/bin/llvm-config -DLLVM_ROOT_DIR=${llvm_39}\
+            -DCLANG_LIBRARY_DIRS=${llvmPackages.clang.cc}/lib \
+            -DCLANG_INCLUDE_DIRS=${llvmPackages.clang.cc}/include \
+            .
+      make
+    '';
   };
 
   vim-buffergator = buildVimPluginFrom2Nix { # created by nix#NixDerivation

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -79,6 +79,7 @@
 "github:JazzCore/ctrlp-cmatcher"
 "github:jceb/vim-hier"
 "github:jceb/vim-orgmode"
+"github:jeaye/color_coded"
 "github:jeetsukumaran/vim-buffergator"
 "github:jgdavey/tslime.vim"
 "github:jhradilek/vim-docbk"

--- a/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/color_coded
+++ b/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/color_coded
@@ -1,0 +1,18 @@
+    buildInputs = [
+      lua51Packages.lua
+      ncurses
+      zlib
+      llvm_39
+    ];
+    nativeBuildInputs = [ cmake ];
+    buildPhase = ''
+      patchShebangs .
+      sed -i "s/add_dependencies(\S\+ \S\+_track_api)//" CMakeLists.txt
+
+      cmake -DDOWNLOAD_CLANG=0 \
+            -DLLVM_CONFIG=${llvm_39}/bin/llvm-config -DLLVM_ROOT_DIR=${llvm_39}\
+            -DCLANG_LIBRARY_DIRS=${llvmPackages.clang.cc}/lib \
+            -DCLANG_INCLUDE_DIRS=${llvmPackages.clang.cc}/include \
+            .
+      make
+    '';


### PR DESCRIPTION
###### Motivation for this change
It's a popular vim plugin which I'd like to have on my NixOS machines.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is a bit messier than it would be with `mkDerivation`, but I've found that `buildVimPluginFrom2Nix` doesn't seem to have very good CMake support.
