### PR TITLE
gcc-wrapper-old: grab name of dynamicLinker from bintools

### DIFF
--- a/pkgs/build-support/gcc-wrapper-old/default.nix
+++ b/pkgs/build-support/gcc-wrapper-old/default.nix
@@ -8,7 +8,7 @@
 { name ? "", stdenv, lib, nativeTools, nativeLibc, nativePrefix ? ""
 , gcc ? null, libc ? null, binutils ? null, coreutils ? null, shell ? stdenv.shell
 , zlib ? null
-, hostPlatform, targetPlatform
+, hostPlatform, targetPlatform, targetPackages
 }:
 
 assert nativeTools -> nativePrefix != "";
@@ -58,18 +58,6 @@ stdenv.mkDerivation {
   zlib = if gcc != null && gcc ? langVhdl then zlib else null;
   shell = shell + shell.shellPath or "";
 
-  crossAttrs = {
-    #
-    # This is not the best way to do this. I think the reference should be
-    # the style in the gcc-cross-wrapper, but to keep a stable stdenv now I
-    # do this sufficient if/else.
-    dynamicLinker =
-      (if hostPlatform.arch == "arm" then "ld-linux.so.3" else
-       if hostPlatform.arch == "mips" then "ld.so.1" else
-       if stdenv.lib.hasSuffix "pc-gnu" hostPlatform.config then "ld.so.1" else
-       abort "don't know the name of the dynamic linker for this platform");
-  };
-
   preferLocalBuild = true;
 
   meta =
@@ -83,17 +71,6 @@ stdenv.mkDerivation {
   # The dynamic linker has different names on different platforms.
   dynamicLinker =
     if !nativeLibc then
-      (if targetPlatform.system == "i686-linux"     then "ld-linux.so.2" else
-       if targetPlatform.system == "x86_64-linux"   then "ld-linux-x86-64.so.2" else
-       # ARM with a wildcard, which can be "" or "-armhf".
-       if targetPlatform.isArm                      then "ld-linux*.so.3" else
-       if targetPlatform.system == "aarch64-linux"  then "ld-linux-aarch64.so.1" else
-       if targetPlatform.system == "powerpc-linux"  then "ld.so.1" else
-       if targetPlatform.system == "mips64el-linux" then "ld.so.1" else
-       if targetPlatform.system == "x86_64-darwin"  then "/usr/lib/dyld" else
-       if stdenv.lib.hasSuffix "pc-gnu" targetPlatform.config then "ld.so.1" else
-       builtins.trace
-         "Don't know the name of the dynamic linker for platform ${targetPlatform.config}, so guessing instead."
-         null)
+      targetPackages.stdenv.cc.bintools.dynamicLinker
     else "";
 }


### PR DESCRIPTION
###### Motivation for this change

Don't duplicate logic for determining this, bintools exports this information.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

