### PR TITLE
veracrypt: refactor

### DIFF
--- a/pkgs/applications/misc/veracrypt/default.nix
+++ b/pkgs/applications/misc/veracrypt/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Free Open-Source filesystem on-the-fly encryption";
-    homepage = https://veracrypt.codeplex.com/;
+    homepage = https://www.veracrypt.fr/;
     license = "VeraCrypt License";
     maintainers = with maintainers; [ dsferruzza ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change
Previous Veracrypt hoster was CodePlex which will be shut down and was set to read only on 27th of November. See the announcement (https://blogs.msdn.microsoft.com/bharry/2017/03/31/shutting-down-codeplex/) . Verycrypt's homepage has since moved to https://www.veracrypt.fr which is owned by IDRIX (https://www.afnic.fr/fr/produits-et-services/services/whois/)

###### Things done
Changed the link in the description; I'm not using veracrypt myself, just stumbled over it - hence untested.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

