### PR TITLE
Documentation: reword "Obtaining NixOS" paragraph to remove contradiction + update link

### DIFF
--- a/nixos/doc/manual/installation/obtaining.xml
+++ b/nixos/doc/manual/installation/obtaining.xml
@@ -12,12 +12,8 @@ download page</link>.  There are a number of installation options.  If
 you happen to have an optical drive and a spare CD, burning the
 image to CD and booting from that is probably the easiest option.
 Most people will need to prepare a USB stick to boot from.
-Unetbootin is recommended and the process is described in brief below.
-Note that systems which use UEFI require some additional manual steps.
-If you run into difficulty a number of alternative methods are presented
-in the <link
-xlink:href="https://nixos.org/wiki/Installing_NixOS_from_a_USB_stick">NixOS
-Wiki</link>.</para>
+<xref linkend="sec-booting-from-usb"/> describes the preferred method
+to prepare a USB stick.
 
 <para>As an alternative to installing NixOS yourself, you can get a
 running NixOS system through several other means:

--- a/nixos/doc/manual/installation/obtaining.xml
+++ b/nixos/doc/manual/installation/obtaining.xml
@@ -14,6 +14,9 @@ image to CD and booting from that is probably the easiest option.
 Most people will need to prepare a USB stick to boot from.
 <xref linkend="sec-booting-from-usb"/> describes the preferred method
 to prepare a USB stick.
+A number of alternative methods are presented in the <link
+xlink:href="https://nixos.wiki/wiki/NixOS_Installation_Guide#Making_the_installation_media">NixOS
+Wiki</link>.</para>
 
 <para>As an alternative to installing NixOS yourself, you can get a
 running NixOS system through several other means:


### PR DESCRIPTION
###### Motivation for this change

Questions asked on `#nixos` channel.

 * https://botbot.me/freenode/nixos/2018-01-04/?msg=95328174&page=1

The paragraph was saying that Unetbootin was the preferred method of creating the USB drive. I'm pretty sure that the preferred method is the one documented in *2.1. Booting from a USB Drive*. 

Furthermore, the wiki link has been changed (in a separate commit) to the new section that describes making the installation media. I think this still relevant since it describes a way to create the USB drive from Windows, which I tested personally recently.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
The manual was built locally and links are working as expected.

* * *

I am asking that the changes are cherry-picked in a way that updates the official documentation on the website. I'm not sure whether it's my job to do so (cherry picking the changes) or if it's a maintainer's job.