### PR TITLE
gnome3.nautilus-sendto: fix gettext setup

### DIFF
--- a/pkgs/desktops/gnome-3/apps/nautilus-sendto/default.nix
+++ b/pkgs/desktops/gnome-3/apps/nautilus-sendto/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, glib, pkgconfig, gnome3, appstream-glib, gettext }:
+{ stdenv, fetchurl, meson, ninja, glib, pkgconfig, gnome3, appstream-glib, gettext, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
   name = "nautilus-sendto-${version}";
@@ -10,7 +10,16 @@ stdenv.mkDerivation rec {
     sha256 = "164d7c6e8bae29c4579bcc67a7bf50d783662b1545b62f3008e7ea3c0410e04d";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig appstream-glib gettext ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    appstream-glib
+    gettext
+    # For setup hook
+    gobjectIntrospection
+  ];
+
   buildInputs = [ glib ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
I think this fixes #33458 in accordance with #32626

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

