### PR TITLE
gopkgs: init at 2017-12-29

### DIFF
--- a/pkgs/development/tools/gopkgs/default.nix
+++ b/pkgs/development/tools/gopkgs/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "gopkgs-${version}";
+  version = "unstable-2017-12-29";
+  rev = "b2ea2ecd37740e6ce0e020317d90c729aab4dc6d";
+
+  goPackagePath = "github.com/uudashr/gopkgs";
+  goDeps = ./deps.nix;
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "uudashr";
+    repo = "gopkgs";
+    sha256 = "1hwzxrf2h8xjbbx6l86mjpjh4csxxsy17zkh8h3qzncyfnsnczzg";
+  };
+
+  meta = {
+    description = "Tool to get list available Go packages.";
+    homepage = https://github.com/uudashr/gopkgs;
+    maintainers = with stdenv.lib.maintainers; [ vdemeester ];
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/development/tools/gopkgs/deps.nix
+++ b/pkgs/development/tools/gopkgs/deps.nix
@@ -1,0 +1,11 @@
+[
+  {
+    goPackagePath = "github.com/MichaelTJones/walk";
+    fetch = {
+      type = "git";
+      url = "https://github.com/MichaelTJones/walk";
+      rev = "4748e29d5718c2df4028a6543edf86fd8cc0f881";
+      sha256 = "03bc3cql3w8cx05xlnzxsff59c6679rcpx4njzk86k00blkkizv7";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13389,6 +13389,8 @@ with pkgs;
 
   goimports = callPackage ../development/tools/goimports { };
 
+  gopkgs = callPackage ../development/tools/gopkgs { };
+
   govers = callPackage ../development/tools/govers { };
 
   gotools = callPackage ../development/tools/gotools { };


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

`gopkgs` is a tool to get list available Go packages. Mainly used by `vscode` and other editor with go support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

