### PR TITLE
rssguard: 3.4.2 -> 3.5.5

### DIFF
--- a/pkgs/applications/networking/feedreaders/rssguard/default.nix
+++ b/pkgs/applications/networking/feedreaders/rssguard/default.nix
@@ -1,21 +1,26 @@
-{ stdenv, fetchgit, qmake, qtwebengine, qttools, wrapGAppsHook }:
+{ stdenv, fetchFromGitHub, qmake, qtwebengine, qttools, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
-  name = "rssguard-${version}";
-  version = "3.4.2";
+  name = "${pname}-${version}";
+  pname = "rssguard";
+  version = "3.5.5";
 
-  src = fetchgit {
-    url = https://github.com/martinrotter/rssguard;
-    rev = "refs/tags/${version}";
-    sha256 = "0iy0fd3qr2dm0pc6xr7sin6cjfxfa0pxhxiwzs55dhsdk9zir62s";
-    # Submodules are required only for Windows (and one of them is a huge binary
-    # package ~400MB). See project wiki for more details.
-    fetchSubmodules = false;
+  src = fetchFromGitHub {
+    owner = "martinrotter";
+    repo = pname;
+    rev = version;
+    sha256 = "0swjh664y1yqr1rn3ym2kicyx7r97ypr4qf7qrjl4a5q1spzsv48";
   };
 
   buildInputs =  [ qtwebengine qttools ];
   nativeBuildInputs = [ qmake wrapGAppsHook ];
   qmakeFlags = [ "CONFIG+=release" ];
+
+  # FIXME: This shouldn't be needed after 3.5.5.
+  # See: https://github.com/martinrotter/rssguard/issues/175
+  preConfigure = ''
+    lrelease rssguard.pro
+  '';
 
   meta = with stdenv.lib; {
     description = "Simple RSS/Atom feed reader with online synchronization";


### PR DESCRIPTION
###### Motivation for this change

Update RSS Guard.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

