### PR TITLE
openvpn: make systemd dependency optional

### DIFF
--- a/pkgs/tools/networking/openvpn/default.nix
+++ b/pkgs/tools/networking/openvpn/default.nix
@@ -1,7 +1,9 @@
-{ stdenv, fetchurl, iproute, lzo, openssl, pam, systemd, pkgconfig
+{ stdenv, fetchurl, iproute, lzo, openssl, pam, pkgconfig
+, useSystemd ? stdenv.isLinux, systemd ? null
 , pkcs11Support ? false, pkcs11helper ? null,
 }:
 
+assert useSystemd -> (systemd != null);
 assert pkcs11Support -> (pkcs11helper != null);
 
 with stdenv.lib;
@@ -17,13 +19,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ lzo openssl ]
-                  ++ optionals stdenv.isLinux [ pam systemd iproute ]
+                  ++ optionals stdenv.isLinux [ pam iproute ]
+                  ++ optional useSystemd systemd
                   ++ optional pkcs11Support pkcs11helper;
 
   configureFlags = optionals stdenv.isLinux [
-    "--enable-systemd"
     "--enable-iproute2"
     "IPROUTE=${iproute}/sbin/ip" ]
+    ++ optional useSystemd "--enable-systemd"
     ++ optional pkcs11Support "--enable-pkcs11"
     ++ optional stdenv.isDarwin "--disable-plugin-auth-pam";
 


### PR DESCRIPTION
systemd is a fairly large dependency, and it doesn't appear to
be necessary in all circumstances - e.g. when openvpn is
not run as a systemd service (as is usually the case when it is
run in a Docker container).

This change makes the dependency on systemd optional, controlled
by a new argument `systemdSupport`. The default behaviour remains
the same as it was before this change: enabled only on Linux systems.

For me, this change reduces the size of my container image (dominated
by the closure of openvpn) from about 110 MB to 45 MB.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

