### PR TITLE
sierra-shared-test: fix build

### DIFF
--- a/pkgs/test/macos-sierra-shared/default.nix
+++ b/pkgs/test/macos-sierra-shared/default.nix
@@ -3,7 +3,7 @@
 let
   makeBigExe = stdenv: prefix: rec {
 
-    count = 500;
+    count = 320;
 
     sillyLibs = lib.genList (i: stdenv.mkDerivation rec {
       name = "${prefix}-fluff-${toString i}";
@@ -75,13 +75,14 @@ in stdenvNoCC.mkDerivation {
   buildInputs = [ good.finalExe bad.finalExe ];
   # TODO(@Ericson2314): Be impure or require exact MacOS version of builder?
   buildCommand = ''
-    if bad-asdf
-    then echo "bad-asdf can succeed on non-sierra, OK" >&2
+    if bad-asdf &> /dev/null
+    then echo "WARNING: bad-asdf did not fail, not running on sierra?" >&2
     else echo "bad-asdf should fail on sierra, OK" >&2
     fi
 
     # Must succeed on all supported MacOS versions
     good-asdf
+    echo "good-asdf should succeed on sierra, OK"
 
     touch $out
   '';


### PR DESCRIPTION
###### Motivation for this change

Using 500 libraries started failing with clang++: Argument list too long
This is enough to reproduce the issue.

/cc @Ericson2314 

```
building '/nix/store/nrilbfs3sdrn45l45djrw16ghf2qsid4-macos-sierra-shared-test.drv'...
/nix/store/yss9k0xkbg44vn3wl3qzr8ybw9hs4pmx-stdenv-darwin/setup: line 1211: 19349 Abort trap: 6           bad-asdf &> /dev/null
bad-asdf should fail on sierra, OK
goo-asdf should succeed on sierra, OK
/nix/store/z5kgmw8fkgvjhpav3bk4f15rk6sfyp2z-macos-sierra-shared-test
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
