### PR TITLE
electrum-ltc: 2.6.4.2 -> 2.9.3.1

### DIFF
--- a/pkgs/applications/misc/electrum-ltc/default.nix
+++ b/pkgs/applications/misc/electrum-ltc/default.nix
@@ -5,16 +5,15 @@
 
 python2Packages.buildPythonApplication rec {
   name = "electrum-ltc-${version}";
-  version = "2.6.4.2";
+  version = "2.9.3.1";
 
   src = fetchurl {
     url = "https://electrum-ltc.org/download/Electrum-LTC-${version}.tar.gz";
-    sha256 = "0sqcyk6n6kgaiinnwh6mzbbn4whk3ga59r5bw5rqmnnfqk1xdnb4";
+    sha256 = "d931a5376b7f38fba7221b01b1010f172c4d662668adae5c38885a646d5ee530";
   };
 
   propagatedBuildInputs = with python2Packages; [
     pyqt4
-    slowaes
     ecdsa
     pbkdf2
     requests
@@ -23,6 +22,8 @@ python2Packages.buildPythonApplication rec {
     protobuf
     dnspython
     jsonrpclib
+    pyaes
+    pysocks
   ];
 
   preBuild = ''


### PR DESCRIPTION
###### Motivation for this change
Updated version, added a needed python dependency

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
