### PR TITLE
jmeter: 2.11 -> 3.3 and fix java command not found

### DIFF
--- a/pkgs/applications/networking/jmeter/default.nix
+++ b/pkgs/applications/networking/jmeter/default.nix
@@ -1,13 +1,17 @@
-{ fetchurl, stdenv, ant }:
+{ fetchurl, stdenv, jre }:
 
 stdenv.mkDerivation rec {
-  name = "jmeter-2.11";
+  name = "jmeter-3.3";
   src = fetchurl {
     url = "http://archive.apache.org/dist/jmeter/binaries/apache-${name}.tgz";
-    sha256 = "1fr3sw06qncb6yygcf2lbnkxma4v1dbigpf39ajrm0isxbpyv944";
+    sha256 = "190k6yrh5casadphkv4azp4nvf4wf2q85mrfysw67r9d96nb9kk5";
   };
 
+  buildInputs = [ jre ];
+
   installPhase = ''
+    substituteInPlace ./bin/jmeter.sh --replace "java $ARGS" "${jre}/bin/java $ARGS"
+    substituteInPlace ./bin/jmeter --replace "java $ARGS" "${jre}/bin/java $ARGS"
     mkdir $out
     cp ./* $out/ -R
   '';


### PR DESCRIPTION
###### Motivation for this change

- jmeter: 2.11 -> 3.3 
- fix java command not found

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

