### PR TITLE
mblaze: init at 0.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -29,6 +29,7 @@
   aherrmann = "Andreas Herrmann <andreash87@gmx.ch>";
   ahmedtd = "Taahir Ahmed <ahmed.taahir@gmail.com>";
   aij = "Ivan Jager <aij+git@mrph.org>";
+  ajgrf = "Alex Griffin <a@ajgrf.com>";
   ak = "Alexander Kjeldaas <ak@formalprivacy.com>";
   akaWolf = "Artjom Vejsel <akawolf0@gmail.com>";
   akc = "Anders Claesson <akc@akc.is>";

--- a/pkgs/applications/networking/mailreaders/mblaze/default.nix
+++ b/pkgs/applications/networking/mailreaders/mblaze/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "mblaze-${version}";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "chneukirchen";
+    repo = "mblaze";
+    rev = "v${version}";
+    sha256 = "0p97zfl35ilrnrx9ynj82igsb698m9klikfaicw5jhjpf6qp2n3y";
+  };
+
+  makeFlags = "PREFIX=$(out)";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/chneukirchen/mblaze;
+    description = "Unix utilities to deal with Maildir";
+    license = licenses.cc0;
+    platforms = platforms.all;
+    maintainers = [ maintainers.ajgrf ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15895,6 +15895,8 @@ with pkgs;
 
   matchbox = callPackage ../applications/window-managers/matchbox { };
 
+  mblaze = callPackage ../applications/networking/mailreaders/mblaze { };
+
   mcpp = callPackage ../development/compilers/mcpp { };
 
   mda_lv2 = callPackage ../applications/audio/mda-lv2 { };


### PR DESCRIPTION
###### Motivation for this change

mblaze is a collection of command line utilities for manipulating and working with maildir. Kind of like the MH email utilities but for the maildir format. As far as I know no other package in nixpkgs does the same thing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

