### PR TITLE
nginx module: only turn on HTTP2 when SSL is enabled

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -168,7 +168,7 @@ let
         listenString = { addr, port, ssl, ... }:
           "listen ${addr}:${toString port} "
           + optionalString ssl "ssl "
-          + optionalString vhost.http2 "http2 "
+          + optionalString (ssl && vhost.http2) "http2 "
           + optionalString vhost.default "default_server "
           + ";";
 


### PR DESCRIPTION
###### Motivation for this change

#32858 did break all my nginx setups. With that patch "http2" gets appended to all vhosts by default, also to http only port 80 server blocks (like the ones generated by `forceSSL=true`). Nginx will then try to communicate securely with clients over port 80 and will return some binary garbage if no TLS certificate was set.

The fix is quite simple, it will now only activate HTTP2 when the `ssl` flag was set as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @nh2 @fpletz @globin