### PR TITLE
test-driver: mention `$user` argument in the NixOS manual and the Impala release notes

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.xml
+++ b/nixos/doc/manual/development/writing-nixos-tests.xml
@@ -272,8 +272,37 @@ startAll;
     </listitem>
   </varlistentry>
 
+  <varlistentry>
+    <term><methodname>systemctl</methodname></term>
+    <listitem>
+      <para>Runs <literal>systemctl</literal> commands with optional support for
+      <literal>systemctl --user</literal></para>
+    <para>
+      <programlisting>
+        $machine->systemctl("list-jobs --no-pager"); // runs `systemctl list-jobs --no-pager`
+        $machine->systemctl("list-jobs --no-pager", "any-user"); // spawns a shell for `any-user` and runs `systemctl --user list-jobs --no-pager`
+      </programlisting>
+    </para>
+    </listitem>
+  </varlistentry>
+
 </variablelist>
 
+</para>
+
+<para>
+  To test user units declared by <literal>systemd.user.services</literal> the optional <literal>$user</literal>
+  argument can be used:
+
+  <programlisting>
+    $machine->start;
+    $machine->waitForX;
+    $machine->waitForUnit("xautolock.service", "x-session-user");
+  </programlisting>
+
+  This applies to <literal>systemctl</literal>, <literal>getUnitInfo</literal>,
+  <literal>waitForUnit</literal>, <literal>startJob</literal>
+  and <literal>stopJob</literal>.
 </para>
 
 </section>

--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -234,6 +234,13 @@ following incompatible changes:</para>
       to your <literal>configuration.nix</literal>.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      The NixOS test driver supports user services declared by <literal>systemd.user.services</literal>.
+      The methods <literal>waitForUnit</literal>, <literal>getUnitInfo</literal>, <literal>startJob</literal>
+      and <literal>stopJob</literal> provide an optional <literal>$user</literal> argument for that purpose.
+    </para>
+  </listitem>
 </itemizedlist>
 
 </section>


### PR DESCRIPTION
###### Motivation for this change

As the changes made in #32845 affect the NixOS internals, I think that it should be mentioned in the docs and the core.
(/cc @Mic92 sorry for the second PR, forgot to add this in the previous one :))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (only `x86_64-linux`)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

