### PR TITLE
electrum: Add QT_QPA_PLATFORM_PLUGIN_PATH

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python3, python3Packages }:
+{ stdenv, fetchurl, python3, python3Packages, qt5 }:
 
 python3Packages.buildPythonApplication rec {
   name = "electrum-${version}";
@@ -48,6 +48,10 @@ python3Packages.buildPythonApplication rec {
 
     substituteInPlace $out/share/applications/electrum.desktop \
       --replace "Exec=electrum %u" "Exec=$out/bin/electrum %u"
+
+    mv $out/bin/electrum $out/bin/.electrum-no-qt
+    makeWrapper $out/bin/.electrum-no-qt $out/bin/electrum \
+      --set QT_QPA_PLATFORM_PLUGIN_PATH ${qt5.qtbase.bin}/lib/qt-*/plugins/platforms
   '';
 
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

This fixes an error that prevents the program from starting:

> This application failed to start because it could not find or load the Qt platform plugin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).