### PR TITLE
fonttools: 3.21.0 -> 3.21.1

### DIFF
--- a/pkgs/development/python-modules/fonttools/default.nix
+++ b/pkgs/development/python-modules/fonttools/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "fonttools";
-  version = "3.21.0";
+  version = "3.21.1";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "95b5c66d19dbffd57be1636d1f737c7644d280a48c28f933aeb4db73a7c83495";
+    sha256 = "1whama3bm34xp9l7f543sz2h9dms77ci820sdbxi5dl9krs4xkxb";
     extension = "zip";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Building `fonttools` currently fails since the releases do not contain all files required for running the tests. ~~I filed a PR with the upstream repository to add the missing line to MANIFEST.in [1].~~

~~This can be reverted with the next fonttools release that contains the fix.~~

The PR has been merged. I've updated this PR to be a simple version bump.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


  
  