### PR TITLE
dattobd: init at 0.10.3 [WIP]

### DIFF
--- a/pkgs/tools/backup/dattobd/default.nix
+++ b/pkgs/tools/backup/dattobd/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+
+  name = "${pname}-${version}";
+  pname = "dattobd";
+  version = "0.10.3";
+
+  src = fetchFromGitHub {
+    owner = "datto";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1fw74b7m3qwd5lfg5vx530n9w02ig6gamzq74hw0rxjp43jmkxx3";
+  };
+
+  postPatch = ''
+    patchShebangs src/genconfig.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Kernel module for snapshots and incremental backups of Linux block devices";
+    homepage = https://github.com/datto/dattobd;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jluttine ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1690,6 +1690,8 @@ with pkgs;
 
   darkstat = callPackage ../tools/networking/darkstat { };
 
+  dattobd = callPackage ../tools/backup/dattobd { };
+
   davfs2 = callPackage ../tools/filesystems/davfs2 { };
 
   dbench = callPackage ../development/tools/misc/dbench { };


### PR DESCRIPTION
###### Motivation for this change

**NOTE: This is still work in progress. Do not merge yet. I hope to get some feedback and help here.**

Add dattobd kernel module: https://github.com/datto/dattobd

"kernel module for taking block-level snapshots and incremental backups of Linux block devices "

However, I'm not able to build the package. If anyone is able to help, that'd be great. I'm getting the following error:

<details>
<summary>Traceback</summary>

