### PR TITLE
gradio: 6.0.2 -> 7.0

### DIFF
--- a/pkgs/applications/audio/gradio/default.nix
+++ b/pkgs/applications/audio/gradio/default.nix
@@ -17,7 +17,7 @@
 , gst_plugins ? with gst_all_1; [ gst-plugins-good gst-plugins-ugly ]
 }:
 let
-  version = "6.0.2";
+  version = "7.0";
 
 in stdenv.mkDerivation rec {
   name = "gradio-${version}";
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
     owner = "haecker-felix";
     repo = "gradio";
     rev = "v${version}";
-    sha256 = "05hg26yr7splgpkl8wjxcsdks9sm1is3hcnp7f5mjnp2ch0nn57s";
+    sha256 = "0kn08k5dv7yh29ksywcpl6ifrp3p8zzk3p3hkbhzc8fpx84jn7r9";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Upstream release notes:
https://github.com/haecker-felix/gradio/releases/tag/v7.0

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS NA
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

