### PR TITLE
Update zathura with plugins

### DIFF
--- a/pkgs/applications/misc/girara/default.nix
+++ b/pkgs/applications/misc/girara/default.nix
@@ -6,11 +6,11 @@ assert withBuildColors -> ncurses != null;
 
 stdenv.mkDerivation rec {
   name = "girara-${version}";
-  version = "0.2.7";
+  version = "0.2.8";
 
   src = fetchurl {
     url    = "http://pwmt.org/projects/girara/download/${name}.tar.gz";
-    sha256 = "1r9jbhf9n40zj4ddqv1q5spijpjm683nxg4hr5lnir4a551s7rlq";
+    sha256 = "18wss3sak3djip090v2vdbvq1mvkwcspfswc87zbvv3magihan98";
   };
 
   preConfigure = ''

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -10,11 +10,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name    = "zathura-core-${version}";
-  version = "0.3.7";
+  version = "0.3.8";
 
   src = fetchurl {
     url    = "http://pwmt.org/projects/zathura/download/zathura-${version}.tar.gz";
-    sha256 = "1w0g74dq4z2vl3f99s2gkaqrb5pskgzig10qhbxj4gq9yj4zzbr2";
+    sha256 = "0dz5pky3vmf3s2cp2rv1c099gb1s49p9xlgm3ghyy4pzyxc8bgs6";
   };
 
   icon = ./icon.xpm;
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "PREFIX=$(out)"
+    "RSTTOMAN=${docutils}/bin/rst2man.py"
     "VERBOSE=1"
     "TPUT=${ncurses.out}/bin/tput"
     (optionalString synctexSupport "WITH_SYNCTEX=1")

--- a/pkgs/applications/misc/zathura/djvu/default.nix
+++ b/pkgs/applications/misc/zathura/djvu/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, gtk, zathura_core, girara, djvulibre, gettext }:
 
 stdenv.mkDerivation rec {
-  name = "zathura-djvu-0.2.5";
+  name = "zathura-djvu-0.2.7";
 
   src = fetchurl {
     url = "http://pwmt.org/projects/zathura/plugins/download/${name}.tar.gz";
-    sha256 = "03cw54d2fipvbrnbqy0xccqkx6s77dyhyymx479aj5ryy4513dq8";
+    sha256 = "1sbfdsyp50qc85xc4458sn4w1rv1qbygdwmcr5kjlfpsmdq98vhd";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/zathura/djvu/gtkflags.patch
+++ b/pkgs/applications/misc/zathura/djvu/gtkflags.patch
@@ -1,7 +1,7 @@
---- a/config.mk	2012-05-14 01:13:09.009740082 +0400
-+++ b/config.mk	2012-05-14 01:13:50.400525700 +0400
-@@ -11,6 +11,9 @@
- LIBDIR ?= ${PREFIX}/lib
+--- zathura-djvu-0.2.7.orig/config.mk	2017-12-21 14:20:24.000000000 +0100
++++ zathura-djvu-0.2.7/config.mk	2017-12-31 00:41:02.580154770 +0100
+@@ -16,6 +16,9 @@
+ DESKTOPPREFIX ?= ${PREFIX}/share/applications
  
  # libs
 +GTK_INC ?= $(shell pkg-config --cflags gtk+-2.0)
@@ -10,14 +10,14 @@
  CAIRO_INC ?= $(shell pkg-config --cflags cairo)
  CAIRO_LIB ?= $(shell pkg-config --libs cairo)
  
-@@ -29,8 +32,8 @@
+@@ -34,8 +37,8 @@
  PLUGINDIR = ${LIBDIR}/zathura
  endif
  
--INCS = ${GIRARA_INC} ${GLIB_INC} ${DJVU_INC} ${ZATHURA_INC}
--LIBS = ${GIRARA_LIB} ${GLIB_LIB} ${DJVU_LIB}
-+INCS = ${GIRARA_INC} ${GLIB_INC} ${DJVU_INC} ${ZATHURA_INC} ${GTK_INC}
-+LIBS = ${GIRARA_LIB} ${GLIB_LIB} ${DJVU_LIB} ${GTK_LIB}
+-INCS = ${GIRARA_INC} ${GLIB_INC} ${DJVU_INC} ${CAIRO_INC} ${ZATHURA_INC}
+-LIBS = ${GIRARA_LIB} ${GLIB_LIB} ${DJVU_LIB} ${CAIRO_LIB}
++INCS = ${GIRARA_INC} ${GLIB_INC} ${DJVU_INC} ${CAIRO_INC} ${ZATHURA_INC} ${GTK_INC}
++LIBS = ${GIRARA_LIB} ${GLIB_LIB} ${DJVU_LIB} ${CAIRO_LIB} ${GTK_LIB}
  
- # flags
- CFLAGS += -std=c99 -fPIC -pedantic -Wall -Wno-format-zero-length $(INCS)
+ # pre-processor flags
+ CPPFLAGS += -D_FILE_OFFSET_BITS=64

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -2,12 +2,12 @@
 , libjpeg, jbig2dec, openjpeg, fetchpatch }:
 
 stdenv.mkDerivation rec {
-  version = "0.3.1";
+  version = "0.3.2";
   name = "zathura-pdf-mupdf-${version}";
 
   src = fetchurl {
     url = "https://pwmt.org/projects/zathura-pdf-mupdf/download/${name}.tar.gz";
-    sha256 = "06zqn8z6a0hfsx3s1kzqvqzb73afgcl6z5r062sxv7kv570fvffr";
+    sha256 = "0xkajc3is7ncmb2fmymbzfgrran2bz12i7zsm1vvxhxds728h7ck";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/zathura/pdf-poppler/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-poppler/default.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, fetchurl, pkgconfig, zathura_core, girara, poppler }:
 
 stdenv.mkDerivation rec {
-  version = "0.2.6";
+  version = "0.2.8";
   name = "zathura-pdf-poppler-${version}";
 
   src = fetchurl {
     url = "http://pwmt.org/projects/zathura/plugins/download/${name}.tar.gz";
-    sha256 = "1maqiv7yv8d8hymlffa688c5z71v85kbzmx2j88i8z349xx0rsyi";
+    sha256 = "1m55m7s7f8ng8a7lmcw9z4n5zv7xk4vp9n6fp9j84z6rk2imf7a2";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     homepage = http://pwmt.org/projects/zathura/;
     description = "A zathura PDF plugin (poppler)";
     longDescription = ''
-      The zathura-pdf-poppler plugin adds PDF support to zathura by 
+      The zathura-pdf-poppler plugin adds PDF support to zathura by
       using the poppler rendering library.
     '';
     license = licenses.zlib;

--- a/pkgs/applications/misc/zathura/ps/default.nix
+++ b/pkgs/applications/misc/zathura/ps/default.nix
@@ -1,11 +1,11 @@
 { stdenv, lib, fetchurl, pkgconfig, gtk, zathura_core, girara, libspectre, gettext }:
 
 stdenv.mkDerivation rec {
-  name = "zathura-ps-0.2.3";
+  name = "zathura-ps-0.2.5";
 
   src = fetchurl {
     url = "http://pwmt.org/projects/zathura/plugins/download/${name}.tar.gz";
-    sha256 = "18wsfy8pqficdgj8wy2aws7j4fy8z78157rhqk17mj5f295zgvm9";
+    sha256 = "1x4knqja8pw2a5cb3y2209nr3iddj1z8nwasy48v5nprj61fdxqj";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/zathura/ps/gtkflags.patch
+++ b/pkgs/applications/misc/zathura/ps/gtkflags.patch
@@ -1,9 +1,7 @@
-diff --git a/config.mk b/config.mk.new
-index c3a7b37..0cbce67 100644
---- a/config.mk
-+++ b/config.mk
-@@ -10,6 +10,9 @@ ZATHURA_VERSION_CHECK ?= $(shell pkg-config --atleast-version=$(ZATHURA_MIN_VERS
- PREFIX ?= /usr
+--- zathura-ps-0.2.5.orig/config.mk	2017-12-21 14:21:17.000000000 +0100
++++ zathura-ps-0.2.5/config.mk	2017-12-31 01:05:17.507268817 +0100
+@@ -16,6 +16,9 @@
+ DESKTOPPREFIX ?= ${PREFIX}/share/applications
  
  # libs
 +GTK_INC ?= $(shell pkg-config --cflags gtk+-2.0)
@@ -12,14 +10,14 @@ index c3a7b37..0cbce67 100644
  CAIRO_INC ?= $(shell pkg-config --cflags cairo)
  CAIRO_LIB ?= $(shell pkg-config --libs cairo)
  
-@@ -26,8 +29,8 @@ ZATHURA_INC ?= $(shell pkg-config --cflags zathura)
- PLUGINDIR ?= $(shell pkg-config --variable=plugindir zathura)
- PLUGINDIR ?= ${PREFIX}/lib/zathura
+@@ -34,8 +37,8 @@
+ PLUGINDIR = ${LIBDIR}/zathura
+ endif
  
--INCS = ${GLIB_INC} ${SPECTRE_INC} ${GIRARA_INC} ${ZATHURA_INC}
--LIBS = ${GLIB_LIB} ${SPECTRE_LIB} ${GIRARA_LIB}
-+INCS = ${GLIB_INC} ${SPECTRE_INC} ${GIRARA_INC} ${ZATHURA_INC} ${GTK_INC}
-+LIBS = ${GLIB_LIB} ${SPECTRE_LIB} ${GIRARA_LIB} ${GTK_LIB}
+-INCS = ${GLIB_INC} ${SPECTRE_INC} ${GIRARA_INC} ${CAIRO_INC} ${ZATHURA_INC}
+-LIBS = ${GLIB_LIB} ${SPECTRE_LIB} ${GIRARA_LIB} ${CAIRO_LIB}
++INCS = ${GLIB_INC} ${SPECTRE_INC} ${GIRARA_INC} ${CAIRO_INC} ${ZATHURA_INC} ${GTK_INC}
++LIBS = ${GLIB_LIB} ${SPECTRE_LIB} ${GIRARA_LIB} ${CAIRO_LIB } ${GTK_LIB}
  
- # flags
- CFLAGS += -std=c99 -fPIC -pedantic -Wall -Wno-format-zero-length $(INCS)
+ # compiler flags
+ CFLAGS += -std=c11 -fPIC -pedantic -Wall -Wno-format-zero-length $(INCS)


### PR DESCRIPTION
###### Motivation for this change

Update zathura with plugins to the last versions. Related to #33221

I've noticed zathura-cb is missing but I don't have time these days to add it to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

