### PR TITLE
denemo: init at 2.2.0

### DIFF
--- a/pkgs/applications/audio/denemo/default.nix
+++ b/pkgs/applications/audio/denemo/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, pkgconfig
+, libjack2, gettext, intltool, guile_2_0, lilypond
+, glib, libxml2, librsvg, libsndfile, aubio
+, gtk3, gtksourceview, evince, fluidsynth, rubberband
+, portaudio, portmidi, fftw, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "denemo-${version}";
+  version = "2.2.0";
+
+  src = fetchurl {
+    url = "http://ftp.gnu.org/gnu/denemo/denemo-${version}.tar.gz";
+    sha256 = "18zcs4xmfj4vpzi15dj7k5bjzzzlr3sjf9xhrrgy4samrrdpqzfh";
+  };
+
+  buildInputs = [
+    libjack2 gettext guile_2_0 lilypond pkgconfig glib libxml2 librsvg libsndfile
+    aubio gtk3 gtksourceview evince fluidsynth rubberband portaudio fftw portmidi
+    makeWrapper
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/denemo --prefix PATH : ${lilypond}/bin
+  '';
+
+  nativeBuildInputs = [
+    intltool
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Music notation and composition software used with lilypond";
+    homepage = http://denemo.org;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.olynch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1220,7 +1220,7 @@ with pkgs;
   mpdris2 = callPackage ../tools/audio/mpdris2 { };
 
   nfdump = callPackage ../tools/networking/nfdump { };
-  
+
   nrsc5 = callPackage ../applications/misc/nrsc5 { };
 
   onboard = callPackage ../applications/misc/onboard { };
@@ -14483,6 +14483,10 @@ with pkgs;
   dunst = callPackage ../applications/misc/dunst { };
 
   devede = callPackage ../applications/video/devede { };
+
+  denemo = callPackage ../applications/audio/denemo {
+    inherit (gnome3) gtksourceview;
+  };
 
   dvb_apps  = callPackage ../applications/video/dvb-apps { };
 


### PR DESCRIPTION
###### Motivation for this change
Added denemo, an app for writing music. My editor seems to have also removed two extraneous from all-packages.nix, I could amend the commit if you want, but if it's not a problem I see no reason why not to leave it in.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

