### PR TITLE
gomodifytags: init at 2017-12-14

### DIFF
--- a/pkgs/development/tools/gomodifytags/default.nix
+++ b/pkgs/development/tools/gomodifytags/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, buildGoPackage, fetchgit }:
+
+buildGoPackage rec {
+  name = "gomodifytags-${version}";
+  version = "unstable-2017-12-14";
+  rev = "20644152db4fe0ac406d81f3848e8a15f0cdeefa";
+
+  goPackagePath = "github.com/fatih/gomodifytags";
+
+  src = fetchgit {
+    inherit rev;
+    url = "https://github.com/fatih/gomodifytags";
+    sha256 = "0k0ly3mmm9zcaxwlzdbvdxr2gn7kvcqzk1bb7blgq7fkkzpp7i1q";
+  };
+
+  meta = {
+    description = "Go tool to modify struct field tags.";
+    homepage = https://github.com/fatih/gomodifytags;
+    maintainers = with stdenv.lib.maintainers; [ vdemeester ];
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13239,6 +13239,8 @@ with pkgs;
 
   gotools = callPackage ../development/tools/gotools { };
 
+  gomodifytags = callPackage ../development/tools/gomodifytags { };
+
   gogoclient = callPackage ../os-specific/linux/gogoclient { };
 
   nss_ldap = callPackage ../os-specific/linux/nss_ldap { };


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

`gomodifytags` is a go tool to modify struct field tags. Mainly used in `vscode` and other editor with go support (like vim-go)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

