### PR TITLE
Improve Tiny Tiny RSS service

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -301,7 +301,6 @@
       pykms = 282;
       kodi = 283;
       restya-board = 284;
-      tt_rss = 285;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -571,7 +570,6 @@
       pykms = 282;
       kodi = 283;
       restya-board = 284;
-      tt_rss = 285;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -301,6 +301,7 @@
       pykms = 282;
       kodi = 283;
       restya-board = 284;
+      tt_rss = 285;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -570,6 +571,7 @@
       pykms = 282;
       kodi = 283;
       restya-board = 284;
+      tt_rss = 285;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -479,7 +479,6 @@ let
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
             fastcgi_pass unix:${phpfpmSocketName};
             fastcgi_index index.php;
-            fastcgi_param SCRIPT_FILENAME ${cfg.root}/$fastcgi_script_name;
           '';
         };
       };

--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -557,6 +557,20 @@ let
         after = ["network.target" "${dbService}"];
     };
 
+    services.mysql = optionalAttrs (cfg.database.type == "mysql") {
+      enable = true;
+      package = mkDefault pkgs.mariadb;
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.user;
+          ensurePermissions = {
+            "${cfg.database.name}.*" = "ALL PRIVILEGES";
+          };
+        }
+      ];
+    };
+
     users = optionalAttrs (cfg.user == "tt_rss") {
       extraUsers = singleton {
         name = "tt_rss";

--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -99,8 +99,8 @@ let
 
       user = mkOption {
         type = types.str;
-        default = "nginx";
-        example = "nginx";
+        default = "tt_rss";
+        example = "tt_rss";
         description = ''
           User account under which both the update daemon and the web-application run.
         '';
@@ -553,5 +553,18 @@ let
         requires = ["${dbService}"];
         after = ["network.target" "${dbService}"];
     };
+
+    users = optionalAttrs (cfg.user == "tt_rss") {
+      extraUsers = singleton {
+        name = "tt_rss";
+        group = "tt_rss";
+        uid = config.ids.uids.tt_rss;
+      };
+      extraGroups = singleton {
+        name = "tt_rss";
+        gid = config.ids.gids.tt_rss;
+      };
+    };
+
   };
 }

--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -466,24 +466,27 @@ let
       '';
     };
 
-    services.nginx.virtualHosts = mkIf (cfg.virtualHost != null) {
-      "${cfg.virtualHost}" = {
-        root = "${cfg.root}";
+    services.nginx = {
+      enable = true;
+      # NOTE: No configuration is done if not using virtual host
+      virtualHosts = mkIf (cfg.virtualHost != null) {
+        "${cfg.virtualHost}" = {
+          root = "${cfg.root}";
 
-        locations."/" = {
-          index = "index.php";
-        };
+          locations."/" = {
+            index = "index.php";
+          };
 
-        locations."~ \.php$" = {
-          extraConfig = ''
-            fastcgi_split_path_info ^(.+\.php)(/.+)$;
-            fastcgi_pass unix:${phpfpmSocketName};
-            fastcgi_index index.php;
-          '';
+          locations."~ \.php$" = {
+            extraConfig = ''
+              fastcgi_split_path_info ^(.+\.php)(/.+)$;
+              fastcgi_pass unix:${phpfpmSocketName};
+              fastcgi_index index.php;
+            '';
+          };
         };
       };
     };
-
 
     systemd.services.tt-rss = let
       dbService = if cfg.database.type == "pgsql" then "postgresql.service" else "mysql.service";

--- a/pkgs/servers/tt-rss/default.nix
+++ b/pkgs/servers/tt-rss/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, fetchgit }:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "tt-rss-${version}";
-  version = "17.4";
+  version = "2018-01-05";
+  rev = "c30f5e18119d1935e8fe6d422053b127e8f4f1b3";
 
-  src = fetchgit {
-    url = "https://git.tt-rss.org/git/tt-rss.git";
-    rev = "refs/tags/${version}";
-    sha256 = "07ng21n4pva56cxnxkzd6vzs381zn67psqpm51ym5wnl644jqh08";
+  src = fetchurl {
+    url = "https://git.tt-rss.org/git/tt-rss/archive/${rev}.tar.gz";
+    sha256 = "18pc1l0dbjr7d5grcrb70y6j7cr2zb9575yqmy6zfwzrlvw0pa0l";
   };
 
   installPhase = ''
@@ -19,8 +19,7 @@ stdenv.mkDerivation rec {
     description = "Web-based news feed (RSS/Atom) aggregator";
     license = licenses.gpl2Plus;
     homepage = http://tt-rss.org;
-    maintainers = with maintainers; [ zohl ];
+    maintainers = with maintainers; [ globin zohl ];
     platforms = platforms.all;
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

Tiny Tiny RSS service was broken, see: https://github.com/NixOS/nixpkgs/issues/27048

This pull request fixes that and also makes a few small improvements to the service, in my opinion. Comments and feedback welcome.

To activate Tiny Tiny RSS service, this suffices:
```
    services.tt-rss = {
      enable = true;
      virtualHost = "domain.com";
      selfUrlPath = "http://domain.com/";
      database.type = "mysql";
    };
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

