### PR TITLE
wireshark: explicitly disable the Qt build when building Gtk

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -23,7 +23,7 @@ in stdenv.mkDerivation {
     sha256 = "0bpiby916k3k8bm7q8b1dflva6zs0a4ircskrck0d538dfcrb50q";
   };
 
-  cmakeFlags = optional withGtk "-DBUILD_wireshark_gtk=TRUE";
+  cmakeFlags = optional withGtk "-DBUILD_wireshark_gtk=TRUE -DBUILD_wireshark=OFF";
 
   nativeBuildInputs = [
     bison cmake extra-cmake-modules flex pkgconfig

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -23,7 +23,10 @@ in stdenv.mkDerivation {
     sha256 = "0bpiby916k3k8bm7q8b1dflva6zs0a4ircskrck0d538dfcrb50q";
   };
 
-  cmakeFlags = optional withGtk "-DBUILD_wireshark_gtk=TRUE -DBUILD_wireshark=OFF";
+  cmakeFlags = [
+    "-DBUILD_wireshark_gtk=${if withGtk then "ON" else "OFF"}"
+    "-DBUILD_wireshark=${if withQt then "ON" else "OFF"}"
+  ];
 
   nativeBuildInputs = [
     bison cmake extra-cmake-modules flex pkgconfig


### PR DESCRIPTION
###### Motivation for this change

In a recent CMAKE(?) or wireshark release the default behavior did
change. A failing build log can be seen at hydra [1].

[1] https://hydra.nixos.org/build/67179559/nixlog/1




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

