### PR TITLE
fastpbkdf2: init at version 1.0.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -361,6 +361,7 @@
   ldesgoui = "Lucas Desgouilles <ldesgoui@gmail.com>";
   league = "Christopher League <league@contrapunctus.net>";
   lebastr = "Alexander Lebedev <lebastr@gmail.com>";
+  ledif = "Adam Fidel <refuse@gmail.com>";
   leemachin = "Lee Machin <me@mrl.ee>";
   leenaars = "Michiel Leenaars <ml.software@leenaa.rs>";
   leonardoce = "Leonardo Cecchi <leonardo.cecchi@gmail.com>";

--- a/pkgs/development/libraries/fastpbkdf2/default.nix
+++ b/pkgs/development/libraries/fastpbkdf2/default.nix
@@ -24,5 +24,6 @@ stdenv.mkDerivation {
     description = "A fast PBKDF2-HMAC-{SHA1,SHA256,SHA512} implementation in C";
     homepage = https://github.com/ctz/fastpbkdf2;
     licenses = licenses.cc0;
+    maintainers = with maintainers; [ ledif ];
   };
 }

--- a/pkgs/development/libraries/fastpbkdf2/default.nix
+++ b/pkgs/development/libraries/fastpbkdf2/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, openssl }:
+
+stdenv.mkDerivation {
+  name = "fastpbkdf2-1.0.0";
+  
+  src = fetchurl {
+    url = https://github.com/ctz/fastpbkdf2/archive/v1.0.0.tar.gz;
+    sha256 = "492874e2088dd38cfa74b1b3a99c0b907ecb8da96c656e618353a2e825b8c152";
+  };
+  
+  buildInputs = [ openssl ];
+
+  preBuild = ''
+    makeFlagsArray=(CFLAGS="-std=c99 -O3 -g")
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{lib,include/fastpbkdf2}
+    cp *.a $out/lib
+    cp fastpbkdf2.h $out/include/fastpbkdf2
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A fast PBKDF2-HMAC-{SHA1,SHA256,SHA512} implementation in C";
+    homepage = https://github.com/ctz/fastpbkdf2;
+    licenses = licenses.cc0;
+  };
+}

--- a/pkgs/development/libraries/fastpbkdf2/default.nix
+++ b/pkgs/development/libraries/fastpbkdf2/default.nix
@@ -1,11 +1,13 @@
-{ stdenv, fetchurl, openssl }:
+{ stdenv, fetchFromGitHub, openssl }:
 
 stdenv.mkDerivation {
   name = "fastpbkdf2-1.0.0";
   
-  src = fetchurl {
-    url = https://github.com/ctz/fastpbkdf2/archive/v1.0.0.tar.gz;
-    sha256 = "492874e2088dd38cfa74b1b3a99c0b907ecb8da96c656e618353a2e825b8c152";
+  src = fetchFromGitHub {
+    owner = "ctz";
+    repo = "fastpbkdf2";
+    rev = "v1.0.0";
+    sha256 = "09ax0h4ik3vhvp3s98lic93l3g9f4v1jkr5k6z4g1lvm7s3lrha2";
   };
   
   buildInputs = [ openssl ];
@@ -23,7 +25,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "A fast PBKDF2-HMAC-{SHA1,SHA256,SHA512} implementation in C";
     homepage = https://github.com/ctz/fastpbkdf2;
-    licenses = licenses.cc0;
+    license = licenses.cc0;
     maintainers = with maintainers; [ ledif ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2027,6 +2027,8 @@ with pkgs;
       pillow;
   };
 
+  fastpbkdf2 = callPackage ../development/libraries/fastpbkdf2 { };
+
   fanficfare = callPackage ../tools/text/fanficfare { };
 
   fastd = callPackage ../tools/networking/fastd { };


### PR DESCRIPTION
###### Motivation for this change

New package for fastpbkdf2, which is a fast PBKDF2-HMAC-{SHA1,SHA256,SHA512} implementation in C.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

