### PR TITLE
gnome_mplayer: 1.0.4 → 1.0.9

### DIFF
--- a/pkgs/applications/video/gnome-mplayer/default.nix
+++ b/pkgs/applications/video/gnome-mplayer/default.nix
@@ -1,20 +1,33 @@
-{stdenv, fetchurl, pkgconfig, glib, gtk2, dbus, dbus_glib, GConf}:
+{stdenv, substituteAll, fetchFromGitHub, pkgconfig, gettext, glib, gtk3, gmtk, dbus, dbus_glib
+, libnotify, libpulseaudio, mplayer, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
-  name = "gnome-mplayer-1.0.4";
+  name = "gnome-mplayer-${version}";
+  version = "1.0.9";
 
-  src = fetchurl {
-    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/gnome-mplayer/${name}.tar.gz";
-    sha256 = "1k5yplsvddcm7xza5h4nfb6vibzjcqsk8gzis890alizk07f5xp2";
+  src = fetchFromGitHub {
+    owner = "kdekorte";
+    repo = "gnome-mplayer";
+    rev = "v${version}";
+    sha256 = "0qvy9fllvg1mad6y1j79iaqa6khs0q2cb0z62yfg4srbr07fi8xr";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib gtk2 dbus dbus_glib GConf];
+  nativeBuildInputs = [ pkgconfig gettext wrapGAppsHook ];
+  buildInputs = [ glib gtk3 gmtk dbus dbus_glib libnotify libpulseaudio ];
 
-  hardeningDisable = [ "format" ];
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      mencoder = "${mplayer}/bin/mencoder";
+      mplayer = "${mplayer}/bin/mplayer";
+    })
+  ];
 
