### PR TITLE
airspy: enable Darwin building

### DIFF
--- a/pkgs/applications/misc/airspy/default.nix
+++ b/pkgs/applications/misc/airspy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ stdenv, lib, fetchFromGitHub
 , cmake , pkgconfig, libusb
 }:
 
@@ -22,13 +22,14 @@ in
     nativeBuildInputs = [ cmake pkgconfig ];
     buildInputs = [ libusb ];
 
-    cmakeFlags = [ "-DINSTALL_UDEV_RULES=ON" ];
+    cmakeFlags =
+      lib.optionals stdenv.isLinux [ "-DINSTALL_UDEV_RULES=ON" ];
 
     meta = with stdenv.lib; {
       homepage = http://github.com/airspy/airspyone_host;
       description = "Host tools and driver library for the AirSpy SDR";
       license = licenses.free;
-      platforms = platforms.linux;
+      platforms = with platforms; linux ++ darwin;
       maintainers = with maintainers; [ markuskowa ];
     };
   }


### PR DESCRIPTION
improves #32378 which disabled gnuradio-osmosdr on darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

