### PR TITLE
transgui: fix crash at startup with file argument

### DIFF
--- a/pkgs/applications/networking/p2p/transgui/r988-compile-fix.patch
+++ b/pkgs/applications/networking/p2p/transgui/r988-compile-fix.patch
@@ -16,7 +16,7 @@ index eb8b828..1ff2440 100644
  function ParamStrUTF8(Param: Integer): utf8string;
  begin
 -  Result:=FileUtil.ParamStrUTF8(Param);
-+  Result:=ParamStrUTF8(Param);
++  Result:=LazUtf8.ParamStrUTF8(Param);
  end;
  
  function ParamCount: integer;


### PR DESCRIPTION
###### Motivation for this change

I messed up this patch last time.  It would compile, but it's just an infinite recursion.  Transgui would crash when launched with a file argument (e.g. xdg-open).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

