### PR TITLE
ckb: 0.2.8 -> 2018-01-01

### DIFF
--- a/pkgs/tools/misc/ckb/default.nix
+++ b/pkgs/tools/misc/ckb/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, libudev, pkgconfig, qtbase, qmake, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.2.8";
+  version = "2018-01-01";
   name = "ckb-next-${version}";
 
   src = fetchFromGitHub {
     owner = "mattanger";
     repo = "ckb-next";
-    rev = "v${version}";
-    sha256 = "0b3h1d54mdyfcx46zvsd7dfqf2656h4jjkiw044170gnfdzxjb3w";
+    rev = "a0e35b5ba4d624210bf40f6c20891d8327ea17dc";
+    sha256 = "14lkhwmpka9vy2xrrsh3lbhqz3dkjvvqshqpg1h1w8qsqaqk3r6m";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
The upstream package has not had a release since May 2017, but the master branch has had a lot of updates since, including support for new devices. I therefore thought it made sense to update the nixos package to the latest master commit.
I don't know if this is common practise though, so if we'd rather follow releases I could as easily make a `ckb-unstable` package.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

