### PR TITLE
minimodem: 0.19->0.24

### DIFF
--- a/pkgs/applications/audio/minimodem/default.nix
+++ b/pkgs/applications/audio/minimodem/default.nix
@@ -1,17 +1,28 @@
-{ stdenv, fetchurl, pkgconfig, fftw, fftwSinglePrec, alsaLib, libsndfile, libpulseaudio }:
+{ stdenv, fetchFromGitHub, pkgconfig, autoconf, automake, libtool
+, fftw, fftwSinglePrec, alsaLib, libsndfile, libpulseaudio
+}:
 
 stdenv.mkDerivation rec {
-  version = "0.19";
+  version = "0.24-1";
   pname = "minimodem";
   name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "http://www.whence.com/${pname}/${name}.tar.gz";
-    sha256 = "003xyqjq59wcjafrdv1b8w34xsn4nvzz51wwd7mqddajh0g4dz4g";
+  src = fetchFromGitHub {
+    owner = "kamalmostafa";
+    repo = "minimodem";
+    rev = "${pname}-${version}";
+    sha256 = "1b5xy36fjcp7vkp115dpx4mlmqg2fc7xvxdy648fb8im953bw7ql";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig autoconf automake libtool ];
   buildInputs = [ fftw fftwSinglePrec alsaLib libsndfile libpulseaudio ];
+
+  preConfigure = ''
+    aclocal \
+    && autoheader \
+    && automake --gnu --add-missing \
+    && autoconf
+  '';
 
   meta = {
     description = "General-purpose software audio FSK modem";
@@ -28,3 +39,4 @@ stdenv.mkDerivation rec {
     maintainers = with stdenv.lib.maintainers; [ relrod ];
   };
 }
+


### PR DESCRIPTION
###### Motivation for this change
Update version, and change source to GitHub

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

