### PR TITLE
gtksourceview: run checks on Linux only

### DIFF
--- a/pkgs/desktops/gnome-3/core/gtksourceview/default.nix
+++ b/pkgs/desktops/gnome-3/core/gtksourceview/default.nix
@@ -14,9 +14,9 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig intltool gettext perl ]
-    ++ stdenv.lib.optionals doCheck checkInputs;
+    ++ checkInputs;
   buildInputs = [ atk cairo glib pango libxml2 ];
-  checkInputs = [ xvfb_run dbus ];
+  checkInputs = stdenv.lib.optionals doCheck [ xvfb_run dbus ];
 
   preBuild = ''
     substituteInPlace gtksourceview/gtksourceview-utils.c --replace "@NIX_SHARE_PATH@" "$out/share"
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./nix_share_path.patch ];
 
-  doCheck = true;
+  doCheck = stdenv.isLinux;
   checkPhase = ''
     export NO_AT_BRIDGE=1
     xvfb-run -s '-screen 0 800x600x24' dbus-run-session \


### PR DESCRIPTION
###### Motivation for this change

The check phase relies on `xvfb-run` which is a Linux-only package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

