### PR TITLE
go-protobuf: init at 2018-01-04

### DIFF
--- a/pkgs/development/tools/go-protobuf/default.nix
+++ b/pkgs/development/tools/go-protobuf/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "go-protobuf-${version}";
+  version = "2018-01-04";
+  rev = "1e59b77b52bf8e4b449a57e6f79f21226d571845";
+
+  goPackagePath = "github.com/golang/protobuf";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "golang";
+    repo = "protobuf";
+    sha256 = "19bkh81wnp6njg3931wky6hsnnl2d1ig20vfjxpv450sd3k6yys8";
+  };
+
+  meta = with stdenv.lib; {
+    homepage    = "https://github.com/golang/protobuf";
+    description = " Go bindings for protocol buffer";
+    maintainers = with maintainers; [ lewo ];
+    license     = licenses.bsd3;
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13111,6 +13111,8 @@ with pkgs;
 
   go-bindata-assetfs = callPackage ../development/tools/go-bindata-assetfs { };
 
+  go-protobuf = callPackage ../development/tools/go-protobuf { };
+
   gocode = callPackage ../development/tools/gocode { };
 
   goconvey = callPackage ../development/tools/goconvey { };


### PR DESCRIPTION
With the commit 1e59b77b52bf8e4b449a57e6f79f21226d571845

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

