### PR TITLE
dotty: wrap to prevent installing all the files in profile

### DIFF
--- a/pkgs/development/compilers/scala/dotty-bare.nix
+++ b/pkgs/development/compilers/scala/dotty-bare.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, makeWrapper, jre }:
+
+stdenv.mkDerivation rec {
+  version = "0.4.0-RC1";
+  name = "dotty-bare-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/lampepfl/dotty/releases/download/${version}/dotty-${version}.tar.gz";
+    sha256 = "1d1ab08b85bd6898ce6273fa50818de0d314fc6e5377fb6ee05494827043321b";
+  };
+
+  propagatedBuildInputs = [ jre ] ;
+  buildInputs = [ makeWrapper ] ;
+
+  installPhase = ''
+    mkdir -p $out
+    mv * $out
+  '';
+
+  fixupPhase = ''
+        bin_files=$(find $out/bin -type f ! -name common)
+        for f in $bin_files ; do
+          wrapProgram $f --set JAVA_HOME ${jre}
+        done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Research platform for new language concepts and compiler technologies for Scala.";
+    longDescription = ''
+       Dotty is a platform to try out new language concepts and compiler technologies for Scala.
+       The focus is mainly on simplification. We remove extraneous syntax (e.g. no XML literals),
+       and try to boil down Scala’s types into a smaller set of more fundamental constructs.
+       The theory behind these constructs is researched in DOT, a calculus for dependent object types.
+    '';
+    homepage = http://dotty.epfl.ch/;
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = [maintainers.karolchmist];
+  };
+}

--- a/pkgs/development/compilers/scala/dotty.nix
+++ b/pkgs/development/compilers/scala/dotty.nix
@@ -1,46 +1,22 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, fetchurl, makeWrapper, jre, callPackage }:
 
-stdenv.mkDerivation rec {
-  version = "0.4.0-RC1";
-  name = "dotty-${version}";
-
-  src = fetchurl {
-    url = "https://github.com/lampepfl/dotty/releases/download/${version}/${name}.tar.gz";
-    sha256 = "1d1ab08b85bd6898ce6273fa50818de0d314fc6e5377fb6ee05494827043321b";
+let
+  dotty-bare = callPackage ./dotty-bare.nix {
+    inherit stdenv fetchurl makeWrapper jre;
   };
+in
 
-  propagatedBuildInputs = [ jre ] ;
-  buildInputs = [ makeWrapper ] ;
+stdenv.mkDerivation {
+  name = "dotty-${dotty-bare.version}";
+
+  unpackPhase = ":";
 
   installPhase = ''
-    mkdir -p $out
-    mv * $out
-
-    mkdir -p $out/shared
-    mv $out/bin/common $out/shared
+    mkdir -p $out/bin
+    ln -s ${dotty-bare}/bin/dotc $out/bin/dotc
+    ln -s ${dotty-bare}/bin/dotd $out/bin/dotd
+    ln -s ${dotty-bare}/bin/dotr $out/bin/dotr
   '';
 
-  fixupPhase = ''
-    for file in $out/bin/* ; do
-      substituteInPlace $file \
-        --replace '$PROG_HOME/bin/common' $out/shared/common
-
-      wrapProgram $file \
-        --set JAVA_HOME ${jre}
-    done
-  '';
-
-  meta = with stdenv.lib; {
-    description = "Research platform for new language concepts and compiler technologies for Scala.";
-    longDescription = ''
-       Dotty is a platform to try out new language concepts and compiler technologies for Scala.
-       The focus is mainly on simplification. We remove extraneous syntax (e.g. no XML literals),
-       and try to boil down Scala’s types into a smaller set of more fundamental constructs.
-       The theory behind these constructs is researched in DOT, a calculus for dependent object types.
-    '';
-    homepage = http://dotty.epfl.ch/;
-    license = licenses.bsd3;
-    platforms = platforms.all;
-    maintainers = [maintainers.karolchmist];
-  };
+  inherit (dotty-bare) meta;
 }


### PR DESCRIPTION
###### Motivation for this change
Fixes  #31858 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

