### PR TITLE
faust2: 2.1.0 -> 2.5.10

### DIFF
--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -16,13 +16,14 @@ with stdenv.lib.strings;
 
 let
 
-  version = "2.1.0";
+  version = "2.5.10";
 
   src = fetchFromGitHub {
     owner = "grame-cncm";
     repo = "faust";
     rev = "v${builtins.replaceStrings ["."] ["-"] version}";
-    sha256 = "1pmiwy287g79ipz9pppnkfrdgls3l912kpkr7dfymk9wk5y5di9m";
+    sha256 = "0sjhy7axa2dj1977iz6zmqvz9qzalcfnrx2fqx3xmk9hly847d6z";
+    fetchSubmodules = true;
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/audio/faust/faust2jack.nix
+++ b/pkgs/applications/audio/faust/faust2jack.nix
@@ -2,6 +2,7 @@
 , gtk2
 , jack2Full
 , opencv
+, libsndfile
 }:
 
 faust.wrapWithBuildEnv {
@@ -18,6 +19,7 @@ faust.wrapWithBuildEnv {
     gtk2
     jack2Full
     opencv
+    libsndfile
   ];
 
 }

--- a/pkgs/applications/audio/faust/faust2jaqt.nix
+++ b/pkgs/applications/audio/faust/faust2jaqt.nix
@@ -2,6 +2,7 @@
 , jack2Full
 , opencv
 , qt4
