### PR TITLE
steam: add wrapper testing for libGL

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -108,10 +108,21 @@ in buildFHSUserEnv rec {
 
   runScript = writeScript "steam-wrapper.sh" ''
     #!${stdenv.shell}
-    glxinfo >/dev/null 2>&1
-    if [ ! "$?" = "0" ]; then
-      echo "*** WARNING: Test for 32-bit libGL unsuccessful."
-      echo "             This could mean you forgot to activate hardware.opengl.driSupport32Bit"
+    if [ -f /host/etc/NIXOS ]; then   # Check only useful on NixOS
+      glxinfo >/dev/null 2>&1
+      # If there was an error running glxinfo, we know something is wrong with the configuration
+      if [ $? -ne 0 ]; then
+        cat <<EOF > /dev/stderr
+    **
+    WARNING: Steam is not set up. Add the following options to /etc/nixos/configuration.nix
+    and then run \`sudo nixos-rebuild switch\`:
+    { 
+      hardware.opengl.driSupport32Bit = true;
+      hardware.pulseaudio.support32Bit = true;
+    }
+    **
+    EOF
+      fi
     fi
     steam
   '';

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -69,6 +69,9 @@ in buildFHSUserEnv rec {
     xlibs.libX11
     xlibs.libXfixes
 
+    # Needed to properly check for libGL.so.1 in steam-wrapper.sh
+    pkgsi686Linux.glxinfo
+
     # Not formally in runtime but needed by some games
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-ugly
@@ -103,7 +106,15 @@ in buildFHSUserEnv rec {
     export TZDIR=/etc/zoneinfo
   '';
 
-  runScript = "steam";
+  runScript = writeScript "steam-wrapper.sh" ''
+    #!${stdenv.shell}
+    glxinfo >/dev/null 2>&1
+    if [ ! "$?" = "0" ]; then
+      echo "*** WARNING: Test for 32-bit libGL unsuccessful."
+      echo "             This could mean you forgot to activate hardware.opengl.driSupport32Bit"
+    fi
+    steam
+  '';
 
   passthru.run = buildFHSUserEnv {
     name = "steam-run";


### PR DESCRIPTION
###### Motivation for this change
Failing to set hardware.opengl.driSupport32Bit will lead to a
confusing error message about missing libGL.so.1 as described in #19518


###### Things done
We include a wrapper around the steam bin to test for working 32bit 
opengl with glxinfo. When failing, we display a proper warning hinting 
towards the option.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Tested on local NixOS machine by activating/deactivating hardware.opengl.driSupport and hardware.opengl.driSupport32Bit. In all cases it gave the expected result:
```
[nix-shell:~/src/nixpkgs]$ steam
*** WARNING: Test for 32-bit libGL unsuccessful.
             This could mean you forgot to activate hardware.opengl.driSupport32Bit
cp: cannot create regular file '/home/user/.local/share/Steam/bootstrap.tar.xz': Permission denied
Running Steam on nixos 17.09.2476.53e6d671a96 64-bit
STEAM_RUNTIME has been set by the user to: /steamrt
Pins potentially out-of-date, rebuilding...
mkdir: cannot create directory ‘/nix/store/rcdiw6bpzdx4i3lqj4pyz546svjlqc96-steam-fhs/steamrt/pinned_libs_32’: Read-only file system
mkdir: cannot create directory ‘/nix/store/rcdiw6bpzdx4i3lqj4pyz546svjlqc96-steam-fhs/steamrt/pinned_libs_64’: Read-only file system
Error: You are missing the following 32-bit libraries, and Steam may not run:
libGL.so.1
Error:
You are missing the following 32-bit libraries, and Steam may not run:
libGL.so.1
Press enter to continue: ^C
```