### PR TITLE
universal-ctags: 2017-09-22 -> 2018-01-05

### DIFF
--- a/pkgs/development/tools/misc/universal-ctags/default.nix
+++ b/pkgs/development/tools/misc/universal-ctags/default.nix
@@ -2,21 +2,24 @@
 
 stdenv.mkDerivation rec {
   name = "universal-ctags-${version}";
-  version = "2017-09-22";
+  version = "2018-01-05";
 
   src = fetchFromGitHub {
     owner = "universal-ctags";
     repo = "ctags";
-    rev = "b9537289952cc7b26526aaff3094599d714d1729";
-    sha256 = "1kbw9ycl2ddzpfs1v4rbqa4gdhw4inrisf4awyaxb7zxfxmbzk1g";
+    rev = "c66bdfb4db99977c1bd0568e33e60853a48dca65";
+    sha256 = "0fdzhr0704cj84ym00plkl5l9w83haal6i6w70lx6f4968pcliyi";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig pythonPackages.docutils ];
   buildInputs = stdenv.lib.optional stdenv.isDarwin libiconv;
 
+  # to generate makefile.in
   autoreconfPhase = ''
-    ./autogen.sh --tmpdir
+    ./autogen.sh
   '';
+
+  configureFlags = [ "--enable-tmpdir=/tmp" ];
 
   postConfigure = ''
     sed -i 's|/usr/bin/env perl|${perl}/bin/perl|' misc/optlib2c


### PR DESCRIPTION


###### Motivation for this change
Fixup of https://github.com/NixOS/nixpkgs/issues/33124 (ctags failed to
create its temporary files when TMPDIR was not in environment). I used
the opportunity to bump version with the improvements made to ctags to
help diagnose these kinds of errors:
https://github.com/universal-ctags/ctags/pull/1648

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

