### PR TITLE
jemalloc: disable transparent hugepages by default on ARMv6/7

### DIFF
--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   name = "jemalloc-${version}";
-  version = "4.5.0";
+  version = "5.0.1";
 
   src = fetchurl {
     url = "https://github.com/jemalloc/jemalloc/releases/download/${version}/${name}.tar.bz2";
-    sha256 = "9409d85664b4f135b77518b0b118c549009dc10f6cba14557d170476611f6780";
+    sha256 = "4814781d395b0ef093b21a08e8e6e0bd3dab8762f9935bbfb71679b0dea7c3e9";
   };
 
   # By default, jemalloc puts a je_ prefix onto all its symbols on OSX, which

--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -1,8 +1,4 @@
-{ stdenv, fetchurl,
-  # jemalloc is unable to correctly detect transparent hugepage support on
-  # ARM (https://github.com/jemalloc/jemalloc/issues/526), and the default
-  # kernel ARMv6/7 kernel does not enable it, so we explicitly disable support
-  thpSupport ? !stdenv.isArm }:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "jemalloc-${version}";
@@ -17,10 +13,11 @@ stdenv.mkDerivation rec {
   # then stops downstream builds (mariadb in particular) from detecting it. This
   # option should remove the prefix and give us a working jemalloc.
   configureFlags = stdenv.lib.optional stdenv.isDarwin "--with-jemalloc-prefix="
-                   ++ stdenv.lib.optional (!thpSupport) "--disable-thp";
-
+                   # jemalloc is unable to correctly detect transparent hugepage support on
+                   # ARM (https://github.com/jemalloc/jemalloc/issues/526), and the default
+                   # kernel ARMv6/7 kernel does not enable it, so we explicitly disable support
+                   ++ stdenv.lib.optional stdenv.isArm "--disable-thp";
   doCheck = true;
-
 
   meta = with stdenv.lib; {
     homepage = http://jemalloc.net;


### PR DESCRIPTION
###### Motivation for this change

This PR disables transparent hugepage support in jemalloc by default on ARMv6/7 (adding a parameter that allows it to be enabled if desired). The NixOS ARMv6/7 kernels do not enable transparent hugepage support, but jemalloc is not able to detect this (see jemalloc/jemalloc#526).

Even though the `--disable-thp` flag is available in jemalloc 4.5.0, it does not work correctly in this version, so this PR also updates jemalloc to 5.0.1 (which requires a large rebuild with the possibility of breakage).

Alternatively, this problem could be solved by enabling THP in the default kernel config, but it still might be good to have an option to disable it in jemalloc.

Also, is `stdenv.system` the correct way to do platform detection nowadays (with the upcoming better cross compiling support)?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

