### PR TITLE
wallabag: 2.2.3 -> 2.3.1

### DIFF
--- a/pkgs/servers/web-apps/wallabag/default.nix
+++ b/pkgs/servers/web-apps/wallabag/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "wallabag-${version}";
-  version = "2.2.3";
+  version = "2.3.1";
 
   # remember to rm -r var/cache/* after a rebuild or unexpected errors will occur
 
   src = fetchurl {
     url = "https://static.wallabag.org/releases/wallabag-release-${version}.tar.gz";
-    sha256 = "0myqarwny9p53g2gmwmg1mcn17jlx5ah0bri13panhf7ryvmrzhk";
+    sha256 = "1qk7jicni5g8acpjybrwnwf7zknk3b0mxiv5876lrsajcxdxwnf4";
   };
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" ];
 
   patchPhase = ''
     rm Makefile # use the "shared hosting" package with bundled dependencies
@@ -22,8 +22,6 @@ stdenv.mkDerivation rec {
   ''; # exposes $WALLABAG_DATA
 
   installPhase = ''
-    mkdir -p $doc/share/doc
-    mv docs $doc/share/doc/wallabag
     mkdir $out/
     cp -R * $out/
   '';


### PR DESCRIPTION
###### Motivation for this change
updated wallabag to latest minor release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
