### PR TITLE
boost: Clean, reducing duplication

### DIFF
--- a/pkgs/development/libraries/boost/1.59.nix
+++ b/pkgs/development/libraries/boost/1.59.nix
@@ -8,33 +8,33 @@ callPackage ./generic.nix (args // rec {
     sha256 = "1jj1aai5rdmd72g90a3pd8sw9vi32zad46xv5av8fhnr48ir6ykj";
   };
 
-  patches = if stdenv.isCygwin then [
-      ./cygwin-fedora-boost-1.50.0-fix-non-utf8-files.patch
-      ./cygwin-fedora-boost-1.50.0-pool.patch
-      ./cygwin-fedora-boost-1.57.0-mpl-print.patch
-      ./cygwin-fedora-boost-1.57.0-spirit-unused_typedef.patch
-      ./cygwin-fedora-boost-1.54.0-locale-unused_typedef.patch
-      ./cygwin-fedora-boost-1.54.0-python-unused_typedef.patch
-      ./cygwin-fedora-boost-1.57.0-pool-test_linking.patch
-      ./cygwin-fedora-boost-1.54.0-pool-max_chunks_shadow.patch
-      ./cygwin-fedora-boost-1.57.0-signals2-weak_ptr.patch
-      ./cygwin-fedora-boost-1.57.0-uuid-comparison.patch
-      ./cygwin-fedora-boost-1.57.0-move-is_class.patch
-      ./cygwin-1.40.0-cstdint-cygwin.patch
-      ./cygwin-1.57.0-asio-cygwin.patch
-      ./cygwin-1.55.0-asio-MSG_EOR.patch
-      ./cygwin-1.57.0-config-cygwin.patch
-      ./cygwin-1.57.0-context-cygwin.patch
-      ./cygwin-1.57.0-filesystem-cygwin.patch
-      ./cygwin-1.55.0-interlocked-cygwin.patch
-      ./cygwin-1.40.0-iostreams-cygwin.patch
-      ./cygwin-1.57.0-locale-cygwin.patch
-      ./cygwin-1.57.0-log-cygwin.patch
-      ./cygwin-1.40.0-python-cygwin.patch
-      ./cygwin-1.40.0-regex-cygwin.patch
-      ./cygwin-1.57.0-smart_ptr-cygwin.patch
-      ./cygwin-1.57.0-system-cygwin.patch
-      ./cygwin-1.45.0-jam-cygwin.patch
-      ./cygwin-1.50.0-jam-pep3149.patch
-    ] else null;
+  patches = stdenv.lib.optionals stdenv.isCygwin [
+    ./cygwin-fedora-boost-1.50.0-fix-non-utf8-files.patch
+    ./cygwin-fedora-boost-1.50.0-pool.patch
+    ./cygwin-fedora-boost-1.57.0-mpl-print.patch
+    ./cygwin-fedora-boost-1.57.0-spirit-unused_typedef.patch
+    ./cygwin-fedora-boost-1.54.0-locale-unused_typedef.patch
+    ./cygwin-fedora-boost-1.54.0-python-unused_typedef.patch
+    ./cygwin-fedora-boost-1.57.0-pool-test_linking.patch
+    ./cygwin-fedora-boost-1.54.0-pool-max_chunks_shadow.patch
+    ./cygwin-fedora-boost-1.57.0-signals2-weak_ptr.patch
+    ./cygwin-fedora-boost-1.57.0-uuid-comparison.patch
+    ./cygwin-fedora-boost-1.57.0-move-is_class.patch
+    ./cygwin-1.40.0-cstdint-cygwin.patch
+    ./cygwin-1.57.0-asio-cygwin.patch
+    ./cygwin-1.55.0-asio-MSG_EOR.patch
+    ./cygwin-1.57.0-config-cygwin.patch
+    ./cygwin-1.57.0-context-cygwin.patch
+    ./cygwin-1.57.0-filesystem-cygwin.patch
+    ./cygwin-1.55.0-interlocked-cygwin.patch
+    ./cygwin-1.40.0-iostreams-cygwin.patch
+    ./cygwin-1.57.0-locale-cygwin.patch
+    ./cygwin-1.57.0-log-cygwin.patch
+    ./cygwin-1.40.0-python-cygwin.patch
+    ./cygwin-1.40.0-regex-cygwin.patch
+    ./cygwin-1.57.0-smart_ptr-cygwin.patch
+    ./cygwin-1.57.0-system-cygwin.patch
+    ./cygwin-1.45.0-jam-cygwin.patch
+    ./cygwin-1.50.0-jam-pep3149.patch
+  ];
 })

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -1,18 +1,19 @@
 { stdenv, fetchurl, icu, expat, zlib, bzip2, python, fixDarwinDylibNames, libiconv
-, buildPlatform, hostPlatform
-, toolset ? if stdenv.cc.isClang then "clang" else null
+, which
+, buildPackages, buildPlatform, hostPlatform
+, toolset ? /**/ if stdenv.cc.isClang                                then "clang"
+            else if stdenv.cc.isGNU && hostPlatform != buildPlatform then "gcc-cross"
+            else null
 , enableRelease ? true
 , enableDebug ? false
 , enableSingleThreaded ? false
 , enableMultiThreaded ? true
 , enableShared ? !(hostPlatform.libc == "msvcrt") # problems for now
 , enableStatic ? !enableShared
-, enablePIC ? false
-, enableExceptions ? false
 , enablePython ? hostPlatform == buildPlatform
 , enableNumpy ? false
 , taggedLayout ? ((enableRelease && enableDebug) || (enableSingleThreaded && enableMultiThreaded) || (enableShared && enableStatic))
-, patches ? null
+, patches ? []
 , mpi ? null
 
 # Attributes inherit from specific versions
@@ -21,8 +22,9 @@
 }:
 
 # We must build at least one type of libraries
