### PR TITLE
hash_extender: init at 2017-04-10

### DIFF
--- a/pkgs/tools/security/hash_extender/default.nix
+++ b/pkgs/tools/security/hash_extender/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, openssl }:
+
+stdenv.mkDerivation rec {
+  name = "hash_extender-${version}";
+  version = "2017-04-10";
+
+  src = fetchFromGitHub {
+    owner = "iagox86";
+    repo = "hash_extender";
+    rev = "d27581e062dd0b534074e11d7d311f65a6d7af21";
+    sha256 = "1npwbgqaynjh5x39halw43i116v89sxkpa1g1bbvc1lpi8hkhhcb";
+  };
+
+  buildInputs = [ openssl ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp hash_extender $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tool to automate hash length extension attacks";
+    homepage = https://github.com/iagox86/hash_extender;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ geistesk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2609,6 +2609,8 @@ with pkgs;
 
   hashcat = callPackage ../tools/security/hashcat { };
 
+  hash_extender = callPackage ../tools/security/hash_extender { };
+
   hash-slinger = callPackage ../tools/security/hash-slinger { };
 
   hal-flash = callPackage ../os-specific/linux/hal-flash { };


### PR DESCRIPTION
###### Motivation for this change
This PR adds the [hash_extender](https://github.com/iagox86/hash_extender) software to the nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

