### PR TITLE
geoclue2: Fix geoclue2 for macOS

### DIFF
--- a/pkgs/development/libraries/geoclue/2.0.nix
+++ b/pkgs/development/libraries/geoclue/2.0.nix
@@ -23,7 +23,8 @@ stdenv.mkDerivation rec {
      dbus dbus_glib avahi
    ] ++ optionals (!stdenv.isDarwin) [ modemmanager ];
 
-  propagatedBuildInputs = [ dbus dbus_glib glib glib_networking ];
+  propagatedBuildInputs = [ dbus dbus_glib glib ] ++
+    optionals (!stdenv.isDarwin) [ glib_networking ];
 
   preConfigure = ''
      substituteInPlace configure --replace "-Werror" ""


### PR DESCRIPTION
###### Motivation for this change
glib_networking is a propagatedBuildInput of geoclue2, but it does not build on macOS.

This change fixes this by excluding glib_networking from the propagatedBuildInputs on macOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

