### PR TITLE
 haskell generic-builder: Fix Dependencies

### DIFF
--- a/pkgs/build-support/setup-hooks/haskell-deps.bash
+++ b/pkgs/build-support/setup-hooks/haskell-deps.bash
@@ -1,0 +1,73 @@
+set -u
+
+(( "$hostOffset" < 0 )) || return 0
+
+function accum_haskell_deps () {
+    case $depHostOffset in
+        -1) local role='_FOR_BUILD' ;;
+        0)  local role='' ;;
+        1)  local role='_FOR_TARGET' ;;
+        *)  return -1 ;; # should already be caught
+    esac
+
+    local db="$1/lib/@ghcName@/package.conf.d"
+    if [[ -d "$db" ]]; then
+        eval "HS_PKG_DBS${role}"'+=("$db")'
+    else
+        if [ -d "$1/include" ]; then
+            eval "HS_FOREIGN_INCDIRS${role}"'+=("$1/include")'
+        fi
+        if [ -d "$1/lib" ]; then
+            eval "HS_FOREIGN_LIBDIRS${role}"'+=("$1/lib")'
+        fi
+    fi
+}
+
+
+function cabal_deps() {
+    local offset="$1"
+
+    case $offset in
+        -1) local role='_FOR_BUILD' ;;
+        0)  local role='' ;;
+        1)  local role='_FOR_TARGET' ;;
+        *)  return -1 ;; # should already be caught
+    esac
+
+    local db inc lib
+
+    local -na dbs="HS_PKG_DBS${role}"
+    local -na incs="HS_FOREIGN_INCDIRS${role}"
+    local -na libs="HS_FOREIGN_LIBDIRS${role}"
+
+    for db in "${dbs[@]}"; do
+        export CABAL_CONFIG${role}+=" --@pkgdbFlag@=$db"
+    done
+    for inc in "${incs[@]}"; do
+        export CABAL_CONFIG${role}+=" --extra-include-dirs=$inc"
+    done
+    for lib in "${libs[@]}"; do
+        export CABAL_CONFIG${role}+=" --extra-lib-dirs=$lib"
+    done
+}
+
+preHooks+=("cabal_deps $targetOffset")
+
+
+case $targetOffset in
+    -1) role='_FOR_BUILD' ;;
+    0)  role='' ;;
+    1)  role='_FOR_TARGET' ;;
+    *)  echo "cabal_add_deps: Error: used as improper sort of dependency" >2;
+        return 1 ;;
+esac
+
+addEnvHooks "$targetOffset" accum_haskell_deps
+
+declare -a HS_PKG_DBS${role}
+declare -a HS_FOREIGN_INCDIRS${role}
+declare -a HS_FOREIGN_LIBDIRS${role}
+
+declare CABAL_DEPS${role}
+
+unset role

--- a/pkgs/build-support/setup-hooks/no-cc-deps.sh
+++ b/pkgs/build-support/setup-hooks/no-cc-deps.sh
@@ -1,0 +1,19 @@
+# Prevent ccWrapper_addCVars from firing
+set -u
+
+(( "$hostOffset" < 0 )) || return 0
+
+declare -na hooksVar="${pkgHookVarVars[$targetOffset]}"
+
+for hooks in "${hooksVar[@]}"; do
+    declare -na hooks
+    for i in "${!hooks[@]}"; do
+        if [[ "${hooks[i]}" == "ccWrapper_addCVars" ]]; then
+            hooks[i]=true
+        fi
+        unset i
+    done
+    unset hook
+done
+
+unset hookVar

