### PR TITLE
sambaMaster: init at 4.8_2017-12-25

### DIFF
--- a/nixos/modules/services/network-filesystems/samba.nix
+++ b/nixos/modules/services/network-filesystems/samba.nix
@@ -54,10 +54,12 @@ let
       };
 
       serviceConfig = {
-        ExecStart = "${samba}/sbin/${appName} ${args}";
+        ExecStart = "${samba}/sbin/${appName} --foreground --no-process-group ${args}";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         LimitNOFILE = 16384;
+        PIDFile = "/run/${appName}.pid";
         Type = "notify";
+        NotifyAccess = "all"; #may not do anything...
       };
 
       restartTriggers = [ configFile ];
@@ -231,11 +233,12 @@ in
             after = [ "samba-setup.service" "network.target" ];
             wantedBy = [ "multi-user.target" ];
           };
-
+          # Refer to https://github.com/samba-team/samba/tree/master/packaging/systemd
+          # for correct use with systemd
           services = {
-            "samba-smbd" = daemonService "smbd" "-F";
-            "samba-nmbd" = mkIf cfg.enableNmbd (daemonService "nmbd" "-F");
-            "samba-winbindd" = mkIf cfg.enableWinbindd (daemonService "winbindd" "-F");
+            "samba-smbd" = daemonService "smbd" "";
+            "samba-nmbd" = mkIf cfg.enableNmbd (daemonService "nmbd" "");
+            "samba-winbindd" = mkIf cfg.enableWinbindd (daemonService "winbindd" "");
             "samba-setup" = {
               description = "Samba Setup Task";
               script = setupScript;

--- a/pkgs/servers/samba/4.x-no-persistent-install-dynconfig.patch
+++ b/pkgs/servers/samba/4.x-no-persistent-install-dynconfig.patch
@@ -1,0 +1,15 @@
+diff -ru3 samba-4.4.6/dynconfig/wscript samba-4.4.6-new/dynconfig/wscript
+--- samba-4.4.6/dynconfig/wscript	2016-01-26 14:45:46.000000000 +0300
++++ samba-4.4.6-new/dynconfig/wscript	2016-10-15 22:21:18.159705132 +0300
+@@ -416,11 +416,3 @@
+                         public_headers=os_path_relpath(os.path.join(Options.launch_dir, version_header), bld.curdir),
+                         header_path='samba',
+                         cflags=cflags)
+-
+-    # install some extra empty directories
+-    bld.INSTALL_DIRS("", "${CONFIGDIR} ${PRIVATE_DIR} ${LOGFILEBASE}");
+-    bld.INSTALL_DIRS("", "${PRIVATE_DIR} ${PRIVILEGED_SOCKET_DIR}")
+-    bld.INSTALL_DIRS("", "${STATEDIR} ${CACHEDIR}");
+-
+-    # these might be on non persistent storage
+-    bld.INSTALL_DIRS("", "${LOCKDIR} ${PIDDIR} ${SOCKET_DIR}")

--- a/pkgs/servers/samba/4.x-no-persistent-install.patch
+++ b/pkgs/servers/samba/4.x-no-persistent-install.patch
@@ -37,18 +37,3 @@ diff -ru3 samba-4.4.6/ctdb/wscript samba-4.4.6-new/ctdb/wscript
      # Unit tests
      ctdb_unit_tests = [
          'db_hash_test',
-diff -ru3 samba-4.4.6/dynconfig/wscript samba-4.4.6-new/dynconfig/wscript
---- samba-4.4.6/dynconfig/wscript	2016-01-26 14:45:46.000000000 +0300
-+++ samba-4.4.6-new/dynconfig/wscript	2016-10-15 22:21:18.159705132 +0300
-@@ -416,11 +416,3 @@
-                         public_headers=os_path_relpath(os.path.join(Options.launch_dir, version_header), bld.curdir),
-                         header_path='samba',
-                         cflags=cflags)
--
--    # install some extra empty directories
--    bld.INSTALL_DIRS("", "${CONFIGDIR} ${PRIVATE_DIR} ${LOGFILEBASE}");
--    bld.INSTALL_DIRS("", "${PRIVATE_DIR} ${PRIVILEGED_SOCKET_DIR}")
--    bld.INSTALL_DIRS("", "${STATEDIR} ${CACHEDIR}");
--
--    # these might be on non persistent storage
--    bld.INSTALL_DIRS("", "${LOCKDIR} ${PIDDIR} ${SOCKET_DIR}")

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
   patches =
     [ ./4.x-no-persistent-install.patch
       ./patch-source3__libads__kerberos_keytab.c.patch
+      ./4.x-no-persistent-install-dynconfig.patch
     ];
 
   buildInputs =

--- a/pkgs/servers/samba/master.nix
+++ b/pkgs/servers/samba/master.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub
+, samba4
+, nettle
+} :
+
+  (samba4.overrideAttrs(oldAttrs: rec {
+    name = "samba-master${version}";
+    version = "4.8_2017-12-25";
+
+    src = fetchFromGitHub {
+      owner = "samba-team";
+      repo = "samba";
+      rev = "8a42954775df6795efa9b5ba5676301d14b3efac";
+      sha256 = "19pdnvs23ny8cbfd119dqv8mc1qbay6c2ibsn0imc9cnl4wdzqdg";
+    };
+
+    # Remove unnecessary install flags, same as <4.8 patch
+    postPatch = oldAttrs.postPatch + ''
+      sed -i '423,433d' dynconfig/wscript
+    '';
+
+    patches = [ ./4.x-no-persistent-install.patch ];
+    buildInputs = [ nettle ] ++ oldAttrs.buildInputs;
+    meta.branch = "master";
+  })).override {
+    # samba4.8+ removed the ability to disable LDAP.
+    # Enable for base derivation here:
+    enableLDAP = true;
+  }

