### PR TITLE
Flatpak

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -214,6 +214,7 @@
   ./services/desktops/accountsservice.nix
   ./services/desktops/dleyna-renderer.nix
   ./services/desktops/dleyna-server.nix
+  ./services/desktops/flatpak.nix
   ./services/desktops/geoclue2.nix
   ./services/desktops/pipewire.nix
   ./services/desktops/gnome3/at-spi2-core.nix

--- a/nixos/modules/services/desktops/flatpak.nix
+++ b/nixos/modules/services/desktops/flatpak.nix
@@ -6,6 +6,11 @@ with lib;
 let
   cfg = config.services.flatpak;
 in {
+  meta = {
+    doc = ./flatpak.xml;
+    maintainers = pkgs.flatpak.meta.maintainers;
+  };
+
   ###### interface
   options = {
     services.flatpak = {

--- a/nixos/modules/services/desktops/flatpak.nix
+++ b/nixos/modules/services/desktops/flatpak.nix
@@ -1,0 +1,28 @@
+# flatpak service.
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  ###### interface
+  options = {
+    services.flatpak = {
+      enable = mkEnableOption "flatpak";
+    };
+  };
+
+
+  ###### implementation
+  config = mkIf config.services.flatpak.enable {
+    environment.systemPackages = [ pkgs.flatpak ];
+
+    services.dbus.packages = [ pkgs.flatpak ];
+
+    systemd.packages = [ pkgs.flatpak ];
+
+    environment.variables.PATH = [
+      "$HOME/.local/share/flatpak/exports/bin"
+      "/var/lib/flatpak/exports/bin"
+    ];
+  };
+}

--- a/nixos/modules/services/desktops/flatpak.nix
+++ b/nixos/modules/services/desktops/flatpak.nix
@@ -3,26 +3,45 @@
 
 with lib;
 
-{
+let
+  cfg = config.services.flatpak;
+in {
   ###### interface
   options = {
     services.flatpak = {
       enable = mkEnableOption "flatpak";
+
+      extraPortals = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        description = ''
+          List of additional portals to add to path. Portals allow interaction
+          with system, like choosing files or taking screenshots. At minimum,
+          a desktop portal implementation should be listed. GNOME already
+          adds <package>xdg-desktop-portal-gtk</package>; for KDE, there
+          is <package>xdg-desktop-portal-kde</package>. Other desktop
+          environments will probably want to do the same.
+        '';
+      };
     };
   };
 
 
   ###### implementation
-  config = mkIf config.services.flatpak.enable {
+  config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.flatpak ];
 
-    services.dbus.packages = [ pkgs.flatpak ];
+    services.dbus.packages = [ pkgs.flatpak pkgs.xdg-desktop-portal ] ++ cfg.extraPortals;
 
-    systemd.packages = [ pkgs.flatpak ];
+    systemd.packages = [ pkgs.flatpak pkgs.xdg-desktop-portal ] ++ cfg.extraPortals;
 
-    environment.variables.PATH = [
-      "$HOME/.local/share/flatpak/exports/bin"
-      "/var/lib/flatpak/exports/bin"
-    ];
+    environment.variables = {
+      PATH = [
+        "$HOME/.local/share/flatpak/exports/bin"
+        "/var/lib/flatpak/exports/bin"
+      ];
+
+      XDG_DESKTOP_PORTAL_PATH = map (p: "${p}/share/xdg-desktop-portal/portals") cfg.extraPortals;
+    };
   };
 }

--- a/nixos/modules/services/desktops/flatpak.xml
+++ b/nixos/modules/services/desktops/flatpak.xml
@@ -1,0 +1,53 @@
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="module-services-flatpak">
+
+<title>Flatpak</title>
+
+<para><emphasis>Source:</emphasis> <filename>modules/services/desktop/flatpak.nix</filename></para>
+
+<para><emphasis>Upstream documentation:</emphasis> <link xlink:href="https://github.com/flatpak/flatpak/wiki"/></para>
+
+<para>Flatpak is a system for building, distributing, and running sandboxed desktop applications on Linux.</para>
+
+<para>
+  To enable Flatpak, add the following to your <filename>configuration.nix</filename>:
+
+  <programlisting>
+  <xref linkend="opt-services.flatpak.enable"/> = true;
+  </programlisting>
+</para>
+
+<para>
+  For the sandboxed apps to work correctly, desktop integration portals need to be installed. If you run GNOME, this will be handled automatically for you; in other cases, you will need to add something like the following to your <filename>configuration.nix</filename>:
+
+  <programlisting>
+  <xref linkend="opt-services.flatpak.extraPortals"/> = [ pkgs.xdg-desktop-portal-gtk ];
+  </programlisting>
+</para>
+
+<para>
+  Then, you will need to add a repository, for example, <link xlink:href="https://github.com/flatpak/flatpak/wiki">Flathub</link>, either using the following commands:
+
+  <programlisting>
+  flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+  flatpak update
+  </programlisting>
+
+  or by opening the <link xlink:href="https://flathub.org/repo/flathub.flatpakrepo">repository file</link> in GNOME Software.
+</para>
+
+<para>
+  Finally, you can search and install programs:
+
+  <programlisting>
+  flatpak search bustle
+  flatpak install flathub org.freedesktop.Bustle
+  flatpak run org.freedesktop.Bustle
+  </programlisting>
+
+  Again, GNOME Software offers graphical interface for these tasks.
+</para>
+</chapter>

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -120,6 +120,7 @@ in {
     services.xserver.libinput.enable = mkDefault true; # for controlling touchpad settings via gnome control center
     services.udev.packages = [ pkgs.gnome3.gnome-settings-daemon ];
     systemd.packages = [ pkgs.gnome3.vino ];
+    services.flatpak.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
 
     # If gnome3 is installed, build vim for gtk3 too.
     nixpkgs.config.vim.gui = "gtk3";

--- a/nixos/modules/system/boot/systemd-lib.nix
+++ b/nixos/modules/system/boot/systemd-lib.nix
@@ -2,9 +2,10 @@
 
 with lib;
 
-let cfg = config.systemd; in
-
-rec {
+let
+  cfg = config.systemd;
+  lndir = "${pkgs.xorg.lndir}/bin/lndir";
+in rec {
 
   shellEscape = s: (replaceChars [ "\\" ] [ "\\\\" ] s);
 
@@ -136,7 +137,13 @@ rec {
       for i in ${toString cfg.packages}; do
         for fn in $i/etc/systemd/${type}/* $i/lib/systemd/${type}/*; do
           if ! [[ "$fn" =~ .wants$ ]]; then
-            ln -s $fn $out/
+            if [[ -d "$fn" ]]; then
+              targetDir="$out/$(basename "$fn")"
+              mkdir -p "$targetDir"
+              ${lndir} "$fn" "$targetDir"
+            else
+              ln -s $fn $out/
+            fi
           fi
         done
       done
@@ -151,7 +158,7 @@ rec {
           if [ "$(readlink -f $i/$fn)" = /dev/null ]; then
             ln -sfn /dev/null $out/$fn
           else
-            mkdir $out/$fn.d
+            mkdir -p $out/$fn.d
             ln -s $i/$fn $out/$fn.d/overrides.conf
           fi
        else

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -399,6 +399,7 @@ in rec {
   tests.virtualbox = callSubTestsOnMatchingSystems ["x86_64-linux"] tests/virtualbox.nix {};
   tests.wordpress = callTest tests/wordpress.nix {};
   tests.xautolock = callTest tests/xautolock.nix {};
+  tests.xdg-desktop-portal = callTest tests/xdg-desktop-portal.nix {};
   tests.xfce = callTest tests/xfce.nix {};
   tests.xmonad = callTest tests/xmonad.nix {};
   tests.xrdp = callTest tests/xrdp.nix {};

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -284,6 +284,7 @@ in rec {
   tests.env = callTest tests/env.nix {};
   tests.ferm = callTest tests/ferm.nix {};
   tests.firefox = callTest tests/firefox.nix {};
+  tests.flatpak = callTest tests/flatpak.nix {};
   tests.firewall = callTest tests/firewall.nix {};
   tests.fwupd = callTest tests/fwupd.nix {};
   #tests.gitlab = callTest tests/gitlab.nix {};

--- a/nixos/tests/flatpak.nix
+++ b/nixos/tests/flatpak.nix
@@ -1,0 +1,23 @@
+# run installed tests
+import ./make-test.nix ({ pkgs, ... }:
+
+{
+  name = "flatpak";
+  meta = {
+    maintainers = pkgs.flatpak.meta.maintainers;
+  };
+
+  machine = { config, pkgs, ... }: {
+    imports = [ ./common/x11.nix ];
+    services.xserver.desktopManager.gnome3.enable = true; # TODO: figure out minimal environment where the tests work
+    services.flatpak.enable = true;
+    environment.systemPackages = with pkgs; [ gnupg gnome-desktop-testing ostree python2 ];
+    virtualisation.memorySize = 2047;
+    virtualisation.diskSize = 1024;
+  };
+
+  testScript = ''
+    $machine->waitForX();
+    $machine->succeed("gnome-desktop-testing-runner -d '${pkgs.flatpak.installedTests}/share' --timeout 3600");
+  '';
+})

--- a/nixos/tests/xdg-desktop-portal.nix
+++ b/nixos/tests/xdg-desktop-portal.nix
@@ -1,0 +1,17 @@
+# run installed tests
+import ./make-test.nix ({ pkgs, ... }:
+
+{
+  name = "xdg-desktop-portal";
+  meta = {
+    maintainers = pkgs.xdg-desktop-portal.meta.maintainers;
+  };
+
+  machine = { config, pkgs, ... }: {
+    environment.systemPackages = with pkgs; [ gnome-desktop-testing ];
+  };
+
+  testScript = ''
+    $machine->succeed("gnome-desktop-testing-runner -d '${pkgs.xdg-desktop-portal.installedTests}/share'");
+  '';
+})

--- a/pkgs/desktops/gnome-3/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-software/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, substituteAll, pkgconfig, meson, ninja, gettext, gnome3, wrapGAppsHook, packagekit, ostree
-, glib, appstream-glib, libsoup, polkit, isocodes, gspell, libxslt, gobjectIntrospection
+, glib, appstream-glib, libsoup, polkit, isocodes, gspell, libxslt, gobjectIntrospection, flatpak
 , json-glib, libsecret, valgrind-light, docbook_xsl, docbook_xml_dtd_42, gtk-doc, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
@@ -27,11 +27,10 @@ stdenv.mkDerivation rec {
     gnome3.gtk glib packagekit appstream-glib libsoup
     gnome3.gsettings-desktop-schemas gnome3.gnome-desktop
     gspell json-glib libsecret ostree
-    polkit
+    polkit flatpak
   ];
 
   mesonFlags = [
-    "-Denable-flatpak=false"
     "-Denable-rpm=false"
     "-Denable-fwupd=false"
     "-Denable-oauth=false"

--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -1,0 +1,74 @@
+{ stdenv, fetchurl, autoreconfHook, docbook_xml_dtd_412, docbook_xml_dtd_42, docbook_xml_dtd_43, docbook_xsl, which, libxml2
+, gobjectIntrospection, gtk_doc, intltool, libxslt, pkgconfig, xmlto, appstream-glib, substituteAll, glibcLocales, yacc
+, bubblewrap, bzip2, dbus, glib, gpgme, json_glib, libarchive, libcap, libseccomp, coreutils, python2, hicolor-icon-theme
+, libsoup, lzma, ostree, polkit, python3, systemd, xlibs, valgrind, glib_networking, makeWrapper, gnome3 }:
+
+let
+  version = "0.11.7";
+  desktop_schemas = gnome3.gsettings_desktop_schemas;
+in stdenv.mkDerivation rec {
+  name = "flatpak-${version}";
+
+  outputs = [ "out" "man" "doc" "installedTests" ];
+
+  src = fetchurl {
+    url = "https://github.com/flatpak/flatpak/releases/download/${version}/${name}.tar.xz";
+    sha256 = "1vq4j7v68lp4fsvpas1bcsx1z4snpj0mkbq2mi00kx3jb48z768h";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./fix-test-paths.patch;
+      inherit coreutils python2 glibcLocales;
+      hicolorIconTheme = hicolor-icon-theme;
+    })
+    # patch taken from gtk_doc
+    ./respect-xml-catalog-files-var.patch
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook libxml2 docbook_xml_dtd_412 docbook_xml_dtd_42 docbook_xml_dtd_43 docbook_xsl which gobjectIntrospection
+    gtk_doc intltool libxslt pkgconfig xmlto appstream-glib yacc makeWrapper
+  ] ++ stdenv.lib.optionals doCheck checkInputs;
+
+  buildInputs = [
+    bubblewrap bzip2 dbus glib gpgme json_glib libarchive libcap libseccomp
+    libsoup lzma ostree polkit python3 systemd xlibs.libXau
+  ];
+
+  checkInputs = [ valgrind ];
+
+  doCheck = false; # TODO: some issues with temporary files
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--with-system-bubblewrap=${bubblewrap}/bin/bwrap"
+    "--localstatedir=/var"
+    "--enable-installed-tests"
+  ];
+
+  makeFlags = [
+    "installed_testdir=$(installedTests)/libexec/installed-tests/flatpak"
+    "installed_test_metadir=$(installedTests)/share/installed-tests/flatpak"
+  ];
+
+  postPatch = ''
+    patchShebangs buildutil
+    patchShebangs tests
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/flatpak \
+      --prefix GIO_EXTRA_MODULES : "${glib_networking.out}/lib/gio/modules" \
+      --prefix XDG_DATA_DIRS : "${desktop_schemas}/share/gsettings-schemas/${desktop_schemas.name}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Linux application sandboxing and distribution framework";
+    homepage = https://flatpak.org/;
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/flatpak/fix-test-paths.patch
+++ b/pkgs/development/libraries/flatpak/fix-test-paths.patch
@@ -1,0 +1,46 @@
+--- a/tests/libtest.sh
++++ b/tests/libtest.sh
+@@ -322,7 +322,7 @@
+         # running installed-tests: assume we know what we're doing
+         :
+     elif ! "$FLATPAK_BWRAP" --unshare-ipc --unshare-net --unshare-pid \
+-            --ro-bind / / /bin/true > bwrap-result 2>&1; then
++            --ro-bind / / @coreutils@/bin/true > bwrap-result 2>&1; then
+         sed -e 's/^/# /' < bwrap-result
+         echo "1..0 # SKIP Cannot run bwrap"
+         exit 0
+@@ -330,7 +330,7 @@
+ }
+ 
+ skip_without_python2 () {
+-    if ! test -f /usr/bin/python2 || ! /usr/bin/python2 -c "import sys; sys.exit(0 if sys.version_info >= (2, 7) else 1)" ; then
++    if ! test -f @python2@/bin/python2 || ! @python2@/bin/python2 -c "import sys; sys.exit(0 if sys.version_info >= (2, 7) else 1)" ; then
+         echo "1..0 # SKIP this test requires /usr/bin/python2 (2.7) support"
+         exit 0
+     fi
+@@ -350,12 +350,12 @@
+ export DBUS_SESSION_BUS_ADDRESS="$(cat dbus-session-bus-address)"
+ DBUS_SESSION_BUS_PID="$(cat dbus-session-bus-pid)"
+ 
+-if ! /bin/kill -0 "$DBUS_SESSION_BUS_PID"; then
++if ! @coreutils@/bin/kill -0 "$DBUS_SESSION_BUS_PID"; then
+     assert_not_reached "Failed to start dbus-daemon"
+ fi
+ 
+ cleanup () {
+-    /bin/kill $DBUS_SESSION_BUS_PID ${FLATPAK_HTTP_PID:-}
++    @coreutils@/bin/kill $DBUS_SESSION_BUS_PID ${FLATPAK_HTTP_PID:-}
+     gpg-connect-agent --homedir "${FL_GPG_HOMEDIR}" killagent /bye || true
+     fusermount -u $XDG_RUNTIME_DIR/doc || :
+     if test -n "${TEST_SKIP_CLEANUP:-}"; then
+--- a/tests/testlibrary.c
++++ b/tests/testlibrary.c
+@@ -378,7 +378,7 @@
+     {
+       gint exit_code = 0;
+       char *argv[] = { (char *)bwrap, "--unshare-ipc", "--unshare-net",
+-          "--unshare-pid", "--ro-bind", "/", "/", "/bin/true", NULL };
++          "--unshare-pid", "--ro-bind", "/", "/", "@coreutils@/bin/true", NULL };
+       g_autofree char *argv_str = g_strjoinv (" ", argv);
+       g_test_message ("Spawning %s", argv_str);
+       g_spawn_sync (NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL, &exit_code, &error);

--- a/pkgs/development/libraries/flatpak/fix-test-paths.patch
+++ b/pkgs/development/libraries/flatpak/fix-test-paths.patch
@@ -33,6 +33,81 @@
      gpg-connect-agent --homedir "${FL_GPG_HOMEDIR}" killagent /bye || true
      fusermount -u $XDG_RUNTIME_DIR/doc || :
      if test -n "${TEST_SKIP_CLEANUP:-}"; then
+--- a/tests/make-test-runtime.sh
++++ b/tests/make-test-runtime.sh
+@@ -21,6 +21,7 @@
+ cat ${DIR}/metadata
+ 
+ # Add bash and dependencies
++mkdir -p ${DIR}/nix/store
+ mkdir -p ${DIR}/usr/bin
+ mkdir -p ${DIR}/usr/lib
+ ln -s ../lib ${DIR}/usr/lib64
+@@ -30,47 +31,27 @@
+ else
+     cp `which ldconfig` ${DIR}/usr/bin
+ fi
+-T=`mktemp`
+-for i in $@; do
+-    I=`which $i`
+-    cp $I ${DIR}/usr/bin
+-    ldd $I | sed "s/.* => //"  | awk '{ print $1}' | grep ^/ | grep ^/ >> $T
+-    if test $i == python2; then
+-        mkdir -p ${DIR}/usr/lib/python2.7/lib-dynload
+-        # This is a hardcoded minimal set of modules we need in the current tests.
+-        # Pretty hacky stuff. Add modules as needed.
+-        PYDIR=/usr/lib/python2.7
+-        if test -d /usr/lib64/python2.7; then PYDIR=/usr/lib64/python2.7; fi
+-        for py in site os stat posixpath genericpath warnings \
+-                       linecache types UserDict abc _abcoll \
+-                       _weakrefset copy_reg traceback sysconfig \
+-                       re sre_compile sre_parse sre_constants \
+-                       _sysconfigdata ; do
+-            cp ${PYDIR}/$py.py ${DIR}/usr/lib/python2.7
+-        done
+-        # These might not exist, depending how Python was configured; and the
+-        # part after ${so} might be "module" or ".x86_64-linux-gnu" or
+-        # something else
+-        for so in _locale strop ; do
+-            cp ${PYDIR}/lib-dynload/${so}*.so ${DIR}/usr/lib/python2.7/lib-dynload || :
+-        done
+-        for plat in $( cd ${PYDIR} && echo plat-* ); do
+-            test -e ${PYDIR}/${plat} || continue
+-            mkdir -p ${DIR}/usr/lib/python2.7/${plat}
+-            cp ${PYDIR}/${plat}/*.py ${DIR}/usr/lib/python2.7/${plat}/
+-        done
+-    fi
+-done
+ ln -s bash ${DIR}/usr/bin/sh
+-for i in `sort -u $T`; do
+-    cp "$i" ${DIR}/usr/lib/
++for i in $@; do
++    I=$(readlink -f $(which $i))
++    requisites=$(nix-store --query --requisites "$I")
++    for r in $requisites; do
++        # a single store item can be needed by multiple paths, no need to copy it again
++        if [ ! -e ${DIR}/$r ]; then
++            cp -r $r ${DIR}/$r
++        fi
++    done
++    ln -s $I ${DIR}/usr/bin/$i
+ done
+ 
+-# We copy the C.UTF8 locale and call it en_US. Its a bit of a lie, but
+-# the real en_US locale is often not available, because its in the
+-# local archive.
++mv ${DIR}/nix/store ${DIR}/usr/store # files outside /usr are not permitted, we will have to replace /nix/store with /usr/store
++chmod -R u+w ${DIR} # nix store has read-only directories which would cause problems during clean-up, files need to be writable for sed
++find ${DIR} -type f -print0 | xargs -0 sed -i 's~/nix/store/~/usr/store/~g' # replace hardcoded paths
++find ${DIR} -type l | xargs -I '{}' sh -c 'tg="$(readlink "$1")"; newtg="${tg#/nix/store/}"; if [ "$tg" != "$newtg" ]; then ln -fs "/usr/store/$newtg" "$1"; fi' -- '{}' # replace symlink targets
++
++# We copy the whole locale archive because we do not have C.UTF8 locale
+ mkdir -p ${DIR}/usr/lib/locale/
+-cp -r /usr/lib/locale/C.* ${DIR}/usr/lib/locale/en_US
++cp @glibcLocales@/lib/locale/locale-archive ${DIR}/usr/lib/locale/locale-archive
+ 
+ if [ x$COLLECTION_ID != x ]; then
+     collection_args=--collection-id=${COLLECTION_ID}
 --- a/tests/testlibrary.c
 +++ b/tests/testlibrary.c
 @@ -378,7 +378,7 @@
@@ -44,3 +119,14 @@
        g_autofree char *argv_str = g_strjoinv (" ", argv);
        g_test_message ("Spawning %s", argv_str);
        g_spawn_sync (NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL, &exit_code, &error);
+--- a/triggers/gtk-icon-cache.trigger
++++ b/triggers/gtk-icon-cache.trigger
+@@ -1,7 +1,7 @@
+ #!/bin/sh
+ 
+ if test \( -x "$(which gtk-update-icon-cache 2>/dev/null)" \) -a \( -d $1/exports/share/icons/hicolor \); then
+-    cp /usr/share/icons/hicolor/index.theme $1/exports/share/icons/hicolor/
++    cp @hicolorIconTheme@/share/icons/hicolor/index.theme $1/exports/share/icons/hicolor/
+     for dir in $1/exports/share/icons/*; do
+         if test -f $dir/index.theme; then
+             if ! gtk-update-icon-cache --quiet $dir; then

--- a/pkgs/development/libraries/flatpak/respect-xml-catalog-files-var.patch
+++ b/pkgs/development/libraries/flatpak/respect-xml-catalog-files-var.patch
@@ -1,0 +1,13 @@
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -40,8 +40,8 @@
+ [
+   AC_REQUIRE([JH_PATH_XML_CATALOG],[JH_PATH_XML_CATALOG(,[:])])dnl
+   AC_MSG_CHECKING([for ifelse([$2],,[$1],[$2]) in XML catalog])
+-  if $jh_found_xmlcatalog && \
+-     AC_RUN_LOG([$XMLCATALOG --noout "$XML_CATALOG_FILE" "$1" >&2]); then
++  # empty argument forces libxml to use XML_CATALOG_FILES variable
++  if AC_RUN_LOG([$XMLCATALOG --noout "" "$1" >&2]); then
+     AC_MSG_RESULT([found])
+     ifelse([$3],,,[$3
+ ])dnl

--- a/pkgs/development/libraries/xdg-desktop-portal-gtk/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-gtk/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libxml2, xdg-desktop-portal, gtk3, glib }:
+
+let
+  version = "0.11";
+in stdenv.mkDerivation rec {
+  name = "xdg-desktop-portal-gtk-${version}";
+
+  src = fetchFromGitHub {
+    owner = "flatpak";
+    repo = "xdg-desktop-portal-gtk";
+    rev = version;
+    sha256 = "03ysv29k7fp14hx0gakjigzzlniwicqd81nrhnc6w4pgin0y0zwg";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig libxml2 xdg-desktop-portal ];
+  buildInputs = [ glib gtk3 ];
+
+  meta = with stdenv.lib; {
+    description = "Desktop integration portals for sandboxed apps";
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.linux;
+    license = licenses.lgpl21;
+  };
+}

--- a/pkgs/development/libraries/xdg-desktop-portal/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libxml2, glib, pipewire, fuse }:
+
+let
+  version = "0.11";
+in stdenv.mkDerivation rec {
+  name = "xdg-desktop-portal-${version}";
+
+  outputs = [ "out" "installedTests" ];
+
+  src = fetchFromGitHub {
+    owner = "flatpak";
+    repo = "xdg-desktop-portal";
+    rev = version;
+    sha256 = "06gipd51snvlp2jp68v2c8rwbsv36kjzg9xacm81n1w4b2dpz4g0";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig libxml2 ];
+  buildInputs = [ glib pipewire fuse ];
+
+  doCheck = true;
+
+  configureFlags = [
+    "--enable-installed-tests"
+  ];
+
+  makeFlags = [
+    "installed_testdir=$(installedTests)/libexec/installed-tests/xdg-desktop-portal"
+    "installed_test_metadir=$(installedTests)/share/installed-tests/xdg-desktop-portal"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Desktop integration portals for sandboxed apps";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/xdg-desktop-portal/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal/default.nix
@@ -14,6 +14,10 @@ in stdenv.mkDerivation rec {
     sha256 = "06gipd51snvlp2jp68v2c8rwbsv36kjzg9xacm81n1w4b2dpz4g0";
   };
 
+  patches = [
+    ./respect-path-env-var.patch
+  ];
+
   nativeBuildInputs = [ autoreconfHook pkgconfig libxml2 ];
   buildInputs = [ glib pipewire fuse ];
 

--- a/pkgs/development/libraries/xdg-desktop-portal/respect-path-env-var.patch
+++ b/pkgs/development/libraries/xdg-desktop-portal/respect-path-env-var.patch
@@ -1,0 +1,76 @@
+--- a/src/xdg-desktop-portal.c
++++ b/src/xdg-desktop-portal.c
+@@ -177,38 +177,50 @@
+ static void
+ load_installed_portals (void)
+ {
+-  const char *portal_dir = PKGDATADIR "/portals";
+-  g_autoptr(GFile) dir = g_file_new_for_path (portal_dir);
+-  g_autoptr(GFileEnumerator) enumerator = NULL;
+ 
+-  enumerator = g_file_enumerate_children (dir, "*", G_FILE_QUERY_INFO_NONE, NULL, NULL);
++  g_auto(GStrv) portal_dir_list;
++  int i;
++  const char *portal_dir = g_getenv ("XDG_DESKTOP_PORTAL_PATH");
++
++  if (portal_dir == NULL)
++    portal_dir = PKGDATADIR "/portals";
+ 
+-  if (enumerator == NULL)
+-    return;
++  portal_dir_list = g_strsplit (portal_dir, G_SEARCHPATH_SEPARATOR_S, 0);
+ 
+-  while (TRUE)
++  for (i = 0; portal_dir_list[i] != NULL; i++)
+     {
+-      g_autoptr(GFileInfo) info = g_file_enumerator_next_file (enumerator, NULL, NULL);
+-      g_autoptr(GFile) child = NULL;
+-      g_autofree char *path = NULL;
+-      const char *name;
+-      g_autoptr(GError) error = NULL;
++      portal_dir = portal_dir_list[i];
++      g_autoptr(GFile) dir = g_file_new_for_path (portal_dir);
++      g_autoptr(GFileEnumerator) enumerator = NULL;
++      enumerator = g_file_enumerate_children (dir, "*", G_FILE_QUERY_INFO_NONE, NULL, NULL);
+ 
+-      if (info == NULL)
+-        break;
++      if (enumerator == NULL)
++        continue;
+ 
+-      name = g_file_info_get_name (info);
++      while (TRUE)
++        {
++          g_autoptr(GFileInfo) info = g_file_enumerator_next_file (enumerator, NULL, NULL);
++          g_autoptr(GFile) child = NULL;
++          g_autofree char *path = NULL;
++          const char *name;
++          g_autoptr(GError) error = NULL;
+ 
+-      if (!g_str_has_suffix (name, ".portal"))
+-        continue;
++          if (info == NULL)
++            break;
+ 
+-      child = g_file_enumerator_get_child (enumerator, info);
+-      path = g_file_get_path (child);
++          name = g_file_info_get_name (info);
+ 
+-      if (!register_portal (path, &error))
+-        {
+-          g_warning ("Error loading %s: %s", path, error->message);
+-          continue;
++          if (!g_str_has_suffix (name, ".portal"))
++            continue;
++
++          child = g_file_enumerator_get_child (enumerator, info);
++          path = g_file_get_path (child);
++
++          if (!register_portal (path, &error))
++            {
++              g_warning ("Error loading %s: %s", path, error->message);
++              continue;
++            }
+         }
+     }
+ 

--- a/pkgs/development/tools/flatpak-builder/default.nix
+++ b/pkgs/development/tools/flatpak-builder/default.nix
@@ -1,0 +1,103 @@
+{ stdenv
+, fetchurl
+, substituteAll
+
+, autoreconfHook
+, docbook_xml_dtd_412
+, docbook_xml_dtd_42
+, docbook_xml_dtd_43
+, docbook_xsl
+, gettext
+, libxml2
+, libxslt
+, pkgconfig
+, xmlto
+
+, acl
+, bazaar
+, binutils
+, bzip2
+, coreutils
+, cpio
+, elfutils
+, flatpak
+, gitMinimal
+, glib
+, gnutar
+, json_glib
+, libcap
+, libdwarf
+, libsoup
+, ostree
+, patch
+, rpm
+, unzip
+}:
+
+let
+  version = "0.10.10";
+in stdenv.mkDerivation rec {
+  name = "flatpak-builder-${version}";
+
+  outputs = [ "out" "doc" "man" ];
+
+  src = fetchurl {
+    url = "https://github.com/flatpak/flatpak-builder/releases/download/${version}/${name}.tar.xz";
+    sha256 = "0b0c2rmf2vj596600blbhsiv2dg7qwpr33lgdcn0bnqc4ddri6f2";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    docbook_xml_dtd_412
+    docbook_xml_dtd_42
+    docbook_xml_dtd_43
+    docbook_xsl
+    gettext
+    libxml2
+    libxslt
+    pkgconfig
+    xmlto
+  ];
+
+  buildInputs = [
+    acl
+    bzip2
+    elfutils
+    flatpak
+    glib
+    json_glib
+    libcap
+    libdwarf
+    libsoup
+    libxml2
+    ostree
+  ];
+
+  patches = [
+    # patch taken from gtk_doc
+    ./respect-xml-catalog-files-var.patch
+    (substituteAll {
+      src = ./fix-paths.patch;
+      bzr = "${bazaar}/bin/bzr";
+      cp = "${coreutils}/bin/cp";
+      patch = "${patch}/bin/patch";
+      tar = "${gnutar}/bin/tar";
+      unzip = "${unzip}/bin/unzip";
+      rpm2cpio = "${rpm}/bin/rpm2cpio";
+      cpio = "${cpio}/bin/cpio";
+      git = "${gitMinimal}/bin/git";
+      rofilesfuse = "${ostree}/bin/rofiles-fuse";
+      strip = "${binutils}/bin/strip";
+      eustrip = "${elfutils}/bin/eu-strip";
+      euelfcompress = "${elfutils}/bin/eu-elfcompress";
+    })
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Tool to build flatpaks from source";
+    homepage = https://flatpak.org/;
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/tools/flatpak-builder/fix-paths.patch
+++ b/pkgs/development/tools/flatpak-builder/fix-paths.patch
@@ -1,0 +1,116 @@
+--- a/src/builder-context.c
++++ b/src/builder-context.c
+@@ -711,7 +711,7 @@
+   g_autoptr(GFile) rofiles_base = NULL;
+   g_autoptr(GFile) rofiles_dir = NULL;
+   g_autofree char *tmpdir_name = NULL;
+-  char *argv[] = { "rofiles-fuse",
++  char *argv[] = { "@rofilesfuse@",
+                    "-o",
+                    "kernel_cache,entry_timeout=60,attr_timeout=60,splice_write,splice_move",
+                    (char *)flatpak_file_get_path_cached (self->app_dir),
+--- a/src/builder-git.c
++++ b/src/builder-git.c
+@@ -44,7 +44,7 @@
+   va_list ap;
+ 
+   va_start (ap, error);
+-  res = flatpak_spawn (dir, output, flags, error, "git", ap);
++  res = flatpak_spawn (dir, output, flags, error, "@git@", ap);
+   va_end (ap);
+ 
+   return res;
+@@ -58,7 +58,7 @@
+   va_list ap;
+ 
+   va_start (ap, error);
+-  res = flatpak_spawn (NULL, NULL, 0, error, "cp", ap);
++  res = flatpak_spawn (NULL, NULL, 0, error, "@cp@", ap);
+   va_end (ap);
+ 
+   return res;
+--- a/src/builder-source-archive.c
++++ b/src/builder-source-archive.c
+@@ -401,7 +401,7 @@
+   va_list ap;
+ 
+   va_start (ap, error);
+-  res = flatpak_spawn (dir, NULL, 0, error, "tar", ap);
++  res = flatpak_spawn (dir, NULL, 0, error, "@tar@", ap);
+   va_end (ap);
+ 
+   return res;
+@@ -416,7 +416,7 @@
+   va_list ap;
+ 
+   va_start (ap, error);
+-  res = flatpak_spawn (dir, NULL, 0, error, "unzip", ap);
++  res = flatpak_spawn (dir, NULL, 0, error, "@unzip@", ap);
+   va_end (ap);
+ 
+   return res;
+@@ -428,7 +428,7 @@
+        GError **error)
+ {
+   gboolean res;
+-  const gchar *argv[] = { "sh", "-c", "rpm2cpio \"$1\" | cpio -i -d",
++  const gchar *argv[] = { "sh", "-c", "@rpm2cpio@ \"$1\" | @cpio@ -i -d",
+       "sh", /* shell's $0 */
+       rpm_path, /* shell's $1 */
+       NULL };
+--- a/src/builder-source-bzr.c
++++ b/src/builder-source-bzr.c
+@@ -124,7 +124,7 @@
+   va_list ap;
+ 
+   va_start (ap, error);
+-  res = flatpak_spawn (dir, output, 0, error, "bzr", ap);
++  res = flatpak_spawn (dir, output, 0, error, "@bzr@", ap);
+   va_end (ap);
+ 
+   return res;
+--- a/src/builder-source-patch.c
++++ b/src/builder-source-patch.c
+@@ -204,11 +204,11 @@
+ 
+   args = g_ptr_array_new ();
+   if (use_git) {
+-    g_ptr_array_add (args, "git");
++    g_ptr_array_add (args, "@git@");
+     g_ptr_array_add (args, "apply");
+     g_ptr_array_add (args, "-v");
+   } else {
+-    g_ptr_array_add (args, "patch");
++    g_ptr_array_add (args, "@patch@");
+   }
+   for (i = 0; extra_options != NULL && extra_options[i] != NULL; i++)
+     g_ptr_array_add (args, (gchar *) extra_options[i]);
+--- a/src/builder-utils.c
++++ b/src/builder-utils.c
+@@ -139,7 +139,7 @@
+   va_list ap;
+ 
+   va_start (ap, error);
+-  res = flatpak_spawn (NULL, NULL, 0, error, "strip", ap);
++  res = flatpak_spawn (NULL, NULL, 0, error, "@strip@", ap);
+   va_end (ap);
+ 
+   return res;
+@@ -153,7 +153,7 @@
+   va_list ap;
+ 
+   va_start (ap, error);
+-  res = flatpak_spawn (NULL, NULL, 0, error, "eu-strip", ap);
++  res = flatpak_spawn (NULL, NULL, 0, error, "@eustrip@", ap);
+   va_end (ap);
+ 
+   return res;
+@@ -167,7 +167,7 @@
+   va_list ap;
+ 
+   va_start (ap, error);
+-  res = flatpak_spawn (NULL, NULL, 0, error, "eu-elfcompress", ap);
++  res = flatpak_spawn (NULL, NULL, 0, error, "@euelfcompress@", ap);
+   va_end (ap);
+ 
+   return res;

--- a/pkgs/development/tools/flatpak-builder/respect-xml-catalog-files-var.patch
+++ b/pkgs/development/tools/flatpak-builder/respect-xml-catalog-files-var.patch
@@ -1,0 +1,13 @@
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -40,8 +40,8 @@
+ [
+   AC_REQUIRE([JH_PATH_XML_CATALOG],[JH_PATH_XML_CATALOG(,[:])])dnl
+   AC_MSG_CHECKING([for ifelse([$2],,[$1],[$2]) in XML catalog])
+-  if $jh_found_xmlcatalog && \
+-     AC_RUN_LOG([$XMLCATALOG --noout "$XML_CATALOG_FILE" "$1" >&2]); then
++  # empty argument forces libxml to use XML_CATALOG_FILES variable
++  if AC_RUN_LOG([$XMLCATALOG --noout "" "$1" >&2]); then
+     AC_MSG_RESULT([found])
+     ifelse([$3],,,[$3
+ ])dnl

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2297,6 +2297,8 @@ with pkgs;
 
   flashbench = callPackage ../os-specific/linux/flashbench { };
 
+  flatpak = callPackage ../development/libraries/flatpak { };
+
   figlet = callPackage ../tools/misc/figlet { };
 
   file = callPackage ../tools/misc/file { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18720,6 +18720,8 @@ with pkgs;
 
   xdg-desktop-portal = callPackage ../development/libraries/xdg-desktop-portal { };
 
+  xdg-desktop-portal-gtk = callPackage ../development/libraries/xdg-desktop-portal-gtk { };
+
   xdg-user-dirs = callPackage ../tools/X11/xdg-user-dirs { };
 
   xdg_utils = callPackage ../tools/X11/xdg-utils {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18718,6 +18718,8 @@ with pkgs;
 
   xdaliclock = callPackage ../tools/misc/xdaliclock {};
 
+  xdg-desktop-portal = callPackage ../development/libraries/xdg-desktop-portal { };
+
   xdg-user-dirs = callPackage ../tools/X11/xdg-user-dirs { };
 
   xdg_utils = callPackage ../tools/X11/xdg-utils {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2299,6 +2299,8 @@ with pkgs;
 
   flatpak = callPackage ../development/libraries/flatpak { };
 
+  flatpak-builder = callPackage ../development/tools/flatpak-builder { };
+
   figlet = callPackage ../tools/misc/figlet { };
 
   file = callPackage ../tools/misc/file { };


### PR DESCRIPTION
###### Motivation for this change
Allows running sandboxed applications.

Closes: #32807

###### How to test

Enable the service by adding `services.flatpak.enable = true;` to your `configuration.nix`

```
flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
flatpak update
flatpak search bustle
flatpak install flathub org.freedesktop.Bustle
flatpak run org.freedesktop.Bustle
```

###### Things done

Installing and running applications works, ~we still need to check whether all the portals and interactions work.~ Portals work as well.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


  
  