### PR TITLE
python3Packages.pythonix: init at 0.1.0

### DIFF
--- a/pkgs/development/python-modules/pythonix/default.nix
+++ b/pkgs/development/python-modules/pythonix/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, ninja, meson, pkgconfig, gcc7, nixUnstable, isPy3k }:
+
+assert isPy3k;
+
+stdenv.mkDerivation rec {
+  name = "pythonix-${version}";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Mic92";
+    repo = "pythonix";
+    rev = "v${version}";
+    sha256 = "1piblysypyr442a6najk4mdh87xc377i2fdbfw6fr569z60mnnnj";
+  };
+
+  nativeBuildInputs = [ meson pkgconfig ninja gcc7 ];
+
+  buildInputs = [ nixUnstable ];
+
+  meta = with stdenv.lib; {
+    description = ''
+       Eval nix code from python.
+    '';
+    maintainers = [ maintainers.mic92 ];
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6646,6 +6646,8 @@ in {
     };
   };
 
+  pythonix = callPackage ../development/python-modules/pythonix { };
+
   pypolicyd-spf = buildPythonPackage rec {
     name = "pypolicyd-spf-${version}";
     majorVersion = "2.0";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

