### PR TITLE
 firefox: 57.0.2 -> 57.0.3, firefox-esr: 52.5.2esr -> 52.5.3esr 

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,955 +1,955 @@
 {
-  version = "57.0.2";
+  version = "57.0.3";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/ach/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/ach/firefox-57.0.3.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "cdbdf196dcfbf94762d8cc0c4db9e774df785c980c31d196a59c9bb0d5144811bf01cf01c755f2bc36ecbc3f2e17bc6d2e89a177ec5b67a2ad7d7b96c5958bcf";
+      sha512 = "7e783e4ecefefcc03eda1eea18216b95aa0473f6f911320c08c478dc68543f9ae1ddde67a6f5f4e6147633b72b416ef04f91c390b66c24eb7369b258721ea9ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/af/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/af/firefox-57.0.3.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "98185dccf6261423ca09725f1c04fe65cf147d0b396dad5817d7114408982671f349290a45d448eb4a5cf1e2330f09fce4a2176e7b79f0696c853efd91de6695";
+      sha512 = "615abeb7d8e4b3e9c40e1a97bb6b9e9a44e8d7d1430be3bda06fe89eedc67f8b01fdb6c7284a27b1a23ca9b367990b2e952e086b0cbd8f07a0f9c9b03e7b64e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/an/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/an/firefox-57.0.3.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "a6a76ed69f5e5a05bc17050f49a1ea445d48c5fd879372189d5c4e6d678e9b0853665492e7ca5caae8cd37f5f3912d768b2a51e5d23caa65852a470404ae9205";
+      sha512 = "12576dd70c416c33c464c43001f9a2e8896ffc41afe1b012178e6b5bea399ba4ed6812dae6a3f95c775a4e2989e21c8929de130c0c4fb80afc59b91e4bafae2b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/ar/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/ar/firefox-57.0.3.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "526046d6931a0b2eb562c8f9996151af027ab715460d27d0106ef8a16cdd8e4fb04531a7dcd57c2fe4ac2883156ae8b9e5fb622adec326cb0490e65864bddd00";
+      sha512 = "b33f949093ba7ceb852ade0ef5f771fbeb9e225f66df152ee7079b56737a85bfb7e8bec1cc47e4b76a089e357878a37b6e94f82aac691d139410556c6496d528";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/as/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/as/firefox-57.0.3.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "2c7b5bda872ba60afdd06374a59c7c44790b7fe35777eaf6e8808af153da462f58ca2d18d587df81e76eb11aefdd808e7913d16ad0429aa9a0660774ba3f3600";
+      sha512 = "a73bf7a1a35b83bcf28d0dabe1597b0c6f1c6a617e5193bd9177841b93ba02399fab6baad83268825c1dc753572e8eb2e3147afbba17a338bdce68742f80ae30";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/ast/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/ast/firefox-57.0.3.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "5946fefe494c0883f602f5f6c6c4686215583b8c5824504c7296f80294a18e7954b86c99b613f494e2981de0af3f59faf24f0abab85e7ab46f4fc7b5730e27e1";
+      sha512 = "8671c892f024bb16ebec39aada71975f511642e6d38d22998b5224735e2030dca4b2b2507fb0426825f4ec238d3ce5d33770802fdd22c8ed383feb341b549694";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/az/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/az/firefox-57.0.3.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "b6402986ccc5d19ec65ab77da4d1a7a4d97b109e344066911f3ae36580b42a7051e0dde10bc957676d6d7f46a9803803191f981d4fe219f1772767320d79784c";
+      sha512 = "8e6ec01b879abd9d6af2e39cca088b3c325242a214d64f27ac01320174316974b9900678c896f0c9a42ecf85692f998064d59a1db69ae9642663b5313d2a6ac8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/be/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/be/firefox-57.0.3.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "8c71ea8ec89ffff3150205d7f09823ec6fcd6f4787495da35a5b21e4b63651c50c715d5861f0e49e1ec0439046fc4e96bc9e8195820230894a2b27fb03bd1c22";
+      sha512 = "33e097eb0c3750fdb85e19b30d6b760b693957b674c56cbb9130ce24786af23509e34d447a686a98f725ec326a0705cdd1403d19ed0579c5cec3b9b1e0d55cf7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/bg/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/bg/firefox-57.0.3.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "48e544ced24598031e4c66b6f5640ec0450e327b8a32dd8f3a2a2124f232152482eb204bff8dc65928a0f67ebeb98fd12197d6bf3383e6ae43142eea6e077050";
+      sha512 = "33f6750887c2f86a10ac0d47f13addfe5a0de9b911fd06c7c7115f6e9dc94fb95c8cd6ad1ad11de9443d734f927a70d56bd35911076ee47f9afb9dc3fd94e612";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/bn-BD/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/bn-BD/firefox-57.0.3.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "ed2a97d3438c9e27390617c57adbb0ecf5ca8a60139a79773e71e104d3eb71a429d448d15e8e736fe326ba66330d0e46156026ad1870f775ad00917d68f28c4e";
+      sha512 = "03a1662fe4aebbba790fcc859df9436e1d2eb2c5c8d2927119f7e1f629ce48aa355897f1fdd0cec74c00a0fcb9c9339b96aad1f71ab6e15d18f09a196b834141";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/bn-IN/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/bn-IN/firefox-57.0.3.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "e90ec533d16cf1fe569d0e3c00646984f77dd769bf4e482a9e5cc5e70c9b67aa5fd6fa74921a32d0124f6a2ce8d4fc6c504bc0ab64844dd66fd46f7adce8ac2f";
+      sha512 = "0014a45b28c117549bb6d5ec77a4a7656fcac5924e30f2b2c5f28a583f3e4e68f8e81d622418c4586446b103f878862f75d8877fbadc58689ae4de036ab51db9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/br/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/br/firefox-57.0.3.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "9feac6509d6b45c9b330d90f35719f9bc657b11faf8899d4a8aee59fe2db5cf69fff6870c0465d319d2b85d1b21a2fe02c651b0bb4536054021e5e5257ed44ad";
+      sha512 = "0078d101f4a6dfefd9a3a1a35ac733aad43e3b6574e3a4cb1b0ee9b04ab2363f0c0fff52f019eb38a85c9e0dfb930900ee1e5264dd92e0aa40c58de0c6dbc692";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/bs/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/bs/firefox-57.0.3.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "f22df0d0d97c02c3e507ce75d6b005ebd293a9747441731f418a870262a51c7e24a500edaf898ae9ac1752eb3b44127f5718845dcacfc8c63443262a03316c0a";
+      sha512 = "4475c7cb7da700da33ff41708eef052ba634e8a1286444688ff61d721d55f98387038bf2c815b2c9c5e0fd5feea5f7e47c04a91447a9cf99532430af28e7d748";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/ca/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/ca/firefox-57.0.3.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "d77b2e2f02b659f57aff3142f266d304492ebc2d4a0f97f6ad826e2753c7915519581206626e21cad0d65db185ab4c92e05c7e1aaa0c05904b96e1aa09c42ddb";
+      sha512 = "47d5e1feb1188bac57b36829fa458ac47eb4bee1c9bfd24b412f36bd3a8d7d12c755ebefba6f61cde1144e3586c99391ba8734e69ccd99c5f404ad5065e77a70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/cak/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/cak/firefox-57.0.3.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "0275f0bb7d846aa0346255dfee76af8d4c23ef06631974b7667041b9e1be736b256bc73c82ce445a63b1c3c80d2afd46057a17d25e60dd979625d756be9c75c9";
+      sha512 = "8e8bd52dc36d3df42e7ef6ba604c0401b7ab7f45d54803c16f1ceae89b2f1dcb08644a462d660ff53c6288319c19e34b261f0a06f0b0354daed7e7dcb617c3c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/cs/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/cs/firefox-57.0.3.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "2ec61ffdead584bf93436a0499fbab2284be9aacc8a3b61d1b237a78f1b2322e92ffe2816eb601bf58cff49af10bccd51a28eaaf18d076baab5f1821b5e20bbe";
+      sha512 = "78d3e4b2cb1f07a401c00e9e54ea65e33c7c4b74a8f3e71c0342cbd4933043d82c372600084455fa253d3cc6befa6f046740b1e47aa639577954db52cf86a319";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/cy/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/cy/firefox-57.0.3.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "a6a8963cf9e92f5078753890e9c7438d1e50e9fb4ed32c6910f7b01c45e8c31cc395212e45557fbfd963682dd6da1252f91cbb7efc73ee0209096869c9cfea19";
+      sha512 = "cf89564ad1c1d8d346fd655cb27c219689fae63040ec2775d0a588551884fe75ebb80cb842840b7cb16d1d9b20d215f44e5e0f9287169d0b2a376586e33e31f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/da/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/da/firefox-57.0.3.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "022c6a8c7827c6316d50cd0f33e1a9fcfcbcf9e25d799e64649dcb81b191e0edfcc37447b2417eef5720dbea513abc1a539bb77813e17d7245c4c8a0b21f4540";
+      sha512 = "f403324556a40d82b9fb52ab25e4ef92c6e65d44a5cbb6a3fbf581a4f0d189b716af031857137e665b8bd7c7c500a1403746a8c973c282776dad09df80fc5839";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/de/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/de/firefox-57.0.3.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "1190182a39de202345b30d9014a4a3981ee7255802ea8ce4e72f00e3f3be54f6ab5500d7e425c3ff34934451f8eb2ce2a62a33949b02b2146dbb1026f7711fe0";
+      sha512 = "07cd39dd4fdd91ae6fc445727f35c42adaacc8a71c81e8d2f565f22b4d26d4e9d4108487626c28e982e551cbc65dc3eb3830cdef6163ee9a029d1592ee095910";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/dsb/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/dsb/firefox-57.0.3.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "34f73baf07ba592788a06b143704f53952e005cf8ce41dc7d22ea15cfd2ce7187eb67a8c63cc53370fa79f67c41fccffbde3553bbe8b9e23b73524b0c01f3d39";
+      sha512 = "07c8eac5714b7fbd5442e994168fd95f18260b6aaf74e97c664f750be699f2bbb61eb34d591788db45841f1df17c1f977d668acfb40004d2cc4716a705a4218c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/el/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/el/firefox-57.0.3.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "e1480e1a9c98788c52db06f87085abe233ec4e05c53bb17d77dad1810f32fd8d74e07d370e555e04b280c4b620e9bc032adbc80b037d7a0b0f8b5ad2396ac170";
+      sha512 = "02add1f0db002936b8ae153dbfb04392fda5a8948d2008e86acebcabeba4734a36f8e3983c1c218fb87c26d0673e305bce031bf5b91fd8ce1448ce9119aed117";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/en-GB/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/en-GB/firefox-57.0.3.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "95e7a8d50d4f4711dacccaea3f50e701f0ca36c8af66c40dfffc6f4b6d02b42b26d0b4015461ea730575cee9a2228fc7769543ff1b8137c7bf833ad85454d831";
+      sha512 = "799dda485a170ee5f4767385a2c7773fd6d8584d5d15058a18969ab81b11f6e06da0e12351c0cda80124ae683a8b82ff28c0bb052e6577ded1756b3ba29518dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/en-US/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/en-US/firefox-57.0.3.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "b696fe306e84927407f0c216fb8672beb33c7bf000abf6e390df52f8eeae9373d2764c6ec9678302f57fae34f7fdfb986577823528a48ee2972e13c8970382ca";
+      sha512 = "9b9a795664c7d2aef7539b7ea6093af55883e4ab055b1cb5cfaae01cf8f87b6c295e9ad69903b67225ec750ca594f3eba836a502928470f86d277706bf1b58aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/en-ZA/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/en-ZA/firefox-57.0.3.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "f4c1ab045d17d529e9331e2723a7e006ae1b1381fcb1c52c5a6a48f1d95cdf3d19363faba82c6fa5a27cd776b83e34721c107c4e008c0e607d4265fc8f5d1275";
+      sha512 = "82a1c617ffb51ce228f34d277ff466e1c37b8263c7b3817484c4513fcb7511e442eb449e3e53bcfd4c92eef94d19f0d810411d23831b6b28a3f12eeddea2547e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/eo/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/eo/firefox-57.0.3.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "c5aa2220b72efc9d176fe86c213656be129a1fe7b21927b085a468544eb6aef91ef6fd91adb4eedd474aa55743dfa47932ff8bd3c695d8232326cce5c33ac564";
+      sha512 = "aeecd1a2169a8f1c61db4681363f95a523602be751288854f2469627fd603a9990c78123ca43d5a66bd2df92a08d7a09c13cf24f14f7afa63f8de928a9e304c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/es-AR/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/es-AR/firefox-57.0.3.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "9131379168adb3c18bee9a2f98df521c211b84d05a9209303026efb0b9992c462f6cc0c1689c941732123581ebbc5f63bc644dd44eaea2d86ecbf7812e569699";
+      sha512 = "539eb57257d82ce3d8bf3254560118da7d81a3cbbb877bd5db3ed10b7cf672a2d7fdf479f175f2b78f79003dfc2d9818d1034b063643c1307294e6da5dd3063c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/es-CL/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/es-CL/firefox-57.0.3.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "65b994ee4ca70d3b92e513517a44dfe50e130bfde860720e7da295f083617ba1602b3d2926a3f12cb21b1fc74ff063f17d671b8085bcc45254fccea034c82b7f";
+      sha512 = "676b2199127683831f6112ff6847c4a46bb9aeee225cd08673a2d7d8a8a8b62a7aaed22d406653cb839500b0da7d26ebb22dcb4e3c00395eb462732f686a9477";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/es-ES/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/es-ES/firefox-57.0.3.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "0ebf79bee68243642d2f6fa0280cecb01ee23727ffcb49c86beef59dd3099eda475f24da59c1f74a9ac0473ec8e4dab195a10e97a7bee0ae06e7e4ee7b682f05";
+      sha512 = "e76ca567c4f82f91bec00fc1d66b6aeaa0f91a62ed88d39337eb9017707c13099d0e98b7e2177c729f1af47a42273fa01128f7360fa5097c5bb4369abd84f7c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/es-MX/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/es-MX/firefox-57.0.3.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "70231a639d7fa5307f6354a744beae51bbe0181199c4b626151ddd071b43f6a6884113a267ea527491fd7baf0f2fd4c0c21c299494cf1e0f3cc771a04c3c2f0a";
+      sha512 = "07f481896b44b119b311c5c717bfb5567219bd78d3990c2dc7ea76dcc7a1d907f78907971dac71acc6b8efba519efbdd73951975ce953bb939196a433f103a83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/et/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/et/firefox-57.0.3.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "03ea6fbfe517f8d69ac66c4897635b3ff00d9d9c8a4ca2669343f9b410c58039a35de05fc223320c2b2e60ee4701928dcc2aff194ec640d3b78f1dbb91dffefb";
+      sha512 = "38d0c69e6a8f86a4f7717fc73d4bf08bdcef0e7f7283da4712ef325f80f440d8e906877ca304d8ec92e11df14b42a9c0b70f33437d7b76634c892a860eedb942";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/eu/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/eu/firefox-57.0.3.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "31c996da3408f227a3e1e02f680eeef3f977fb9b74d763ec4aadfbe1381db374efd88a564b20adeff6185420b6a36df894b0ff177ed63221056e3c87a8600add";
+      sha512 = "6ef281592e2ba0cb4d83956048535f070e18cc72f69b5e425ecb9172abe67055cdb81b182733f23cfc41e0e69d61c162c974a3ce221766b6f6ea1a3c7dae5864";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/fa/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/fa/firefox-57.0.3.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "525d764c216651bca83f21c180963f0f3b2d0437d20f6a580099df81c465fde790361148ad943d6df84c1f7fd01b643d3ac192844bfe59a84cd3812dcf06bb5c";
+      sha512 = "12353ec2052be27681828ed57ed3d40aee84ee6c370901b70ae8a391b06f7ce8ae771a90ab7cb7f6c3d190326548eba5488d9e7eab2e68de8eae481bddf71e33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/ff/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/ff/firefox-57.0.3.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "2a2cdee1e8d6f05f89e105c4415c873ab374984ca02d7dcc7b0b67a839538a2c9878993d9bdc78f1f1a8932e70418789e264d69ddddecf60b1c0487fc942dd52";
+      sha512 = "0d425d4220eb45cfee960cee97ac6abc985c19d774283cb6eeb4cc51f4f26c781e1037f9360d85366a4cab85752e32feb1e37f40eaff896f3a0a8bab43a6fbaf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/fi/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/fi/firefox-57.0.3.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "2d92ced89557270a84c787300d1a48e93c44b337b08b859c097daf0edb190c801316a9aa70b9e9b74b27f032c9dc935698956916c434f95412af126f7f927e73";
+      sha512 = "8e4e256390c026f6dc151ae39026b9dc232cc00a27b5ae62176add02404941e38801f9ab71a63a715a9257281bee2eade5d677e73e8a79786f3b4a37ca5ef685";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/fr/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/fr/firefox-57.0.3.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "2f81777d6d45d2ef51b3356fe30734015d016539bc149fcfc773e0c2cacd4b06be9d1c62cc603d2614857ec8af1dd33e9e30e1e5a5536a8cba5411d8ea274e48";
+      sha512 = "b0acb5c1729163c5fc28dd38da1cc99899bdfd861b79a1c886e09bc5cbbe677822196343800e62ea8ba3b02f9819e85af13c362d772d4bf301f93b122c21ec11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/fy-NL/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/fy-NL/firefox-57.0.3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "7d3debe9c5e18db87cccbfd50e5ba2aae7aecf577cedf32c95b7f70d4ca5f1946e8e67b2a69d4f0cd6d780f91f91f4b902a6f33a2a2d01198407f9a0ce1a3c11";
+      sha512 = "ee936cd1431432767b51a628867f92f3ef0565f69e305856c55fa66ea00e5c930fb479e6032b64ecd60299e56b6d43f1b198fdf99db645505f76c7901ef719b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/ga-IE/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/ga-IE/firefox-57.0.3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "c57bf7127462e64a2a6beb7dab0889c2b84e337017faf3f38e7bbfa1a893ea0df9a1d2dc2070d0c0fed8961cc9d657203dba00fdf1cb7bd67f40207c5c98ed55";
+      sha512 = "f5c41fab676f6007d218141ede1fc6f86d46998dd4b4c6be25061a19277bfd6cbd5ff2ba44b312360224cc12a1f56d4558edaec95cca198a877a45090b0432c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/gd/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/gd/firefox-57.0.3.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "c4d88329d4f80c389fa8aeed33e7b25a4430484b3ef3e76076dd42f87cb57a61608d8a1aa770f4b108d14ab2017f0c2d1944838b747798e75c9a51a95ffcd6b2";
+      sha512 = "bf0bddd8a9849c6f406d1009317c9e93d82868e9d2a621524f2bf40e6f6b6586c368515f18e331c9a871a78339cdeca90686adb7ffb4edabb9e78951d91e2008";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/gl/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/gl/firefox-57.0.3.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "0961cf5df1a7459c2629b59f0b68dc9a8a0b6487a82826f0e29d22ce7054740625f30561379df8a347f917b54e67c09b7266b5d4408dfca176268900630e2e74";
+      sha512 = "e50d6b80f7833b2e417bd6429b83b07e34c951a55eb8eb5df3a254976fff1e23c5dc3567263ee0a0830c65c9452830e488ebeda9e604e3eb099e09141596201c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/gn/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/gn/firefox-57.0.3.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "4c2a93d7fef39a8af3dd882b595ac9e89f7617857953ba405fb492777051f087d14fd0f5080ce39a8c4be039d4159c3c6c4f119395dbd9d12157d4e67f01432e";
+      sha512 = "00abd6b13e6bc65b4c69b0ba4ae7538c9a6e8a4e8545153ece51029504aab8ef77f3eec09272d3ea6c51da1e8e8c3a77589889ecedaa6cba57c4191e2b8acd35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/gu-IN/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/gu-IN/firefox-57.0.3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "10521b904aae0ac32ee4b5a6a8a7ae3f3208550421d16965a60fa32da8ab0c74853200d2f8a1625c0cd36dcb0694390ddd4270698afccb2c79731a6a9a86f772";
+      sha512 = "5ea5297d8f7f1b6a78314579b4f11dcc792172f47773ca448e0818254b150d3c384ae2cda62b12d4388b2b19f352a526520636afdc44ebbf9d3fbf1ca79c07a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/he/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/he/firefox-57.0.3.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "b77916118d994883dcfdeb2e505992064f379dd9ef1e1d2143bb670d825a6ac3b90eba41503acd1ff8366e5a29b3111e52c1fdc35d16456f2b8f40d12ecbbda5";
+      sha512 = "2a4300e271285f926657cc02c80f35d9e3f8c2c09efe6fff5976dfeedc4877219a4c7e3d45ddf77987ac24024df1a89a4b49fe85b2cf250c4ba1c980be5254e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/hi-IN/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/hi-IN/firefox-57.0.3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "955b9c76fe94415550d135ead50c2533f2aa3079785f9fa05e6af96f7ca43d5c7c2867bda8943ed30dda83a6db6a1813f1d0d3d3d88262cd92a842379eb4188c";
+      sha512 = "23213f41de69b819bb96b975f7698cd9ab662d9b8f6b77d69a127f70426873f28ae298836bffebe289a7eb6dc0493f5ad50bcfa364c76edcd10727a82cdc60e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/hr/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/hr/firefox-57.0.3.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "4b1ae414990d759dc04c17b7095bf13240f8a3ff7fc86eabe251776247093b8b610ffb0432f54167758c9dc6a1a21b6340ee10de6298cc7c36b15657a424da42";
+      sha512 = "b229241f8c3965baaabefae35c92b1faaee95aef4105b11a6af46e92f0999f37a6e61339c9ecabb3c1ee97c0582db5783d1f92d867a7298fda6476824c0b1bd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/hsb/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/hsb/firefox-57.0.3.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "00e416c7341489218a0e6630ce049eb45c71916469ccd91e3570842452a3823f9fb38d811820f06e266756cb79420682b71bf7d0f7f87b232fb2a1e1d70107bb";
+      sha512 = "b463568cef3931a3a290c37aaaaf91cf65d0dd1dcee8695054ada4bba0cd91e4fd0e88f797302a67f9610639504ea8f2f428b512258d49cdd6f8be564aa79c03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/hu/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/hu/firefox-57.0.3.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "fbb7032669dab46160f1d423d51f7ecf3fec3ee02e492c6b95d4cd298e25713bd57d0efbc2524cb6d0b2da6d14fe88c261e9597170d1ad34ea464ef55654542a";
+      sha512 = "21da18ed2c20bcf93aa1fac251762bffac5555562015116c38d2b3711c9ac4e16a3c3ea8ae5a882e1a9f8a72a6479215e65163516149037b8b1e7256ba0b3e70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/hy-AM/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/hy-AM/firefox-57.0.3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "9c9cc52f5ca0cf79f65336d7db2ba29b8a675a3e005b24851f231566829a017350cf461a6b184bda21ab8a531c57a7fade7cd6a65de440cdc056b8d9b06b0024";
+      sha512 = "babcdb2439d6de5c1ed85f8d5ede8c3bcff9a6dd448589d822c510aad350da580e26f37ab46891260244087c51ade46517a54fed76805a336d2b8e22d468dae1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/id/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/id/firefox-57.0.3.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "95a9089a75f4ff07c99710fbf65452d32ac150c29d8400c2b94a6c064985c2394e4cfc625b53724c7c21f43f441a9cd39f84ab4c23803479077a2021852a619a";
+      sha512 = "a2f68ca0a667f8c9d2777dbdbe6ef927fe296991daeda11ebfd50c84ae9343728e707b71265cbd0cd93506b2322cc09c7ab541bee15b918a292964061471592d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/is/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/is/firefox-57.0.3.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "2eac5967c82531aa761ee23044b65b82384a0fcc956216faa2313cac5c10f6a28925f4604b022bf67237451438a0c8d2369b54a1c40799602f2fae607a6a12b6";
+      sha512 = "316cb66e3101d297b771b211bd0e3a3c57abddafcb01f15e4a5821a45af0fcf8d70a97082815c43724c3954be63795747a4483011695ffef46713feb66d94e61";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/it/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/it/firefox-57.0.3.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "83695972d7aa487325891e62247772e553a1c29642fd2fd6697a4cfccc331005b1829141b92b43dff305761c2576eb755f8e9ac1e88062efa43a887d46e4625b";
+      sha512 = "8998f85ae38c92722c87ab47ce257dfde4f713d167dbdf79983b3c8d979f9e47f14c44e520a266e8e58d31d2eb50270f56d5d395014a7037426fecf3d683db28";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/ja/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/ja/firefox-57.0.3.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "4baa3fe584c2d002e83410bd0f7748c72cc737d9fc3850752d62ddc8e80eabeb472e4425d55d12891b4241dba389258935df23342183fa565dc4c6286acdc757";
+      sha512 = "cae82ff29c8f228f4f5d50914520b4f962b322793fad4637540c471b367a2fa8809c3097e23f52e33c412571acb398d59dbd8acd6b641ed3ef50952f460ea534";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/ka/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/ka/firefox-57.0.3.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "68db6af187d82cbecf9ab4f20017c6457b06a0ca743a281a7a254a3706b8f02b84a39a0639fe2bceb750730e991fbc4b4e2c220f946b4db92e0c04ef61df3cc5";
+      sha512 = "2e4534bbcfd879741ab0abfa5123ee112ff06cc9ea9fb5483d9f58f704b25db79b8acf1c09e2b9fa00584ee5331f964f07771951601f8f84e81ba507a320896a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/kab/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/kab/firefox-57.0.3.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "b51c02ea58dd6b50771dbec2cd07ee091a85688612653a52af4b66769b489604f9b092a9de184a447a7913d414cc6ac25baf6d6458ca7f7a121bf3c9b2892b00";
+      sha512 = "cd7d7d7627ea3a9bfb2c9f04f37cecc79c80bfc5054a10b1fca41077bd9ef79b25fe7601915c16f2b6b92cd7cfba104a58e586819da4a76055554665f5f2d425";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/kk/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/kk/firefox-57.0.3.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "c9fb3234acf8a49404c7474ae78e86c7e0ffa00f5a6bd92ab210b7d18a86c2c82db684a81efd583eec2ae0be6c8b2d52cef407d936c2a9522f2df8ffb9af8163";
+      sha512 = "19fb1b47c1512b7657a2b2e5381488cd3856518f41eb87429000be1a90e4463d30d2dd813e752d088ff366551a90a458dbb55e44f552dcfcdb37dec502755437";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/km/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/km/firefox-57.0.3.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "3620c323f7412aef138ee1c6638a35b98c3c654b394f10802325f709a736635553081a7dd70bf0b91d0fe79d825856cb2ca58f20a84ded32ea4f277fcd5714e7";
+      sha512 = "f104e24c2499832e4e5393973aa4b1b2a8757b18ba1861cf3e105994e5865e236c92ab1f1f66e94896daf65660a0d1fc11b126e64b5ed7ca8d47ff307f6e820c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/kn/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/kn/firefox-57.0.3.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "d12554f6668b12c0bf154ea7cb07f288f9f7592191c32e6ff927133b4aaedb526119558d7fa76fa09a37be1e8634d7c8e0d14786edbe55fc5e3d4205fde27d29";
+      sha512 = "66e159c7f6d8fccf316d9e06a9fbe43b9d37c54dac91a45605d5f43de943b1ad37c5a67fdab405d147346184d9360c90e7f2fbcabef2dc4152f384ee17a1e040";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/ko/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/ko/firefox-57.0.3.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "fc17302e3eefe61eb081563f01e316985decf5f311480fd1e61a4a78c0ace18667cca724cb627a86224c2829c5366352740b28ec496389d0be9bc7d1d7b92954";
+      sha512 = "f609ccc5b9ef40a1fb5190440acc7ae5bb040944c535a86ba4e218cdafa587cbd4e7f34b8cb27815698af33a5cd0c59c17f71e911735e41c03c66a7663ff8872";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/lij/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/lij/firefox-57.0.3.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "6c9ba11b4a4e9f6b4905b1c6c9eda4cc9484803ecfcbf0e0f7539aa29623cd05a7833a97f4e05b60d708d6d01e09632d9d49d85ba8cbbf5a71e3b4a0611921f0";
+      sha512 = "fdfdedddf2c05b6be1e1e36cb707ec1c0f93b1c989b540b025962bc09f777533b276c6cdce1ab60df68899f4b9c36da03bc2ab08cc8857f0dc5c8ec02da5ac14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/lt/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/lt/firefox-57.0.3.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "0deea3c74031524e9acc022d51640956f4befbf41315eacd958ed515dd26d9fe12ce5ee6f2e7c5020e1a5ba76059c302c035346c65f0f4af58418f0532a378ae";
+      sha512 = "7f7d3d627db0180c9aaf12795fcc52e1839c58545390cbc3bf656fc71a8eafaad158af833b74879cf37ee762e838369756c9b062697162fb3d03d2597847db94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/lv/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/lv/firefox-57.0.3.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "a782afe808892eb73929f951c9be730e7d8f6ddfdd12b36440d6f63a3826ca09b62d24a28bdc417c9dc80fa10adac8c63aa3e3e981353a844c8e6f9610edcc2a";
+      sha512 = "c996b2c766dcf866fc851ce8ff548ef5103af6fa6925c480fb91be5886abe5330f298bb8c5590918252b2fa0aad4f9666293e3f59ded03b17c6b0e0d7c374aeb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/mai/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/mai/firefox-57.0.3.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "955599681aa46826ff48a506ba60a00aae0005079d0f370e0a330375ef5392b677ce1d5a0f2638d593de3a37b99398b3b59875e0b1afa5e15d332b879d9cd387";
+      sha512 = "89bcc8b7b9fcb4318e0a5e80a9fdcc5aefe5ba42deb0d62bde813ee95ef5f32da1939e4816b7b92d47ad343e9ef89e7e73803394953df6cf9ca22b15af63ffc4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/mk/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/mk/firefox-57.0.3.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "f134dc4d37f5c959247acca393290f050239bd877821e3123539532a2f74eb99d1d7df1d7c4fb05959f0059ba1617b91316fa06ebcf4001318d8d937bbd2d7c3";
+      sha512 = "c89c0c7ba6ecc1bdd2a36de4536fa32c1fa098faea7aa3aa44ba7d533a773d41b7d38d7d6ea749298e20a36cc26b0fc55a49028f50b39472e6e624a0d664cb54";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/ml/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/ml/firefox-57.0.3.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "7ed4e45dee60b8fce59c4b6e05566964e0b9c05be8391e669fae3f21519136d9d8c55dcdd63806493eee7b9b621afd12a31c678265af08a00e807e74e2e6b33b";
+      sha512 = "a6fb93a79f54b58a2409f70a5ad08478a2b8f561876b29c07750ce84103186787fd842b5a850f91adb881dc9b1203ee5f1481af5bf891c09bc6f7026ed21dbd0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/mr/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/mr/firefox-57.0.3.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "8ea097c99b599e0afe9b45e4a0f897dbadea805663513be81ee31ff430fdec89f619ac360c17cb09f13c4f7c907d8fa685755f885beacbdf83944d265fbf7aed";
+      sha512 = "656ccbd9b8997e27a9cc35fc10d70b946e6e4a18c622c1b28fdbc16f07ba2f3b617a4b1e0513cb26a763f412deb1551754abb241cd3e186e3da3ecbf90d2f17f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/ms/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/ms/firefox-57.0.3.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "73d5c2ecdf6d76cc447ff99f975daccb1db44059b9fcbc50cd86dfd7b5360ce363fb5976f92a7b31dc5cfa37cde6d2a6c30fd1280e4920d224eab2c0a2f77b67";
+      sha512 = "ac06ccbfdd34fa1ef9f106d0127f0095d581bde5a07c3d85af08c9093c22919e1accb8d98b754392598d5a7c48d6d9b81222ffc228b7e93fe3bdfff1d8ab34de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/my/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/my/firefox-57.0.3.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "3a7f1e1234b3120dfdf3d450848f63ff1a745bd1e57581c9466869eddbb74baf5bd7fdb0284b8752c440b6abd5b0cd233523c6f93a2800b953eed6f0bb97a26d";
+      sha512 = "651c57dfb2b11cef2226d28d372c58755e0a99d992537ea3d32250a478cf81b3048dbb916708d20482ac29c8303d9cb7e3756849974ea46f7dd2dd36824dd9bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/nb-NO/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/nb-NO/firefox-57.0.3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "39942038719188bc85d61a5ce47a672ac54e75a8fc51e48185b284fc39a14ac77c6745c51abe85dc4f387b9cf3205f4e4915584914e56a75cc463c9dbe99e8e0";
+      sha512 = "ca1e488d2847bfb945e17d9bafad01d696b6dab2adb7e53c286c18041a3022a38f23b916a95f1645c8b8677964f0a0654a6c87c63f0fe8a3a120de595c862087";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/nl/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/nl/firefox-57.0.3.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "ce0ee056c6f34c15d81861605dd005f72a9a660a2d78565eec0499cee587c10e91e07ca06724139aea137ef4500b3c1a5bab5af3c9dc2d9cb41e5f15c6ed6b5e";
+      sha512 = "3b41a4bd3177f56cfcb7fec27f8671984e8375673cd48e97a1a0c3d00c8ff2c2a591521b6fea6f5b1ac82e3e68da94b69dc835bf21348584a8ca7c97f9fae5c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/nn-NO/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/nn-NO/firefox-57.0.3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "6cb72241f70b0fa57db9895ec251e4ef69e5008e0c7b368ea161936616cf61274bfe6ecd755dab871350d5f1bbf8cb64cb6bea1d6c8db944dad18b5fa128c34f";
+      sha512 = "87ee51682fd0de072f24da52700a69e168540b566cb8d4aeddf243f83178b743f4841ab00cccebb12cc329a9be5d964e2e95df273aa53035125b3102162c0d0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/or/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/or/firefox-57.0.3.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "f7b6be03b9974d7c444f1e7b74af78d61a136fc02455d28ca149bae5eb808f3f1ff4b9624517bdf8276986350712de436c16177b999c038e17630798dddec709";
+      sha512 = "421b7268ec03f0dfc64c85b7d4cf21b56809d32135261914824939a08783991329b3bcc11064df88bce4143cba7216c7bbb29ad552b9f6648007b63bc6275f6a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/pa-IN/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/pa-IN/firefox-57.0.3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "d6e8d2b801890b375336502a95af1f32462550c4590db6da208d05fae1c56545966004b7bce9e82f6a691b41fcc38ade0a5ab4842869658af256e1465a9e684e";
+      sha512 = "28a1e054f493f0d9bf39283b5f5001b6479442b3cc00904f197fb76810cff9835dc80e78136947471a8efe40ec29233653180c418c1d1d24625ca5d22c642930";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/pl/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/pl/firefox-57.0.3.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "f0422006ccc68b448f5f455607357cafc547515948d457e1bc82f6845c4709399195c84c9c7894b6a20fc9c78adf4a0234e46af7e404dac4de5a52d76b8c5d7b";
+      sha512 = "757d79018c843a9740f44a0c1b034a669af98782dff3ce31f2ea57a09d74912c55984334f7ffa5a94637726561627f09b3477fee8f0b48697df29c000cb4f13f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/pt-BR/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/pt-BR/firefox-57.0.3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "f6fd2a885c0236407a14f6fd67064a078706c87efc42a9bc0fd5087c0a50adcdbfcf57823fc5ce3d2d73709e08fa9e99e78a8a447957a8925a64dacfc4659529";
+      sha512 = "f145ebdb0a161b71c6c7515e39b54b3125c76625cee8a3e59b2a069ae3d5600b62eb4388d96a2527e40d453c05e3209066379639a49991e6345068504ff96807";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/pt-PT/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/pt-PT/firefox-57.0.3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "547fbf162b849432b52546450f00551849c4d1e5951680308f2395905e6d1615595436c079d10a4fe08d93a8444164c50a2adbaa4b23b6e2995d6928040752c8";
+      sha512 = "97a86780284eaf856ca69ccfee1a14f00ea9b92aad96f2172ddf6d3c26116287deb03971f7afa31b73def8257866586ad03d7d962fe1d22b0492f252e9c45a73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/rm/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/rm/firefox-57.0.3.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "708b40a8660e3ba358a6c52139ea3253e5c2833ec560a387fc07d9d113bf335d228f9f16d6f8fbdd1b0bcb2a9bc4a45acbe11295c0c90c8c6b9f522cdc2326ac";
+      sha512 = "f06a3fe73e45d9e226572a6987a978623fd0c77a3da81819f22bf9d4d754dee3c12326287e1a2d12e87261f582f57d55d4b72143bb72b42ce24c0c035659c702";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/ro/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/ro/firefox-57.0.3.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "71af24efe6b5892e5cbccd863379feb411b21a3b25717d79fef17b2e6828e124fd1c5833e8c60ae188fcf491029824747435361225318e776cc086e28678c3bf";
+      sha512 = "f3a3d226f2666e11bf1e5dcfdd952cbbb9b087409732f219764a88de95d88789dc78cfefa6ddfacaaa005a2bf9215c9b33362d617789d4bf803927e4981ccd40";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/ru/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/ru/firefox-57.0.3.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "a69baf2bde1866be4f0fa90de8eeb94a8484ee1011f625548109dfca7cf38104eedd8099741e96f3686aed5af58b9cbf256e14a0661c63efeab501f41ebb1507";
+      sha512 = "737d4f3d446a88dda0b2302ac775832d7127e3344b7a1392dbbb714619833f146b1696007cc079fab30f1c9227c0eeb0fc73d5d3ebad51543bd6bf7fa9b9bdab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/si/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/si/firefox-57.0.3.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "91f9a79a090fa93756fe2cc1866acb2505523684fa21ed7181c3f91a183497a6a20e2c0963e1f38267b1e80d2479707d21532ba6c1ac8393bb336007d671d45b";
+      sha512 = "d01009524ccb39bf9ef751d80de5d9c52d5abb4a5d7c8e69875debdd9c06b9d699132a7a9883c65175eff1c78ff22a2e5bec4890d6335b75bc5bcc7f9dcf38bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/sk/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/sk/firefox-57.0.3.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "c25d91d7700da70b9e8c683f23fd22775f95da96f3a06878f3b85771d95abd6f7929985d4c7911c62529706c9227969347230768f7155df33ac6a6877c3265a1";
+      sha512 = "6d51939fac75d1cbc9d9ad11409e5a9cc75ad430cbf68253a31b97a932d27e235a900993d83875359d2a0d7030f3cc4f6a91ed37d528157dac328c7ec1017a96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/sl/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/sl/firefox-57.0.3.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "6295d9a4803ec8cf9472582c9e916973ed3463791d62c226f4ac07e830c4f1c550065d82ad96e7f7430302d3eee93483e6417b8763ae3d93c0c456d69db0aac6";
+      sha512 = "f1661fe168d09cafaec34bc8d1367b97d5564eff3166e7a8212b2c2d9f9e52ab62f5f8148159f6446d91da3a20c8e1bbebea837cf518cd121fda529d86eb8561";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/son/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/son/firefox-57.0.3.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "faf8e5c6061dbeab02e525a75fe979ff7fd180f5a84510e4087fd841c8adb035288b7f84ee15e622dff709f3b2016d533599fc64c2b5ca2425b480fc75420646";
+      sha512 = "4ee61282564908f2d822a2ff34a0a086fbd954854080851e57690d39ec8479e4a809818141a78a89e705e565f868eff328f32ee687e0ffb1faa93c2aa67d716a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/sq/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/sq/firefox-57.0.3.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "dd8afb42a6bca64c56a81c72bb665b1fa5a0889b942b7b0c7762e47112f0341506d220f742d2396f04d7ee037e061e8ec8900978b87d9e3e9bd2245da1353268";
+      sha512 = "429969333bfff2cb9c43132f1221d373dda9391c7cc0b669f490ca0c75afc889113dee7e369c395f722ac072ce46b692d206ba5b37215a02f5d4ef2c79e1eb58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/sr/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/sr/firefox-57.0.3.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "4c5d5a6f02c78dbc95d922211bc451e37cf5345e87644d2bb709e025dd88d8d620b9ca3a4fc412e08eff635502d300be48e8c86130b4bd3246a44fd552a30b7e";
+      sha512 = "b5a97775f6d7c8c434fcf3c50f80f09dfcef3f327c6728d0eb74189ca53d853beb029de22fa02d0894de9cc660161516b525837b0ee3ba3e10f273ee60b69e87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/sv-SE/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/sv-SE/firefox-57.0.3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "a5ca9583c1f9c64b92b150fabca892c1345cdec1f33fb129cc084225919528df92c3124037545f4eee1ab0d5fdd8b6b0f0252108c1aa851ac6192379c18304f4";
+      sha512 = "20883637d383f87b9aa789b2d41de462990b5f4531a8cb205fc1350c0c2e7b473039ed176d3ba84d695f05ea8717eabee1d309481d210b1a01eb37943f3ee085";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/ta/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/ta/firefox-57.0.3.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "156d2d3cb255f7cd82a1db2c4aa08ab671162eb9bec2ccd9ab79dc968490c2e12d5466c214d847322d9f244b9c6adfc0f91347bf717bc41bbff89294629d93d7";
+      sha512 = "e5c084ac35f92d1bad2cd9a69d35904e313b5e36e9427d235c41ec98e1cfe05ff2a00b554b2fd0b202fba0f641b1437afad3c0cdedf12715ece2f6bae6cf2cee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/te/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/te/firefox-57.0.3.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "75fe5bba7d212514b26597d1ff573ad9e4941fa205a94b30a5d152d8dee892a8a88fa117aef1a886f9695590b8b0a370a0fd740cb12ebe6c90b568968c74009f";
+      sha512 = "38ce280f6b2f24edd6b5f8d8a4ce790b4462edc01f3189deb9a1b59ee65a4f2627ad040d94f79dea7f73d92c2f747adb4ee55f8946c41e104b3a2a2a3cf580e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/th/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/th/firefox-57.0.3.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "2f5bf7a4092a5a50f4540676e0f104da8e83043bc97bf4f2aba62bbccde882f7281cd18a2a60d9dd08ceb50a21e825ca316d09a1e6e67cba44c5de934b5f0292";
+      sha512 = "502037d125ec37094254017853de4efd96a22d2993dac438fda625d04acef44ca0482913f654a742f12d97567e019d75f4a3533b55396b42350b50f7d1c21874";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/tr/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/tr/firefox-57.0.3.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "e176a13f6876e4a56b218403c9b7dc872b6899133edb4a61d0640181057b275cdddab2abab12d713cf4d203fc867279c9c0ed96f2312441207bde88e686456f2";
+      sha512 = "f8017379c524949fd5a72c3be969ed7ce2fe0ba545e4f51c677bc270592cddfcb32ccd92c810e274021d354fa2f0a27d3f89fdb762961797bf03e8686cf59cc6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/uk/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/uk/firefox-57.0.3.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "ab51d55fbc297fc42d11749205d8babb07bf4ebe1fa5c338ac443d22bfaf608b2fcbf2065aeb55a4a1d06e3b69e70a6fa8ca8202607b9a1f475e0fb6b5bfbf7f";
+      sha512 = "0c3c25769d58dd438e3cd363a43b09fee159c271d996debbfa34bca7538853c72d60eded3e913ad400733e9e0e761337064f5917b79257e0cd081301e9eac386";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/ur/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/ur/firefox-57.0.3.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "ea71403b62089380db7cba0c473d513794846d279c88ace7f5212958c527442ebd8344f95acf5d5674e040d75ff29256cc59f47f538599974c55bd46b353a964";
+      sha512 = "3d8f09d6d8b098d88514cb0fff725a1bcaa9b84b786d68bdc502cdea8ab7b0e94b894e3cf28c9808c60cc201e5cf8eb1403e72ef22d22efc6ea91b1a6cc2bece";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/uz/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/uz/firefox-57.0.3.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "dd498dfe76fdd4d84dfd11ab529e7021905a212256bfc0760ade1e34e8433c1dd3c37b969d214a422c3c525985e9d3ff53760f930fe7428e5271a5f7941be84b";
+      sha512 = "cb7bab29b6f84b3bd3f7cfb162027f3801eed54291c6f3f2b7d56078e6729485478a0b77b0ab523aa2a74d8da4a69c2cafb115e9ce516ae79671ced4b88c2fcd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/vi/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/vi/firefox-57.0.3.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "fc6e588cd5c7ab2ff076104fce5e954e186fe420a34c8043cadeef6f94f0abd71ec4e8dcb59806fa7165545b490ccacc24de40bd47972fad13d1871eaa05e96e";
+      sha512 = "774a7556cb81e6650758867612a1bd80b623a72ca42fca4e01060ab7251cc79feadc28921618cf5e2338d4b4b9ec4459f950685ebee67650baff54d23b284fa8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/xh/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/xh/firefox-57.0.3.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "23d7fa08f37ec4745b47cf5fe5b684fab541926d3822e3042aae7a2c3b3e3dbcf03e7d51e68c3d3d938d0d0d0271cb953d24311eacd6eab860933f244f96b9dd";
+      sha512 = "87c114b73ffe949ea78eff0279c522406f95cab80bbde6e65435704e5c94b30f99dcf41be311b29491440de55fbd1af50d6bb8744e8f84cd0ed593c74153e2e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/zh-CN/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/zh-CN/firefox-57.0.3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "6ef8400344a0f450dcffae1e297bc2b333a5f8e606e0a6dd7b5a623452e60e942b95cc58c295a4b23578ac270d532e9381c4aba691496aaa153691ffb02b7a01";
+      sha512 = "dd12c41346fb17efa534505d3af6a114c8fc5efa047de05d1fce97a1afdedd8e6f27906fd922e1685eabbbd773baf4f4d3bdacabb154d95dbb794129d4c45adf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-x86_64/zh-TW/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-x86_64/zh-TW/firefox-57.0.3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "2b6072c7d2fe8d5517504c14ddb7198ec66050faaabd37c64fb2e67f30320f113f5eab0005ad7e375385dd77fcaf7eca95180f3cb64bee7c925cdfef5c9dcd7e";
+      sha512 = "bc6c7b9bbd211d31c904c815b6c716441bd330d3f2490b333610f9208f95afe083e5b7e75438167d3e28e7a22a8c2c2f4a1b6b0143980b9d79e5cec0f0f4e9b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/ach/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/ach/firefox-57.0.3.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "f26e36860eca48558358c5f71225a83741e31d3cb3aa637eacc19c2f66c1ff617975179474863764404a2c4696be7722b632e9389abf8acf56ef3b501aaae5ad";
+      sha512 = "8756fc8508f62a34a6609000e7a80ea094d44b160091c4ec8f967cd48699ae6673b5fb6518251f9153faebd6b707ab9e492398e3ac973f5921f3ddde05425f00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/af/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/af/firefox-57.0.3.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "cf0e803829d3c567c42e42d760226b35d81a5e24093de70aee9ce84e8eac8317d0c298d26e848d3075cae43b80ec1896dd03fcdf36f235cc71062795bc29b6c2";
+      sha512 = "a47dcdca5a84d842111b45760dc139575652ef8b37ea0ef1ab7abb2f1602f11c78aa00a5c3b844fe1226c60a73ff96c2c873353c63b5841496672fabc7d3f81a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/an/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/an/firefox-57.0.3.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "267eab32a78296d04fef98f392b7944902d75a46f032f903bec7ea2c8a4fa9fe96290f09526c4b5e43af9862bd41ddcb1a764d10aa23e1824b0835e55e74ca94";
+      sha512 = "2b1127ecb63f4e10be8dcfa9bde47a8071f3182d73b3f0f0a3b9661977cfccca21707f8eb783e8dc5211ee6e8d4f1b748547f58723e3e7299f1d7792f56c5548";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/ar/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/ar/firefox-57.0.3.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "e60272d8eb45baa4363b2e6fcf77d7991fe8b8650bd6b1f7f94cdcd7fbb7bcc5087e6dae07b85dc1e830454b0958d2aee553127aa4e89b9d44872bd5741c8823";
+      sha512 = "d16d3397e025523fa0aec5c0b4856ff2afd0624fcba31c8e26f917c2609b359afe1d1929ad93b3a795c0803270652d6192cc2cd77518f6c7ab8c0d92c8e37ae3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/as/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/as/firefox-57.0.3.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "ae067590af09c9f4c2446ce4c459623412767e0ba38d59d832722e0f144f7029bd2b381a68d435226eaee1fab45cc695b3947bc23e43c4c854c8d8c70175d074";
+      sha512 = "b5d740ce732c4265f198095cd8d6020af6d1c69f717e1e253d0ec6ddf997d0c84a109d1dadd2aac7e4bc501a5853d46a0d583133986e8d78c20e8f28a232bb13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/ast/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/ast/firefox-57.0.3.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "c41da767c5fd59b94a1256775da344a1cbe8a478561aeb1f54dbbe1e2297364fc790ec15e15cc0d37dbc41c8137d7d466f59c8be5e3378e4642eb7444d110b08";
+      sha512 = "b43a307983ecd261b789d9335c65497c80ce65ba3fd5e594c326cb30a526eb2819777cf5f2f4bec0c481c850434b1ba376ae381f8d78f9a3ca469fa923b27cfb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/az/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/az/firefox-57.0.3.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "a6b54c4386a4c7cb12b81fec013e175c00bf05f79c8285f7e7739c83431e38685ca19b9977fb36c3c4f7503790184b5564403fc030678cc80e1bd290492bc972";
+      sha512 = "4a8102dcab4619d1b119afbcc6a3a35b421b570b9e387aeac730a2cb071b9eb123054a0daab6f32d238023311ea4436867b6d506091e271e59ae95f677687879";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/be/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/be/firefox-57.0.3.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "257f9f78aff4fc5c965192b228fe1b2140d68a2721cfc2bee3f8ebc963d0e009c6b977315b939969b4202808574054aa0296cc19ae12d880d613ae8d6ce04fbe";
+      sha512 = "57747a6ce33486d8cc73c14124db8e3ca04d9f5598e7ab748bb57ad625052872423baef1b2d14c830476a6e2f49ef8c9c78b2d176a1b2ccaf4043007c76a422f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/bg/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/bg/firefox-57.0.3.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "fef5031f5b45d77632528f0824afb7cb2ffd175808a7164c727699f7427b891d2912b1f7fe5e63953c765eb2b4bfb9e6219d543a832edf8d789e93fabf4269a8";
+      sha512 = "f600f82587e327477cf1f35317516026d5fecaeccf45cbe8125ec2862789faa35b2450a29400507b57c92682248aacbae8df343b3f4916d58ecc1506fd3358f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/bn-BD/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/bn-BD/firefox-57.0.3.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "f2629cf851f3e096db61ab970d93ba0aa798d2f20dd072cba81526ebc040c661f3b5b202b13f3037d5ed6ad5d286487b45f707df898b24762c489a0c442e338a";
+      sha512 = "1288ec7872408a84760015d23cd249e2407ece44ae0adcc0c999db57e1412e355237bb4432fbf9fc4f1a7f15f798612069c9f0fdb24072da9d5c098c8b137af5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/bn-IN/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/bn-IN/firefox-57.0.3.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "9f5f732506fa1d24bec4139c7f706225d050000558bfe376d786e6555400980ac5e59b48b9cc2ffb9468bc421f0791e3927cd52328224a5be8902e3d0250e406";
+      sha512 = "59d07361e4196270e8907cec0dd6e9368c51c374c71d6266d198cc76fd9e3ecc959b30384ff9430773f1d387aea63174378c0c9b0df750a359713b79cdf4509d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/br/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/br/firefox-57.0.3.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "4c6af1a9210f9c46411d32126f7d72e5e2782262bac3ef229c7a3e6d5523b45c848e6304d4f9adf419cf0684812c2c24b9dfd89b786ffec8b30b7c7467317f7d";
+      sha512 = "987369a0aec78602941df46cf3e15df5e3bb822e35e74dbf199e4cdf6010c2133efae9c5bc60fc3922a86a82f41243d8792bbde1a220e492f9b1d61f57cc4023";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/bs/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/bs/firefox-57.0.3.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "a363f64f5cec1d41c458caa08c1261922cb9a485684e65f5bde92c289b28adb2a6a7b9017a7af0d6f6a929e6cfe79827237dfc431456b930348f2a3bf3599d57";
+      sha512 = "d93a3f274dda1a8b30b902f0925211b9c4490014f0ddf9ffb33c6c77eedb0df1a0cdc4e0448311b23264ea07c7e32be954637b62c1e6b3f6e1f249ca0ed0d9f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/ca/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/ca/firefox-57.0.3.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "fba95d45ec566f6ea266d34031b8f8bc7fb8812458910e20943eb7815336b30772bb4b5ff7c8b44249a05b1851e76876220a869deaf4451a0c3eb153f6c4591d";
+      sha512 = "a39ba910f7a9e97d0f51db2f1eb77f1c4111552cd70e619d564c241d28a9ea5b425f80123b0827f02c06c688a8f68da9e87253a9d92cfc0d31debcbfc227cc0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/cak/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/cak/firefox-57.0.3.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "5f61c68251b9f053b22c99980f43ae240c9cc9e6737d00e70878380f5979686dafed82350519254fa805a0d9f31e52dfb484baef0b5e99a000c96fe61c30341c";
+      sha512 = "845210b43958d4cdfe98f4f079b42c093e4e01fe6302fbf6d6cfcf32f156f3ac72d69dcaf88f1b4db50a509c7c9bbcc649d9a44e9e32ee8f9285844c1d354c88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/cs/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/cs/firefox-57.0.3.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "265c0b1ee00f61c71abd91476d2334701076f6fe5b6ce78e3e63798e2af6b0b30d3c64f24d1340cbabbf9393bf9125ccc3c66a2d09f235e572c46105eab931e7";
+      sha512 = "4f75b07055ecf79a0ea5e9cdd531b17419fc56da891cd5ebcd1c70e544c311696f300066b7f1a670caad80856db05ab7463ab3c7f714e37119dd39cf0402e7ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/cy/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/cy/firefox-57.0.3.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "d60f2b92bba38449fb9f54e590d4c3c8a69112fc29ff6e5e8906a3f6b57c0806c89714e334e89b1fa1523587da9f5871110ca4966fbcc26a5fe696e6f0634667";
+      sha512 = "e03f8434b9e062e1854e51d10628a6c8b070fe54b9c437a971caf560cf2d076173c3ba70a06b79e3a2d8d90dddf95af11501001a29aa30e3df805450c533143e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/da/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/da/firefox-57.0.3.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "a17da9a657d92d8a24c6eced37215106c90830fa9fb381547da3e3df11bd3cfdc6f3a9272d2f2ebed0cb19e488c411fc30f6365e9839b8a24b9e5bceddaaa267";
+      sha512 = "77656ac653e3aa31c6fa1d682468b22c2262d1c81c9413c3f498bccebceb21fd15f95f9230794eb102516b1a7f2def73f2296e8b86255df52d3389974a3f630d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/de/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/de/firefox-57.0.3.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "97bd32360ba6a6cb2206866da08cc71bdb7b263137c77d7918bdddc839691f4193b54e9ee714b28ef338a5b6639948c51ecf74fdb8ab25af1b87cba6f07f0166";
+      sha512 = "73b7ec4d7452ce1ec2501df01185c46678c41507adc5a94fec9b96d2f83775066826744404e6524a549146461ea5377d3868694164ed8c8eef4a2b846513ef19";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/dsb/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/dsb/firefox-57.0.3.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "e003bdc7beb0faa57bee3b3e0f65e9bd74a90f8690e0e2811ab4f0a16a1711ae49ea072df75c9b4af1fbe4b7fcd835c46e0d312a9d50e97443edf101aac71638";
+      sha512 = "32ebc64e788801b01e4b9d9de6edc2f419a94c737ddc51258a6cc9a910603dde7869a051e05d771b4f0def34b72ea71763b66b38a0f4a71276428d6bd1d05992";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/el/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/el/firefox-57.0.3.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "f6262456f377208e49c6b78782091fdc4ad5f2621e6fd93091f5c873083ad1da483c82680382b636d1a906d711b6919d8623115738315a9145bd5e163cc2ccfe";
+      sha512 = "a9035ad5de2506f44e48b48a4a7eef316cfb8b90c9f8f255f34fbcdcb785a390365f87972379b666f857574c41f841019709ff7721cec5f7173034a35f66cbfb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/en-GB/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/en-GB/firefox-57.0.3.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "e96ff5ed84ec15f2de98e97da08cdce9621d92c30137c344c4404e8aa7a7875a7877aa26e0a0dec4add605a686e89eb8eae68f3adfd17f6b49d31ed22d1c17d1";
+      sha512 = "7cce5795c2d91e8754504358672db85b3f20e1cf86659b5e4f5b2197728333c225f6a05bf675dcf9e390c727fe07b5f42e51bca096188777dcc937ecca7686b7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/en-US/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/en-US/firefox-57.0.3.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "122d91799f704be16525bba403686e861ccbd85862a64dd57dbda89b28fc14958c2cedebf83a3c61de1439afc4c87fcdc4666d3f237f6b0484850ab7c97995b4";
+      sha512 = "1399c978a800ccbe2b2e57e3acd65722ad423d0188073ff24d2d386479670b1616eca5cc3111dfc6c9ce4f9048112f610d6d00c510934fe5ca8745a5eda26fea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/en-ZA/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/en-ZA/firefox-57.0.3.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "243625c2657053b9e5406407cfa242dff02c5877d0fb1c21f53b867e4ea823edab1895411697ceb17f08b7db7204519a0f68dfba706c6938b56e741e0aaff171";
+      sha512 = "8613b67a20cd19a29141890933ab9a2fbff03d8f8e2c94ef1c298ad19a711ef29630ca46a43a5c5842d8ecc9eabb45f1d37e6496f48451a6702a67520a2e42ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/eo/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/eo/firefox-57.0.3.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "e3e72073f3eb299df330a0603c846cf8fb12f900d3e178bfb03de26fb1a03875b3869a58afd664367cb8eb81230b0ef463bf95127e29e1af0cb81513a7eaa242";
+      sha512 = "1654635d26f67d34fa710d732afaed7344244f83c891078a10e15b5f154422a339d60f84232c09effc1e9f8feb5bb97e84caae4c689d5017f97dfaa0c91a8543";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/es-AR/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/es-AR/firefox-57.0.3.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "999c2627062723bd2283b865f37a51ee8b54fe5f71b6f339a83fe18f441c88bb177ee986cea81b982ccd7fc905b498a4ea7c8bd8c2198c3bd7b87610187679bf";
+      sha512 = "cfc1a7eafcdc2809020228dbe13656b4f99ccc73e630f15610ece0f4afe6100dc09d09c7d7c7e84f408b471839197a901140e8b613bf7f7ad46789df62b8bacb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/es-CL/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/es-CL/firefox-57.0.3.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "294c518f8fb62aeb02b2c8ae88f2150e6a588dacf7e9bd6f2dc5f39176553b5f2682cb0f43fa123b3e3a13e0b9e8216cead37969fe49819875e3e1886e3285df";
+      sha512 = "e99ee28e7815434982013749bfcc9db359cb33f9ee71fa82594cf3e31f059cd56c167cda2e8356ff5ea0eaaeb737d8baa2a235003147d397d3d5f78f01db3d4a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/es-ES/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/es-ES/firefox-57.0.3.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "26f684cac176e86bea72d99b5db3923f66731cdc119505561873995a3cb48c59ed6a3f1044d6b8d8c201b508ccc3f50b1a13b156c0eaf186d9f272faee9c9326";
+      sha512 = "536e87efce7e93c0461abba20230cc88ab838b5cb7f9b970f901b9186626c080fe92822b8a80c35235b55598e3ec617f4fb25e933347426bcad77ab208154a95";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/es-MX/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/es-MX/firefox-57.0.3.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "97e6c04bbb044eb6186a76f72cbc3183abda61ebe8a9c3d114c1768cf6fd423924b3f3bf45d8de127487c02795ec5697a493c92a5670c1d99a238ec124a0263a";
+      sha512 = "9d0d41142fd2dbe89ddc6e7ac57617efce3f0f8c8631a708f0a0568f532518ebba36e6e7d6bcddd00fbc9d856adf785635702f7660c036a9e92fa30dbe7ba4ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/et/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/et/firefox-57.0.3.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "a92b7c9bfc9ccaa4af1d1123178d44060c3734534922127df187d417bc3ce69fdbba32dfda6b581fac6676783e181cb1cb7137d2910144c96ef24f91c4d62a79";
+      sha512 = "e5d69d12669016c9466a48da3a67aedad13ee0290fe69225490ba9490a8cbee681a5cad1bce73fb9bcf4a1d72d140d24f892e4ea0e368cf83a74b2e1da9bab3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/eu/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/eu/firefox-57.0.3.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "8019412526acb948afb183cba043e3934feb5338c7397588f6baac6ec5ed2057fbc5d9b4db901d927b8ca4692d2243fc1d5a7f67d1b6ef9f7156c18b2194383b";
+      sha512 = "c916f3ed272661c34909deb58835323e55883acd6c941e52fdb398522d54f4fd91869140554954528a95e5e62d2576c2ff13691c5b2e99e4641902eb73e6fbe9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/fa/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/fa/firefox-57.0.3.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "40c30df6d0a70559b4fafe760deb0a66da25174362154cb0cea015931218bb71756b59cb5fd5de10e7743563ddb104e7b4f6b76e8a4928f63f4a8d920c3910fb";
+      sha512 = "a8b6c52f80fb4719469e5992cd0b837c9d06ee4109089cb508f931a2723df585990b915c7f95086bdc483c354a948c76799542b8474ce55df6927b3b617b298b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/ff/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/ff/firefox-57.0.3.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "2b9b66e9f10c4743b6e4f5562efb3e108b65d977307ce9055ef2bf1389a2ac30f6e43a942bbb80d04c87fc1effafd332654bff102c4f17a9754d22c8ada0ddfb";
+      sha512 = "c640bd0852970fb9910aaa187903bfd767992222525e7ee0ce80f485f6665391a18a8a36d482e8366310a1f3b655fcf04206afb12aa77b4130fed8497a2137ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/fi/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/fi/firefox-57.0.3.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "d6df4629a8b7c3a8441b314bbb0e58b9dc8534902154eb00777df46546accd79169cf3add27b7bbf92f973a6fc9aa3e836ee1d4ade31ba1f970cbea58ba4799b";
+      sha512 = "d1d85a118e05e36adb41708ae30103aa2e3aecbeba26d6308fdf3f362829af84416b4753df95958e6a82b7c7e46526e41bde663ecf235768db8902e81c479b10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/fr/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/fr/firefox-57.0.3.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "8da9af23a0a54a968992f9fcf11543c4fa9378cdebad2de50a1d96a896b20dcf80b8eee80a38884056bb204725e717e51c8c375cc3e060829df3c960aa130f0d";
+      sha512 = "c7ca1e93b0ed5a81c288158f5257739f87b99b244bca7f52c6a81e49ad2f120708dc304720e27b482c11480a38f367e0cbd19f94af637b142d51bf5b2c9efb30";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/fy-NL/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/fy-NL/firefox-57.0.3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "bf08ad07d9c8c2ea2d307c46b1c0e865b983ec1cd6d90092e510ef448c3fb007bd92d58aafc98b0c6267a4bca61708baaedccf09832f8b7943b5166d564e7f1a";
+      sha512 = "805dd607f6f08df62e9145cd68e25bd58bfd27d0aaa14d8ad8ea2eb3a0c884853767f99c53c0cbd346b5bf26ecf25f0c2f4ffd47b838cf7f2497dcfbd6a71486";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/ga-IE/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/ga-IE/firefox-57.0.3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "aee747a77b19c256f7cd4e24af642e99f1313df556bcd327b06e424098920394c2d999cf864660f004cc8067621a0478c45fcee812849237181ca76e0a7bdf98";
+      sha512 = "c25645d57a5c238ee848203a8b76b6be734cef1b72049688d34d0e873ef41319a0f71b477e46ee693b82612a1a7b4350fcf6eae64b33827ef19fde5901144632";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/gd/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/gd/firefox-57.0.3.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "3b03a0544021c26446fe8884c4054ec689b45d6c613409885b21c11ead0160534ba8963d564cc6863792f73e9808317e53604d45a8dc802adbe98e771e5d0f07";
+      sha512 = "ca4c81d0b8e886ec0909e74888d0f575df1b0e8b26ff0f948981fb7d8006aa08ae486722a19cdb575c80f6bd98f2f713a2643b6815c62dbd9d32eb5c22965cb1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/gl/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/gl/firefox-57.0.3.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "e041a7f7abaf1f772d00780bffd872f18858c6a052bacce79be3cb764fb604334270b4f8becc115aac9bff4346732c719855bc3be3cd5a94e425acb6d1750183";
+      sha512 = "30a4c10653edcf897c0f93b363a5012f55a1603bebf98c3769eae5c41fdf359017a79cf84ab98ad3fb3e4b2b3291c1a16d7f0608bc1072c32bcc3c470f519697";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/gn/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/gn/firefox-57.0.3.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "698341a2b37904753fa1d96eb195baa892e12e760e9296582f8e5939c51a1b442c5515959c893c27110fa881a3b8962478ac5d109952a21b8805a5bbf0d6d7ef";
+      sha512 = "1fe4444e9d7431ba877b04c62f91cfb0838b92bb9d9be758b460ed2d25ab6bc840d6cb164508298c12cf340562d23760cf685d8b279a7060028ab84b70ab45e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/gu-IN/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/gu-IN/firefox-57.0.3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "5a1b6a24a586e0ed08a9c93d413a5c87c254ba780959fe734dbf12db49bc8676dfcec631eb4633bcf06bde93ff7b492d491678821853e894266eb3ed4ec61c9b";
+      sha512 = "2df2a7a88c5871116621a5847f193881228d89be2b7c6f9741ae689ee28303b2bbcb5a6c8cb0b7e4a187fe12959b475063b706a9af0fdcbc4ec168ffc0ce3725";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/he/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/he/firefox-57.0.3.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "f03349f009bdd061f4971a2d61f7e6e895c93ee431852223c00f741d2fec60f5978ba0606e5dac6b35abfe7ebf5611d94c22c1401fbd54d7c4d39c8e5f3e8a17";
+      sha512 = "86b89434222c99d7485cd5df1e1597ecae5cca98704fcec4ef4467d89358e290d857fb18389af6f075d9c5369b62c0edf54c747b03eb73482d5c9a622cc870ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/hi-IN/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/hi-IN/firefox-57.0.3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "f7ec471bc7e0949732bef8d2abc8982c9280bc31cd69d2e077b86753bda2e373b661c7528a2be016b08d9134f44f4a860381b8d4ebd5d4f3db0b57fc8496fc94";
+      sha512 = "b0f992412f108226be8d632e860c74832a986a969fc27882f5a2ad1165923ad0fee1c40d9f2f58e0d2b676d3ba42d2fb83a58f4934787acd1a4ec032aadf793a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/hr/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/hr/firefox-57.0.3.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "bd1bf0e25017784223fcb89e65b2300a37e1b173449cb0fa9d05a95eb92d780b8ec8c1f86f12286a95a7a94a9de51ab45d2d1d1587c6c4868585a5c61ab2437f";
+      sha512 = "fcb6e3e3c35e80ce54cb9d1b7e28cb4e3119966e9fcae00123560837f62ada7fec5e2bc099daa9d75e5437405d4a41f89533ff425144a84c99e61e36ce88d579";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/hsb/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/hsb/firefox-57.0.3.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "8bb53e163295c3e6076e414e10872876926df5e8896f5a981ed5c23f010fa8389680a7b291e571c34cac52632ae194fc7b872b106c512561e65850568e24a2d0";
+      sha512 = "7b201321e567455615fd0bd3cf04db132f78b8a196868897450c6b4f89c6c16ee2ec285457731589f74e715906c0a2492ab72563c35e3d9263d4d598c096b218";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/hu/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/hu/firefox-57.0.3.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "f3a5b79e49a7d6078dacc46db5e6e9e4dfe2511cb0d2d7439161bfe733565e8f05a7f8ba9132b717f595df1f2399656d47018da3ea1fce8d801d6a9f14395bed";
+      sha512 = "2ba67f65a06ae537b3d579b1a6c0b817bfc56148db4f51d44605dfcaf4267f8f06a2953342eedddff9913ac03bf43d7bdb05e674137ba68530a8f4ef2747f260";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/hy-AM/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/hy-AM/firefox-57.0.3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "0a7cdff0c865dabd64d830b27fb28aa11d9656e94b0994e0dd89d85d97a82c4849236f94f110747a5b5af08020b1c1fb4c8894a5452fdcf485c6b3f5a0d587f3";
+      sha512 = "66601e8af60c2d0d3e83fcfb1a4eb565101ef7db402154456876af725162487d1de74dc57765475c50e877574df2cf2a256bcd314f4cc6e95be6deade9a9fc5e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/id/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/id/firefox-57.0.3.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "c3717bf3cfe7fab099abbd3307d18b18f8faf6f8c77a9e89452a930fcf7d5c60f38d5c6d341eede78885d1205d26b4149f01b54c2e13852473017805c4629bed";
+      sha512 = "61d3e8e598dc32c28c9f0396ef51d2f7ba919812d1e0eb8aa75aa5a25d3fdb39e398ad9ccb7fb0349d2b6fa6d184586a3228979a3ccd21344da5cc3d8bdac712";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/is/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/is/firefox-57.0.3.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "1aa74ab93fdac1cb61e78f687502bdc7deef8f7d720b6c3f99852883c21218c664b18a1301ab3e05118856e8ed0a6600347efec52fa945a59a40a526198bcd16";
+      sha512 = "99738c5975e92e409d85e7a5861fac32ff9bde85758c9c19a8a630648746afd70f59e5f6c49744b56bc860964a994d3f127df11e79a697c2e163a2e95c0f9496";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/it/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/it/firefox-57.0.3.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "d68aca6e221907169ca9c0b504dcb0569a4732b10c465805843bb67f2513ea29d8848ee386c2f09b3033e868c80c7142a72a79c4d1e55a9f6a2aae178396aea1";
+      sha512 = "c35609aa667d707893259b86b4a410cc258ae617b2736e75eb75aea4223634f0a44e0f32cac397320d60fd16cf0325641c1ea3ae9a75fbe64d382571c77aee5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/ja/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/ja/firefox-57.0.3.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "6c5f5bdd91cb8ae02a6443c7d2be20b7ae0544b54cc3c2d2894069b3df89934721ef5fdf1dfe824316f0e07969a27df1f28e73c5ee17781be67b40eb1b63f02b";
+      sha512 = "f53742b610ab338e0f7f2b76492979653f1243b8163076052ea450d66839c21fa860b2f9e9d412f9822f87050f4aae34158ddd0ee5a8220c4c7546ac28c066d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/ka/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/ka/firefox-57.0.3.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "9f5f794964fc39b3f6516781eacea068970b397d3624b339be2aed2142cf7791cb61cdd2ab59cad052e34f3216e36eeb19132655145088b37e8f0c2cede6d394";
+      sha512 = "020462ebf2e5a98822cd6fae5deed631afc112b7040b58542d4b1589af3ff0504affdf417e9d1568f74a12eee246c3b6498a0c2338575ab485c812182913e190";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/kab/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/kab/firefox-57.0.3.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "2b068facb186f39744ce49b2e849e24df8667cd81bd5d0bd25aa8d7c68ea70ac8080e51165b5b2af09238593a1f58b418d2adc4df170073e3a7eb65f70566b78";
+      sha512 = "a0e55697e83f2a9685669fc97656548bfafe88685df234cd61738e1338a76dceeea17f57eb0316c884c851d410a482731d01881525a6864ae2042a5503c1d6c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/kk/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/kk/firefox-57.0.3.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "49710f8e65bcafb88b6270e2100f50623fda1a916e105cad3cc247a929e98889456652006566bb7a3be8f6de2ba9102a4bcf36b01a94bd362ed11eca3c969db8";
+      sha512 = "a97362931d2979f1b3d8893688d6e1009dc05ce87a16eb63978b4bfbca5abd815a9691470c5f02c47b99c93a7bb1c71f298392cc45e5f00d2602f2e808eca3d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/km/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/km/firefox-57.0.3.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "fe35dd90c5aad2e0690ab007952ebca82724613dc8b2cb92777690ba63b48e51dd7392abf4b2f1e668794647a3dacc1541ce92a2d51404f3198d3701f5160fbe";
+      sha512 = "3c14ff4420c4a6c4ce8f4fe7979971ed252c1ead1bd50ec134a765403c1eba35c944fb5aa2cbbd6d8623107a7d2b319fd9739cc93373b23729fafebc83928445";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/kn/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/kn/firefox-57.0.3.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "344419e9b47786936294babb49d905deda79fd7164a8b994fa3df87e2f1f5284aab1f2c4862a4d4f247cdb68fae322ea2e3a766d5c03ed192179699db0b4ee1e";
+      sha512 = "2c06895f2fac1060b7794859f354ecc4ae8dd791d42d2639352226a6adb03725814d77101e232c6cc926966be3a6db0ff7eedb212f6612dae7adb61caba3c210";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/ko/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/ko/firefox-57.0.3.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "970ac1bccb69e05eaa767ba621263bb46e706f38cb1647cf453d2a9f34f5f358eac599a02baece223b5d25816a5dd4822835362b98bddfa7a2022403087ad9b3";
+      sha512 = "0bd5f1e98d39447285503c73bfba2ec5839af9bfd1c8800f5023e5b26b77d0371366f9e5411ed273d0d560ce3943e606b58c020ce2ebb2f16054ffe6ba58e3a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/lij/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/lij/firefox-57.0.3.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "1b4a72183476ec147b76fa7c6e7ac01f920173cb9a23d646ce383c50677b818742d47d8e8ce35aba2fab31be6ff128fd82555aceaa05f75aba1e9a5e3482a20a";
+      sha512 = "335b199471c7fdd43c4601a512eca015cf88c10dcb52850a6598b9970fe4300f3fcf59b78cf551af1469cfe085253e709a87341a3fcc669e3a7facb8ab6826f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/lt/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/lt/firefox-57.0.3.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "39b8aa096583e62e7e43ec14c798b24a8f5c746e7ba749172228ba59dffd2861e1d122920a4ab1ce256c2c8407feab6443308bc08d50dca44e7d19569c3c31cc";
+      sha512 = "b497abcdc0964fffdf05180064fd6df4d0a4187ace3070c3f6076c9c4db4a93cca48b14814ced2e94407885d294b3d6ec1c44dd92497912a390b1f97e8627576";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/lv/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/lv/firefox-57.0.3.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "3c0f580ec1f6b780be801cc8fc5a375bd71ecafa5e0931f263de7264117c8d32e372445ce7eaee90cf3aac52aeb929a73b9fa857aba66cb9351443f200492275";
+      sha512 = "7877e07a97eeaa2e66b2be49a48eb5fbf2af64247230703f04fb80b960127e5cc39101ccdeb1ffe35b2e5ff01b64396c880dc145636f92661b47066e0cf3af0b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/mai/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/mai/firefox-57.0.3.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "0f86af1b078c76573da49f427662bd43752b5f351592b2a78406405535e15d13937e83598ddd8aa95e0f2b19d29eec64b4c5220aa2a3ff86410a2f25f891ce0f";
+      sha512 = "24fbd2b86511aef229a16396cf954360a61f7377de53253d83e7fed81a22f5ae5196889337edfec488b48283d4fde8f9f8f072d1ee276a5b310973a2c1aaa837";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/mk/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/mk/firefox-57.0.3.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "f31fc0df700b2b00ce12c39a45165151b5154ba7ca06eae9a57cfcec8553eeb3609663515f9ecdfe27e6fc8e8e42d43407cc478564f80eb1b2f232eedce8433c";
+      sha512 = "2fc3df289505893490be4954309aadee8a6189488b1d99237f577bc61c8829d6a08f2cf18aed14518f2d40fa2744dc0061413811f7701438a4cf464b623f8b48";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/ml/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/ml/firefox-57.0.3.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "2dfbe2d64ea9d79d836773fddd7e31912107c10ee9eddb59ce547a2c6a1d53918f203eb20c5517a7c810024caa690e05a21f939a8a6e3cc1c08e081ad0e1c1db";
+      sha512 = "3941b7516a0ad4d6308c9c7252a38ad26fd551b3bb09ccf973b71d8fbaaba3f420064b02b4ff30986f0cc54149d9df293aed0c05b31f8582bda07e52ee5c3418";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/mr/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/mr/firefox-57.0.3.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "fddb7600432b7253159570e21a45bb2f906cd6606212ee163b128045fa298020ada2a494124b4398f2878abe6027ad7678bcea99bf31b01c2f51128b5b5322c2";
+      sha512 = "dc64a90547e7ddbc02715d774063d258da0873728691f2f39a5c6821fc918b41fb83277ee65ab88b6df657aaada87821dc2824fd3f13e2c317638c81bc0362a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/ms/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/ms/firefox-57.0.3.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "0801d30f9b059ae9602b435beec4d683167f881909b2aca90eb20967faa20ecb8ee1fbe000403498f450d8dc7240b8839a83be9cf6c8b792179cf73c31e1264a";
+      sha512 = "c4b10e0f4e200823b1c1a0d660811373c31b7e008df573d633499734a137c031799df162a06772eb087411912c955cb01f912b7849ed798ef40a65ce4298e77c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/my/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/my/firefox-57.0.3.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "6c2fefbf04fd9c0d65e4bb9efc8f7cab998f6e6a0a1c9882357dfac21f14f6008433dd0243354545949afbf4c2041e1c761275a846eeea47f8238984a532fff9";
+      sha512 = "e9e3dbb826645d272dc5432e921b8577037bfeaecefa92bb7cdaa3015b463e72475d9faa58f3a1bdb57393602843e186e132f9879f325b62bd6c6504c8d1d965";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/nb-NO/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/nb-NO/firefox-57.0.3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "b896ae8e005dd46d5e25752e780bc720e3e647de17fc6864716341b1ac9e7ae7c5b203d1ca3b3afd914b83eb54419120604e1f9802a5f0a7b0c7924677812057";
+      sha512 = "d0f575f930d9943b8d926b03aaa919780c6218e4cc4279b319540f2807494a9af14e6fbda9e0673673c9abceb20d2152e499e879a906305af3d6d10c8f5dcf79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/nl/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/nl/firefox-57.0.3.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "c97442a61a72bb80c59e32756038b665b9842c9afd4c874a4138aeb0bb5e498d7efc2e437b2d291a63e6805328dd5f1dfa9f60cbae8e19de53f33cb889da70c3";
+      sha512 = "7ff62ae89ca5934e6efa6402ab73dcbbc4a968d49141760d36cf2b199ed081fb615cac7e0a90e67cafa372455ef2163407e5bbdb4910eb8038fdb138fe086c00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/nn-NO/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/nn-NO/firefox-57.0.3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "566432e4939a804821b5775a00757223f420a3bd8b0916d057ecf8999181d1c998d84f28f39fc3fb2a61d8e76cc7930d4ed3e0540f58e6327d8a9b3d978f3a74";
+      sha512 = "bedb7c2fde56acada9519ba0b82bca658fd8b169602c028473c84c421db169b807a9d13137c4be2ae3c6fe03887f619dd89f3d192e6f3f4e61411c2ae1873460";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/or/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/or/firefox-57.0.3.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "38f694105912a9a34f54d96a607db504580b9d32ec3e79a7e8e7c5d22f392286d0ca7c0b3a51cd5a70167d86ceab27461a68baef4982bbb5af9441117c455f0b";
+      sha512 = "a43d11ed724709844b26ae50bc2ccd4c74368d3437eba883f56511094847985c2e6a10159da9d711ca2913bbccceda9ec2bea0631d601c88ef68e31f06016fe0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/pa-IN/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/pa-IN/firefox-57.0.3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "8524c3de930b061a086ec9c8eab55255a93ce21d3b205cf8c187fb6c7957921f761d921802b1a87c7f7439c86d506adaaae37bc219e110de4c9248b451be61b3";
+      sha512 = "c66315bb44d02eede78d019c7c4f8384ba64b74e364c5849de034ac3c988dfac5664cb16d0ccadb06315f980bcf51f38d3eb8aada990d3bf69185e53dbf74f64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/pl/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/pl/firefox-57.0.3.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "29bf7fd1ccc860565c0fafd1d4f5adb2a90c4493a7bcadb64c4e86d47f423a2ba119770b20df06d368c1f456bea8ddc57dd21280be3e34b286bdba2d6e9250fc";
+      sha512 = "6e8362e71b8ed437666c49215cd9bafee308073ce62022481948c6935ad51f4ab1558b7a1c5c19d0a69db79231879485e1a77b895fe61c040b19789ec2353077";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/pt-BR/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/pt-BR/firefox-57.0.3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "eb953ba93d7e96049758096e10335bfcc1199cfa3b0c4e7c1a0bfd7294bb95849b0fdca34ca5068ef02dee6cfea09537c362b8d35a3800e7ad42bfa22ae5daf5";
+      sha512 = "8ff7f3ff2d8d98ad374571ae4dc5b19bd19fb882a95965f6bde116a42fe09a94e2a6da65b6403a882aebb85b6c6da987a592dd4b80daa8cb09602f7fe124b467";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/pt-PT/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/pt-PT/firefox-57.0.3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "6922ae12e56178fda49792c62e6cd40e78696739fd2ec680bb4fd5391d43babbce5f5a9d1dd30b5113323d77d03940c64a1a05a1f1e06031a63b4bcd4ac9739c";
+      sha512 = "0c950dc7e68e163536abbabc7138425e126798fca19db2f3aecc4da90fd84846abb86fa6e830ccad4580131749d96f2d731fde13c608b57f4a14a57443447ae0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/rm/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/rm/firefox-57.0.3.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "b690ee89fbb1846328cde39bc4f6f51bfe7d5239c190ca29b62c5c4bb9b7cf86235fa17b7d35b85055fd7e6e99a14d87758a9b1b3bbbbd9093a0742729ef0383";
+      sha512 = "25f6187c98cad96f4c14872a0724979cb6051328dfff16bb9384dc59972e9bf41bb1e9bd7fffb58a0c0cad8dee4da817ddc86f6e40dea29758751fbcfe2e4abb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/ro/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/ro/firefox-57.0.3.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "976d41585a6c8c5c83d8d4ce1d78687830cf780f7eb5003ec25e3fc82f08902014540f1b4bd913955f49c122c57d560928c826a643febe536b434b715ecab7ce";
+      sha512 = "afabdbf4516aa1f9f6cc39025f867e507668609e9f2cb754a92ee00960d0d3628df3c931b25c63668e42f6647b733e6429b304405636477eece998ecf6078cb9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/ru/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/ru/firefox-57.0.3.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "54cf44e265870c317803db753abf4ae9b0efc8c2afb21c137a79a7b0eb81f07baeae737051384927cc7b07aaacf5c745dc4777bf24c9f38311ecc28e81d2dd69";
+      sha512 = "6525efa101eab27af2f1e91576ac4ec4183d7f53fce1e08fbab683c9830634391f379606da588ec912f641898aa296ab6b252dc863e78f1410ae4a136440cae9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/si/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/si/firefox-57.0.3.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "1d27e3b6be480668410adc8cadac2cd477a5ce5e31a45498474bfb77c1b975cc9c55c03a1ec50132a660100ae5e5b0307302623861b546b3f995f09e9ebd4ad3";
+      sha512 = "654e128ee1910a6f2e56c0216945981fafa39c1c12f18312ec1bb9616c83ff5ad64b1315497b6d313ebaf31f6c0a59ed7791836dc80ca1bbde2556665e9a6ca5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/sk/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/sk/firefox-57.0.3.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "6812a0563712e9d3aefbb2c112e564b7147b96869ef333991aa86ea6a37f345f8636ab5dea6fe37eb46912bc5dafa08d4bded06757aa76bed09ff924ac916858";
+      sha512 = "a6b27276e43fd74ef08087a3ee9e741fc492c3e04f04c37f496644393d0d49b3dd697beb04537ea5f2faf0ad41a0cf90cc6fbd06bc49d30340449b68c9d4812c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/sl/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/sl/firefox-57.0.3.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "514bc5af454a4e3ad96d7b589c1193f02ad7013f9d58b0da592037ea98aa72f47b6e36a147edd52e74fcc89881acc7ded8043d8733afd1503266730707c30c4e";
+      sha512 = "e4e2eb23c4da496d8725902d82bb3fc8d96fec65bcca1bab839de1589378825203ba6d6ffdfbc1df6b82d8e3f49a3c2a271ce0cb659008b29cad4fa7c5fef8b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/son/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/son/firefox-57.0.3.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "3172ce00f9c32e7acd18b98033e120aacf28e60f08252fdda4db40930be03d66d9465ca8967ce984b233962f4c34fd4dc79941e867417405d0b7401c78f76386";
+      sha512 = "185dfe1f335d9d74de153c7083e739a48970b3abe970dab57ab5f50d813df0ddc4b5e592e394a2e7d61baab7032571f15ff9621a729c51a47b75a8ae7cd18f4d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/sq/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/sq/firefox-57.0.3.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "72e2cecba9d83e557bd4caa7b7b94b61f7903ae544ef60eccb65030c9b618c0b3486849ed3ed6f579b019fa56afe1c9af5a44fa263cfcf5e99614f79ba0c185a";
+      sha512 = "8772ad36a9e51fd413f0afbe4436f973ff6daeb6c062fb833b8387a6ca1960bc3b699aa730cd3e991aa39ce0d061e2b452c5d79ffd519fe05295cffb7cf4ba35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/sr/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/sr/firefox-57.0.3.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "bc9c6640d18a385ce331318093cde67ae2f257952f4c356413f63f851e3bb1b82d30836fee53963f7b3764b4e12873c89e5938c372617fd628ecfcf9bf9bee4e";
+      sha512 = "59c7ba1b9f0a1f45b2086fd6ed87a85c7bfc858a480c54972950fc4839109954d4e51e4dce864b3b23148b629e000e13d4ef49b718fbd5d8bb1d8cc7a738567a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/sv-SE/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/sv-SE/firefox-57.0.3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "67b463ea15b104b44084aee81e47ddb1644780aef2c598db1ce01bee3e3eecbbee7e6bd211c5839b00c3d055e3931f7bdc686bfede36ea3b1364a65b91413e03";
+      sha512 = "3f4aac40aae1b2efd92a4c1f1f65ff75a7199b955edeab5eb4ffc58d8c899ab05d160e9f0468be6a5cbd5da67110b4fd703214a5ccd75392add3f833f09df670";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/ta/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/ta/firefox-57.0.3.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "9f584d50557cbbdbcc291788c8ce6b325e66041401127c28ed387c3431d36edb10f51b34724bac52e44deb86ba0159b4744edd7e44c2239e15752dfaf88ed036";
+      sha512 = "698dc4daeda232bf73cc876c027b0398b6c26c7a65b5b5c403f275e275fe3399c66219c7d9916f2713342d04d8bc33186b68ec5b738ccac7665bad7ae073b408";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/te/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/te/firefox-57.0.3.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "1572472578a3c692403fca59282640fcf222d4d49d265f3e24b280f553fa6ebad8e4974497ee0dca9748263a48846455a0abcd955ca4e1d6b65b391451c3e9c7";
+      sha512 = "2e85fbadafd18140f75b7b1f9aef525c90f363dc5649aeee177cf86b24adb55cdb6c594457c5a7509177076b750a79e48785ed73343fe480ea33b696bb4d33b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/th/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/th/firefox-57.0.3.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "f9040dbc10e0db7c895356caa42e4f4b6a069e4abd3c1151adaf11f7dfb24e66340031d2f8f4ec0c1a7de81a27703ca3fb4e11757486dfd46611b3e388dfff9e";
+      sha512 = "28236c8b7d3dacf156e65faa9d72cae11d8726dabd5b4408b556f9f2beb073469c4cb285721ed9ccb438df618f1be503717399d7e6669a308c45858a5962c0df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/tr/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/tr/firefox-57.0.3.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "7bcc301e575d10778f7a318d7570b7c1e6edaef4df6db93e78997fe66dbf97fe1019d183aa61055bc8b7d0daa660d433ea915b5f1ff5369494c04c4fad2d2aa1";
+      sha512 = "4691739124c0ac4c5da2ff478f51205849e816428bc4dbdc5ea93abaae41b12d27ab316d4294d44b155378cd80370dff8da53a5bf2adbbaa44d6732607642aee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/uk/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/uk/firefox-57.0.3.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "5444a561aa4610c22b1db8f954029380013f016a7efc642e7c845bad676c9c7eed45a54dbfd6d07dfd106c193a0be1c3b663ae909995273adeec8e0a28def584";
+      sha512 = "89483ebc8c4baab09c88a221bdf0740415cb80e376d6c8c0db449cf96d9283a9f43c4568bd9c67ee170173caa9a5e8b86ebf096acdc1f1b514de6747dc04aad7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/ur/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/ur/firefox-57.0.3.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "bd8f9bf1d698ca331862715e7d3974c84363d133e0593c47059e33bc58891665768b08722fda7e3d56d6303d08457b6c2da9c2dd26cd01be4be21b3e2998d9e9";
+      sha512 = "9df394814870aef097880ca8d5b012652968cc0832a5bc166d95a5adb52d996c4cac87e08f3543e704460e8165bcada3b03de36566b1772ba072cd61605bef4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/uz/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/uz/firefox-57.0.3.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "75a4544a44284c97a99a7209b099416e5c6cfb035f3abdb6fdf4567efb42b8b71ad078595460b2b49f9dc165a0cb8306f0b9e586e86e83a77ec56557900b7d4b";
+      sha512 = "f3d28a80144fc542c9fe8f1c607c35c14fa561ba5c7030f9b69515eb29ad7fc87f8fe45406fc8c86e3428bed20e7c7c9714192720ec2ec29cc532206e510797d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/vi/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/vi/firefox-57.0.3.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "ead2e55cccfdd98b1134dd1b958a6e55b6847cec26068891d98354752efc24f7f5a22220f315c7b662a7253950188bd773666a0f1814c3c6bc0ace6d78937b1e";
+      sha512 = "506b68ead1facd94b90ef2b5096760748ba234c71f01c22cb202a9ef59aff3257eca92f238357ddc51ff0d21e72d2ec32371e7f4add4c0f8ce534447dd622dcc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/xh/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/xh/firefox-57.0.3.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "7fa5de93fa29cb6d6927e2c9aefd2895c2383d252c2c2cbcc8cc2922406db03e0f8937acd71ed16a92bd4a90ff7b45a8b627edd73f64e8763b59aaf388668308";
+      sha512 = "44ea4098952c2a289a25e90f2e8d12efa58294169f79c47a445d53fee0a0c8dffdb567b6745b55e581c70475855d2142e0cfd9c79faa354606a354a83a70e105";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/zh-CN/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/zh-CN/firefox-57.0.3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "fdc4652edaa272e245a05160b5669b70a416a09ec784ab59df5ba4de0bf652ad8112533759f44e4496ebd38decdb4ce32119da761f0518d8f7bbf99ddffb4254";
+      sha512 = "cc7a52f748adfea0366f02536f22c384fdd39cfd792a4995e0f7b85e6835df08780fe3b3779922eed6958082c8df8d471cf18f5e65a613d7aec4b27db9a0a863";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.2/linux-i686/zh-TW/firefox-57.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.3/linux-i686/zh-TW/firefox-57.0.3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "993f1034938e4a33f4bd68e1328f708c285e23a11013d6d164d0eaf833f1600c192dd80480a20c51640223fcbc0be29a182fb4c662f2d46b933d41cc12a4e5b1";
+      sha512 = "eb5638f8a1f4a1b63d7c7681bba31b1fffd4826476442ee971e5844611b53bc3b070f8033c49f17d45d9cc9e7b9567805578cd3ced63ba186ac67d341544c0fe";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -32,10 +32,10 @@ rec {
 
   firefox-esr = common rec {
     pname = "firefox-esr";
-    version = "52.5.2esr";
+    version = "52.5.3esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "bbc7dcc4cb392f06fe2e963a3b6372efcfbbcc1ca7218a3ef05885285fe00c9e87e0f8d307bd9363668327eb43542c0600443bd9e6744de64494b96dd00efa5a";
+      sha512 = "7b9c87905c53bc681dc6475e05596449fed88850f9dc07c8223d0d3edd2dd9d8a0dd88ebae1cd59eced2165696df9370de5e85cc03cded58ec4d0f622634417f";
     };
 
     patches =

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -6,10 +6,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "57.0.2";
+    version = "57.0.3";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "e66402c182fae579dc645de1570a2eba4f95953f608de668da07a1ee4f371041cbdb3e01ce6e4708d8fa3b6b3ebe5b79e03e48ced3605f66cb09ac49abf3bbcd";
+      sha512 = "1f887ab6bb16ef69bce56b689e761b3e09fc106b4bee7842be2c8e7eac05981f9922e9c3a8bd22b4935545cbbc10bf0a0c79df7800cd3c80fd4137070c9bfd09";
     };
 
     patches =


### PR DESCRIPTION
###### Motivation for this change

The release notes are not updated yet. Maybe security fixes.

https://www.mozilla.org/en-US/firefox/57.0.3/releasenotes/
https://www.mozilla.org/en-US/firefox/52.5.3/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

