### PR TITLE
sc-controller: init at 0.4.0.1

### DIFF
--- a/pkgs/misc/drivers/sc-controller/default.nix
+++ b/pkgs/misc/drivers/sc-controller/default.nix
@@ -1,0 +1,62 @@
+{ lib, buildPythonApplication, fetchFromGitHub, wrapGAppsHook
+, gtk3, gobjectIntrospection, libappindicator-gtk3, librsvg
+, evdev, pygobject3, pylibacl, pytest
+, linuxHeaders
+, libX11, libXext, libXfixes, libusb1
+}:
+
+buildPythonApplication rec {
+  pname = "sc-controller";
+  version = "0.4.0.1";
+
+  src = fetchFromGitHub {
+    owner = "kozec";
+    repo = "sc-controller";
+    rev = "v${version}";
+    sha256 = "0vhgiqg4r4bnn004ql80rvi23y05wlax80sj8qsr91pvqsxwv3yl";
+  };
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  buildInputs = [ gtk3 gobjectIntrospection libappindicator-gtk3 librsvg ];
+
+  propagatedBuildInputs = [ evdev pygobject3 pylibacl ];
+
+  checkInputs = [ pytest ];
+
+  postPatch = ''
+    substituteInPlace scc/paths.py --replace sys.prefix "'$out'"
+    substituteInPlace scc/uinput.py --replace /usr/include ${linuxHeaders}/include
+  '';
+
+  LD_LIBRARY_PATH = lib.makeLibraryPath [ libX11 libXext libXfixes libusb1 ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "$LD_LIBRARY_PATH")
+    # gdk-pixbuf setup hook can not choose between propagated librsvg
+    # and our librsvg with GObject introspection.
+    GDK_PIXBUF_MODULE_FILE=$(echo ${librsvg}/lib/gdk-pixbuf-2.0/*/loaders.cache)
+  '';
+
+  postFixup = ''
+    (
+      # scc runs these scripts as programs. (See find_binary() in scc/tools.py.)
+      cd $out/lib/python*/site-packages/scc/x11
+      patchPythonScript scc-autoswitch-daemon.py
+      patchPythonScript scc-osd-daemon.py
+    )
+  '';
+
+  checkPhase = ''
+    PYTHONPATH=. py.test
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/kozec/sc-controller;
+    # donations: https://www.patreon.com/kozec
+    description = "User-mode driver and GUI for Steam Controller and other controllers";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.orivej ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19754,6 +19754,11 @@ with pkgs;
 
   sane-frontends = callPackage ../applications/graphics/sane/frontends.nix { };
 
+  sc-controller = pythonPackages.callPackage ../misc/drivers/sc-controller {
+    inherit libusb1; # Shadow python.pkgs.libusb1.
+    librsvg = librsvg.override { enableIntrospection = true; };
+  };
+
   sct = callPackage ../tools/X11/sct {};
 
   seafile-shared = callPackage ../misc/seafile-shared { };


### PR DESCRIPTION
###### Motivation for this change

This driver is more mature than the one added in #33201, and it provides GUI configuration and overlays for Steam Controller and generic gamepads.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).