### PR TITLE
qt5.6: backport seccomp patch to fix errors w/new glibc + epoll_pwait

### DIFF
--- a/pkgs/development/libraries/qt-5/5.6/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/default.nix
@@ -51,8 +51,8 @@ let
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
     qttools = [ ./qttools.patch ];
-    qtwebengine =
-      optional stdenv.needsPax ./qtwebengine-paxmark-mksnapshot.patch;
+    qtwebengine = [ ./qtwebengine-seccomp.patch ]
+      ++ optional stdenv.needsPax ./qtwebengine-paxmark-mksnapshot.patch;
     qtwebkit = [ ./qtwebkit.patch ];
   };
 

--- a/pkgs/development/libraries/qt-5/5.6/qtwebengine-seccomp.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtwebengine-seccomp.patch
@@ -1,0 +1,24 @@
+Backported to Qt 5.6 for epoll_pwait fix on newer glibc
+Part of upstream Chromium's 4e8083b4ab953ba298aedfc4e79d464be15e4012
+Review URL: https://codereview.chromium.org/1613883002
+---
+diff --git a/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc b/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+index 10278dc5fc9b..b30b3e6acef6 100644
+--- a/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
++++ b/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+@@ -414,6 +414,7 @@ bool SyscallSets::IsAllowedEpoll(int sysno) {
+     case __NR_epoll_create:
+     case __NR_epoll_wait:
+ #endif
++    case __NR_epoll_pwait:
+     case __NR_epoll_create1:
+     case __NR_epoll_ctl:
+       return true;
+@@ -421,7 +422,6 @@ bool SyscallSets::IsAllowedEpoll(int sysno) {
+ #if defined(__x86_64__)
+     case __NR_epoll_ctl_old:
+ #endif
+-    case __NR_epoll_pwait:
+ #if defined(__x86_64__)
+     case __NR_epoll_wait_old:
+ #endif


### PR DESCRIPTION
Based on:
https://chromium.googlesource.com/chromium/src/+/4e8083b4ab953ba298aedfc4e79d464be15e4012

Fixes mendeley bug mentioned in #33396,
which links to related issues in other distributions and upstream Qt.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

