### PR TITLE
openssl_1_1_0: Fix CVE-2017-3738

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, buildPackages, perl
 , hostPlatform
+, fetchpatch
 , withCryptodev ? false, cryptodevHeaders
 , enableSSL2 ? false
 }:
@@ -114,6 +115,13 @@ in {
   openssl_1_1_0 = common {
     version = "1.1.0g";
     sha256 = "1bvka2wf33w2vxv7yw578nnjqyhz2b3chvfb0l4k2ffscw950kfy";
+    patches = [
+      (fetchpatch {
+        name = "CVE-2017-3738.patch";
+        url = "https://github.com/openssl/openssl/commit/563066.patch";
+        sha256 = "0ni9fwpxf8raw8b58pfa15akbqmxx4q64v0ldsm4b9dqhbxf8mkz";
+      })
+    ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

