### PR TITLE
opencv: 3.3.1 -> 3.4.0

### DIFF
--- a/pkgs/applications/graphics/digikam/default.nix
+++ b/pkgs/applications/graphics/digikam/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchurl, cmake, doxygen, extra-cmake-modules, wrapGAppsHook, fetchpatch
+{ mkDerivation, lib, fetchFromGitHub, cmake, doxygen, extra-cmake-modules, wrapGAppsHook, fetchpatch
 
 # For `digitaglinktree`
 , perl, sqlite
@@ -50,11 +50,13 @@
 
 mkDerivation rec {
   name    = "digikam-${version}";
-  version = "5.7.0";
+  version = "5.8.0";
 
-  src = fetchurl {
-    url = "mirror://kde/stable/digikam/${name}.tar.xz";
-    sha256 = "1xah079g47fih8l9qy1ifppfvmq5yms5y1z54nvxdyz8nsszy19n";
+  src = fetchFromGitHub {
+    owner  = "KDE";
+    repo   = "digikam";
+    rev    = "v${version}";
+    sha256 = "1bvidg0fn92xvw5brhb34lm7m4iy4jb5xpvnhbgh8vik2m4n41w1";
   };
 
   nativeBuildInputs = [ cmake doxygen extra-cmake-modules kdoctools wrapGAppsHook ];
@@ -83,8 +85,7 @@ mkDerivation rec {
     qtsvg
     qtwebkit
 
-    # https://bugs.kde.org/show_bug.cgi?id=387960
-    #kcalcore
+    kcalcore
     kconfigwidgets
     kcoreaddons
     kfilemetadata
@@ -111,20 +112,6 @@ mkDerivation rec {
       --replace "/usr/bin/perl" "${perl}/bin/perl" \
       --replace "/usr/bin/sqlite3" "${sqlite}/bin/sqlite3"
   '';
-
-  patches = [
-    # fix Qt-5.9.3 empty album problem
-    (fetchpatch {
-      url = "https://cgit.kde.org/digikam.git/patch/?id=855ba5b7d4bc6337234720a72ea824ddd3b32e5b";
-      sha256 = "0zk8p182piy6xn9v0mhwawya9ciq596vql1qc3lgnx371a97mmni";
-    })
-  ];
-
-  patchFlags = "-d core -p1";
-
-  # `en make -f core/utilities/assistants/expoblending/CMakeFiles/expoblending_src.dir/build.make core/utilities/assistants/expoblending/CMakeFiles/expoblending_src.dir/manager/expoblendingthread.cpp.o`:
-  # digikam_version.h:37:24: fatal error: gitversion.h: No such file or directory
-  enableParallelBuilding = false;
 
   meta = with lib; {
     description = "Photo Management Program";

--- a/pkgs/development/libraries/ogre/1.9.x.nix
+++ b/pkgs/development/libraries/ogre/1.9.x.nix
@@ -1,0 +1,46 @@
+{ fetchFromGitHub, stdenv, lib
+, cmake, mesa
+, freetype, freeimage, zziplib, randrproto, libXrandr
+, libXaw, freeglut, libXt, libpng, boost, ois
+, xproto, libX11, libXmu, libSM, pkgconfig
+, libXxf86vm, xf86vidmodeproto, libICE
+, renderproto, libXrender
+, withNvidiaCg ? false, nvidia_cg_toolkit
+, withSamples ? false }:
+
+stdenv.mkDerivation rec {
+  pname = "ogre";
+  version = "1.9.1";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "OGRECave";
+    repo = "ogre";
+    rev = "v${version}";
+    sha256 = "11lfgzqaps3728dswrq3cbwk7aicigyz08q4hfyy6ikc6m35r4wg";
+  };
+
+  cmakeFlags = [ "-DOGRE_BUILD_SAMPLES=${toString withSamples}" ]
+    ++ map (x: "-DOGRE_BUILD_PLUGIN_${x}=on")
+           ([ "BSP" "OCTREE" "PCZ" "PFX" ] ++ lib.optional withNvidiaCg "CG")
+    ++ map (x: "-DOGRE_BUILD_RENDERSYSTEM_${x}=on") [ "GL" ];
+
+  enableParallelBuilding = true;
+
+  buildInputs =
+   [ cmake mesa
+     freetype freeimage zziplib randrproto libXrandr
+     libXaw freeglut libXt libpng boost ois
+     xproto libX11 libXmu libSM pkgconfig
+     libXxf86vm xf86vidmodeproto libICE
+     renderproto libXrender
+   ] ++ lib.optional withNvidiaCg nvidia_cg_toolkit;
+
+  meta = {
+    description = "A 3D engine";
+    homepage = http://www.ogre3d.org/;
+    maintainers = [ stdenv.lib.maintainers.raskin ];
+    platforms = stdenv.lib.platforms.linux;
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/development/libraries/ogre/default.nix
+++ b/pkgs/development/libraries/ogre/default.nix
@@ -9,11 +9,11 @@
 , withSamples ? false }:
 
 stdenv.mkDerivation {
-  name = "ogre-1.10.10";
+  name = "ogre-1.10.11";
 
   src = fetchurl {
-     url = "https://bitbucket.org/sinbad/ogre/get/v1-10-10.tar.gz";
-     sha256 = "1wi6h1jwqpmpxiy2kwns24qw8gi6s5h40fnikdk4v1r5hdgw4bla";
+     url = "https://bitbucket.org/sinbad/ogre/get/v1-10-11.tar.gz";
+     sha256 = "1zwvlx5dz9nwjazhnrhzb0w8ilpa84r0hrxrmmy69pgr1p1yif5a";
   };
 
   cmakeFlags = [ "-DOGRE_BUILD_SAMPLES=${toString withSamples}" ]

--- a/pkgs/development/libraries/ogre/default.nix
+++ b/pkgs/development/libraries/ogre/default.nix
@@ -9,11 +9,11 @@
 , withSamples ? false }:
 
 stdenv.mkDerivation {
-  name = "ogre-1.9-hg-20160322";
+  name = "ogre-1.10.10";
 
   src = fetchurl {
-     url = "https://bitbucket.org/sinbad/ogre/get/v1-9.tar.gz";
-     sha256 = "0w3argjy1biaxwa3c80zxxgll67wjp8czd83p87awlcvwzdk5mz9";
+     url = "https://bitbucket.org/sinbad/ogre/get/v1-10-10.tar.gz";
+     sha256 = "1wi6h1jwqpmpxiy2kwns24qw8gi6s5h40fnikdk4v1r5hdgw4bla";
   };
 
   cmakeFlags = [ "-DOGRE_BUILD_SAMPLES=${toString withSamples}" ]

--- a/pkgs/development/libraries/ogrepaged/default.nix
+++ b/pkgs/development/libraries/ogrepaged/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig, ois, ogre, libX11, boost }:
+{ stdenv, fetchurl, fetchpatch, cmake, pkgconfig, ois, ogre, libX11, boost }:
 
 stdenv.mkDerivation rec {
   name = "ogre-paged-${version}";
@@ -8,6 +8,23 @@ stdenv.mkDerivation rec {
     url = "https://github.com/RigsOfRods/ogre-pagedgeometry/archive/v${version}.tar.gz";
     sha256 = "17j7rw9wbkynxbhm2lay3qgjnnagb2vd5jn9iijnn2lf8qzbgy82";
   };
+
+  patches = [
+    # These patches come from https://github.com/RigsOfRods/ogre-pagedgeometry/pull/6
+    # and make ogre-paged build with ogre-1.10.
+    (fetchpatch {
+      url = "https://github.com/RigsOfRods/ogre-pagedgeometry/commit/2d4df577decba37ec3cdafc965deae0f6d31fe45.patch";
+      sha256 = "0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73";
+    })
+    (fetchpatch {
+      url = "https://github.com/RigsOfRods/ogre-pagedgeometry/commit/4d81789ec6f55e294a5ad040ea7abe2b415cbc92.patch";
+      sha256 = "17q8djdz2y3g46azxc3idhyvi6vf0sqkxld4bbyp3l9zn7dq76rp";
+    })
+    (fetchpatch {
+      url = "https://github.com/RigsOfRods/ogre-pagedgeometry/commit/10f7c5ce5b422e9cbac59d466f3567a24c8831a4.patch";
+      sha256 = "1kk0dbadzg73ai99l3w04q51sil36vzbkaqc79mdwy0vjrn4ardb";
+    })
+  ];
 
   buildInputs = [ ois ogre libX11 boost ];
   nativeBuildInputs = [ cmake pkgconfig ];

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -1,5 +1,5 @@
 { lib, stdenv
-, fetchurl, fetchFromGitHub
+, fetchurl, fetchFromGitHub, fetchpatch
 , cmake, pkgconfig, unzip, zlib, pcre, hdf5
 , caffe, glog, boost, google-gflags, protobuf
 , config
@@ -151,6 +151,14 @@ stdenv.mkDerivation rec {
   name = "opencv-${version}";
   inherit version src;
 
+  patches = [
+    # Fix for: https://github.com/opencv/opencv/issues/10474
+    (fetchpatch {
+      url = "https://github.com/opencv/opencv/commit/ea5a3e557f93844fdb5e54e3e8acfc5f61c6fd9f.patch";
+      sha256 = "1w7jmqlrx73ydh9jjsnnic5xz8r04kxbjpzkcfyb91v3az9132r1";
+    })
+  ];
+
   postUnpack = lib.optionalString buildContrib ''
     cp --no-preserve=mode -r "${contribSrc}/modules" "$NIX_BUILD_TOP/opencv_contrib"
   '';
@@ -241,11 +249,6 @@ stdenv.mkDerivation rec {
     ];
 
   enableParallelBuilding = true;
-
-  # Workaround for: https://github.com/opencv/opencv/issues/10474
-  preBuild = ''
-    make opencv_dnn
-  '';
 
   postBuild = lib.optionalString enableDocs ''
     make doxygen

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -232,7 +232,13 @@ stdenv.mkDerivation rec {
     "-DCUDA_FAST_MATH=ON"
     "-DCUDA_HOST_COMPILER=${cudatoolkit.cc}/bin/gcc"
   ]
-    ++ lib.optionals stdenv.isDarwin ["-DWITH_OPENCL=OFF" "-DWITH_LAPACK=OFF"];
+    ++ lib.optionals stdenv.isDarwin [
+      "-DWITH_OPENCL=OFF"
+      "-DWITH_LAPACK=OFF"
+
+      # On OS X the tiny-dnn-1.0.0a3 dependency of dnn_modern fails to build.
+      "-DBUILD_opencv_dnn_modern=OFF"
+    ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -15,6 +15,7 @@
 
 , enableCuda      ? (config.cudaSupport or false), cudatoolkit
 
+, enableUnfree    ? false
 , enableIpp       ? false
 , enableContrib   ? false
 , enablePython    ? false, pythonPackages
@@ -141,8 +142,9 @@ let
     dst  = ".cache/tiny_dnn";
   };
 
-  opencvFlag = name: enabled: "-DWITH_${name}=${if enabled then "ON" else "OFF"}";
+  opencvFlag = name: enabled: "-DWITH_${name}=${printEnabled enabled}";
 
+  printEnabled = enabled : if enabled then "ON" else "OFF";
 in
 
 stdenv.mkDerivation rec {
@@ -216,6 +218,7 @@ stdenv.mkDerivation rec {
     "-DWITH_OPENMP=ON"
     "-DBUILD_PROTOBUF=OFF"
     "-DPROTOBUF_UPDATE_FILES=ON"
+    "-DOPENCV_ENABLE_NONFREE=${printEnabled enableUnfree}"
     (opencvFlag "IPP" enableIpp)
     (opencvFlag "TIFF" enableTIFF)
     (opencvFlag "JASPER" enableJPEG2K)
@@ -249,7 +252,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Open Computer Vision Library with more than 500 algorithms";
     homepage = http://opencv.org/;
-    license = stdenv.lib.licenses.bsd3;
+    license = with stdenv.lib.licenses; if enableUnfree then unfree else bsd3;
     maintainers = with stdenv.lib.maintainers; [viric mdaiter basvandijk];
     platforms = with stdenv.lib.platforms; linux ++ darwin;
   };

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -205,7 +205,7 @@ stdenv.mkDerivation rec {
     # tesseract & leptonica.
     ++ lib.optionals enableTesseract [ tesseract leptonica ]
     ++ lib.optional enableCuda cudatoolkit
-    ++ lib.optionals stdenv.isDarwin [ AVFoundation Cocoa QTKit ]
+    ++ lib.optionals stdenv.isDarwin [ AVFoundation Cocoa QTKit VideoDecodeAcceleration bzip2 ]
     ++ lib.optionals enableDocs [ doxygen graphviz-nox ];
 
   propagatedBuildInputs = lib.optional enablePython pythonPackages.numpy;

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -214,6 +214,8 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DWITH_OPENMP=ON"
+    "-DBUILD_PROTOBUF=OFF"
+    "-DPROTOBUF_UPDATE_FILES=ON"
     (opencvFlag "IPP" enableIpp)
     (opencvFlag "TIFF" enableTIFF)
     (opencvFlag "JASPER" enableJPEG2K)
@@ -230,6 +232,11 @@ stdenv.mkDerivation rec {
     ++ lib.optionals stdenv.isDarwin ["-DWITH_OPENCL=OFF" "-DWITH_LAPACK=OFF"];
 
   enableParallelBuilding = true;
+
+  # Workaround for: https://github.com/opencv/opencv/issues/10474
+  preBuild = ''
+    make opencv_dnn
+  '';
 
   postBuild = lib.optionalString enableDocs ''
     make doxygen

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18289,7 +18289,9 @@ with pkgs;
 
   openarena = callPackage ../games/openarena { };
 
-  opendungeons = callPackage ../games/opendungeons { };
+  opendungeons = callPackage ../games/opendungeons {
+    ogre = ogre1_9;
+  };
 
   openlierox = callPackage ../games/openlierox { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18074,6 +18074,7 @@ with pkgs;
   digikam = libsForQt5.callPackage ../applications/graphics/digikam {
     inherit (plasma5) oxygen;
     inherit (kdeApplications) kcalcore;
+    opencv3 = opencv3.override { enableContrib = true; };
   };
 
   displaycal = (newScope pythonPackages) ../applications/graphics/displaycal {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18374,6 +18374,9 @@ with pkgs;
   rigsofrods = callPackage ../games/rigsofrods {
     angelscript = angelscript_2_22;
     ogre = ogre1_9;
+    ogrepaged = ogrepaged.override {
+      ogre = ogre1_9;
+    };
     mygui = mygui.override {
       withOgre = true;
     };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10195,7 +10195,9 @@ with pkgs;
 
   mygpoclient = pythonPackages.mygpoclient;
 
-  mygui = callPackage ../development/libraries/mygui {};
+  mygui = callPackage ../development/libraries/mygui {
+    ogre = ogre1_9;
+  };
 
   mysocketw = callPackage ../development/libraries/mysocketw { };
 
@@ -10270,6 +10272,7 @@ with pkgs;
   ode = callPackage ../development/libraries/ode { };
 
   ogre = callPackage ../development/libraries/ogre {};
+  ogre1_9 = callPackage ../development/libraries/ogre/1.9.x.nix {};
 
   ogrepaged = callPackage ../development/libraries/ogrepaged { };
 
@@ -18370,6 +18373,7 @@ with pkgs;
 
   rigsofrods = callPackage ../games/rigsofrods {
     angelscript = angelscript_2_22;
+    ogre = ogre1_9;
     mygui = mygui.override {
       withOgre = true;
     };
@@ -18464,6 +18468,7 @@ with pkgs;
   };
 
   stuntrally = callPackage ../games/stuntrally {
+    ogre = ogre1_9;
     mygui = mygui.override {
       withOgre = true;
     };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/opencv/opencv/wiki/ChangeLog#version34

The upgraded `ogre-1.10.10` is a dependency of the optional `ovis` module of `opencv-3.4.0`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

