### PR TITLE
metabase: init at 0.27.2

### DIFF
--- a/pkgs/servers/metabase/default.nix
+++ b/pkgs/servers/metabase/default.nix
@@ -1,0 +1,28 @@
+{ pkgs, stdenv, lib, fetchurl, makeWrapper, jre }:
+
+stdenv.mkDerivation rec {
+  name = "metabase-${version}";
+  version = "0.27.2";
+
+  jar = fetchurl {
+    url = "http://downloads.metabase.com/v${version}/metabase.jar";
+    sha256 = "1xsd6k362kajbf6sw0pb7zkd686i350fqqin858a5mmjlm5jkci7";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  phases = "installPhase";
+
+  installPhase = ''
+    mkdir -p $out/share/java
+    ln -s $jar $out/share/java/metabase.jar
+    makeWrapper ${jre}/bin/java $out/bin/metabase --add-flags "-jar $out/share/java/metabase.jar"
+  '';
+
+  meta = with lib; {
+    description = "Metabase is the easy, open source way for everyone in your company to ask questions and learn from data.";
+    homepage = https://metabase.com;
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ schneefux ];
+  };
+}

--- a/pkgs/servers/metabase/default.nix
+++ b/pkgs/servers/metabase/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, fetchurl, makeWrapper, jre }:
 
 stdenv.mkDerivation rec {
   name = "metabase-${version}";
@@ -14,9 +14,7 @@ stdenv.mkDerivation rec {
   unpackPhase = "true";
 
   installPhase = ''
-    mkdir -p $out/share/java
-    ln -s $jar $out/share/java/metabase.jar
-    makeWrapper ${jre}/bin/java $out/bin/metabase --add-flags "-jar $out/share/java/metabase.jar"
+    makeWrapper ${jre}/bin/java $out/bin/metabase --add-flags "-jar $jar"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/metabase/default.nix
+++ b/pkgs/servers/metabase/default.nix
@@ -1,17 +1,17 @@
-{ pkgs, stdenv, lib, fetchurl, makeWrapper, jre }:
+{ pkgs, stdenv, fetchurl, makeWrapper, jre }:
 
 stdenv.mkDerivation rec {
   name = "metabase-${version}";
-  version = "0.27.2";
+  version = "0.28.1";
 
   jar = fetchurl {
     url = "http://downloads.metabase.com/v${version}/metabase.jar";
-    sha256 = "1xsd6k362kajbf6sw0pb7zkd686i350fqqin858a5mmjlm5jkci7";
+    sha256 = "1nv3y4pnvzd7lwyj14nmhr3k52qd8hilcjxvd7qr3hb7kzmjvbzk";
   };
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
-  phases = "installPhase";
+  unpackPhase = "true";
 
   installPhase = ''
     mkdir -p $out/share/java
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
     makeWrapper ${jre}/bin/java $out/bin/metabase --add-flags "-jar $out/share/java/metabase.jar"
   '';
 
-  meta = with lib; {
-    description = "Metabase is the easy, open source way for everyone in your company to ask questions and learn from data.";
+  meta = with stdenv.lib; {
+    description = "The easy, open source way for everyone in your company to ask questions and learn from data.";
     homepage = https://metabase.com;
     license = licenses.agpl3;
     maintainers = with maintainers; [ schneefux ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1270,6 +1270,8 @@ with pkgs;
 
   meson = callPackage ../development/tools/build-managers/meson { };
 
+  metabase = callPackage ../servers/metabase { };
+
   mp3blaster = callPackage ../applications/audio/mp3blaster { };
 
   mp3fs = callPackage ../tools/filesystems/mp3fs { };


### PR DESCRIPTION
###### Motivation for this change
Added the https://metabase.com "uberjar". Tested on NixOS, the only issue I found was a compatibility problem with MariaDB which has already been reported [upstream](https://github.com/metabase/metabase/issues/2581).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).