### PR TITLE
treewide: A few misc cross changes from #26805

### DIFF
--- a/pkgs/applications/kde/kmime.nix
+++ b/pkgs/applications/kde/kmime.nix
@@ -10,7 +10,7 @@ mkDerivation {
     license = [ lib.licenses.lgpl21 ];
     maintainers = kdepimTeam;
   };
-  nativeBuildInputs = [ extra-cmake-modules ki18n ];
-  buildInputs = [ kcodecs qtbase ];
+  nativeBuildInputs = [ extra-cmake-modules ];
+  buildInputs = [ kcodecs ki18n qtbase ];
   outputs = [ "out" "dev" ];
 }

--- a/pkgs/development/libraries/libelf/default.nix
+++ b/pkgs/development/libraries/libelf/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl
-, gettext, glibc
+{ stdenv
+, fetchurl, autoreconfHook, gettext
 , buildPlatform, hostPlatform
 }:
 
@@ -17,12 +17,20 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  # Libelf's custom NLS macros fail to determine the catalog file extension on
-  # Darwin, so disable NLS for now.
-  # FIXME: Eventually make Gettext a build input on all platforms.
-  configureFlags = stdenv.lib.optional hostPlatform.isDarwin "--disable-nls";
+  configureFlags = []
+       # Configure check for dynamic lib support is broken, see
+       # http://lists.uclibc.org/pipermail/uclibc-cvs/2005-August/019383.html
+    ++ stdenv.lib.optional (hostPlatform != buildPlatform) "mr_cv_target_elf=yes"
+       # Libelf's custom NLS macros fail to determine the catalog file extension
+       # on Darwin, so disable NLS for now.
+    ++ stdenv.lib.optional hostPlatform.isDarwin "--disable-nls";
 
-  nativeBuildInputs = [ gettext ];
+  nativeBuildInputs = [ gettext ]
+       # Need to regenerate configure script with newer version in order to pass
+       # "mr_cv_target_elf=yes", but `autoreconfHook` brings in `makeWrapper`
+       # which doesn't work with the bootstrapTools bash, so can only do this
+       # for cross builds when `stdenv.shell` is a newer bash.
+    ++ stdenv.lib.optional (hostPlatform != buildPlatform) autoreconfHook;
 
   meta = {
     description = "ELF object file access library";

--- a/pkgs/tools/misc/colord-kde/default.nix
+++ b/pkgs/tools/misc/colord-kde/default.nix
@@ -14,11 +14,11 @@ stdenv.mkDerivation rec {
     sha256 = "0brdnpflm95vf4l41clrqxwvjrdwhs859n7401wxcykkmw4m0m3c";
   };
 
-  nativeBuildInputs = [ extra-cmake-modules ki18n ];
+  nativeBuildInputs = [ extra-cmake-modules ];
 
   buildInputs = [
     kconfig kconfigwidgets kcoreaddons kdbusaddons kiconthemes
-    kcmutils kio knotifications plasma-framework kwidgetsaddons
+    kcmutils ki18n kio knotifications plasma-framework kwidgetsaddons
     kwindowsystem kitemviews lcms2 libXrandr qtx11extras
   ];
 

--- a/pkgs/tools/text/diffutils/default.nix
+++ b/pkgs/tools/text/diffutils/default.nix
@@ -17,7 +17,8 @@ stdenv.mkDerivation rec {
   configureFlags =
     # "pr" need not be on the PATH as a run-time dep, so we need to tell
     # configure where it is. Covers the cross and native case alike.
-    stdenv.lib.optional (coreutils != null) "PR_PROGRAM=${coreutils}/bin/pr";
+    stdenv.lib.optional (coreutils != null) "PR_PROGRAM=${coreutils}/bin/pr"
+    ++ stdenv.lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "gl_cv_func_getopt_gnu=yes";
 
   meta = {
     homepage = http://www.gnu.org/software/diffutils/diffutils.html;

--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -41,6 +41,8 @@ stdenv.mkDerivation rec {
     (if interactive then "--with-readline=${readline.dev}" else "--without-readline")
   ];
 
+  makeFlags = "AR=${stdenv.cc.targetPrefix}ar";
+
   inherit doCheck;
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

These are already tested. They should be uncontroversial, and in the Qt cases I talked them over with @ttuegel (this is an unintersting subset of what we talked about in the thread).

Trying to lesson the diff before #26805 is (hopefully very soon!) merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

