### PR TITLE
libvirt: Avoid patchShebangs in the darwin build

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -43,7 +43,10 @@ stdenv.mkDerivation rec {
     # do not use "''${qemu_kvm}/bin/qemu-kvm" to avoid bound VMs to particular qemu derivations
     substituteInPlace src/lxc/lxc_conf.c \
       --replace 'lxc_path,' '"/run/libvirt/nix-emulators/libvirt_lxc",'
-  '' + ''
+  ''
+  # "patchShebangs" causes issues in the Darwin build.
+  # See https://github.com/NixOS/nixpkgs/pull/33084 regarding details.
+  + optionalString (! stdenv.isDarwin) ''
     PATH=${dnsmasq}/bin:$PATH
     patchShebangs . # fixes /usr/bin/python references
   '';


### PR DESCRIPTION
###### Motivation for this change

Noticed that libvirt did not build on darwin. Tracked the problem down to the
call to "patchShebangs" in the hook "preConfigure".

libvirt is a new dependency in NixOPS, that's why I found it.

The error during the build looked as follows:

```
Can't exec "no": No such file or directory at ./rpc/genprotocol.pl line 45.
cannot run no -h locking/lock_protocol.x: No such file or directory at ./rpc/genprotocol.pl line 45.
make[2]: *** [Makefile:12060: locking/lock_protocol.h] Error 2
make[2]: Leaving directory '/private/var/folders/v2/kx2sg5693tb1h84zc2hmjjgr0000gn/T/nix-build-libvirt-3.10.0.drv-0/libvirt-3.10.0/src'
make[1]: *** [Makefile:2119: all-recursive] Error 1
make[1]: Leaving directory '/private/var/folders/v2/kx2sg5693tb1h84zc2hmjjgr0000gn/T/nix-build-libvirt-3.10.0.drv-0/libvirt-3.10.0'
make: *** [Makefile:2012: all] Error 2
builder for ‘/nix/store/m0riralw5x2dwj9p1fgfq2rihysbvahc-libvirt-3.10.0.drv’ failed with exit code 2
cannot build derivation ‘/nix/store/3ij4hh2b5ikn1ndss5hi0s5i0nyrzsnz-python2.7-libvirt-3.10.0.drv’: 1 dependencies couldn't be built
error: build of ‘/nix/store/3ij4hh2b5ikn1ndss5hi0s5i0nyrzsnz-python2.7-libvirt-3.10.0.drv’ failed
```

When investigating via `make --trace` I found the following details:

```
Makefile:12060: update target 'locking/lock_protocol.h' due to: locking/lock_protocol.x rpc/genprotocol.pl
echo "  GEN     " locking/lock_protocol.h;/nix/store/204x8f9ii18sszpfqmq35rqdpmzm482w-perl-5.24.3/bin/perl -w ./rpc/genprotocol.pl no -h \
       locking/lock_protocol.x ./locking/lock_protocol.h
  GEN      locking/lock_protocol.h
Can't exec "no": No such file or directory at ./rpc/genprotocol.pl line 45.
cannot run no -h locking/lock_protocol.x: No such file or directory at ./rpc/genprotocol.pl line 45.
```

I did notice by accident that things were working when I forgot to run the hook `preConfigure`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

