### PR TITLE
newsboat: init at 2.10.2

### DIFF
--- a/pkgs/applications/networking/feedreaders/newsboat/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsboat/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, stfl, sqlite, curl, gettext, pkgconfig, libxml2, json_c, ncurses
+, asciidoc, docbook_xml_dtd_45, libxslt, docbook_xml_xslt, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "newsboat-${version}";
+  version = "2.10.2";
+
+  src = fetchurl {
+    url = "https://newsboat.org/releases/${version}/${name}.tar.xz";
+    sha256 = "1x4nxx1kvmrcm8jy73dvg56h4z15y3sach2vr13cw8rsbi7v99px";
+  };
+
+  prePatch = ''
+    substituteInPlace Makefile --replace "|| true" ""
+  '';
+
+  nativeBuildInputs = [ pkgconfig asciidoc docbook_xml_dtd_45 libxslt docbook_xml_xslt ]
+                      ++ stdenv.lib.optional stdenv.isDarwin makeWrapper;
+
+  buildInputs = [ stfl sqlite curl gettext libxml2 json_c ncurses ];
+
+  installFlags = [ "DESTDIR=$(out)" "prefix=" ];
+
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    for prog in $out/bin/*; do
+      wrapProgram "$prog" --prefix DYLD_LIBRARY_PATH : "${stfl}/lib"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    homepage    = https://newsboat.org/;
+    description = "A fork of Newsbeuter, an RSS/Atom feed reader for the text console.";
+    maintainers = with maintainers; [ dotlambda ];
+    license     = licenses.mit;
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3644,6 +3644,8 @@ with pkgs;
 
   newsbeuter = callPackage ../applications/networking/feedreaders/newsbeuter { };
 
+  newsboat = callPackage ../applications/networking/feedreaders/newsboat { };
+
   nextcloud = callPackage ../servers/nextcloud { };
 
   nextcloud-client = libsForQt5.callPackage ../applications/networking/nextcloud-client { };


### PR DESCRIPTION
###### Motivation for this change
Newsboat is a fork of Newsbeuter, which is unmaintained.

I have no way to test on Darwin. So I just copied the lines from Newsbeuter's default.nix.
It would be nice if someone could test this.

There is also #31719, but that PR seems to be stuck.
Also, I was able to build the docs using the proper docbook packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @lovek323 @joachifm @tasmo 