### PR TITLE
mgba: 0.6.0 -> 0.6.1

### DIFF
--- a/pkgs/misc/emulators/mgba/default.nix
+++ b/pkgs/misc/emulators/mgba/default.nix
@@ -1,20 +1,33 @@
-{ stdenv, fetchFromGitHub
+{ stdenv, fetchFromGitHub, fetchpatch
 , pkgconfig, cmake, libzip, epoxy, ffmpeg, imagemagick, SDL2
 , qtbase, qtmultimedia }:
 
 stdenv.mkDerivation rec {
   name = "mgba-${version}";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "mgba-emu";
     repo = "mgba";
     rev = version;
-    sha256 = "1kzb6zj2lxfaiyfq9h7q26fh7xh1ggybmh5pin5rcgs7jyygrsjb";
+    sha256 = "1fgxn3j6wc5mcgb81sc6fzy5m4saz02jz4zlms51dgycvy0flbz7";
   };
 
   nativeBuildInputs = [ pkgconfig cmake ];
+
   buildInputs = [ libzip epoxy ffmpeg imagemagick SDL2 qtbase qtmultimedia ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/mgba-emu/mgba/commit/e31373560535203d826687044290a4994706c2dd.patch";
+      sha256 = "07582vj0fqgsgryx28pnshiwri9dn88l1rr4vkraib7bzx7cs4f9";
+    })
+
+    (fetchpatch {
+      url = "https://github.com/mgba-emu/mgba/commit/baabe0090bb1fd5997e531fd9568c2de09b5fc21.patch";
+      sha256 = "1kv9dxxna35s050q9af9nzskplz2x1aq8avg0ihbznhxjl8vmxz9";
+    })
+  ];
 
   meta = with stdenv.lib; {
     homepage = https://mgba.io;


### PR DESCRIPTION
Also fixes build with qt 5.10.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

