### PR TITLE
Xfig update

### DIFF
--- a/pkgs/tools/graphics/fig2dev/default.nix
+++ b/pkgs/tools/graphics/fig2dev/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, fetchurl, zlib, libjpeg, libpng, xorg }:
+
+stdenv.mkDerivation rec {
+  name = "fig2dev-3.2.6a";
+  src = fetchurl {
+    url = https://sourceforge.net/projects/mcj/files/fig2dev-3.2.6a.tar.xz;
+    sha256 = "19v72vvlri064s5f7s7id51m8nxn9gajvs4y36rv8ggqlkcs6qay";
+  };
+
+  buildInputs = [ zlib libjpeg libpng xorg.libXpm ];
+
+  hardeningDisable = [ "format" ];
+
+  meta = {
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/tools/graphics/transfig/default.nix
+++ b/pkgs/tools/graphics/transfig/default.nix
@@ -1,61 +1,16 @@
-{stdenv, fetchurl, zlib, libjpeg, libpng, imake}:
+{ stdenv, fetchurl, zlib, libjpeg, libpng, xorg, Xaw3d }:
 
 stdenv.mkDerivation rec {
-  name = "transfig-3.2.4";
+  name = "transfig-3.2.6a";
   src = fetchurl {
-    url = ftp://ftp.tex.ac.uk/pub/archive/graphics/transfig/transfig.3.2.4.tar.gz;
-    sha256 = "0429snhp5acbz61pvblwlrwv8nxr6gf12p37f9xxwrkqv4ir7dd4";
+    url = https://sourceforge.net/projects/mcj/files/xfig-3.2.6a.tar.xz;
+    sha256 = "0z1636w27hvgjpq98z40k8h535b4x2xr2whkvr7bibaa89fynym8";
   };
 
-  buildInputs = [zlib libjpeg libpng imake];
-
-  patches = [
-    ./patch-fig2dev-dev-Imakefile
-    ./patch-fig2dev-Imakefile
-    ./patch-transfig-Imakefile
-    ./patch-fig2dev-fig2dev.h
-    ./patch-fig2dev-dev-gensvg.c
-  ];
-
-  patchPhase = ''
-    runHook prePatch
-
-    configureImakefiles() {
-        local sedcmd=$1
-
-        sed "$sedcmd" fig2dev/Imakefile > tmpsed
-        cp tmpsed fig2dev/Imakefile
-
-        sed "$sedcmd" fig2dev/dev/Imakefile > tmpsed
-        cp tmpsed fig2dev/dev/Imakefile
-
-        sed "$sedcmd" transfig/Imakefile > tmpsed
-        cp tmpsed transfig/Imakefile
-    }
-
-    for i in $patches; do
-        header "applying patch $i" 3
-        patch -p0 < $i
-        stopNest
-    done
-
-    configureImakefiles "s:__PREFIX_PNG:${libpng}:"
-    configureImakefiles "s:__PREFIX:$out:"
-
-    runHook postPatch
-  '';
-
-  preBuild = ''
-    xmkmf
-    make Makefiles
-  '';
-
-  makeFlags = [ "CC=cc" ];
-
-  preInstall = ''
-    mkdir -p $out
-    mkdir -p $out/lib
-  '';
+  buildInputs = with xorg;
+    [ zlib libjpeg libpng Xaw3d
+      libX11 libXau libXaw libXext libXft libXmu libXpm libXt
+];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5091,6 +5091,9 @@ with pkgs;
   transfig = callPackage ../tools/graphics/transfig {
     libpng = libpng12;
   };
+  fig2dev = callPackage ../tools/graphics/fig2dev {
+    libpng = libpng12;
+  };
 
   truecrypt = callPackage ../applications/misc/truecrypt {
     stdenv = overrideInStdenv stdenv [ useOldCXXAbi ];


### PR DESCRIPTION
###### Motivation for this change

I found that `transfig` doesn't build `fig2dev` on darwin, which is needed to build documentation for `coq`.  This updates to the latest version of `xfig`, and splits out `fig2dev` into its own build. Since I'm not entirely sure whether this supplants the earlier build of `transfig` (especially because there is no longer a `transfig` binary as a result), I would like solicit comments on this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

