### PR TITLE
nmon: init at 16g

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -707,6 +707,7 @@
   volhovm = "Mikhail Volkhov <volhovm.cs@gmail.com>";
   volth = "Jaroslavas Pocepko <jaroslavas@volth.com>";
   vozz = "Oliver Hunt <oliver.huntuk@gmail.com>";
+  vquintin = "Virgile Quintin <virgile.quintin@gmail.com>";
   vrthra = "Rahul Gopinath <rahul@gopinath.org>";
   vyp = "vyp <elisp.vim@gmail.com>";
   wedens = "wedens <kirill.wedens@gmail.com>";

--- a/pkgs/os-specific/linux/nmon/builder.sh
+++ b/pkgs/os-specific/linux/nmon/builder.sh
@@ -1,0 +1,11 @@
+source $stdenv/setup
+
+CFLAGS="-g -O3 -Wall -D JFS -D GETUSER -D LARGEMEM"
+LDFLAGS="-lncurses -lm -g"
+
+cc -o nmon $src $CFLAGS $LDFLAGS -D X86
+
+mkdir -p $out/bin
+
+mv nmon $out/bin
+

--- a/pkgs/os-specific/linux/nmon/default.nix
+++ b/pkgs/os-specific/linux/nmon/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "nmon-${version}";
+  version = "16g";
+
+  src = fetchurl {
+    url = "http://sourceforge.net/projects/nmon/files/lmon${version}.c";
+    sha256 = "127n8xvmg7byp42sm924mdr7hd3bsfsxpryzahl0cfsh7dlxv0ns";
+  };
+
+  builder = ./builder.sh;
+
+  buildInputs =
+    [ ncurses ];
+
+  meta = with stdenv.lib; {
+    description = "Nigel's performance Monitor for Linux";
+    homepage = http://nmon.sourceforge.net/pmwiki.php;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ vquintin ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12654,6 +12654,8 @@ with pkgs;
 
   linuxConsoleTools = callPackage ../os-specific/linux/consoletools { };
 
+  nmon = callPackage ../os-specific/linux/nmon { };
+
   openelec-dvb-firmware = callPackage ../os-specific/linux/firmware/openelec-dvb-firmware { };
 
   openiscsi = callPackage ../os-specific/linux/open-iscsi { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds [nmon](http://nmon.sourceforge.net/pmwiki.php) to the nixpkgs.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).