### PR TITLE
radiotray-ng: 0.1.7 -> 0.2.0

### DIFF
--- a/pkgs/applications/audio/radiotray-ng/default.nix
+++ b/pkgs/applications/audio/radiotray-ng/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch
+{ stdenv, fetchFromGitHub
 , cmake, pkgconfig
 # Transport
 , curl
@@ -15,6 +15,7 @@
 , libappindicator-gtk3
 , libnotify
 , libxdg_basedir
+, wxGTK
 # GStreamer
 , gst_all_1
 # User-agent info
@@ -39,13 +40,13 @@ let
 in
 stdenv.mkDerivation rec {
   name = "radiotray-ng-${version}";
-  version = "0.1.7";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "ebruck";
     repo = "radiotray-ng";
     rev = "v${version}";
-    sha256 = "1m853gzh9r249crn0xyrq22x154r005j58b0kq3nsrgi5cps2zdv";
+    sha256 = "12mhi0q137cjdpmpczvrcr7szq1ja1r8bm0gh03b925y8xyrqp5z";
   };
 
   nativeBuildInputs = [ cmake pkgconfig wrapGAppsHook makeWrapper ];
@@ -56,6 +57,7 @@ stdenv.mkDerivation rec {
     glibmm hicolor_icon_theme gnome3.gsettings_desktop_schemas libappindicator-gtk3 libnotify
     libxdg_basedir
     lsb-release
+    wxGTK
   ] ++ stdenv.lib.optional doCheck gmock
     ++ gstInputs
     ++ pythonInputs;
@@ -65,15 +67,13 @@ stdenv.mkDerivation rec {
       --replace /usr $out
     substituteInPlace include/radiotray-ng/common.hpp \
       --replace /usr $out
-  '';
 
-  patches = [
-    (fetchpatch {
-      # Fix menu separators and minor touchup to 'version'
-      url = "https://github.com/ebruck/radiotray-ng/commit/827e9f1baaa03ab4d8a5fb3aab043e72950eb965.patch";
-      sha256 = "1aykl6lq4pga34xg5r9mc616gxnd63q6gr8qzg57w6874cj3csrr";
-    })
-  ];
+    # We don't find the radiotray-ng-notification icon otherwise
+    substituteInPlace data/radiotray-ng.desktop \
+      --replace radiotray-ng-notification radiotray-ng-on
+    substituteInPlace data/rtng-bookmark-editor.desktop \
+      --replace radiotray-ng-notification radiotray-ng-on
+  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16688,7 +16688,9 @@ with pkgs;
 
   renoise = callPackage ../applications/audio/renoise {};
 
-  radiotray-ng = callPackage ../applications/audio/radiotray-ng { };
+  radiotray-ng = callPackage ../applications/audio/radiotray-ng {
+    wxGTK = wxGTK30;
+  };
 
   rapcad = libsForQt56.callPackage ../applications/graphics/rapcad { boost = boost159; };
 


### PR DESCRIPTION
Now with bookmark editor.

###### Motivation for this change

Update, fixes, etc.

https://github.com/ebruck/radiotray-ng/releases/tag/v0.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

