### PR TITLE
qca2 and qca-qt5: use system CA certificates

### DIFF
--- a/pkgs/development/libraries/qca-qt5/default.nix
+++ b/pkgs/development/libraries/qca-qt5/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl qtbase ];
   nativeBuildInputs = [ cmake pkgconfig ];
 
+  # tells CMake to use this CA bundle file if it is accessible
+  preConfigure = ''export QC_CERTSTORE_PATH=/etc/ssl/certs/ca-certificates.crt'';
+
+  # tricks CMake into using this CA bundle file if it is not accessible (in a sandbox)
+  cmakeFlags = [ "-Dqca_CERTSTORE=/etc/ssl/certs/ca-certificates.crt" ];
+
   meta = with stdenv.lib; {
     description = "Qt 5 Cryptographic Architecture";
     homepage = http://delta.affinix.com/qca;

--- a/pkgs/development/libraries/qca2/default.nix
+++ b/pkgs/development/libraries/qca2/default.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # tells CMake to use this CA bundle file if it is accessible
+  preConfigure = ''export QC_CERTSTORE_PATH=/etc/ssl/certs/ca-certificates.crt'';
+
+  # tricks CMake into using this CA bundle file if it is not accessible (in a sandbox)
+  cmakeFlags = [ "-Dqca_CERTSTORE=/etc/ssl/certs/ca-certificates.crt" ];
+
   meta = with stdenv.lib; {
     description = "Qt Cryptographic Architecture";
     license = "LGPL";


### PR DESCRIPTION
###### Motivation for this change

Sandboxed builds fail to detect the presence of `/etc/ssl/certs/ca-certificates.crt`. As a result, qca does not use the system CA bundle and considers all certificates as untrusted. This PR fixes that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

