### PR TITLE
dtools: 2.075.1 -> 2.078.0

### DIFF
--- a/pkgs/development/tools/dtools/default.nix
+++ b/pkgs/development/tools/dtools/default.nix
@@ -2,14 +2,31 @@
 
 stdenv.mkDerivation rec {
   name = "dtools-${version}";
-  version = "2.075.1";
+  version = "2.078.0";
 
-  src = fetchFromGitHub {
-    owner = "dlang";
-    repo = "tools";
-    rev = "v${version}";
-    sha256 = "0lxn400s9las9hq6h9vj4mis2jr662k2yw0zcrvqcm1yg9pd245d";
-  };
+  srcs = [
+    (fetchFromGitHub {
+      owner = "dlang";
+      repo = "dmd";
+      rev = "v${version}";
+      sha256 = "1ia4swyq0xqppnpmcalh2yxywdk2gv3kvni2abx1mq6wwqgmwlcr";
+      name = "dmd";
+    })
+    (fetchFromGitHub {
+      owner = "dlang";
+      repo = "tools";
+      rev = "v${version}";
+      sha256 = "1cydhn8g0h9i9mygzi80fb5fz3z1f6m8b9gypdvmyhkkzg63kf12";
+      name = "dtools";
+    })
+  ];
+
+  sourceRoot = ".";
+
+  postUnpack = ''
+      mv dmd dtools
+      cd dtools
+  '';
 
   postPatch = ''
       substituteInPlace posix.mak \
@@ -26,27 +43,22 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ dmd ];
   buildInputs = [ curl ];
 
+  makeCmd = ''
+    make -f posix.mak DMD=${dmd.out}/bin/dmd DMD_DIR=dmd
+  '';
+
   buildPhase = ''
-    make -f posix.mak DMD=${dmd.out}/bin/dmd INSTALL_DIR=$out
+    $makeCmd
   '';
 
   doCheck = true;
 
   checkPhase = ''
-      export BITS=${builtins.toString stdenv.hostPlatform.parsed.cpu.bits}
-      export OSNAME=${if stdenv.hostPlatform.isDarwin then "osx" else stdenv.hostPlatform.parsed.kernel.name}
-      ./generated/$OSNAME/$BITS/rdmd -main -unittest rdmd.d
-      ${dmd.out}/bin/dmd rdmd_test.d
-      ./rdmd_test
+      $makeCmd test_rdmd
     '';
 
   installPhase = ''
-    mkdir -p $out/bin
-    ${
-      let bits = builtins.toString stdenv.hostPlatform.parsed.cpu.bits;
-      osname = if stdenv.hostPlatform.isDarwin then "osx" else stdenv.hostPlatform.parsed.kernel.name; in
-      "find $PWD/generated/${osname}/${bits} -perm /a+x -type f -exec cp {} $out/bin \\;"
-    }
+      $makeCmd INSTALL_DIR=$out install
 	'';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

dtools: 2.075.1 -> 2.078.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


  