--- a/pkgs/build-support/setup-hooks/no-ld-deps.sh
+++ b/pkgs/build-support/setup-hooks/no-ld-deps.sh
@@ -1,0 +1,19 @@
+# Prevent bintoolsWrapper_addLDVar from firing
+set -u
+
+(( "$hostOffset" < 0 )) || return 0
+
+declare -na hooksVar="${pkgHookVarVars[$targetOffset]}"
+
+for hooks in "${hooksVar[@]}"; do
+    declare -na hooks
+    for i in "${!hooks[@]}"; do
+        if [[ "${hooks[i]}" == "bintoolsWrapper_addLDVars" ]]; then
+            hooks[i]=true
+        fi
+        unset i
+    done
+    unset hook
+done
+
+unset hookVar

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -254,22 +254,7 @@ stdenvNoCC.mkDerivation ({
         configureFlags+=" --extra-lib-dirs=$p/lib"
       fi
     done
-  '' + (optionalString stdenv.isDarwin ''
-    # Work around a limit in the macOS Sierra linker on the number of paths
-    # referenced by any one dynamic library:
-    #
-    # Create a local directory with symlinks of the *.dylib (macOS shared
-    # libraries) from all the dependencies.
-    local dynamicLinksDir="$out/lib/links"
-    mkdir -p $dynamicLinksDir
-    for d in $(grep dynamic-library-dirs "$packageConfDir/"*|awk '{print $2}'|sort -u); do
-      ln -s "$d/"*.dylib $dynamicLinksDir
-    done
-    # Edit the local package DB to reference the links directory.
-    for f in "$packageConfDir/"*.conf; do
-      sed -i "s,dynamic-library-dirs: .*,dynamic-library-dirs: $dynamicLinksDir," $f
-    done
-  '') + ''
+
     ${ghcCommand}-pkg --${packageDbFlag}="$packageConfDir" recache
 
     runHook postSetupCompilerEnvironment

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -98,28 +98,7 @@ symlinkJoin {
         makeWrapper ${ghc}/bin/$prg $out/bin/$prg --add-flags "${packageDBFlag}=${packageCfgDir}"
       fi
     done
-  '' + (lib.optionalString targetPlatform.isDarwin ''
-    # Work around a linker limit in macOS Sierra (see generic-builder.nix):
-    local packageConfDir="$out/lib/${ghc.name}/package.conf.d";
-    local dynamicLinksDir="$out/lib/links"
-    mkdir -p $dynamicLinksDir
-    # Clean up the old links that may have been (transitively) included by
-    # symlinkJoin:
-    rm -f $dynamicLinksDir/*
-    for d in $(grep dynamic-library-dirs $packageConfDir/*|awk '{print $2}'); do
-      ln -s $d/*.dylib $dynamicLinksDir
-    done
-    for f in $packageConfDir/*.conf; do
-      # Initially, $f is a symlink to a read-only file in one of the inputs
-      # (as a result of this symlinkJoin derivation).
-      # Replace it with a copy whose dynamic-library-dirs points to
-      # $dynamicLinksDir
-      cp $f $f-tmp
-      rm $f
-      sed "s,dynamic-library-dirs: .*,dynamic-library-dirs: $dynamicLinksDir," $f-tmp > $f
-      rm $f-tmp
-    done
-  '') + ''
+
     ${lib.optionalString hasLibraries "$out/bin/${ghcCommand}-pkg recache"}
     ${# ghcjs will read the ghc_libdir file when resolving plugins.
       lib.optionalString (isGhcjs && ghcLibdir != null) ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -286,6 +286,11 @@ with pkgs;
     inherit url;
   };
 
+  haskell-deps-hook = { ghcName, packageDbFlag }: {
+    name = "haskell-deps-hook";
+    substitutions = { inherit ghcName packageDbFlag; };
+  } ../build-support/setup-hooks/haskell-deps.bash;
+
   ld-is-cc-hook = makeSetupHook { name = "ld-is-cc-hook"; }
     ../build-support/setup-hooks/ld-is-cc-hook.sh;
 


### PR DESCRIPTION
###### Motivation for this change

The idea is that one can do `cabal configure $NIX_CABAL_FOREIGN_FLAGS` which ensure that Cabal knows about C headers and libs, but not the c compiler itself.

 - nativeGhc          -> depsBuildBuild
 - Setup.hs libraries -> nativeBuildInputs
 - other tools        -> nativeBuildInputs
 - libraries          -> (propagated)NativeBuildInputs

Also, I'm trying to start the process of smoothing over the differences between our builder and shell env.

 - Everyone gets tools
 - Everyone only accesses C through Cabal
 - No one gets extra `-system` or `-L` flags

I'd like to go even farther and 
 1. stop using `ghcWithPackages`
 2. pass `--with-package-db` to `./Setup` / `NIX_CABAL_FOREIGN_FLAGS`
 3. Only use the new db in the builder for the to-be-built package

`ghcWithPackages`, OTOH, should use a `cc-with-packages`, for a completely (cabal-install or stack)-free persistent environments. Granted, I don't know why one would want to not use either of these tools, but if `ghcWithPackages` continues to exist with the plan above, this gives it its own clear-cut and distinct niche.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


  
  