+, libsndfile
 }:
 
 faust.wrapWithBuildEnv {
@@ -17,6 +18,7 @@ faust.wrapWithBuildEnv {
     jack2Full
     opencv
     qt4
+    libsndfile
   ];
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19619,7 +19619,7 @@ with pkgs;
   faust1 = callPackage ../applications/audio/faust/faust1.nix { };
 
   faust2 = callPackage ../applications/audio/faust/faust2.nix {
-    llvm = llvm_38;
+    llvm = llvm_4;
   };
 
   faust2alqt = callPackage ../applications/audio/faust/faust2alqt.nix { };


### PR DESCRIPTION
This partially works, but partially gives some weird, unexpected errors:

```
faust2alqt FFcompressor.dsp                                                                                                                                                                                           [00:03:23]
which: no qmake-qt4 in (/nix/store/qs68njxs4awvjaqf2yw89x8bnb2jwl2a-pkg-config-0.29.2/bin:/nix/store/n7l459d0f28lmdirr1wlzkdi7151jhqk-patchelf-0.9/bin:/nix/store/q7p8jaiymb1k4n44l31xdm753j79h7l5-paxctl-0.9/bin:/nix/store/4cqv0dm94h2sm0xpcqi6h8z6bnxqqlna-gcc-wrapper-6.4.0/bin:/nix/store/d88s1v28v11j2jxshqdvqms6h0pvp8aw-gcc-6.4.0/bin:/nix/store/b25rk6qm6p3af1r1g25lzr16r31336r1-glibc-2.26-75-bin/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/m5s6hd02nlfywi9n3yrgrx3fa8kgp9jd-binutils-wrapper-2.28.1/bin:/nix/store/kcdiibhpjrbpash3r1bvj2ncv4rwr3sm-binutils-2.28.1/bin:/nix/store/b25rk6qm6p3af1r1g25lzr16r31336r1-glibc-2.26-75-bin/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/4k3fsi6wxdqp23q45kj0ibwmi846fwmi-faust-2.5.10/bin:/nix/store/6n2i3r811qk7rwv548cq8mkjy6y4ngfa-alsa-lib-1.1.5/bin:/nix/store/n4q8mxn0n6bdgclwlv7fv4qcyindqv9g-libpng-apng-1.6.34-dev/bin:/nix/store/s03sh263lrxnz8dp9d81is9xwrs67ay9-openssl-1.0.2n-bin/bin:/nix/store/dk1cikc21dss4bnmrl024cj6ms4j0ia4-expat-2.2.5-dev/bin:/nix/store/a0xkfv05rp8saarb1ik314p57ljqxywn-dbus-1.10.24-lib/bin:/nix/store/p5399mglmlbq6fadg0i3agwsr0ba1alg-dbus-1.10.24/bin:/nix/store/fb0n4xavbfhn76n771z8333szvf6d12g-freetype-2.7.1-dev/bin:/nix/store/mi9vmy5nwc4ma33jz6ihrdhh1r6izzv6-bzip2-1.0.6.0.1-bin/bin:/nix/store/ly2vplcw79239w4a7f5mwrn8qj2wghm5-fontconfig-2.12.1-bin/bin:/nix/store/f366k58sbdagaqqz2pa87b8nl4qhn2jd-glib-2.54.2-dev/bin:/nix/store/7gm7piwnvarii3zd61r0rclsl90s2qf3-libdrm-2.4.88-bin/bin:/nix/store/s56jsaswy2csc1rswd1nbxpgs6rbc8ih-libxml2-2.9.7-dev/bin:/nix/store/qhi9rgk9cy9yj3wl7hkb4jkzas3gb269-libxml2-2.9.7-bin/bin:/nix/store/94zdbbpplnjy2gvqnpkdvpbxkcqb4zmq-gstreamer-0.10.36/bin:/nix/store/cba5q2d37njyyvhzw998h5g6qihddsw1-gst-plugins-base-0.10.36/bin:/nix/store/8g1714cgws6zhm3wh0xjssyfq9vlbisw-qt-4.8.7/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/n2p15qg4lxgq0xkfrgqqfgpwkmd3295d-findutils-4.6.0/bin:/nix/store/ajiwrzg6nz9xpifr91wp14cy8al7s4df-diffutils-3.6/bin:/nix/store/n5rsq2cxj7lp4gynkvqrp0xkf78f1ni6-gnused-4.4/bin:/nix/store/nwpv4sxayci7jkjq7fid8hwz6ig5xjzi-gnugrep-3.1/bin:/nix/store/w1cddj0qc3ximvpwrn28rig7wq99ajd7-gawk-4.2.0/bin:/nix/store/7iw6c6nx7spzsp92pqq5qnd7d8jvbdl8-gnutar-1.30/bin:/nix/store/qk11lqm8fz9hpk1682gyf3x51wwasj3z-gzip-1.8/bin:/nix/store/mi9vmy5nwc4ma33jz6ihrdhh1r6izzv6-bzip2-1.0.6.0.1-bin/bin:/nix/store/92cdms75qnqh3hf39wbxra60bxdah9mq-gnumake-4.2.1/bin:/nix/store/65l6hr8snf4v823f974k97jc65i7bhvf-bash-4.4-p12/bin:/nix/store/irwrb341fpqd2lj22j13ffsxcjhayv1m-patch-2.7.5/bin:/nix/store/8fy4c90a0cj1mw2xibvv5k6b0rxx6b09-xz-5.2.3-bin/bin:/home/bart/bin:/run/wrappers/bin:/etc/profiles/per-user/bart/bin:/home/bart/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin)
FFcompressor.cpp:5422:28: fatal error: alsa/asoundlib.h: No such file or directory
 #include <alsa/asoundlib.h>
                            ^
compilation terminated.
make: *** [Makefile:226: FFcompressor.o] Error 1
```

```
faust2alsa FFcompressor.dsp                                                                                                                                                                                           [00:03:59]
FFcompressor;
```

```
faust2firefox FFcompressor.dsp
```

```
faust2jack FFcompressor.dsp                                                                                                                                                                                           [00:05:25]
FFcompressor;
```

```
faust2jackconsole FFcompressor.dsp                                                                                                                                                                                    [00:06:08]
FFcompressor;
```

```
faust2jackinternal FFcompressor.dsp                                                                                                                                                                                   [00:06:39]
FFcompressor.dsp.cpp:171:72: error: ‘Soundfile’ has not been declared
     virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
                                                                        ^~~~~~~~~
```

```
faust2jackserver FFcompressor.dsp                                                                                                                                                                                     [00:07:10]
which: no qmake-qt4 in (/nix/store/qs68njxs4awvjaqf2yw89x8bnb2jwl2a-pkg-config-0.29.2/bin:/nix/store/n7l459d0f28lmdirr1wlzkdi7151jhqk-patchelf-0.9/bin:/nix/store/q7p8jaiymb1k4n44l31xdm753j79h7l5-paxctl-0.9/bin:/nix/store/4cqv0dm94h2sm0xpcqi6h8z6bnxqqlna-gcc-wrapper-6.4.0/bin:/nix/store/d88s1v28v11j2jxshqdvqms6h0pvp8aw-gcc-6.4.0/bin:/nix/store/b25rk6qm6p3af1r1g25lzr16r31336r1-glibc-2.26-75-bin/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/m5s6hd02nlfywi9n3yrgrx3fa8kgp9jd-binutils-wrapper-2.28.1/bin:/nix/store/kcdiibhpjrbpash3r1bvj2ncv4rwr3sm-binutils-2.28.1/bin:/nix/store/b25rk6qm6p3af1r1g25lzr16r31336r1-glibc-2.26-75-bin/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/4k3fsi6wxdqp23q45kj0ibwmi846fwmi-faust-2.5.10/bin:/nix/store/y6l4s711311imqxy1x50ssfq6g45wn76-jack2-1.9.12/bin:/nix/store/9r1g84i71wmrkb51c9cm3fd4jw0zhcxx-opencv-2.4.13/bin:/nix/store/n4q8mxn0n6bdgclwlv7fv4qcyindqv9g-libpng-apng-1.6.34-dev/bin:/nix/store/s03sh263lrxnz8dp9d81is9xwrs67ay9-openssl-1.0.2n-bin/bin:/nix/store/dk1cikc21dss4bnmrl024cj6ms4j0ia4-expat-2.2.5-dev/bin:/nix/store/a0xkfv05rp8saarb1ik314p57ljqxywn-dbus-1.10.24-lib/bin:/nix/store/p5399mglmlbq6fadg0i3agwsr0ba1alg-dbus-1.10.24/bin:/nix/store/fb0n4xavbfhn76n771z8333szvf6d12g-freetype-2.7.1-dev/bin:/nix/store/mi9vmy5nwc4ma33jz6ihrdhh1r6izzv6-bzip2-1.0.6.0.1-bin/bin:/nix/store/ly2vplcw79239w4a7f5mwrn8qj2wghm5-fontconfig-2.12.1-bin/bin:/nix/store/f366k58sbdagaqqz2pa87b8nl4qhn2jd-glib-2.54.2-dev/bin:/nix/store/7gm7piwnvarii3zd61r0rclsl90s2qf3-libdrm-2.4.88-bin/bin:/nix/store/6n2i3r811qk7rwv548cq8mkjy6y4ngfa-alsa-lib-1.1.5/bin:/nix/store/s56jsaswy2csc1rswd1nbxpgs6rbc8ih-libxml2-2.9.7-dev/bin:/nix/store/qhi9rgk9cy9yj3wl7hkb4jkzas3gb269-libxml2-2.9.7-bin/bin:/nix/store/94zdbbpplnjy2gvqnpkdvpbxkcqb4zmq-gstreamer-0.10.36/bin:/nix/store/cba5q2d37njyyvhzw998h5g6qihddsw1-gst-plugins-base-0.10.36/bin:/nix/store/8g1714cgws6zhm3wh0xjssyfq9vlbisw-qt-4.8.7/bin:/nix/store/4s68kfdh72jbcfph40shmdv46p4hyl8g-libsndfile-1.0.28-bin/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/n2p15qg4lxgq0xkfrgqqfgpwkmd3295d-findutils-4.6.0/bin:/nix/store/ajiwrzg6nz9xpifr91wp14cy8al7s4df-diffutils-3.6/bin:/nix/store/n5rsq2cxj7lp4gynkvqrp0xkf78f1ni6-gnused-4.4/bin:/nix/store/nwpv4sxayci7jkjq7fid8hwz6ig5xjzi-gnugrep-3.1/bin:/nix/store/w1cddj0qc3ximvpwrn28rig7wq99ajd7-gawk-4.2.0/bin:/nix/store/7iw6c6nx7spzsp92pqq5qnd7d8jvbdl8-gnutar-1.30/bin:/nix/store/qk11lqm8fz9hpk1682gyf3x51wwasj3z-gzip-1.8/bin:/nix/store/mi9vmy5nwc4ma33jz6ihrdhh1r6izzv6-bzip2-1.0.6.0.1-bin/bin:/nix/store/92cdms75qnqh3hf39wbxra60bxdah9mq-gnumake-4.2.1/bin:/nix/store/65l6hr8snf4v823f974k97jc65i7bhvf-bash-4.4-p12/bin:/nix/store/irwrb341fpqd2lj22j13ffsxcjhayv1m-patch-2.7.5/bin:/nix/store/8fy4c90a0cj1mw2xibvv5k6b0rxx6b09-xz-5.2.3-bin/bin:/home/bart/bin:/run/wrappers/bin:/etc/profiles/per-user/bart/bin:/home/bart/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/usr/local/bin)
FFcompressor.cpp:5421:23: fatal error: jack/jack.h: No such file or directory
 #include <jack/jack.h>
                       ^
compilation terminated.
make: *** [Makefile:219: FFcompressor.o] Error 1
```

```
faust2jaqt FFcompressor.dsp                                                                                                                                                                                           [00:07:34]
which: no qmake-qt5 in (/nix/store/qs68njxs4awvjaqf2yw89x8bnb2jwl2a-pkg-config-0.29.2/bin:/nix/store/n7l459d0f28lmdirr1wlzkdi7151jhqk-patchelf-0.9/bin:/nix/store/q7p8jaiymb1k4n44l31xdm753j79h7l5-paxctl-0.9/bin:/nix/store/4cqv0dm94h2sm0xpcqi6h8z6bnxqqlna-gcc-wrapper-6.4.0/bin:/nix/store/d88s1v28v11j2jxshqdvqms6h0pvp8aw-gcc-6.4.0/bin:/nix/store/b25rk6qm6p3af1r1g25lzr16r31336r1-glibc-2.26-75-bin/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/m5s6hd02nlfywi9n3yrgrx3fa8kgp9jd-binutils-wrapper-2.28.1/bin:/nix/store/kcdiibhpjrbpash3r1bvj2ncv4rwr3sm-binutils-2.28.1/bin:/nix/store/b25rk6qm6p3af1r1g25lzr16r31336r1-glibc-2.26-75-bin/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/4k3fsi6wxdqp23q45kj0ibwmi846fwmi-faust-2.5.10/bin:/nix/store/y6l4s711311imqxy1x50ssfq6g45wn76-jack2-1.9.12/bin:/nix/store/9r1g84i71wmrkb51c9cm3fd4jw0zhcxx-opencv-2.4.13/bin:/nix/store/n4q8mxn0n6bdgclwlv7fv4qcyindqv9g-libpng-apng-1.6.34-dev/bin:/nix/store/s03sh263lrxnz8dp9d81is9xwrs67ay9-openssl-1.0.2n-bin/bin:/nix/store/dk1cikc21dss4bnmrl024cj6ms4j0ia4-expat-2.2.5-dev/bin:/nix/store/a0xkfv05rp8saarb1ik314p57ljqxywn-dbus-1.10.24-lib/bin:/nix/store/p5399mglmlbq6fadg0i3agwsr0ba1alg-dbus-1.10.24/bin:/nix/store/fb0n4xavbfhn76n771z8333szvf6d12g-freetype-2.7.1-dev/bin:/nix/store/mi9vmy5nwc4ma33jz6ihrdhh1r6izzv6-bzip2-1.0.6.0.1-bin/bin:/nix/store/ly2vplcw79239w4a7f5mwrn8qj2wghm5-fontconfig-2.12.1-bin/bin:/nix/store/f366k58sbdagaqqz2pa87b8nl4qhn2jd-glib-2.54.2-dev/bin:/nix/store/7gm7piwnvarii3zd61r0rclsl90s2qf3-libdrm-2.4.88-bin/bin:/nix/store/6n2i3r811qk7rwv548cq8mkjy6y4ngfa-alsa-lib-1.1.5/bin:/nix/store/s56jsaswy2csc1rswd1nbxpgs6rbc8ih-libxml2-2.9.7-dev/bin:/nix/store/qhi9rgk9cy9yj3wl7hkb4jkzas3gb269-libxml2-2.9.7-bin/bin:/nix/store/94zdbbpplnjy2gvqnpkdvpbxkcqb4zmq-gstreamer-0.10.36/bin:/nix/store/cba5q2d37njyyvhzw998h5g6qihddsw1-gst-plugins-base-0.10.36/bin:/nix/store/8g1714cgws6zhm3wh0xjssyfq9vlbisw-qt-4.8.7/bin:/nix/store/4s68kfdh72jbcfph40shmdv46p4hyl8g-libsndfile-1.0.28-bin/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/n2p15qg4lxgq0xkfrgqqfgpwkmd3295d-findutils-4.6.0/bin:/nix/store/ajiwrzg6nz9xpifr91wp14cy8al7s4df-diffutils-3.6/bin:/nix/store/n5rsq2cxj7lp4gynkvqrp0xkf78f1ni6-gnused-4.4/bin:/nix/store/nwpv4sxayci7jkjq7fid8hwz6ig5xjzi-gnugrep-3.1/bin:/nix/store/w1cddj0qc3ximvpwrn28rig7wq99ajd7-gawk-4.2.0/bin:/nix/store/7iw6c6nx7spzsp92pqq5qnd7d8jvbdl8-gnutar-1.30/bin:/nix/store/qk11lqm8fz9hpk1682gyf3x51wwasj3z-gzip-1.8/bin:/nix/store/mi9vmy5nwc4ma33jz6ihrdhh1r6izzv6-bzip2-1.0.6.0.1-bin/bin:/nix/store/92cdms75qnqh3hf39wbxra60bxdah9mq-gnumake-4.2.1/bin:/nix/store/65l6hr8snf4v823f974k97jc65i7bhvf-bash-4.4-p12/bin:/nix/store/irwrb341fpqd2lj22j13ffsxcjhayv1m-patch-2.7.5/bin:/nix/store/8fy4c90a0cj1mw2xibvv5k6b0rxx6b09-xz-5.2.3-bin/bin:/home/bart/bin:/run/wrappers/bin:/etc/profiles/per-user/bart/bin:/home/bart/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/usr/local/bin)
which: no qmake-qt4 in (/nix/store/qs68njxs4awvjaqf2yw89x8bnb2jwl2a-pkg-config-0.29.2/bin:/nix/store/n7l459d0f28lmdirr1wlzkdi7151jhqk-patchelf-0.9/bin:/nix/store/q7p8jaiymb1k4n44l31xdm753j79h7l5-paxctl-0.9/bin:/nix/store/4cqv0dm94h2sm0xpcqi6h8z6bnxqqlna-gcc-wrapper-6.4.0/bin:/nix/store/d88s1v28v11j2jxshqdvqms6h0pvp8aw-gcc-6.4.0/bin:/nix/store/b25rk6qm6p3af1r1g25lzr16r31336r1-glibc-2.26-75-bin/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/m5s6hd02nlfywi9n3yrgrx3fa8kgp9jd-binutils-wrapper-2.28.1/bin:/nix/store/kcdiibhpjrbpash3r1bvj2ncv4rwr3sm-binutils-2.28.1/bin:/nix/store/b25rk6qm6p3af1r1g25lzr16r31336r1-glibc-2.26-75-bin/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/4k3fsi6wxdqp23q45kj0ibwmi846fwmi-faust-2.5.10/bin:/nix/store/y6l4s711311imqxy1x50ssfq6g45wn76-jack2-1.9.12/bin:/nix/store/9r1g84i71wmrkb51c9cm3fd4jw0zhcxx-opencv-2.4.13/bin:/nix/store/n4q8mxn0n6bdgclwlv7fv4qcyindqv9g-libpng-apng-1.6.34-dev/bin:/nix/store/s03sh263lrxnz8dp9d81is9xwrs67ay9-openssl-1.0.2n-bin/bin:/nix/store/dk1cikc21dss4bnmrl024cj6ms4j0ia4-expat-2.2.5-dev/bin:/nix/store/a0xkfv05rp8saarb1ik314p57ljqxywn-dbus-1.10.24-lib/bin:/nix/store/p5399mglmlbq6fadg0i3agwsr0ba1alg-dbus-1.10.24/bin:/nix/store/fb0n4xavbfhn76n771z8333szvf6d12g-freetype-2.7.1-dev/bin:/nix/store/mi9vmy5nwc4ma33jz6ihrdhh1r6izzv6-bzip2-1.0.6.0.1-bin/bin:/nix/store/ly2vplcw79239w4a7f5mwrn8qj2wghm5-fontconfig-2.12.1-bin/bin:/nix/store/f366k58sbdagaqqz2pa87b8nl4qhn2jd-glib-2.54.2-dev/bin:/nix/store/7gm7piwnvarii3zd61r0rclsl90s2qf3-libdrm-2.4.88-bin/bin:/nix/store/6n2i3r811qk7rwv548cq8mkjy6y4ngfa-alsa-lib-1.1.5/bin:/nix/store/s56jsaswy2csc1rswd1nbxpgs6rbc8ih-libxml2-2.9.7-dev/bin:/nix/store/qhi9rgk9cy9yj3wl7hkb4jkzas3gb269-libxml2-2.9.7-bin/bin:/nix/store/94zdbbpplnjy2gvqnpkdvpbxkcqb4zmq-gstreamer-0.10.36/bin:/nix/store/cba5q2d37njyyvhzw998h5g6qihddsw1-gst-plugins-base-0.10.36/bin:/nix/store/8g1714cgws6zhm3wh0xjssyfq9vlbisw-qt-4.8.7/bin:/nix/store/4s68kfdh72jbcfph40shmdv46p4hyl8g-libsndfile-1.0.28-bin/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/n2p15qg4lxgq0xkfrgqqfgpwkmd3295d-findutils-4.6.0/bin:/nix/store/ajiwrzg6nz9xpifr91wp14cy8al7s4df-diffutils-3.6/bin:/nix/store/n5rsq2cxj7lp4gynkvqrp0xkf78f1ni6-gnused-4.4/bin:/nix/store/nwpv4sxayci7jkjq7fid8hwz6ig5xjzi-gnugrep-3.1/bin:/nix/store/w1cddj0qc3ximvpwrn28rig7wq99ajd7-gawk-4.2.0/bin:/nix/store/7iw6c6nx7spzsp92pqq5qnd7d8jvbdl8-gnutar-1.30/bin:/nix/store/qk11lqm8fz9hpk1682gyf3x51wwasj3z-gzip-1.8/bin:/nix/store/mi9vmy5nwc4ma33jz6ihrdhh1r6izzv6-bzip2-1.0.6.0.1-bin/bin:/nix/store/92cdms75qnqh3hf39wbxra60bxdah9mq-gnumake-4.2.1/bin:/nix/store/65l6hr8snf4v823f974k97jc65i7bhvf-bash-4.4-p12/bin:/nix/store/irwrb341fpqd2lj22j13ffsxcjhayv1m-patch-2.7.5/bin:/nix/store/8fy4c90a0cj1mw2xibvv5k6b0rxx6b09-xz-5.2.3-bin/bin:/home/bart/bin:/run/wrappers/bin:/etc/profiles/per-user/bart/bin:/home/bart/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/usr/local/bin)
FFcompressor.cpp:5421:23: fatal error: jack/jack.h: No such file or directory
 #include <jack/jack.h>
                       ^
compilation terminated.
make: *** [Makefile:226: FFcompressor.o] Error 1
```

```
faust2lv2 FFcompressor.dsp                                                                                                                                                                                            [00:08:07]
which: no qmake-qt5 in (/nix/store/qs68njxs4awvjaqf2yw89x8bnb2jwl2a-pkg-config-0.29.2/bin:/nix/store/n7l459d0f28lmdirr1wlzkdi7151jhqk-patchelf-0.9/bin:/nix/store/q7p8jaiymb1k4n44l31xdm753j79h7l5-paxctl-0.9/bin:/nix/store/4cqv0dm94h2sm0xpcqi6h8z6bnxqqlna-gcc-wrapper-6.4.0/bin:/nix/store/d88s1v28v11j2jxshqdvqms6h0pvp8aw-gcc-6.4.0/bin:/nix/store/b25rk6qm6p3af1r1g25lzr16r31336r1-glibc-2.26-75-bin/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/m5s6hd02nlfywi9n3yrgrx3fa8kgp9jd-binutils-wrapper-2.28.1/bin:/nix/store/kcdiibhpjrbpash3r1bvj2ncv4rwr3sm-binutils-2.28.1/bin:/nix/store/b25rk6qm6p3af1r1g25lzr16r31336r1-glibc-2.26-75-bin/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/4k3fsi6wxdqp23q45kj0ibwmi846fwmi-faust-2.5.10/bin:/nix/store/5h7rjc01cqzn68p0kqsv15s6nll3470g-lv2-1.14.0/bin:/nix/store/n4q8mxn0n6bdgclwlv7fv4qcyindqv9g-libpng-apng-1.6.34-dev/bin:/nix/store/s03sh263lrxnz8dp9d81is9xwrs67ay9-openssl-1.0.2n-bin/bin:/nix/store/dk1cikc21dss4bnmrl024cj6ms4j0ia4-expat-2.2.5-dev/bin:/nix/store/a0xkfv05rp8saarb1ik314p57ljqxywn-dbus-1.10.24-lib/bin:/nix/store/p5399mglmlbq6fadg0i3agwsr0ba1alg-dbus-1.10.24/bin:/nix/store/fb0n4xavbfhn76n771z8333szvf6d12g-freetype-2.7.1-dev/bin:/nix/store/mi9vmy5nwc4ma33jz6ihrdhh1r6izzv6-bzip2-1.0.6.0.1-bin/bin:/nix/store/ly2vplcw79239w4a7f5mwrn8qj2wghm5-fontconfig-2.12.1-bin/bin:/nix/store/f366k58sbdagaqqz2pa87b8nl4qhn2jd-glib-2.54.2-dev/bin:/nix/store/7gm7piwnvarii3zd61r0rclsl90s2qf3-libdrm-2.4.88-bin/bin:/nix/store/6n2i3r811qk7rwv548cq8mkjy6y4ngfa-alsa-lib-1.1.5/bin:/nix/store/s56jsaswy2csc1rswd1nbxpgs6rbc8ih-libxml2-2.9.7-dev/bin:/nix/store/qhi9rgk9cy9yj3wl7hkb4jkzas3gb269-libxml2-2.9.7-bin/bin:/nix/store/94zdbbpplnjy2gvqnpkdvpbxkcqb4zmq-gstreamer-0.10.36/bin:/nix/store/cba5q2d37njyyvhzw998h5g6qihddsw1-gst-plugins-base-0.10.36/bin:/nix/store/8g1714cgws6zhm3wh0xjssyfq9vlbisw-qt-4.8.7/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/n2p15qg4lxgq0xkfrgqqfgpwkmd3295d-findutils-4.6.0/bin:/nix/store/ajiwrzg6nz9xpifr91wp14cy8al7s4df-diffutils-3.6/bin:/nix/store/n5rsq2cxj7lp4gynkvqrp0xkf78f1ni6-gnused-4.4/bin:/nix/store/nwpv4sxayci7jkjq7fid8hwz6ig5xjzi-gnugrep-3.1/bin:/nix/store/w1cddj0qc3ximvpwrn28rig7wq99ajd7-gawk-4.2.0/bin:/nix/store/7iw6c6nx7spzsp92pqq5qnd7d8jvbdl8-gnutar-1.30/bin:/nix/store/qk11lqm8fz9hpk1682gyf3x51wwasj3z-gzip-1.8/bin:/nix/store/mi9vmy5nwc4ma33jz6ihrdhh1r6izzv6-bzip2-1.0.6.0.1-bin/bin:/nix/store/92cdms75qnqh3hf39wbxra60bxdah9mq-gnumake-4.2.1/bin:/nix/store/65l6hr8snf4v823f974k97jc65i7bhvf-bash-4.4-p12/bin:/nix/store/irwrb341fpqd2lj22j13ffsxcjhayv1m-patch-2.7.5/bin:/nix/store/8fy4c90a0cj1mw2xibvv5k6b0rxx6b09-xz-5.2.3-bin/bin:/home/bart/bin:/run/wrappers/bin:/etc/profiles/per-user/bart/bin:/home/bart/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin)
which: no qmake in (/opt/local/libexec/qt5/bin)
which: no qmake-qt4 in (/nix/store/qs68njxs4awvjaqf2yw89x8bnb2jwl2a-pkg-config-0.29.2/bin:/nix/store/n7l459d0f28lmdirr1wlzkdi7151jhqk-patchelf-0.9/bin:/nix/store/q7p8jaiymb1k4n44l31xdm753j79h7l5-paxctl-0.9/bin:/nix/store/4cqv0dm94h2sm0xpcqi6h8z6bnxqqlna-gcc-wrapper-6.4.0/bin:/nix/store/d88s1v28v11j2jxshqdvqms6h0pvp8aw-gcc-6.4.0/bin:/nix/store/b25rk6qm6p3af1r1g25lzr16r31336r1-glibc-2.26-75-bin/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/m5s6hd02nlfywi9n3yrgrx3fa8kgp9jd-binutils-wrapper-2.28.1/bin:/nix/store/kcdiibhpjrbpash3r1bvj2ncv4rwr3sm-binutils-2.28.1/bin:/nix/store/b25rk6qm6p3af1r1g25lzr16r31336r1-glibc-2.26-75-bin/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/4k3fsi6wxdqp23q45kj0ibwmi846fwmi-faust-2.5.10/bin:/nix/store/5h7rjc01cqzn68p0kqsv15s6nll3470g-lv2-1.14.0/bin:/nix/store/n4q8mxn0n6bdgclwlv7fv4qcyindqv9g-libpng-apng-1.6.34-dev/bin:/nix/store/s03sh263lrxnz8dp9d81is9xwrs67ay9-openssl-1.0.2n-bin/bin:/nix/store/dk1cikc21dss4bnmrl024cj6ms4j0ia4-expat-2.2.5-dev/bin:/nix/store/a0xkfv05rp8saarb1ik314p57ljqxywn-dbus-1.10.24-lib/bin:/nix/store/p5399mglmlbq6fadg0i3agwsr0ba1alg-dbus-1.10.24/bin:/nix/store/fb0n4xavbfhn76n771z8333szvf6d12g-freetype-2.7.1-dev/bin:/nix/store/mi9vmy5nwc4ma33jz6ihrdhh1r6izzv6-bzip2-1.0.6.0.1-bin/bin:/nix/store/ly2vplcw79239w4a7f5mwrn8qj2wghm5-fontconfig-2.12.1-bin/bin:/nix/store/f366k58sbdagaqqz2pa87b8nl4qhn2jd-glib-2.54.2-dev/bin:/nix/store/7gm7piwnvarii3zd61r0rclsl90s2qf3-libdrm-2.4.88-bin/bin:/nix/store/6n2i3r811qk7rwv548cq8mkjy6y4ngfa-alsa-lib-1.1.5/bin:/nix/store/s56jsaswy2csc1rswd1nbxpgs6rbc8ih-libxml2-2.9.7-dev/bin:/nix/store/qhi9rgk9cy9yj3wl7hkb4jkzas3gb269-libxml2-2.9.7-bin/bin:/nix/store/94zdbbpplnjy2gvqnpkdvpbxkcqb4zmq-gstreamer-0.10.36/bin:/nix/store/cba5q2d37njyyvhzw998h5g6qihddsw1-gst-plugins-base-0.10.36/bin:/nix/store/8g1714cgws6zhm3wh0xjssyfq9vlbisw-qt-4.8.7/bin:/nix/store/hw5a3mifkrzd8y0pxs7nzzr4yscg08mw-coreutils-8.28/bin:/nix/store/n2p15qg4lxgq0xkfrgqqfgpwkmd3295d-findutils-4.6.0/bin:/nix/store/ajiwrzg6nz9xpifr91wp14cy8al7s4df-diffutils-3.6/bin:/nix/store/n5rsq2cxj7lp4gynkvqrp0xkf78f1ni6-gnused-4.4/bin:/nix/store/nwpv4sxayci7jkjq7fid8hwz6ig5xjzi-gnugrep-3.1/bin:/nix/store/w1cddj0qc3ximvpwrn28rig7wq99ajd7-gawk-4.2.0/bin:/nix/store/7iw6c6nx7spzsp92pqq5qnd7d8jvbdl8-gnutar-1.30/bin:/nix/store/qk11lqm8fz9hpk1682gyf3x51wwasj3z-gzip-1.8/bin:/nix/store/mi9vmy5nwc4ma33jz6ihrdhh1r6izzv6-bzip2-1.0.6.0.1-bin/bin:/nix/store/92cdms75qnqh3hf39wbxra60bxdah9mq-gnumake-4.2.1/bin:/nix/store/65l6hr8snf4v823f974k97jc65i7bhvf-bash-4.4-p12/bin:/nix/store/irwrb341fpqd2lj22j13ffsxcjhayv1m-patch-2.7.5/bin:/nix/store/8fy4c90a0cj1mw2xibvv5k6b0rxx6b09-xz-5.2.3-bin/bin:/home/bart/bin:/run/wrappers/bin:/etc/profiles/per-user/bart/bin:/home/bart/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin)
which: no qmake in (/opt/local/libexec/qt4/bin)
lv2.cpp:292:37: fatal error: boost/circular_buffer.hpp: No such file or directory
compilation terminated.
```

```
faust2svg FFcompressor.dsp
```



- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @pmahoney 