### PR TITLE
haskell: configuration-ghc-8.0.x.nix: keep inline-c at 0.5.6.1

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -65,4 +65,7 @@ self: super: {
   # Add appropriate Cabal library to build this code.
   stack = addSetupDepend super.stack self.Cabal_2_0_1_1;
 
+  # inline-c > 0.5.6.0 requires template-haskell >= 2.12
+  inline-c = super.inline-c_0_5_6_1;
+  inline-c-cpp = super.inline-c-cpp_0_1_0_0;
 }

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2689,6 +2689,8 @@ extra-packages:
   - haskell-gi-overloading == 0.0       # gi-* packages use this dependency to disable overloading support
   - haskell-src-exts == 1.19.*          # required by hindent and structured-haskell-mode
   - hpack == 0.20.*                     # required by stack-1.6.1
+  - inline-c < 0.6                      # required on GHC 8.0.x
+  - inline-c-cpp < 0.2                  # required on GHC 8.0.x
   - language-c == 0.7.0                 # required by c2hs hack to work around https://github.com/haskell/c2hs/issues/192.
   - mtl < 2.2                           # newer versions require transformers > 0.4.x, which we cannot provide in GHC 7.8.x
   - mtl-prelude < 2                     # required for to build postgrest on mtl 2.1.x platforms


### PR DESCRIPTION
###### Motivation for this change

`inline-c` > 0.5.6.1 requires `template-haskell` >= 2.12 which is not available on `ghc-8.0` so we keep `inline-c` at 0.5.6.1 and `inline-c-cpp` at 0.1.0.0.

@peti I know I shouldn't edit `hackage-packages.nix` so where should I place the `inline-c_0_5_6_1` and `inline-c-cpp_0_1_0_0` definitions?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

