### PR TITLE
Revert "haskellPackages.{SC,sc}alendar: nullify to fix ofborg eval"

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -951,9 +951,9 @@ self: super: {
   # Hoogle needs a newer version than lts-10 provides.
   hoogle = super.hoogle.override { haskell-src-exts = self.haskell-src-exts_1_20_1; };
 
-  # These packages depend on each other, forming an infinite loop.
-  scalendar = null;
-  SCalendar = null;
+  # These packages depend on each other, forming an infinte loop.
+  scalendar = markBroken super.scalendar;
+  SCalendar = markBroken super.SCalendar;
 
   # Needs QuickCheck <2.10, which we don't have.
   edit-distance = doJailbreak super.edit-distance;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -951,9 +951,9 @@ self: super: {
   # Hoogle needs a newer version than lts-10 provides.
   hoogle = super.hoogle.override { haskell-src-exts = self.haskell-src-exts_1_20_1; };
 
-  # These packages depend on each other, forming an infinte loop.
-  scalendar = markBroken super.scalendar;
-  SCalendar = markBroken super.SCalendar;
+  # These packages depend on each other, forming an infinite loop.
+  scalendar = markBroken (super.scalendar.override { SCalendar = null; });
+  SCalendar = markBroken (super.SCalendar.override { scalendar = null; });
 
   # Needs QuickCheck <2.10, which we don't have.
   edit-distance = doJailbreak super.edit-distance;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#33077. Don't null out  packages! `meta.broken = true` is the API we've been using this for a long time and I didn't get any memo that said that this had been changed.

Cc: @grahamc 