### PR TITLE
ocamlPackages.mstruct: 1.3.3 -> 1.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/mstruct/default.nix
+++ b/pkgs/development/ocaml-modules/mstruct/default.nix
@@ -7,14 +7,14 @@ then throw "mstruct is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-	version = "1.3.3";
+	version = "1.4.0";
 	name = "ocaml${ocaml.version}-mstruct-${version}";
 
 	src = fetchFromGitHub {
 		owner = "mirage";
 		repo = "ocaml-mstruct";
 		rev = "v${version}";
-		sha256 = "1rxjzkg6156vl6yazbk1h0ndqj80wym5aliaapijf60apqqmsp4s";
+		sha256 = "1p4ygwzs3n1fj4apfib0z0sabpph21bkq1dgjk4bsa59pq4prncm";
 	};
 
 	buildInputs = [ ocaml findlib jbuilder opam ];


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

