### PR TITLE
audacious: 3.8.2 -> 3.9

### DIFF
--- a/pkgs/applications/audio/audacious/default.nix
+++ b/pkgs/applications/audio/audacious/default.nix
@@ -8,16 +8,16 @@
 
 stdenv.mkDerivation rec {
   name = "audacious-${version}";
-  version = "3.8.2";
+  version = "3.9";
 
   src = fetchurl {
     url = "http://distfiles.audacious-media-player.org/audacious-${version}-gtk3.tar.bz2";
-    sha256 = "1g08xprc9q0lyw3knq723j7xr7i15f8v1x1j3k5wvi8jv21bvijf";
+    sha256 = "0dc7fg0v2l2j4h9cz1baz7rf4n0a5jgk09qvsj806sh6jp7w6ipm";
   };
 
   pluginsSrc = fetchurl {
     url = "http://distfiles.audacious-media-player.org/audacious-plugins-${version}-gtk3.tar.bz2";
-    sha256 = "1vqcxwqinlwb2l0kkrarg33sw1brjzrnq5jbhzrql6z6x95h4jbq";
+    sha256 = "1gck37c5pnzxdhrnb1g75b5hi31s2dc952wifxns45pkdlayrmra";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/audio/audacious/qt-5.nix
+++ b/pkgs/applications/audio/audacious/qt-5.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, fetchurl,
+  mkDerivation, lib, fetchurl, fetchpatch,
   gettext, pkgconfig,
   qtbase,
   alsaLib, curl, faad2, ffmpeg, flac, fluidsynth, gdk_pixbuf, lame, libbs2b,
@@ -10,17 +10,22 @@
 }:
 
 let
-  version = "3.8.2";
+  version = "3.9";
   sources = {
     "audacious-${version}" = fetchurl {
       url = "http://distfiles.audacious-media-player.org/audacious-${version}.tar.bz2";
-      sha256 = "14xyvmxdax0aj1gqcz8z23cjcavsysyh6b3lkiczkv4vrqf4gwdx";
+      sha256 = "0pmhrhsjhqnrq3zh4rhfys5jas53ph5ijkq010dxg1n779kl901d";
     };
 
     "audacious-plugins-${version}" = fetchurl {
       url = "http://distfiles.audacious-media-player.org/audacious-plugins-${version}.tar.bz2";
-      sha256 = "1m7xln93zc4qvb1fi83icyd5x2r6azqlvs5nigjz8az3l2kzrknp";
+      sha256 = "1f17r7ar0mngcf7z41s6xh073vjafw3i7iy9ijb0cd6bi48g5xwb";
     };
+  };
+
+  qt510_plugins_patch = fetchpatch {
+    url = "https://github.com/audacious-media-player/audacious-plugins/commit/971f7ff7c3d8a0b9b420bf4fd19ab97755607637.patch";
+    sha256 = "15fy37syj9ygl2ibkkz3g3b9wd22vk9bjfmvqhhkpxphry2zwb17";
   };
 in
 
@@ -32,6 +37,8 @@ mkDerivation {
   sourceRoots = lib.attrNames sources;
 
   nativeBuildInputs = [ gettext pkgconfig ];
+
+  inherit qt510_plugins_patch;
 
   buildInputs = [
     # Core dependencies
@@ -55,6 +62,10 @@ mkDerivation {
     for (( i=0 ; i < ''${#sourceFiles[*]} ; i++ )); do
 
       (
+        # only patch the plugins
+        if [ "$i" -eq "1" ]; then
+          patches=( $qt510_plugins_patch )
+        fi
         src=''${sourceFiles[$i]}
         sourceRoot=''${sourceRoots[$i]}
         source $stdenv/setup


### PR DESCRIPTION
Also fixes compilation with qt 5.10.

###### Motivation for this change
Preparation for qt5.10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

