### PR TITLE
go-outline: init at 2017-08-04

### DIFF
--- a/pkgs/development/tools/go-outline/default.nix
+++ b/pkgs/development/tools/go-outline/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "go-outline-${version}";
+  version = "unstable-2017-08-04";
+  rev = "9e9d089bb61a5ce4f8e0c8d8dc5b4e41b0e02a48";
+
+  goPackagePath = "github.com/ramya-rao-a/go-outline";
+  goDeps = ./deps.nix;
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "ramya-rao-a";
+    repo = "go-outline";
+    sha256 = "0kbkv4d6q9w0d41m00sqdm10l0sg56mv8y6rmidqs152mm2w13x0";
+  };
+
+  meta = {
+    description = "Utility to extract JSON representation of declarations from a Go source file.";
+    homepage = https://github.com/ramya-rao-a/go-outline;
+    maintainers = with stdenv.lib.maintainers; [ vdemeester ];
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/development/tools/go-outline/deps.nix
+++ b/pkgs/development/tools/go-outline/deps.nix
@@ -1,0 +1,11 @@
+[
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/tools";
+      rev = "96b5a5404f303f074e6117d832a9873c439508f0";
+      sha256 = "1h6r9xyp1v3w2x8d108vzghn65l6ia2h895irypmrwymfcp30y42";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13373,7 +13373,10 @@ with pkgs;
 
   go-protobuf = callPackage ../development/tools/go-protobuf { };
 
+
   go-symbols = callPackage ../development/tools/go-symbols { };
+
+  go-outline = callPackage ../development/tools/go-outline { };
 
   gocode = callPackage ../development/tools/gocode { };
 


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

`go-outline` is an utility to extract JSON representation of declarations from a Go source file. Mainly used by `vsdcode` and other editor (with go support).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

