### PR TITLE
ncurses: fix ncurses6 build w/clang

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -22,7 +22,9 @@ stdenv.mkDerivation rec {
     sha256 = "11adzj0k82nlgpfrflabvqn2m7fmhp2y6pd7ivmapynxqb9vvb92";
   });
 
-  patches = lib.optionals (abiVersion == "5") [ ./clang.patch ./gcc-5.patch ];
+  # Unnecessarily complicated in order to avoid mass-rebuilds
+  patches = lib.optional (!stdenv.cc.isClang || abiVersion == "5") ./clang.patch
+    ++ lib.optional (stdenv.cc.isGNU && abiVersion == "5") ./gcc-5.patch;
 
   outputs = [ "out" "dev" "man" ];
   setOutputFlags = false; # some aren't supported

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     sha256 = "11adzj0k82nlgpfrflabvqn2m7fmhp2y6pd7ivmapynxqb9vvb92";
   });
 
-  patches = [ ./clang.patch ] ++ lib.optional (abiVersion == "5" && stdenv.cc.isGNU) ./gcc-5.patch;
+  patches = lib.optionals (abiVersion == "5") [ ./clang.patch ./gcc-5.patch ];
 
   outputs = [ "out" "dev" "man" ];
   setOutputFlags = false; # some aren't supported


### PR DESCRIPTION
###### Motivation for this change

Un-break ncurses6 on clang (it's been broken a long time).

Recent hydra log demonstrating this on Darwin: https://hydra.nixos.org/build/66447097/nixlog/3

Follow-up might want to enable ncurses6 on Darwin instead of using 5, not sure if there are other reasons for using 5 on Darwin but 6 on Linux. (cc @LnL7 @copumpkin).

--------

First commit simplifies and is what I think is "best"; second shows what it would look like to un-break ncurses6 on clang but avoids triggering mass-rebuild... at the cost of being significantly uglier :).

I'm good with either being merged, wasn't sure how folks would feel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
