### PR TITLE
bitwig-studio: refactor to support older major versions

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
@@ -1,35 +1,35 @@
-{ stdenv, fetchurl, alsaLib, bzip2, cairo, dpkg, ffmpeg, freetype, gdk_pixbuf
-, glib, gtk2, harfbuzz, jdk, lib, libX11, libXau, libXcursor, libXdmcp
-, libXext, libXfixes, libXrender, libbsd, libjack2, libpng, libxcb
-, libxkbcommon, libxkbfile, makeWrapper, pixman, xcbutil, xcbutilwm
+{ stdenv, fetchurl, alsaLib, bzip2, cairo, dpkg, freetype, gdk_pixbuf
+, glib, gtk2, harfbuzz, jdk, lib, xorg
+, libbsd, libjack2, libpng
+, libxkbcommon
+, makeWrapper, pixman
 , xdg_utils, zenity, zlib }:
 
 stdenv.mkDerivation rec {
   name = "bitwig-studio-${version}";
-  version = "2.2.2";
+  version = "1.3.16";
 
   src = fetchurl {
-    url = "https://downloads.bitwig.com/stable/${version}/bitwig-studio-${version}.deb";
-    sha256 = "1x4wka32xlygmhdh9rb15s37zh5qjrgap2qk35y34c52lf5aak22";
+    url    = "https://downloads.bitwig.com/stable/${version}/bitwig-studio-${version}.deb";
+    sha256 = "0n0fxh9gnmilwskjcayvjsjfcs3fz9hn00wh7b3gg0cv3qqhich8";
   };
 
   nativeBuildInputs = [ dpkg makeWrapper ];
 
   unpackCmd = "mkdir root ; dpkg-deb -x $curSrc root";
 
-  dontBuild = true;
+  dontBuild    = true;
   dontPatchELF = true;
-  dontStrip = true;
+  dontStrip    = true;
 
-  libPath = lib.makeLibraryPath [
-    alsaLib bzip2.out cairo freetype gdk_pixbuf glib gtk2 harfbuzz
-    libX11 libXau libXcursor libXdmcp libXext libXfixes libXrender
-    libbsd libjack2 libpng libxcb libxkbfile pixman xcbutil xcbutilwm
-    zlib
+  libPath = with xorg; lib.makeLibraryPath [
+    alsaLib bzip2.out cairo freetype gdk_pixbuf glib gtk2 harfbuzz libX11 libXau
+    libXcursor libXdmcp libXext libXfixes libXrender libbsd libjack2 libpng libxcb
+    libxkbfile pixman xcbutil xcbutilwm zlib
   ];
 
   binPath = lib.makeBinPath [
-    ffmpeg xdg_utils zenity
+    xdg_utils zenity
   ];
 
   installPhase = ''
@@ -95,6 +95,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.bitwig.com/;
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ michalrus ];
+    maintainers = with maintainers; [ michalrus mrVanDalo ];
   };
 }

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio2.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio2.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchurl, bitwig-studio1,
+  xdg_utils, zenity, ffmpeg }:
+
+bitwig-studio1.overrideAttrs (oldAttrs: rec {
+  name = "bitwig-studio-${version}";
+  version = "2.2.2";
+
+  src = fetchurl {
+    url    = "https://downloads.bitwig.com/stable/${version}/bitwig-studio-${version}.deb";
+    sha256 = "1x4wka32xlygmhdh9rb15s37zh5qjrgap2qk35y34c52lf5aak22";
+  };
+
+  buildInputs = bitwig-studio1.buildInputs ++ [ ffmpeg ];
+
+  binPath = stdenv.lib.makeBinPath [
+    ffmpeg xdg_utils zenity
+  ];
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14191,9 +14191,14 @@ with pkgs;
 
   bitscope = callPackage ../applications/science/electronics/bitscope/packages.nix { };
 
-  bitwig-studio =  callPackage ../applications/audio/bitwig-studio {
+  bitwig-studio1 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio1.nix {
     inherit (gnome2) zenity;
   };
+  bitwig-studio2 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio2.nix {
+    inherit (gnome2) zenity;
+    inherit (self) bitwig-studio1;
+  };
+  bitwig-studio = bitwig-studio2;
 
   bgpdump = callPackage ../tools/networking/bgpdump { };
 


### PR DESCRIPTION
###### Motivation for this change

As discussed in #32206 bitwig has multiple major versions, and a license model that needs people to pay to use the newest versions. So people like me who only own the version 1, we should support older major versions as well. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

