### PR TITLE
hakuneko: mark as broken

### DIFF
--- a/pkgs/tools/misc/hakuneko/default.nix
+++ b/pkgs/tools/misc/hakuneko/default.nix
@@ -21,5 +21,8 @@ stdenv.mkDerivation rec {
     homepage = https://sourceforge.net/projects/hakuneko/;
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.linux;
+
+    # This project was abandoned upstream.
+    broken = true;
   };
 }


### PR DESCRIPTION
This project was abandoned upstream in favor a new project based on
electron. This version builds yet the code doesn't work with most
providers, so it is practically broken.

###### Motivation for this change
Code was deprecated. Maybe it will signal that help for the electron based
 project is needed. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

