### PR TITLE
WIP: waterfox-bin: init at 56.0.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -283,6 +283,7 @@
   hrdinka = "Christoph Hrdinka <c.nix@hrdinka.at>";
   htr = "Hugo Tavares Reis <hugo@linux.com>";
   hyphon81 = "Masato Yonekawa <zero812n@gmail.com>";
+  iamale = "Alexander Pushkov <alexander@notpushk.in>";
   iand675 = "Ian Duncan <ian@iankduncan.com>";
   ianwookim = "Ian-Woo Kim <ianwookim@gmail.com>";
   iblech = "Ingo Blechschmidt <iblech@speicherleck.de>";

--- a/pkgs/applications/networking/browsers/waterfox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/waterfox-bin/default.nix
@@ -1,0 +1,157 @@
+{ stdenv, fetchurl, config, makeWrapper, makeDesktopItem
+, alsaLib
+, at_spi2_atk
+, atk
+, cairo
+, cups
+, curl
+, dbus_glib
+, dbus_libs
+, fontconfig
+, freetype
+, gdk_pixbuf
+, glib
+, glibc
+, gst-plugins-base
+, gstreamer
+, gtk2
+, gtk3
+, kerberos
+, libX11
+, libXScrnSaver
+, libXcomposite
+, libXdamage
+, libXext
+, libXfixes
+, libXinerama
+, libXrender
+, libXt
+, libcanberra_gtk2
+, mesa
+, nspr
+, nss
+, pango
+, writeScript
+, xidel
+, coreutils
+, gnused
+, gnugrep
+, gnupg
+}:
+
+with stdenv.lib;
+
+let
+  # Upstream source
+  version = "56.0.1";
+  lang = "en-US";
+
+  srcs = {
+    "x86_64-linux" = fetchurl {
+      url = "https://storage-waterfox.netdna-ssl.com/releases/linux64/installer/waterfox-${version}.${lang}.linux-x86_64.tar.bz2";
+      sha512 = "82e83f375a06dbe94bd5d7aecaa6da246b622574547baf7d54d27371dfdd0f6499f8302d3d24000302897648a112e1c286d1bb7500a91b03fa860645241225d5";
+    };
+  };
+in
+
+stdenv.mkDerivation rec {
+  name = "waterfox-bin-${version}";
+  inherit version;
+
+  src = srcs."${stdenv.system}" or (throw "unsupported system: ${stdenv.system}");
+
+  preferLocalBuild = true;
+  allowSubstitutes = false;
+
+  libPath = makeLibraryPath ([
+    stdenv.cc.cc
+    alsaLib
+    at_spi2_atk
+    atk
+    cairo
+    cups
+    curl
+    dbus_glib
+    dbus_libs
+    fontconfig
+    freetype
+    gdk_pixbuf
+    glib
+    glibc
+    gst-plugins-base
+    gstreamer
+    gtk2
+    gtk3
+    kerberos
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXdamage
+    libXext
+    libXfixes
+    libXinerama
+    libXrender
+    libXt
+    libcanberra_gtk2
+    mesa
+    nspr
+    nss
+    pango
+  ]);
+
+  desktopItem = makeDesktopItem {
+    name = "waterfox";
+    exec = "waterfox";
+    icon = "waterfox";
+    desktopName = "Waterfox";
+    genericName = "Web Browser";
+    mimeType = stdenv.lib.concatStringsSep ";" [
+      "text/html"
+      "text/xml"
+      "application/xhtml+xml"
+      "x-scheme-handler/http"
+      "x-scheme-handler/https"
+      "x-scheme-handler/ftp"
+      "x-scheme-handler/mailto"
+      "x-scheme-handler/webcal"
+      "x-scheme-handler/about"
+      "x-scheme-handler/unknown"
+    ];
+    comment = "Browse the World Wide Web";
+    categories = "Application;Network;WebBrowser;";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildCommand = ''
+    mkdir -p "$prefix/opt/waterfox-bin-${version}"
+    tar -xf "${src}" -C "$prefix/opt/waterfox-bin-${version}" --strip-components=1
+
+    mkdir -p "$out/bin"
+    ln -s "$prefix/opt/waterfox-bin-${version}/waterfox" "$out/bin/"
+
+    for executable in \
+      waterfox waterfox-bin plugin-container updater
+    do
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        "$prefix/opt/waterfox-bin-${version}/$executable"
+    done
+
+    wrapProgram "$out/bin/waterfox" \
+      --argv0 "$out/bin/.waterfox-wrapped" \
+      --set LD_LIBRARY_PATH "$libPath" \
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:" \
+      --suffix XDG_DATA_DIRS : "$XDG_ICON_DIRS"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A web browser (binary package)";
+    homepage = https://www.waterfoxproject.org/;
+    license = {
+      free = false;
+      url = https://www.waterfoxproject.org/terms;
+    };
+    maintainers = with stdenv.lib.maintainers; [ iamale ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17681,6 +17681,8 @@ with pkgs;
 
   xkbset = callPackage ../tools/X11/xkbset { };
 
+  waterfox-bin = callPackage ../applications/networking/browsers/waterfox-bin { };
+
   win-spice = callPackage ../applications/virtualization/driver/win-spice { };
   win-virtio = callPackage ../applications/virtualization/driver/win-virtio { };
   win-qemu = callPackage ../applications/virtualization/driver/win-qemu { };


### PR DESCRIPTION
###### Motivation for this change

Requested at https://github.com/MrAlex94/Waterfox/issues/297

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~~ **N/A**
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is my first Nix package, so if I'm missing something or doing something wrong, please point me at it :) Thanks!

**UPD: please don't merge yet!** Things currently broken:
- Open / save dialogs crash the app, stating “No GSettings schemas are installed on the system” in stderr
- The desktop entry isn't copied to profile