### PR TITLE
NixOS Tests: record an flv of the test

### DIFF
--- a/nixos/lib/test-driver/test-driver.pl
+++ b/nixos/lib/test-driver/test-driver.pl
@@ -158,6 +158,25 @@ sub runTests {
     }
 }
 
+sub record {
+    my ($name, $display) = @_;
+
+    my $n;
+    for ($n  = 899; $n >=0; $n--) {
+        $log->log("waiting for vnc for $name on display $display");
+        last if system("nc -z 127.0.0.1 590$display") == 0;
+        sleep 1;
+    }
+
+    $log->log("starting recording for $name on display $display");
+    my $recording = Cwd::abs_path "./$name-$display.flv";
+
+    my $pid = fork(); die "cannot fork" unless defined $pid;
+    if ($pid == 0) {
+        exec "flvrec.py -o $recording 127.0.0.1 590$display" or _exit(1);
+    }
+    die unless -e "$recording";
+}
 
 # Create an empty raw virtual disk with the given name and size (in
 # MiB).

--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -29,7 +29,7 @@ rec {
         cp ${./test-driver/Logger.pm} $libDir/Logger.pm
 
         wrapProgram $out/bin/nixos-test-driver \
-          --prefix PATH : "${lib.makeBinPath [ qemu vde2 netpbm coreutils ]}" \
+          --prefix PATH : "${lib.makeBinPath [ qemu vde2 netpbm coreutils vnc2flv netcat ]}" \
           --prefix PERL5LIB : "${with perlPackages; lib.makePerlPath [ TermReadLineGnu XMLWriter IOTty FileSlurp ]}:$out/lib/perl5/site_perl"
       '';
   };
@@ -50,6 +50,8 @@ rec {
           mkdir -p $out/nix-support
 
           LOGFILE=$out/log.xml tests='eval $ENV{testScript}; die $@ if $@;' ${driver}/bin/nixos-test-driver
+
+          cp ./*.flv $out/ # */
 
           # Generate a pretty-printed log.
           xsltproc --output $out/log.html ${./test-driver/log2html.xsl} $out/log.xml
@@ -131,8 +133,8 @@ rec {
       test = passMeta (runTests driver);
       report = passMeta (releaseTools.gcovReport { coverageRuns = [ test ]; });
 
-    in (if makeCoverageReport then report else test) // { 
-      inherit nodes driver test; 
+    in (if makeCoverageReport then report else test) // {
+      inherit nodes driver test;
     };
 
   runInMachine =

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -35,6 +35,7 @@ let
 
   qemuGraphics = if cfg.graphics then "" else "-nographic";
   kernelConsole = if cfg.graphics then "" else "console=${serialDevice}";
+  vncDisplay = if cfg.vncDisplay == null then "" else "-vnc :${toString cfg.vncDisplay}";
   ttys = [ "tty1" "tty2" "tty3" "tty4" "tty5" "tty6" ];
 
   # Shell script to start the VM.
@@ -106,6 +107,7 @@ let
           ''} \
           $extraDisks \
           ${qemuGraphics} \
+          ${vncDisplay} \
           ${toString config.virtualisation.qemu.options} \
           $QEMU_OPTS \
           $@
@@ -244,6 +246,18 @@ in
           ''
             Whether to run QEMU with a graphics window, or access
             the guest computer serial port through the host tty.
+          '';
+      };
+
+    virtualisation.vncDisplay =
+      mkOption {
+        default = null;
+        type = types.int;
+        description =
+          ''
+            If specified, expose a VNC server for the specified display.
+            It will listen on 5900 +  the option, ie: 5, will be
+            listening on 5905.
           '';
       };
 

--- a/nixos/tests/keymap.nix
+++ b/nixos/tests/keymap.nix
@@ -49,6 +49,7 @@ let
     machine.i18n.consoleKeyMap = mkOverride 900 layout;
     machine.services.xserver.layout = mkOverride 900 layout;
     machine.imports = [ ./common/x11.nix extraConfig ];
+    machine.virtualisation.vncDisplay = 0;
     machine.services.xserver.displayManager.slim = {
       enable = true;
 
@@ -107,7 +108,8 @@ let
           die "tests for $desc failed" if $exitcode ne 0;
         };
       }
-
+      $machine->start;
+      record "machine", 0;
       $machine->waitForX;
 
       mkTest "VT keymap", "openvt -sw --";


### PR DESCRIPTION
###### Motivation for this change

Sometimes tests can be hard to debug. Maybe recording an FLV from the VNC could help with that? To start, enable the recording on the flaky keymap test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

