### PR TITLE
gopass: 1.6.6 -> 1.6.7

### DIFF
--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -1,7 +1,7 @@
 { stdenv, buildGoPackage, fetchFromGitHub, git, gnupg, makeWrapper }:
 
 buildGoPackage rec {
-  version = "1.6.6";
+  version = "1.6.7";
   name = "gopass-${version}";
 
   goPackagePath = "github.com/justwatchcom/gopass";
@@ -12,7 +12,7 @@ buildGoPackage rec {
     owner = "justwatchcom";
     repo = "gopass";
     rev = "v${version}";
-    sha256 = "0n3isjrjpn2cnlwfdkjdcz5j8n16dhyaw4zyjpmis51nl0bqd3jw";
+    sha256 = "0al2avdvmnnz7h21hnvlacr20k50my5l67plgf4cphy52p9461vp";
   };
 
   wrapperPath = with stdenv.lib; makeBinPath ([


### PR DESCRIPTION
###### Motivation for this change

Bumping the package version to latest upstream release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

