### PR TITLE
bintools-wrapper: symlink all programs that do not need wrapping

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -141,10 +141,12 @@ stdenv.mkDerivation {
     '')
 
     + ''
-      # Create a symlink to as (the assembler).
-      if [ -e $ldPath/${targetPrefix}as ]; then
-        ln -s $ldPath/${targetPrefix}as $out/bin/${targetPrefix}as
-      fi
+      # Create symlinks to programs that do not need wraps
+      for exe in addr2line coffdump gprof nm readelf strip ar dlltool objcopy size sysdump as dllwrap objdump srconv windmc c++filt elfedit nlmconv ranlib strings windres; do 
+        if [ -e $ldPath/${targetPrefix}$exe ]; then
+           ln -s $ldPath/${targetPrefix}$exe $out/bin/${targetPrefix}$exe
+        fi
+      done
 
     '' + (if !useMacosReexportHack then ''
       wrap ${targetPrefix}ld ${./ld-wrapper.sh} ''${ld:-$ldPath/${targetPrefix}ld}


### PR DESCRIPTION
###### Motivation for this change

Cross compilation for mingw32 targets is broken  earlier than before the binutil-wrapping. This gets us back to where we were ~6weeks ago.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

