### PR TITLE
Update LLVM default 4 -> 5

### DIFF
--- a/pkgs/development/compilers/zig/default.nix
+++ b/pkgs/development/compilers/zig/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, llvmPackages_5, llvm_5 }:
+{ stdenv, fetchFromGitHub, cmake, llvmPackages }:
 
 stdenv.mkDerivation rec {
   version = "0.1.1";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "01yqjyi25f99bfmxxwyh45k7j84z0zg7n9jl8gg0draf96mzdh06";
   };
 
-  buildInputs = [ cmake llvmPackages_5.clang-unwrapped llvm_5 ];
+  buildInputs = [ cmake llvmPackages.clang-unwrapped llvmPackages.llvm ];
 
   cmakeFlags = [
     "-DZIG_LIBC_INCLUDE_DIR=${stdenv.cc.libc_dev}/include"

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -258,7 +258,7 @@ self: super: builtins.intersectAttrs super {
       }
     );
 
-  llvm-hs = super.llvm-hs.override { llvm-config = pkgs.llvm_5; };
+  llvm-hs = super.llvm-hs.override { llvm-config = pkgs.llvm; };
 
   # Needs help finding LLVM.
   spaceprobe = addBuildTool super.spaceprobe self.llvmPackages.llvm;

--- a/pkgs/development/libraries/pixman/default.nix
+++ b/pkgs/development/libraries/pixman/default.nix
@@ -1,16 +1,25 @@
-{ fetchurl, stdenv, pkgconfig, libpng, glib /*just passthru*/ }:
+{ stdenv, fetchurl, fetchpatch, autoconf, automake, libtool, pkgconfig, libpng, glib /*just passthru*/ }:
 
 stdenv.mkDerivation rec {
-  name = "pixman-0.34.0";
+  name = "pixman-${version}";
+  version = "0.34.0";
 
   src = fetchurl {
     url = "mirror://xorg/individual/lib/${name}.tar.bz2";
     sha256 = "184lazwdpv67zrlxxswpxrdap85wminh1gmq1i5lcz6iycw39fir";
   };
 
-  patches = [];
+  patches = stdenv.lib.optionals stdenv.cc.isClang [
+    (fetchpatch {
+      name = "builtin-shuffle.patch";
+      url = https://patchwork.freedesktop.org/patch/177506/raw;
+      sha256 = "0rvraq93769dy2im2m022rz99fcdxprgc2fbmasnddcwrqy1x3xr";
+    })
+  ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ]
+    ++ stdenv.lib.optionals stdenv.cc.isClang [ autoconf automake libtool ];
+
   buildInputs = stdenv.lib.optional doCheck libpng;
 
   configureFlags = stdenv.lib.optional stdenv.isArm "--disable-arm-iwmmxt";

--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/clang-5.patch
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/clang-5.patch
@@ -1,0 +1,22 @@
+diff --git a/icuSources/i18n/ucoleitr.cpp b/icuSources/i18n/ucoleitr.cpp
+index ecc94c9..936452f 100644
+--- a/icuSources/i18n/ucoleitr.cpp
++++ b/icuSources/i18n/ucoleitr.cpp
+@@ -320,7 +320,7 @@ ucol_nextProcessed(UCollationElements *elems,
+                    int32_t            *ixHigh,
+                    UErrorCode         *status)
+ {
+-    return (UCollationPCE::UCollationPCE(elems)).nextProcessed(ixLow, ixHigh, status);
++    return (UCollationPCE(elems)).nextProcessed(ixLow, ixHigh, status);
+ }
+ 
+ 
+@@ -384,7 +384,7 @@ ucol_previousProcessed(UCollationElements *elems,
+                    int32_t            *ixHigh,
+                    UErrorCode         *status)
+ {
+-    return (UCollationPCE::UCollationPCE(elems)).previousProcessed(ixLow, ixHigh, status);
++    return (UCollationPCE(elems)).previousProcessed(ixLow, ixHigh, status);
+ }
+ 
+ U_NAMESPACE_BEGIN

--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
@@ -3,6 +3,8 @@
 appleDerivation {
   nativeBuildInputs = [ cctools ];
 
+  patches = [ ./clang-5.patch ];
+
   postPatch = ''
     substituteInPlace makefile \
       --replace /usr/bin/ "" \

--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, makeWrapper, cmake, llvmPackages_5, kernel
+{ stdenv, fetchFromGitHub, fetchpatch, makeWrapper, cmake, llvmPackages, kernel
 , flex, bison, elfutils, python, pythonPackages, luajit, netperf, iperf, libelf }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    llvmPackages_5.llvm llvmPackages_5.clang-unwrapped kernel
+    llvmPackages.llvm llvmPackages.clang-unwrapped kernel
     elfutils python pythonPackages.netaddr luajit netperf iperf
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6251,7 +6251,7 @@ with pkgs;
   llvm_35 = llvmPackages_35.llvm;
   llvm_34 = llvmPackages_34.llvm;
 
-  llvmPackages = recurseIntoAttrs llvmPackages_4;
+  llvmPackages = recurseIntoAttrs llvmPackages_5;
 
   llvmPackagesSelf = llvmPackages_34.override {
     stdenv = libcxxStdenv;
@@ -6277,17 +6277,17 @@ with pkgs;
     inherit (stdenvAdapters) overrideCC;
   };
 
-  llvmPackages_4 = callPackage ../development/compilers/llvm/4 ({
+  llvmPackages_4 = callPackage ../development/compilers/llvm/4 {
+    inherit (stdenvAdapters) overrideCC;
+  };
+
+  llvmPackages_5 = callPackage ../development/compilers/llvm/5 ({
     inherit (stdenvAdapters) overrideCC;
   } // stdenv.lib.optionalAttrs stdenv.isDarwin {
     cmake = cmake.override { isBootstrap = true; };
     libxml2 = libxml2.override { pythonSupport = false; };
     python2 = callPackage ../development/interpreters/python/cpython/2.7/boot.nix { inherit (darwin) CF configd; };
   });
-
-  llvmPackages_5 = callPackage ../development/compilers/llvm/5 {
-    inherit (stdenvAdapters) overrideCC;
-  };
 
   manticore = callPackage ../development/compilers/manticore { };
 
@@ -7944,7 +7944,6 @@ with pkgs;
 
   ycmd = callPackage ../development/tools/misc/ycmd {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
-    llvmPackages = llvmPackages_5;
     python = python2;
   };
 
@@ -10100,8 +10099,6 @@ with pkgs;
     # makes it slower, but during runtime we link against just mesa_drivers
     # through /run/opengl-driver*, which is overriden according to config.grsecurity
     # grsecEnabled = true; # no more support in nixpkgs ATM
-
-    llvmPackages = llvmPackages_5;
   });
 
   mesa_glu =  mesaDarwinOr (callPackage ../development/libraries/mesa-glu { });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5611,9 +5611,7 @@ with pkgs;
     '';
   });
 
-  crystal = callPackage ../development/compilers/crystal {
-    llvm = llvm_5;
-  };
+  crystal = callPackage ../development/compilers/crystal { };
 
   devpi-client = callPackage ../development/tools/devpi-client {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9935,7 +9935,7 @@ in {
 
   locustio = callPackage ../development/python-modules/locustio { };
 
-  llvmlite = callPackage ../development/python-modules/llvmlite {llvm=pkgs.llvm_5;};
+  llvmlite = callPackage ../development/python-modules/llvmlite { llvm = pkgs.llvm; };
 
   lockfile = buildPythonPackage rec {
     pname = "lockfile";


### PR DESCRIPTION
###### Motivation for this change

Bit overdue, submitting to get this started and to track testing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Darwin will certainly want to test this, cc @LnL7 @copumpkin