### PR TITLE
r2-cutter: init at 1.1(.0), radare2 qt gui

### DIFF
--- a/pkgs/development/tools/analysis/radare2-cutter/default.nix
+++ b/pkgs/development/tools/analysis/radare2-cutter/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, fetchpatch, qmake, pkgconfig, qtbase, qtsvg, radare2 }:
+
+
+stdenv.mkDerivation rec {
+  name = "radare2-cutter-${version}";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "radareorg";
+    repo = "cutter";
+    rev = "v${version}";
+    sha256 = "02m5sf45n455hn34y7hrqanj830rc5xhz2ppp1z3mzbz0s515pfl";
+  };
+
+  postUnpack = "export sourceRoot=$sourceRoot/src";
+
+  patches = [
+    # Fixup version number :D
+    (fetchpatch {
+      url = "https://github.com/radareorg/cutter/commit/69506b64600df632afdca8b680baa7d946c78644.patch";
+      sha256 = "0ks3ixz8bycjcfi26bd0p6z7qaplhq00alw44hsfzpdm4bmr01x0";
+    })
+    (fetchpatch {
+      url = "https://github.com/radareorg/cutter/commit/8b52c66f4f0091cd9d97389b32aa519c2c602e2b.patch";
+      sha256 = "0wcdn35lx2943pfzm7mkg4sr82pm0qz3yxf74m8fxbd70s3w0gkm";
+    })
+
+    # case-insensitive filtering
+    (fetchpatch {
+      url = "https://github.com/radareorg/cutter/commit/0ebd34370bcaed00000168147572bb78106eeab1.patch";
+      sha256 = "0sc50jwhncfnd2i5mlyld4dbdzi2ws7nh4yglkhlap9l9h1jxn20";
+    })
+  ];
+
+  patchFlags = [ "-p2" ];
+
+  nativeBuildInputs = [ qmake pkgconfig ];
+  buildInputs = [ qtbase qtsvg radare2 ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A Qt and C++ GUI for radare2 reverse engineering framework";
+    homepage = src.meta.homepage;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7812,6 +7812,7 @@ with pkgs;
     rubyBindings = config.radare.rubyBindings or false;
     luaBindings = config.radare.luaBindings or false;
   };
+  radare2-cutter = libsForQt5.callPackage ../development/tools/analysis/radare2-cutter { };
 
   ragel = ragelStable;
 


### PR DESCRIPTION
Naming "r2-cutter" since "cutter" already exists,
but AFAIK this naming is not used anywhere else currently.

###### Motivation for this change

Updated version of #32345 for 1.1 release (and new radare2 in #33194)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

