### PR TITLE
leocad: 17.02 -> 17.07

### DIFF
--- a/pkgs/applications/graphics/leocad/default.nix
+++ b/pkgs/applications/graphics/leocad/default.nix
@@ -7,13 +7,13 @@ set the variable LEOCAD_LIB=/path/to/libs/ or use option -l /path/to/libs/
 
 stdenv.mkDerivation rec {
   name = "leocad-${version}";
-  version = "17.02";
+  version = "17.07";
 
   src = fetchFromGitHub {
     owner = "leozide";
     repo = "leocad";
     rev = "v${version}";
-    sha256 = "0d7l2il6r4swnmrmaf1bsrgpjgai5xwhwk2mkpcsddnk59790mmc";
+    sha256 = "1j361pvxywi4nb2alhnnd4qpqrpg6503gbi17cadcdi434gbqbsd";
   };
 
   nativeBuildInputs = [ qmake4Hook ];


### PR DESCRIPTION
###### Motivation for this change

Release notes: https://github.com/leozide/leocad/releases/tag/v17.07

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

