### PR TITLE
fix kernel modules that broke with 4.14

### DIFF
--- a/pkgs/os-specific/linux/ena/default.nix
+++ b/pkgs/os-specific/linux/ena/default.nix
@@ -1,41 +1,41 @@
 { lib, stdenv, fetchFromGitHub, kernel, kmod }:
 
 stdenv.mkDerivation rec {
-  version = "1.2.0";
+  version = "1.5.0";
   name = "ena-${version}-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "amzn";
     repo = "amzn-drivers";
     rev = "ena_linux_${version}";
-    sha256 = "0m0jqd6gyk4r43w6p5dvp1djg2qgvyhnzmg53sszlh55mlgla714";
+    sha256 = "1h3vnwa2129advyws69n0sqyra4nz68mng6g84whbvhzjyx810sj";
   };
 
   hardeningDisable = [ "pic" ];
 
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
   # linux 3.12
   NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
 
-  configurePhase =
-    ''
-      cd kernel/linux/ena
-      substituteInPlace Makefile --replace '/lib/modules/$(BUILD_KERNEL)' ${kernel.dev}/lib/modules/${kernel.modDirVersion}
-    '';
+  configurePhase = ''
+    cd kernel/linux/ena
+    substituteInPlace Makefile --replace '/lib/modules/$(BUILD_KERNEL)' ${kernel.dev}/lib/modules/${kernel.modDirVersion}
+  '';
 
-  installPhase =
-    ''
-      strip -S ena.ko
-      dest=$out/lib/modules/${kernel.modDirVersion}/misc
-      mkdir -p $dest
-      cp ena.ko $dest/
-      xz $dest/ena.ko
-    '';
+  installPhase = ''
+    strip -S ena.ko
+    dest=$out/lib/modules/${kernel.modDirVersion}/misc
+    mkdir -p $dest
+    cp ena.ko $dest/
+    xz $dest/ena.ko
+  '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Amazon Elastic Network Adapter (ENA) driver for Linux";
     homepage = https://github.com/amzn/amzn-drivers;
-    license = lib.licenses.gpl2;
-    maintainers = [ lib.maintainers.eelco ];
-    platforms = lib.platforms.linux;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.eelco ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/ixgbevf/default.nix
+++ b/pkgs/os-specific/linux/ixgbevf/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "ixgbevf-${version}-${kernel.version}";
-  version = "4.2.1";
+  version = "4.3.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/e1000/ixgbevf-${version}.tar.gz";
-    sha256 = "1666hsavaspjmf45ij396mkndzk6g0n3ibr2glfdhjfqhfy35zb8";
+    sha256 = "0kq8y0944kaprw445wb8iswdck2jmc0xpkx0iv6idy3r5cc4hvyg";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

