### PR TITLE
libcroco: Fixes for CVE-2017-7960 & CVE-2017-7961

### DIFF
--- a/pkgs/desktops/gnome-3/core/libcroco/default.nix
+++ b/pkgs/desktops/gnome-3/core/libcroco/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libxml2, glib }:
+{ stdenv, fetchurl, pkgconfig, libxml2, glib, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "libcroco-0.6.12";
@@ -7,6 +7,19 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/libcroco/0.6/${name}.tar.xz";
     sha256 = "0q7qhi7z64i26zabg9dbs5706fa8pmzp1qhpa052id4zdiabbi6x";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2017-7960.patch";
+      url = "https://git.gnome.org/browse/libcroco/patch/?id=898e3a8c8c0314d2e6b106809a8e3e93cf9d4394";
+      sha256 = "1xjwdqijxf4b7mhdp3kkgnb6c14y0bn3b3gg79kyrm82x696d94l";
+    })
+    (fetchpatch {
+      name = "CVE-2017-7961.patch";
+      url = "https://git.gnome.org/browse/libcroco/patch/?id=9ad72875e9f08e4c519ef63d44cdbd94aa9504f7";
+      sha256 = "0zakd72ynzjgzskwyvqglqiznsb93j1bkvc1lgyrzgv9rwrbwv9s";
+    })
+  ];
 
   outputs = [ "out" "dev" ];
   outputBin = "dev";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @jtojnar 