### PR TITLE
deepin-gtk-theme: 17.10.4 -> 17.10.5

### DIFF
--- a/pkgs/misc/themes/deepin/default.nix
+++ b/pkgs/misc/themes/deepin/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "deepin-gtk-theme-${version}";
-  version = "17.10.4";
+  version = "17.10.5";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = "deepin-gtk-theme";
     rev = version;
-    sha256 = "1hb0y72fzmcj2yl6q7mbc0c7yxkd1qgnyw4vixdqxnxk2c82sxzw";
+    sha256 = "0ff1yg4gz4p7nd0qg3dcbsiw8yqlvqccm55kxi998w8j1wrg6pq3";
   };
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).