### PR TITLE
osrm-backend: 5.14.1 -> 5.14.3

### DIFF
--- a/pkgs/servers/osrm-backend/default.nix
+++ b/pkgs/servers/osrm-backend/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "osrm-backend-${version}";
-  version = "5.14.1";
+  version = "5.14.3";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner  = "Project-OSRM";
     repo   = "osrm-backend";
-    sha256 = "0n7fpm8m5r93dxciagp2n8ij1wg483yb9srbzdzjqf1zzyh637sz";
+    sha256 = "1ajgybjx7g6qzddavab8bj7il7wn5wy24nivjj5rk84mfbi71s5v";
   };
 
   buildInputs = [ cmake pkgconfig bzip2 libxml2 libzip boost lua luabind tbb expat];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

