### PR TITLE
sqldeveloper: 17.3.1.279.0537 -> 17.4.0.355.2349

### DIFF
--- a/pkgs/development/tools/database/sqldeveloper/default.nix
+++ b/pkgs/development/tools/database/sqldeveloper/default.nix
@@ -1,7 +1,7 @@
 { stdenv, makeWrapper, requireFile, unzip, openjdk }:
 
 stdenv.mkDerivation rec {
-  version = "17.3.1.279.0537";
+  version = "17.4.0.355.2349";
   name = "sqldeveloper-${version}";
 
   src = requireFile rec {
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
         nix-prefetch-url --type sha256 file:///path/to/${name}
     '';
     # obtained by `sha256sum sqldeveloper-${version}-no-jre.zip`
-    sha256 = "d9c3c61b12a57d6b0fd6e172bf5716d6e829306d44815bf68ae42eab8a51bea3";
+    sha256 = "70add9b5c998583416e3d127aeb63dde8e3d0489036982026b930c85496c7850";
   };
 
   buildInputs = [ makeWrapper unzip ];


### PR DESCRIPTION
###### Motivation for this change
Changelog:

 - Java 9 (JDK) is now supported
 - Data Guard in DBA panel is only available for 12c and higher connections
 - Updated the NoSQL drivers to version 4.5
 - Added support for defining consumer group mappings for CLIENT_ID
 - Preferences Search feature now covers all options
 - Differentiate between a temporary connection used in the unshared worksheet and a truly private connection used internally for things like the UT Repos or the Instance Viewer....the naming logic for the Unshared Worksheet is now 'MyConn (Unshared)' instead of 'MyConn__1'
 - RAC support added to Real Time SQL Monitoring

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

