### PR TITLE
Correct derivation of pthreads on mingw64

### DIFF
--- a/pkgs/development/pharo/vm/build-vm.nix
+++ b/pkgs/development/pharo/vm/build-vm.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     else if stdenv.isLinux && stdenv.isx86_64  then "linux64x64"
     else if stdenv.isDarwin && stdenv.isi686   then "macos32x86"
     else if stdenv.isDarwin && stdenv.isx86_64 then "macos64x64"
-    else abort "Unsupported platform: only Linux/Darwin x86/x64 are supported.";
+    else throw "Unsupported platform: only Linux/Darwin x86/x64 are supported.";
 
   # Shared data (for the sources file)
   pharo-share = import ./share.nix { inherit stdenv fetchurl unzip; };
@@ -106,7 +106,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ bash unzip glibc openssl gcc48 mesa freetype xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share libuuid ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Clean and innovative Smalltalk-inspired environment";
     longDescription = ''
       Pharo's goal is to deliver a clean, innovative, free open-source
@@ -122,8 +122,8 @@ stdenv.mkDerivation rec {
       packaging (ppa:pharo/stable)' project.
     '';
     homepage = http://pharo.org;
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.lukego ];
-    platforms = [ "i686-linux" "x86_64-linux" "i686-darwin" "x86_64-darwin" ];
+    license = licenses.mit;
+    maintainers = [ maintainers.lukego ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/os-specific/windows/mingw-w64/pthreads.nix
+++ b/pkgs/os-specific/windows/mingw-w64/pthreads.nix
@@ -1,9 +1,9 @@
-{ stdenvNoCC, callPackage }:
+{ stdenv, callPackage }:
 
 let
   inherit (callPackage ./common.nix {}) name src;
 
-in stdenvNoCC.mkDerivation {
+in stdenv.mkDerivation {
   name = name + "-pthreads";
   inherit src;
 

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -41,6 +41,7 @@ let
     libtool = nativePlatforms;
     libunistring = nativePlatforms;
     windows.wxMSW = nativePlatforms;
+    windows.mingw_w64_pthreads = nativePlatforms;
   };
 
   darwinCommon = {


### PR DESCRIPTION
The C compiler is needed -- copy and paste error from the headers
derivation?

###### Motivation for this change

Mingw64-pthreads fails to configure currently as it can not find the C compiler. This correct the defect.

###### Things done

https://hydra.nixos.org/eval/1423028

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

