### PR TITLE
uwsgi: fix php plugin build

### DIFF
--- a/pkgs/servers/uwsgi/default.nix
+++ b/pkgs/servers/uwsgi/default.nix
@@ -5,6 +5,7 @@
 , systemd, withSystemd ? false
 , python2, python3, ncurses
 , ruby, php-embed
+, mysql
 }:
 
 let pythonPlugin = pkg : lib.nameValuePair "python${if pkg ? isPy2 then "2" else "3"}" {
@@ -33,7 +34,7 @@ let pythonPlugin = pkg : lib.nameValuePair "python${if pkg ? isPy2 then "2" else
                   (lib.nameValuePair "php" {
                     # usage: https://uwsgi-docs.readthedocs.io/en/latest/PHP.html#running-php-apps-with-nginx
                     path = "plugins/php";
-                    inputs = [ php-embed ] ++ php-embed.buildInputs;
+                    inputs = [ php-embed mysql.client ] ++ php-embed.buildInputs;
                   })
                 ];
 


### PR DESCRIPTION
###### Motivation for this change
Workaround for #33400.

It does not compile with `mysql.connector-c` which was introduced in #30546.
It compiles with `config.php.mysqlnd = true`, but fails at runtime with "failed to connect to the database - an exception occured in driver - no such file or directory" (tested with Nextcloud).

Can someone with more C/Nix experience help me update the plugin the right way? I do not really understand what is happening and why it fails without the direct mysql dependency.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).