### PR TITLE
fileshelter: init at 3.0.0

### DIFF
--- a/pkgs/development/libraries/wt/default.nix
+++ b/pkgs/development/libraries/wt/default.nix
@@ -1,42 +1,56 @@
-{ stdenv, fetchFromGitHub, cmake, boost, pkgconfig, doxygen, qt48Full, libharu
+{ stdenv, fetchFromGitHub, cmake, boost165, pkgconfig, doxygen, qt48Full, libharu
 , pango, fcgi, firebird, mysql, postgresql, graphicsmagick, glew, openssl
 , pcre
 }:
 
-stdenv.mkDerivation rec {
-  name = "wt-${version}";
-  version = "4.0.0";
+let
+  generic =
+    { version, sha256 }:
+    stdenv.mkDerivation rec {
+      name = "wt-${version}";
 
-  src = fetchFromGitHub {
-    owner = "kdeforche";
-    repo = "wt";
-    rev = version;
-    sha256 = "1451xxvnx6mlvxg0jxlr1mfv5v18h2214kijk5kacilqashfc43i";
+      src = fetchFromGitHub {
+        owner = "kdeforche";
+        repo = "wt";
+        rev = version;
+        inherit sha256;
+      };
+
+      enableParallelBuilding = true;
+
+      nativeBuildInputs = [ pkgconfig ];
+      buildInputs = [
+        cmake boost165 doxygen qt48Full libharu
+        pango fcgi firebird mysql.connector-c postgresql graphicsmagick glew
+        openssl pcre
+      ];
+
+      cmakeFlags = [
+        "-DWT_WRASTERIMAGE_IMPLEMENTATION=GraphicsMagick"
+        "-DWT_CPP_11_MODE=-std=c++11"
+        "-DGM_PREFIX=${graphicsmagick}"
+        "-DMYSQL_PREFIX=${mysql.connector-c}"
+        "--no-warn-unused-cli"
+      ];
+
+      meta = with stdenv.lib; {
+        homepage = https://www.webtoolkit.eu/wt;
+        description = "C++ library for developing web applications";
+        platforms = platforms.linux;
+        license = licenses.gpl2;
+        maintainers = with maintainers; [ juliendehos willibutz ];
+      };
+    };
+in {
+  wt3 = generic {
+    # with the next version update the version pinning of boost should be omitted
+    version = "3.3.9";
+    sha256 = "1mkflhvzzzxkc5yzvr6nk34j0ldpwxjxb6n7xml59h3j3px3ixjm";
   };
 
-  enableParallelBuilding = true;
-
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
-    cmake boost doxygen qt48Full libharu
-    pango fcgi firebird mysql.connector-c postgresql graphicsmagick glew
-    openssl pcre
-  ];
-
-  cmakeFlags = [
-    "-DWT_WRASTERIMAGE_IMPLEMENTATION=GraphicsMagick"
-    "-DWT_CPP_11_MODE=-std=c++11"
-    "-DGM_PREFIX=${graphicsmagick}"
-    "-DMYSQL_PREFIX=${mysql.connector-c}"
-    "--no-warn-unused-cli"
-  ];
-
-  meta = with stdenv.lib; {
-    homepage = https://www.webtoolkit.eu/wt;
-    description = "C++ library for developing web applications";
-    platforms = platforms.linux;
-    license = licenses.gpl2;
-    maintainers = [ maintainers.juliendehos ];
+  wt4 = generic {
+    # with the next version update the version pinning of boost should be omitted
+    version = "4.0.2";
+    sha256 = "0r729gjd1sy0pcmir2r7ga33mp5cr5b4gvf44852q65hw2577w1x";
   };
 }
-

--- a/pkgs/servers/web-apps/fileshelter/default.nix
+++ b/pkgs/servers/web-apps/fileshelter/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, libzip, boost, wt3, libconfig, pkgconfig } :
+
+stdenv.mkDerivation rec {
+  name = "fileshelter";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "epoupon";
+    repo = "fileshelter";
+    rev = "v${version}";
+    sha256 = "1n9hrls3l9gf8wfz6m9bylma1b1hdvdqsksv2dlp1zdgjdzv200b";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ libzip boost wt3 libconfig ];
+
+  postInstall = ''
+    ln -s ${wt3}/share/Wt/resources $out/share/fileshelter/docroot/resources
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/epoupon/fileshelter;
+    description = "FileShelter is a 'one-click' file sharing web application";
+    maintainers = [ maintainers.willibutz ];
+    license = licenses.gpl3;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1106,6 +1106,8 @@ with pkgs;
 
   filebench = callPackage ../tools/misc/filebench { };
 
+  fileshelter = callPackage ../servers/web-apps/fileshelter { };
+
   fsmon = callPackage ../tools/misc/fsmon { };
 
   fsql = callPackage ../tools/misc/fsql { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11278,7 +11278,10 @@ with pkgs;
 
   wiredtiger = callPackage ../development/libraries/wiredtiger { };
 
-  wt = callPackage ../development/libraries/wt { };
+  wt = wt4;
+  inherit (callPackages ../development/libraries/wt {})
+    wt3
+    wt4;
 
   wxGTK = wxGTK28;
 


### PR DESCRIPTION
###### Motivation for this change
adds the web-app fileshelter

###### Things done

- split `wt` into `wt3` and `wt4` as both versions are still maintained and used by this package for example
- `wt` defaults to `wt4`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

