### PR TITLE
supercollider: added alsaLib as dependency, req. for MIDI on Linux

### DIFF
--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -1,8 +1,7 @@
 { stdenv, fetchurl, cmake, pkgconfig
 , libjack2, libsndfile, fftw, curl, gcc
 , libXt, qtbase, qttools, qtwebkit, readline
-, withAlsa ? !stdenv.isDarwin, alsaLib             # ALSA is required for MIDI to work in SC
-, withAvahi ? false, avahi                         # Avahai is optional dependency
+, alsaLib , avahi
 , useSCEL ? false, emacs
 }:
 
@@ -26,12 +25,10 @@ stdenv.mkDerivation rec {
     -DSC_EL=${if useSCEL then "ON" else "OFF"}
   '';
 
-  nativeBuildInputs = [cmake pkgconfig qttools ]
-    ++ optional withAlsa alsaLib;
+  nativeBuildInputs = [ cmake pkgconfig qttools alsaLib ];
 
   buildInputs = [
-    gcc libjack2 libsndfile fftw curl libXt qtbase qtwebkit readline ]
-      ++ optional withAvahi avahi
+    gcc libjack2 libsndfile fftw curl libXt qtbase qtwebkit readline avahi ]
       ++ optional useSCEL emacs;
 
   meta = {

--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -1,6 +1,8 @@
 { stdenv, fetchurl, cmake, pkgconfig
 , libjack2, libsndfile, fftw, curl, gcc
 , libXt, qtbase, qttools, qtwebkit, readline
+, withAlsa ? !stdenv.isDarwin, alsaLib             # ALSA is required for MIDI to work in SC
+, withAvahi ? false, avahi                         # Avahai is optional dependency
 , useSCEL ? false, emacs
 }:
 
@@ -24,10 +26,12 @@ stdenv.mkDerivation rec {
     -DSC_EL=${if useSCEL then "ON" else "OFF"}
   '';
 
-  nativeBuildInputs = [ cmake pkgconfig qttools ];
+  nativeBuildInputs = [cmake pkgconfig qttools ]
+    ++ optional withAlsa alsaLib;
 
   buildInputs = [
     gcc libjack2 libsndfile fftw curl libXt qtbase qtwebkit readline ]
+      ++ optional withAvahi avahi
       ++ optional useSCEL emacs;
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
Currently ```MIDIClient.init``` command in SC fails mysteriously on Linux. SC requires alsa at compile time to enable MIDI. This commit fixes that issue. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

