### PR TITLE
dump1090: fix html path

### DIFF
--- a/pkgs/applications/misc/dump1090/default.nix
+++ b/pkgs/applications/misc/dump1090/default.nix
@@ -15,11 +15,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libusb rtl-sdr ];
 
-  makeFlags = [ "PREFIX=$out" ];
+  makeFlags = [ "PREFIX=$(out)" ];
 
   installPhase = ''
     mkdir -p $out/bin $out/share
-    cp -v dump1090 $out/bin/dump1090
+    cp -v dump1090 view1090 $out/bin
     cp -vr public_html $out/share/dump1090
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Running `dump1090 --net` and navigating to port `8080` does not work because the `makeFlags` were incorrectly specified, causing the program to look in `ut/share/dump1090` for its HTML resources. The `makeFlags` are escaped but not expanded, so they need to use the parenthesized variable syntax required by GNU Make.

I also added the `view1090` binary to the package output. This should be run after `dump1090 --net` is started.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

