### PR TITLE
skopeo: 0.1.23 to 0.1.27

### DIFF
--- a/pkgs/development/tools/skopeo/default.nix
+++ b/pkgs/development/tools/skopeo/default.nix
@@ -4,7 +4,7 @@ with stdenv.lib;
 
 buildGoPackage rec {
   name = "skopeo-${version}";
-  version = "0.1.23";
+  version = "0.1.27";
   rev = "v${version}";
 
   goPackagePath = "github.com/projectatomic/skopeo";
@@ -17,7 +17,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "projectatomic";
     repo = "skopeo";
-    sha256 = "1axxnm87fpsd7q28v951ilhmzd42k8wyh741gdfdcajjwglfj0nn";
+    sha256 = "1xwwzxjczz8qdk1rf0h78qd3vk9mxxb8yi6f8kfqvcdcsvkajd5g";
   };
 
   patches = [

--- a/pkgs/development/tools/skopeo/path.patch
+++ b/pkgs/development/tools/skopeo/path.patch
@@ -22,17 +22,4 @@ index 50e29b2..7108df5 100644
  	if c.GlobalBool("insecure-policy") {
  		policy = &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
  	} else if policyPath == "" {
-diff --git a/vendor/github.com/containers/image/docker/docker_client.go b/vendor/github.com/containers/image/docker/docker_client.go
-index b989770..697d2ee 100644
---- a/vendor/github.com/containers/image/docker/docker_client.go
-+++ b/vendor/github.com/containers/image/docker/docker_client.go
-@@ -154,6 +154,9 @@ func setupCertificates(dir string, tlsc *tls.Config) error {
- 		if os.IsNotExist(err) {
- 			return nil
- 		}
-+		if os.IsPermission(err) {
-+			return nil
-+		}
- 		return err
- 	}
  


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Bump version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

