### PR TITLE
bdsync: init at 0.10.1

### DIFF
--- a/pkgs/tools/backup/bdsync/default.nix
+++ b/pkgs/tools/backup/bdsync/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, openssl, coreutils, which }:
+
+stdenv.mkDerivation rec {
+
+  name = "${pname}-${version}";
+  pname = "bdsync";
+  version = "0.10.1";
+
+  src = fetchFromGitHub {
+    owner = "TargetHolding";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "144hlbk3k29l7sja6piwhd2jsnzzsak13fcjbahd6m8yimxyb2nf";
+  };
+
+  postPatch = ''
+    patchShebangs ./tests.sh
+    patchShebangs ./tests/
+  '';
+
+  buildInputs = [ openssl coreutils which ];
+
+  doCheck = true;
+  checkPhase = ''
+    make test
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man1
+    cp bdsync $out/bin/
+    cp bdsync.1 $out/share/man/man1/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Fast block device synchronizing tool";
+    homepage = https://github.com/TargetHolding/bdsync;
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ jluttine ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1314,6 +1314,8 @@ with pkgs;
 
   bats = callPackage ../development/interpreters/bats { };
 
+  bdsync = callPackage ../tools/backup/bdsync { };
+
   beanstalkd = callPackage ../servers/beanstalkd { };
 
   beets = callPackage ../tools/audio/beets {


### PR DESCRIPTION
###### Motivation for this change

bdsync: a fast block device synchronizing tool https://github.com/TargetHolding/bdsync

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

