### PR TITLE
toot: 0.15.0 -> 0.16.2

### DIFF
--- a/pkgs/applications/misc/toot/default.nix
+++ b/pkgs/applications/misc/toot/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, fetchFromGitHub, pythonPackages }:
+{ stdenv, fetchFromGitHub, python3Packages }:
 
-pythonPackages.buildPythonApplication rec {
-  version = "0.15.0";
+python3Packages.buildPythonApplication rec {
+  version = "0.16.2";
   name    = "toot-${version}";
 
   src = fetchFromGitHub {
     owner  = "ihabunek";
     repo   = "toot";
     rev    = "${version}";
-    sha256 = "08k913gw0ip2q686z9k63bcn1n5s4w6b7jj6jmmamm427xmibkph";
+    sha256 = "19n6rmm44y24zvkpk56vd2xmx49sn6wc5qayi1jm83jlnlbbwfh7";
   };
 
-  checkInputs = with pythonPackages; [ pytest ];
+  checkInputs = with python3Packages; [ pytest ];
 
-  propagatedBuildInputs = with pythonPackages;
+  propagatedBuildInputs = with python3Packages;
     [ requests beautifulsoup4 future ];
 
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Closes https://github.com/ihabunek/toot/issues/29

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).