### PR TITLE
jbake: init at 2.5.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -432,6 +432,7 @@
   mjanczyk = "Marcin Janczyk <m@dragonvr.pl>";
   mjp = "Mike Playle <mike@mythik.co.uk>"; # github = "MikePlayle";
   mlieberman85 = "Michael Lieberman <mlieberman85@gmail.com>";
+  moaxcp = "John Mercier <moaxcp@gmail.com>";
   modulistic = "Pablo Costa <modulistic@gmail.com>";
   mog = "Matthew O'Gorman <mog-lists@rldn.net>";
   montag451 = "montag451 <montag451@laposte.net>";

--- a/pkgs/development/tools/jbake/default.nix
+++ b/pkgs/development/tools/jbake/default.nix
@@ -1,0 +1,27 @@
+{stdenv, fetchurl, unzip, jre, ...}:
+
+stdenv.mkDerivation rec {
+    version = "2.5.1";
+    name = "jbake-${version}";
+    src = fetchurl {
+        url = "http://jbake.org/files/jbake-${version}-bin.zip";
+        sha256="1r46y84q5x915055hx2vxydaqng3cz0clwz0yhwapgmi4sliygjd";
+    };
+
+    buildInputs = [ unzip jre ];
+
+    unpackPhase = "unzip ${src}";
+
+    installPhase = ''
+        substituteInPlace $name/bin/jbake --replace "java" "${jre}/bin/java" 
+        mkdir -p $out
+        cp -r $name/* $out
+    '';
+
+    meta = with stdenv; {
+        description = "JBake is a Java based, open source, static site/blog generator for developers & designers";
+        homepage = "http://jbake.org/";
+        license = lib.licenses.mit;
+        maintainers = with lib.maintainers; [moaxcp];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7504,6 +7504,8 @@ with pkgs;
 
   jamomacore = callPackage ../development/libraries/audio/jamomacore { };
 
+  jbake = callPackage ../development/tools/jbake { };
+
   jikespg = callPackage ../development/tools/parsing/jikespg { };
 
   jenkins = callPackage ../development/tools/continuous-integration/jenkins { };


### PR DESCRIPTION
###### Motivation for this change

Adding jbake to nixos.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

