### PR TITLE
pjsip: 2.6 -> 2.7.1

### DIFF
--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -2,14 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "pjsip-${version}";
-  version = "2.6";
+  version = "2.7.1";
 
   src = fetchurl {
     url = "http://www.pjsip.org/release/${version}/pjproject-${version}.tar.bz2";
-    sha256 = "1d67c58jn22f7h6smkykk5vwl3sqpc7xi2vm3j3lbn3lq6hisnig";
+    sha256 = "09ii5hgl5s7grx4fiimcl3s77i385h7b3kwpfa2q0arbl1ibryjr";
   };
 
   buildInputs = [ openssl libsamplerate alsaLib ];
+
+  preConfigure = ''
+    export LD=$CC
+  '';
 
   postInstall = ''
     mkdir -p $out/bin
@@ -25,7 +29,7 @@ stdenv.mkDerivation rec {
     description = "A multimedia communication library written in C, implementing standard based protocols such as SIP, SDP, RTP, STUN, TURN, and ICE";
     homepage = http://pjsip.org/;
     license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [viric];
+    maintainers = with stdenv.lib.maintainers; [viric olynch];
     platforms = with stdenv.lib.platforms; linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Updated version, fixed compilation issue (ld has trouble linking c++ binaries).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

