### PR TITLE
haskellPackages.lzma: loosen version bounds for test dependencies

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -566,7 +566,7 @@ self: super: {
   # https://github.com/alphaHeavy/lzma-enumerator/issues/3
   lzma-enumerator = dontCheck super.lzma-enumerator;
 
-  # Unpin some versions
+  # https://github.com/haskell-hvr/lzma/issues/8
   lzma = appendPatch super.lzma ./patches/lzma-tests.patch;
 
   # https://github.com/BNFC/bnfc/issues/140

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -566,6 +566,9 @@ self: super: {
   # https://github.com/alphaHeavy/lzma-enumerator/issues/3
   lzma-enumerator = dontCheck super.lzma-enumerator;
 
+  # Unpin some versions
+  lzma = appendPatch super.lzma ./patches/lzma-tests.patch;
+
   # https://github.com/BNFC/bnfc/issues/140
   BNFC = dontCheck super.BNFC;
 

--- a/pkgs/development/haskell-modules/patches/lzma-tests.patch
+++ b/pkgs/development/haskell-modules/patches/lzma-tests.patch
@@ -1,0 +1,13 @@
+--- a/lzma.cabal
++++ b/lzma.cabal
+@@ -70,8 +70,8 @@ test-suite lzma-tests
+                      , base
+                      , bytestring
+   -- additional dependencies that require version bounds
+-  build-depends:       HUnit                      >= 1.2      && <1.4
+-                     , QuickCheck                 >= 2.8      && <2.9
++  build-depends:       HUnit                      >= 1.2      && <2
++                     , QuickCheck                 >= 2.8      && <3
+                      , tasty                      >= 0.10     && <0.12
+                      , tasty-hunit                == 0.9.*
+                      , tasty-quickcheck           >= 0.8.3.2  && < 0.9


### PR DESCRIPTION
###### Motivation for this change

The Haskell `lzma` library refuses to build, complaining that HUnit and QuickCheck are outside of the given version bounds.

###### Things done

One option would be to disable the unit tests, but the tests pass just fine with the versions in nixpkgs, so I just patched the cabal file to loosen the bounds.

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

