### PR TITLE
wordgrinder: Fix darwin build

### DIFF
--- a/pkgs/applications/office/wordgrinder/default.nix
+++ b/pkgs/applications/office/wordgrinder/default.nix
@@ -16,8 +16,7 @@ stdenv.mkDerivation rec {
     "PREFIX=$(out)"
     "LUA_INCLUDE=${lua52Packages.lua}/include"
     "LUA_LIB=${lua52Packages.lua}/lib/liblua.so"
-    "XFT_PACKAGE=--libs=\{-lX11 -lXft\}"
-  ];
+  ] ++ stdenv.lib.optional stdenv.isLinux "XFT_PACKAGE=--libs=\{-lX11 -lXft\}";
 
   dontUseNinjaBuild = true;
   dontUseNinjaInstall = true;
@@ -37,11 +36,12 @@ stdenv.mkDerivation rec {
   ];
 
   # To be able to find <Xft.h>
-  NIX_CFLAGS_COMPILE = "-I${libXft.dev}/include/X11";
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isLinux "-I${libXft.dev}/include/X11";
 
   # Binaries look for LuaFileSystem library (lfs.so) at runtime
   postInstall = ''
     wrapProgram $out/bin/wordgrinder --set LUA_CPATH "${lua52Packages.luafilesystem}/lib/lua/5.2/lfs.so";
+  '' + stdenv.lib.optionalString stdenv.isLinux ''
     wrapProgram $out/bin/xwordgrinder --set LUA_CPATH "${lua52Packages.luafilesystem}/lib/lua/5.2/lfs.so";
   '';
 
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     homepage = https://cowlark.com/wordgrinder;
     license = licenses.mit;
     maintainers = with maintainers; [ matthiasbeyer ];
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Upstream added official darwin support so I think we should add it too.

I dont actually have a darwin machine to test this on but I think it should work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @matthiasbeyer 