### PR TITLE
ocamlPackages.notty: 0.1.1a -> 0.2.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -3,20 +3,20 @@
 assert stdenv.lib.versionAtLeast ocamlPackages.ocaml.version "4.02.2";
 
 stdenv.mkDerivation rec {
-  version = "2017-08-17";
+  version = "2017-12-24";
   name = "jackline-${version}";
 
   src = fetchFromGitHub {
     owner  = "hannesm";
     repo   = "jackline";
-    rev    = "26688f07c3edc3b83e7aa0b9136cd1e9dcb58ed5";
-    sha256 = "0yspgjhp7zy9rzvwl4pxppf5wkpa07y0122s7n09kvr0fzsh6aqf";
+    rev    = "8678e8a1a06e641218a31ae25150040202f89289";
+    sha256 = "05z9kvd7gwr59ic7hnmbayhwyyqd41xxz01cvdlcgplk3z7zlwg5";
   };
 
   buildInputs = with ocamlPackages; [
                   ocaml ocamlbuild findlib topkg ppx_sexp_conv
                   erm_xmpp_0_3 tls nocrypto x509 ocaml_lwt otr astring
-                  ptime notty sexplib_p4 hex uutf
+                  ptime notty sexplib hex uutf
                 ];
 
   buildPhase = "${ocamlPackages.topkg.run} build --pinned true";

--- a/pkgs/development/ocaml-modules/notty/default.nix
+++ b/pkgs/development/ocaml-modules/notty/default.nix
@@ -1,30 +1,27 @@
-{ stdenv, buildOcaml, fetchpatch, fetchFromGitHub, findlib, topkg, ocb-stubblr
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, ocb-stubblr
 , result, uucp, uuseg, uutf
 , lwt     ? null }:
 
 with stdenv.lib;
 
+if !versionAtLeast ocaml.version "4.03"
+then throw "notty is not available for OCaml ${ocaml.version}"
+else
+
 let withLwt = lwt != null; in
 
-buildOcaml rec {
-  version = "0.1.1a";
-  name = "notty";
+stdenv.mkDerivation rec {
+  version = "0.2.1";
+  name = "ocaml${ocaml.version}-notty-${version}";
 
-  minimumSupportedOcamlVersion = "4.02";
-
-  src = fetchFromGitHub {
-    owner  = "pqwy";
-    repo   = "notty";
-    rev    = "53f5946653490fce980dc5d8cadf8b122cff4f19";
-    sha256 = "0qmwb1hrp04py2i5spy0yd6c5jqxyss3wzvlkgxyl9r07kvsx6xf";
+  src = fetchurl {
+    url = "https://github.com/pqwy/notty/releases/download/v${version}/notty-${version}.tbz";
+    sha256 = "0wdfmgx1mz77s7m451vy8r9i4iqwn7s7b39kpbpckf3w9417riq0";
   };
 
-  patches = [ (fetchpatch {
-    url = https://github.com/dbuenzli/notty/commit/b0e12930acc26d030a74d6d63d622ae220b12c92.patch;
-    sha256 = "0pklplbnjbsjriqj73pc8fsadg404px534w7zknz2617zb44m6x6";
-  })];
+  unpackCmd = "tar -xjf $curSrc";
 
-  buildInputs = [ findlib topkg ocb-stubblr ];
+  buildInputs = [ ocaml findlib ocamlbuild topkg ocb-stubblr ];
   propagatedBuildInputs = [ result uucp uuseg uutf ] ++
                           optional withLwt lwt;
 
@@ -34,7 +31,8 @@ buildOcaml rec {
   inherit (topkg) installPhase;
 
   meta = {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/pqwy/notty";
+    inherit (ocaml.meta) platforms;
     description = "Declarative terminal graphics for OCaml";
     license = licenses.isc;
     maintainers = with maintainers; [ sternenseemann ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15341,9 +15341,7 @@ with pkgs;
   hyper = callPackage ../applications/misc/hyper { inherit (gnome2) GConf; };
   hyperterm = self.hyper;
 
-  jackline = callPackage ../applications/networking/instant-messengers/jackline {
-    ocamlPackages = ocaml-ng.ocamlPackages_4_02;
-  };
+  jackline = callPackage ../applications/networking/instant-messengers/jackline { };
 
   slack = callPackage ../applications/networking/instant-messengers/slack { };
 


### PR DESCRIPTION
Also updates jackline.

###### Motivation for this change

Support for OCaml 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

