### PR TITLE
godef: 20160620-ee532b9 -> 20170920-b692db1

### DIFF
--- a/pkgs/development/tools/godef/default.nix
+++ b/pkgs/development/tools/godef/default.nix
@@ -2,8 +2,8 @@
 
 buildGoPackage rec {
   name = "godef-${version}";
-  version = "20160620-${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "ee532b944160bb27b6f23e4f5ef38b8fdaa2a6bd";
+  version = "20170920-${stdenv.lib.strings.substring 0 7 rev}";
+  rev = "b692db1de5229d4248e23c41736b431eb665615d";
 
   goPackagePath = "github.com/rogpeppe/godef";
   excludedPackages = "go/printer/testdata";
@@ -11,7 +11,7 @@ buildGoPackage rec {
   src = fetchgit {
     inherit rev;
     url = "https://github.com/rogpeppe/godef";
-    sha256 = "1r8c4ijjnwvb9pci4wasmq88yj0ginwly2542kw4hyg2c87j613l";
+    sha256 = "0xqp9smfyznm8v2iy4wyy3kd24mga12fx0y0896qimac4hj2al15";
   };
 
   meta = {


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Bump godef version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

