### PR TITLE
tcpdump: fix eval if no kernelMajor specified, assume compat

### DIFF
--- a/pkgs/tools/networking/tcpdump/default.nix
+++ b/pkgs/tools/networking/tcpdump/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   crossAttrs = {
     LDFLAGS = if enableStatic then "-static" else "";
     configureFlags = [ "ac_cv_linux_vers=2" ] ++ (stdenv.lib.optional
-      (hostPlatform.platform.kernelMajor == "2.4") "--disable-ipv6");
+      (hostPlatform.platform.kernelMajor or null == "2.4") "--disable-ipv6");
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Minor fix to prevent eval failure.

Note that many platforms don't specify `kernelMajor`, although most (all?) of the current cross ones do.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

