### PR TITLE
gauge: init at 0.9.6

### DIFF
--- a/pkgs/development/tools/gauge/default.nix
+++ b/pkgs/development/tools/gauge/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "gauge-${version}";
+  version = "0.9.6";
+
+  goPackagePath = "github.com/getgauge/gauge";
+
+  src = fetchFromGitHub {
+    owner = "getgauge";
+    repo = "gauge";
+    rev = "v${version}";
+    sha256 = "0p2bnrzgx616jbyr9h4h9azaq7ry63z4qkwgy0ivwrpmhfqfqwmh";
+  };
+
+  meta = with stdenv.lib; {
+   description = "Light weight cross-platform test automation";
+   homepage    = http://gauge.org;
+   license     = licenses.gpl3;
+   maintainers = [ maintainers.vdemeester ];
+   platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2238,6 +2238,8 @@ with pkgs;
 
   garmintools = callPackage ../development/libraries/garmintools {};
 
+  gauge = callPackage ../development/tools/gauge { };
+
   gawk = callPackage ../tools/text/gawk {
     inherit (darwin) locale;
   };


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

[Gauge](https://getgauge.io/) is a light weight cross-platform test automation where tests are written in markdown (implementation can be in several languages.. a bit like `cucumber`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

