### PR TITLE
percona-xtrabackup: init at 2.4.9

### DIFF
--- a/pkgs/tools/backup/percona-xtrabackup/default.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
+, boost, bison, curl, ncurses, openssl, readline, xxd
+, libaio, libev, libgcrypt, libgpgerror, libtool, zlib
+}:
+
+stdenv.mkDerivation rec {
+  name = "percona-xtrabackup-${version}";
+  version = "2.4.9";
+
+  src = fetchFromGitHub {
+    owner = "percona";
+    repo = "percona-xtrabackup";
+    rev = name;
+    sha256 = "11w87wj2jasrnygzjg3b59q9x0m6lhyg1wzdvclmgbmqsk9bvqv4";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [
+    boost bison curl ncurses openssl readline xxd
+    libaio libev libgcrypt libgpgerror libtool zlib
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_CONFIG=xtrabackup_release"
+    "-DINSTALL_MYSQLTESTDIR=OFF"
+    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
+    "-DWITH_SSL=system"
+    "-DWITH_ZLIB=system"
+    "-DWITH_MECAB=system"
+    "-DWITH_EXTRA_CHARSETS=all"
+    "-DWITH_INNODB_MEMCACHED=1"
+    "-DWITH_MAN_PAGES=OFF"
+    "-DWITH_HTML_DOCS=OFF"
+    "-DWITH_LATEX_DOCS=OFF"
+    "-DWITH_PDF_DOCS=OFF"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Non-blocking backup tool for MySQL";
+    homepage = http://www.percona.com/software/percona-xtrabackup;
+    license = licenses.lgpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ izorkin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3926,6 +3926,10 @@ with pkgs;
 
   pepper = callPackage ../tools/admin/salt/pepper { };
 
+  percona-xtrabackup = callPackage ../tools/backup/percona-xtrabackup {
+    boost = boost159;
+  };
+
   pick = callPackage ../tools/misc/pick { };
 
   pitivi = callPackage ../applications/video/pitivi {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

