### PR TITLE
clang: add lib output

### DIFF
--- a/pkgs/development/compilers/llvm/3.8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/clang/default.nix
@@ -29,7 +29,7 @@ let
       sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/ToolChains.cpp
     '';
 
-    outputs = [ "out" "python" ];
+    outputs = [ "out" "lib" "python" ];
 
     # Clang expects to find LLVMgold in its own prefix
     # Clang expects to find sanitizer libraries in its own prefix
@@ -37,6 +37,9 @@ let
       ln -sv ${llvm}/lib/LLVMgold.so $out/lib
       ln -sv ${llvm}/lib/clang/${version}/lib $out/lib/clang/${version}/
       ln -sv $out/bin/clang $out/bin/cpp
+
+      # Move libclang to 'lib' output
+      moveToOutput "lib/libclang.*" "$lib"
 
       mkdir -p $python/bin $python/share/clang/
       mv $out/bin/{git-clang-format,scan-view} $python/bin
@@ -51,7 +54,6 @@ let
     enableParallelBuilding = true;
 
     passthru = {
-      lib = self; # compatibility with gcc, so that `stdenv.cc.cc.lib` works on both
       isClang = true;
       inherit llvm;
     } // stdenv.lib.optionalAttrs stdenv.isLinux {

--- a/pkgs/development/compilers/llvm/3.8/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/default.nix
@@ -22,6 +22,8 @@ let
       inherit clang-tools-extra_src stdenv;
     };
 
+    libclang = self.clang-unwrapped.lib;
+
     clang = if stdenv.cc.isGNU then self.libstdcxxClang else self.libcxxClang;
 
     libstdcxxClang = ccWrapperFun {

--- a/pkgs/development/compilers/llvm/3.9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/clang/default.nix
@@ -31,7 +31,7 @@ let
       sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/ToolChains.cpp
     '';
 
-    outputs = [ "out" "python" ];
+    outputs = [ "out" "lib" "python" ];
 
     # Clang expects to find LLVMgold in its own prefix
     # Clang expects to find sanitizer libraries in its own prefix
@@ -39,6 +39,9 @@ let
       ln -sv ${llvm}/lib/LLVMgold.so $out/lib
       ln -sv ${llvm}/lib/clang/${version}/lib $out/lib/clang/${version}/
       ln -sv $out/bin/clang $out/bin/cpp
+
+      # Move libclang to 'lib' output
+      moveToOutput "lib/libclang.*" "$lib"
 
       mkdir -p $python/bin $python/share/clang/
       mv $out/bin/{git-clang-format,scan-view} $python/bin
@@ -53,7 +56,6 @@ let
     enableParallelBuilding = true;
 
     passthru = {
-      lib = self; # compatibility with gcc, so that `stdenv.cc.cc.lib` works on both
       isClang = true;
       inherit llvm;
     } // stdenv.lib.optionalAttrs stdenv.isLinux {

--- a/pkgs/development/compilers/llvm/3.9/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/default.nix
@@ -22,6 +22,8 @@ let
       inherit clang-tools-extra_src stdenv;
     };
 
+    libclang = self.clang-unwrapped.lib;
+
     clang = if stdenv.cc.isGNU then self.libstdcxxClang else self.libcxxClang;
 
     libstdcxxClang = ccWrapperFun {

--- a/pkgs/development/compilers/llvm/4/default.nix
+++ b/pkgs/development/compilers/llvm/4/default.nix
@@ -34,6 +34,7 @@ let
     llvm = overrideManOutput llvm;
     clang-unwrapped = overrideManOutput clang-unwrapped;
 
+    libclang = self.clang-unwrapped.lib;
     llvm-manpages = lowPrio self.llvm.man;
     clang-manpages = lowPrio self.clang-unwrapped.man;
 

--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -50,7 +50,7 @@ let
       sed -i '1s,^,find_package(Sphinx REQUIRED)\n,' docs/CMakeLists.txt
     '';
 
-    outputs = [ "out" "python" ]
+    outputs = [ "out" "lib" "python" ]
       ++ stdenv.lib.optional enableManpages "man";
 
     # Clang expects to find LLVMgold in its own prefix
@@ -60,13 +60,15 @@ let
       ln -sv ${llvm}/lib/clang/${release_version}/lib $out/lib/clang/${release_version}/
       ln -sv $out/bin/clang $out/bin/cpp
 
+      # Move libclang to 'lib' output
+      moveToOutput "lib/libclang.*" "$lib"
+
       mkdir -p $python/bin $python/share/clang/
       mv $out/bin/{git-clang-format,scan-view} $python/bin
       if [ -e $out/bin/set-xcode-analyzer ]; then
         mv $out/bin/set-xcode-analyzer $python/bin
       fi
       mv $out/share/clang/*.py $python/share/clang
-
       rm $out/bin/c-index-test
     ''
     + stdenv.lib.optionalString enableManpages ''
@@ -80,7 +82,6 @@ let
     enableParallelBuilding = true;
 
     passthru = {
-      lib = self; # compatibility with gcc, so that `stdenv.cc.cc.lib` works on both
       isClang = true;
       inherit llvm;
     } // stdenv.lib.optionalAttrs stdenv.isLinux {

--- a/pkgs/development/compilers/llvm/5/default.nix
+++ b/pkgs/development/compilers/llvm/5/default.nix
@@ -34,6 +34,7 @@ let
     llvm = overrideManOutput llvm;
     clang-unwrapped = overrideManOutput clang-unwrapped;
 
+    libclang = self.clang-unwrapped.lib;
     llvm-manpages = lowPrio self.llvm.man;
     clang-manpages = lowPrio self.clang-unwrapped.man;
 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -365,7 +365,7 @@ in rec {
       xz.out xz.bin libcxx libcxxabi gmp.out gnumake findutils bzip2.out
       bzip2.bin llvmPackages.llvm llvmPackages.llvm.lib zlib.out zlib.dev libffi.out coreutils ed diffutils gnutar
       gzip ncurses.out ncurses.dev ncurses.man gnused bash gawk
-      gnugrep llvmPackages.clang-unwrapped patch pcre.out gettext
+      gnugrep llvmPackages.clang-unwrapped llvmPackages.clang-unwrapped.lib patch pcre.out gettext
       binutils-raw.bintools binutils binutils.bintools
       cc.expand-response-params
     ]) ++ (with pkgs.darwin; [


### PR DESCRIPTION
###### Motivation for this change

This should make it easier to depend on libclang without shadowing clang/clang++ on darwin.

/cc @copumpkin @Ericson2314 

Still needs testing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
