### PR TITLE
bitscope: init at 2017-12-28

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -684,6 +684,7 @@
   vcunat = "Vladimír Čunát <vcunat@gmail.com>";
   vdemeester = "Vincent Demeester <vincent@sbr.pm>";
   veprbl = "Dmitry Kalinkin <veprbl@gmail.com>";
+  vidbina = "David Asabina <vid@bina.me>";
   vifino = "Adrian Pistol <vifino@tty.sh>";
   vinymeuh = "VinyMeuh <vinymeuh@gmail.com>";
   viric = "Lluís Batlle i Rossell <viric@viric.name>";

--- a/pkgs/applications/science/electronics/bitscope/common.nix
+++ b/pkgs/applications/science/electronics/bitscope/common.nix
@@ -1,0 +1,67 @@
+{ atk
+, buildFHSUserEnv
+, cairo
+, dpkg
+, fetchurl
+, gdk_pixbuf
+, glib
+, gtk2-x11
+, makeWrapper
+, pango
+, stdenv
+, writeScriptBin
+, xorg
+}:
+
+{ src, toolName, version, ... } @ attrs:
+let
+  wrapBinary = libPaths: binaryName: ''
+    wrapProgram "$out/bin/${binaryName}" \
+      --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath libPaths}"
+  '';
+  pkg = stdenv.mkDerivation (rec {
+    inherit (attrs) version src;
+
+    name = "${toolName}-${version}";
+
+    meta = with stdenv.lib; {
+      homepage = http://bitscope.com/software/;
+      license = licenses.unfree;
+      platforms = [ "x86_64-linux" ];
+      maintainers = with maintainers; [
+        vidbina
+      ];
+    } // (attrs.meta or {});
+
+    buildInputs = [
+      dpkg
+      makeWrapper
+    ];
+
+    libs = attrs.libs or [
+      atk
+      cairo
+      gdk_pixbuf
+      glib
+      gtk2-x11
+      pango
+      xorg.libX11
+    ];
+
+    dontBuild = true;
+
+    unpackPhase = attrs.unpackPhase or ''
+      dpkg-deb -x ${attrs.src} ./
+    '';
+
+    installPhase = attrs.installPhase or ''
+      mkdir -p "$out/bin"
+      cp -a usr/* "$out/"
+      ${(wrapBinary libs) attrs.toolName}
+    '';
+  });
+in buildFHSUserEnv {
+  name = attrs.toolName;
+  meta = pkg.meta;
+  runScript = "${pkg.outPath}/bin/${attrs.toolName}";
+}

--- a/pkgs/applications/science/electronics/bitscope/packages.nix
+++ b/pkgs/applications/science/electronics/bitscope/packages.nix
@@ -1,0 +1,153 @@
+{ buildFHSUserEnv
+, callPackage
+, fetchurl
+, makeWrapper
+, stdenv
+}:
+
+let
+  wrapBinary = libPaths: binaryName: ''
+    wrapProgram "$out/bin/${binaryName}" \
+      --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath libPaths}"
+  '';
+  mkBitscope = callPackage (import ./common.nix) { };
+in {
+  chart = let
+    toolName = "bitscope-chart";
+    version = "2.0.FK22M";
+  in mkBitscope {
+    inherit toolName version;
+
+    meta = {
+      description = "Multi-channel waveform data acquisition and chart recording application";
+      homepage = "http://bitscope.com/software/chart/";
+    };
+
+    src = fetchurl {
+      url = "http://bitscope.com/download/files/${toolName}_${version}_amd64.deb";
+      sha256 = "08mc82pjamyyyhh15sagsv0sc7yx5v5n54bg60fpj7v41wdwrzxw";
+    };
+  };
+
+  console = let
+    toolName = "bitscope-console";
+    version = "1.0.FK29A";
+  in mkBitscope {
+    # NOTE: this is meant as a demo by BitScope
+    inherit toolName version;
+
+    meta = {
+      description = "Demonstrative communications program designed to make it easy to talk to any model BitScope";
+    };
+
+    src = fetchurl {
+      url = "http://bitscope.com/download/files/${toolName}_${version}_amd64.deb";
+      sha256 = "00b4gxwz7w6pmfrcz14326b24kl44hp0gzzqcqxwi5vws3f0y49d";
+    };
+  };
+
+  display = let
+    toolName = "bitscope-display";
+    version = "1.0.EC17A";
+  in mkBitscope {
+    inherit toolName version;
+
+    meta = {
+      description = "Display diagnostic application for BitScope";
+      homepage = "http://bitscope.com/software/display/";
+    };
+
+    src = fetchurl {
+      url = "http://bitscope.com/download/files/${toolName}_${version}_amd64.deb";
+      sha256 = "05xr5mnka1v3ibcasg74kmj6nlv1nmn3lca1wv77whkq85cmz0s1";
+    };
+  };
+
+  dso = let
+    toolName = "bitscope-dso";
+    version = "2.8.FE22H";
+  in mkBitscope {
+    inherit toolName version;
+
+    meta = {
+      description = "Test and measurement software for BitScope";
+      homepage = "http://bitscope.com/software/dso/";
+    };
+
+    src = fetchurl {
+      url = "http://bitscope.com/download/files/${toolName}_${version}_amd64.deb";
+      sha256 = "0fc6crfkprj78dxxhvhbn1dx1db5chm0cpwlqpqv8sz6whp12mcj";
+    };
+  };
+
+  logic = let
+    toolName = "bitscope-logic";
+    version = "1.2.FC20C";
+  in mkBitscope {
+    inherit toolName version;
+
+    meta = {
+      description = "Mixed signal logic timing and serial protocol analysis software for BitScope";
+      home = "http://bitscope.com/software/logic/";
+    };
+
+    src = fetchurl {
+      url = "http://bitscope.com/download/files/${toolName}_${version}_amd64.deb";
+      sha256 = "0lkb7z9gfkiyxdwh4dq1zxfls8gzdw0na1vrrbgnxfg3klv4xns3";
+    };
+  };
+
+  meter = let
+    toolName = "bitscope-meter";
+    version = "2.0.FK22G";
+  in mkBitscope {
+    inherit toolName version;
+
+    meta = {
+      description = "Automated oscilloscope, voltmeter and frequency meter for BitScope";
+      homepage = "http://bitscope.com/software/logic/";
+    };
+
+    src = fetchurl {
+      url = "http://bitscope.com/download/files/${toolName}_${version}_amd64.deb";
+      sha256 = "0nirbci6ymhk4h4bck2s4wbsl5r9yndk2jvvv72zwkg21248mnbp";
+    };
+  };
+
+  proto = let
+    toolName = "bitscope-proto";
+    version = "0.9.FG13B";
+  in mkBitscope rec {
+    inherit toolName version;
+    # NOTE: this is meant as a demo by BitScope
+    # NOTE: clicking on logo produces error
+    # TApplication.HandleException Executable not found: "http://bitscope.com/blog/DK/?p=DK15A"
+
+    meta = {
+      description = "Demonstrative prototype oscilloscope built using the BitScope Library";
+      homepage = "http://bitscope.com/blog/DK/?p=DK15A";
+    };
+
+    src = fetchurl {
+      url = "http://bitscope.com/download/files/${toolName}_${version}_amd64.deb";
+      sha256 = "1ybjfbh3narn29ll4nci4b7rnxy0hj3wdfm4v8c6pjr8pfvv9spy";
+    };
+  };
+
+  server = let
+    toolName = "bitscope-server";
+    version = "1.0.FK26A";
+  in mkBitscope {
+    inherit toolName version;
+
+    meta = {
+      description = "Remote access server solution for any BitScope";
+      homepage = "http://bitscope.com/software/server/";
+    };
+
+    src = fetchurl {
+      url = "http://bitscope.com/download/files/${toolName}_${version}_amd64.deb";
+      sha256 = "1079n7msq6ks0n4aasx40rd4q99w8j9hcsaci71nd2im2jvjpw9a";
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14046,6 +14046,8 @@ with pkgs;
 
   bitmeter = callPackage ../applications/audio/bitmeter { };
 
+  bitscope = callPackage ../applications/science/electronics/bitscope/packages.nix { };
+
   bitwig-studio =  callPackage ../applications/audio/bitwig-studio {
     inherit (gnome2) zenity;
   };


### PR DESCRIPTION
###### Motivation for this change

BitScope makes some pretty sweet and affordable [scopes and logic analysers](http://bitscope.com/product/) of which I own a unit that I needed to use recently. Sadly the source doesn't seem to be open (hence the submission with the unfree license), but they at least offer some reference [schematics for the hardware](http://bitscope.com/design/hardware/).

Several [deb](http://my.bitscope.com/download/?p=download&f=APDI) and rpm packages, among other formats for other platforms, are available on [their website](http://my.bitscope.com/download/) so I figured it made sense to take the deb and package it for use in NixOS. I ended up using a FHS env to get everything up and running and mostly tested the additions with a combination of

```
nix-shell --pure --show-trace -I nixpkgs=$NIXPKGS -p bitscope.dso bitscope.chart bitscope.meter
```

which drops me in a shell where I have access to the executables, or

```
nix-repl -I nixpkgs=$NIXPKGS
```

from within the nixpkgs directory, loading the whole shebang and inspecting the `bitscope` set.

The added packages along with the executables they install are:

 - `bitscope.chart`, [:link:](http://bitscope.com/software/chart/) accessible through the binary `bitscope-chart`
 - `bitscope.console`, accessible through the binary `bitscope-console`
 - `bitscope.display`, [:link:](http://bitscope.com/software/display/) accessible through the binary `bitscope-display`
 - `bitscope.dso`, [:link:](http://bitscope.com/software/dso/) accessible through the binary `bitscope-dso`
 - `bitscope.logic`, [:link:](http://bitscope.com/software/logic/) accessible through the binary `bitscope-logic`
 - `bitscope.meter`, [:link:](http://bitscope.com/software/meter/) accessible through the binary `bitscope-meter`
 - `bitscope.proto`, accessible through the binary `bitscope-proto`
 - `bitscope.server` [:link:](http://bitscope.com/blog/DL/?p=DL15A), accessible through the binary `bitscope-server`

Every binary is pinned to the latest stable version as of 2017-12-28 and works on my setup.

![2017-12-28-183236_3200x1800_scrot](https://user-images.githubusercontent.com/335406/34424222-51adfd9c-ec22-11e7-9976-ab325d8ab5fe.png)



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

