### PR TITLE
Bluez fixed test scripts & bumped to  5.48 

### DIFF
--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   pythonPath = with pythonPackages;
-    [ dbus pygobject2 pygobject3 recursivePthLoader ];
+    [ dbus-python pygobject2 pygobject3 recursivePthLoader ];
 
   buildInputs = [
     pkgconfig dbus glib alsaLib pythonPackages.python pythonPackages.wrapPython

--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -5,11 +5,11 @@
 assert stdenv.isLinux;
 
 stdenv.mkDerivation rec {
-  name = "bluez-5.47";
+  name = "bluez-5.48";
 
   src = fetchurl {
     url = "mirror://kernel/linux/bluetooth/${name}.tar.xz";
-    sha256 = "1j22hfjz0fp4pgclgz9mfcwjbr4wqgah3gd2qhfg4r6msmybyxfg";
+    sha256 = "140fjyxa2q4y35d9n52vki649jzb094pf71hxkkvlrpgf8q75a5r";
   };
 
   pythonPath = with pythonPackages;


### PR DESCRIPTION
###### Motivation for this change

I started playing around with bluez and a new bluetooth headset so I discovered the scripts in `bluez.test` aren't working since the dbus bindings aren't properly provided. Also bumped the version to the latest upstream release with a couple of bug fixes [1]:

```
-	Fix issue with subscriptions for unpaired devices.
-	Fix issue with handling A2DP and no available SEP.
-	Fix issue with handling AVCTP change path support.
-	Fix issue with handling AVCTP browsing channel.
-	Fix issue with handling AVCTP passthrough PDUs.
-	Fix issue with handling detaching of controller.
-	Fix issue with handling start discovery results.
-	Fix issue with handling non-connectable devices.
-	Fix issue with handling unused parameter in WriteValue.
-	Add support for service side AcquireWrite and AcquireNotify.
-	Add support for providing address type information.
-	Add support for cable based authentication and pairing.
-	Add support for Bluetooth Low-Energy battery service.
-	Add support for BTP client for qualification testing.
-	Add support for additional Mesh control functionality.
-	Mark advertising manager APIs as stable interfaces.
```

[1] https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/?h=5.48&id=0d1e3b9c5754022c779da129025d493a198d49cf

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

