### PR TITLE
opera: 48.0.2685.52 -> 50.0.2762.45

### DIFF
--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -37,7 +37,7 @@
 let
 
   mirror = https://get.geo.opera.com/pub/opera/desktop;
-  version = "48.0.2685.52";
+  version = "50.0.2762.45";
 
   rpath = stdenv.lib.makeLibraryPath [
 
@@ -89,7 +89,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "${mirror}/${version}/linux/opera-stable_${version}_amd64.deb";
-    sha256 = "027njqh2as4d0xsnvzamqiplghb8cxqnc19y0vqkvjnsw57v828p";
+    sha256 = "1ajdr6yzqc9xkvdcgkps6j5996n60ibjhj518gmminx90da6x5dy";
   };
 
   unpackCmd = "${dpkg}/bin/dpkg-deb -x $curSrc .";


### PR DESCRIPTION
###### Motivation for this change

Update to latest stable.

Determining what exactly *is* the "latest stable" Opera is a bit non-obvious,
but this the version they offered when I attempted to download it manually.

Interestingly '50' isn't in the [version history](http://www.opera.com/docs/history/) yet.

But it has 'stable' in the URL ;) and the beta version it gives you is different anyway.

Related: http://blogs.opera.com/desktop/2018/01/opera-50-introduces-anti-bitcoin-mining-tool/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I don't use opera normally, but it launches and I was able to visit pages and play youtube videos, so seems fine :).