### PR TITLE
dmd: 2.075.1 -> 2.078.0

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -3,10 +3,10 @@
 , curl, tzdata, gdb, darwin
 , callPackage
 , bootstrapVersion ? false
-, version ? "2.075.1"
-, dmdSha256 ? "0kq6r8rcghvzk5jcphg89l85rg734s29bssd2rcw3fygx0k9a9k5"
-, druntimeSha256 ? "0idn2v1lmp7hl637g3i7pdfj9mjk4sclkz4cm77nl8873k2fhk8j"
-, phobosSha256 ? "1a7q5fd15yspgs5plxgx54jyrcwgzlyw3rahmz04jd2s5h56dj04"
+, version ? "2.078.0"
+, dmdSha256 ? "1ia4swyq0xqppnpmcalh2yxywdk2gv3kvni2abx1mq6wwqgmwlcr"
+, druntimeSha256 ? "0inyvcjc5qn8277d1zlfvgdgiss86rkjg9mhkw5l31hix8yan372"
+, phobosSha256 ? "1vb5xnysja9l8hvv9gy4c05vihmblz7ga005761jbazxkmlfirj4"
 }:
 
 let
@@ -125,10 +125,6 @@ let
         # Use proper C++ compiler
         substituteInPlace ${dmdPath}/posix.mak \
             --replace g++ $CXX
-
-        # TODO
-        substituteInPlace druntime/src/core/memory.d \
-            --replace "assert(z is null);" "//assert(z is null);"
     ''
 
     + stdenv.lib.optionalString (!bootstrapVersion) ''


### PR DESCRIPTION
###### Motivation for this change

Update dmd to 2.078.0 and run disabled assert.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


  