### PR TITLE
gnomeExtensions.mediaplayer: init at 3.5

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -663,6 +663,7 @@
   thpham = "Thomas Pham <thomas.pham@ithings.ch>";
   timbertson = "Tim Cuthbertson <tim@gfxmonk.net>";
   timokau = "Timo Kaufmann <timokau@zoho.com>";
+  tiramiseb = "Sébastien Maccagnoni <sebastien@maccagnoni.eu>";
   titanous = "Jonathan Rudenberg <jonathan@titanous.com>";
   tnias = "Philipp Bartsch <phil@grmr.de>";
   tohl = "Tomas Hlavaty <tom@logand.com>";

--- a/pkgs/desktops/gnome-3/extensions/mediaplayer/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/mediaplayer/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, glib, meson, gettext, ninja }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-extensions-mediaplayer-${version}";
+  version = "3.5";
+
+  src = fetchFromGitHub {
+    owner = "JasonLG1979";
+    repo = "gnome-shell-extensions-mediaplayer";
+    rev = version;
+    sha256 = "0b8smid9vdybgs0601q9chlbgfm1rzrj3vmd3i6p2a5d1n4fyvsc";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+  buildInputs = [
+    glib
+    gettext
+  ];
+
+  postPatch = ''
+    rm build
+    chmod +x meson_post_install.py
+    patchShebangs meson_post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Control MPRIS Version 2 Capable Media Players";
+    license = licenses.gpl2Plus;
+    homepage = https://github.com/JasonLG1979/gnome-shell-extensions-mediaplayer/;
+    maintainers = with maintainers; [ tiramiseb ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18593,6 +18593,7 @@ with pkgs;
     caffeine = callPackage ../desktops/gnome-3/extensions/caffeine { };
     dash-to-dock = callPackage ../desktops/gnome-3/extensions/dash-to-dock { };
     dash-to-panel = callPackage ../desktops/gnome-3/extensions/dash-to-panel { };
+    mediaplayer = callPackage ../desktops/gnome-3/extensions/mediaplayer { };
     topicons-plus = callPackage ../desktops/gnome-3/extensions/topicons-plus { };
   };
 


### PR DESCRIPTION
###### Motivation for this change

Allow to install the mediaplayer GNOME Shell extension from a package

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
