### PR TITLE
hyperv-daemons: package and nixos module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -746,6 +746,7 @@
   ./virtualisation/lxcfs.nix
   ./virtualisation/lxd.nix
   ./virtualisation/amazon-options.nix
+  ./virtualisation/hyperv-guest.nix
   ./virtualisation/openvswitch.nix
   ./virtualisation/parallels-guest.nix
   ./virtualisation/rkt.nix

--- a/nixos/modules/virtualisation/hyperv-guest.nix
+++ b/nixos/modules/virtualisation/hyperv-guest.nix
@@ -1,0 +1,37 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.virtualisation.hypervGuest;
+
+in {
+  options = {
+    virtualisation.hypervGuest = {
+      enable = mkEnableOption "Hyper-V Guest Support";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ config.boot.kernelPackages.hyperv-daemons.bin ];
+
+    security.rngd.enable = false;
+
+    # enable hotadding memory
+    services.udev.packages = lib.singleton (pkgs.writeTextFile {
+      name = "hyperv-memory-hotadd-udev-rules";
+      destination = "/etc/udev/rules.d/99-hyperv-memory-hotadd.rules";
+      text = ''
+        ACTION="add", SUBSYSTEM=="memory", ATTR{state}="online"
+      '';
+    });
+
+    systemd = {
+      packages = [ config.boot.kernelPackages.hyperv-daemons.lib ];
+
+      targets.hyperv-daemons = {
+        wantedBy = [ "multi-user.target" ];
+      };
+    };
+  };
+}

--- a/pkgs/os-specific/linux/hyperv-daemons/default.nix
+++ b/pkgs/os-specific/linux/hyperv-daemons/default.nix
@@ -1,0 +1,109 @@
+{ stdenv, lib, python, kernel, makeWrapper, writeText }:
+
+let
+  daemons = stdenv.mkDerivation rec {
+    name = "hyperv-daemons-bin-${version}";
+    inherit (kernel) src version;
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    # as of 4.9 compilation will fail due to -Werror=format-security
+    hardeningDisable = [ "format" ];
+
+    preConfigure = ''
+      cd tools/hv
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      for f in fcopy kvp vss ; do
+        install -Dm755 hv_''${f}_daemon -t $out/bin
+      done
+
+      install -Dm755 hv_get_dns_info.sh lsvmbus -t $out/bin
+
+      # I don't know why this isn't being handled automatically by fixupPhase
+      substituteInPlace $out/bin/lsvmbus \
+        --replace '/usr/bin/env python' ${python.interpreter}
+
+      runHook postInstall
+    '';
+
+    postFixup = ''
+      # kvp needs to be able to find the script(s)
+      wrapProgram $out/bin/hv_kvp_daemon --prefix PATH : $out/bin
+    '';
+  };
+
+  service = bin: title: check:
+    writeText "hv-${bin}.service" ''
+      [Unit]
+      Description=Hyper-V ${title} daemon
+      ConditionVirtualization=microsoft
+      ${lib.optionalString (check != "") ''
+        ConditionPathExists=/dev/vmbus/${check}
+      ''}
+      [Service]
+      ExecStart=@out@/hv_${bin}_daemon -n
+      Restart=on-failure
+      PrivateTmp=true
+      Slice=hyperv.slice
+
+      [Install]
+      WantedBy=hyperv-daemons.target
+    '';
+
+in stdenv.mkDerivation rec {
+  name    = "hyperv-daemons-${version}";
+
+  inherit (kernel) version;
+
+  # we just stick the bins into out as well as it requires "out"
+  outputs = [ "bin" "lib" "out" ];
+
+  phases = [ "installPhase" ];
+
+  buildInputs = [ daemons ];
+
+  installPhase = ''
+    system=$lib/lib/systemd/system
+
+    mkdir -p $system
+
+    cp ${service "fcopy" "file copy (FCOPY)" "hv_fcopy" } $system/hv-fcopy.service
+    cp ${service "kvp"   "key-value pair (KVP)"     ""  } $system/hv-kvp.service
+    cp ${service "vss"   "volume shadow copy (VSS)" ""  } $system/hv-vss.service
+
+    cat > $system/hyperv-daemons.target <<EOF
+    [Unit]
+    Description=Hyper-V Daemons
+    Wants=hv-fcopy.service hv-kvp.service hv-vss.service
+    EOF
+
+    for f in $lib/lib/systemd/system/* ; do
+      substituteInPlace $f --replace @out@ ${daemons}/bin
+    done
+
+    # we need to do both $out and $bin as $out is required
+    for d in $out/bin $bin/bin ; do
+      # make user binaries available
+      mkdir -p $d
+      ln -s ${daemons}/bin/lsvmbus $d/lsvmbus
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Integration Services for running NixOS under HyperV";
+    longDescription = ''
+      This packages contains the daemons that are used by the Hyper-V hypervisor
+      on the host.
+
+      Microsoft calls their guest agents "Integration Services" which is why
+      we use that name here.
+    '';
+    homepage = https://kernel.org;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = kernel.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12858,6 +12858,8 @@ with pkgs;
 
     pktgen = callPackage ../os-specific/linux/pktgen { };
 
+    hyperv-daemons = callPackage ../os-specific/linux/hyperv-daemons { };
+
     odp-dpdk = callPackage ../os-specific/linux/odp-dpdk { };
 
     ofp = callPackage ../os-specific/linux/ofp { };


### PR DESCRIPTION
###### Motivation for this change

This makes NixOS behave nicely under Hyper-V.

We have been running this in production for the last 6 months or so on 2012, 2012R2 and 2016.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

