### PR TITLE
yabar-unstable: 2017-10-12 -> 2018-01-02

### DIFF
--- a/pkgs/applications/window-managers/yabar/build.nix
+++ b/pkgs/applications/window-managers/yabar/build.nix
@@ -2,7 +2,6 @@
 , xcbutilwm, alsaLib, wirelesstools, asciidoc, libxslt, makeWrapper, docbook_xsl
 , configFile ? null, lib
 , rev, sha256, version
-, playerctl
 }:
 
 stdenv.mkDerivation {
@@ -21,7 +20,6 @@ stdenv.mkDerivation {
   buildInputs = [
     cairo gdk_pixbuf libconfig pango xcbutilwm docbook_xsl
     alsaLib wirelesstools asciidoc libxslt makeWrapper
-    playerctl
   ];
 
   postPatch = ''
@@ -30,7 +28,7 @@ stdenv.mkDerivation {
       --replace "a2x" "${asciidoc}/bin/a2x --no-xmllint"
   '';
 
-  makeFlags = [ "DESTDIR=$(out)" "PREFIX=/" "PLAYERCTL=1" ];
+  makeFlags = [ "DESTDIR=$(out)" "PREFIX=/" ];
 
   postInstall = ''
     mkdir -p $out/share/yabar/examples

--- a/pkgs/applications/window-managers/yabar/unstable.nix
+++ b/pkgs/applications/window-managers/yabar/unstable.nix
@@ -1,10 +1,18 @@
-{ callPackage, attrs ? {} }:
+{ playerctl, libxkbcommon, callPackage, attrs ? {} }:
 
 let
-  overrides = {
-    version = "unstable-2017-10-12";
+  pkg = callPackage ./build.nix ({
+    version = "unstable-2018-01-02";
 
-    rev    = "cbecc7766e37f29d50705da0a82dc76ce7c3b86e";
-    sha256 = "1wprjas3k14rxfl06mgr0xq2ra735w1c7dq4xrdvii887wnl37xb";
-  } // attrs;
-in callPackage ./build.nix overrides
+    rev    = "d9f75933f1fdd7bec24bf7db104c7e1df2728b98";
+    sha256 = "0ry2pgqsnl6cmvkhakm73cjqdnirkimldnmbngl6hbvggx32z8c9";
+  } // attrs);
+in pkg.overrideAttrs (o: {
+  buildInputs = o.buildInputs ++ [
+    playerctl libxkbcommon
+  ];
+
+  makeFlags = o.makeFlags ++ [
+    "PLAYERCTL=1"
+  ];
+})


### PR DESCRIPTION
###### Motivation for this change

The unstable branch of `yabar` received some minor useful changes:

- Fixed missprint (https://github.com/geommer/yabar/commit/f1b1eff48108654219311e63147365cd6f006593)
- Update information on Debian installation (https://github.com/geommer/yabar/commit/ce20fe75f7bca2488168e45c577d6bb4996f7377)
- Add indicator to show current indicator using `libxkbcommon` (https://github.com/geommer/yabar/commit/5aa1fb5eb558f58f0bcfe495b8f49414aa6d88a2)

The last change requires a `libxkbcommon` as additional build input.

Furthermore I thought that it might be better to add the dependencies of
unstable (namely `playerctl` and `libxkbcommon`) to the `unstable.nix`
to reduce the closure size of the stable build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

