### PR TITLE
vdrift: fix build, allow parallel building

### DIFF
--- a/pkgs/games/vdrift/0001-Ignore-missing-data-for-installation.patch
+++ b/pkgs/games/vdrift/0001-Ignore-missing-data-for-installation.patch
@@ -1,0 +1,27 @@
+From 7ebe252a8488a63675d1c50c0faa1bdc5ff97889 Mon Sep 17 00:00:00 2001
+From: Linus Heckemann <git@sphalerite.org>
+Date: Fri, 5 Jan 2018 21:27:28 +0100
+Subject: [PATCH] Ignore missing data for installation
+
+This is for packaging vdrift separately from its data in nixpkgs.
+---
+ SConstruct | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/SConstruct b/SConstruct
+index 4394de0b..beef29a4 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -511,9 +511,6 @@ env.Alias(target = 'bin-package', source = bin_archive)
+ #----------------#
+ Export(['env', 'version', 'src_dir', 'bin_dir'])
+ if 'install' in COMMAND_LINE_TARGETS:
+-    if not os.path.isfile('data/SConscript'):
+-        raise 'VDrift data not found. Please make sure data is placed in vdrift directory. See README.md and http://wiki.vdrift.net.' 
+-    SConscript('data/SConscript')
+     # desktop appdata installation
+     install_desktop = env.Install(env['destdir'] + env['prefix'] + '/share/applications', 'vdrift.desktop')
+     install_appdata = env.Install(env['destdir'] + env['prefix'] + '/share/appdata', 'vdrift.appdata.xml')
+-- 
+2.15.0
+

--- a/pkgs/games/vdrift/default.nix
+++ b/pkgs/games/vdrift/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "Car racing game";
     homepage = http://vdrift.net/;
     license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [viric];
+    maintainers = with stdenv.lib.maintainers; [viric lheckemann];
     platforms = stdenv.lib.platforms.linux;
     hydraPlatforms = [];
   };

--- a/pkgs/games/vdrift/default.nix
+++ b/pkgs/games/vdrift/default.nix
@@ -2,14 +2,14 @@
   bullet, curl, gettext }:
 
 stdenv.mkDerivation rec {
-  version = "2014-10-20";
+  version = "git";
   name = "vdrift-${version}";
 
   src = fetchFromGitHub {
-    owner = "VDrift";
+    owner = "vdrift";
     repo = "vdrift";
-    rev = version;
-    sha256 = "09yny5qzdrpffq3xhqwfymsracwsxwmdd5xa8bxx9a56hhxbak2l";
+    rev = "12d444ed18395be8827a21b96cc7974252fce6d1";
+    sha256 = "001wq3c4n9wzxqfpq40b1jcl16sxbqv2zbkpy9rq2wf9h417q6hg";
   };
 
   data = fetchsvn {
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     chmod -R +w data
     sed -i -e s,/usr/local,$out, SConstruct
     export CXXFLAGS="$(pkg-config --cflags SDL2_image)"
-    scons
+    scons -j$NIX_BUILD_CORES
   '';
   installPhase = "scons install";
 

--- a/pkgs/games/vdrift/default.nix
+++ b/pkgs/games/vdrift/default.nix
@@ -1,41 +1,60 @@
-{ stdenv, fetchFromGitHub, fetchsvn, pkgconfig, scons, mesa, SDL2, SDL2_image, libvorbis,
-  bullet, curl, gettext }:
+{ stdenv, fetchFromGitHub, fetchsvn, pkgconfig, scons, mesa, SDL2, SDL2_image
+, libvorbis, bullet, curl, gettext, writeTextFile, writeShellScriptBin
 
-stdenv.mkDerivation rec {
-  version = "git";
-  name = "vdrift-${version}";
-
-  src = fetchFromGitHub {
-    owner = "vdrift";
-    repo = "vdrift";
-    rev = "12d444ed18395be8827a21b96cc7974252fce6d1";
-    sha256 = "001wq3c4n9wzxqfpq40b1jcl16sxbqv2zbkpy9rq2wf9h417q6hg";
-  };
-
-  data = fetchsvn {
+, data ? fetchsvn {
     url = "svn://svn.code.sf.net/p/vdrift/code/vdrift-data";
     rev = 1386;
     sha256 = "0ka6zir9hg0md5p03dl461jkvbk05ywyw233hnc3ka6shz3vazi1";
+  }
+}:
+let
+  version = "git";
+  bin = stdenv.mkDerivation {
+    name = "vdrift-${version}";
+
+    src = fetchFromGitHub {
+      owner = "vdrift";
+      repo = "vdrift";
+      rev = "12d444ed18395be8827a21b96cc7974252fce6d1";
+      sha256 = "001wq3c4n9wzxqfpq40b1jcl16sxbqv2zbkpy9rq2wf9h417q6hg";
+    };
+
+    nativeBuildInputs = [ pkgconfig ];
+    buildInputs = [ scons mesa SDL2 SDL2_image libvorbis bullet curl gettext ];
+
+    patches = [ ./0001-Ignore-missing-data-for-installation.patch ];
+
+    buildPhase = ''
+      sed -i -e s,/usr/local,$out, SConstruct
+      export CXXFLAGS="$(pkg-config --cflags SDL2_image)"
+      scons -j$NIX_BUILD_CORES
+    '';
+    installPhase = "scons install";
+
+    meta = {
+      description = "Car racing game";
+      homepage = http://vdrift.net/;
+      license = stdenv.lib.licenses.gpl2Plus;
+      maintainers = with stdenv.lib.maintainers; [viric];
+      platforms = stdenv.lib.platforms.linux;
+    };
   };
-
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ scons mesa SDL2 SDL2_image libvorbis bullet curl gettext ];
-
-  buildPhase = ''
-    cp -r --reflink=auto $data data
-    chmod -R +w data
-    sed -i -e s,/usr/local,$out, SConstruct
-    export CXXFLAGS="$(pkg-config --cflags SDL2_image)"
-    scons -j$NIX_BUILD_CORES
+  wrappedName = "vdrift-${version}-with-data-${toString data.rev}";
+in writeTextFile {
+  name = wrappedName;
+  text = ''
+    export VDRIFT_DATA_DIRECTORY="${data}"
+    exec ${bin}/bin/vdrift "$@"
   '';
-  installPhase = "scons install";
-
-  meta = {
-    description = "Car racing game";
-    homepage = http://vdrift.net/;
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [viric lheckemann];
-    platforms = stdenv.lib.platforms.linux;
+  destination = "/bin/vdrift";
+  executable = true;
+  checkPhase = ''
+    ${stdenv.shell} -n $out/bin/vdrift
+  '';
+} // {
+  meta = bin.meta // {
     hydraPlatforms = [];
   };
+  unwrapped = bin;
+  inherit bin data;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18533,6 +18533,9 @@ with pkgs;
 
   vdrift = callPackage ../games/vdrift { };
 
+  # To ensure vdrift's code is built on hydra
+  vdrift-bin = vdrift.bin;
+
   vectoroids = callPackage ../games/vectoroids { };
 
   vessel = callPackage_i686 ../games/vessel { };


### PR DESCRIPTION
###### Motivation for this change
VDrift previously failed to build on gcc 6. This isn't fixed in any
released version (I don't think the last released version being from
2014 helps), but the latest git version at least builds.


###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

