### PR TITLE
update libwebsockets from 2.3.0 to 2.4.1

### DIFF
--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -1,17 +1,17 @@
-{ fetchFromGitHub, stdenv, cmake, openssl, zlib, libuv }:
+{ fetchFromGitHub, stdenv, cmake, openssl, zlib, libuv, libev }:
 
 stdenv.mkDerivation rec {
   name = "libwebsockets-${version}";
-  version = "2.3.0";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "warmcat";
     repo = "libwebsockets";
     rev = "v${version}";
-    sha256 = "1hv2b5r6sg42xnqhm4ysjvyiz3cqpfmwaqm33vpbx0k7arj4ixvy";
+    sha256 = "0d3xqdq3hpk5l9cg4dqkba6jm6620y6knqqywya703662spmj2xw";
   };
 
-  buildInputs = [ cmake openssl zlib libuv ];
+  buildInputs = [ cmake openssl zlib libuv libev ];
   cmakeFlags = [ "-DLWS_WITH_PLUGINS=ON" ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

