### PR TITLE
ghc: bootstrap 8.2.2 with 8.2.1-binary.

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -72,7 +72,7 @@ in rec {
       sphinx = pkgs.python27Packages.sphinx;
     };
     ghc822 = callPackage ../development/compilers/ghc/8.2.2.nix rec {
-      bootPkgs = packages.ghc7103Binary;
+      bootPkgs = packages.ghc821Binary;
       inherit (bootPkgs) hscolour alex happy;
       inherit buildPlatform targetPlatform;
       sphinx = pkgs.python3Packages.sphinx;


### PR DESCRIPTION
###### Motivation for this change

8.2.1-binary will be necessary to bootstrap `aarch64-linux` as 7.10.3-binary is not supported on that platform.

###### Things done

I have tested this on `x86_64-linux` by bootstrapping GHC and building a subset of `haskellPackages`. `armv7l-linux` and `aarch64-linux` still cannot bootstrap GHC due to unrelated issues, but as this is a prerequisite and it will cause a rebuild of `haskellPackages`, it might be a good idea to check it in before the other changes needed to get those platforms working, especially considering it's a straightforward change that shouldn't need any real review.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

