### PR TITLE
libelf required by some module compilation (on kernel >= 4.14.9)

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
 
   NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
 
-  buildInputs = [ patchelf cdrkit makeWrapper dbus ];
+  buildInputs = [ patchelf cdrkit makeWrapper dbus ] ++ kernel.moduleBuildDependencies;
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -42,7 +42,9 @@ in {
   # Use defaultMeta // extraMeta
   extraMeta ? {},
   # Whether to utilize the controversial import-from-derivation feature to parse the config
-  allowImportFromDerivation ? false
+  allowImportFromDerivation ? false,
+  # Dependencies that are required to build kernel modules
+  moduleBuildDependencies ? stdenv.lib.optional (stdenv.lib.versionAtLeast version "4.14") libelf
 }:
 
 let
@@ -85,7 +87,7 @@ let
         (isModular || (config.isDisabled "FIRMWARE_IN_KERNEL"));
     in (optionalAttrs isModular { outputs = [ "out" "dev" ]; }) // {
       passthru = {
-        inherit version modDirVersion config kernelPatches configfile;
+        inherit version modDirVersion config kernelPatches configfile moduleBuildDependencies;
       };
 
       inherit src;

--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -25,7 +25,7 @@ let
 
       patches = [ ./const.patch ./install_prefix.patch ];
 
-      nativeBuildInputs = [ autoreconfHook ];
+      nativeBuildInputs = [ autoreconfHook ] ++ optional (kernel != null) kernel.moduleBuildDependencies;
 
       hardeningDisable = [ "pic" ];
 

--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     cmake zlib luajit ncurses perl jsoncpp libb64 openssl curl jq gcc
-  ];
+  ] ++ optional (kernel != null) kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];
 

--- a/pkgs/os-specific/linux/tp_smapi/default.nix
+++ b/pkgs/os-specific/linux/tp_smapi/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     name = "tp-smapi-${version}";
   };
 
+  buildInputs =  kernel.moduleBuildDependencies;
+
   hardeningDisable = [ "pic" ];
 
   makeFlags = [

--- a/pkgs/os-specific/linux/virtualbox/default.nix
+++ b/pkgs/os-specific/linux/virtualbox/default.nix
@@ -7,6 +7,8 @@ stdenv.mkDerivation {
     "fortify" "pic" "stackprotector"
   ];
 
+  buildInputs = kernel.moduleBuildDependencies;
+
   patches = [
     ./fix_kerndir.patch
     ./fix_kbuild.patch

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -38,7 +38,8 @@ let
 
       patches = extraPatches;
 
-      nativeBuildInputs = [ autoreconfHook nukeReferences ];
+      nativeBuildInputs = [ autoreconfHook nukeReferences ]
+         ++ optional (kernel != null) kernel.moduleBuildDependencies;
       buildInputs =
            optionals buildKernel [ spl ]
         ++ optionals buildUser [ zlib libuuid python attr ]


### PR DESCRIPTION
###### Motivation for this change

Kernel 4.14 require libelf to compile modules.
[...]
make modules -C /nix/store/h1vzl6bq4wif3m8dd1bw2p3fv4shjg3n-linux-4.14.9-dev/lib/modules/4.14.9/build EXTRA_CFLAGS=-Werror-implicit-function-declaration   M=/tmp/nix-build-spl-kernel-2017-11-16-4.14.9.drv-0/source/build
    /nix/store/h1vzl6bq4wif3m8dd1bw2p3fv4shjg3n-linux-4.14.9-dev/lib/modules/4.14.9/source/Makefile:939: *** "Cannot generate ORC metadata for CONFIG_UNWINDER_ORC=y, please install libelf-dev, libelf-devel or elfutils-libelf-devel".  Stop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

