### PR TITLE
WIP: add gnome3.gnome-builder

### DIFF
--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -311,6 +311,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   gdl = callPackage ./devtools/gdl { };
 
+  gnome-builder = callPackage ./devtools/gnome-builder { };
+
   gnome-devel-docs = callPackage ./devtools/gnome-devel-docs { };
 
   nemiver = callPackage ./devtools/nemiver { };

--- a/pkgs/desktops/gnome-3/devtools/gnome-builder/default.nix
+++ b/pkgs/desktops/gnome-3/devtools/gnome-builder/default.nix
@@ -1,0 +1,114 @@
+{ stdenv
+, appstream-glib
+, autoconf
+, clang
+, clang-tools
+, cmake
+, ctags
+, defaultIconTheme
+, desktop-file-utils
+, devhelp
+, docbook_xsl
+, fetchurl
+, gettext
+, gjs
+, glib
+, gnome3
+, gnumake
+, gspell
+, gtk-doc
+, gtk3
+, gtksourceview
+, indent
+, json-glib
+, jsonrpc-glib
+, libdazzle
+, libgit2-glib
+, libpeas
+, libxml2
+, llvmPackages
+, meson
+, ninja
+, packagekit
+, pcre
+, pkgconfig
+, python3
+, substituteAll
+, sysprof
+, template-glib
+, unzip
+, vala
+, vte
+, webkitgtk
+, which
+, wrapGAppsHook
+}:
+
+let
+  version = "3.28.3";
+  pname = "gnome-builder";
+  python = python3.withPackages (pkgs: with pkgs; [ jedi pygobject3 sphinx sphinx_rtd_theme ]);
+in stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  nativeBuildInputs = [ gettext meson ninja pkgconfig wrapGAppsHook appstream-glib desktop-file-utils gtk-doc docbook_xsl ];
+  buildInputs = [
+    ctags defaultIconTheme devhelp gspell gtk3 gtksourceview json-glib
+    jsonrpc-glib libdazzle libgit2-glib libpeas libxml2 python
+    llvmPackages.clang llvmPackages.llvm pcre sysprof template-glib vala
+    vte webkitgtk
+  ];
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "0vvj1fipip572h23kd780mfiq7hymbxdqkl2k5l0q27hxgpp4ax6";
+  };
+
+  mesonFlags = [
+    "-Dwith_flatpak=false"
+    "-Dwith_clang=false" # Compiler /nix/store/xxx-gcc-wrapper-7.3.0/bin/c++ can not compile programs.
+    "-Dwith_docs=true"
+  ];
+
+  patches = [
+    # ./fix-libide.patch
+    # (substituteAll {
+    #   src = ./fix-clang-plugin.patch;
+    #   clangCc = clang.cc;
+    # })
+    (substituteAll {
+      src = ./fix-paths.patch;
+      glibDev = glib.dev;
+      sitePackages = python3.sitePackages;
+      inherit autoconf clang clang-tools cmake gjs gnumake indent meson packagekit pkgconfig unzip which;
+    })
+  ];
+
+  postPatch = ''
+    patchShebangs build-aux/meson/post_install.py
+  '';
+
+
+  preFixup =
+    let
+      pythonPath = with python3.pkgs; makePythonPath [ pygobject3 ];
+    in ''
+      gappsWrapperArgs+=(
+        --set PYTHONPATH "${pythonPath}" # for libpeas plugin loader
+      )
+    '';
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      attrPath = "gnome3.${pname}";
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "An IDE for writing GNOME-based software";
+    homepage = https://wiki.gnome.org/Apps/Builder;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.andir ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/devtools/gnome-builder/fix-clang-plugin.patch
+++ b/pkgs/desktops/gnome-3/devtools/gnome-builder/fix-clang-plugin.patch
@@ -1,0 +1,13 @@
+--- a/src/plugins/clang/meson.build
++++ b/src/plugins/clang/meson.build
+@@ -38,8 +38,8 @@
+ 
+ add_languages('cpp') # Needed for llvm dep
+ llvm_dep = dependency('llvm', version: '>= 3.5')
+-clang_include = llvm_dep.get_configtool_variable('includedir')
+-clang_libdir = llvm_dep.get_configtool_variable('libdir').split(' ')
++clang_include = '@clangCc@/include/'
++clang_libdir = '@clangCc@/lib/'
+ 
+ if not cc.has_header('clang-c/Index.h', args: '-I' + clang_include)
+   error('clang: Failed to find headers')

