### PR TITLE
wsjtx: init at 1.8.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -357,6 +357,7 @@
   kristoff3r = "Kristoffer Søholm <k.soeholm@gmail.com>";
   ktosiek = "Tomasz Kontusz <tomasz.kontusz@gmail.com>";
   kuznero = "Roman Kuznetsov <roman@kuznero.com>";
+  lasandell = "Luke Sandell <lasandell@gmail.com>";
   lassulus = "Lassulus <lassulus@gmail.com>";
   layus = "Guillaume Maudoux <layus.on@gmail.com>";
   ldesgoui = "Lucas Desgouilles <ldesgoui@gmail.com>";

--- a/pkgs/applications/misc/wsjtx/default.nix
+++ b/pkgs/applications/misc/wsjtx/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ fftw fftwFloat libusb1 qtbase qtmultimedia qtserialport ];
 
   # Composite build has its own patch step after it extracts the inner archives
-  patchPhase = "cp ${./wsjtx.patch} wsjtx.patch";
+  postPatch = "cp ${./wsjtx.patch} wsjtx.patch";
 
   meta = with stdenv.lib; {
     description = "Weak-signal digital communication modes for amateur radio";

--- a/pkgs/applications/misc/wsjtx/default.nix
+++ b/pkgs/applications/misc/wsjtx/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, asciidoc, asciidoctor, autoconf, automake, cmake,
+  docbook_xsl, fftw, fftwFloat, gfortran, libtool, libpulseaudio, qtbase,
+  qtmultimedia, qtserialport, texinfo, libusb1 }:
+
+stdenv.mkDerivation rec {
+  name = "wsjtx-${version}";
+  version = "1.8.0";
+
+  # This is a composite source tarball containing both wsjtx and a hamlib fork
+  src = fetchurl {
+    url = "http://physics.princeton.edu/pulsar/K1JT/wsjtx-${version}.tgz";
+    sha256 = "21603ad4d5f43cd9c79a6e8cf468bde88c554654012b2c6c1ef9144cfbf668ce";
+  };
+
+  # Hamlib builds with autotools, wsjtx builds with cmake
+  # Omitting pkgconfig because it causes issues locating the built hamlib
+  nativeBuildInputs = [
+    asciidoc asciidoctor autoconf automake cmake docbook_xsl gfortran libtool
+    texinfo
+  ];
+  buildInputs = [ fftw fftwFloat libusb1 qtbase qtmultimedia qtserialport ];
+
+  # Composite build has its own patch step after it extracts the inner archives
+  patchPhase = "cp ${./wsjtx.patch} wsjtx.patch";
+
+  meta = with stdenv.lib; {
+    description = "Weak-signal digital communication modes for amateur radio";
+    longDescription = ''
+      WSJT-X implements communication protocols or "modes" called FT8, JT4, JT9,
+      JT65, QRA64, ISCAT, MSK144, and WSPR, as well as one called Echo for
+      detecting and measuring your own radio signals reflected from the Moon.
+      These modes were all designed for making reliable, confirmed ham radio
+      contacts under extreme weak-signal conditions.
+    '';
+    homepage = http://physics.princeton.edu/pulsar/k1jt/wsjtx.html;
+    # Older licenses are for the statically-linked hamlib
+    license = with licenses; [ gpl3Plus gpl2Plus lgpl21Plus ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.lasandell ];
+  };
+}

--- a/pkgs/applications/misc/wsjtx/wsjtx.patch
+++ b/pkgs/applications/misc/wsjtx/wsjtx.patch
@@ -1,0 +1,12 @@
+Index: wsjtx/CMakeLists.txt
+===================================================================
+--- wsjtx/CMakeLists.txt	(revision 8382)
++++ wsjtx/CMakeLists.txt	(working copy)
+@@ -866,6 +866,7 @@
+ find_package (Qt5Widgets 5 REQUIRED)
+ find_package (Qt5Multimedia 5 REQUIRED)
+ find_package (Qt5PrintSupport 5 REQUIRED)
++find_package (Qt5SerialPort 5 REQUIRED)
+ 
+ if (WIN32)
+   add_definitions (-DQT_NEEDS_QTMAIN)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17603,6 +17603,8 @@ with pkgs;
       );
   };
 
+  wsjtx = qt5.callPackage ../applications/misc/wsjtx { };
+
   wtftw = callPackage ../applications/window-managers/wtftw {};
 
   wxhexeditor = callPackage ../applications/editors/wxhexeditor { };


### PR DESCRIPTION
###### Motivation for this change

Add popular WSJT-X program for ham radio.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