```
$ nix-shell -p dattobd
these de$ nix-shell -p dattobd
these derivations will be built:
  /nix/store/addqz6d0yrv0rv3cbm5br1zwv1cq1i5a-dattobd-0.10.3.drv
building path(s) ‘/nix/store/xl3n1p3ipb8gdyb3bywaq8f95qa2n5rl-dattobd-0.10.3’
unpacking sources
unpacking source archive /nix/store/blbm08xqi7lhc37fkvbpd69lxjxi0264-source
source root is source
patching sources
patching script interpreter paths in src/genconfig.sh
src/genconfig.sh: interpreter directive changed from "/bin/bash" to "/nix/store/sxwh6a4v8xdlvg4jf3vl2jh9l5760hsc-bash-4.4-p12/bin/bash"
configuring
no configure script, doing nothing
building
build flags: SHELL=/nix/store/sxwh6a4v8xdlvg4jf3vl2jh9l5760hsc-bash-4.4-p12/bin/bash
make -C src
make[1]: Entering directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src'
if [ ! -f kernel-config.h ] || tail -1 kernel-config.h | grep -qv '#endif'; then ./genconfig.sh 4.9.68; fi;
generating configurations
make[2]: Entering directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
make[3]: Entering directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
make[3]: *** /lib/modules/4.9.68/build: No such file or directory.  Stop.
make[3]: Leaving directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
make[2]: *** [Makefile:11: clean] Error 2
make[2]: Leaving directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
performing configure test: HAVE___DENTRY_PATH - not present
performing configure test: HAVE_BD_SUPER - not present
performing configure test: HAVE_BDEV_STACK_LIMITS - not present
performing configure test: HAVE_BDOPS_OPEN_INODE - not present
performing configure test: HAVE_BDOPS_OPEN_INT - not present
performing configure test: HAVE_BIO_BI_POOL - not present
performing configure test: HAVE_BIO_BI_REMAINING - not present
performing configure test: HAVE_BIO_ENDIO_1 - not present
performing configure test: HAVE_BIO_ENDIO_INT - not present
performing configure test: HAVE_BIO_LIST - not present
performing configure test: HAVE_BIOSET_CREATE_3 - not present
performing configure test: HAVE_BIOSET_NEED_BVECS_FLAG - not present
performing configure test: HAVE_BLK_SET_DEFAULT_LIMITS - not present
performing configure test: HAVE_BLK_SET_STACKING_LIMITS - not present
performing configure test: HAVE_BLK_STATUS_T - not present
performing configure test: HAVE_BLKDEV_GET_BY_PATH - not present
performing configure test: HAVE_BLKDEV_PUT_1 - not present
performing configure test: HAVE_BVEC_ITER - not present
performing configure test: HAVE_BVEC_MERGE_DATA - not present
performing configure test: HAVE_D_UNLINKED - not present
performing configure test: HAVE_DENTRY_PATH_RAW - not present
performing configure test: HAVE_ENUM_REQ_OP - not present
performing configure test: HAVE_ENUM_REQ_OPF - not present
performing configure test: HAVE_FILE_INODE - not present
performing configure test: HAVE_FMODE_T - not present
performing configure test: HAVE_FOPS_FALLOCATE - not present
performing configure test: HAVE_GENHD_FL_NO_PART_SCAN - not present
performing configure test: HAVE_INODE_LOCK - not present
performing configure test: HAVE_IOPS_FALLOCATE - not present
performing configure test: HAVE_KERN_PATH - not present
performing configure test: HAVE_MAKE_REQUEST_FN_INT - not present
performing configure test: HAVE_MAKE_REQUEST_FN_VOID - not present
performing configure test: HAVE_MERGE_BVEC_FN - not present
performing configure test: HAVE_MNT_WANT_WRITE - not present
performing configure test: HAVE_NOOP_LLSEEK - not present
performing configure test: HAVE_NOTIFY_CHANGE_2 - not present
performing configure test: HAVE_PART_NR_SECTS_READ - not present
performing configure test: HAVE_PATH_PUT - not present
performing configure test: HAVE_PROC_CREATE - not present
performing configure test: HAVE_SB_START_WRITE - not present
performing configure test: HAVE_STRUCT_PATH - not present
performing configure test: HAVE_SUBMIT_BIO_1 - not present
performing configure test: HAVE_SUBMIT_BIO_WAIT - not present
performing configure test: HAVE_SYS_OLDUMOUNT - not present
performing configure test: HAVE_TASK_STRUCT_TASK_WORKS_CB_HEAD - not present
performing configure test: HAVE_TASK_STRUCT_TASK_WORKS_HLIST - not present
performing configure test: HAVE_THAW_BDEV_INT - not present
performing configure test: HAVE_USER_PATH_AT - not present
performing configure test: HAVE_UUID_H - not present
performing configure test: HAVE_VFS_FALLOCATE - not present
performing configure test: HAVE_VFS_UNLINK_2 - not present
performing configure test: HAVE_VZALLOC - not present
make[2]: Entering directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
make[3]: Entering directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
make[3]: *** /lib/modules/4.9.68/build: No such file or directory.  Stop.
make[3]: Leaving directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
make[2]: *** [Makefile:11: clean] Error 2
make[2]: Leaving directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
performing sys_mount lookup
grep: /boot/System.map-4.9.68: No such file or directory
performing sys_umount lookup
grep: /boot/System.map-4.9.68: No such file or directory
performing sys_oldumount lookup
grep: /boot/System.map-4.9.68: No such file or directory
performing sys_call_table lookup
grep: /boot/System.map-4.9.68: No such file or directory
performing printk lookup
grep: /boot/System.map-4.9.68: No such file or directory
make -C /lib/modules/4.9.68/build M=/tmp/nix-build-dattobd-0.10.3.drv-0/source/src modules
make[2]: Entering directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src'
make[2]: *** /lib/modules/4.9.68/build: No such file or directory.  Stop.
make[2]: Leaving directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src'
make[1]: *** [Makefile:10: default] Error 2
make[1]: Leaving directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src'
make: *** [Makefile:13: driver] Error 2
builder for ‘/nix/store/addqz6d0yrv0rv3cbm5br1zwv1cq1i5a-dattobd-0.10.3.drv’ failed with exit code 2
error: build of ‘/nix/store/addqz6d0yrv0rv3cbm5br1zwv1cq1i5a-dattobd-0.10.3.drv’ failed
/run/current-system/sw/bin/nix-shell: failed to build all dependencies
rivations will be built:
  /nix/store/addqz6d0yrv0rv3cbm5br1zwv1cq1i5a-dattobd-0.10.3.drv
building path(s) ‘/nix/store/xl3n1p3ipb8gdyb3bywaq8f95qa2n5rl-dattobd-0.10.3’
unpacking sources
unpacking source archive /nix/store/blbm08xqi7lhc37fkvbpd69lxjxi0264-source
source root is source
patching sources
patching script interpreter paths in src/genconfig.sh
src/genconfig.sh: interpreter directive changed from "/bin/bash" to "/nix/store/sxwh6a4v8xdlvg4jf3vl2jh9l5760hsc-bash-4.4-p12/bin/bash"
configuring
no configure script, doing nothing
building
build flags: SHELL=/nix/store/sxwh6a4v8xdlvg4jf3vl2jh9l5760hsc-bash-4.4-p12/bin/bash
make -C src
make[1]: Entering directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src'
if [ ! -f kernel-config.h ] || tail -1 kernel-config.h | grep -qv '#endif'; then ./genconfig.sh 4.9.68; fi;
generating configurations
make[2]: Entering directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
make[3]: Entering directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
make[3]: *** /lib/modules/4.9.68/build: No such file or directory.  Stop.
make[3]: Leaving directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
make[2]: *** [Makefile:11: clean] Error 2
make[2]: Leaving directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
performing configure test: HAVE___DENTRY_PATH - not present
performing configure test: HAVE_BD_SUPER - not present
performing configure test: HAVE_BDEV_STACK_LIMITS - not present
performing configure test: HAVE_BDOPS_OPEN_INODE - not present
performing configure test: HAVE_BDOPS_OPEN_INT - not present
performing configure test: HAVE_BIO_BI_POOL - not present
performing configure test: HAVE_BIO_BI_REMAINING - not present
performing configure test: HAVE_BIO_ENDIO_1 - not present
performing configure test: HAVE_BIO_ENDIO_INT - not present
performing configure test: HAVE_BIO_LIST - not present
performing configure test: HAVE_BIOSET_CREATE_3 - not present
performing configure test: HAVE_BIOSET_NEED_BVECS_FLAG - not present
performing configure test: HAVE_BLK_SET_DEFAULT_LIMITS - not present
performing configure test: HAVE_BLK_SET_STACKING_LIMITS - not present
performing configure test: HAVE_BLK_STATUS_T - not present
performing configure test: HAVE_BLKDEV_GET_BY_PATH - not present
performing configure test: HAVE_BLKDEV_PUT_1 - not present
performing configure test: HAVE_BVEC_ITER - not present
performing configure test: HAVE_BVEC_MERGE_DATA - not present
performing configure test: HAVE_D_UNLINKED - not present
performing configure test: HAVE_DENTRY_PATH_RAW - not present
performing configure test: HAVE_ENUM_REQ_OP - not present
performing configure test: HAVE_ENUM_REQ_OPF - not present
performing configure test: HAVE_FILE_INODE - not present
performing configure test: HAVE_FMODE_T - not present
performing configure test: HAVE_FOPS_FALLOCATE - not present
performing configure test: HAVE_GENHD_FL_NO_PART_SCAN - not present
performing configure test: HAVE_INODE_LOCK - not present
performing configure test: HAVE_IOPS_FALLOCATE - not present
performing configure test: HAVE_KERN_PATH - not present
performing configure test: HAVE_MAKE_REQUEST_FN_INT - not present
performing configure test: HAVE_MAKE_REQUEST_FN_VOID - not present
performing configure test: HAVE_MERGE_BVEC_FN - not present
performing configure test: HAVE_MNT_WANT_WRITE - not present
performing configure test: HAVE_NOOP_LLSEEK - not present
performing configure test: HAVE_NOTIFY_CHANGE_2 - not present
performing configure test: HAVE_PART_NR_SECTS_READ - not present
performing configure test: HAVE_PATH_PUT - not present
performing configure test: HAVE_PROC_CREATE - not present
performing configure test: HAVE_SB_START_WRITE - not present
performing configure test: HAVE_STRUCT_PATH - not present
performing configure test: HAVE_SUBMIT_BIO_1 - not present
performing configure test: HAVE_SUBMIT_BIO_WAIT - not present
performing configure test: HAVE_SYS_OLDUMOUNT - not present
performing configure test: HAVE_TASK_STRUCT_TASK_WORKS_CB_HEAD - not present
performing configure test: HAVE_TASK_STRUCT_TASK_WORKS_HLIST - not present
performing configure test: HAVE_THAW_BDEV_INT - not present
performing configure test: HAVE_USER_PATH_AT - not present
performing configure test: HAVE_UUID_H - not present
performing configure test: HAVE_VFS_FALLOCATE - not present
performing configure test: HAVE_VFS_UNLINK_2 - not present
performing configure test: HAVE_VZALLOC - not present
make[2]: Entering directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
make[3]: Entering directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
make[3]: *** /lib/modules/4.9.68/build: No such file or directory.  Stop.
make[3]: Leaving directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
make[2]: *** [Makefile:11: clean] Error 2
make[2]: Leaving directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src/configure-tests/feature-tests'
performing sys_mount lookup
grep: /boot/System.map-4.9.68: No such file or directory
performing sys_umount lookup
grep: /boot/System.map-4.9.68: No such file or directory
performing sys_oldumount lookup
grep: /boot/System.map-4.9.68: No such file or directory
performing sys_call_table lookup
grep: /boot/System.map-4.9.68: No such file or directory
performing printk lookup
grep: /boot/System.map-4.9.68: No such file or directory
make -C /lib/modules/4.9.68/build M=/tmp/nix-build-dattobd-0.10.3.drv-0/source/src modules
make[2]: Entering directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src'
make[2]: *** /lib/modules/4.9.68/build: No such file or directory.  Stop.
make[2]: Leaving directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src'
make[1]: *** [Makefile:10: default] Error 2
make[1]: Leaving directory '/tmp/nix-build-dattobd-0.10.3.drv-0/source/src'
make: *** [Makefile:13: driver] Error 2
builder for ‘/nix/store/addqz6d0yrv0rv3cbm5br1zwv1cq1i5a-dattobd-0.10.3.drv’ failed with exit code 2
error: build of ‘/nix/store/addqz6d0yrv0rv3cbm5br1zwv1cq1i5a-dattobd-0.10.3.drv’ failed
/run/current-system/sw/bin/nix-shell: failed to build all dependencies
```
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

