### PR TITLE
aws-sdk-cpp: Enable cross-compilation

### DIFF
--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -28,7 +28,8 @@ in stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
   separateDebugInfo = stdenv.isLinux;
 
-  buildInputs = [ cmake curl ];
+  nativeBuildInputs = [ cmake curl ];
+  buildInputs = [ zlib curl openssl ];
 
   cmakeFlags =
     lib.optional (!customMemoryManagement) "-DCUSTOM_MEMORY_MANAGEMENT=0"
@@ -50,10 +51,6 @@ in stdenv.mkDerivation rec {
     ''
       rm aws-cpp-sdk-core-tests/aws/auth/AWSCredentialsProviderTest.cpp
     '';
-
-  NIX_LDFLAGS = lib.concatStringsSep " " (
-    (map (pkg: "-rpath ${lib.getOutput "lib" pkg}/lib"))
-      [ curl openssl zlib stdenv.cc.cc ]);
 
   meta = {
     description = "A C++ interface for Amazon Web Services";


### PR DESCRIPTION
###### Motivation for this change

Small rebuild change from #30882 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

