### PR TITLE
Make GHC work on armv7l-linux

### DIFF
--- a/pkgs/development/compilers/ghc/7.10.3-binary.nix
+++ b/pkgs/development/compilers/ghc/7.10.3-binary.nix
@@ -1,7 +1,7 @@
 { stdenv
 , fetchurl, perl
 , ncurses5, gmp, libiconv
-, gcc
+, gcc, llvm_35
 }:
 
 # Prebuilt only does native
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
     or (throw "cannot bootstrap GHC on this platform"));
 
   nativeBuildInputs = [ perl ];
+  buildInputs = stdenv.lib.optionals stdenv.isArm [ llvm_35 ];
 
   # Cannot patchelf beforehand due to relative RPATHs that anticipate
   # the final install location/

--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -2,7 +2,7 @@
 , buildPlatform, hostPlatform, targetPlatform
 
 # build-tools
-, bootPkgs, hscolour
+, bootPkgs, hscolour, llvm_35
 , coreutils, fetchurl, fetchpatch, perl
 , docbook_xsl, docbook_xml_dtd_45, docbook_xml_dtd_42, libxml2, libxslt
 
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     ./relocation.patch
   ];
 
-  buildInputs = [ ghc perl libxml2 libxslt docbook_xsl docbook_xml_dtd_45 docbook_xml_dtd_42 hscolour ];
+  buildInputs = [ ghc perl libxml2 libxslt docbook_xsl docbook_xml_dtd_45 docbook_xml_dtd_42 hscolour ] ++ stdenv.lib.optionals stdenv.isArm [ llvm_35 ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -2,7 +2,7 @@
 , buildPlatform, hostPlatform, targetPlatform
 
 # build-tools
-, bootPkgs, hscolour
+, bootPkgs, hscolour, llvm_37
 , coreutils, fetchurl, fetchpatch, patchutils, perl, sphinx
 
 , libiconv ? null, ncurses
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional stdenv.isLinux ./ghc-no-madv-free.patch
     ++ stdenv.lib.optional stdenv.isDarwin ./ghc-8.0.2-no-cpp-warnings.patch;
 
-  buildInputs = [ ghc perl hscolour sphinx ];
+  buildInputs = [ ghc perl hscolour sphinx ] ++ stdenv.lib.optionals (stdenv.isArm || stdenv.isAarch64) [ llvm_37 ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/ghc/8.2.1-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.1-binary.nix
@@ -1,5 +1,5 @@
 { stdenv
-, fetchurl, perl, gcc
+, fetchurl, perl, gcc, llvm_39
 , ncurses5, gmp, libiconv
 }:
 
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
     or (throw "cannot bootstrap GHC on this platform"));
 
   nativeBuildInputs = [ perl ];
+  buildInputs = stdenv.lib.optionals (stdenv.isArm || stdenv.isAarch64) [ llvm_39 ];
 
   # Cannot patchelf beforehand due to relative RPATHs that anticipate
   # the final install location/

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -58,6 +58,8 @@ stdenv.mkDerivation (rec {
     "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
   ] ++ stdenv.lib.optional stdenv.isDarwin [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
+  ] ++ stdenv.lib.optional stdenv.isArm [
+    "LD=${stdenv.cc}/bin/ld.gold"
   ];
 
   # required, because otherwise all symbols from HSffi.o are stripped, and

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -3,7 +3,7 @@
 , selfPkgs, cross ? null
 
 # build-tools
-, bootPkgs, alex, happy, hscolour
+, bootPkgs, alex, happy, hscolour, llvm_39
 , autoconf, automake, coreutils, fetchurl, perl, python3, sphinx
 
 , libiconv ? null, ncurses
@@ -46,7 +46,7 @@ stdenv.mkDerivation (rec {
     sed 's|#BuildFlavour  = quick-cross|BuildFlavour  = perf-cross|' mk/build.mk.sample > mk/build.mk
   '';
 
-  buildInputs = [ alex autoconf automake ghc happy hscolour perl python3 sphinx ];
+  buildInputs = [ alex autoconf automake ghc happy hscolour perl python3 sphinx ] ++ stdenv.lib.optionals (stdenv.isArm || stdenv.isAarch64) [ llvm_39 ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1023,4 +1023,6 @@ self: super: {
   # https://github.com/Twinside/Juicy.Pixels/issues/149
   JuicyPixels = dontHaddock super.JuicyPixels;
 
+  # armv7l fixes.
+  happy = if pkgs.stdenv.isArm then dontCheck super.happy else super.happy; # Similar to https://ghc.haskell.org/trac/ghc/ticket/13062
 }

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -130,7 +130,7 @@ let
     (optionalString (enableSharedExecutables && stdenv.isDarwin) "--ghc-option=-optl=-Wl,-headerpad_max_install_names")
     (optionalString enableParallelBuilding "--ghc-option=-j$NIX_BUILD_CORES")
     (optionalString useCpphs "--with-cpphs=${cpphs}/bin/cpphs --ghc-options=-cpp --ghc-options=-pgmP${cpphs}/bin/cpphs --ghc-options=-optP--cpp")
-    (enableFeature (enableDeadCodeElimination && (versionAtLeast "8.0.1" ghc.version)) "split-objs")
+    (enableFeature (enableDeadCodeElimination && !stdenv.isArm && !stdenv.isAarch64 && (versionAtLeast "8.0.1" ghc.version)) "split-objs")
     (enableFeature enableLibraryProfiling "library-profiling")
     (enableFeature enableExecutableProfiling (if versionOlder ghc.version "8" then "executable-profiling" else "profiling"))
     (enableFeature enableSharedLibraries "shared")


### PR DESCRIPTION
###### Motivation for this change

Get GHC working on `armv7l-linux`

###### Things done

`master` on `armv7l-linux` is currently broken due to #33403, so I can't test this yet on `master`, but it is currently building on the `nixos-unstable-small` channel. I will update this PR when I can make progress on `master`, but these changes are straightforward and only affect ARM builds.

Note that in a few places there are fixes that are also obviously needed for `aarch64-linux` (e.g., LLVM support), but these patches do not address `aarch64-linux` in general as there is more work needed to bootstrap that platform due to GHC 7.10.3 and 8.0.2 dependencies in the toolchain for building 8.2.2.

There will also inevitably be more `haskellPackages` fixes needed for `armv7l-linux` (usually a `dontCheck` here and there, in my experience with my own GHC ARM overlay), but I will tackle those as they come up, as compiling even a small subset of `haskellPackages` on `armv7l-linux` is a multi-day effort.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

