### PR TITLE
vim-plugins: don't override default phases

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -1341,17 +1341,11 @@ rec {
       sha256 = "0x5jac7x85bqdh38vggi1fvxjw2z29b2227n471f3cxy8arvylrw";
     };
     dependencies = [];
-    buildInputs = [
-      python3
-      stdenv
-      cmake
-      boost
-      icu
-    ];
-    buildPhase = ''
+    nativeBuildInputs = [ cmake ];
+    buildInputs = [ boost icu python3 ];
+    cmakeFlags = [ "-DPY3:BOOL=ON" ];
+    preConfigure = ''
       patchShebangs .
-      export PY3=ON
-      ./install.sh
     '';
   };
 

--- a/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/cpsm
+++ b/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/cpsm
@@ -1,12 +1,6 @@
-    buildInputs = [
-      python3
-      stdenv
-      cmake
-      boost
-      icu
-    ];
-    buildPhase = ''
+    nativeBuildInputs = [ cmake ];
+    buildInputs = [ boost icu python3 ];
+    cmakeFlags = [ "-DPY3:BOOL=ON" ];
+    preConfigure = ''
       patchShebangs .
-      export PY3=ON
-      ./install.sh
     '';


### PR DESCRIPTION
The buildPhase is still disabled by default unless it's customized.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

