### PR TITLE
flow: 0.61.0 -> 0.62.0

### DIFF
--- a/pkgs/development/ocaml-modules/dtoa/default.nix
+++ b/pkgs/development/ocaml-modules/dtoa/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, ocaml, findlib, jbuilder, ounit }:
+
+assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.01";
+
+stdenv.mkDerivation rec {
+  pname = "dtoa";
+  name = "ocaml-${pname}-${version}";
+  version = "0.3.1";
+
+  src = fetchurl {
+    url = "https://github.com/flowtype/ocaml-${pname}/releases/download/v${version}/${pname}-${version}.tbz";
+    sha256 = "0rzysj07z2q6gk0yhjxnjnba01vmdb9x32wwna10qk3rrb8r2pnn";
+  };
+
+  unpackCmd = "tar xjf $src";
+
+  buildInputs = [ ocaml findlib jbuilder ounit ];
+
+  buildPhase = "jbuilder build -p dtoa";
+
+  inherit (jbuilder) installPhase;
+
+  createFindLibDestdir = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/flowtype/ocaml-dtoa;
+    description = "Converts OCaml floats into strings (doubles to ascii, \"d to a\"), using the efficient Grisu3 algorithm.";
+    license = licenses.mit;
+    platforms = ocaml.meta.platforms or [];
+    maintainers = [ maintainers.eqyiel ];
+  };
+}

--- a/pkgs/development/ocaml-modules/wtf8/default.nix
+++ b/pkgs/development/ocaml-modules/wtf8/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, ocaml, findlib, jbuilder }:
+
+assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.01";
+
+stdenv.mkDerivation rec {
+  pname = "wtf8";
+  name = "ocaml-${pname}-${version}";
+  version = "1.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/flowtype/ocaml-${pname}/releases/download/v${version}/${pname}-${version}.tbz";
+    sha256 = "1msg3vycd3k8qqj61sc23qks541cxpb97vrnrvrhjnqxsqnh6ygq";
+  };
+
+  unpackCmd = "tar xjf $src";
+
+  buildInputs = [ ocaml findlib jbuilder ];
+
+  buildPhase = "jbuilder build -p wtf8";
+
+  inherit (jbuilder) installPhase;
+
+  createFindLibDestdir = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/flowtype/ocaml-wtf8;
+    description = "WTF-8 is a superset of UTF-8 that allows unpaired surrogates.";
+    license = licenses.mit;
+    platforms = ocaml.meta.platforms or [];
+    maintainers = [ maintainers.eqyiel ];
+  };
+}

--- a/pkgs/development/tools/analysis/flow/default.nix
+++ b/pkgs/development/tools/analysis/flow/default.nix
@@ -1,16 +1,17 @@
-{ stdenv, fetchFromGitHub, lib, ocaml, libelf, cf-private, CoreServices, findlib, camlp4, sedlex, ocamlbuild, ocaml_lwt }:
+{ stdenv, fetchFromGitHub, lib, ocaml, libelf, cf-private, CoreServices,
+  findlib, camlp4, sedlex, ocamlbuild, ocaml_lwt, wtf8, dtoa }:
 
 with lib;
 
 stdenv.mkDerivation rec {
-  version = "0.61.0";
+  version = "0.62.0";
   name = "flow-${version}";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "flow";
     rev = "v${version}";
-    sha256 = "0742hcg97gw6zsvm5j30rfyj71n71pfag3vcmjdh7yamn8gpn8ga";
+    sha256 = "03la72wgsh7s063h2l171h74c84haqsinnnk8fwifq3id0gq6xk1";
   };
 
   installPhase = ''
@@ -18,8 +19,9 @@ stdenv.mkDerivation rec {
     cp bin/flow $out/bin/
   '';
 
-  buildInputs = [ ocaml libelf findlib camlp4 sedlex ocamlbuild ocaml_lwt ]
-    ++ optionals stdenv.isDarwin [ cf-private CoreServices ];
+  buildInputs = [
+    ocaml libelf findlib camlp4 sedlex ocamlbuild ocaml_lwt wtf8 dtoa
+  ] ++ optionals stdenv.isDarwin [ cf-private CoreServices ];
 
   meta = with stdenv.lib; {
     description = "A static type checker for JavaScript";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7404,7 +7404,8 @@ with pkgs;
   flow = callPackage ../development/tools/analysis/flow {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
     inherit (darwin) cf-private;
-    inherit (ocamlPackages) ocaml findlib camlp4 sedlex ocamlbuild ocaml_lwt;
+    inherit (ocamlPackages) ocaml findlib camlp4 sedlex ocamlbuild ocaml_lwt
+      wtf8 dtoa;
   };
 
   framac = callPackage ../development/tools/analysis/frama-c { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -208,6 +208,8 @@ let
 
     dolog = callPackage ../development/ocaml-modules/dolog { };
 
+    dtoa = callPackage ../development/ocaml-modules/dtoa { };
+
     easy-format = callPackage ../development/ocaml-modules/easy-format { };
 
     eff = callPackage ../development/interpreters/eff { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -681,6 +681,8 @@ let
 
     wasm = callPackage ../development/ocaml-modules/wasm { };
 
+    wtf8 = callPackage ../development/ocaml-modules/wtf8 { };
+
     x509 = callPackage ../development/ocaml-modules/x509 { };
 
     xmlm = callPackage ../development/ocaml-modules/xmlm { };


### PR DESCRIPTION
###### Motivation for this change

New flow release!

###### Things done

There are two new ocaml dependencies, `dtoa` and `wtf8`.

I don't really know what I'm doing with ocaml but it seems to work.  😅 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

