### PR TITLE
nixos/borgbackup: add test

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -227,6 +227,7 @@ in rec {
   tests.blivet = callTest tests/blivet.nix {};
   tests.boot = callSubTests tests/boot.nix {};
   tests.boot-stage1 = callTest tests/boot-stage1.nix {};
+  tests.borgbackup = callTest tests/borgbackup.nix {};
   tests.cadvisor = callTestOnTheseSystems ["x86_64-linux"] tests/cadvisor.nix {};
   tests.chromium = (callSubTestsOnTheseSystems ["x86_64-linux"] tests/chromium.nix {}).stable;
   tests.cjdns = callTest tests/cjdns.nix {};

--- a/nixos/tests/borgbackup.nix
+++ b/nixos/tests/borgbackup.nix
@@ -1,0 +1,21 @@
+import ./make-test.nix ({ pkgs, ...}: {
+  name = "borgbackup";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ mic92 ];
+  };
+
+  nodes = {
+    machine = { config, pkgs, ... }: {
+      environment.systemPackages = [ pkgs.borgbackup ];
+    };
+  };
+
+  testScript = ''
+    my $borg = "BORG_PASSPHRASE=supersecret borg";
+    $machine->succeed("$borg init --encryption=repokey /tmp/backup");
+    $machine->succeed("mkdir /tmp/data/ && echo 'data' >/tmp/data/file");
+    $machine->succeed("$borg create --stats /tmp/backup::test /tmp/data");
+    $machine->succeed("$borg extract /tmp/backup::test");
+    $machine->succeed('c=$(cat data/file) && echo "c = $c" >&2 && [[ "$c" == "data" ]]');
+  '';
+})


### PR DESCRIPTION
We had problems to get borg's own test suite running.
This test is intended to perform a quick smoke test to see whether we
have missed not any important dependency necessary to create backups
with borg.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

