### PR TITLE
vndr: 20170511-0cb33a0 -> 20171005-b57c579

### DIFF
--- a/pkgs/development/tools/vndr/default.nix
+++ b/pkgs/development/tools/vndr/default.nix
@@ -2,8 +2,8 @@
 
 buildGoPackage rec {
   name = "vndr-${version}";
-  version = "20170511-${lib.strings.substring 0 7 rev}";
-  rev = "0cb33a0eb64c8ca73b8e2939a3430b22fbb8d3e3";
+  version = "20171005-${lib.strings.substring 0 7 rev}";
+  rev = "b57c5799efd5ed743f347a025482babf01ba963e";
 
   goPackagePath = "github.com/LK4D4/vndr";
   excludedPackages = "test";
@@ -12,7 +12,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "LK4D4";
     repo = "vndr";
-    sha256 = "02vdr59xn79hffayfcxg29nf62rdc33a60i104fgj746kcswgy5n";
+    sha256 = "15mmy4a06jgzvlbjbmd89f0xx695x8wg7jqi76kiz495i6figk2v";
   };
 
   meta = {


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Bump `vndr` version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

