### PR TITLE
WIP: vmpk: 0.5.1 -> 0.6.2

### DIFF
--- a/pkgs/applications/audio/vmpk/default.nix
+++ b/pkgs/applications/audio/vmpk/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchurl, cmake, pkgconfig
-, qt4, libjack2
+, qt5, libpthreadstubs, libXdmcp, drumstick, docbook_xsl, libjack2
 }:
 
 let
-  version = "0.5.1";
+  version = "0.6.2";
 in stdenv.mkDerivation rec {
   name = "vmpk-${version}";
 
@@ -15,11 +15,11 @@ in stdenv.mkDerivation rec {
   };
 
   src = fetchurl {
-    url = "mirror://sourceforge/vmpk/${version}/${name}.tar.bz2";
-    sha256 = "11fqnxgs9hr9255d93n7lazxzjwn8jpmn23nywdksh0pb1ffvfrc";
+    url = "mirror://sourceforge/vmpk/${version}/${name}a.tar.bz2";
+    sha256 = "0259iikvxnfdiifrh02g8xgcxikrkca4nhd3an8xzx0bd6bk8ifi";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
 
-  buildInputs = [ qt4 libjack2 ];
+  buildInputs = [ qt5.qtbase qt5.qtsvg qt5.qttools qt5.qtx11extras libpthreadstubs libXdmcp drumstick docbook_xsl libjack2 ];
 }


### PR DESCRIPTION
###### Motivation for this change

Doesn't do anything:  when I run it, I get no program, but also no errors in the cli.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

