### PR TITLE
Fixed airmon complaining about tools

### DIFF
--- a/pkgs/tools/networking/aircrack-ng/default.nix
+++ b/pkgs/tools/networking/aircrack-ng/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, libpcap, openssl, zlib, wirelesstools, libnl, pkgconfig }:
+{ stdenv, fetchurl, libpcap, openssl, zlib, wirelesstools
+, iw, ethtool, pciutils, libnl, pkgconfig, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "aircrack-ng-1.2-rc4";
@@ -8,13 +9,19 @@ stdenv.mkDerivation rec {
     sha256 = "0dpzx9kddxpgzmgvdpl3rxn0jdaqhm5wxxndp1xd7d75mmmc2fnr";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libpcap openssl zlib libnl ];
+  nativeBuildInputs = [ pkgconfig makeWrapper ];
+  buildInputs = [ libpcap openssl zlib libnl iw ethtool pciutils ];
 
   patchPhase = ''
     sed -e 's@^prefix.*@prefix = '$out@ -i common.mak
     sed -e 's@/usr/local/bin@'${wirelesstools}@ -i src/osdep/linux.c
-    '';
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/airmon-ng --prefix PATH : ${stdenv.lib.makeBinPath [
+      ethtool iw pciutils
+    ]}
+  '';
 
   meta = with stdenv.lib; {
     description = "Wireless encryption cracking tools";


### PR DESCRIPTION
###### Motivation for this change

Before this change `airmon-ng` was refusing to start without `iw`, `ethtool` and `lspci`(there was also same messages for `ethtool` and `lspci`):

``` console
$ sudo airmon-ng -h
You don't have iw installed, please install it from your distro's package manager.
If your distro doesn't have a recent version you can download it from this link:
https://www.kernel.org/pub/software/network/iw/iw-4.3.tar.gz

...
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

