### PR TITLE
palemoon: use upstream recommended options

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -59,12 +59,18 @@ stdenv.mkDerivation rec {
     echo > $MOZ_CONFIG "
     . $src/build/mozconfig.common
     ac_add_options --prefix=$out
+    ac_add_options --with-pthreads
     ac_add_options --enable-application=browser
     ac_add_options --enable-official-branding
     ac_add_options --enable-optimize="-O2"
+    ac_add_options --enable-release
+    ac_add_options --enable-devtools
     ac_add_options --enable-jemalloc
     ac_add_options --enable-shared-js
+    ac_add_options --enable-strip
     ac_add_options --disable-tests
+    ac_add_options --disable-installer
+    ac_add_options --disable-updaters
     "
   '';
 


### PR DESCRIPTION
###### Motivation for this change
Fix #33078 

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

