### PR TITLE
dash-to-panel: init at v11

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/dash-to-panel/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/dash-to-panel/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, glib, gettext }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-dash-to-panel-${version}";
+  version = "11";
+
+  src = fetchFromGitHub {
+    owner = "jderose9";
+    repo = "dash-to-panel";
+    rev = "v${version}";
+    sha256 = "1bfcnrhw6w8yrz8sw520kwwshmplkg4awpvz07kg4d73m6zn4mw2";
+  };
+
+  buildInputs = [
+    glib gettext
+  ];
+
+  makeFlags = [ "INSTALLBASE=$(out)/share/gnome-shell/extensions" ];
+
+  meta = with stdenv.lib; {
+    description = "An icon taskbar for Gnome Shell";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ mounium ];
+    homepage = https://github.com/jderose9/dash-to-panel;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18585,6 +18585,7 @@ with pkgs;
   gnomeExtensions = {
     caffeine = callPackage ../desktops/gnome-3/extensions/caffeine { };
     dash-to-dock = callPackage ../desktops/gnome-3/extensions/dash-to-dock { };
+    dash-to-panel = callPackage ../desktops/gnome-3/extensions/dash-to-panel { };
     topicons-plus = callPackage ../desktops/gnome-3/extensions/topicons-plus { };
   };
 


### PR DESCRIPTION
###### Motivation for this change
A useful gnome shell extension, likely used by many and as chrome-gnome-shell doesn't work I couldn't install it in an easier way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

