### PR TITLE
pelican: Disable pandoc support for now

### DIFF
--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -25,7 +25,10 @@ buildPythonPackage rec {
 
   buildInputs = [
     glibcLocales
-    pandoc
+    # Note: Pelican has to adapt to a changed CLI of pandoc before enabling this
+    # again. Compare https://github.com/getpelican/pelican/pull/2252.
+    # Version 3.7.1 is incompatible with our current pandoc version.
+    # pandoc
     git
     mock
     nose


### PR DESCRIPTION
Version 3.7.1 is not compatible with the current (more recent) pandoc version.
Since pandoc support is optional in pelican, we can ship it without pandoc
support until a fix will be applied upstream.

Kept a note in the buildInputs so that the improvement opportunity can be
spotted again on future updates of pelican.

###### Motivation for this change

Noticed that the build of pelican is failing since a few days: https://hydra.nixos.org/job/nixpkgs/trunk/python36Packages.pelican.x86_64-linux

Got hit by it myself a few hours ago.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

