### PR TITLE
chkrootkit: fixup relative path usage

### DIFF
--- a/pkgs/tools/security/chkrootkit/default.nix
+++ b/pkgs/tools/security/chkrootkit/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
   # TODO: a lazy work-around for linux build failure ...
   makeFlags = [ "STATIC=" ];
 
+   postPatch = ''
+    substituteInPlace chkrootkit \
+      --replace " ./" " $out/bin/"
+   '';
+
   installPhase = ''
     mkdir -p $out/sbin
     cp check_wtmpx chkdirs chklastlog chkproc chkrootkit chkutmp chkwtmp ifpromisc strings-static $out/sbin


### PR DESCRIPTION
###### Motivation for this change

Help find the binaries installed alongside!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

