### PR TITLE
mupdf: 1.11 -> 1.12.0

### DIFF
--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -1,7 +1,8 @@
 { stdenv, lib, fetchurl, fetchpatch, pkgconfig
 , freetype, harfbuzz, openjpeg, jbig2dec, libjpeg
-, enableX11 ? true, libX11, libXext
+, enableX11 ? true, libX11, libXext, libXi, libXrandr
 , enableCurl ? true, curl, openssl
+, enableGL ? true, freeglut, mesa_glu
 }:
 
 let
@@ -13,63 +14,24 @@ let
 
 
 in stdenv.mkDerivation rec {
-  version = "1.11";
+  version = "1.12.0";
   name = "mupdf-${version}";
 
   src = fetchurl {
     url = "http://mupdf.com/downloads/archive/${name}-source.tar.gz";
-    sha256 = "02phamcchgsmvjnb3ir7r5sssvx9fcrscn297z73b82n1jl79510";
+    sha256 = "0mc7a92zri27lk17wdr2iffarbfi4lvrmxhc53sz84hm5yl56qsw";
   };
 
   patches = [
     # Compatibility with new openjpeg
     (fetchpatch {
-      name = "mupdf-1.11-openjpeg-version.patch";
-      url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/0001-mupdf-openjpeg.patch?h=packages/mupdf&id=c19349f42838e4dca02e564b97e0a5ab3e1b943f";
-      sha256 = "0sx7jq84sr8bj6sg2ahg9cdgqz8dh4w6r0ah2yil8vrsznn4la8r";
+      name = "mupdf-1.12-openjpeg-version.patch";
+      url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/0001-mupdf-openjpeg.patch?h=packages/mupdf&id=a910cd33a2b311712f83710dc042fbe80c104306";
+      sha256 = "05i9v2ia586jyjqdb7g68ss4vkfwgp6cwhagc8zzggsba83azyqk";
     })
 
-    (fetchurl {
-      name = "mupdf-1.11-CVE-2017-6060.patch";
-      url = "http://git.ghostscript.com/?p=mupdf.git;a=blobdiff_plain;f=platform/x11/jstest_main.c;h=f158d9628ed0c0a84e37fe128277679e8334422a;hp=13c3a0a3ba3ff4aae29f6882d23740833c1d842f;hb=06a012a42c9884e3cd653e7826cff1ddec04eb6e;hpb=34e18d127a02146e3415b33c4b67389ce1ddb614";
-      sha256 = "163bllvjrbm0gvjb25lv7b6sih4zr4g4lap3h0cbq8dvpjxx0jfc";
-    })
+    ./mupdf-1.12-shared_libs-1.patch
 
-    (fetchpatch {
-      name = "mupdf-1.11-shared_libs-1.patch";
-      url = "https://ftp.osuosl.org/pub/blfs/conglomeration/mupdf/mupdf-1.11-shared_libs-1.patch";
-      sha256 = "127x8jhyj3i9cn3mxw9mm5barw2yk43rvmghg54bhn4rjalx857j";
-    })
-
-    (fetchurl {
-      name = "mupdf-1.11-CVE-2017-14685.patch";
-      url = "http://git.ghostscript.com/?p=mupdf.git;a=patch;h=ab1a420613dec93c686acbee2c165274e922f82a";
-      sha256 = "120xapwj0af333n3a32ypxk0jmjv2ia476jg8pzsfqk9a5qqkx46";
-    })
-
-    (fetchurl {
-      name = "mupdf-1.11-CVE-2017-14686.patch";
-      url = "http://git.ghostscript.com/?p=mupdf.git;a=patch;h=0f0fbc07d9be31f5e83ec5328d7311fdfd8328b1";
-      sha256 = "0pkn7mfqhmnsyia4rh4mw4q435bzvlc22crqa1bxpaa0gcyky51c";
-    })
-
-    (fetchurl {
-      name = "mupdf-1.11-CVE-2017-14687.patch";
-      url = "http://git.ghostscript.com/?p=mupdf.git;a=patch;h=2b16dbd8f73269cb15ca61ece75cf8d2d196ed28";
-      sha256 = "01v41cwrdnz3k32fcadk2gk4knqrm3mavzp6pxhn19nwgmqkshjd";
-    })
-
-    (fetchurl {
-      name = "mupdf-1.11-CVE-2017-15587.patch";
-      url = "http://git.ghostscript.com/?p=mupdf.git;a=patch;h=82df2631d7d0446b206ea6b434ea609b6c28b0e8";
-      sha256 = "04kfww7y0wazg6372g44fa2k5kiiigq4616ihkvmp18rz86903n9";
-    })
-
-    (fetchurl {
-      name = "mupdf-1.11-CVE-2017-15369.patch";
-      url = "http://git.ghostscript.com/?p=mupdf.git;a=patch;h=c2663e51238ec8256da7fc61ad580db891d9fe9a";
-      sha256 = "0xx2mrbjcymi3gh0l3cq81m6bygp9dv79v1kyrbcvpl5z6wgl71y";
-    })
   ];
 
   postPatch = ''
@@ -78,9 +40,10 @@ in stdenv.mkDerivation rec {
 
   makeFlags = [ "prefix=$(out)" ];
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ freetype harfbuzz openjpeg jbig2dec libjpeg ]
-                ++ lib.optionals enableX11 [ libX11 libXext ]
-                ++ lib.optionals enableCurl [ curl openssl ];
+  buildInputs = [ freetype harfbuzz openjpeg jbig2dec libjpeg freeglut mesa_glu ]
+                ++ lib.optionals enableX11 [ libX11 libXext libXi libXrandr ]
+                ++ lib.optionals enableCurl [ curl openssl ]
+                ++ lib.optionals enableGL [ freeglut mesa_glu ];
   outputs = [ "bin" "dev" "out" "man" "doc" ];
 
   preConfigure = ''

--- a/pkgs/applications/misc/mupdf/mupdf-1.12-shared_libs-1.patch
+++ b/pkgs/applications/misc/mupdf/mupdf-1.12-shared_libs-1.patch
@@ -1,0 +1,41 @@
+--- mupdf-1.12.0-source.orig/Makefile	2017-12-13 15:00:30.000000000 +0100
++++ mupdf-1.12.0-source/Makefile	2017-12-31 00:05:23.003277481 +0100
+@@ -14,7 +14,7 @@
+ # Do not specify CFLAGS or LIBS on the make invocation line - specify
+ # XCFLAGS or XLIBS instead. Make ignores any lines in the makefile that
+ # set a variable that was set on the command line.
+-CFLAGS += $(XCFLAGS) -Iinclude
++CFLAGS += $(XCFLAGS) -Iinclude -fPIC
+ LIBS += $(XLIBS) -lm
+ 
+ LIBS += $(FREETYPE_LIBS)
+@@ -312,9 +312,9 @@
+ 
+ # --- Library ---
+ 
+-MUPDF_LIB = $(OUT)/libmupdf.a
+-THIRD_LIB = $(OUT)/libmupdfthird.a
+-THREAD_LIB = $(OUT)/libmuthreads.a
++MUPDF_LIB = $(OUT)/libmupdf.so
++THIRD_LIB = $(OUT)/libmupdfthird.so
++THREAD_LIB = $(OUT)/libmuthreads.so
+ 
+ MUPDF_OBJ := \
+ 	$(FITZ_OBJ) \
+@@ -343,11 +343,14 @@
+ 
+ THREAD_OBJ := $(THREAD_OBJ)
+ 
+-$(MUPDF_LIB) : $(MUPDF_OBJ)
++$(MUPDF_LIB) : $(MUPDF_OBJ) $(THIRD_LIB) $(THREAD_LIB)
++	$(LINK_CMD) -shared -Wl,-soname -Wl,libmupdf.so -Wl,--no-undefined
+ $(THIRD_LIB) : $(THIRD_OBJ)
++	$(LINK_CMD) -shared -Wl,-soname -Wl,libmupdfthird.so -Wl,--no-undefined
+ $(THREAD_LIB) : $(THREAD_OBJ)
++	$(LINK_CMD) -shared -Wl,-soname -Wl,libmuthreads.so -Wl,--no-undefined -lpthread
+ 
+-INSTALL_LIBS := $(MUPDF_LIB) $(THIRD_LIB)
++INSTALL_LIBS := $(MUPDF_LIB) $(THIRD_LIB) $(THREAD_LIB)
+ 
+ # --- Tools and Apps ---
+ 


### PR DESCRIPTION
###### Motivation for this change

Update mupdf to the last version

https://mupdf.com/news.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

