### PR TITLE
ckb: fix missing modprobe dependency

### DIFF
--- a/pkgs/tools/misc/ckb/ckb-modprobe.patch
+++ b/pkgs/tools/misc/ckb/ckb-modprobe.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ckb-daemon/usb_linux.c b/src/ckb-daemon/usb_linux.c
+index 8673f86..4714305 100644
+--- a/src/ckb-daemon/usb_linux.c
++++ b/src/ckb-daemon/usb_linux.c
+@@ -440,7 +440,7 @@ static void udev_enum(){
+ 
+ int usbmain(){
+     // Load the uinput module (if it's not loaded already)
+-    if(system("modprobe uinput") != 0)
++    if(system("@kmod@/bin/modprobe uinput") != 0)
+         ckb_warn("Failed to load uinput module\n");
+ 
+     // Create the udev object

--- a/pkgs/tools/misc/ckb/default.nix
+++ b/pkgs/tools/misc/ckb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, libudev, pkgconfig, qtbase, qmake, zlib }:
+{ stdenv, fetchFromGitHub, substituteAll, libudev, pkgconfig, qtbase, qmake, zlib, kmod }:
 
 stdenv.mkDerivation rec {
   version = "0.2.8";
@@ -24,6 +24,11 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./ckb-animations-location.patch
+    (substituteAll {
+      name = "ckb-modprobe.patch";
+      src = ./ckb-modprobe.patch;
+      inherit kmod;
+    })
   ];
 
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
When plugging a new device, the service tries to run `modprobe` and fails. This PR adds modprobe to the path of the service to fix this.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

