### PR TITLE
ocamlPackages.git: 1.11.2 -> 1.11.4

### DIFF
--- a/pkgs/development/ocaml-modules/git-http/default.nix
+++ b/pkgs/development/ocaml-modules/git-http/default.nix
@@ -15,6 +15,5 @@ stdenv.mkDerivation rec {
 	meta = {
 		description = "Client implementation of the “Smart” HTTP Git protocol in pure OCaml";
 		inherit (git.meta) homepage license maintainers platforms;
-		broken = true;
 	};
 }

--- a/pkgs/development/ocaml-modules/git/default.nix
+++ b/pkgs/development/ocaml-modules/git/default.nix
@@ -3,14 +3,14 @@
 }:
 
 stdenv.mkDerivation rec {
-	version = "1.11.2";
+	version = "1.11.4";
 	name = "ocaml${ocaml.version}-git-${version}";
 
 	src = fetchFromGitHub {
 		owner = "mirage";
 		repo = "ocaml-git";
 		rev = version;
-		sha256 = "1z5b0g4vck1sh1w076i2p3ppxrmb9h30q3nip5snw2r9prkm6y1j";
+		sha256 = "182b6shcfcq50r5snm01hwalnmck43x1xgdd4fvjb6q78pbwag2x";
 	};
 
 	buildInputs = [ ocaml findlib jbuilder ];


### PR DESCRIPTION
###### Motivation for this change

Unbreak `ocamlPackages.git-http`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