-  meta = {
-    homepage = http://kdekorte.googlepages.com/gnomemplayer;
+  meta = with stdenv.lib; {
     description = "Gnome MPlayer, a simple GUI for MPlayer";
+    homepage = https://sites.google.com/site/kdekorte2/gnomemplayer;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/video/gnome-mplayer/fix-paths.patch
+++ b/pkgs/applications/video/gnome-mplayer/fix-paths.patch
@@ -1,0 +1,87 @@
+--- a/src/gui.c
++++ b/src/gui.c
+@@ -7470,7 +7470,7 @@
+         filename = g_strdup_printf("%s/00000001.jpg", dirname);
+         g_free(basepath);
+         // run mplayer and try to get the first frame and convert it to a jpeg
+-        av[ac++] = g_strdup_printf("mplayer");
++        av[ac++] = g_strdup_printf("@mplayer@");
+         av[ac++] = g_strdup_printf("-vo");
+         av[ac++] = g_strdup_printf("jpeg:outdir=%s", dirname);
+         av[ac++] = g_strdup_printf("-ao");
+--- a/src/property_page_common.c
++++ b/src/property_page_common.c
+@@ -80,7 +80,7 @@
+     MetaData *ret;
+     ret = g_new0(MetaData, 1);
+ 
+-    av[ac++] = g_strdup_printf("mplayer");
++    av[ac++] = g_strdup_printf("@mplayer@");
+     av[ac++] = g_strdup_printf("-vo");
+     av[ac++] = g_strdup_printf("null");
+     av[ac++] = g_strdup_printf("-ao");
+--- a/src/support.c
++++ b/src/support.c
+@@ -566,7 +566,7 @@
+     } else {
+         playlist = FALSE;
+         if (mplayer_bin == NULL || !g_file_test(mplayer_bin, G_FILE_TEST_EXISTS)) {
+-            av[ac++] = g_strdup_printf("mplayer");
++            av[ac++] = g_strdup_printf("@mplayer@");
+         } else {
+             av[ac++] = g_strdup_printf("%s", mplayer_bin);
+         }
+@@ -728,7 +728,7 @@
+         playlist = FALSE;
+         // run mplayer and try to get the first frame and convert it to a jpeg
+         if (mplayer_bin == NULL || !g_file_test(mplayer_bin, G_FILE_TEST_EXISTS)) {
+-            av[ac++] = g_strdup_printf("mplayer");
++            av[ac++] = g_strdup_printf("@mplayer@");
+         } else {
+             av[ac++] = g_strdup_printf("%s", mplayer_bin);
+         }
+@@ -825,7 +825,7 @@
+         playlist = FALSE;
+ 
+         if (mplayer_bin == NULL || !g_file_test(mplayer_bin, G_FILE_TEST_EXISTS)) {
+-            av[ac++] = g_strdup_printf("mplayer");
++            av[ac++] = g_strdup_printf("@mplayer@");
+         } else {
+             av[ac++] = g_strdup_printf("%s", mplayer_bin);
+         }
+@@ -1251,7 +1251,7 @@
+     gm_log(verbose, G_LOG_LEVEL_INFO, "getting file metadata for %s", name);
+ 
+     if (mplayer_bin == NULL || !g_file_test(mplayer_bin, G_FILE_TEST_EXISTS)) {
+-        av[ac++] = g_strdup_printf("mplayer");
++        av[ac++] = g_strdup_printf("@mplayer@");
+     } else {
+         av[ac++] = g_strdup_printf("%s", mplayer_bin);
+     }
+@@ -1532,7 +1532,7 @@
+         return 0;
+ 
+     if (mplayer_bin == NULL || !g_file_test(mplayer_bin, G_FILE_TEST_EXISTS)) {
+-        av[ac++] = g_strdup_printf("mplayer");
++        av[ac++] = g_strdup_printf("@mplayer@");
+     } else {
+         av[ac++] = g_strdup_printf("%s", mplayer_bin);
+     }
+@@ -1597,7 +1597,7 @@
+ 
+     if (control_id == 0) {
+         ac = 0;
+-        av[ac++] = g_strdup_printf("mencoder");
++        av[ac++] = g_strdup_printf("@mencoder@");
+         av[ac++] = g_strdup_printf("-ovc");
+         av[ac++] = g_strdup_printf("copy");
+         av[ac++] = g_strdup_printf("-oac");
+@@ -2830,7 +2830,7 @@
+     gboolean ret = TRUE;
+ 
+     if (mplayer_bin == NULL || !g_file_test(mplayer_bin, G_FILE_TEST_EXISTS)) {
+-        av[ac++] = g_strdup_printf("mplayer");
++        av[ac++] = g_strdup_printf("@mplayer@");
+     } else {
+         av[ac++] = g_strdup_printf("%s", mplayer_bin);
+     }

--- a/pkgs/development/libraries/gmtk/default.nix
+++ b/pkgs/development/libraries/gmtk/default.nix
@@ -1,0 +1,32 @@
+{stdenv, substituteAll, fetchFromGitHub, libtool, pkgconfig, intltool, glib, gtk3
+, libpulseaudio, mplayer, gnome_mplayer }:
+
+stdenv.mkDerivation rec {
+  name = "gmtk-${version}";
+  version = "1.0.9";
+
+  src = fetchFromGitHub {
+    owner = "kdekorte";
+    repo = "gmtk";
+    rev = "v${version}";
+    sha256 = "1zb5m1y1gckal3140gvx31572a6xpccwfmdwa1w5lx2wdq1pwk1i";
+  };
+
+  nativeBuildInputs = [ libtool pkgconfig intltool ];
+  buildInputs = [ glib gtk3 libpulseaudio ];
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      mplayer = "${mplayer}/bin/mplayer";
+    })
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Common functions for gnome-mplayer and gecko-mediaplayer";
+    homepage = https://sites.google.com/site/kdekorte2/gnomemplayer;
+    license = licenses.gpl2;
+    maintainers = gnome_mplayer.meta.maintainers;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/gmtk/fix-paths.patch
+++ b/pkgs/development/libraries/gmtk/fix-paths.patch
@@ -1,0 +1,20 @@
+--- a/src/gmtk_media_player.c
++++ b/src/gmtk_media_player.c
+@@ -2449,7 +2449,7 @@
+         player->minimum_mplayer = detect_mplayer_features(player);
+ 
+         if (player->mplayer_binary == NULL || !g_file_test(player->mplayer_binary, G_FILE_TEST_EXISTS)) {
+-            argv[argn++] = g_strdup_printf("mplayer");
++            argv[argn++] = g_strdup_printf("@mplayer@");
+         } else {
+             argv[argn++] = g_strdup_printf("%s", player->mplayer_binary);
+         }
+@@ -4135,7 +4135,7 @@
+         return ret;
+ 
+     if (player->mplayer_binary == NULL || !g_file_test(player->mplayer_binary, G_FILE_TEST_EXISTS)) {
+-        av[ac++] = g_strdup_printf("mplayer");
++        av[ac++] = g_strdup_printf("@mplayer@");
+     } else {
+         av[ac++] = g_strdup_printf("%s", player->mplayer_binary);
+     }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15237,6 +15237,8 @@ with pkgs;
     inherit (darwin) IOKit;
   };
 
+  gmtk = callPackage ../development/libraries/gmtk { };
+
   gmu = callPackage ../applications/audio/gmu { };
 
   gnome_mplayer = callPackage ../applications/video/gnome-mplayer {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15241,9 +15241,7 @@ with pkgs;
 
   gmu = callPackage ../applications/audio/gmu { };
 
-  gnome_mplayer = callPackage ../applications/video/gnome-mplayer {
-    inherit (gnome2) GConf;
-  };
+  gnome_mplayer = callPackage ../applications/video/gnome-mplayer { };
 
   gnumeric = callPackage ../applications/office/gnumeric { };
 


### PR DESCRIPTION
###### Motivation for this change
Update and change to gtk3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

