### PR TITLE
libxc: init at 2.2.3

### DIFF
--- a/pkgs/development/libraries/libxc/default.nix
+++ b/pkgs/development/libraries/libxc/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, gfortran, perl }:
+
+let
+  version = "2.2.3";
+in stdenv.mkDerivation {
+  name = "libxc-${version}";
+  src = fetchurl {
+    url = "http://www.tddft.org/programs/octopus/down.php?file=libxc/libxc-${version}.tar.gz";
+    sha256 = "1rv8vsf7zzw0g7j93rqcipzhk2pj1iq71bpkwf7zxivmgavh0arg";
+  };
+
+  buildInputs = [ gfortran ];
+  nativeBuildInputs = [ perl ];
+
+  preConfigure = ''
+    patchShebangs ./
+  '';
+
+  configureFlags = [ "--enable-shared" ];
+
+  doCheck = true;
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Library of exchange-correlation functionals for density-functional theory";
+    homepage = http://octopus-code.org/wiki/Libxc;
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainer = with maintainers; [ markuskowa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3230,6 +3230,8 @@ with pkgs;
 
   libibverbs = callPackage ../development/libraries/libibverbs { };
 
+  libxc = callPackage ../development/libraries/libxc { };
+
   libxcomp = callPackage ../development/libraries/libxcomp { };
 
   libxl = callPackage ../development/libraries/libxl {};


### PR DESCRIPTION
###### Motivation for this change
Libxc is a library with density functionals used by quantum chemistry programs
(e.g. octopus, PR will follow).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

