### PR TITLE
electrum: 3.0.3 -> 3.0.4

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -2,11 +2,11 @@
 
 python3Packages.buildPythonApplication rec {
   name = "electrum-${version}";
-  version = "3.0.3";
+  version = "3.0.4";
 
   src = fetchurl {
     url = "https://download.electrum.org/${version}/Electrum-${version}.tar.gz";
-    sha256 = "09h3s1mbkliwh8758prbdk3sm19bnma7wy3k10pl9q9fkarbhp75";
+    sha256 = "03vvxbyci9acss9sfdjcvdp0ny1fvyj29q261lxqr416vvfparjj";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
From the release notes [1]:

>   Fix a vulnerability caused by Cross-Origin Resource Sharing (CORS)
>   in the JSONRPC interface. Previous versions of Electrum are
>   vulnerable to port scanning and deanonimization attacks from
>   malicious websites. Wallets that are not password-protected are
>   vulnerable to theft.

See this [2] for explanation.

I did not even build or test that, but wanted to notify the maintainers @ehmry @joachifm @np in the first place.

As all previous versions seem to be affected, it might be necessary to backport to 17.09? As far as I can tell, the `electrum` developers fixed only the recent version.

[1] https://github.com/spesmilo/electrum/blob/3.0.4/RELEASE-NOTES
[2] https://github.com/spesmilo/electrum/issues/3374

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


  