### PR TITLE
betaflight: init at 3.2.3

### DIFF
--- a/pkgs/development/stm32/betaflight/default.nix
+++ b/pkgs/development/stm32/betaflight/default.nix
@@ -1,0 +1,65 @@
+{ stdenv, fetchFromGitHub
+, gcc-arm-embedded, python2
+, skipTargets ? [
+  # These targets do not build for various unexplored reasons
+  # TODO ... fix them
+  "AFROMINI"
+  "ALIENWHOOP"
+  "BEEBRAIN"
+  "CJMCU"
+  "FRSKYF3"
+]}:
+
+let
+
+  version = "3.2.3";
+
+in stdenv.mkDerivation rec {
+
+  name = "betaflight-${version}";
+
+  src = fetchFromGitHub {
+    owner = "betaflight";
+    repo = "betaflight";
+    rev = "v${version}";
+    sha256 = "0vbjyxfjxgpaiiwvj5bscrlfikzp3wnxpmc4sxcz5yw5mwb9g428";
+  };
+
+  buildInputs = [
+    gcc-arm-embedded
+    python2
+  ];
+
+  postPatch = ''
+    sed -ri "s/REVISION.*=.*git log.*/REVISION = ${builtins.substring 0 9 src.rev}/" Makefile # Let's not require git in shell
+    sed -ri "s/binary hex/hex/" Makefile # No need for anything besides .hex
+  '';
+
+  enableParallelBuilding = true;
+
+  preBuild = ''
+    buildFlagsArray=(
+      "SKIP_TARGETS=${toString skipTargets}"
+      "GCC_REQUIRED_VERSION=$(arm-none-eabi-gcc -dumpversion)"
+      all
+    )
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp obj/*.hex $out
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Flight controller software (firmware) used to fly multi-rotor craft and fixed wing craft";
+    homepage = https://github.com/betaflight/betaflight;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ elitak ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6998,6 +6998,8 @@ with pkgs;
 
   avr8burnomat = callPackage ../development/misc/avr8-burn-omat { };
 
+  betaflight = callPackage ../development/stm32/betaflight { };
+
   sourceFromHead = callPackage ../build-support/source-from-head-fun.nix {};
 
   ecj = callPackage ../development/eclipse/ecj { };


### PR DESCRIPTION
###### Motivation for this change

This derivation builds the firmware for as many targets as possible as `.hex` files in `result/`(should they be placed in some subdirectory?). The tool used to flash this is a chrome plugin, which I may add a derivation for later, but for now is available in the Google chrome web store.

I wasn't able to test it, but this may build okay on windows, so possibly, `meta.platforms` should be changed to `x86`.

Maybe this should go in a directory other than `pkgs/development/stm32`? I have plans to add other branches of flight-controller firmware into there.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested flashing a target in ./result/*.hex
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

