### PR TITLE
fdr: 4.2.0 -> 4.2.3

### DIFF
--- a/pkgs/applications/science/programming/fdr/default.nix
+++ b/pkgs/applications/science/programming/fdr/default.nix
@@ -1,9 +1,9 @@
 {stdenv, fetchurl, qtbase, qtx11extras, ncurses, xorg, zlib, python27Packages}:
 stdenv.mkDerivation {
-  name = "fdr-4.2.0";
+  name = "fdr-4.2.3";
   src = fetchurl {
-    url = https://www.cs.ox.ac.uk/projects/fdr/downloads/fdr-3754-linux-x86_64.tar.gz;
-    sha256 = "d24492485db9b8b95c62c53a6396094f836ee079cfc743688a397503c3ec9bf8";
+    url = https://www.cs.ox.ac.uk/projects/fdr/downloads/fdr-3789-linux-x86_64.tar.gz;
+    sha256 = "0n2yqichym5xdawlgk3r7yha88k7ycnx6585jfrcm7043sls1i88";
   };
 
   libPath = stdenv.lib.makeLibraryPath [
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
     cp -r * "$out"
     # Hack around lack of libtinfo in NixOS
     ln -s ${ncurses.out}/lib/libncursesw.so.6 $out/lib/libtinfo.so.5
-    ln -s ${qtbase.out}/$qtPluginPrefix $out/lib/qt_plugins
+    ln -s ${qtbase.bin}/${qtbase.qtPluginPrefix} $out/lib/qt_plugins
     ln -s ${zlib.out}/lib/libz.so.1 $out/lib/libz.so.1
 
     for b in fdr4 _fdr4 refines _refines cspmprofiler cspmexplorerprof


### PR DESCRIPTION
Update and fix FDR following QT distribution changes.

Fixes #30713.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---