### PR TITLE
wallabag: fix config file not being loaded from WALLABAG_DATA

### DIFF
--- a/pkgs/servers/web-apps/wallabag/default.nix
+++ b/pkgs/servers/web-apps/wallabag/default.nix
@@ -13,13 +13,11 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" ];
 
-  patchPhase = ''
+  patches = [ ./wallabag-data.patch ]; # exposes $WALLABAG_DATA
+
+  prePatch = ''
     rm Makefile # use the "shared hosting" package with bundled dependencies
-    substituteInPlace app/AppKernel.php \
-      --replace "__DIR__" "getenv('WALLABAG_DATA')"
-    substituteInPlace var/bootstrap.php.cache \
-      --replace "\$this->rootDir = \$this->getRootDir()" "\$this->rootDir = getenv('WALLABAG_DATA')"
-  ''; # exposes $WALLABAG_DATA
+  '';
 
   installPhase = ''
     mkdir $out/
@@ -31,11 +29,12 @@ stdenv.mkDerivation rec {
     longDescription = ''
       wallabag is a self hostable application for saving web pages.
 
-      To use, point the environment variable $WALLABAG_DATA to a directory called `app` that contains the folder `config` with wallabag's configuration files. These need to be updated every package upgrade. In `app`'s parent folder, a directory called `var` containing wallabag's data will be created.
+      Point the environment variable $WALLABAG_DATA to a data directory that contains the folder `app/config` which must be a clone of wallabag's configuration files with your customized `parameters.yml`. These need to be updated every package upgrade.
       After a package upgrade, empty the `var/cache` folder.
     '';
     license = licenses.mit;
     homepage = http://wallabag.org;
+    maintainers = with maintainers; [ schneefux ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/servers/web-apps/wallabag/wallabag-data.patch
+++ b/pkgs/servers/web-apps/wallabag/wallabag-data.patch
@@ -1,0 +1,26 @@
+diff --git a/app/AppKernel.php b/app/AppKernel.php
+index 40726f05..7d44e600 100644
+--- a/app/AppKernel.php
++++ b/app/AppKernel.php
+@@ -58,14 +58,19 @@ class AppKernel extends Kernel
+         return $bundles;
+     }
+ 
++    public function getProjectDir()
++    {
++        return getenv('WALLABAG_DATA') ?: dirname(__DIR__);
++    }
++
+     public function getCacheDir()
+     {
+-        return dirname(__DIR__) . '/var/cache/' . $this->getEnvironment();
++        return $this->getProjectDir() . '/var/cache/' . $this->getEnvironment();
+     }
+ 
+     public function getLogDir()
+     {
+-        return dirname(__DIR__) . '/var/logs';
++        return $this->getProjectDir() . '/var/logs';
+     }
+ 
+     public function registerContainerConfiguration(LoaderInterface $loader)


### PR DESCRIPTION
###### Motivation for this change
Refactored and updated the `$WALLABAG_DATA` patch for changes in wallabag 2.3, replacing sed expressions by a patch file, falling back to default behavior if the environment variable is not set.

Fixes #20214.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
