### PR TITLE
arduino: 1.8.2 -> 1.8.5

### DIFF
--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -20,8 +20,8 @@ let
   externalDownloads = import ./downloads.nix {inherit fetchurl; inherit (lib) optionalAttrs; inherit (stdenv) system;};
   # Some .so-files are later copied from .jar-s to $HOME, so patch them beforehand
   patchelfInJars =
-       lib.optional (stdenv.system == "x86_64-linux") {jar = "share/arduino/lib/jssc-2.8.0.jar"; file = "libs/linux/libjSSC-2.8_x86_64.so";}
-    ++ lib.optional (stdenv.system == "i686-linux") {jar = "share/arduino/lib/jssc-2.8.0.jar"; file = "libs/linux/libjSSC-2.8_x86.so";}
+       lib.optional (stdenv.system == "x86_64-linux") {jar = "share/arduino/lib/jssc-2.8.0-arduino1.jar"; file = "libs/linux/libjSSC-2.8_x86_64.so";}
+    ++ lib.optional (stdenv.system == "i686-linux") {jar = "share/arduino/lib/jssc-2.8.0-arduino1.jar"; file = "libs/linux/libjSSC-2.8_x86.so";}
   ;
   # abiVersion 6 is default, but we need 5 for `avrdude_bin` executable
   ncurses5 = ncurses.override { abiVersion = "5"; };
@@ -54,25 +54,25 @@ let
              + stdenv.lib.optionalString (!withGui) "-core";
 in
 stdenv.mkDerivation rec {
-  version = "1.8.2";
+  version = "1.8.5";
   name = "${flavor}-${version}";
 
   src = fetchFromGitHub {
     owner = "arduino";
     repo = "Arduino";
     rev = "${version}";
-    sha256 = "1ssznjmzmahayslj2xnci9b5wpsl53nyg85say54akng93qipmfb";
+    sha256 = "0ww72qfk7fyvprz15lc80i1axfdacb5fij4h5j5pakrg76mng2c3";
   };
 
   teensyduino_src = fetchurl {
-    url = "https://www.pjrc.com/teensy/td_136/TeensyduinoInstall.${teensy_architecture}";
+    url = "https://www.pjrc.com/teensy/td_140/TeensyduinoInstall.${teensy_architecture}";
     sha256 =
       lib.optionalString ("${teensy_architecture}" == "linux64")
-        "0qvb5z9y6nsqy0kzib9fvvbn8dakl50vib6r3nm6bnpvyxzwjl2r"
+        "0127a1ak31252dbmr5niqa5mkvbm8dnz1cfcnmydzx9qn9rk00ir"
       + lib.optionalString ("${teensy_architecture}" == "linux32")
-        "14ca62vq7cpx269vfd92shi80qj8spf0dzli8gfcb39ss2zc4jf1"
+        "01mxj5xsr7gka652c9rp4szy5mkcka8mljk044v4agk3sxvx3v3i"
       + lib.optionalString ("${teensy_architecture}" == "linuxarm")
-        "122z1gxcgkmwjb8wdklb2w8c3qkj5rc1ap5n4a8fi3kjz29va9rx";
+        "1dff3alhvk9x8qzy3n85qrg6rfmy6l9pj6fmrlzpli63lzykvv4i";
   };
 
   buildInputs = [ jdk ant libusb libusb1 unzip zlib ncurses5 readline

--- a/pkgs/development/arduino/arduino-core/downloads.nix
+++ b/pkgs/development/arduino/arduino-core/downloads.nix
@@ -1,5 +1,8 @@
 {fetchurl, optionalAttrs, system}:
-
+# This file preloads all the archives which Arduino's build/build.xml
+# would otherwise try to download itself. When updating this for a new
+# version of Arduino, check build.xml for version numbers and new
+# urls.
 {
   "build/shared/reference-1.6.6-3.zip" = fetchurl {
     url = "https://downloads.arduino.cc/reference-1.6.6-3.zip";
@@ -21,17 +24,17 @@
     url = "https://github.com/arduino-libraries/Bridge/archive/1.6.3.zip";
     sha256 = "1lha5wkzz63bgcn7bhx4rmgsh9ywa47lffycpyz6qjnl1pvm5mmj";
   };
-  "build/Robot_Control-1.0.3.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/Robot_Control/archive/1.0.3.zip";
-    sha256 = "1pc3b8skbpx7j32jnxa67mfqhnsmfz3876pc9mdyzpsad4mmcn62";
+  "build/Robot_Control-1.0.4.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Robot_Control/archive/1.0.4.zip";
+    sha256 = "1pkabrghx3h8l60x571vwkbhfm02nhyn5x2vqz4vhx9cczr70zq7";
   };
-  "build/Robot_Motor-1.0.2.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/Robot_Motor/archive/1.0.2.zip";
-    sha256 = "0da21kfzy07kk2qnkprs3lj214fgkcjxlkk3hdp306jfv8ilmvy2";
+  "build/Robot_Motor-1.0.3.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Robot_Motor/archive/1.0.3.zip";
+    sha256 = "1pkvrimg77jrhdsz4l81y59hv50h6cl7hvhk9w8ac7ckg70lvxkw";
   };
-  "build/RobotIRremote-1.0.2.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/RobotIRremote/archive/1.0.2.zip";
-    sha256 = "0wkya7dy4x0xyi7wn5aghmr1gj0d0wszd61pq18zgfdspz1gi6xn";
+  "build/RobotIRremote-2.0.0.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/RobotIRremote/archive/2.0.0.zip";
+    sha256 = "0j5smap74j8p3wc6k0h73b1skj4gkr7r25jbjh1j1cg052dxri86";
   };
   "build/SpacebrewYun-1.0.1.zip" = fetchurl {
     url = "https://github.com/arduino-libraries/SpacebrewYun/archive/1.0.1.zip";
@@ -61,9 +64,13 @@
     url = "https://github.com/arduino-libraries/Servo/archive/1.1.2.zip";
     sha256 = "14k1883qrx425wnm0r8kszzq32yvvs3jwxf3g7ybp7v0ga0q47l7";
   };
