### PR TITLE
ocaml-modules/dtoa: disable hardening (strictoverflow) on darwin

### DIFF
--- a/pkgs/development/ocaml-modules/dtoa/default.nix
+++ b/pkgs/development/ocaml-modules/dtoa/default.nix
@@ -20,8 +20,6 @@ stdenv.mkDerivation rec {
 
   inherit (jbuilder) installPhase;
 
-  createFindLibDestdir = true;
-
   hardeningDisable = stdenv.lib.optional stdenv.isDarwin "strictoverflow";
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/dtoa/default.nix
+++ b/pkgs/development/ocaml-modules/dtoa/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, jbuilder, ounit }:
+{ stdenv, fetchurl, ocaml, findlib, jbuilder }:
 
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.01";
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   unpackCmd = "tar xjf $src";
 
-  buildInputs = [ ocaml findlib jbuilder ounit ];
+  buildInputs = [ ocaml findlib jbuilder ];
 
   buildPhase = "jbuilder build -p dtoa";
 

--- a/pkgs/development/ocaml-modules/dtoa/default.nix
+++ b/pkgs/development/ocaml-modules/dtoa/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
 
   createFindLibDestdir = true;
 
+  hardeningDisable = stdenv.lib.optional stdenv.isDarwin "strictoverflow";
+
   meta = with stdenv.lib; {
     homepage = https://github.com/flowtype/ocaml-dtoa;
     description = "Converts OCaml floats into strings (doubles to ascii, \"d to a\"), using the efficient Grisu3 algorithm.";


### PR DESCRIPTION
###### Motivation for this change

This prevents a compile-time error on macOS:

```
clang-4.0: error: argument unused during compilation: '-fno-strict-overflow' [-Werror,-Wunused-command-line-argument]
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (by building and running `flow`, which this is a dependency of)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

