### PR TITLE
libresolv: fix library version

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/libresolv/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libresolv/default.nix
@@ -33,7 +33,7 @@ appleDerivation {
     cc -I. -c res_send.c
     cc -I. -c res_sendsigned.c
     cc -I. -c res_update.c
-    cc -dynamiclib -install_name $out/lib/libresolv.9.dylib -o libresolv.9.dylib *.o
+    cc -dynamiclib -install_name $out/lib/libresolv.9.dylib -current_version 1.0.0 -compatibility_version 1.0.0 -o libresolv.9.dylib *.o
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

The rust binary builds (and possibly other things) don't like that our version of libresolv doesn't have any version.
.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

