### PR TITLE
micro: init at 1.3.4

### DIFF
--- a/pkgs/applications/editors/micro/default.nix
+++ b/pkgs/applications/editors/micro/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage  rec {
+  name = "micro-${version}";
+  version = "1.3.4";
+
+  goPackagePath = "github.com/zyedidia/micro";
+
+  src = fetchFromGitHub {
+    owner = "zyedidia";
+    repo = "micro";
+    rev = "v${version}";
+    sha256 = "1giyp2xk2rb6vdyfnj5wa7qb9fwbcmmwm16wdlnmq7xnp7qamdkw";
+    fetchSubmodules = true;
+  };
+
+  subPackages = [ "cmd/micro" ];
+
+  buildFlagsArray = [ "-ldflags=" "-X main.Version=${version}" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://micro-editor.github.io;
+    description = "Modern and intuitive terminal-based text editor";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16252,6 +16252,8 @@ with pkgs;
 
   mythtv = callPackage ../applications/video/mythtv { };
 
+  micro = callPackage ../applications/editors/micro { };
+
   nano = callPackage ../applications/editors/nano { };
 
   nanoblogger = callPackage ../applications/misc/nanoblogger { };


### PR DESCRIPTION
###### Motivation for this change

Wanted to try it, wasn't available, so addding it! :)

Don't really plan on using it but seems like a good addition to have around :).

https://repology.org/metapackage/micro/versions <-- can't let all these guys show us up!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

