### PR TITLE
rage: 0.2.1 -> 0.3.0

### DIFF
--- a/pkgs/desktops/enlightenment/rage.nix
+++ b/pkgs/desktops/enlightenment/rage.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchurl, pkgconfig, efl, gst_all_1, pcre, curl, wrapGAppsHook }:
+{ stdenv, fetchurl, meson, ninja, pkgconfig, efl, gst_all_1, pcre, curl, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "rage-${version}";
-  version = "0.2.1";
+  version = "0.3.0";
   
   src = fetchurl {
-    url = "http://download.enlightenment.org/rel/apps/rage/${name}.tar.gz";
-    sha256 = "0xlxb1hmbnqcy088cqpj2i87hsd5h3da7d2f9afiavz0ssw4ll94";
+    url = "http://download.enlightenment.org/rel/apps/rage/${name}.tar.xz";
+    sha256 = "0gfzdd4jg78bkmj61yg49w7bzspl5m1nh6agqgs8k7qrq9q26xqy";
   };
 
   nativeBuildInputs = [
+    meson
+    ninja
     (pkgconfig.override { vanilla = true; })
     wrapGAppsHook
   ];


### PR DESCRIPTION
###### Motivation for this change

Update to version [0.3.0](https://www.enlightenment.org/news/rage-0.3.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).