### PR TITLE
melpaPackages: match version of magit-popup to magit

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -137,6 +137,12 @@ self:
       # upstream issue: missing file header
       maxframe = markBroken super.maxframe;
 
+      # version of magit-popup needs to match magit
+      # https://github.com/magit/magit/issues/3286
+      magit = super.magit.override {
+        inherit (self.melpaPackages) magit-popup;
+      };
+
       # missing OCaml
       merlin = markBroken super.merlin;
 


### PR DESCRIPTION
Related to https://github.com/magit/magit/issues/3286

###### Motivation for this change
I was getting weird errors trying to use magit features that involved magit-popup

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

