### PR TITLE
Update a bunch (148+) of homepages (permanent redirect problems as found by repology)

### DIFF
--- a/pkgs/applications/audio/jackmeter/default.nix
+++ b/pkgs/applications/audio/jackmeter/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "jackmeter-0.4";
 
   src = fetchurl {
-    url = "http://www.aelius.com/njh/jackmeter/${name}.tar.gz";
+    url = "https://www.aelius.com/njh/jackmeter/${name}.tar.gz";
     sha256 = "1cnvgx3jv0yvxlqy0l9k285zgvazmh5k8m4l7lxckjfm5bn6hm1r";
   };
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = { 
     description = "Console jack loudness meter";
-    homepage = http://www.aelius.com/njh/jackmeter/;
+    homepage = https://www.aelius.com/njh/jackmeter/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.marcweber ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -33,7 +33,7 @@ pythonPackages.buildPythonApplication rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.mopidy.com/;
+    homepage = https://www.mopidy.com/;
     description = ''
       An extensible music server that plays music from local disk, Spotify,
       SoundCloud, Google Play Music, and more

--- a/pkgs/applications/audio/mpc/default.nix
+++ b/pkgs/applications/audio/mpc/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A minimalist command line interface to MPD";
-    homepage = http://www.musicpd.org/clients/mpc/;
+    homepage = https://www.musicpd.org/clients/mpc/;
     license = licenses.gpl2;
     maintainers = with maintainers; [ algorith ];
     platforms = with platforms; linux ++ darwin;

--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Music notation and composition software";
-    homepage = http://musescore.org/;
+    homepage = https://musescore.org/;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ maintainers.vandenoever ];

--- a/pkgs/applications/audio/ncmpc/default.nix
+++ b/pkgs/applications/audio/ncmpc/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Curses-based interface for MPD (music player daemon)";
-    homepage    = http://www.musicpd.org/clients/ncmpc/;
+    homepage    = https://www.musicpd.org/clients/ncmpc/;
     license     = licenses.gpl2Plus;
     platforms   = platforms.all;
     maintainers = with maintainers; [ fpletz ];

--- a/pkgs/applications/display-managers/lightdm-gtk-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-gtk-greeter/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://launchpad.net/lightdm-gtk-greeter;
+    homepage = https://launchpad.net/lightdm-gtk-greeter;
     platforms = platforms.linux;
     license = licenses.gpl3;
     maintainers = with maintainers; [ ocharles wkennington ];

--- a/pkgs/applications/editors/geany/default.nix
+++ b/pkgs/applications/editors/geany/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
       - Simple project management
       - Plugin interface
     '';
-    homepage = http://www.geany.org/;
+    homepage = https://www.geany.org/;
     license = "GPL";
     maintainers = [];
     platforms = platforms.all;

--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -124,7 +124,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib;
     { description = "Set of integrated tools for the R language";
-      homepage = http://www.rstudio.com/;
+      homepage = https://www.rstudio.com/;
       license = licenses.agpl3;
       maintainers = with maintainers; [ ehmry changlinli ciil ];
       platforms = platforms.linux;

--- a/pkgs/applications/editors/vbindiff/default.nix
+++ b/pkgs/applications/editors/vbindiff/default.nix
@@ -7,13 +7,13 @@ stdenv.mkDerivation rec {
   buildInputs = [ ncurses ];
 
   src = fetchurl {
-    url = "http://www.cjmweb.net/vbindiff/${name}.tar.gz";
+    url = "https://www.cjmweb.net/vbindiff/${name}.tar.gz";
     sha256 = "0gcqy4ggp60qc6blq1q1gc90xmhip1m6yvvli4hdqlz9zn3mlpbx";
   };
 
   meta = {
     description = "A terminal visual binary diff viewer";
-    homepage = http://www.cjmweb.net/vbindiff/;
+    homepage = https://www.cjmweb.net/vbindiff/;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/applications/graphics/displaycal/default.nix
+++ b/pkgs/applications/graphics/displaycal/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage {
 
   meta = {
     description = "Display Calibration and Characterization powered by Argyll CMS";
-    homepage = http://displaycal.net/;
+    homepage = https://displaycal.net/;
     license = stdenv.lib.licenses.gpl3;
     maintainers = [stdenv.lib.maintainers.marcweber];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/graphics/meh/default.nix
+++ b/pkgs/applications/graphics/meh/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A minimal image viewer using raw XLib";
-    homepage = http://www.johnhawthorn.com/meh/;
+    homepage = https://www.johnhawthorn.com/meh/;
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/applications/graphics/photoqt/default.nix
+++ b/pkgs/applications/graphics/photoqt/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "1.5.1";
 
   src = fetchurl {
-    url = "http://photoqt.org/pkgs/photoqt-${version}.tar.gz";
+    url = "https://photoqt.org/pkgs/photoqt-${version}.tar.gz";
     sha256 = "17kkpzkmzfnigs26jjyd75iy58qffjsclif81cmviq73lzmqy0b1";
   };
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    homepage = http://photoqt.org/;
+    homepage = https://photoqt.org/;
     description = "Simple, yet powerful and good looking image viewer";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/applications/misc/airspy/default.nix
+++ b/pkgs/applications/misc/airspy/default.nix
@@ -25,7 +25,7 @@ in
     cmakeFlags = [ "-DINSTALL_UDEV_RULES=ON" ];
 
     meta = with stdenv.lib; {
-      homepage = http://github.com/airspy/airspyone_host;
+      homepage = https://github.com/airspy/airspyone_host;
       description = "Host tools and driver library for the AirSpy SDR";
       license = licenses.free;
       platforms = platforms.linux;

--- a/pkgs/applications/misc/jekyll/default.nix
+++ b/pkgs/applications/misc/jekyll/default.nix
@@ -11,7 +11,7 @@ bundlerEnv rec {
 
   meta = with lib; {
     description = "Simple, blog aware, static site generator";
-    homepage    =  http://jekyllrb.com/;
+    homepage    =  https://jekyllrb.com/;
     license     = licenses.mit;
     maintainers = with maintainers; [ pesterhazy ];
     platforms   = platforms.unix;

--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -101,7 +101,7 @@ in pythonPackages.buildPythonApplication rec {
   checkPhase = "nosetests";
 
   meta = with stdenv.lib; {
-    homepage = http://octoprint.org/;
+    homepage = https://octoprint.org/;
     description = "The snappy web interface for your 3D printer";
     license = licenses.agpl3;
     maintainers = with maintainers; [ abbradar ];

--- a/pkgs/applications/misc/redis-desktop-manager/default.nix
+++ b/pkgs/applications/misc/redis-desktop-manager/default.nix
@@ -76,7 +76,7 @@ EOF
 
   meta = with lib; {
     description = "Cross-platform open source Redis DB management tool";
-    homepage = http://redisdesktop.com/;
+    homepage = https://redisdesktop.com/;
     license = licenses.lgpl21;
     platforms = platforms.linux;
     maintainers = with maintainers; [ cstrahan ];

--- a/pkgs/applications/misc/terminator/default.nix
+++ b/pkgs/applications/misc/terminator/default.nix
@@ -32,7 +32,7 @@ pythonPackages.buildPythonApplication rec {
       quadkonsole, etc. in that the main focus is arranging terminals in grids
       (tabs is the most common default method, which Terminator also supports).
     '';
-    homepage = http://gnometerminator.blogspot.no/p/introduction.html;
+    homepage = https://gnometerminator.blogspot.no/p/introduction.html;
     license = licenses.gpl2;
     maintainers = with maintainers; [ bjornfor globin ];
     platforms = platforms.linux;

--- a/pkgs/applications/misc/timewarrior/default.nix
+++ b/pkgs/applications/misc/timewarrior/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A command-line time tracker";
-    homepage = http://tasktools.org/projects/timewarrior.html;
+    homepage = https://tasktools.org/projects/timewarrior.html;
     license = licenses.mit;
     maintainers = with maintainers; [ matthiasbeyer ];
     platforms = platforms.linux;

--- a/pkgs/applications/misc/urlview/default.nix
+++ b/pkgs/applications/misc/urlview/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Extract URLs from text";
-    homepage = http://packages.qa.debian.org/u/urlview.html;
+    homepage = https://packages.qa.debian.org/u/urlview.html;
     license = stdenv.lib.licenses.gpl2;
     platforms = with stdenv.lib.platforms; linux ++ darwin;
   };

--- a/pkgs/applications/misc/vifm/default.nix
+++ b/pkgs/applications/misc/vifm/default.nix
@@ -21,8 +21,8 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ raskin garbas ];
     platforms = platforms.linux;
     license = licenses.gpl2;
-    downloadPage = "http://vifm.info/downloads.shtml";
-    homepage = http://vifm.info/;
+    downloadPage = "https://vifm.info/downloads.shtml";
+    homepage = https://vifm.info/;
     inherit version;
     updateWalker = true;
   };

--- a/pkgs/applications/misc/wmname/default.nix
+++ b/pkgs/applications/misc/wmname/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Prints or set the window manager name property of the root window";
-    homepage = http://tools.suckless.org/wmname;
+    homepage = https://tools.suckless.org/wmname;
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/applications/misc/xfontsel/default.nix
+++ b/pkgs/applications/misc/xfontsel/default.nix
@@ -1,5 +1,5 @@
 # This program used to come with xorg releases, but now I could only find it
-# at http://www.x.org/releases/individual/.
+# at https://www.x.org/releases/individual/.
 # That is why this expression is not inside pkgs.xorg
 
 {stdenv, fetchurl, makeWrapper, libX11, pkgconfig, libXaw}:
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.x.org/;
+    homepage = https://www.x.org/;
     description = "Allows testing the fonts available in an X server";
     license = stdenv.lib.licenses.free;
     maintainers = with stdenv.lib.maintainers; [viric];

--- a/pkgs/applications/misc/zathura/wrapper.nix
+++ b/pkgs/applications/misc/zathura/wrapper.nix
@@ -16,7 +16,7 @@ in symlinkJoin {
   '';
 
   meta = with lib; {
-    homepage = http://pwmt.org/projects/zathura/;
+    homepage = https://pwmt.org/projects/zathura/;
     description = "A highly customizable and functional PDF viewer";
     longDescription = ''
       Zathura is a highly customizable and functional PDF viewer based on the

--- a/pkgs/applications/networking/browsers/vimb/default.nix
+++ b/pkgs/applications/networking/browsers/vimb/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
       editor and also easily configurable during runtime. Vimb is mostly
       keyboard driven and does not detract you from your daily work.
     '';
-    homepage = http://fanglingsu.github.io/vimb/;
+    homepage = https://fanglingsu.github.io/vimb/;
     license = stdenv.lib.licenses.gpl3;
     maintainers = [ stdenv.lib.maintainers.rickynils ];
     platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/applications/networking/irc/ii/default.nix
+++ b/pkgs/applications/networking/irc/ii/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://tools.suckless.org/ii/;
+    homepage = https://tools.suckless.org/ii/;
     license = stdenv.lib.licenses.mit;
     description = "Irc it, simple FIFO based irc client";
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -74,7 +74,7 @@ in with stdenv; mkDerivation rec {
     '';
 
   meta = with stdenv.lib; {
-    homepage = http://quassel-irc.org/;
+    homepage = https://quassel-irc.org/;
     description = "Qt/KDE distributed IRC client suppporting a remote daemon";
     longDescription = ''
       Quassel IRC is a cross-platform, distributed IRC client,

--- a/pkgs/applications/networking/irc/sic/default.nix
+++ b/pkgs/applications/networking/irc/sic/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Simple IRC client";
-    homepage = http://tools.suckless.org/sic/;
+    homepage = https://tools.suckless.org/sic/;
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/applications/networking/p2p/ncdc/default.nix
+++ b/pkgs/applications/networking/p2p/ncdc/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Modern and lightweight direct connect client with a friendly ncurses interface";
-    homepage = http://dev.yorhel.nl/ncdc;
+    homepage = https://dev.yorhel.nl/ncdc;
     license = licenses.mit;
     platforms = platforms.linux; # arbitrary
     maintainers = with maintainers; [ ehmry ];

--- a/pkgs/applications/networking/p2p/qbittorrent/default.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Free Software alternative to µtorrent";
-    homepage    = http://www.qbittorrent.org/;
+    homepage    = https://www.qbittorrent.org/;
     license     = licenses.gpl2;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ viric ];

--- a/pkgs/applications/networking/p2p/tribler/default.nix
+++ b/pkgs/applications/networking/p2p/tribler/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     maintainers = with maintainers; [ xvapx ];
-    homepage = http://www.tribler.org/;
+    homepage = https://www.tribler.org/;
     description = "A completely decentralised P2P filesharing client based on the Bittorrent protocol";
     license = licenses.lgpl21;
     platforms = platforms.linux;

--- a/pkgs/applications/office/ledger/default.nix
+++ b/pkgs/applications/office/ledger/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://ledger-cli.org/;
+    homepage = https://ledger-cli.org/;
     description = "A double-entry accounting system with a command-line reporting interface";
     license = licenses.bsd3;
 

--- a/pkgs/applications/office/mmex/default.nix
+++ b/pkgs/applications/office/mmex/default.nix
@@ -17,7 +17,7 @@ in
 
     meta = {
       description = "Easy-to-use personal finance software";
-      homepage = http://www.moneymanagerex.org/;
+      homepage = https://www.moneymanagerex.org/;
       license = stdenv.lib.licenses.gpl2Plus;
       maintainers = with stdenv.lib.maintainers; [viric];
       platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/applications/office/mytetra/default.nix
+++ b/pkgs/applications/office/mytetra/default.nix
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Smart manager for information collecting";
-    homepage = http://webhamster.ru/site/page/index/articles/projectcode/138;
+    homepage = https://webhamster.ru/site/page/index/articles/projectcode/138;
     license = licenses.gpl3;
     maintainers = [ maintainers.gnidorah ];
     platforms = platforms.linux;

--- a/pkgs/applications/office/tagainijisho/default.nix
+++ b/pkgs/applications/office/tagainijisho/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "A free, open-source Japanese dictionary and kanji lookup tool";
-    homepage = http://www.tagaini.net/;
+    homepage = https://www.tagaini.net/;
     license = with licenses; [
       /* program */ gpl3Plus
       /* data */ cc-by-sa-30

--- a/pkgs/applications/office/tudu/default.nix
+++ b/pkgs/applications/office/tudu/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.10";
 
   src = fetchurl {
-    url = "http://code.meskio.net/tudu/${name}.tar.gz";
+    url = "https://code.meskio.net/tudu/${name}.tar.gz";
     sha256 = "0571wh5hn0hgadyx34zq1zi35pzd7vpwkavm7kzb9hwgn07443x4";
   };
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "ncurses-based hierarchical todo list manager with vim-like keybindings";
-    homepage = http://code.meskio.net/tudu/;
+    homepage = https://code.meskio.net/tudu/;
     license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/applications/science/electronics/verilator/default.nix
+++ b/pkgs/applications/science/electronics/verilator/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Fast and robust (System)Verilog simulator/compiler";
-    homepage    = "http://www.veripool.org/wiki/verilator";
+    homepage    = "https://www.veripool.org/wiki/verilator";
     license     = stdenv.lib.licenses.lgpl3;
     platforms   = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ thoughtpolice ];

--- a/pkgs/applications/search/doodle/default.nix
+++ b/pkgs/applications/search/doodle/default.nix
@@ -6,12 +6,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ libextractor gettext ];
 
   src = fetchurl {
-    url = "http://grothoff.org/christian/doodle/download/${name}.tar.gz";
+    url = "https://grothoff.org/christian/doodle/download/${name}.tar.gz";
     sha256 = "0ayx5q7chzll9sv3miq35xl36r629cvgdzphf379kxzlzhjldy3j";
   };
 
   meta = {
-    homepage = http://grothoff.org/christian/doodle/;
+    homepage = https://grothoff.org/christian/doodle/;
     description = "Tool to quickly index and search documents on a computer";
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = with stdenv.lib.maintainers; [viric];

--- a/pkgs/applications/video/minitube/default.nix
+++ b/pkgs/applications/video/minitube/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
       you an endless video stream. Minitube is not about cloning the YouTube
       website, it aims to create a new TV-like experience.
     '';
-    homepage = http://flavio.tordini.org/minitube;
+    homepage = https://flavio.tordini.org/minitube;
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ nckx ];

--- a/pkgs/applications/video/ogmtools/default.nix
+++ b/pkgs/applications/video/ogmtools/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "ogmtools-1.5";
 
   src = fetchurl {
-    url = "http://www.bunkus.org/videotools/ogmtools/${name}.tar.bz2";
+    url = "https://www.bunkus.org/videotools/ogmtools/${name}.tar.bz2";
     sha256 = "1spx81p5wf59ksl3r3gvf78d77sh7gj8a6lw773iv67bphfivmn8";
   };
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
       (ogmdemux) or creation of (ogmmerge) OGG media streams. Includes dvdxchap
       tool for extracting chapter information from DVD.
     '';
-    homepage = http://www.bunkus.org/videotools/ogmtools/;
+    homepage = https://www.bunkus.org/videotools/ogmtools/;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -207,7 +207,7 @@ in stdenv.mkDerivation {
   meta = {
     description = "PC emulator";
     license = licenses.gpl2;
-    homepage = http://www.virtualbox.org/;
+    homepage = https://www.virtualbox.org/;
     maintainers = with maintainers; [ flokli sander ];
     platforms = [ "x86_64-linux" "i686-linux" ];
   };

--- a/pkgs/applications/window-managers/dwm/default.nix
+++ b/pkgs/applications/window-managers/dwm/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   buildPhase = " make ";
  
   meta = {
-    homepage = http://suckless.org/;
+    homepage = https://suckless.org/;
     description = "Dynamic window manager for X";
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [viric];

--- a/pkgs/applications/window-managers/oroborus/default.nix
+++ b/pkgs/applications/window-managers/oroborus/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A really minimalistic X window manager";
-    homepage = http://www.oroborus.org/;
+    homepage = https://www.oroborus.org/;
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.linux;

--- a/pkgs/data/documentation/zeal/default.nix
+++ b/pkgs/data/documentation/zeal/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       Zeal is a simple offline API documentation browser inspired by Dash (macOS
       app), available for Linux and Windows.
     '';
-    homepage    = http://zealdocs.org/;
+    homepage    = https://zealdocs.org/;
     license     = licenses.gpl3;
     maintainers = with maintainers; [ skeidel peterhoeg ];
     platforms   = platforms.linux;

--- a/pkgs/data/fonts/gentium/default.nix
+++ b/pkgs/data/fonts/gentium/default.nix
@@ -18,7 +18,7 @@ in fetchzip rec {
   sha256 = "1qr2wjdmm93167b0w9cidlf3wwsyjx4838ja9jmm4jkyian5whhp";
 
   meta = with stdenv.lib; {
-    homepage = http://software.sil.org/gentium/;
+    homepage = https://software.sil.org/gentium/;
     description = "A high-quality typeface family for Latin, Cyrillic, and Greek";
     longDescription = ''
       Gentium is a typeface family designed to enable the diverse ethnic groups
@@ -35,7 +35,7 @@ in fetchzip rec {
       This package contains the regular and italic styles for the Gentium Plus
       font family, along with documentation.
     '';
-    downloadPage = "http://software.sil.org/gentium/download/";
+    downloadPage = "https://software.sil.org/gentium/download/";
     maintainers = with maintainers; [ raskin rycee ];
     license = licenses.ofl;
     platforms = platforms.all;

--- a/pkgs/data/fonts/open-dyslexic/default.nix
+++ b/pkgs/data/fonts/open-dyslexic/default.nix
@@ -16,7 +16,7 @@ in fetchzip {
   sha256 = "045xc7kj56q4ygnjppm8f8fwqqvf21x1piabm4nh8hwgly42a3w2";
 
   meta = with stdenv.lib; {
-    homepage = http://opendyslexic.org/;
+    homepage = https://opendyslexic.org/;
     description = "Font created to increase readability for readers with dyslexia";
     license = "Bitstream Vera License (https://www.gnome.org/fonts/#Final_Bitstream_Vera_Fonts)";
     platforms = platforms.all;

--- a/pkgs/desktops/gnome-3/core/sushi/default.nix
+++ b/pkgs/desktops/gnome-3/core/sushi/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = "http://en.wikipedia.org/wiki/Sushi_(software)";
+    homepage = "https://en.wikipedia.org/wiki/Sushi_(software)";
     description = "A quick previewer for Nautilus";
     maintainers = gnome3.maintainers;
     license = licenses.gpl2Plus;

--- a/pkgs/desktops/lxde/core/lxappearance/default.nix
+++ b/pkgs/desktops/lxde/core/lxappearance/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A lightweight program for configuring the theme and fonts of gtk applications";
-    homepage = http://lxde.org/;
+    homepage = https://lxde.org/;
     maintainers = [ stdenv.lib.maintainers.hinton ];
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.gpl2;

--- a/pkgs/development/compilers/coreclr/default.nix
+++ b/pkgs/development/compilers/coreclr/default.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://dotnet.github.io/core/;
+    homepage = https://dotnet.github.io/core/;
     description = ".NET is a general purpose development platform";
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ kuznero ];

--- a/pkgs/development/compilers/mentor/default.nix
+++ b/pkgs/development/compilers/mentor/default.nix
@@ -46,7 +46,7 @@ let
 
       meta = with stdenv.lib; {
         inherit description;
-        homepage = http://www.mentor.com/embedded-software/sourcery-tools/sourcery-codebench/editions/lite-edition/;
+        homepage = https://www.mentor.com/embedded-software/sourcery-tools/sourcery-codebench/editions/lite-edition/;
         license = licenses.gpl3;
         platforms = platforms.linux;
         maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.17.2";
 
   src = fetchurl {
-    url = "http://nim-lang.org/download/${name}.tar.xz";
+    url = "https://nim-lang.org/download/${name}.tar.xz";
     sha256 = "1gc2xk3ygmz9y4pm75pligssgw995a7gvnfpy445fjpw4d81pzxa";
   };
 
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Statically typed, imperative programming language";
-    homepage = http://nim-lang.org/;
+    homepage = https://nim-lang.org/;
     license = licenses.mit;
     maintainers = with maintainers; [ ehmry peterhoeg ];
     platforms = with platforms; linux ++ darwin; # arbitrary

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -168,7 +168,7 @@ stdenv.mkDerivation {
   # enableParallelBuilding = false;
 
   meta = with stdenv.lib; {
-    homepage = http://www.rust-lang.org/;
+    homepage = https://www.rust-lang.org/;
     description = "A safe, concurrent, practical language";
     maintainers = with maintainers; [ madjar cstrahan wizeman globin havvy wkennington ];
     license = [ licenses.mit licenses.asl20 ];

--- a/pkgs/development/libraries/curlcpp/default.nix
+++ b/pkgs/development/libraries/curlcpp/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ cmake curl ];
 
   meta = with stdenv.lib; {
-    homepage = http://josephp91.github.io/curlcpp/;
+    homepage = https://josephp91.github.io/curlcpp/;
     description = "Object oriented C++ wrapper for CURL";
     platforms = platforms.unix;
     license = licenses.mit;

--- a/pkgs/development/libraries/ignition-math/default.nix
+++ b/pkgs/development/libraries/ignition-math/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://ignitionrobotics.org/libraries/math;
+    homepage = https://ignitionrobotics.org/libraries/math;
     description = "Math library by Ingition Robotics, created for the Gazebo project";
     license = licenses.asl20;
     maintainers = with maintainers; [ pxc ];

--- a/pkgs/development/libraries/libmysqlconnectorcpp/default.nix
+++ b/pkgs/development/libraries/libmysqlconnectorcpp/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DMYSQL_LIB_DIR=${mysql}/lib" ];
 
   meta = {
-    homepage = http://dev.mysql.com/downloads/connector/cpp/;
+    homepage = https://dev.mysql.com/downloads/connector/cpp/;
     description = "C++ library for connecting to mysql servers.";
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/libserialport/default.nix
+++ b/pkgs/development/libraries/libserialport/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "libserialport-0.1.1";
 
   src = fetchurl {
-    url = "http://sigrok.org/download/source/libserialport/${name}.tar.gz";
+    url = "https://sigrok.org/download/source/libserialport/${name}.tar.gz";
     sha256 = "17ajlwgvyyrap8z7f16zcs59pksvncwbmd3mzf98wj7zqgczjaja";
   };
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Cross-platform shared library for serial port access";
-    homepage = http://sigrok.org/;
+    homepage = https://sigrok.org/;
     license = licenses.gpl3Plus;
     # macOS, Windows and Android is also supported (according to upstream).
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libsexy/default.nix
+++ b/pkgs/development/libraries/libsexy/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "A collection of GTK+ widgets";
-    homepage = http://blog.chipx86.com/tag/libsexy/;
+    homepage = https://blog.chipx86.com/tag/libsexy/;
     license = licenses.lgpl21;
     maintainers = with maintainers; [ ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libsrs2/default.nix
+++ b/pkgs/development/libraries/libsrs2/default.nix
@@ -5,14 +5,14 @@ stdenv.mkDerivation rec {
   version = "1.0.18";
 
   src = fetchurl {
-    url = "http://www.libsrs2.org/srs/libsrs2-${version}.tar.gz";
+    url = "https://www.libsrs2.org/srs/libsrs2-${version}.tar.gz";
     sha256 = "9d1191b705d7587a5886736899001d04168392bbb6ed6345a057ade50943a492";
   };
 
   meta = {
     description = "The next generation SRS library from the original designer of SRS";
     license = with lib.licenses; [ gpl2 bsd3 ];
-    homepage = http://www.libsrs2.org/;
+    homepage = https://www.libsrs2.org/;
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libstatgrab/default.nix
+++ b/pkgs/development/libraries/libstatgrab/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [] ++ stdenv.lib.optional stdenv.isDarwin IOKit;
 
   meta = with stdenv.lib; {
-    homepage = http://www.i-scream.org/libstatgrab/;
+    homepage = https://www.i-scream.org/libstatgrab/;
     description = "A library that provides cross platforms access to statistics about the running system";
     license = licenses.gpl2;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libsvm/default.nix
+++ b/pkgs/development/libraries/libsvm/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "3.20";
 
   src = fetchurl {
-    url = "http://www.csie.ntu.edu.tw/~cjlin/libsvm/libsvm-${version}.tar.gz";
+    url = "https://www.csie.ntu.edu.tw/~cjlin/libsvm/libsvm-${version}.tar.gz";
     sha256 = "1gj5v5zp1qnsnv0iwxq0ikhf8262d3s5dq6syr6yqkglps0284hg";
   };
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A library for support vector machines";
-    homepage = http://www.csie.ntu.edu.tw/~cjlin/libsvm/;
+    homepage = https://www.csie.ntu.edu.tw/~cjlin/libsvm/;
     license = licenses.bsd3;
     maintainers = [ maintainers.spwhitt ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libvdpau/default.nix
+++ b/pkgs/development/libraries/libvdpau/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "libvdpau-1.1.1";
 
   src = fetchurl {
-    url = "http://people.freedesktop.org/~aplattner/vdpau/${name}.tar.bz2";
+    url = "https://people.freedesktop.org/~aplattner/vdpau/${name}.tar.bz2";
     sha256 = "857a01932609225b9a3a5bf222b85e39b55c08787d0ad427dbd9ec033d58d736";
   };
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   installFlags = [ "moduledir=$(out)/lib/vdpau" ];
 
   meta = with stdenv.lib; {
-    homepage = http://people.freedesktop.org/~aplattner/vdpau/;
+    homepage = https://people.freedesktop.org/~aplattner/vdpau/;
     description = "Library to use the Video Decode and Presentation API for Unix (VDPAU)";
     license = licenses.mit; # expat version
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libvorbis/default.nix
+++ b/pkgs/development/libraries/libvorbis/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with stdenv.lib; {
-    homepage = http://xiph.org/vorbis/;
+    homepage = https://xiph.org/vorbis/;
     license = licenses.bsd3;
     maintainers = [ maintainers.ehmry ];
     platforms = platforms.all;

--- a/pkgs/development/libraries/libvpx/default.nix
+++ b/pkgs/development/libraries/libvpx/default.nix
@@ -173,7 +173,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "WebM VP8/VP9 codec SDK";
-    homepage    = http://www.webmproject.org/;
+    homepage    = https://www.webmproject.org/;
     license     = licenses.bsd3;
     maintainers = with maintainers; [ codyopel ];
     platforms   = platforms.all;

--- a/pkgs/development/libraries/libzip/default.nix
+++ b/pkgs/development/libraries/libzip/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.3.0";
 
   src = fetchurl {
-    url = "http://www.nih.at/libzip/${name}.tar.gz";
+    url = "https://www.nih.at/libzip/${name}.tar.gz";
     sha256 = "1633dvjc08zwwhzqhnv62rjf1abx8y5njmm8y16ik9iwd07ka6d9";
   };
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.nih.at/libzip;
+    homepage = https://www.nih.at/libzip;
     description = "A C library for reading, creating and modifying zip archives";
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/libraries/lightstep-tracer-cpp/default.nix
+++ b/pkgs/development/libraries/lightstep-tracer-cpp/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Distributed tracing system built on top of the OpenTracing standard";
-    homepage = "http://lightstep.com/";
+    homepage = "https://lightstep.com/";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = with maintainers; [ cstrahan ];

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -214,7 +214,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "An open source implementation of OpenGL";
-    homepage = http://www.mesa3d.org/;
+    homepage = https://www.mesa3d.org/;
     license = licenses.mit; # X11 variant, in most files
     platforms = platforms.mesaPlatforms;
     maintainers = with maintainers; [ eduarrrd vcunat ];

--- a/pkgs/development/libraries/mlt/qt-5.nix
+++ b/pkgs/development/libraries/mlt/qt-5.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Open source multimedia framework, designed for television broadcasting";
-    homepage = http://www.mltframework.org/;
+    homepage = https://www.mltframework.org/;
     license = licenses.gpl3;
     maintainers = [ maintainers.goibhniu ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/mps/default.nix
+++ b/pkgs/development/libraries/mps/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.116.0";
 
   src = fetchurl {
-    url    = "http://www.ravenbrook.com/project/mps/release/${version}/mps-kit-${version}.tar.gz";
+    url    = "https://www.ravenbrook.com/project/mps/release/${version}/mps-kit-${version}.tar.gz";
     sha256 = "1k7vnanpgawnj84x2xs6md57pfib9p7c3acngqzkl3c2aqw8qay0";
   };
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A flexible memory management and garbage collection library";
-    homepage    = "http://www.ravenbrook.com/project/mps";
+    homepage    = "https://www.ravenbrook.com/project/mps";
     license     = stdenv.lib.licenses.sleepycat;
     platforms   = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];

--- a/pkgs/development/libraries/ndpi/default.nix
+++ b/pkgs/development/libraries/ndpi/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     longDescription = ''
       nDPI is a library for deep-packet inspection based on OpenDPI.
     '';
-    homepage = http://www.ntop.org/products/deep-packet-inspection/ndpi/;
+    homepage = https://www.ntop.org/products/deep-packet-inspection/ndpi/;
     license = with licenses; lgpl3;
     maintainers = with maintainers; [ takikawa ];
     platforms = with platforms; unix;

--- a/pkgs/development/libraries/netcdf-cxx4/default.nix
+++ b/pkgs/development/libraries/netcdf-cxx4/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "C++ API to manipulate netcdf files";
-    homepage = http://www.unidata.ucar.edu/software/netcdf/;
+    homepage = https://www.unidata.ucar.edu/software/netcdf/;
     license = stdenv.lib.licenses.free;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/libraries/ogre/default.nix
+++ b/pkgs/development/libraries/ogre/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "A 3D engine";
-    homepage = http://www.ogre3d.org/;
+    homepage = https://www.ogre3d.org/;
     maintainers = [ stdenv.lib.maintainers.raskin ];
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.mit;

--- a/pkgs/development/libraries/opencv/default.nix
+++ b/pkgs/development/libraries/opencv/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Open Computer Vision Library with more than 500 algorithms";
-    homepage = http://opencv.org/;
+    homepage = https://opencv.org/;
     license = licenses.bsd3;
     maintainers = with maintainers; [ viric ];
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/development/libraries/speex/default.nix
+++ b/pkgs/development/libraries/speex/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.speex.org/;
+    homepage = https://www.speex.org/;
     description = "An Open Source/Free Software patent-free audio compression format designed for speech";
     license = licenses.bsd3;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/theft/default.nix
+++ b/pkgs/development/libraries/theft/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A C library for property-based testing";
     platforms = stdenv.lib.platforms.linux;
-    homepage = "http://github.com/silentbicycle/theft/";
+    homepage = "https://github.com/silentbicycle/theft/";
     license = stdenv.lib.licenses.isc;
     maintainers = [ stdenv.lib.maintainers.kquick ];
   };

--- a/pkgs/development/libraries/tremor/default.nix
+++ b/pkgs/development/libraries/tremor/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://xiph.org/tremor/;
+    homepage = https://xiph.org/tremor/;
     description = "Fixed-point version of the Ogg Vorbis decoder";
     license = stdenv.lib.licenses.bsd3;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/vaapi-intel/default.nix
+++ b/pkgs/development/libraries/vaapi-intel/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://cgit.freedesktop.org/vaapi/intel-driver/;
+    homepage = https://cgit.freedesktop.org/vaapi/intel-driver/;
     license = licenses.mit;
     description = "Intel driver for the VAAPI library";
     platforms = platforms.unix;

--- a/pkgs/development/libraries/vaapi-vdpau/default.nix
+++ b/pkgs/development/libraries/vaapi-vdpau/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
 
   meta = {
-    homepage = http://cgit.freedesktop.org/vaapi/vdpau-driver/;
+    homepage = https://cgit.freedesktop.org/vaapi/vdpau-driver/;
     license = stdenv.lib.licenses.gpl2Plus;
     description = "VDPAU driver for the VAAPI library";
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/vigra/default.nix
+++ b/pkgs/development/libraries/vigra/default.nix
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Novel computer vision C++ library with customizable algorithms and data structures";
-    homepage = http://hci.iwr.uni-heidelberg.de/vigra;
+    homepage = https://hci.iwr.uni-heidelberg.de/vigra;
     license = licenses.mit;
     maintainers = [ maintainers.viric ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/vmime/default.nix
+++ b/pkgs/development/libraries/vmime/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    homepage = http://www.vmime.org/;
+    homepage = https://www.vmime.org/;
     description = "Free mail library for C++";
     license = stdenv.lib.licenses.gpl3;
     maintainers = with stdenv.lib.maintainers; [viric];

--- a/pkgs/development/libraries/vmmlib/default.nix
+++ b/pkgs/development/libraries/vmmlib/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
             computations and frustum culling classes, and spatial data structures'';
 
     license     = licenses.bsd2;
-    homepage    = http://github.com/VMML/vmmlib/;
+    homepage    = https://github.com/VMML/vmmlib/;
     maintainers = [ maintainers.adev ];
     platforms   = platforms.all;
   };

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   version = "1.14.0";
 
   src = fetchurl {
-    url = "http://wayland.freedesktop.org/releases/${name}.tar.xz";
+    url = "https://wayland.freedesktop.org/releases/${name}.tar.xz";
     sha256 = "1f3sla6h0bw15fz8pjc67jhwj7pwmfdc7qlj42j5k9v116ycm07d";
   };
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Reference implementation of the wayland protocol";
-    homepage    = http://wayland.freedesktop.org/;
+    homepage    = https://wayland.freedesktop.org/;
     license     = lib.licenses.mit;
     platforms   = lib.platforms.linux;
     maintainers = with lib.maintainers; [ codyopel wkennington ];

--- a/pkgs/development/libraries/websocket++/default.nix
+++ b/pkgs/development/libraries/websocket++/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ cmake ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.zaphoyd.com/websocketpp/;
+    homepage = https://www.zaphoyd.com/websocketpp/;
     description = "C++/Boost Asio based websocket client/server library";
     license = licenses.bsd3;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/wxsqlite3/default.nix
+++ b/pkgs/development/libraries/wxsqlite3/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Cocoa darwin.stubs.setfile darwin.stubs.rez darwin.stubs.derez ];
 
   meta = with stdenv.lib; {
-    homepage = http://utelle.github.io/wxsqlite3/ ;
+    homepage = https://utelle.github.io/wxsqlite3/ ;
     description = "A C++ wrapper around the public domain SQLite 3.x for wxWidgets";
     platforms = platforms.unix;
     maintainers = with maintainers; [ vrthra ];

--- a/pkgs/development/libraries/xapian/default.nix
+++ b/pkgs/development/libraries/xapian/default.nix
@@ -27,7 +27,7 @@ let
 
     meta = with stdenv.lib; {
       description = "Search engine library";
-      homepage = http://xapian.org/;
+      homepage = https://xapian.org/;
       license = licenses.gpl2Plus;
       maintainers = with maintainers; [ chaoflow ];
       platforms = platforms.unix;

--- a/pkgs/development/libraries/xcb-util-cursor/HEAD.nix
+++ b/pkgs/development/libraries/xcb-util-cursor/HEAD.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "XCB cursor library (libxcursor port)";
-    homepage    = http://cgit.freedesktop.org/xcb/util-cursor;
+    homepage    = https://cgit.freedesktop.org/xcb/util-cursor;
     license     = licenses.mit;
     maintainers = with maintainers; [ lovek323 ];
     platforms   = platforms.linux ++ platforms.darwin;

--- a/pkgs/development/ocaml-modules/cpdf/default.nix
+++ b/pkgs/development/ocaml-modules/cpdf/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = http://www.coherentpdf.com/;
+    homepage = https://www.coherentpdf.com/;
     platforms = ocaml.meta.platforms or [];
     description = "PDF Command Line Tools";
     maintainers = with stdenv.lib.maintainers; [ vbgl ];

--- a/pkgs/development/tools/build-managers/pants/default.nix
+++ b/pkgs/development/tools/build-managers/pants/default.nix
@@ -32,7 +32,7 @@ in buildPythonApplication rec {
 
   meta = {
     description = "A build system for software projects in a variety of languages";
-    homepage    = "http://www.pantsbuild.org/";
+    homepage    = "https://www.pantsbuild.org/";
     license     = licenses.asl20;
     maintainers = with maintainers; [ copumpkin ];
     platforms   = platforms.unix;

--- a/pkgs/development/tools/misc/opengrok/default.nix
+++ b/pkgs/development/tools/misc/opengrok/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Source code search and cross reference engine";
-    homepage = http://opengrok.github.io/OpenGrok/;
+    homepage = https://opengrok.github.io/OpenGrok/;
     license = licenses.cddl;
     maintainers = [ maintainers.lethalman ];
   };

--- a/pkgs/development/tools/misc/sloccount/default.nix
+++ b/pkgs/development/tools/misc/sloccount/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "sloccount-2.26";
 
   src = fetchurl {
-    url = "http://www.dwheeler.com/sloccount/${name}.tar.gz";
+    url = "https://www.dwheeler.com/sloccount/${name}.tar.gz";
     sha256 = "0ayiwfjdh1946asah861ah9269s5xkc8p5fv1wnxs9znyaxs4zzs";
   };
 
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl2Plus;
 
-    homepage = http://www.dwheeler.com/sloccount/;
+    homepage = https://www.dwheeler.com/sloccount/;
 
     maintainers = [ ];
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/development/tools/misc/teensy-loader-cli/default.nix
+++ b/pkgs/development/tools/misc/teensy-loader-cli/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     license = licenses.gpl3;
     description = "Firmware uploader for the Teensy microcontroller boards";
-    homepage = http://www.pjrc.com/teensy/;
+    homepage = https://www.pjrc.com/teensy/;
     maintainers = with maintainers; [ the-kenny ];
     platforms = platforms.linux;
   };

--- a/pkgs/development/tools/ocaml/ocaml-top/default.nix
+++ b/pkgs/development/tools/ocaml/ocaml-top/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   inherit (jbuilder) installPhase;
 
   meta = {
-    homepage = http://www.typerex.org/ocaml-top.html;
+    homepage = https://www.typerex.org/ocaml-top.html;
     license = stdenv.lib.licenses.gpl3;
     description = "A simple cross-platform OCaml code editor built for top-level evaluation";
     platforms = ocamlPackages.ocaml.meta.platforms or [];

--- a/pkgs/development/tools/ocaml/ocp-build/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-build/default.nix
@@ -22,7 +22,7 @@ buildOcaml {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.typerex.org/ocp-build.html;
+    homepage = https://www.typerex.org/ocp-build.html;
     description = "A build tool for OCaml";
     longDescription = ''
       ocp-build is a build system for OCaml application, based on simple

--- a/pkgs/games/mnemosyne/default.nix
+++ b/pkgs/games/mnemosyne/default.nix
@@ -26,7 +26,7 @@ in pythonPackages.buildPythonApplication rec {
     rm -r $out/lib/python2.7/site-packages/nix
   '';
   meta = {
-    homepage = http://mnemosyne-proj.org/;
+    homepage = https://mnemosyne-proj.org/;
     description = "Spaced-repetition software";
     longDescription = ''
       The Mnemosyne Project has two aspects:

--- a/pkgs/games/moon-buggy/default.nix
+++ b/pkgs/games/moon-buggy/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2;
     maintainers = [stdenv.lib.maintainers.rybern];
     platforms = stdenv.lib.platforms.linux;
-    homepage = http://www.seehuhn.de/pages/moon-buggy;
+    homepage = https://www.seehuhn.de/pages/moon-buggy;
   };
 }

--- a/pkgs/games/neverball/default.nix
+++ b/pkgs/games/neverball/default.nix
@@ -4,7 +4,7 @@
 stdenv.mkDerivation rec {
   name = "neverball-1.6.0";
   src = fetchurl {
-    url = "http://neverball.org/${name}.tar.gz";
+    url = "https://neverball.org/${name}.tar.gz";
     sha256 = "184gm36c6p6vaa6gwrfzmfh86klhnb03pl40ahsjsvprlk667zkk";
   };
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    homepage = http://neverball.org/;
+    homepage = https://neverball.org/;
     description = "Tilt the floor to roll a ball";
     license = "GPL";
     maintainers = with stdenv.lib.maintainers; [viric];

--- a/pkgs/games/teeworlds/default.nix
+++ b/pkgs/games/teeworlds/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
       Flag.  You can even design your own maps!
     '';
 
-    homepage = http://teeworlds.com/;
+    homepage = https://teeworlds.com/;
     license = "BSD-style, see `license.txt'";
     maintainers = with stdenv.lib.maintainers; [ astsmtl ];
     platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/games/tome4/default.nix
+++ b/pkgs/games/tome4/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   version = "1.4.9";
   name = "tome4-${version}";
   src = fetchurl {
-    url = "http://te4.org/dl/t-engine/t-engine4-src-${version}.tar.bz2";
+    url = "https://te4.org/dl/t-engine/t-engine4-src-${version}.tar.bz2";
     sha256 = "0c82m0g1ps64zghgdrp78m6bvfngcb75whhknqiailld7kz1g9xl";
   };
   nativeBuildInputs = [ premake4 ];
@@ -34,7 +34,7 @@ EOF
     cp -r game $out/opt/tome4
   '';
   meta = with stdenv.lib; {
-    homepage = http://te4.org/;
+    homepage = https://te4.org/;
     description = "Tales of Maj'eyal (rogue-like game)";
     maintainers = [ maintainers.chattered ];
     license = licenses.gpl3;

--- a/pkgs/games/unnethack/default.nix
+++ b/pkgs/games/unnethack/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Fork of NetHack";
-    homepage = http://unnethack.wordpress.com/;
+    homepage = https://unnethack.wordpress.com/;
     license = "nethack";
     platforms = platforms.all;
     maintainers = with maintainers; [ abbradar ];

--- a/pkgs/misc/drivers/xboxdrv/default.nix
+++ b/pkgs/misc/drivers/xboxdrv/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation {
   buildInputs = [ scons libX11 libusb1 boost glib dbus_glib];
 
   meta = with stdenv.lib; {
-    homepage = http://pingus.seul.org/~grumbel/xboxdrv/;
+    homepage = https://pingus.seul.org/~grumbel/xboxdrv/;
     description = "Xbox/Xbox360 (and more) gamepad driver for Linux that works in userspace";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.fuuzetsu ];

--- a/pkgs/misc/emulators/gens-gs/default.nix
+++ b/pkgs/misc/emulators/gens-gs/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   NIX_CFLAGS_COMPILE = "-UGTK_DISABLE_DEPRECATED -UGSEAL_ENABLE";
 
   meta = {
-    homepage = http://segaretro.org/Gens/GS;
+    homepage = https://segaretro.org/Gens/GS;
     description = "A Genesis/Mega Drive emulator";
     platforms = [ "i686-linux" ];
     maintainers = [ stdenv.lib.maintainers.eelco ];

--- a/pkgs/misc/screensavers/xscreensaver/default.nix
+++ b/pkgs/misc/screensavers/xscreensaver/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   name = "xscreensaver-${version}";
 
   src = fetchurl {
-    url = "http://www.jwz.org/xscreensaver/${name}.tar.gz";
+    url = "https://www.jwz.org/xscreensaver/${name}.tar.gz";
     sha256 = "1ng5ddzb4k2h1w54pvk9hzxvnxxmc54bc4a2ibk974nzjjjaxivs";
   };
 
@@ -47,12 +47,12 @@ stdenv.mkDerivation rec {
   ;
 
   meta = {
-    homepage = http://www.jwz.org/xscreensaver/;
+    homepage = https://www.jwz.org/xscreensaver/;
     description = "A set of screensavers";
     maintainers = with stdenv.lib.maintainers; [ raskin ];
     platforms = with stdenv.lib.platforms; allBut cygwin;
     inherit version;
-    downloadPage = "http://www.jwz.org/xscreensaver/download.html";
+    downloadPage = "https://www.jwz.org/xscreensaver/download.html";
     updateWalker = true;
   };
 }

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -1786,7 +1786,7 @@ rec {
 
     meta = {
       description = "Fastest non utf-8 aware word and C completion engine for Vim";
-      homepage = http://github.com/Valloric/YouCompleteMe;
+      homepage = https://github.com/Valloric/YouCompleteMe;
       license = stdenv.lib.licenses.gpl3;
       maintainers = with stdenv.lib.maintainers; [marcweber jagajaga];
       platforms = stdenv.lib.platforms.unix;

--- a/pkgs/os-specific/linux/netatop/default.nix
+++ b/pkgs/os-specific/linux/netatop/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Network monitoring module for atop";
-    homepage = http://www.atoptool.nl/downloadnetatop.php;
+    homepage = https://www.atoptool.nl/downloadnetatop.php;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [viric];

--- a/pkgs/os-specific/linux/pam_krb5/default.nix
+++ b/pkgs/os-specific/linux/pam_krb5/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ pam kerberos ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.eyrie.org/~eagle/software/pam-krb5/;
+    homepage = https://www.eyrie.org/~eagle/software/pam-krb5/;
     description = "PAM module allowing PAM-aware applications to authenticate users by performing an AS exchange with a Kerberos KDC";
     longDescription = ''
       pam_krb5 can optionally convert Kerberos 5 credentials to Kerberos IV

--- a/pkgs/os-specific/linux/sinit/default.nix
+++ b/pkgs/os-specific/linux/sinit/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
     license = stdenv.lib.licenses.mit ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;
-    homepage = http://tools.suckless.org/sinit;
+    homepage = https://tools.suckless.org/sinit;
     downloadPage = "http://git.suckless.org/sinit";
   };
 }

--- a/pkgs/os-specific/linux/upower/default.nix
+++ b/pkgs/os-specific/linux/upower/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   name = "upower-0.99.4";
 
   src = fetchurl {
-    url = "http://upower.freedesktop.org/releases/${name}.tar.xz";
+    url = "https://upower.freedesktop.org/releases/${name}.tar.xz";
     sha256 = "1c1ph1j1fnrf3vipxb7ncmdfc36dpvcvpsv8n8lmal7grjk2b8ww";
   };
 
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   installFlags = "historydir=$(TMPDIR)/foo";
 
   meta = {
-    homepage = http://upower.freedesktop.org/;
+    homepage = https://upower.freedesktop.org/;
     description = "A D-Bus service for power management";
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/os-specific/linux/xf86-video-nested/default.nix
+++ b/pkgs/os-specific/linux/xf86-video-nested/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   CFLAGS = "-I${pixman}/include/pixman-1";
 
   meta = {
-    homepage = http://cgit.freedesktop.org/xorg/driver/xf86-video-nested;
+    homepage = https://cgit.freedesktop.org/xorg/driver/xf86-video-nested;
     description = "A driver to run Xorg on top of Xorg or something else";
     maintainers = [ stdenv.lib.maintainers.goibhniu ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/servers/dns/pdns-recursor/default.nix
+++ b/pkgs/servers/dns/pdns-recursor/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A recursive DNS server";
-    homepage = http://www.powerdns.com/;
+    homepage = https://www.powerdns.com/;
     platforms = platforms.linux;
     license = licenses.gpl2;
     maintainers = with maintainers; [ rnhmjoj ];

--- a/pkgs/servers/monitoring/nagios/default.nix
+++ b/pkgs/servers/monitoring/nagios/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A host, service and network monitoring program";
-    homepage    = http://www.nagios.org/;
+    homepage    = https://www.nagios.org/;
     license     = stdenv.lib.licenses.gpl2;
     platforms   = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ thoughtpolice relrod ];

--- a/pkgs/servers/monitoring/sensu/default.nix
+++ b/pkgs/servers/monitoring/sensu/default.nix
@@ -9,7 +9,7 @@ bundlerEnv rec {
 
   meta = with lib; {
     description = "A monitoring framework that aims to be simple, malleable, and scalable";
-    homepage    = http://sensuapp.org/;
+    homepage    = https://sensuapp.org/;
     license     = licenses.mit;
     maintainers = with maintainers; [ theuni peterhoeg ];
     platforms   = platforms.unix;

--- a/pkgs/servers/monitoring/zabbix/default.nix
+++ b/pkgs/servers/monitoring/zabbix/default.nix
@@ -44,7 +44,7 @@ in
 
     meta = {
       description = "An enterprise-class open source distributed monitoring solution";
-      homepage = http://www.zabbix.com/;
+      homepage = https://www.zabbix.com/;
       license = "GPL";
       maintainers = [ stdenv.lib.maintainers.eelco ];
       platforms = stdenv.lib.platforms.linux;
@@ -60,7 +60,7 @@ in
 
     meta = with stdenv.lib; {
       description = "An enterprise-class open source distributed monitoring solution (client-side agent)";
-      homepage = http://www.zabbix.com/;
+      homepage = https://www.zabbix.com/;
       license = licenses.gpl2;
       maintainers = [ maintainers.eelco ];
       platforms = platforms.linux;

--- a/pkgs/servers/sql/mysql/5.5.x.nix
+++ b/pkgs/servers/sql/mysql/5.5.x.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
   passthru.mysqlVersion = "5.5";
 
   meta = {
-    homepage = http://www.mysql.com/;
+    homepage = https://www.mysql.com/;
     description = "The world's most popular open source database";
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/shells/nix-bash-completions/default.nix
+++ b/pkgs/shells/nix-bash-completions/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/hedning/nix-bash-completions;
+    homepage = https://github.com/hedning/nix-bash-completions;
     description = "Bash completions for Nix, NixOS, and NixOps";
     license = licenses.bsd3;
     platforms = platforms.all;

--- a/pkgs/tools/X11/sselp/default.nix
+++ b/pkgs/tools/X11/sselp/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://tools.suckless.org/sselp;
+    homepage = https://tools.suckless.org/sselp;
     description = "Prints the X selection to stdout, useful in scripts";
     license = stdenv.lib.licenses.mit;
     maintainers = [stdenv.lib.maintainers.magnetophon ];

--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://portland.freedesktop.org/wiki/;
+    homepage = https://portland.freedesktop.org/wiki/;
     description = "A set of command line tools that assist applications with a variety of desktop integration tasks";
     license = if mimiSupport then licenses.gpl2 else licenses.free;
     maintainers = [ maintainers.eelco ];

--- a/pkgs/tools/archivers/cromfs/default.nix
+++ b/pkgs/tools/archivers/cromfs/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "FUSE Compressed ROM filesystem with lzma";
-    homepage = http://bisqwit.iki.fi/source/cromfs.html;
+    homepage = https://bisqwit.iki.fi/source/cromfs.html;
     maintainers = [ stdenv.lib.maintainers.viric ];
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "xz-5.2.3";
 
   src = fetchurl {
-    url = "http://tukaani.org/xz/${name}.tar.bz2";
+    url = "https://tukaani.org/xz/${name}.tar.bz2";
     sha256 = "1ha08wxcldgcl81021x5nhknr47s1p95ljfkka4sqah5w5ns377x";
   };
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   postInstall = "rm -rf $out/share/doc";
 
   meta = with stdenv.lib; {
-    homepage = http://tukaani.org/xz/;
+    homepage = https://tukaani.org/xz/;
     description = "XZ, general-purpose data compression software, successor of LZMA";
 
     longDescription =

--- a/pkgs/tools/filesystems/mp3fs/default.nix
+++ b/pkgs/tools/filesystems/mp3fs/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
       which only understands the MP3 format, or transcode files through
       simple drag-and-drop in a file browser.
     '';
-    homepage = http://khenriks.github.io/mp3fs/;
+    homepage = https://khenriks.github.io/mp3fs/;
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ nckx ];

--- a/pkgs/tools/filesystems/ntfs-3g/default.nix
+++ b/pkgs/tools/filesystems/ntfs-3g/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.tuxera.com/community/open-source-ntfs-3g/;
+    homepage = https://www.tuxera.com/community/open-source-ntfs-3g/;
     description = "FUSE-based NTFS driver with full write support";
     maintainers = with maintainers; [ dezgeg ];
     platforms = platforms.linux;

--- a/pkgs/tools/graphics/wkhtmltopdf/default.nix
+++ b/pkgs/tools/graphics/wkhtmltopdf/default.nix
@@ -129,7 +129,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://wkhtmltopdf.org/;
+    homepage = https://wkhtmltopdf.org/;
     description = "Tools for rendering web pages to PDF or images";
     longDescription = ''
       wkhtmltopdf and wkhtmltoimage are open source (LGPL) command line tools

--- a/pkgs/tools/misc/keychain/default.nix
+++ b/pkgs/tools/misc/keychain/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Keychain management tool";
-    homepage = http://www.funtoo.org/Keychain;
+    homepage = https://www.funtoo.org/Keychain;
     license = stdenv.lib.licenses.gpl2;
     # other platforms are untested (AFAIK)
     platforms =

--- a/pkgs/tools/misc/mrtg/default.nix
+++ b/pkgs/tools/misc/mrtg/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   name = "mrtg-${version}";
 
   src = fetchurl {
-    url = "http://oss.oetiker.ch/mrtg/pub/${name}.tar.gz";
+    url = "https://oss.oetiker.ch/mrtg/pub/${name}.tar.gz";
     sha256 = "0r93ipscfp7py0b1dcx65s58q7dlwndqhprf8w4945a0h2p7zyjy";
   };
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "The Multi Router Traffic Grapher";
-    homepage = http://oss.oetiker.ch/mrtg/;
+    homepage = https://oss.oetiker.ch/mrtg/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.robberer ];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/tools/misc/testdisk/default.nix
+++ b/pkgs/tools/misc/testdisk/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   meta = {
-    homepage = http://www.cgsecurity.org/wiki/TestDisk;
+    homepage = https://www.cgsecurity.org/wiki/TestDisk;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.all;
     maintainers = [ stdenv.lib.maintainers.eelco ];

--- a/pkgs/tools/misc/tmate/default.nix
+++ b/pkgs/tools/misc/tmate/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage    = http://tmate.io/;
+    homepage    = https://tmate.io/;
     description = "Instant Terminal Sharing";
     license     = licenses.mit;
     platforms   = platforms.unix;

--- a/pkgs/tools/misc/vmtouch/default.nix
+++ b/pkgs/tools/misc/vmtouch/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Portable file system cache diagnostics and control";
     longDescription = "vmtouch is a tool for learning about and controlling the file system cache of unix and unix-like systems.";
-    homepage = http://hoytech.com/vmtouch/;
+    homepage = https://hoytech.com/vmtouch/;
     license = stdenv.lib.licenses.bsd3;
     maintainers = [ stdenv.lib.maintainers.garrison ];
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/tools/networking/megatools/default.nix
+++ b/pkgs/tools/networking/megatools/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "1.9.98";
 
   src = fetchurl {
-    url = "http://megatools.megous.com/builds/${name}.tar.gz";
+    url = "https://megatools.megous.com/builds/${name}.tar.gz";
     sha256 = "0vx1farp0dpg4zwvxdbfdnzjk9qx3sn109p1r1zl3g3xsaj221cv";
   };
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Command line client for Mega.co.nz";
-    homepage = http://megatools.megous.com/;
+    homepage = https://megatools.megous.com/;
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.viric maintainers.AndersonTorres ];
     platforms = platforms.linux;

--- a/pkgs/tools/networking/miredo/default.nix
+++ b/pkgs/tools/networking/miredo/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Teredo IPv6 Tunneling Daemon";
-    homepage = http://www.remlab.net/miredo/;
+    homepage = https://www.remlab.net/miredo/;
     license = licenses.gpl2;
     maintainers = [ maintainers.volth ];
     platforms = platforms.unix;

--- a/pkgs/tools/networking/mitmproxy/default.nix
+++ b/pkgs/tools/networking/mitmproxy/default.nix
@@ -31,7 +31,7 @@ python3.pkgs.buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Man-in-the-middle proxy";
-    homepage = http://mitmproxy.org/;
+    homepage = https://mitmproxy.org/;
     license = licenses.mit;
     maintainers = with maintainers; [ fpletz kamilchm ];
   };

--- a/pkgs/tools/networking/netrw/default.nix
+++ b/pkgs/tools/networking/netrw/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Simple tool for transporting data over the network";
     license = stdenv.lib.licenses.gpl2;
-    homepage = http://mamuti.net/netrw/index.en.html;
+    homepage = https://mamuti.net/netrw/index.en.html;
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/networking/nss-pam-ldapd/default.nix
+++ b/pkgs/tools/networking/nss-pam-ldapd/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.9.7";
   
   src = fetchurl {
-    url = "http://arthurdejong.org/nss-pam-ldapd/${name}.tar.gz";
+    url = "https://arthurdejong.org/nss-pam-ldapd/${name}.tar.gz";
     sha256 = "1sw36w6zkzvabvjckqick032j5p5xi0qi3sgnh0znzxz31jqvf0d";
   };
   
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "LDAP identity and authentication for NSS/PAM";
-    homepage = http://arthurdejong.org/nss-pam-ldapd/;
+    homepage = https://arthurdejong.org/nss-pam-ldapd/;
     license = licenses.lgpl21;
     platforms = platforms.linux;
   };

--- a/pkgs/tools/networking/openresolv/default.nix
+++ b/pkgs/tools/networking/openresolv/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A program to manage /etc/resolv.conf";
-    homepage = http://roy.marples.name/projects/openresolv;
+    homepage = https://roy.marples.name/projects/openresolv;
     license = stdenv.lib.licenses.bsd2;
     maintainers = [ stdenv.lib.maintainers.eelco ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/networking/stun/default.nix
+++ b/pkgs/tools/networking/stun/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Stun server and test client";
-    homepage    = http://sourceforge.net/projects/stun/;
+    homepage    = https://sourceforge.net/projects/stun/;
     license     = licenses.vsl10;
     maintainers = with maintainers; [ marcweber obadz ];
     platforms   = platforms.linux;

--- a/pkgs/tools/networking/swec/default.nix
+++ b/pkgs/tools/networking/swec/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   checkPhase = "make test";
 
   meta = {
-    homepage = http://random.zerodogg.org/swec/;
+    homepage = https://random.zerodogg.org/swec/;
 
     description = "Simple Web Error Checker (SWEC)";
 

--- a/pkgs/tools/networking/trickle/default.nix
+++ b/pkgs/tools/networking/trickle/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Lightweight userspace bandwidth shaper";
     license = stdenv.lib.licenses.bsd3;
-    homepage = http://monkey.org/~marius/pages/?page=trickle;
+    homepage = https://monkey.org/~marius/pages/?page=trickle;
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/tools/networking/vpnc/default.nix
+++ b/pkgs/tools/networking/vpnc/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.unix-ag.uni-kl.de/~massar/vpnc/;
+    homepage = https://www.unix-ag.uni-kl.de/~massar/vpnc/;
     description = "Virtual private network (VPN) client for Cisco's VPN concentrators";
     license = stdenv.lib.licenses.gpl2Plus;
 

--- a/pkgs/tools/security/fpm2/default.nix
+++ b/pkgs/tools/security/fpm2/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   version = "0.79";
 
   src = fetchurl {
-    url = "http://als.regnet.cz/fpm2/download/fpm2-${version}.tar.bz2";
+    url = "https://als.regnet.cz/fpm2/download/fpm2-${version}.tar.bz2";
     sha256 = "d55e9ce6be38a44fc1053d82db2d117cf3991a51898bd86d7913bae769f04da7";
   };
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "FPM2 is GTK2 port from Figaro's Password Manager originally developed by John Conneely, with some new enhancements.";
-    homepage    = http://als.regnet.cz/fpm2/;
+    homepage    = https://als.regnet.cz/fpm2/;
     license     = licenses.gpl2;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ hce ];

--- a/pkgs/tools/security/mkpasswd/default.nix
+++ b/pkgs/tools/security/mkpasswd/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   installPhase = "make install-mkpasswd";
 
   meta = with stdenv.lib; {
-    homepage = http://packages.qa.debian.org/w/whois.html;
+    homepage = https://packages.qa.debian.org/w/whois.html;
     description = "Overfeatured front-end to crypt, from the Debian whois package";
     license = licenses.gpl2;
     maintainers = with maintainers; [ cstrahan fpletz ];

--- a/pkgs/tools/security/polkit-gnome/default.nix
+++ b/pkgs/tools/security/polkit-gnome/default.nix
@@ -23,7 +23,7 @@ in stdenv.mkDerivation rec {
     '';
 
   meta = {
-    homepage = http://hal.freedesktop.org/docs/PolicyKit/;
+    homepage = https://hal.freedesktop.org/docs/PolicyKit/;
     description = "A dbus session bus service that is used to bring up authentication dialogs";
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ phreedom ];

--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -70,9 +70,9 @@ stdenv.mkDerivation rec {
       providing an audit trail of the commands and their arguments.
       '';
 
-    homepage = http://www.sudo.ws/;
+    homepage = https://www.sudo.ws/;
 
-    license = http://www.sudo.ws/sudo/license.html;
+    license = https://www.sudo.ws/sudo/license.html;
 
     maintainers = [ stdenv.lib.maintainers.eelco ];
 

--- a/pkgs/tools/security/tboot/default.nix
+++ b/pkgs/tools/security/tboot/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A pre-kernel/VMM module that uses Intel(R) TXT to perform a measured and verified launch of an OS kernel/VMM";
-    homepage    = http://sourceforge.net/projects/tboot/;
+    homepage    = https://sourceforge.net/projects/tboot/;
     license     = licenses.bsd3;
     maintainers = with maintainers; [ ak ];
     platforms   = [ "x86_64-linux" "i686-linux" ];

--- a/pkgs/tools/security/tpm-tools/default.nix
+++ b/pkgs/tools/security/tpm-tools/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       application enablement of Trusted Computing using a Trusted Platform
       Module (TPM), similar to a smart card environment.
     '';
-    homepage    = http://sourceforge.net/projects/trousers/files/tpm-tools/;
+    homepage    = https://sourceforge.net/projects/trousers/files/tpm-tools/;
     license     = licenses.cpl10;
     maintainers = [ maintainers.ak ];
     platforms   = platforms.unix;

--- a/pkgs/tools/system/ctop/default.nix
+++ b/pkgs/tools/system/ctop/default.nix
@@ -18,7 +18,7 @@ buildGoPackage rec {
 
   meta = with stdenv.lib; {
     description = "Concise commandline monitoring for containers";
-    homepage = http://ctop.sh/;
+    homepage = https://ctop.sh/;
     license = licenses.mit;
     maintainers = with maintainers; [ apeyroux ];
   };

--- a/pkgs/tools/system/lshw/default.nix
+++ b/pkgs/tools/system/lshw/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://ezix.org/project/wiki/HardwareLiSter;
+    homepage = https://ezix.org/project/wiki/HardwareLiSter;
     description = "Provide detailed information on the hardware configuration of the machine";
     license = licenses.gpl2;
     maintainers = with maintainers; [ phreedom jgeerds ];

--- a/pkgs/tools/text/replace/default.nix
+++ b/pkgs/tools/text/replace/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   patches = [./malloc.patch];
 
   meta = {
-    homepage = http://replace.richardlloyd.org.uk/;
+    homepage = https://replace.richardlloyd.org.uk/;
     description = "A tool to replace verbatim strings";
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/tools/text/txt2tags/default.nix
+++ b/pkgs/tools/text/txt2tags/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    homepage = http://txt2tags.org/;
+    homepage = https://txt2tags.org/;
     description = "A KISS markup language";
     license  = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ kovirobi ];

--- a/pkgs/tools/typesetting/pdf2odt/default.nix
+++ b/pkgs/tools/typesetting/pdf2odt/default.nix
@@ -40,7 +40,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "PDF to ODT format converter";
-    homepage    = http://github.com/gutschke/pdf2odt;
+    homepage    = https://github.com/gutschke/pdf2odt;
     license     = licenses.mit;
     platforms   = platforms.all;
     maintainers = with maintainers; [ peterhoeg ];

--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -101,7 +101,7 @@ in with localPython.pkgs; buildPythonApplication rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://aws.amazon.com/elasticbeanstalk/;
+    homepage = https://aws.amazon.com/elasticbeanstalk/;
     description = "A command line interface for Elastic Beanstalk.";
     maintainers = with maintainers; [ eqyiel ];
     license = licenses.asl20;

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -872,7 +872,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
 
     meta = {
       description = "Popular high-performance JSON framework for .NET";
-      homepage = "http://www.newtonsoft.com/json";
+      homepage = "https://www.newtonsoft.com/json";
       license = stdenv.lib.licenses.mit;
       maintainers = with stdenv.lib.maintainers; [ obadz ];
       platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -715,7 +715,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
 
     meta = {
       description = "Math.NET Numerics is an opensource numerical library for .Net, Silverlight and Mono";
-      homepage = http://numerics.mathdotnet.com/;
+      homepage = https://numerics.mathdotnet.com/;
       license = stdenv.lib.licenses.mit;
       maintainers = with stdenv.lib.maintainers; [ obadz ];
       platforms = with stdenv.lib.platforms; linux;


### PR DESCRIPTION
###### Motivation for this change

This is my effort for #30636, well, a first blast at trying to fix the easy issues.

The repository was passed through a script, specific version used available here:

 * https://github.com/samueldr/repology-autofixer/commit/1730c627bc0a28990072aadc9836cf882ad1ad3c

It has changed *mostly* meta homepage URLs, **BUT**, some download URLs have been changed. This is a side-effect of the dumb (but effective) way the change is handled. All download URLs that were a sub-path of the homepages have been automatically converted. For all URLs changed, this happened to be http→https.

###### Things done

*Nothing was tested*, no build of any of the affected software was done as this is all metadata changes.

The commits have been viewed (with my eyeballs) one by one. I have checked a couple of them manually to see whether all was right or not, especially when download URLs were changed too. If something fails, it's likely that it is the download URL, and that download URL already was previously failing.

YES, if anything fails, (except for URLs having disappeared), I'll take responsibility and *clean it through the script*.

* * *

Last, I would like to know if there's already some guidelines for commits made with automated tools. This is the way my commits look (the quote quotes the problem as stated in repology):

```
zeal: Updates homepage URL.

This commit automatically fixes the following problem:

> Homepage link "http://zealdocs.org/" is a permanent redirect to
> "https://zealdocs.org/" and should be updated

(Commit automatically made using repology-autofixer)
```

If there is anything you would like added or changed to the messages, just ask, running this script is *really cheap*, it's basically one API request, and some (short) waiting time.