### PR TITLE
platformio: 3.4.1 -> 3.5.0

### DIFF
--- a/pkgs/development/arduino/platformio/chrootenv.nix
+++ b/pkgs/development/arduino/platformio/chrootenv.nix
@@ -18,8 +18,8 @@ buildFHSUserEnv {
       python27Packages.setuptools
       python27Packages.pip
       python27Packages.bottle
-      zlib
       python27Packages.platformio
+      zlib
     ]);
 
   meta = with stdenv.lib; {
@@ -29,6 +29,10 @@ buildFHSUserEnv {
     license = licenses.asl20;
     platforms = with platforms; linux;
   };
+
+  extraInstallCommands = ''
+    ln -s $out/bin/platformio $out/bin/pio
+  '';
 
   runScript = "platformio";
 }

--- a/pkgs/development/python-modules/platformio/default.nix
+++ b/pkgs/development/python-modules/platformio/default.nix
@@ -8,12 +8,12 @@ buildPythonPackage rec {
   disabled = isPy3k || isPyPy;
 
   pname = "platformio";
-  version="3.4.1";
+  version="3.5.0";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1b4lba672l851sv1xwc320xbh46x7hx4ms6whc0k37hxkxj0nwm2";
+    sha256 = "0gy13cwp0i97lgjd8hh8kh9cswxh53x4cx2sq5b7d7vv8kd7bh6c";
   };
 
   propagatedBuildInputs =  [


### PR DESCRIPTION
###### Motivation for this change
i wanted to use an esp32 so i needed to update platformio. it needs a specific version of lru_cache because arrow 0.12.0 needs a specific version it seems. also the wrapper function had to be changed as it was not linking to the lru package correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

