### PR TITLE
gnome3.gnome-screenshot: fix gettext setup

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-screenshot/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-screenshot/default.nix
@@ -1,6 +1,6 @@
 { stdenv, gettext, libxml2, fetchurl, pkgconfig, libcanberra_gtk3
 , bash, gtk3, glib, meson, ninja, wrapGAppsHook, appstream-glib
-, gnome3, librsvg, gdk_pixbuf }:
+, gnome3, librsvg, gdk_pixbuf, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
@@ -18,7 +18,17 @@ stdenv.mkDerivation rec {
   propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
   propagatedBuildInputs = [ gdk_pixbuf gnome3.defaultIconTheme librsvg ];
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext appstream-glib libxml2 wrapGAppsHook ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    gettext
+    appstream-glib
+    libxml2
+    wrapGAppsHook
+    # For setup hook
+    gobjectIntrospection
+  ];
   buildInputs = [ bash gtk3 glib libcanberra_gtk3
                   gnome3.gsettings_desktop_schemas ];
 


### PR DESCRIPTION
###### Motivation for this change
Fixes build in accordance with #32626

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

