### PR TITLE
Bullet: upgrade and fix on aarch64

### DIFF
--- a/pkgs/development/libraries/bullet/default.nix
+++ b/pkgs/development/libraries/bullet/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
      then with darwin.apple_sdk.frameworks; [ Cocoa OpenGL ]
      else [mesa freeglut]);
 
+  patches = [ ./gwen-narrowing.patch ];
+
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     sed -i 's/FIND_PACKAGE(OpenGL)//' CMakeLists.txt
     sed -i 's/FIND_LIBRARY(COCOA_LIBRARY Cocoa)//' CMakeLists.txt

--- a/pkgs/development/libraries/bullet/default.nix
+++ b/pkgs/development/libraries/bullet/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "bullet-${version}";
-  version = "2.86.1";
+  version = "2.87";
 
   src = fetchFromGitHub {
     owner = "bulletphysics";
     repo = "bullet3";
     rev = version;
-    sha256 = "1k81hr5y9rs2nsal6711fal21rxp6h573cpmjjk8x8ji2crqbqlz";
+    sha256 = "1msp7w3563vb43w70myjmqsdb97kna54dcfa7yvi9l3bvamb92w3";
   };
 
   buildInputs = [ cmake ] ++

--- a/pkgs/development/libraries/bullet/gwen-narrowing.patch
+++ b/pkgs/development/libraries/bullet/gwen-narrowing.patch
@@ -1,0 +1,22 @@
+commit a5d3497577c78b03c05c69d17df972fa9fb54f53
+Author: Linus Heckemann <git@sphalerite.org>
+Date:   Fri Jan 5 23:57:09 2018 +0100
+
+    Add -Wno-narrowing to GWEN's CMakeLists
+    
+    This avoids the compilation issue that occurs on aarch64 with gcc6.
+    (nixpkgs-specific patch)
+
+diff --git a/examples/ThirdPartyLibs/Gwen/CMakeLists.txt b/examples/ThirdPartyLibs/Gwen/CMakeLists.txt
+index 82fa0ffba..26c4bbd37 100644
+--- a/examples/ThirdPartyLibs/Gwen/CMakeLists.txt
++++ b/examples/ThirdPartyLibs/Gwen/CMakeLists.txt
+@@ -15,7 +15,7 @@ IF(NOT WIN32 AND NOT APPLE)
+         ADD_DEFINITIONS("-DDYNAMIC_LOAD_X11_FUNCTIONS=1")
+ ENDIF()
+ 
+-ADD_DEFINITIONS( -DGLEW_STATIC -DGWEN_COMPILE_STATIC -D_HAS_EXCEPTIONS=0 -D_STATIC_CPPLIB )
++ADD_DEFINITIONS( -DGLEW_STATIC -DGWEN_COMPILE_STATIC -D_HAS_EXCEPTIONS=0 -D_STATIC_CPPLIB -Wno-narrowing )
+ 
+ FILE(GLOB gwen_SRCS "*.cpp" "Controls/*.cpp" "Controls/Dialog/*.cpp" "Controls/Dialogs/*.cpp" "Controls/Layout/*.cpp" "Controls/Property/*.cpp" "Input/*.cpp" "Platforms/*.cpp" "Renderers/*.cpp" "Skins/*.cpp")
+ FILE(GLOB gwen_HDRS "*.h" "Controls/*.h" "Controls/Dialog/*.h" "Controls/Dialogs/*.h" "Controls/Layout/*.h" "Controls/Property/*.h" "Input/*.h" "Platforms/*.h" "Renderers/*.h" "Skins/*.h")


### PR DESCRIPTION
###### Motivation for this change
New upstream version, aarch64 build was broken

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).