### PR TITLE
llvm: differentiate manpage builds, use recurseintoattrs to build and cache contents

### DIFF
--- a/pkgs/development/compilers/llvm/4/clang/default.nix
+++ b/pkgs/development/compilers/llvm/4/clang/default.nix
@@ -5,8 +5,9 @@
 
 let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
+  mantag = stdenv.lib.optionalString enableManpages "-manpages";
   self = stdenv.mkDerivation {
-    name = "clang-${version}";
+    name = "clang${mantag}-${version}";
 
     unpackPhase = ''
       unpackFile ${fetch "cfe" "16vnv3msnvx33dydd17k2cq0icndi1a06bg5vcxkrhjjb1rqlwv1"}

--- a/pkgs/development/compilers/llvm/4/llvm.nix
+++ b/pkgs/development/compilers/llvm/4/llvm.nix
@@ -27,8 +27,9 @@ let
   # Used when creating a version-suffixed symlink of libLLVM.dylib
   shortVersion = with stdenv.lib;
     concatStringsSep "." (take 2 (splitString "." release_version));
+  mantag = stdenv.lib.optionalString enableManpages "-manpages";
 in stdenv.mkDerivation rec {
-  name = "llvm-${version}";
+  name = "llvm${mantag}-${version}";
 
   unpackPhase = ''
     unpackFile ${src}

--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -5,8 +5,9 @@
 
 let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
+  mantag = stdenv.lib.optionalString enableManpages "-manpages";
   self = stdenv.mkDerivation {
-    name = "clang-${version}";
+    name = "clang${mantag}-${version}";
 
     unpackPhase = ''
       unpackFile ${fetch "cfe" "1zyh4dggxd55lnfg73c8fybnkssqcaa6bq2h4bzimnnj1jdnqpqk"}

--- a/pkgs/development/compilers/llvm/5/llvm.nix
+++ b/pkgs/development/compilers/llvm/5/llvm.nix
@@ -27,8 +27,9 @@ let
   # Used when creating a version-suffixed symlink of libLLVM.dylib
   shortVersion = with stdenv.lib;
     concatStringsSep "." (take 2 (splitString "." release_version));
+  mantag = stdenv.lib.optionalString enableManpages "-manpages";
 in stdenv.mkDerivation rec {
-  name = "llvm-${version}";
+  name = "llvm${mantag}-${version}";
 
   unpackPhase = ''
     unpackFile ${src}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6248,37 +6248,37 @@ with pkgs;
     stdenv = libcxxStdenv;
   };
 
-  llvmPackages_34 = callPackage ../development/compilers/llvm/3.4 {
+  llvmPackages_34 = recurseIntoAttrs (callPackage ../development/compilers/llvm/3.4 {
     isl = isl_0_12;
-  };
+  });
 
-  llvmPackages_35 = callPackage ../development/compilers/llvm/3.5 {
+  llvmPackages_35 = recurseIntoAttrs (callPackage ../development/compilers/llvm/3.5 {
     isl = isl_0_14;
-  };
+  });
 
-  llvmPackages_37 = callPackage ../development/compilers/llvm/3.7 {
+  llvmPackages_37 = recurseIntoAttrs (callPackage ../development/compilers/llvm/3.7 {
     inherit (stdenvAdapters) overrideCC;
-  };
+  });
 
-  llvmPackages_38 = callPackage ../development/compilers/llvm/3.8 {
+  llvmPackages_38 = recurseIntoAttrs (callPackage ../development/compilers/llvm/3.8 {
     inherit (stdenvAdapters) overrideCC;
-  };
+  });
 
-  llvmPackages_39 = callPackage ../development/compilers/llvm/3.9 {
+  llvmPackages_39 = recurseIntoAttrs (callPackage ../development/compilers/llvm/3.9 {
     inherit (stdenvAdapters) overrideCC;
-  };
+  });
 
-  llvmPackages_4 = callPackage ../development/compilers/llvm/4 ({
+  llvmPackages_4 = recurseIntoAttrs (callPackage ../development/compilers/llvm/4 ({
     inherit (stdenvAdapters) overrideCC;
   } // stdenv.lib.optionalAttrs stdenv.isDarwin {
     cmake = cmake.override { isBootstrap = true; };
     libxml2 = libxml2.override { pythonSupport = false; };
     python2 = callPackage ../development/interpreters/python/cpython/2.7/boot.nix { inherit (darwin) CF configd; };
-  });
+  }));
 
-  llvmPackages_5 = callPackage ../development/compilers/llvm/5 {
+  llvmPackages_5 = recurseIntoAttrs (callPackage ../development/compilers/llvm/5 {
     inherit (stdenvAdapters) overrideCC;
-  };
+  });
 
   manticore = callPackage ../development/compilers/manticore { };
 


### PR DESCRIPTION
###### Motivation for this change

#33369 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

