### PR TITLE
nixos/netdata: support adding extra packages to service PATH

### DIFF
--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -12,10 +12,19 @@ let
 in {
   options = {
     services.netdata = {
-      enable = mkOption {
-        default = false;
-        type = types.bool;
-        description = "Whether to enable netdata monitoring.";
+      enable = mkEnableOption "netdata";
+
+      extraPackages = mkOption {
+          type = with types; listOf package;
+          default = [];
+          example = literalExample ''
+            with pkgs; [ python3 lm_sensors ]
+          '';
+          description = ''
+            Extra packages available in the service context.
+
+            Useful for enabling netdata's built-in plugins.
+          '';
       };
 
       user = mkOption {
@@ -47,6 +56,7 @@ in {
 
   config = mkIf cfg.enable {
     systemd.services.netdata = {
+      path = cfg.extraPackages;
       description = "Real time performance monitoring";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION


###### Motivation for this change

Fixes #33366, although a fair number of python plugins seem to fail
for subsequent reasons (as triaged by viewing netdata's error.log).

cc @jtojnar @davidak @cransom 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

