### PR TITLE
nixos/dnscrypt-wrapper: fix rotate script failing to restart the service

### DIFF
--- a/nixos/modules/services/networking/dnscrypt-wrapper.nix
+++ b/nixos/modules/services/networking/dnscrypt-wrapper.nix
@@ -145,6 +145,16 @@ in {
     };
     users.groups.dnscrypt-wrapper = { };
 
+    security.polkit.extraConfig = ''
+      // Allow dnscrypt-wrapper user to restart dnscrypt-wrapper.service
+      polkit.addRule(function(action, subject) {
+          if (action.id == "org.freedesktop.systemd1.manage-units" &&
+              action.lookup("unit") == "dnscrypt-wrapper.service" &&
+              subject.user == "dnscrypt-wrapper") {
+              return polkit.Result.YES;
+          }
+        });
+    '';
 
     systemd.services.dnscrypt-wrapper = {
       description = "dnscrypt-wrapper daemon";


### PR DESCRIPTION
###### Motivation for this change
Sorry it took me a while to notice this.
There is an issue with ca54a86: when the script runs as a normal user `systemctl restart dnscrypt-wrapper` fails with "Interactive authentication required." so dnscrypt-wrapper it's never restarted.
There a two possible solutions I can think of: running it as root (as it was before) and fixing the permission after or adding a polkit rule. I'd prefer not running as root since it's not really needed.

###### Things done
- [x] Tested the rotate script in a VM

---
cc @makefu 
  