### PR TITLE
font-lock-plus: 2017-0222.1755 -> 20180101.25

### DIFF
--- a/pkgs/applications/editors/emacs-modes/font-lock-plus/default.nix
+++ b/pkgs/applications/editors/emacs-modes/font-lock-plus/default.nix
@@ -2,11 +2,11 @@
 
 melpaBuild {
   pname = "font-lock-plus";
-  version = "20170222.1755";
+  version = "20180101.25";
 
   src = fetchurl {
-    url = "https://www.emacswiki.org/emacs/download/font-lock+.el";
-    sha256 = "0iajkgh0n3pbrwwxx9rmrrwz8dw2m7jsp4mggnhq7zsb20ighs30";
+    url = "https://www.emacswiki.org/emacs/download/font-lock%2b.el?revision=25";
+    sha256 = "0197yzn4hbjmw5h3m08264b7zymw63pdafph5f3yzfm50q8p7kp4";
     name = "font-lock+.el";
   };
 


### PR DESCRIPTION
###### Motivation for this change
Also specified specific revisions of the file to download to not have
a breaking package whenever the author decides to update the package.

This happened on 2018-01-01 when the author updated the copyright of
the package to match the new year.

I have not managed to build it with nox, nox promptly told me that there was no change, which I don't agree to. And I've also been unable to build it with nix-build like this:
```
nix-build -A emacsPackagesNgGen.font-lock-plus
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

