### PR TITLE
Update macos USB instructions

### DIFF
--- a/nixos/doc/manual/installation/installing-usb.xml
+++ b/nixos/doc/manual/installation/installing-usb.xml
@@ -11,10 +11,24 @@ a USB stick. You can use the <command>dd</command> utility to write the image:
 <command>dd if=<replaceable>path-to-image</replaceable>
 of=<replaceable>/dev/sdb</replaceable></command>. Be careful about specifying the
 correct drive; you can use the <command>lsblk</command> command to get a list of
-block devices. If you're on macOS you can run <command>diskutil list</command>
-to see the list of devices; the device you'll use for the USB must be ejected
-before writing the image.</para>
+block devices.</para>
 
+<para>On macOS:
+<programlisting>
+$ diskutil list
+[..]
+/dev/diskN (external, physical):
+   #:                       TYPE NAME                    SIZE       IDENTIFIER
+[..]
+$ diskutil unmountDisk diskN
+Unmount of all volumes on diskN was successful
+$ sudo dd bs=1m if=nix.iso of=/dev/rdiskN
+</programlisting>
+Using the 'raw' <command>rdiskN</command> device instead of <command>diskN</command>
+completes in minutes instead of hours. After <command>dd</command> completes, a GUI
+dialog "The disk you inserted was not readable by this computer" will pop up, which
+can be ignored.</para>
+         
 <para>The <command>dd</command> utility will write the image verbatim to the drive,
 making it the recommended option for both UEFI and non-UEFI installations. For
 non-UEFI installations, you can alternatively use


### PR DESCRIPTION
"Ejecting" from the Finder ejects the entire device which is then not available for dd. diskutil unmountDisk does the right thing. Furthermore writing to diskN instead of rdiskN failed to complete even after waiting >10 minutes.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

