### PR TITLE
ghc: wire up new binary ghc for bootstrapping

### DIFF
--- a/pkgs/development/compilers/ghc/7.10.3-binary.nix
+++ b/pkgs/development/compilers/ghc/7.10.3-binary.nix
@@ -1,7 +1,6 @@
 { stdenv
 , fetchurl, perl
 , ncurses5, gmp, libiconv
-, enableIntegerSimple ? false
 , gcc
 }:
 

--- a/pkgs/development/compilers/ghc/7.8.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.8.4-binary.nix
@@ -1,7 +1,6 @@
 { stdenv
 , fetchurl, perl
 , ncurses5, gmp, libiconv
-, enableIntegerSimple ? false
 }:
 
 let

--- a/pkgs/development/compilers/ghc/8.2.1-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.1-binary.nix
@@ -1,7 +1,6 @@
 { stdenv
 , fetchurl, perl, gcc
 , ncurses5, gmp, libiconv
-, enableIntegerSimple ? false
 }:
 
 let

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -6,6 +6,9 @@ let
     "ghc6102Binary"
     "ghc704Binary"
     "ghc742Binary"
+    "ghc784Binary"
+    "ghc7103Binary"
+    "ghc821Binary"
     "ghc6104"
     "ghc6123"
     "ghc704"
@@ -63,41 +66,41 @@ in rec {
       ghc = compiler.ghc742Binary;
     };
     ghc7103 = callPackage ../development/compilers/ghc/7.10.3.nix rec {
-      bootPkgs = packages.ghc784;
+      bootPkgs = packages.ghc7103Binary;
       inherit (bootPkgs) hscolour;
     };
     ghc802 = callPackage ../development/compilers/ghc/8.0.2.nix rec {
-      bootPkgs = packages.ghc7103;
+      bootPkgs = packages.ghc7103Binary;
       inherit (bootPkgs) hscolour;
       sphinx = pkgs.python27Packages.sphinx;
     };
     ghc822 = callPackage ../development/compilers/ghc/8.2.2.nix rec {
-      bootPkgs = packages.ghc802;
+      bootPkgs = packages.ghc7103Binary;
       inherit (bootPkgs) hscolour alex happy;
       inherit buildPlatform targetPlatform;
       sphinx = pkgs.python3Packages.sphinx;
       selfPkgs = packages.ghc822;
     };
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix rec {
-      bootPkgs = packages.ghc822;
+      bootPkgs = packages.ghc821Binary;
       inherit (bootPkgs) alex happy;
       inherit buildPlatform targetPlatform;
       selfPkgs = packages.ghcHEAD;
     };
     ghcjs = packages.ghc7103.callPackage ../development/compilers/ghcjs {
-      bootPkgs = packages.ghc7103;
+      bootPkgs = packages.ghc821Binary;
     };
     ghcjsHEAD = packages.ghc802.callPackage ../development/compilers/ghcjs/head.nix {
-      bootPkgs = packages.ghc802;
+      bootPkgs = packages.ghc821Binary;
     };
     ghcHaLVM240 = callPackage ../development/compilers/halvm/2.4.0.nix rec {
-      bootPkgs = packages.ghc802;
+      bootPkgs = packages.ghc7103Binary;
       inherit (bootPkgs) hscolour alex happy;
     };
 
     uhc = callPackage ../development/compilers/uhc/default.nix ({
       stdenv = pkgs.clangStdenv;
-      inherit (pkgs.haskellPackages) ghcWithPackages;
+      inherit (packages.ghc7103Binary) ghcWithPackages;
     });
 
     # The integer-simple attribute set contains all the GHC compilers
@@ -124,12 +127,20 @@ in rec {
       ghc = compiler.ghc7103;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-7.10.x.nix { };
     };
+    ghc7103Binary = callPackage ../development/haskell-modules {
+      ghc = compiler.ghc7103Binary;
+      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-7.10.x.nix { };
+    };
     ghc802 = callPackage ../development/haskell-modules {
       ghc = compiler.ghc802;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.0.x.nix { };
     };
     ghc822 = callPackage ../development/haskell-modules {
       ghc = compiler.ghc822;
+      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.2.x.nix { };
+    };
+    ghc821Binary = callPackage ../development/haskell-modules {
+      ghc = compiler.ghc821Binary;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.2.x.nix { };
     };
     ghcHEAD = callPackage ../development/haskell-modules {


### PR DESCRIPTION
This change brings development feedback loop improvement
from a couple of ghc rebuilds to only one for working on generic
builder.

To completely eliminate the rebuilds, use two nixpkgs clones
and point boot packages to the unmodified one.

Fixes https://github.com/NixOS/nixpkgs/issues/19926

Tested only on linux, I've found no regressions.