### PR TITLE
wordgrinder: 0.6 -> 0.7.1

### DIFF
--- a/pkgs/applications/office/wordgrinder/default.nix
+++ b/pkgs/applications/office/wordgrinder/default.nix
@@ -1,24 +1,32 @@
 { stdenv, fetchFromGitHub, pkgconfig, makeWrapper
-, lua52Packages, libXft, ncurses, readline, zlib }:
+, lua52Packages, libXft, ncurses, ninja, readline, zlib }:
 
 stdenv.mkDerivation rec {
   name = "wordgrinder-${version}";
-  version = "0.6-db14181";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     repo = "wordgrinder";
     owner = "davidgiven";
-    rev = "db141815e8bd1da6e684a1142a59492e516f3041";
-    sha256 = "1l1jqzcqiwnc8r1igfi7ay4pzzhdhss81znnmfr4rc1ia8bpdjc2";
+    rev = "${version}";
+    sha256 = "19n4vn8zyvcvgwygm63d3jcmiwh6a2ikrrqqmkm8fvhdvwkqgr9k";
   };
 
   makeFlags = [
     "PREFIX=$(out)"
     "LUA_INCLUDE=${lua52Packages.lua}/include"
     "LUA_LIB=${lua52Packages.lua}/lib/liblua.so"
+    "XFT_PACKAGE=--libs=\{-lX11 -lXft\}"
   ];
 
-  nativeBuildInputs = [ pkgconfig makeWrapper ];
+  dontUseNinjaBuild = true;
+  dontUseNinjaInstall = true;
+
+  nativeBuildInputs = [
+    pkgconfig
+    makeWrapper
+    ninja
+  ];
 
   buildInputs = [
     libXft


### PR DESCRIPTION
###### Motivation for this change

Package bump.

Required adding `ninja` for changed build system, but it is all driven by `make`, so the default ninja build phases had to be disabled.

Also, I needed to specify a value for `XFT_PACKAGE` as the auto-detect assumes standard paths for the header.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