--- a/pkgs/desktops/gnome-3/devtools/gnome-builder/fix-libide.patch
+++ b/pkgs/desktops/gnome-3/devtools/gnome-builder/fix-libide.patch
@@ -1,0 +1,15 @@
+diff --git a/meson.build b/meson.build
+index 7caf19aea..20f9d093b 100644
+--- a/meson.build
++++ b/meson.build
+@@ -171,9 +171,7 @@ configure_file(
+ )
+
+ # Check if we can use version scripts for ABI exports
+-ld_supports_version_script = cc.links('''
+-  int main (void) { return 0; }
+-''', args: '-Wl,--version-script,' + join_paths(meson.source_root(), 'libide/ide.map'))
++ld_supports_version_script = false
+ message('Linker supports --version-script: @0@'.format(ld_supports_version_script))
+
+ # Commonly used deps

--- a/pkgs/desktops/gnome-3/devtools/gnome-builder/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/devtools/gnome-builder/fix-paths.patch
@@ -1,0 +1,250 @@
+--- a/doc/help/examples/format_on_save.py
++++ b/doc/help/examples/format_on_save.py
+@@ -40,7 +40,7 @@
+                            Gio.SubprocessFlags.STDOUT_PIPE)
+ 
+         # Setup our cmdline arguments
+-        launcher.push_argv('indent')
++        launcher.push_argv('@indent@/bin/indent')
+ 
+         # If your target program is installed on the host (and not bundled
+         # or found in the build environment runtime) you might need to set
+--- a/src/libide/meson.build
++++ b/src/libide/meson.build
+@@ -188,7 +188,7 @@
+ if ret.returncode() != 0
+   error('Failed to determine pygobject overridedir')
+ else
+-  pygobject_override_dir = join_paths(get_option('libdir'), ret.stdout().strip())
++  pygobject_override_dir = join_paths(get_option('prefix'), '@sitePackages@', 'gi', 'overrides')
+ endif
+ 
+ install_data('Ide.py', install_dir: pygobject_override_dir)
+--- a/src/libide/projects/ide-project.c
++++ b/src/libide/projects/ide-project.c
+@@ -665,7 +665,7 @@
+ 
+       launcher = ide_subprocess_launcher_new (0);
+       ide_subprocess_launcher_set_run_on_host (launcher, TRUE);
+-      ide_subprocess_launcher_push_argv (launcher, "gio");
++      ide_subprocess_launcher_push_argv (launcher, "@glibDev@/bin/gio");
+       ide_subprocess_launcher_push_argv (launcher, "trash");
+       ide_subprocess_launcher_push_argv (launcher, uri);
+ 
+--- a/src/libide/runtimes/ide-runtime.c
++++ b/src/libide/runtimes/ide-runtime.c
+@@ -107,7 +107,7 @@
+           g_autoptr(IdeSubprocess) subprocess = NULL;
+ 
+           ide_subprocess_launcher_set_run_on_host (launcher, TRUE);
+-          ide_subprocess_launcher_push_argv (launcher, "which");
++          ide_subprocess_launcher_push_argv (launcher, "@which@/bin/which");
+           ide_subprocess_launcher_push_argv (launcher, program);
+ 
+           if (NULL != (subprocess = ide_subprocess_launcher_spawn (launcher, cancellable, NULL)))
+--- a/src/libide/transfers/ide-pkcon-transfer.c
++++ b/src/libide/transfers/ide-pkcon-transfer.c
+@@ -140,7 +140,7 @@
+ 
+   launcher = ide_subprocess_launcher_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE);
+   ide_subprocess_launcher_set_run_on_host (launcher, TRUE);
+-  ide_subprocess_launcher_push_argv (launcher, "pkcon");
++  ide_subprocess_launcher_push_argv (launcher, "@packagekit@/bin/pkcon");
+   ide_subprocess_launcher_push_argv (launcher, "install");
+   ide_subprocess_launcher_push_argv (launcher, "-y");
+   ide_subprocess_launcher_push_argv (launcher, "-p");
+--- a/src/plugins/autotools/ide-autotools-autogen-stage.c
++++ b/src/plugins/autotools/ide-autotools-autogen-stage.c
+@@ -94,7 +94,7 @@
+     }
+   else
+     {
+-      ide_subprocess_launcher_push_argv (launcher, "autoreconf");
++      ide_subprocess_launcher_push_argv (launcher, "@autoconf@/bin/autoreconf");
+       ide_subprocess_launcher_push_argv (launcher, "-fiv");
+     }
+ 
+--- a/src/plugins/autotools/ide-autotools-make-stage.c
++++ b/src/plugins/autotools/ide-autotools-make-stage.c
+@@ -96,7 +96,7 @@
+       if (ide_runtime_contains_program_in_path (runtime, "gmake", cancellable))
+         self->make = "gmake";
+       else
+-        self->make = "make";
++        self->make = "@gnumake@/bin/make";
+     }
+ 
+   if (NULL == (launcher = ide_build_pipeline_create_launcher (pipeline, error)))
+--- a/src/plugins/autotools/ide-makecache.c
++++ b/src/plugins/autotools/ide-makecache.c
+@@ -1042,7 +1042,7 @@
+ {
+   DZL_COUNTER_INC (instances);
+ 
+-  self->make_name = "make";
++  self->make_name = "@gnumake@/bin/make";
+ 
+   self->file_targets_cache = dzl_task_cache_new ((GHashFunc)g_file_hash,
+                                                  (GEqualFunc)g_file_equal,
+--- a/src/plugins/beautifier/gb-beautifier-process.c
++++ b/src/plugins/beautifier/gb-beautifier-process.c
+@@ -210,7 +210,7 @@
+     return NULL;
+ 
+   args = g_ptr_array_new ();
+-  g_ptr_array_add (args, "clang-format");
++  g_ptr_array_add (args, "@clang-tools@/bin/clang-format");
+   g_ptr_array_add (args, "-style=file");
+   g_ptr_array_add (args, tmp_src_path);
+   g_ptr_array_add (args, NULL);
+--- a/src/plugins/clang/ide-clang-service.c
++++ b/src/plugins/clang/ide-clang-service.c
+@@ -213,7 +213,7 @@
+ 
+   subprocess = g_subprocess_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE,
+                                  &error,
+-                                 "clang",
++                                 "@clang@/bin/clang",
+                                  "-print-file-name=include",
+                                  NULL);
+ 
+--- a/src/plugins/cmake/gbp-cmake-pipeline-addin.c
++++ b/src/plugins/cmake/gbp-cmake-pipeline-addin.c
+@@ -29,7 +29,7 @@
+   IdeObject parent_instance;
+ };
+ 
+-static const gchar *ninja_names[] = { "ninja-build", "ninja" };
++static const gchar *ninja_names[] = { "@ninja@/bin/ninja", "ninja" };
+ 
+ static void build_pipeline_addin_iface_init (IdeBuildPipelineAddinInterface *iface);
+ 
+@@ -106,7 +106,7 @@
+   g_assert (srcdir != NULL);
+ 
+   if (!(cmake = ide_configuration_getenv (configuration, "CMAKE")))
+-    cmake = "cmake";
++    cmake = "@cmake@/bin/cmake";
+ 
+   for (guint i = 0; i < G_N_ELEMENTS (ninja_names); i++)
+     {
+--- a/src/plugins/flatpak/gbp-flatpak-sources.c
++++ b/src/plugins/flatpak/gbp-flatpak-sources.c
+@@ -281,7 +281,7 @@
+   va_list ap;
+ 
+   va_start (ap, error);
+-  res = archive_spawn (dir, NULL, error, "unzip", ap);
++  res = archive_spawn (dir, NULL, error, "@unzip@/bin/unzip", ap);
+   va_end (ap);
+ 
+   return res;
+--- a/src/plugins/gjs-symbols/gjs_symbols.py
++++ b/src/plugins/gjs-symbols/gjs_symbols.py
+@@ -270,7 +270,7 @@
+         runtime = context.get_configuration_manager().get_current().get_runtime()
+         launcher = runtime.create_launcher()
+         launcher.set_flags(Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE)
+-        launcher.push_args(('gjs', '-c', script))
++        launcher.push_args(('@gjs@/bin/gjs', '-c', script))
+         if unsaved_file is not None:
+             launcher.push_argv(unsaved_file.get_content().get_data().decode('utf-8'))
+         else:
+--- a/src/plugins/jhbuild/jhbuild_plugin.py
++++ b/src/plugins/jhbuild/jhbuild_plugin.py
+@@ -98,7 +98,7 @@
+             try:
+                 launcher = Ide.SubprocessLauncher.new(Gio.SubprocessFlags.STDOUT_SILENCE |
+                                                       Gio.SubprocessFlags.STDERR_SILENCE)
+-                launcher.push_argv('which')
++                launcher.push_argv('@which@/bin/which')
+                 launcher.push_argv(jhbuild_bin)
+ 
+                 launcher.set_run_on_host(True)
+--- a/src/plugins/meson/gbp-meson-build-target-provider.c
++++ b/src/plugins/meson/gbp-meson-build-target-provider.c
+@@ -282,7 +282,7 @@
+   pipeline = ide_build_manager_get_pipeline (build_manager);
+   cancellable = g_task_get_cancellable (task);
+ 
+-  ide_subprocess_launcher_push_argv (launcher, "meson");
++  ide_subprocess_launcher_push_argv (launcher, "@meson@/bin/meson");
+   ide_subprocess_launcher_push_argv (launcher, "introspect");
+   ide_subprocess_launcher_push_argv (launcher, "--installed");
+   ide_subprocess_launcher_push_argv (launcher, ide_build_pipeline_get_builddir (pipeline));
+@@ -359,7 +359,7 @@
+       IDE_EXIT;
+     }
+ 
+-  ide_subprocess_launcher_push_argv (launcher, "meson");
++  ide_subprocess_launcher_push_argv (launcher, "@meson@/bin/meson");
+   ide_subprocess_launcher_push_argv (launcher, "introspect");
+   ide_subprocess_launcher_push_argv (launcher, "--targets");
+ 
+--- a/src/plugins/meson/gbp-meson-pipeline-addin.c
++++ b/src/plugins/meson/gbp-meson-pipeline-addin.c
+@@ -115,7 +115,7 @@
+   parallel = ide_configuration_get_parallelism (config);
+ 
+   if (NULL == (meson = ide_configuration_getenv (config, "MESON")))
+-    meson = "meson";
++    meson = "@meson@/bin/meson";
+ 
+   /* Setup our meson configure stage. */
+ 
+--- a/src/plugins/meson/gbp-meson-test-provider.c
++++ b/src/plugins/meson/gbp-meson-test-provider.c
+@@ -205,7 +205,7 @@
+   builddir = ide_build_pipeline_get_builddir (pipeline);
+   ide_subprocess_launcher_set_cwd (launcher, builddir);
+ 
+-  ide_subprocess_launcher_push_argv (launcher, "meson");
++  ide_subprocess_launcher_push_argv (launcher, "@meson@/bin/meson");
+   ide_subprocess_launcher_push_argv (launcher, "introspect");
+   ide_subprocess_launcher_push_argv (launcher, "--tests");
+ 
+--- a/src/plugins/phpize/phpize_plugin.py
++++ b/src/plugins/phpize/phpize_plugin.py
+@@ -116,7 +116,7 @@
+             launcher.set_flags(Gio.SubprocessFlags.STDIN_PIPE |
+                                Gio.SubprocessFlags.STDOUT_PIPE |
+                                Gio.SubprocessFlags.STDERR_PIPE)
+-            launcher.push_argv('make')
++            launcher.push_argv('@gnumake@/bin/make')
+             launcher.push_argv('-f')
+             launcher.push_argv('-')
+             launcher.push_argv('print-CFLAGS')
+@@ -228,11 +228,11 @@
+ 
+         # Build the project using make.
+         build_launcher = pipeline.create_launcher()
+-        build_launcher.push_argv('make')
++        build_launcher.push_argv('@gnumake@/bin/make')
+         if config.props.parallelism > 0:
+             build_launcher.push_argv('-j{}'.format(config.props.parallelism))
+         clean_launcher = pipeline.create_launcher()
+-        clean_launcher.push_argv('make')
++        clean_launcher.push_argv('@gnumake@/bin/make')
+         clean_launcher.push_argv('clean')
+         build_stage = Ide.BuildStageLauncher.new(context, build_launcher)
+         build_stage.set_name(_("Building project"))
+@@ -242,7 +242,7 @@
+ 
+         # Use "make install" to install the project.
+         install_launcher = pipeline.create_launcher()
+-        install_launcher.push_argv('make')
++        install_launcher.push_argv('@gnumake@/bin/make')
+         install_launcher.push_argv('install')
+         install_stage = Ide.BuildStageLauncher.new(context, install_launcher)
+         install_stage.set_name(_("Installing project"))
+--- a/src/plugins/vala-pack/ide-vala-index.vala
++++ b/src/plugins/vala-pack/ide-vala-index.vala
+@@ -550,7 +550,7 @@
+ 				var pkgname = "libvala-%s".printf (Config.VALA_VERSION);
+ 				string outstr = null;
+ 				var subprocess = new GLib.Subprocess (GLib.SubprocessFlags.STDOUT_PIPE,
+-					                                  "pkg-config",
++					                                  "@pkgconfig@/bin/pkg-config",
+ 					                                  "--variable=vapidir",
+ 					                                  pkgname,
+ 					                                  null);

