### PR TITLE
qutebrowser: make gstreamer and pdfjs configurable

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -1,19 +1,13 @@
-{ stdenv, lib, fetchurl, fetchzip, buildPythonApplication
-, makeWrapper, wrapGAppsHook, qtbase, pyqt5, jinja2, pygments
-, pyyaml, pypeg2, pyopengl, cssutils, glib_networking, asciidoc
-, docbook_xml_dtd_45, docbook_xsl, libxml2, libxslt, attrs
-, gst-plugins-base ? null
-, gst-plugins-good ? null
-, gst-plugins-bad  ? null
-, gst-plugins-ugly ? null
-, gst-libav        ? null
-, qtwebkit-plugins ? null
+{ stdenv, lib, fetchurl, fetchzip, python3Packages
+, makeWrapper, wrapGAppsHook, qtbase, glib_networking
+, asciidoc, docbook_xml_dtd_45, docbook_xsl, libxml2
+, libxslt, gst_all_1 ? null
 , withPdfReader        ? true
 , withMediaPlayback    ? true
 , withWebEngineDefault ? true
 }:
 
-assert (! withWebEngineDefault) -> qtwebkit-plugins != null;
+assert withMediaPlayback -> gst_all_1 != null;
 
 let
   pdfjs = stdenv.mkDerivation rec {
@@ -32,7 +26,7 @@ let
     '';
   };
 
-in buildPythonApplication rec {
+in python3Packages.buildPythonApplication rec {
   name = "qutebrowser-${version}${versionPostfix}";
   namePrefix = "";
   version = "1.0.4";
@@ -49,17 +43,17 @@ in buildPythonApplication rec {
   buildInputs = [
     qtbase
     glib_networking
-  ] ++ lib.optionals withMediaPlayback [
+  ] ++ lib.optionals withMediaPlayback (with gst_all_1; [
     gst-plugins-base gst-plugins-good
     gst-plugins-bad gst-plugins-ugly gst-libav
-  ] ++ lib.optional (!withWebEngineDefault) qtwebkit-plugins;
+  ]) ++ lib.optional (!withWebEngineDefault) python3Packages.qtwebkit-plugins;
 
   nativeBuildInputs = [
     makeWrapper wrapGAppsHook asciidoc
     docbook_xml_dtd_45 docbook_xsl libxml2 libxslt
   ];
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with python3Packages; [
     pyyaml pyqt5 jinja2 pygments
     pypeg2 cssutils pyopengl attrs
   ];

--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -1,9 +1,15 @@
-{ stdenv, lib, fetchurl, unzip, buildPythonApplication, makeWrapper, wrapGAppsHook
-, qtbase, pyqt5, jinja2, pygments, pyyaml, pypeg2, pyopengl, cssutils, glib_networking
-, asciidoc, docbook_xml_dtd_45, docbook_xsl, libxml2, libxslt
-, gst-plugins-base, gst-plugins-good, gst-plugins-bad, gst-plugins-ugly, gst-libav
+{ stdenv, lib, fetchurl, fetchzip, buildPythonApplication
+, makeWrapper, wrapGAppsHook, qtbase, pyqt5, jinja2, pygments
+, pyyaml, pypeg2, pyopengl, cssutils, glib_networking, asciidoc
+, docbook_xml_dtd_45, docbook_xsl, libxml2, libxslt, attrs
+, gst-plugins-base ? null
+, gst-plugins-good ? null
+, gst-plugins-bad  ? null
+, gst-plugins-ugly ? null
+, gst-libav        ? null
 , qtwebkit-plugins ? null
-, attrs
+, withPdfReader        ? true
+, withMediaPlayback    ? true
 , withWebEngineDefault ? true
 }:
 
@@ -14,24 +20,23 @@ let
     name = "pdfjs-${version}";
     version = "1.7.225";
 
-    src = fetchurl {
+    src = fetchzip {
       url = "https://github.com/mozilla/pdf.js/releases/download/v${version}/${name}-dist.zip";
-      sha256 = "1n8ylmv60r0qbw2vilp640a87l4lgnrsi15z3iihcs6dj1n1yy67";
+      sha256 = "0bsmbz7bbh0zpd70dlhss4fjdw7zq356091wld9s7kxnb2rixqd8";
+      stripRoot = false;
     };
-
-    nativeBuildInputs = [ unzip ];
 
     buildCommand = ''
       mkdir $out
-      unzip -d $out $src
+      cp -r $src $out
     '';
   };
 
 in buildPythonApplication rec {
-  name = "qutebrowser-${version}${fix_postfix}";
-  fix_postfix = "";
-  version = "1.0.4";
+  name = "qutebrowser-${version}${versionPostfix}";
   namePrefix = "";
+  version = "1.0.4";
+  versionPostfix = "";
 
   src = fetchurl {
     url = "https://github.com/qutebrowser/qutebrowser/releases/download/v${version}/${name}.tar.gz";
@@ -43,21 +48,25 @@ in buildPythonApplication rec {
 
   buildInputs = [
     qtbase
-    gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav
     glib_networking
-  ]
-    ++ lib.optional (! withWebEngineDefault) qtwebkit-plugins;
+  ] ++ lib.optionals withMediaPlayback [
+    gst-plugins-base gst-plugins-good
+    gst-plugins-bad gst-plugins-ugly gst-libav
+  ] ++ lib.optional (!withWebEngineDefault) qtwebkit-plugins;
 
   nativeBuildInputs = [
-    makeWrapper wrapGAppsHook asciidoc docbook_xml_dtd_45 docbook_xsl libxml2 libxslt
+    makeWrapper wrapGAppsHook asciidoc
+    docbook_xml_dtd_45 docbook_xsl libxml2 libxslt
   ];
 
   propagatedBuildInputs = [
-    pyyaml pyqt5 jinja2 pygments pypeg2 cssutils pyopengl attrs
+    pyyaml pyqt5 jinja2 pygments
+    pypeg2 cssutils pyopengl attrs
   ];
 
   postPatch = ''
     sed -i "s,/usr/share/qutebrowser,$out/share/qutebrowser,g" qutebrowser/utils/standarddir.py
+  '' + lib.optionalString withPdfReader ''
     sed -i "s,/usr/share/pdf.js,${pdfjs},g" qutebrowser/browser/pdfjs.py
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16618,10 +16618,7 @@ with pkgs;
 
   quodlibet-xine-full = quodlibet-full.override { xineBackend = true; tag = "-xine-full"; };
 
-  qutebrowser = libsForQt5.callPackage ../applications/networking/browsers/qutebrowser {
-    inherit (python3Packages) buildPythonApplication pyqt5 jinja2 pygments pyyaml pypeg2 cssutils pyopengl attrs;
-    inherit (gst_all_1) gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav;
-  };
+  qutebrowser = libsForQt5.callPackage ../applications/networking/browsers/qutebrowser { };
 
   rabbitvcs = callPackage ../applications/version-management/rabbitvcs {};
 


### PR DESCRIPTION
###### Motivation for this change
PDF.js and gstreamer are optional dependencies in other distros.
I added two options to control these but kept the same behavior by default.
Also a small refactor.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using nox
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

