### PR TITLE
llvm-hs: fix llvm-config dependency

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -258,7 +258,7 @@ self: super: builtins.intersectAttrs super {
       }
     );
 
-  llvm-hs = super.llvm-hs.override { llvm-config = pkgs.llvm_4; };
+  llvm-hs = super.llvm-hs.override { llvm-config = pkgs.llvm_5; };
 
   # Needs help finding LLVM.
   spaceprobe = addBuildTool super.spaceprobe self.llvmPackages.llvm;


### PR DESCRIPTION
`llvm-hs` doesn't work because it gets the wrong version of `llvm-config`:

```
 ❯ nix-shell -p "haskellPackages.ghcWithPackages (pkgs: with pkgs; [llvm-hs])"
these derivations will be built:
  /nix/store/l4mp28y39sja49x6f8yaz42z3kk0rxar-llvm-hs-5.1.0.drv
  /nix/store/2jkahs1rvdkhkn5x357byn2ksjkiay6w-ghc-8.2.2-with-packages.drv
building path(s) ‘/nix/store/1i2ppvn4bqbp57fbm7raxg1rxl8ffc8f-llvm-hs-5.1.0’, ‘/nix/store/wd1xirb1g92g7cv19jy124l5jwxbq9hr-llvm-hs-5.1.0-doc’
setupCompilerEnvironmentPhase
Build with /nix/store/qfqapyxjch75m64xp3ck7c83kilwfjxq-ghc-8.2.2.
unpacking sources
unpacking source archive /nix/store/7f9mkc1nzscipz4blpiybg9i8b1gx7gp-llvm-hs-5.1.0.tar.gz
source root is llvm-hs-5.1.0
setting SOURCE_DATE_EPOCH to timestamp 1507800599 of file llvm-hs-5.1.0/test/Test.hs
patching sources
compileBuildDriverPhase
setupCompileFlags: -package-db=/tmp/nix-build-llvm-hs-5.1.0.drv-0/package.conf.d -j8 -threaded
[1 of 1] Compiling Main             ( Setup.hs, /tmp/nix-build-llvm-hs-5.1.0.drv-0/Main.o )
Linking Setup ...
configuring
configureFlags: --verbose --prefix=/nix/store/1i2ppvn4bqbp57fbm7raxg1rxl8ffc8f-llvm-hs-5.1.0 --libdir=$prefix/lib/$compiler --libsubdir=$pkgid --docdir=/nix/store/wd1xirb1g92g7cv19jy124l5jwxbq9hr-llvm-hs-5.1.0-doc/share/doc --with-gcc=gcc --package-db=/tmp/nix-build-llvm-hs-5.1.0.drv-0/package.conf.d --ghc-option=-optl=-Wl,-rpath=/nix/store/1i2ppvn4bqbp57fbm7raxg1rxl8ffc8f-llvm-hs-5.1.0/lib/ghc-8.2.2/llvm-hs-5.1.0 --ghc-option=-j8 --disable-split-objs --disable-library-profiling --disable-profiling --enable-shared --disable-coverage --enable-library-vanilla --enable-executable-dynamic --enable-tests --ghc-option=-split-sections --extra-include-dirs=/nix/store/3ml8dkcnd935wll0b4zhkn1d8iyl6yys-llvm-4.0.1/include --extra-lib-dirs=/nix/store/3ml8dkcnd935wll0b4zhkn1d8iyl6yys-llvm-4.0.1/lib --extra-include-dirs=/nix/store/c3l4fxg7mrvkfklrl65249y9l54d116b-ncurses-6.0-20171125-dev/include --extra-lib-dirs=/nix/store/c3l4fxg7mrvkfklrl65249y9l54d116b-ncurses-6.0-20171125-dev/lib --extra-lib-dirs=/nix/store/31wchyrnz58z4jwc2jnwymlyw1y35yam-ncurses-6.0-20171125/lib --extra-include-dirs=/nix/store/ggxa0sw8h1y0yjvfb7agi7vniyax70dn-zlib-1.2.11-dev/include --extra-lib-dirs=/nix/store/ggxa0sw8h1y0yjvfb7agi7vniyax70dn-zlib-1.2.11-dev/lib --extra-lib-dirs=/nix/store/4zs260xcpyzf9h252lw2qny8wwpm97wm-zlib-1.2.11/lib --extra-lib-dirs=/nix/store/wi9baq9m4xwqxm3lnvaaz9r2z4whmcy2-llvm-4.0.1-lib/lib
/nix/store/3ml8dkcnd935wll0b4zhkn1d8iyl6yys-llvm-4.0.1/bin/llvm-config --version
CallStack (from HasCallStack):
  die', called at libraries/Cabal/Cabal/Distribution/Simple/Program/Db.hs:484:18 in Cabal-2.0.1.0:Distribution.Simple.Program.Db
  requireProgramVersion, called at Setup.hs:68:22 in main:Main
Setup: The program 'llvm-config' version ==5.0.* is required but the version
found at
/nix/store/3ml8dkcnd935wll0b4zhkn1d8iyl6yys-llvm-4.0.1/bin/llvm-config is
version 4.0.1
builder for ‘/nix/store/l4mp28y39sja49x6f8yaz42z3kk0rxar-llvm-hs-5.1.0.drv’ failed with exit code 1
cannot build derivation ‘/nix/store/2jkahs1rvdkhkn5x357byn2ksjkiay6w-ghc-8.2.2-with-packages.drv’: 1 dependencies couldn't be built
error: build of ‘/nix/store/2jkahs1rvdkhkn5x357byn2ksjkiay6w-ghc-8.2.2-with-packages.drv’ failed
/run/current-system/sw/bin/nix-shell: failed to build all dependencies
```

This gives it the correct version.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---