### PR TITLE
 boost: Do not force numpy support from 1.65

### DIFF
--- a/pkgs/development/libraries/boost/1.65.nix
+++ b/pkgs/development/libraries/boost/1.65.nix
@@ -9,6 +9,4 @@ callPackage ./generic.nix (args // rec {
     sha256 = "9807a5d16566c57fd74fb522764e0b134a8bbe6b6e8967b83afefd30dcd3be81";
   };
 
-  enableNumpy = args.enableNumpy or true;
-
 })

--- a/pkgs/development/libraries/boost/1.66.nix
+++ b/pkgs/development/libraries/boost/1.66.nix
@@ -9,6 +9,4 @@ callPackage ./generic.nix (args // rec {
     sha256 = "5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9";
   };
 
-  enableNumpy = args.enableNumpy or true;
-
 })

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -11,7 +11,7 @@
 , enableShared ? !(hostPlatform.libc == "msvcrt") # problems for now
 , enableStatic ? !enableShared
 , enablePython ? hostPlatform == buildPlatform
-, enableNumpy ? false
+, enableNumpy ? enablePython && stdenv.lib.versionAtLeast version "1.65"
 , taggedLayout ? ((enableRelease && enableDebug) || (enableSingleThreaded && enableMultiThreaded) || (enableShared && enableStatic))
 , patches ? []
 , mpi ? null


### PR DESCRIPTION
###### Motivation for this change

The reason is that if cross compiling (or for other reasons) python bindings as a whole are turned off. Those two lines then trigger assertion errors unless manually overridden for cross compilation.

This way:

 1. The `enableNumpy` default respects the `enablePython deafult.
 2. Cross works by default
 3. Absurd manual overrides still break as they should
 4. The `>= 1.65` logic is direct and not a maintaince gotcha.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

