### PR TITLE
Xaw3d: 1.6 -> 1.6.2

### DIFF
--- a/pkgs/development/libraries/Xaw3d/default.nix
+++ b/pkgs/development/libraries/Xaw3d/default.nix
@@ -4,9 +4,9 @@ stdenv.mkDerivation {
   name = "Xaw3d-1.6.2";
   src = fetchurl {
     urls = [ 
-      ftp://ftp.x.org/pub/xorg/individual/lib/libXaw3d-1.6.tar.bz2
+      ftp://ftp.x.org/pub/xorg/individual/lib/libXaw3d-1.6.2.tar.bz2
       ];
-    sha256 = "099kx6ni5vkgr3kf40glif8m6r1m1hq6hxqlqrblaj1w5cphh8hi";
+    sha256 = "0awplv1nf53ywv01yxphga3v6dcniwqnxgnb0cn4khb121l12kxp";
   };
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [imake gccmakedep libXpm libXp bison flex];


### PR DESCRIPTION
###### Motivation for this change

Previously the version was given as 1.6.2, but the tarball it was installing
from was only 1.6.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).