### PR TITLE
gotests: init at 1.5.2

### DIFF
--- a/pkgs/development/tools/gotests/default.nix
+++ b/pkgs/development/tools/gotests/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "gotests-${version}";
+  version = "1.5.2";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/cweill/gotests";
+  excludedPackages = "testdata";
+  goDeps = ./deps.nix;
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "cweill";
+    repo = "gotests";
+    sha256 = "0ff2jvpc1xb5jr6dv9izlpfavxaivzirqmdmicpznrqjz0d56pri";
+  };
+
+  meta = {
+    description = "Generate Go tests from your source code.";
+    homepage = https://github.com/cweill/gotests;
+    maintainers = with stdenv.lib.maintainers; [ vdemeester ];
+    license = stdenv.lib.licenses.asl20;
+  };
+}

--- a/pkgs/development/tools/gotests/deps.nix
+++ b/pkgs/development/tools/gotests/deps.nix
@@ -1,0 +1,11 @@
+[
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/tools";
+      rev = "96b5a5404f303f074e6117d832a9873c439508f0";
+      sha256 = "1h6r9xyp1v3w2x8d108vzghn65l6ia2h895irypmrwymfcp30y42";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13395,6 +13395,8 @@ with pkgs;
 
   gomodifytags = callPackage ../development/tools/gomodifytags { };
 
+  gotests = callPackage ../development/tools/gotests { };
+
   gogoclient = callPackage ../os-specific/linux/gogoclient { };
 
   nss_ldap = callPackage ../os-specific/linux/nss_ldap { };


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

`gotests` is a tool to generate Go tests from your source code. Mainly used by `vscode` and other editor with go support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

