### PR TITLE
protocol: init at 20171226

### DIFF
--- a/pkgs/development/python-modules/protocol/default.nix
+++ b/pkgs/development/python-modules/protocol/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  pname = "protocol";
+  version = "20171226";
+
+  src = fetchFromGitHub {
+    owner = "luismartingarcia";
+    repo = "protocol";
+    rev = "d450da7d8a58595d8ef82f1d199a80411029fc7d";
+    sha256 = "1g31s2xx0bw8ak5ag1c6mv0p0b8bj5dp3lkk9mxaf2ndj1m1qdkw";
+  };
+
+  meta = with stdenv.lib; {
+    description = "An ASCII Header Generator for Network Protocols";
+    homepage = https://github.com/luismartingarcia/protocol;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ teto ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22384,6 +22384,8 @@ EOF
 
   trezor = callPackage ../development/python-modules/trezor { };
 
+  protocol = callPackage ../development/python-modules/protocol { };
+
   trezor_agent = buildPythonPackage rec{
     name = "${pname}-${version}";
     pname = "trezor_agent";


### PR DESCRIPTION
An ASCII Header Generator for Network Protocols http://www.luismg.com/protocol/

Run with `$ protocol tcp` for instance to see:

```
 0                   1                   2                   3  
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|          Source Port          |        Destination Port       |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                        Sequence Number                        |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                     Acknowledgment Number                     |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
| Offset|  Res. |     Flags     |             Window            |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|            Checksum           |         Urgent Pointer        |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                    Options                    |    Padding    |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+

```

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

