### PR TITLE
mariadb: fix darwin build

### DIFF
--- a/pkgs/servers/sql/mariadb/clang-isfinite.patch
+++ b/pkgs/servers/sql/mariadb/clang-isfinite.patch
@@ -1,0 +1,17 @@
+diff --git a/include/my_global.h b/include/my_global.h
+index cb31ae2..2866f87 100644
+--- a/include/my_global.h
++++ b/include/my_global.h
+@@ -803,12 +803,6 @@ inline unsigned long long my_double2ulonglong(double d)
+ #endif
+ 
+ #ifndef isfinite
+-#ifdef HAVE_FINITE
+-#define isfinite(x) finite(x)
+-#else
+-#define finite(x) (1.0 / fabs(x) > 0.0)
+-#endif /* HAVE_FINITE */
+-#elif (__cplusplus >= 201103L)
+ #include <cmath>
+ static inline bool isfinite(double x) { return std::isfinite(x); }
+ #endif /* isfinite */

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -34,7 +34,8 @@ common = rec { # attributes common to both builds
     sed -i 's,[^"]*/var/log,/var/log,g' storage/mroonga/vendor/groonga/CMakeLists.txt
   '';
 
-  patches = [ ./cmake-includedir.patch ];
+  patches = [ ./cmake-includedir.patch ]
+    ++ stdenv.lib.optional stdenv.cc.isClang ./clang-isfinite.patch;
 
   cmakeFlags = [
     "-DBUILD_CONFIG=mysql_release"
@@ -121,7 +122,8 @@ everything = stdenv.mkDerivation (common // {
   buildInputs = common.buildInputs ++ [
     xz lzo lz4 bzip2 snappy
     libxml2 boost judy libevent cracklib
-  ] ++ optionals (stdenv.isLinux && !stdenv.isArm) [ numactl ];
+  ] ++ optional (stdenv.isLinux && !stdenv.isArm) numactl
+    ++ optional stdenv.isDarwin libiconv;
 
   cmakeFlags = common.cmakeFlags ++ [
     "-DMYSQL_DATADIR=/var/lib/mysql"
@@ -157,7 +159,8 @@ everything = stdenv.mkDerivation (common // {
     rm "$out"/bin/rcmysql
   '';
 
-  CXXFLAGS = optionalString stdenv.isi686 "-fpermissive";
+  CXXFLAGS = optionalString stdenv.isi686 "-fpermissive"
+    + optionalString stdenv.isDarwin " -std=c++11";
 });
 
 connector-c = stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

