### PR TITLE
programs.zsh.ohMyZsh: add `cacheDir` option

### DIFF
--- a/nixos/modules/programs/zsh/oh-my-zsh.nix
+++ b/nixos/modules/programs/zsh/oh-my-zsh.nix
@@ -50,7 +50,7 @@ in
         };
 
         cacheDir = mkOption {
-          default = null;
+          default = "$HOME/.cache/oh-my-zsh";
           type = types.str;
           description = ''
             Cache directory to be used by `oh-my-zsh`.

--- a/nixos/modules/programs/zsh/oh-my-zsh.nix
+++ b/nixos/modules/programs/zsh/oh-my-zsh.nix
@@ -48,6 +48,15 @@ in
             Name of the theme to be used by oh-my-zsh.
           '';
         };
+
+        cacheDir = mkOption {
+          default = null;
+          type = types.str;
+          description = ''
+            Cache directory to be used by `oh-my-zsh`.
+            Default is /nix/store/<oh-my-zsh>/cache.
+          '';
+        };
       };
     };
 
@@ -73,6 +82,13 @@ in
         ${optionalString (stringLength(cfg.theme) > 0)
           "ZSH_THEME=\"${cfg.theme}\""
         }
+
+        ${optionalString (cfg.cacheDir != null) ''
+          if [[ ! -d "${cfg.cacheDir}" ]]; then
+            mkdir -p "${cfg.cacheDir}"
+          fi
+          ZSH_CACHE_DIR=${cfg.cacheDir}
+        ''}
 
         source $ZSH/oh-my-zsh.sh
       '';


### PR DESCRIPTION
###### Motivation for this change

The default cache directory set by oh-my-zsh is $ohMyZsh/cache which
lives in the Nix store in our case. This causes issues with several
completion plugins provided by oh-my-zsh:

```
λ ma27 [~] → systemctl show <TAB>
_store_cache:46: read-only file system: /nix/store/xgc17vs8as4m793kb6ss89a3d4pz7x9d-oh-my-zsh-2017-09-24/share/oh-my-zsh/cache/SYS_ALL_UNITS
_store_cache:46: read-only file system: /nix/store/xgc17vs8as4m793kb6ss89a3d4pz7x9d-oh-my-zsh-2017-09-24/share/oh-my-zsh/cache/SYS_REALLY_ALL_UNITS
```

The entire change can be tested using a VM declaration like this:

``` nix
{
  ohmyzsh = {
    users.extraUsers.vm = {
      password = "vm";
      isNormalUser = true;
    };
    programs.zsh.enable = true;
    programs.zsh.ohMyZsh.enable = true;
    programs.zsh.ohMyZsh.theme = "lambda";
    programs.zsh.ohMyZsh.cacheDir = "$HOME/.cache/ohMyZsh";
  };
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

