### PR TITLE
Init thunderbolt at 0.9.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -581,6 +581,7 @@
   ryanartecona = "Ryan Artecona <ryanartecona@gmail.com>";
   ryansydnor = "Ryan Sydnor <ryan.t.sydnor@gmail.com>";
   ryantm = "Ryan Mulligan <ryan@ryantm.com>";
+  ryantrinkle = "Ryan Trinkle <ryan.trinkle@gmail.com>";
   rybern = "Ryan Bernstein <ryan.bernstein@columbia.edu>";
   rycee = "Robert Helgesson <robert@rycee.net>";
   ryneeverett = "Ryne Everett <ryneeverett@gmail.com>";

--- a/pkgs/os-specific/linux/thunderbolt/default.nix
+++ b/pkgs/os-specific/linux/thunderbolt/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, boost
+, cmake
+, fetchFromGitHub
+, pkgconfig
+, txt2tags
+}:
+
+stdenv.mkDerivation rec {
+  name = "thunderbolt-${version}";
+  version = "0.9.2";
+  src = fetchFromGitHub {
+    owner = "01org";
+    repo = "thunderbolt-software-user-space";
+    rev = "1ae06410180320a5d0e7408a8d1a6ae2aa443c23";
+    sha256 = "03yk419gj0767lpk6zvla4jx3nx56zsg4x4adl4nd50xhn409rcc";
+  };
+
+  buildInputs = [
+    boost
+    cmake
+    pkgconfig
+    txt2tags
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE='Release'"
+    "-DUDEV_BIN_DIR=$out/bin"
+    "-DUDEV_RULES_DIR=$out/udev"
+  ];
+
+  meta = {
+    description = "Thunderbolt(TM) user-space components";
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.ryantrinkle ];
+    homepage = https://01.org/thunderbolt-sw;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17111,6 +17111,8 @@ with pkgs;
     enableGTK3 = true;
   };
 
+  thunderbolt = callPackage ../os-specific/linux/thunderbolt {};
+
   thunderbird-bin = callPackage ../applications/networking/mailreaders/thunderbird-bin {
     gconf = pkgs.gnome2.GConf;
     inherit (pkgs.gnome2) libgnome libgnomeui;


### PR DESCRIPTION
###### Motivation for this change

Add package for [thunderbolt userspace utilities](https://github.com/01org/thunderbolt-software-user-space).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

