### PR TITLE
xkbmon: init at 0.1

### DIFF
--- a/pkgs/applications/misc/xkbmon/default.nix
+++ b/pkgs/applications/misc/xkbmon/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, libX11 }:
+
+stdenv.mkDerivation rec {
+  name = "xkbmon-${version}";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "xkbmon";
+    repo = "xkbmon";
+    rev = version;
+    sha256 = "1smyqsd9cpbzqaplm221a8mq0nham6rg6hjsm9g5gph94xmk6d67";
+  };
+
+  buildInputs = [ libX11 ];
+
+  installPhase = "install -D -t $out/bin xkbmon";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/xkbmon/xkbmon;
+    description = "Command-line keyboard layout monitor for X11";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17730,6 +17730,8 @@ with pkgs;
 
   xkbset = callPackage ../tools/X11/xkbset { };
 
+  xkbmon = callPackage ../applications/misc/xkbmon { };
+
   win-spice = callPackage ../applications/virtualization/driver/win-spice { };
   win-virtio = callPackage ../applications/virtualization/driver/win-virtio { };
   win-qemu = callPackage ../applications/virtualization/driver/win-qemu { };


### PR DESCRIPTION
###### Motivation for this change

Add [`xkbmon`](https://github.com/xkbmon/xkbmon), a command-line keyboard layout monitor for X11.

Features:
- real-time monitoring with zero CPU usage
- output layout in lower, upper or camel case

It can easily be used as a [keyboard layout applet in the `tint2`](https://gitlab.com/o9000/tint2/wikis/ThirdPartyApplets#keyboard-layout) panel.

![tint2](https://user-images.githubusercontent.com/1217934/34496733-6f92312e-efd9-11e7-8664-0cf56946433c.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).