### PR TITLE
goconvey: init at 1.6.3

### DIFF
--- a/pkgs/development/tools/goconvey/default.nix
+++ b/pkgs/development/tools/goconvey/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "goconvey-${version}";
+  version = "1.6.3";
+
+  goPackagePath = "github.com/smartystreets/goconvey";
+  excludedPackages = "web/server/watch/integration_testing";
+
+  goDeps = ./deps.nix;
+
+  src = fetchFromGitHub {
+    owner = "smartystreets";
+    repo = "goconvey";
+    rev = "${version}";
+    sha256 = "1ph18rkl3ns3fgin5i4j54w5a69grrmf3apcsmnpdn1wlrbs3dxh";
+  };
+
+  meta = {
+    description = "Go testing in the browser. Integrates with `go test`. Write behavioral tests in Go.";
+    homepage = https://github.com/smartystreets/goconvey;
+    maintainers = with stdenv.lib.maintainers; [ vdemeester ];
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/development/tools/goconvey/deps.nix
+++ b/pkgs/development/tools/goconvey/deps.nix
@@ -1,0 +1,20 @@
+[
+  {
+    goPackagePath = "github.com/jtolds/gls";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jtolds/gls";
+      rev = "77f18212c9c7edc9bd6a33d383a7b545ce62f064";
+      sha256 = "1vm37pvn0k4r6d3m620swwgama63laz8hhj3pyisdhxwam4m2g1h";
+    };
+  }
+  {
+    goPackagePath = "github.com/smartystreets/assertions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smartystreets/assertions";
+      rev = "0b37b35ec7434b77e77a4bb29b79677cced992ea";
+      sha256 = "1j0adgbykl55rf2945g0n5bmqdsnjcqlx5dcmpfh4chki43hiwg9";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13108,6 +13108,8 @@ with pkgs;
 
   gocode = callPackage ../development/tools/gocode { };
 
+  goconvey = callPackage ../development/tools/goconvey { };
+
   gotags = callPackage ../development/tools/gotags { };
 
   golint = callPackage ../development/tools/golint { };


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

`goconvey` is both a *continuous test* runner with a web ui and a way to write behavioral tests. This packages the `cli` to do some `golang` *continuous testing*.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

