### PR TITLE
werkzeug: patch reloader to find nix wrapped python scripts

### DIFF
--- a/pkgs/development/python-modules/werkzeug/0001-Check-wrapped-path-when-reloading-scripts.patch
+++ b/pkgs/development/python-modules/werkzeug/0001-Check-wrapped-path-when-reloading-scripts.patch
@@ -1,0 +1,35 @@
+From ed50577064391a247e03082dcebf5ba118020bd6 Mon Sep 17 00:00:00 2001
+From: Sam Parkinson <sam@sam.today>
+Date: Wed, 27 Dec 2017 11:15:59 +1100
+Subject: [PATCH] Check wrapped path when reloading scripts
+
+Nix wraps the python script in a shell script for system installed
+utils (like Flask).  This previously caused a crash; as python can not
+run a shell script.
+
+This commit makes the reloader check for the wrapped version; so
+that the reloader finds the python script as it expects
+---
+ werkzeug/_reloader.py | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/werkzeug/_reloader.py b/werkzeug/_reloader.py
+index c4ca2714..883879b7 100644
+--- a/werkzeug/_reloader.py
++++ b/werkzeug/_reloader.py
+@@ -60,6 +60,12 @@ def _get_args_for_reloading():
+     if os.name == 'nt' and not os.path.exists(py_script) and \
+        os.path.exists(py_script + '.exe'):
+         py_script += '.exe'
++
++    dirname, basename = os.path.split(py_script)
++    nix_inner = os.path.join(dirname, '.{}-wrapped'.format(basename))
++    if os.path.isfile(nix_inner):
++        py_script = nix_inner
++
+     rv.append(py_script)
+     rv.extend(sys.argv[1:])
+     return rv
+-- 
+2.15.0
+

--- a/pkgs/development/python-modules/werkzeug/default.nix
+++ b/pkgs/development/python-modules/werkzeug/default.nix
@@ -11,6 +11,7 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "09mv4cya3lywkn4mi3qrqmjgwiw99kdk03dk912j8da6ny3pnflh";
   };
+  patches = [ ./0001-Check-wrapped-path-when-reloading-scripts.patch ];
 
   LC_ALL = "en_US.UTF-8";
 


### PR DESCRIPTION
Fixes #33093

###### Motivation for this change

Currently, the werkzeug will crash if the entrypoint is wrapped by Nix (for example; 

This commit adds a patch to fix this.  This patch is quite Nix specific; and therefore would not make sense to upstream.

An alternate way to fix this would be to stop Nix from changing the `sys.argv[0]` value when wrapping python scripts.  However, I assume that the `sys.argv[0]` reassignment happens for a reason; and it is simple to patch werkzeug.

###### How to test

This can be tested using Flask.

Create a script `main.py`:

```python3
from flask import Flask

app = Flask(__name__)

@app.route('/')
def index():
    return 'Hello World'
```

Then run it using Flask:

```
nix-env -i python3.6-Flask
FLASK_APP=main.py flask run --reloader
```

When using the old version; this will crash during startup (as descried in https://github.com/NixOS/nixpkgs/issues/33093).

When using the patch; this will run and not crash.  The reloader will as intended.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

