### PR TITLE
binutils: Fix cross, again

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -164,6 +164,20 @@ stdenv.mkDerivation {
       set +u
     '';
 
+  emulation = let
+    fmt =
+      /**/ if targetPlatform.isDarwin  then "mach-o"
+      else if targetPlatform.isWindows then "pe"
+      else "elf" + toString targetPlatform.parsed.cpu.bits;
+    endianPrefix = if targetPlatform.isBigEndian then "big" else "little";
+    arch =
+      /**/ if targetPlatform.isAarch64 then endianPrefix + "aarch64"
+      else if targetPlatform.isArm     then endianPrefix + "arm"
+      else if targetPlatform.isx86_64  then "x86-64"
+      else if targetPlatform.isi686    then "i386"
+      else throw "unknown emulation for platform: " + targetPlatform.config;
+    in targetPlatform.platform.bfdEmulation or (fmt + "-" + arch);
+
   propagatedBuildInputs = extraPackages;
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -67,6 +67,11 @@ fi
 
 extraAfter+=($NIX_@infixSalt@_LDFLAGS_AFTER)
 
+# Specify the target emulation if nothing is passed in ("-m" overrides this
+# environment variable). Ensures we never blindly fallback on targeting the host
+# platform.
+: ${LDEMULATION:=@emulation@}
+
 # Three tasks:
 #
 #   1. Find all -L... switches for rpath

--- a/pkgs/development/tools/misc/binutils/always-search-rpath.patch
+++ b/pkgs/development/tools/misc/binutils/always-search-rpath.patch
@@ -1,0 +1,14 @@
+diff --git a/ld/genscripts.sh b/ld/genscripts.sh
+index b6940d376d..0feb1adfd0 100755
+--- a/ld/genscripts.sh
++++ b/ld/genscripts.sh
+@@ -125,6 +125,9 @@ if test "x$NATIVE" = "xyes" ; then
+   USE_LIBPATH=yes
+ fi
+ 
++# TODO: why is this needed?
++USE_LIBPATH=yes
++
+ # Set the library search path, for libraries named by -lfoo.
+ # If LIB_PATH is defined (e.g., by Makefile) and non-empty, it is used.
+ # Otherwise, the default is set here.

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -53,6 +53,14 @@ stdenv.mkDerivation rec {
     # elf32-littlearm-vxworks in favor of the first.
     # https://github.com/NixOS/nixpkgs/pull/30484#issuecomment-345472766
     ./disambiguate-arm-targets.patch
+
+    # For some reason bfd ld doesn't search DT_RPATH when cross-compiling. It's
+    # not clear why this behavior was decided upon but it has the unfortunate
+    # consequence that the linker will fail to find transitive dependencies of
+    # shared objects when cross-compiling. Consequently, we are forced to
+    # override this behavior, forcing ld to search DT_RPATH even when
+    # cross-compiling.
+    ./always-search-rpath.patch
   ];
 
   outputs = [ "out" "info" "man" ];

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -74,8 +74,7 @@ rec {
     };
   in stdenv // {
     mkDerivation =
-      { buildInputs ? [], nativeBuildInputs ? []
-      , propagatedBuildInputs ? [], propagatedNativeBuildInputs ? []
+      { nativeBuildInputs ? []
       , selfNativeBuildInput ? args.crossAttrs.selfNativeBuildInput or false
       , ...
       } @ args:
@@ -97,14 +96,6 @@ rec {
             ++ stdenv.lib.optional (hostPlatform.config == "x86_64-w64-mingw32") pkgs.file
             ++ stdenv.lib.optional hostPlatform.isAarch64 pkgs.updateAutotoolsGnuConfigScriptsHook
             ;
-
-          # Cross-linking dynamic libraries, every buildInput should
-          # be propagated because ld needs the -rpath-link to find
-          # any library needed to link the program dynamically at
-          # loader time. ld(1) explains it.
-          buildInputs = [];
-          propagatedBuildInputs = propagatedBuildInputs ++ buildInputs;
-          propagatedNativeBuildInputs = propagatedNativeBuildInputs;
 
           crossConfig = hostPlatform.config;
         } // args.crossAttrs or {});


### PR DESCRIPTION
###### Motivation for this change

It's been broken since I made it multi-arch, but this fixes it. Making this a separate PR to lessen the diff, and in case anything breaks later.

###### Things done

Tested exhaustively in #26805.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