--- a/pkgs/servers/samba/master.nix
+++ b/pkgs/servers/samba/master.nix
@@ -5,13 +5,13 @@
 
   (samba4.overrideAttrs(oldAttrs: rec {
     name = "samba-master${version}";
-    version = "4.8_2017-12-25";
+    version = "4.8.0_2018-01-25";
 
     src = fetchFromGitHub {
       owner = "samba-team";
       repo = "samba";
-      rev = "8a42954775df6795efa9b5ba5676301d14b3efac";
-      sha256 = "19pdnvs23ny8cbfd119dqv8mc1qbay6c2ibsn0imc9cnl4wdzqdg";
+      rev = "849169a7b6ed0beb78bbddf25537521c1ed2f8e1";
+      sha256 = "1535w787cy1x5ia9arjrg6hhf926wi8wm9qj0k0jgydy3600zpbv";
     };
 
     # Remove unnecessary install flags, same as <4.8 patch

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12321,6 +12321,8 @@ with pkgs;
     python = python2;
   };
 
+  sambaMaster = callPackage ../servers/samba/master.nix { };
+
   samba = samba4;
 
   smbclient = samba;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12319,7 +12319,6 @@ with pkgs;
 
   samba4 = callPackage ../servers/samba/4.x.nix {
     python = python2;
-    # enableLDAP
   };
 
   samba = samba4;


### PR DESCRIPTION
###### Motivation for this change
Samba 4.8 releases around March 2018. sambaMaster may be useful for those who would like to test experimental macOS Time Machine support, which is what I'm using this for.

##### To use this on NixOS:
```
services.samba.package = pkgs.sambaMaster;
```
##### To enable TM for a share, add the following to the share definition:
```
"fruit:aapl" = "yes";
"fruit:time machine" = "yes";
"vfs objects" = "catia fruit streams_xattr";
```

Currently master piggybacks off of the 4.x definition with minimal modifications (overrideAttrs+override)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

