### PR TITLE
pythonPackages.chainer: init at 3.2.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -282,6 +282,7 @@
   hodapp = "Chris Hodapp <hodapp87@gmail.com>";
   hrdinka = "Christoph Hrdinka <c.nix@hrdinka.at>";
   htr = "Hugo Tavares Reis <hugo@linux.com>";
+  hyphon81 = "Masato Yonekawa <zero812n@gmail.com>";
   iand675 = "Ian Duncan <ian@iankduncan.com>";
   ianwookim = "Ian-Woo Kim <ianwookim@gmail.com>";
   iblech = "Ingo Blechschmidt <iblech@speicherleck.de>";

--- a/pkgs/development/libraries/science/math/nccl/default.nix
+++ b/pkgs/development/libraries/science/math/nccl/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub
+, gcc5, eject, cudatoolkit
+}:
+
+stdenv.mkDerivation rec {
+  name = "cudatoolkit-${cudatoolkit.majorVersion}-nccl-${version}";
+  version = "1.3.4-1";
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "nccl";
+    rev = "v${version}";
+    sha256 = "0fvnrfn572lc6i2a3xyhbifm53ivcrr46z6cqr3b0bwb1iq79m7q";
+  };
+
+  nativeBuildInputs = [
+    gcc5
+    eject
+  ];
+
+  propagatedBuildInputs = [
+    cudatoolkit
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "CUDA_HOME=${cudatoolkit}"
+    "CUDA_LIB=${cudatoolkit.lib}/lib"
+  ];
+
+  meta = with stdenv.lib; {
+    description = ''
+      NVIDIA Collective Communications Library.
+      Multi-GPU and multi-node collective communication primitives.
+    '';
+    homepage = https://developer.nvidia.com/nccl;
+    license = licenses.bsd3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ hyphon81 ];
+  };
+}

--- a/pkgs/development/python-modules/chainer/default.nix
+++ b/pkgs/development/python-modules/chainer/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, python
+, buildPythonPackage, fetchPypi, isPy3k
+, filelock, protobuf, numpy, pytest, mock
+, cupy, cudaSupport ? false
+}:
+
+buildPythonPackage rec {
+  pname = "chainer";
+  version = "3.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0mbc8kwk7pvg03bf0j57a48gr6rsdg4lzmyj0dak8y2l4lmyskpw";
+  };
+
+  checkInputs = [
+    pytest
+    mock
+  ];
+
+  propagatedBuildInputs = [
+    filelock
+    protobuf
+    numpy
+  ] ++ lib.optionals cudaSupport [ cupy ];
+
+  # In python3, test was failed...
+  doCheck = !isPy3k;
+
+  meta = with stdenv.lib; {
+    description = "A flexible framework of neural networks for deep learning";
+    homepage = https://chainer.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ hyphon81 ];
+  };
+}

--- a/pkgs/development/python-modules/cupy/default.nix
+++ b/pkgs/development/python-modules/cupy/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, python, buildPythonPackage
+, fetchPypi, isPy3k, linuxPackages, gcc5
+, fastrlock, numpy, six, wheel, pytest, mock
+, cudatoolkit, cudnn, nccl
+}:
+
+buildPythonPackage rec {
+  pname = "cupy";
+  version = "2.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0si0ri8azxvxh3lpm4l4g60jf4nwzibi53yldbdbzb1svlqq060r";
+  };
+
+  checkInputs = [
+    pytest
+    mock
+  ];
+
+  nativeBuildInputs = [
+    gcc5
+  ];
+
+  propagatedBuildInputs = [
+    cudatoolkit
+    cudnn
+    linuxPackages.nvidia_x11
+    nccl
+    fastrlock
+    numpy
+    six
+    wheel
+  ];
+
+  # In python3, test was failed...
+  doCheck = !isPy3k;
+
+  meta = with stdenv.lib; {
+    description = "A NumPy-compatible matrix library accelerated by CUDA";
+    homepage = https://cupy.chainer.org/;
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ hyphon81 ];
+  };
+}

--- a/pkgs/development/python-modules/fastrlock/default.nix
+++ b/pkgs/development/python-modules/fastrlock/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "fastrlock";
+  version = "0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "00mr9b15d539z89ng5nf89s2ryhk90xwx95jal77ma0wslixrk5d";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/scoder/fastrlock;
+    description = "A fast RLock implementation for CPython";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hyphon81 ];
+  };
+}

--- a/pkgs/development/python-modules/filelock/default.nix
+++ b/pkgs/development/python-modules/filelock/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "filelock";
+  version = "2.0.13";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1n67dw7np5gsy5whynyk8c46pjlr353d6j9735p5gryaszkpjl6h";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/benediktschmitt/py-filelock;
+    description = "A platform independent file lock for Python";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ hyphon81 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3545,6 +3545,10 @@ with pkgs;
 
   nbd = callPackage ../tools/networking/nbd { };
 
+  nccl = callPackage ../development/libraries/science/math/nccl {
+    cudatoolkit = cudatoolkit8;
+  };
+
   ndjbdns = callPackage ../tools/networking/ndjbdns { };
 
   ndppd = callPackage ../applications/networking/ndppd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1467,6 +1467,9 @@ in {
       substituteInPlace setup.py --replace "argparse" ""
     '';
 
+  chainer = callPackage ../development/python-modules/chainer {
+    cudaSupport = pkgs.config.cudaSupport or false;
+  };
 
   channels = callPackage ../development/python-modules/channels {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8268,6 +8268,8 @@ in {
     };
   };
 
+  filelock = callPackage ../development/python-modules/filelock {};
+
   fiona = callPackage ../development/python-modules/fiona { gdal = pkgs.gdal; };
 
   flake8 = callPackage ../development/python-modules/flake8 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8148,6 +8148,8 @@ in {
 
   fastimport = callPackage ../development/python-modules/fastimport { };
 
+  fastrlock = callPackage ../development/python-modules/fastrlock {};
+
   feedgen = callPackage ../development/python-modules/feedgen { };
 
   feedgenerator = callPackage ../development/python-modules/feedgenerator {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1567,6 +1567,12 @@ in {
 
   cufflinks = callPackage ../development/python-modules/cufflinks { };
 
+  cupy = callPackage ../development/python-modules/cupy {
+    cudatoolkit = pkgs.cudatoolkit8;
+    cudnn = pkgs.cudnn6_cudatoolkit8;
+    nccl = pkgs.nccl;
+  };
+
   cx_Freeze = callPackage ../development/python-modules/cx_freeze {};
 
   cvxopt = buildPythonPackage rec {


### PR DESCRIPTION
cupy: init at 2.2.0

nccl: init at 1.3.4

filelock: init at 2.0.13

fastrlock: init at 0.3

###### Motivation for this change
Adding the chainer and related packages.
The chainer is a python framework for writing neural networks codes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

