### PR TITLE
Clamav privatetmp

### DIFF
--- a/nixos/modules/services/security/clamav.nix
+++ b/nixos/modules/services/security/clamav.nix
@@ -43,6 +43,14 @@ in
             configuration file.
           '';
         };
+
+        privateTmp = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Whether to run clamd with a private /tmp.
+          '';
+        };
       };
       updater = {
         enable = mkEnableOption "ClamAV freshclam updater";
@@ -110,7 +118,7 @@ in
       serviceConfig = {
         ExecStart = "${pkg}/bin/clamd";
         ExecReload = "${pkgs.coreutils}/bin/kill -USR2 $MAINPID";
-        PrivateTmp = "yes";
+        PrivateTmp = if cfg.daemon.privateTmp then "yes" else "no";
         PrivateDevices = "yes";
         PrivateNetwork = "yes";
       };

--- a/nixos/modules/services/security/clamav.nix
+++ b/nixos/modules/services/security/clamav.nix
@@ -105,8 +105,8 @@ in
 
     systemd.services.clamav-daemon = optionalAttrs cfg.daemon.enable {
       description = "ClamAV daemon (clamd)";
-      after = mkIf cfg.updater.enable [ "clamav-freshclam.service" ];
-      requires = mkIf cfg.updater.enable [ "clamav-freshclam.service" ];
+      after = optional cfg.updater.enable "clamav-freshclam.service";
+      requires = optional cfg.updater.enable "clamav-freshclam.service";
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ clamdConfigFile ];
 


### PR DESCRIPTION
###### Motivation for this change

Allow to disable `clamav` running with a private `/tmp`. Turning this on fixes `clamdscan` not working for files in `/tmp`. Not turning `PrivateTmp` off altogether as I'd guess it has been added here for some reason.

I also replaced some `mkIf x [y]` with `optional x y` while I was at it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

