### PR TITLE
sharutils: don't hardcode AR

### DIFF
--- a/pkgs/tools/archivers/sharutils/default.nix
+++ b/pkgs/tools/archivers/sharutils/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
     in ''
       substituteInPlace tests/shar-1 --replace '${shar_sub}' '${shar_sub} -s submitter'
       substituteInPlace tests/shar-2 --replace '${shar_sub}' '${shar_sub} -s submitter'
+
+      substituteInPlace intl/Makefile.in --replace "AR = ar" ""
     '';
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change

Fixes cross-build by avoiding invoking naked 'ar'.

Huge rebuild, unfortunately.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

