### PR TITLE
nixos/memcached: make unix sockets usuable

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -131,6 +131,14 @@ following incompatible changes:</para>
       Other types dependencies should be unaffected.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      The <literal>memcached</literal> service no longer accept dynamic socket
+      paths via <option>services.memcached.socket</option>. Unix sockets can be
+      still enabled by <option>services.memcached.enableUnixSocket</option> and
+      will be accessible at <literal>/run/memcached/memcached.sock</literal>.
+    </para>
+  </listitem>
 </itemizedlist>
 
 </section>

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -197,7 +197,7 @@
       #input = 174; # unused
       sddm = 175;
       tss = 176;
-      memcached = 177;
+      #memcached = 177; removed 2018-01-03
       ntp = 179;
       zabbix = 180;
       redis = 181;
@@ -475,7 +475,7 @@
       input = 174;
       sddm = 175;
       tss = 176;
-      #memcached = 177; # unused
+      #memcached = 177; # unused, removed 2018-01-03
       #ntp = 179; # unused
       #zabbix = 180; # unused
       #redis = 181; # unused


### PR DESCRIPTION
before:
  - /var/run/memcached is a bad default for a socket path, since its
    parent directory must be writeable by memcached.
  - Socket directory was not created by the module itself -> this was
    left as a burden to the user?
  - Having a static uid with a dynamic user name is not very useful.

after:
  - Replace services.memcached.socket by a boolean flag. This simplifies
    our code, since we do not have to check if the user specifies a
    path with a parent directory that should be owned by memcached
    (/run/memcached/memcached.sock -> /run/memcached).
  - Remove fixed uid/gid allocation. The only file ever owned by the
    daemon is the socket that will be recreated on every start.
    Therefore user and group ids do not need to be static.
  - only create the memcached user, if the user has not specified a
    different one. The major use case for changing option is to allow
    existing services (such as php-fpm) opening the local unix socket.
    If we would unconditionally create a user that option would be
    useless.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

