### PR TITLE
libinput: disableWhileTyping = false by default

### DIFF
--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -170,7 +170,7 @@ in {
 
       disableWhileTyping = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         description =
           ''
             Disable input method while typing.


### PR DESCRIPTION
Enabling it is not a libinput default, and makes it impossible to play games, or even use shortcuts comfortably. More importantly, libinput palm rejection is good enough to prevent accidental cursor movement on typing.