### PR TITLE
arc-kde-theme: init 2017-11-09

### DIFF
--- a/pkgs/misc/themes/arc-kde/default.nix
+++ b/pkgs/misc/themes/arc-kde/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "arc-kde-theme-${version}";
+  version = "2017-11-09";
+
+  src = fetchFromGitHub {
+    owner = "PapirusDevelopmentTeam";
+    repo = "arc-kde";
+    rev = "a0abe6fc5ebf74f9ae88b8a2035957cc16f706f5";
+    sha256 = "1p6f4ny97096nb054lrgyjwikmvg0qlbcnsjag7m5dfbclfnvzkg";
+  };
+
+  makeFlags = ["PREFIX=$(out)" ];
+
+  # Make this a fixed-output derivation
+  outputHashMode = "recursive";
+  outputHashAlgo = "sha256";
+  ouputHash = "2c2def57092a399aa1c450699cbb8639f47d751157b18db17";
+
+  meta = {
+    description = "A port of the arc theme for Plasma";
+    homepage = https://git.io/arc-kde;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.nixy ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -667,6 +667,8 @@ with pkgs;
 
   arc-theme = callPackage ../misc/themes/arc { };
 
+  arc-kde-theme = callPackage ../misc/themes/arc-kde { };
+
   adapta-gtk-theme = callPackage ../misc/themes/adapta { };
 
   aria2 = callPackage ../tools/networking/aria2 {


### PR DESCRIPTION
###### Motivation for this change

I was looking to add some QT themes besides breeze to KDE. I looked through nixpkgs and couldn't find any other themes to base this off of. I've tested this and it seems to work, but if there is any way to make it better let me know.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

