### PR TITLE
openexr: 2.2.0 -> 2.2.1

### DIFF
--- a/pkgs/development/libraries/ilmbase/default.nix
+++ b/pkgs/development/libraries/ilmbase/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, which }:
 
 stdenv.mkDerivation rec {
-  name = "ilmbase-2.2.0";
+  name = "ilmbase-2.2.1";
 
   src = fetchurl {
     url = "http://download.savannah.nongnu.org/releases/openexr/${name}.tar.gz";
-    sha256 = "1izddjwbh1grs8080vmaix72z469qy29wrvkphgmqmcm0sv1by7c";
+    sha256 = "17k0hq19wplx9s029kjrq6c51x2ryrfmaavcappkd0g67gk0dhna";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/openexr/default.nix
+++ b/pkgs/development/libraries/openexr/default.nix
@@ -5,19 +5,11 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://download.savannah.nongnu.org/releases/openexr/${name}.tar.gz";
-    sha256 = "0ca2j526n4wlamrxb85y2jrgcv0gf21b3a19rr0gh4rjqkv1581n";
+    sha256 = "1kdf2gqznsdinbd5vcmqnif442nyhdf9l7ckc51410qm2gv5m6lg";
   };
 
   patches = [
     ./bootstrap.patch
-    (fetchpatch {
-      # https://github.com/openexr/openexr/issues/232
-      # https://github.com/openexr/openexr/issues/238
-      name = "CVE-2017-12596.patch";
-      url = "https://github.com/openexr/openexr/commit/f09f5f26c1924.patch";
-      sha256 = "1d014da7c8cgbak5rgr4mq6wzm7kwznb921pr7nlb52vlfvqp4rs";
-      stripLen = 1;
-    })
   ];
 
   outputs = [ "bin" "dev" "out" "doc" ];


### PR DESCRIPTION
###### Motivation for this change
Maintenance release - security patches for OpenEXR

The 2.2.1 release addresses the known OpenEXR security vulnerabilities, specifically CVE-2017-9110, CVE-2017-9111, CVE-2017-9112, CVE-2017-9113, CVE-2017-9114, CVE-2017-9115, CVE-2017-9116.

Should be backported to `17.09`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @wkennington 