### PR TITLE
go-symbols: init at 2017-02-06

### DIFF
--- a/pkgs/development/tools/go-symbols/default.nix
+++ b/pkgs/development/tools/go-symbols/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, buildGoPackage, fetchgit }:
+
+buildGoPackage rec {
+  name = "go-symbols-${version}";
+  version = "unstable-2017-02-06";
+  rev = "5a7f75904fb552189036c640d04cd6afef664836";
+
+  goPackagePath = "github.com/acroca/go-symbols";
+  goDeps = ./deps.nix;
+
+  src = fetchgit {
+    inherit rev;
+    url = "https://github.com/acroca/go-symbols";
+    sha256 = "0qh2jjhwwk48gi8yii0z031bah11anxfz81nwflsiww7n426a8bb";
+  };
+
+  meta = {
+    description = "A utility for extracting a JSON representation of the package symbols from a go source tree.";
+    homepage = https://github.com/acroca/go-symbols;
+    maintainers = with stdenv.lib.maintainers; [ vdemeester ];
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/development/tools/go-symbols/deps.nix
+++ b/pkgs/development/tools/go-symbols/deps.nix
@@ -1,0 +1,11 @@
+[
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/tools";
+      rev = "96b5a5404f303f074e6117d832a9873c439508f0";
+      sha256 = "1h6r9xyp1v3w2x8d108vzghn65l6ia2h895irypmrwymfcp30y42";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13221,6 +13221,8 @@ with pkgs;
 
   go-protobuf = callPackage ../development/tools/go-protobuf { };
 
+  go-symbols = callPackage ../development/tools/go-symbols { };
+
   gocode = callPackage ../development/tools/gocode { };
 
   goconvey = callPackage ../development/tools/goconvey { };


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

`go-symbols` is an utility for extracting a JSON representation of the package symbols from a go source tree. It's used in `vscode` and other editors 👼

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

