### PR TITLE
ruby: init at 2.5.0

### DIFF
--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -39,4 +39,9 @@ rec {
     "${patchSet}/patches/ruby/2.4/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.4/head/railsexpress/03-display-more-detailed-stack-trace.patch"
   ];
+  "2.5.0" = ops useRailsExpress [
+    "${patchSet}/patches/ruby/2.5/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch"
+    "${patchSet}/patches/ruby/2.5/head/railsexpress/02-improve-gc-stats.patch"
+    "${patchSet}/patches/ruby/2.5/head/railsexpress/03-more-detailed-stacktrace.patch"
+  ];
 }

--- a/pkgs/development/interpreters/ruby/rvm-patchsets.nix
+++ b/pkgs/development/interpreters/ruby/rvm-patchsets.nix
@@ -3,6 +3,6 @@
 fetchFromGitHub {
   owner  = "skaes";
   repo   = "rvm-patchsets";
-  rev    = "15f5df0fba0e2fb489856b5bdb67a52fb9745f94";
-  sha256 = "0vdgr7xp3gbmsyaz4q78qlbwmp006b1gkgj0kwi6h8d80dclbzny";
+  rev    = "ba5a3c6f972e1b957b4b3fe28b5730ef0e27bff3";
+  sha256 = "0sjmhhb8hshxa58x062j44w0xdck8ykgpsg33wjr0wv9npwpkwrz";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6916,12 +6916,13 @@ with pkgs;
   bundlerEnv = callPackage ../development/ruby-modules/bundler-env { };
   bundlerApp = callPackage ../development/ruby-modules/bundler-app { };
 
-  inherit (callPackage ../development/interpreters/ruby {})
+  inherit (callPackage ../development/interpreters/ruby { inherit (darwin.apple_sdk.frameworks) Foundation; })
     ruby_2_0_0
     ruby_2_1_10
     ruby_2_2_8
     ruby_2_3_5
-    ruby_2_4_2;
+    ruby_2_4_2
+    ruby_2_5_0;
 
   # Ruby aliases
   ruby = ruby_2_3;
@@ -6930,6 +6931,7 @@ with pkgs;
   ruby_2_2 = ruby_2_2_8;
   ruby_2_3 = ruby_2_3_5;
   ruby_2_4 = ruby_2_4_2;
+  ruby_2_5 = ruby_2_5_0;
 
   scsh = callPackage ../development/interpreters/scsh { };
 


### PR DESCRIPTION
###### Motivation for this change
Add [ruby 2.5.0](https://www.ruby-lang.org/en/news/2017/12/25/ruby-2-5-0-released/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

