### PR TITLE
haskell docs: add info about hoogle's --local flag to section 9.5.2.3

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -339,7 +339,7 @@ hoogle server --local -p 8080
 and navigate to http://localhost:8080/ for your own local
 [Hoogle](https://www.haskell.org/hoogle/). The `--local` flag makes the hoogle
 server serve files from your nix store over http, without the flag it will use
-`file:\\` URIs. Note, however, that Firefox and possibly other browsers
+`file://` URIs. Note, however, that Firefox and possibly other browsers
 disallow navigation from `http://` to `file://` URIs for security reasons,
 which might be quite an inconvenience. Versions before v5 did not have this
 flag. See

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -334,15 +334,29 @@ navigate there.
 
 Finally, you can run
 ```shell
-hoogle server -p 8080 --local
+hoogle server --local -p 8080
 ```
 and navigate to http://localhost:8080/ for your own local
-[Hoogle](https://www.haskell.org/hoogle/). Note, however, that Firefox and
-possibly other browsers disallow navigation from `http:` to `file:` URIs for
-security reasons, which might be quite an inconvenience. Since version 5 hoogle
-server has a `--local` flag that solves the problem. For older versions see
+[Hoogle](https://www.haskell.org/hoogle/). The `--local` flag makes the hoogle
+server serve files from your nix store over http, without the flag it will use
+`file:\\` URIs. Note, however, that Firefox and possibly other browsers
+disallow navigation from `http://` to `file://` URIs for security reasons,
+which might be quite an inconvenience. Versions before v5 did not have this
+flag. See
 [this page](http://kb.mozillazine.org/Links_to_local_pages_do_not_work) for
 workarounds.
+
+For NixOS users there's a service which runs this exact command for you.
+Specify the `packages` you want documentation for and the `haskellPackages` set
+you want them to come from. Add the following to `configuration.nix`.
+
+```nix
+services.hoogle = {
+enable = true;
+packages = (hpkgs: with hpkgs; [text cryptonite]);
+haskellPackages = pkgs.haskellPackages;
+};
+```
 
 ### How to build a Haskell project using Stack
 

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -337,7 +337,12 @@ Finally, you can run
 hoogle server -p 8080 --local
 ```
 and navigate to http://localhost:8080/ for your own local
-[Hoogle](https://www.haskell.org/hoogle/).
+[Hoogle](https://www.haskell.org/hoogle/). Note, however, that Firefox and
+possibly other browsers disallow navigation from `http:` to `file:` URIs for
+security reasons, which might be quite an inconvenience. Since version 5 hoogle
+server has a `--local` flag that solves the problem. For older versions see
+[this page](http://kb.mozillazine.org/Links_to_local_pages_do_not_work) for
+workarounds.
 
 ### How to build a Haskell project using Stack
 


### PR DESCRIPTION
Relevant section: 9.5.2.3. How to install a compiler with libraries, hoogle and documentation indexes

Since version 5 `hoogle server`s --local flag solves the problem with links from
`http:` to `file:` URIs:

    hoogle server --local -p 8080

###### Motivation for this change

Using the --local flag is easier than the workarounds and not very discoverable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

