### PR TITLE
glib: preFixupPhases should be a string, and not an array

### DIFF
--- a/pkgs/development/libraries/glib/setup-hook.sh
+++ b/pkgs/development/libraries/glib/setup-hook.sh
@@ -11,7 +11,7 @@ addEnvHooks "$hostOffset" make_glib_find_gsettings_schemas
 glibPreInstallPhase() {
   installFlagsArray+=("gsettingsschemadir=${!outputLib}/share/gsettings-schemas/$name/glib-2.0/schemas/")
 }
-preInstallPhases+=(glibPreInstallPhase)
+preInstallPhases+=" glibPreInstallPhase"
 
 glibPreFixupPhase() {
     # Move gschemas in case the install flag didn't help
@@ -22,5 +22,4 @@ glibPreFixupPhase() {
 
     addToSearchPath GSETTINGS_SCHEMAS_PATH "${!outputLib}/share/gsettings-schemas/$name"
 }
-preFixupPhases+=(glibPreFixupPhase)
-
+preFixupPhases+=" glibPreFixupPhase"


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/33388.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).