### PR TITLE
weechat: add NixOS module

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -301,6 +301,7 @@
       pykms = 282;
       kodi = 283;
       restya-board = 284;
+      weechat = 285;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -570,6 +571,7 @@
       pykms = 282;
       kodi = 283;
       restya-board = 284;
+      weechat = 285;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -357,6 +357,7 @@
   ./services/misc/taskserver
   ./services/misc/tzupdate.nix
   ./services/misc/uhub.nix
+  ./services/misc/weechat.nix
   ./services/misc/xmr-stak.nix
   ./services/misc/zookeeper.nix
   ./services/monitoring/apcupsd.nix

--- a/nixos/modules/services/misc/weechat.nix
+++ b/nixos/modules/services/misc/weechat.nix
@@ -1,0 +1,69 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.weechat;
+in
+
+{
+  options.services.weechat = {
+    enable = mkEnableOption "weechat";
+    init = mkOption {
+      description = "Weechat commands applied at start, one command per line.";
+      example = ''
+        /set relay.network.password correct-horse-battery-staple
+        /relay add weechat 9001
+      '';
+      type = types.str;
+      default = "";
+    };
+    root = mkOption {
+      description = "Weechat state directory.";
+      type = types.str;
+      default = "/var/lib/weechat";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users = {
+      groups.weechat.gid = config.ids.gids.weechat;
+      users.weechat = {
+        createHome = true;
+        group = "weechat";
+        home = cfg.root;
+        uid = config.ids.uids.weechat;
+      };
+    };
+
+    systemd.services.weechat = {
+      environment.WEECHAT_HOME = cfg.root;
+      serviceConfig = {
+        User = "weechat";
+        Group = "weechat";
+      };
+      script = "exec ${pkgs.screen}/bin/screen -D -m ${pkgs.weechat}/bin/weechat";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network.target" ];
+    };
+
+    systemd.paths.weechat-fifo = {
+      pathConfig = {
+        PathExists = "${cfg.root}/weechat_fifo";
+        Unit = "weechat-apply-init.service";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    systemd.services.weechat-apply-init = let
+      initFile = pkgs.writeText "weechat-init" cfg.init;
+    in {
+      script = "sed 's/^/*/' ${initFile} > ${cfg.root}/weechat_fifo";
+      serviceConfig = {
+        Type = "oneshot";
+        User = "weechat";
+        Group = "weechat";
+      };
+    };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Mainly for use with [Glowing Bear](http://www.glowing-bear.org/) or any other Weechat frontends, i.e. as an IRC relay/bouncer. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

