### PR TITLE
chkrootkit: 0.51 -> 0.52

### DIFF
--- a/pkgs/tools/security/chkrootkit/default.nix
+++ b/pkgs/tools/security/chkrootkit/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "chkrootkit-0.51";
+  name = "chkrootkit-0.52";
 
   src = fetchurl {
     url = "ftp://ftp.pangeia.com.br/pub/seg/pac/${name}.tar.gz";
-    sha256 = "0y0kbhy8156y8zli0wcqbakb9rprzl1w7jn0kw3xjfgzrgsncqgn";
+    sha256 = "04d2yxpy99y90rvrlc9fqmlffs6iyfbghxbhvv12j1xfr2ww0y65";
   };
 
   # TODO: a lazy work-around for linux build failure ...


### PR DESCRIPTION
###### Motivation for this change

Noticed updated version available while investigating #33091 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

