### PR TITLE
init subdl package

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -218,6 +218,7 @@
   ertes = "Ertugrul Söylemez <esz@posteo.de>";
   ethercrow = "Dmitry Ivanov <ethercrow@gmail.com>";
   etu = "Elis Hirwing <elis@hirwing.se>";
+  exfalso = "Andras Slemmer <0slemi0@gmail.com>";
   exi = "Reno Reckling <nixos@reckling.org>";
   exlevan = "Alexey Levan <exlevan@gmail.com>";
   expipiplus1 = "Joe Hermaszewski <nix@monoid.al>";

--- a/pkgs/applications/video/subdl/default.nix
+++ b/pkgs/applications/video/subdl/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python3 }:
 
 stdenv.mkDerivation rec {
-  name = "subdl";
+  name = "subdl-0.0pre.2017.11.06";
 
   src = fetchFromGitHub {
     owner = "alexanderwink";

--- a/pkgs/applications/video/subdl/default.nix
+++ b/pkgs/applications/video/subdl/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, python3 }:
+
+stdenv.mkDerivation rec {
+  name = "subdl";
+
+  src = fetchFromGitHub {
+    owner = "alexanderwink";
+    repo = "subdl";
+    rev = "4cf5789b11f0ff3f863b704b336190bf968cd471";
+    sha256 = "0kmk5ck1j49q4ww0lvas2767kwnzhkq0vdwkmjypdx5zkxz73fn8";
+  };
+
+  meta = {
+    homepage = https://github.com/alexanderwink/subdl;
+    description = "A command-line tool to download subtitles from opensubtitles.org";
+    platforms = stdenv.lib.platforms.all;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.exfalso ];
+  };
+
+  buildInputs = [ python3 ];
+
+  installPhase = ''
+    install -vD subdl $out/bin/subdl
+  '';  
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10944,6 +10944,8 @@ with pkgs;
 
   strigi = callPackage ../development/libraries/strigi { clucene_core = clucene_core_2; };
 
+  subdl = callPackage ../applications/video/subdl { };
+  
   subtitleeditor = callPackage ../applications/video/subtitleeditor { };
 
   suil-qt4 = callPackage ../development/libraries/audio/suil {


### PR DESCRIPTION
###### Motivation for this change

Add the subdl tool

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
