### PR TITLE
kdeconnect: Add `sshfs` as a dependency

### DIFF
--- a/pkgs/applications/misc/kdeconnect/default.nix
+++ b/pkgs/applications/misc/kdeconnect/default.nix
@@ -13,6 +13,8 @@
 , libfakekey
 , libXtst
 , qtx11extras
+, sshfs
+, makeWrapper
 }:
 
 stdenv.mkDerivation rec {
@@ -28,10 +30,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libfakekey libXtst
     ki18n kiconthemes kcmutils kconfigwidgets kdbusaddons knotifications
-    qca-qt5 qtx11extras
+    qca-qt5 qtx11extras makeWrapper
   ];
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+
+  postInstall = ''
+    wrapProgram $out/lib/libexec/kdeconnectd --prefix PATH : ${lib.makeBinPath [ sshfs ]}
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

kdeconnect depends on `sshfs` to mount the filesystem of android devices as discussed in #33442 and #27806

###### Things done

I've built this on a Linux server to test the build works, but haven't yet tested that kdeconnect works. I likely won't be able to finish testing this till Sunday night.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

