### PR TITLE
Correct boost configure phase when enablePython is false

### DIFF
--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -125,9 +125,9 @@ stdenv.mkDerivation {
   configureFlags = [
     "--includedir=$(dev)/include"
     "--libdir=$(out)/lib"
-    (if enablePython then "--with-python=${python.interpreter}" else "--without-python")
-    (if hostPlatform == buildPlatform then "--with-icu=${icu.dev}" else  "--without-icu")
-  ] ++ optional (toolset != null) "--with-toolset=${toolset}";
+  ] ++ optional enablePython "--with-python=${python.interpreter}"
+    ++ [ (if hostPlatform == buildPlatform then "--with-icu=${icu.dev}" else "--without-icu") ]
+    ++ optional (toolset != null) "--with-toolset=${toolset}";
 
   buildPhase = ''
     ./b2 ${b2Args}


### PR DESCRIPTION
The bootstrap script does not seem to have --without-python; instead
just omit --with-python option

###### Motivation for this change

configurationPhase currently fails when enablePython is false (e.g., when cross-compiling this is the default). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

