### PR TITLE
buildRustCrate: Set target_os to "macos" on darwin

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate.nix
@@ -98,7 +98,7 @@ let makeDeps = dependencies:
       export CARGO_PKG_AUTHORS="${authors}"
 
       export CARGO_CFG_TARGET_ARCH=${buildPlatform.parsed.cpu.name}
-      export CARGO_CFG_TARGET_OS=${buildPlatform.parsed.kernel.name}
+      export CARGO_CFG_TARGET_OS=${if buildPlatform.isDarwin then "macos" else buildPlatform.parsed.kernel.name}
       export CARGO_CFG_TARGET_FAMILY="unix"
       export CARGO_CFG_UNIX=1
       export CARGO_CFG_TARGET_ENV="gnu"


### PR DESCRIPTION
The rust compiler uses "macos" as "target_os" conditional on Mac OS[1]

[1] https://github.com/rust-lang/rust/blob/8e7a609e635b728eba65d471c985ab462dc4cfc7/src/librustc_back/target/x86_64_apple_darwin.rs#L29

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


  