--- a/pkgs/development/libraries/jsonrpc-glib/default.nix
+++ b/pkgs/development/libraries/jsonrpc-glib/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, meson, ninja, glib, json-glib, pkgconfig, gobjectIntrospection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_43, gnome3 }:
+let
+  version = "3.28.1";
+  pname = "jsonrpc-glib";
+in
+stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  outputs = [ "out" "dev" "devdoc" ];
+
+  nativeBuildInputs = [ meson ninja pkgconfig gobjectIntrospection vala gtk-doc docbook_xsl docbook_xml_dtd_43 ];
+  buildInputs = [ glib json-glib ];
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "0avff2ldjvwrb8rnzlgslagdjf6x7bmdx69rsq20k6f38icw4ang";
+  };
+
+  mesonFlags = [
+    "-Denable_gtk_doc=true"
+  ];
+
+  # Tests fail non-deterministically
+  # https://gitlab.gnome.org/GNOME/jsonrpc-glib/issues/2
+  doCheck = false;
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "A library to communicate using the JSON-RPC 2.0 specification";
+    homepage = https://gitlab.gnome.org/GNOME/jsonrpc-glib;
+    license = licenses.lgpl21Plus;
+    maintainers = gnome3.maintainers;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/template-glib/default.nix
+++ b/pkgs/development/libraries/template-glib/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, meson, ninja, pkgconfig, glib, gobjectIntrospection, flex, bison, vala, gettext, gnome3, gtk-doc, docbook_xsl, docbook_xml_dtd_43 }:
+let
+  version = "3.28.0";
+  pname = "template-glib";
+in
+stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  outputs = [ "out" "dev" "devdoc" ];
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "18bic41f9cx8h6n5bz80z4ridb8c1h1yscicln8zsn23zmp44x3c";
+  };
+
+  buildInputs = [ meson ninja pkgconfig gettext flex bison vala glib gtk-doc docbook_xsl docbook_xml_dtd_43 ];
+  nativeBuildInputs = [ glib gobjectIntrospection ];
+
+  mesonFlags = [
+    "-Denable_gtk_doc=true"
+  ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "A library for template expansion which supports calling into GObject Introspection from templates";
+    homepage = https://gitlab.gnome.org/GNOME/template-glib;
+    license = licenses.lgpl21Plus;
+    maintainers = gnome3.maintainers;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14965,6 +14965,8 @@ with pkgs;
 
   theano = callPackage ../data/fonts/theano { };
 
+  template-glib = callPackage ../development/libraries/template-glib { };
+
   tempora_lgc = callPackage ../data/fonts/tempora-lgc { };
 
   terminus_font = callPackage ../data/fonts/terminus-font { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9778,6 +9778,8 @@ with pkgs;
     emscripten = emscripten.override {python=python2;};
   };
 
+  jsonrpc-glib = callPackage ../development/libraries/jsonrpc-glib { };
+
   libjson = callPackage ../development/libraries/libjson { };
 
   libb64 = callPackage ../development/libraries/libb64 { };


### PR DESCRIPTION
###### Motivation for this change

I was tempted to build a GTK application using gnome-builder. This is my current WIP on getting it to run on NixOS. 

Current remaining issues:

- [x] Add `meta` attribute to the new packages
- [x] icons in gnome-builder do not show up
- [ ] python modules throw many errors e.g.:
  - `TypeError: must be an interface`
  - `NotImplementedError: <GType void (4)>`
- [ ] Templates for new projects do not render (probably related to the previous issues)
- [x] `typelib` seems to have constructed an invalid path to a shared library during build:
  `WARNING: Failed to load shared library '/nix/store/x30dzq82zv0w4nxg42bd7q60zlmi6jk0-gnome-builder-3.27.2/lib/libide-1.0.so' referenced by the typelib: /nix/store/x30dzq82zv0w4nxg42bd7q60zlmi6jk0-gnome-builder-3.27.2/lib/libide-1.0.so: cannot open shared object file: No such file or directory`


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

