### PR TITLE
svgcleaner: 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/tools/graphics/svgcleaner/default.nix
+++ b/pkgs/tools/graphics/svgcleaner/default.nix
@@ -1,19 +1,17 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
-with rustPlatform;
-
-buildRustPackage rec {
+rustPlatform.buildRustPackage rec {
   name = "svgcleaner-${version}";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
     owner = "RazrFalcon";
     repo = "svgcleaner";
     rev = "v${version}";
-    sha256 = "0l75a2kqh2syl14pmywrkxhr19fcnfpzjj9gj3503aw0r800g16m";
+    sha256 = "1jpnqsln37kkxz98vj7gly3c2170v6zamd876nc9nfl9vns41s0f";
   };
 
-  cargoSha256 = "1hl04wqdgspajf2w664i00vgp13yi0sxvjjpfs5vfhm641z3j69y";
+  cargoSha256 = "0d5jlq301s55xgdg9mv26hbj75pkjkyxfny7vbiqp9igj128lza3";
 
   meta = with stdenv.lib; {
     description = "A tool for tidying and optimizing SVGs";


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

