### PR TITLE
lvmsync: init at 3.3.2

### DIFF
--- a/pkgs/tools/backup/lvmsync/Gemfile
+++ b/pkgs/tools/backup/lvmsync/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org/'
+gem 'lvmsync'

--- a/pkgs/tools/backup/lvmsync/Gemfile.lock
+++ b/pkgs/tools/backup/lvmsync/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    git-version-bump (0.15.1)
+    lvmsync (3.3.2)
+      git-version-bump (~> 0.10)
+      treetop
+    polyglot (0.3.5)
+    treetop (1.6.9)
+      polyglot (~> 0.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  lvmsync
+
+BUNDLED WITH
+   1.14.6

--- a/pkgs/tools/backup/lvmsync/default.nix
+++ b/pkgs/tools/backup/lvmsync/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, bundlerEnv, ruby, makeWrapper }:
+
+let
+
+  pname = "lvmsync";
+  version = (import ./gemset.nix)."${pname}".version;
+
+in stdenv.mkDerivation rec {
+
+  name = "${pname}-${version}";
+
+  env = bundlerEnv {
+    name = "${pname}-${version}-gems";
+    ruby = ruby;
+    gemfile  = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset   = ./gemset.nix;
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  phases = ["installPhase"];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    makeWrapper ${env}/bin/lvmsync $out/bin/lvmsync
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Optimised synchronisation of LVM snapshots over a network";
+    homepage = http://theshed.hezmatt.org/lvmsync/;
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ jluttine ];
+  };
+
+}

--- a/pkgs/tools/backup/lvmsync/gemset.nix
+++ b/pkgs/tools/backup/lvmsync/gemset.nix
@@ -1,0 +1,36 @@
+{
+  git-version-bump = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xcj20gmbpqn2gcpid4pxpnimfdg2ip9jnl1572naz0magcrwl2s";
+      type = "gem";
+    };
+    version = "0.15.1";
+  };
+  lvmsync = {
+    dependencies = ["git-version-bump" "treetop"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "02mdrvfibvab4p4yrdzxvndhy8drss3ri7izybcwgpbyc7isk8mv";
+      type = "gem";
+    };
+    version = "3.3.2";
+  };
+  polyglot = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1bqnxwyip623d8pr29rg6m8r0hdg08fpr2yb74f46rn1wgsnxmjr";
+      type = "gem";
+    };
+    version = "0.3.5";
+  };
+  treetop = {
+    dependencies = ["polyglot"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0sdkd1v2h8dhj9ncsnpywmqv7w1mdwsyc5jwyxlxwriacv8qz8bd";
+      type = "gem";
+    };
+    version = "1.6.9";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3008,6 +3008,8 @@ with pkgs;
 
   ltwheelconf = callPackage ../applications/misc/ltwheelconf { };
 
+  lvmsync = callPackage ../tools/backup/lvmsync { };
+
   kippo = callPackage ../servers/kippo { };
 
   kzipmix = callPackage_i686 ../tools/compression/kzipmix { };


### PR DESCRIPTION
###### Motivation for this change

Add lvmsync: Synchronise LVM LVs across a network by sending only snapshotted changes http://theshed.hezmatt.org/lvmsync

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

