### PR TITLE
treewide: Clean up multi-arch tools and usage

### DIFF
--- a/pkgs/applications/audio/airwave/default.nix
+++ b/pkgs/applications/audio/airwave/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cmake, fetchFromGitHub, file, gcc_multi, libX11, makeWrapper
+{ stdenv, multiStdenv, cmake, fetchFromGitHub, file, libX11, makeWrapper
 , overrideCC, qt5, requireFile, unzip, wine
 }:
 
@@ -12,8 +12,6 @@ let
     rev = version;
     sha256 = "1ban59skw422mak3cp57lj27hgq5d3a4f6y79ysjnamf8rpz9x4s";
   };
-
-  stdenv_multi = overrideCC stdenv gcc_multi;
 
   vst-sdk = stdenv.mkDerivation rec {
     name = "vstsdk368_08_11_2017_build_121";
@@ -38,7 +36,7 @@ let
 
 in
 
-stdenv_multi.mkDerivation {
+multiStdenv.mkDerivation {
   name = "airwave-${version}";
 
   src = airwave-src;
@@ -54,7 +52,7 @@ stdenv_multi.mkDerivation {
     # For airwave-host-32.exe.so, point wineg++ to 32-bit versions of
     # these libraries, as $NIX_LDFLAGS contains only 64-bit ones.
     substituteInPlace src/host/CMakeLists.txt --replace '-m32' \
-      '-m32 -L${wine-xembed}/lib -L${wine-xembed}/lib/wine -L${stdenv_multi.cc.libc.out}/lib/32'
+      '-m32 -L${wine-xembed}/lib -L${wine-xembed}/lib/wine -L${multiStdenv.cc.libc.out}/lib/32'
   '';
 
   # libstdc++.so link gets lost in 64-bit executables during

--- a/pkgs/os-specific/linux/statifier/default.nix
+++ b/pkgs/os-specific/linux/statifier/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchurl, gcc_multi, glibc_multi }:
+{ multiStdenv, fetchurl }:
 
 let version = "1.7.4"; in
-stdenv.mkDerivation {
+multiStdenv.mkDerivation {
   name = "statifier-${version}";
 
   src = fetchurl {
@@ -9,16 +9,14 @@ stdenv.mkDerivation {
     sha256 = "03lzkla6knjhh186b43cac410x2fmhi28pkmzb3d211n3zp5i9y8";
   };
 
-  buildInputs = [ gcc_multi glibc_multi ];
-
   phaseNames = [ "patchPhase" "installPhase" ];
 
   postPatch = ''
     sed -e s@/usr/@"$out/"@g -i */Makefile src/statifier
-    sed -e s@/bin/bash@"${stdenv.shell}"@g -i src/*.sh
+    sed -e s@/bin/bash@"${multiStdenv.shell}"@g -i src/*.sh
   '';
 
-  meta = with stdenv.lib; {
+  meta = with multiStdenv.lib; {
     description = "Tool for creating static Linux binaries";
     platforms = platforms.linux;
   };

--- a/pkgs/tools/misc/loadlibrary/default.nix
+++ b/pkgs/tools/misc/loadlibrary/default.nix
@@ -1,4 +1,4 @@
-{ cabextract, glibc_multi, fetchFromGitHub, readline, stdenv_32bit }:
+{ cabextract, fetchFromGitHub, readline, stdenv_32bit }:
 
 # stdenv_32bit is needed because the program depends upon 32-bit libraries and does not have
 # support for 64-bit yet: it requires libc6-dev:i386, libreadline-dev:i386.
@@ -14,7 +14,7 @@ stdenv_32bit.mkDerivation rec {
     sha256 = "01hb7wzfh1s5b8cvmrmr1gqknpq5zpzj9prq3wrpsgg129jpsjkb";
   };
 
-  buildInputs = [ glibc_multi cabextract readline stdenv_32bit.cc.libc ];
+  buildInputs = [ cabextract readline ];
 
   installPhase = ''
     mkdir -p $out/bin/

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1556,7 +1556,6 @@ with pkgs;
     m17n = callPackage ../tools/inputmethods/ibus-engines/ibus-m17n { };
 
     mozc = callPackage ../tools/inputmethods/ibus-engines/ibus-mozc rec {
-      clangStdenv = libcxxStdenv; # workaround for https://github.com/NixOS/nixpkgs/issues/28223
       python = python2;
       inherit (python2Packages) gyp;
       protobuf = pkgs.protobuf.overrideDerivation (oldAttrs: { stdenv = clangStdenv; });
@@ -2043,7 +2042,6 @@ with pkgs;
     m17n = callPackage ../tools/inputmethods/fcitx-engines/fcitx-m17n { };
 
     mozc = callPackage ../tools/inputmethods/fcitx-engines/fcitx-mozc rec {
-      clangStdenv = libcxxStdenv; # workaround for https://github.com/NixOS/nixpkgs/issues/28223
       python = python2;
       inherit (python2Packages) gyp;
       protobuf = pkgs.protobuf.overrideDerivation (oldAttrs: { stdenv = clangStdenv; });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34,11 +34,7 @@ with pkgs;
   # A stdenv capable of building 32-bit binaries.  On x86_64-linux,
   # it uses GCC compiled with multilib support; on i686-linux, it's
   # just the plain stdenv.
-  stdenv_32bit = lowPrio (
-    if system == "x86_64-linux" then
-      overrideCC stdenv gcc_multi
-    else
-      stdenv);
+  stdenv_32bit = lowPrio (if hostPlatform.is32bit then stdenv else multiStdenv);
 
   stdenvNoCC = stdenv.override { cc = null; };
 
@@ -5544,7 +5540,7 @@ with pkgs;
   };
 
   #Use this instead of stdenv to build with clang
-  clangStdenv = if stdenv.isDarwin then stdenv else lowPrio llvmPackages.stdenv;
+  clangStdenv = if stdenv.cc.isClang then stdenv else lowPrio llvmPackages.stdenv;
   clang-sierraHack-stdenv = overrideCC stdenv clang-sierraHack;
   libcxxStdenv = if stdenv.isDarwin then stdenv else lowPrio llvmPackages.libcxxStdenv;
 
@@ -5601,11 +5597,12 @@ with pkgs;
   gcc = gcc6;
   gcc-unwrapped = gcc.cc;
 
-  gccStdenv = if (!stdenv.isDarwin) then stdenv else stdenv.override {
+  gccStdenv = if stdenv.cc.isGNU then stdenv else stdenv.override {
     allowedRequisites = null;
     cc = gcc;
-    # Include unwrapped binaries like AS, etc. and remove libcxx/libcxxabi
-    extraBuildInputs = [ stdenv.cc.cc ];
+    # Remove libcxx/libcxxabi, and add clang for AS if on darwin (it uses
+    # clang's internal assembler).
+    extraBuildInputs = lib.optional hostPlatform.isDarwin clang.cc;
   };
 
   wrapCCMulti = cc:
@@ -5645,6 +5642,7 @@ with pkgs;
 
   gccMultiStdenv = overrideCC stdenv gcc_multi;
   clangMultiStdenv = overrideCC stdenv clang_multi;
+  multiStdenv = if stdenv.cc.isClang then clangMultiStdenv else gccMultiStdenv;
 
   gcc_debug = lowPrio (wrapCC (gcc.cc.override {
     stripped = false;


### PR DESCRIPTION
###### Motivation for this change

See the commit messages for more details, but the principles basically are:

  - Prefer custom stdenvs to tools as extra deps
  - Don't needlessly force gcc or clang
  - Dispatch on more appropriate conditions


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

