### PR TITLE
miller: init at 5.2.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -451,6 +451,7 @@
   mrVanDalo = "Ingolf Wanger <contact@ingolf-wagner.de>";
   msackman = "Matthew Sackman <matthew@wellquite.org>";
   mschristiansen = "Mikkel Christiansen <mikkel@rheosystems.com>";
+  mstarzyk = "Maciek Starzyk <mstarzyk@gmail.com>";
   msteen = "Matthijs Steen <emailmatthijs@gmail.com>";
   mt-caret = "Masayuki Takeda <mtakeda.enigsol@gmail.com>";
   mtreskin = "Max Treskin <zerthurd@gmail.com>";

--- a/pkgs/tools/text/miller/default.nix
+++ b/pkgs/tools/text/miller/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, flex, libtool }:
+
+stdenv.mkDerivation rec {
+  name = "miller-${version}";
+
+  version = "5.2.2";
+
+  src = fetchFromGitHub {
+    owner = "johnkerl";
+    repo = "miller";
+    rev = "v${version}";
+    sha256 = "1i5lyknsf4vif601l070xh5sz8jy2h359jrb0kc0s0pl8lypxs4i";
+  };
+
+  nativeBuildInputs = [ autoreconfHook flex libtool ];
+
+  meta = with stdenv.lib; {
+    description = "Miller is like awk, sed, cut, join, and sort for name-indexed data such as CSV, TSV, and tabular JSON.";
+    homepage    = "http://johnkerl.org/miller/";
+    license     = licenses.bsd2;
+    maintainers = with maintainers; [ mstarzyk ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3646,6 +3646,8 @@ with pkgs;
 
   nomad = callPackage ../applications/networking/cluster/nomad { };
 
+  miller = callPackage ../tools/text/miller { };
+
   milu = callPackage ../applications/misc/milu { };
 
   mpack = callPackage ../tools/networking/mpack { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

