### PR TITLE
fontconfig: fix postPatch phase for building on GPFS

### DIFF
--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -38,8 +38,7 @@ stdenv.mkDerivation rec {
   ];
   # additionally required for the glibc-2.25 patch; avoid requiring gperf
   postPatch = ''
-    sed s/CHAR_WIDTH/CHARWIDTH/g -i src/fcobjshash.{h,gperf}
-    touch src/*
+    sed s/CHAR_WIDTH/CHARWIDTH/g -i src/fcobjshash.{gperf,h}
   '';
 
   outputs = [ "bin" "dev" "lib" "out" ]; # $out contains all the config


### PR DESCRIPTION
The postPatch phase of the fontconfig expression performs patching of
src/fcobjshash.{gperf,h} files and performs "touch" to ensure the make
rule will not get triggered. Editing files in the right order seems to
be a more robust way to do both tasks.

###### Motivation for this change

This is basically a black magic to fix the build work when $TMP is on a network file system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


  