### PR TITLE
icesl: init at 2.1.10

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -309,6 +309,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     free      = false;
   };
 
+  inria-icesl = {
+    fullName = "INRIA Non-Commercial License Agreement for IceSL";
+    url      = "http://shapeforge.loria.fr/icesl/EULA_IceSL_binary.pdf";
+    free     = false;
+  };
+
   ipa = spdx {
     spdxId = "IPA";
     fullName = "IPA Font License";

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -421,6 +421,7 @@
   meisternu = "Matt Miemiec <meister@krutt.org>";
   metabar = "Celine Mercier <softs@metabarcoding.org>";
   mgdelacroix = "Miguel de la Cruz <mgdelacroix@gmail.com>";
+  mgttlinger = "Merlin Göttlinger <megoettlinger@gmail.com";
   mguentner = "Maximilian Güntner <code@klandest.in>";
   mic92 = "Jörg Thalheim <joerg@thalheim.io>";
   michaelpj = "Michael Peyton Jones <michaelpj@gmail.com>";

--- a/pkgs/applications/misc/icesl/default.nix
+++ b/pkgs/applications/misc/icesl/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, fetchzip, patchelf, freeglut, libXmu, libXi, libX11, libICE, mesa, libSM, libXext, dialog, makeWrapper }:
+let
+  lpath = stdenv.lib.makeLibraryPath [ libXmu libXi libX11 freeglut libICE mesa libSM libXext ];
+in
+stdenv.mkDerivation rec {
+  name = "iceSL-${version}";
+  version = "2.1.10";
+
+  src =  if stdenv.system == "x86_64-linux" then fetchzip {
+    url = "https://gforge.inria.fr/frs/download.php/file/37268/icesl${version}-amd64.zip";
+    sha256 = "0dv3mq6wy46xk9blzzmgbdxpsjdaxid3zadfrysxlhmgl7zb2cn2";
+  } else if stdenv.system == "i686-linux" then fetchzip {
+    url = "https://gforge.inria.fr/frs/download.php/file/37267/icesl${version}-i386.zip";
+    sha256 = "0sl54fsb2gz6dy0bwdscpdq1ab6ph5b7zald3bwzgkqsvna7p1jr";
+  } else throw "Unsupported architecture";
+
+  buildInputs = [ makeWrapper ];
+  installPhase = ''
+    cp -r ./ $out
+    mkdir $out/oldbin
+    mv $out/bin/IceSL-slicer $out/oldbin/IceSL-slicer
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${lpath}" \
+      $out/oldbin/IceSL-slicer
+    makeWrapper $out/oldbin/IceSL-slicer $out/bin/icesl --prefix PATH : ${dialog}/bin
+  '';
+
+  meta = with lib; {
+    description = "IceSL is a GPU-accelerated procedural modeler and slicer for 3D printing.";
+    homepage = http://shapeforge.loria.fr/icesl/index.html;
+    license = licenses.inria-icesl;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = with maintainers; [ mgttlinger ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14824,6 +14824,8 @@ with pkgs;
 
   gpg-mdp = callPackage ../applications/misc/gpg-mdp { };
 
+  icesl = callPackage ../applications/misc/icesl { };
+
   keepassx = callPackage ../applications/misc/keepassx { };
   keepassx2 = callPackage ../applications/misc/keepassx/2.0.nix { };
   keepassxc = libsForQt5.callPackage ../applications/misc/keepassx/community.nix { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

