### PR TITLE
lxterminal: use nativeBuildInputs for compile-time-only deps

### DIFF
--- a/pkgs/applications/misc/lxterminal/default.nix
+++ b/pkgs/applications/misc/lxterminal/default.nix
@@ -16,10 +16,12 @@ stdenv.mkDerivation rec {
     "--enable-man"
   ];
 
-  buildInputs = [
-    automake autoconf intltool pkgconfig gtk2 vte libxslt docbook_xml_dtd_412
-    docbook_xml_xslt libxml2 findXMLCatalogs
+  nativeBuildInputs = [
+    automake autoconf intltool pkgconfig
+    libxslt docbook_xml_dtd_412 docbook_xml_xslt libxml2 findXMLCatalogs
   ];
+
+  buildInputs = [ gtk2 vte ];
 
   patches = [
     ./respect-xml-catalog-files-var.patch


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

