### PR TITLE
wrapPythonPrograms: do not propagate disabling user site-packages to child-processes

### DIFF
--- a/pkgs/development/interpreters/python/wrap.sh
+++ b/pkgs/development/interpreters/python/wrap.sh
@@ -67,7 +67,7 @@ wrapPythonProgramsIn() {
                     # (see pkgs/build-support/setup-hooks/make-wrapper.sh)
                     local -a wrap_args=("$f"
                                     --prefix PATH ':' "$program_PATH"
-                                    --set PYTHONNOUSERSITE "true"
+                                    --add-flags '-s'
                                     )
 
                     # Add any additional arguments provided by makeWrapperArgs


### PR DESCRIPTION
The `PYTHONNOUSERSITE` was exported to prevent impurities during
runtime. The downside of exporting environment variables is that they
always propagate all the way down the process tree, unless they are
explicitly unset at some point. Using the `-s` argument applies it only
to the process executed in the wrapper. That way, subprocesses are free
to do impure things.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