-assert !enableShared -> enableStatic;
+assert enableShared || enableStatic;
 
+# Python isn't supported when cross-compiling
 assert enablePython -> hostPlatform == buildPlatform;
 assert enableNumpy -> enablePython;
 
@@ -46,86 +48,41 @@ let
   # To avoid library name collisions
   layout = if taggedLayout then "tagged" else "system";
 
-  cflags = if enablePIC && enableExceptions then
-             "cflags=\"-fPIC -fexceptions\" cxxflags=-fPIC linkflags=-fPIC"
-           else if enablePIC then
-             "cflags=-fPIC cxxflags=-fPIC linkflags=-fPIC"
-           else if enableExceptions then
-             "cflags=-fexceptions"
-           else
-             "";
-
-  withToolset = stdenv.lib.optionalString (toolset != null) "--with-toolset=${toolset}";
-
-  genericB2Flags = [
+  b2Args = concatStringsSep " " ([
     "--includedir=$dev/include"
     "--libdir=$out/lib"
     "-j$NIX_BUILD_CORES"
     "--layout=${layout}"
     "variant=${variant}"
     "threading=${threading}"
-  ] ++ optional (link != "static") "runtime-link=${runtime-link}" ++ [
+    "runtime-link=${runtime-link}"
     "link=${link}"
-    "${cflags}"
-  ] ++ optional (variant == "release") "debug-symbols=off"
-    ++ optional (!enablePython) "--without-python";
-
-  nativeB2Flags = [
     "-sEXPAT_INCLUDE=${expat.dev}/include"
     "-sEXPAT_LIBPATH=${expat.out}/lib"
-  ] ++ optional (toolset != null) "toolset=${toolset}"
-    ++ optional (mpi != null) "--user-config=user-config.jam";
-  nativeB2Args = concatStringsSep " " (genericB2Flags ++ nativeB2Flags);
-
-  crossB2Flags = [
-    "-sEXPAT_INCLUDE=${expat.crossDrv}/include"
-    "-sEXPAT_LIBPATH=${expat.crossDrv}/lib"
-    "--user-config=user-config.jam"
-    "toolset=gcc-cross"
-  ] ++ optionals (hostPlatform.libc == "msvcrt") [
+  ] ++ optional (variant == "release") "debug-symbols=off"
+    ++ optional (toolset != null) "toolset=${toolset}"
+    ++ optional (mpi != null || hostPlatform != buildPlatform) "--user-config=user-config.jam"
+    ++ optionals (hostPlatform.libc == "msvcrt") [
     "target-os=windows"
     "threadapi=win32"
     "binary-format=pe"
     "address-model=${toString hostPlatform.parsed.cpu.bits}"
     "architecture=x86"
-  ];
-  crossB2Args = concatStringsSep " " (genericB2Flags ++ crossB2Flags);
-
-  builder = b2Args: ''
-    ./b2 ${b2Args}
-  '';
-
-  installer = b2Args: ''
-    # boostbook is needed by some applications
-    mkdir -p $dev/share/boostbook
-    cp -a tools/boostbook/{xsl,dtd} $dev/share/boostbook/
-
-    # Let boost install everything else
-    ./b2 ${b2Args} install
-  '';
-
-  commonConfigureFlags = [
-    "--includedir=$(dev)/include"
-    "--libdir=$(out)/lib"
-  ];
-
-  fixup = ''
-    # Make boost header paths relative so that they are not runtime dependencies
-    (
-      cd "$dev"
-      find include \( -name '*.hpp' -or -name '*.h' -or -name '*.ipp' \) \
-        -exec sed '1i#line 1 "{}"' -i '{}' \;
-    )
-  '' + optionalString (hostPlatform.libc == "msvcrt") ''
-    ${stdenv.cc.targetPrefix}ranlib "$out/lib/"*.a
-  '';
+  ]);
 
 in
 
 stdenv.mkDerivation {
   name = "boost-${version}";
 
-  inherit src patches version;
+  inherit src;
+
+  patchFlags = optionalString (hostPlatform.libc == "msvcrt") "-p0";
+  patches = patches ++ optional (hostPlatform.libc == "msvcrt") (fetchurl {
+    url = "https://svn.boost.org/trac/boost/raw-attachment/tickaet/7262/"
+        + "boost-mingw.patch";
+    sha256 = "0s32kwll66k50w6r5np1y5g907b7lcpsjhfgr7rsw7q5syhzddyj";
+  });
 
   meta = {
     homepage = http://boost.org/;
@@ -142,8 +99,12 @@ stdenv.mkDerivation {
           --replace '@rpath/$(<[1]:D=)' "$out/lib/\$(<[1]:D=)";
     fi;
   '' + optionalString (mpi != null) ''
-    cat << EOF > user-config.jam
+    cat << EOF >> user-config.jam
     using mpi : ${mpi}/bin/mpiCC ;
+    EOF
+  '' + optionalString (hostPlatform != buildPlatform) ''
+    cat << EOF >> user-config.jam
+    using gcc : cross : ${stdenv.cc.targetPrefix}c++ ;
     EOF
   '';
 
@@ -152,6 +113,7 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  nativeBuildInputs = [ which buildPackages.stdenv.cc ];
   buildInputs = [ expat zlib bzip2 libiconv ]
     ++ optional (hostPlatform == buildPlatform) icu
     ++ optional stdenv.isDarwin fixDarwinDylibNames
@@ -159,39 +121,35 @@ stdenv.mkDerivation {
     ++ optional enableNumpy python.pkgs.numpy;
 
   configureScript = "./bootstrap.sh";
-  configureFlags = commonConfigureFlags
-    ++ [ "--with-python=${python.interpreter}" ]
-    ++ optional (hostPlatform == buildPlatform) "--with-icu=${icu.dev}"
-    ++ optional (toolset != null) "--with-toolset=${toolset}";
+  configurePlatforms = [];
+  configureFlags = [
+    "--includedir=$(dev)/include"
+    "--libdir=$(out)/lib"
+    (if enablePython then "--with-python=${python.interpreter}" else "--without-python")
+    (if hostPlatform == buildPlatform then "--with-icu=${icu.dev}" else  "--without-icu")
+  ] ++ optional (toolset != null) "--with-toolset=${toolset}";
 
-  buildPhase = builder nativeB2Args;
+  buildPhase = ''
+    ./b2 ${b2Args}
+  '';
 
-  installPhase = installer nativeB2Args;
+  installPhase = ''
+    # boostbook is needed by some applications
+    mkdir -p $dev/share/boostbook
+    cp -a tools/boostbook/{xsl,dtd} $dev/share/boostbook/
 
-  postFixup = fixup;
+    # Let boost install everything else
+    ./b2 ${b2Args} install
+  '';
+
+  postFixup = ''
+    # Make boost header paths relative so that they are not runtime dependencies
+    find "$dev/include" \( -name '*.hpp' -or -name '*.h' -or -name '*.ipp' \) \
+      -exec sed '1i#line 1 "{}"' -i '{}' \;
+  '' + optionalString (hostPlatform.libc == "msvcrt") ''
+    $RANLIB "$out/lib/"*.a
+  '';
 
   outputs = [ "out" "dev" ];
   setOutputFlags = false;
-
-  crossAttrs = rec {
-    # We want to substitute the contents of configureFlags, removing thus the
-    # usual --build and --host added on cross building.
-    preConfigure = ''
-      export configureFlags="--without-icu ${concatStringsSep " " commonConfigureFlags}"
-      cat << EOF > user-config.jam
-      using gcc : cross : $crossConfig-g++ ;
-      EOF
-    '';
-    buildPhase = builder crossB2Args;
-    installPhase = installer crossB2Args;
-    postFixup = fixup;
-  } // optionalAttrs (hostPlatform.libc == "msvcrt") {
-    patches = fetchurl {
-      url = "https://svn.boost.org/trac/boost/raw-attachment/ticket/7262/"
-          + "boost-mingw.patch";
-      sha256 = "0s32kwll66k50w6r5np1y5g907b7lcpsjhfgr7rsw7q5syhzddyj";
-    };
-
-    patchFlags = "-p0";
-  };
 }


### PR DESCRIPTION
###### Motivation for this change

This was motivated originally by my cross work, but that goal requires a few more commits to other things. Still, it's good to start the cleanup now / get things out of the way.

###### Things done

Native is almost exactly tested as part of #26805. However, In that version I had this setup hook replicating some logic with `findInputs` downstream that's since been removed. I removed the setup hook for this PR so now this is technically untested, but I doubt anything changed.

Actually its even better, the setup hook traverses propagated dependencies, but no version of boost has any, so its demonstrably a no-op!

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