-  "build/Adafruit_CircuitPlayground-1.6.4.zip" = fetchurl {
-    url = "https://github.com/Adafruit/Adafruit_CircuitPlayground/archive/1.6.4.zip";
-    sha256 = "1ph7m0l1sfx9db56n2h6vi78pn3zyah813lfhqiqghncx34amrhj";
+  "build/LiquidCrystal-1.0.7.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/LiquidCrystal/archive/1.0.7.zip";
+    sha256 = "1wrxrqz3n4yrj9j1a2b7pdd7a1rlyi974ra7crv5amjng8817x9n";
+  };
+  "build/Adafruit_CircuitPlayground-1.6.8.zip" = fetchurl {
+    url = "https://github.com/Adafruit/Adafruit_CircuitPlayground/archive/1.6.8.zip";
+    sha256 = "0zm667xiaygx8v1ygcls43s6qd5n7pf21n0998n1z7nf18s35j41";
   };
   "build/libastylej-2.05.1-3.zip" = fetchurl {
     url = "https://downloads.arduino.cc/libastylej-2.05.1-3.zip";
@@ -73,9 +80,9 @@
     url = "https://downloads.arduino.cc/liblistSerials/liblistSerials-1.4.0.zip";
     sha256 = "129mfbyx7snq3znzhkfbdjiifdr85cwk6wjn8l9ia0wynszs5zyv";
   };
-  "build/shared/WiFi101-Updater-ArduinoIDE-Plugin-0.9.0.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/WiFi101-FirmwareUpdater-Plugin/releases/download/v0.9.0/WiFi101-Updater-ArduinoIDE-Plugin-0.9.0.zip";
-    sha256 = "1nkk87q2l3bs9y387hdxzgqllm0lqpmc5kdmr6my4hjz5lcpgbza";
+  "build/shared/WiFi101-Updater-ArduinoIDE-Plugin-0.9.1.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/WiFi101-FirmwareUpdater-Plugin/releases/download/v0.9.1/WiFi101-Updater-ArduinoIDE-Plugin-0.9.1.zip";
+    sha256 = "15przp8z1dp6lamcvqdx4daq6fqi3c1algc3sbinyh25pm69pq74";
   };
 }
 // optionalAttrs (system == "x86_64-linux") {


### PR DESCRIPTION
###### Motivation for this change
Update to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notes
`teensyduino` fails to build but that is due to #33147 which is about `openjdk` versions. I was able to build an updated `teensyduino` using this patch and `openjdk` version `8u144`.

CC @antono @auntie @robberer @bjornfor
---

