### PR TITLE
uhd: apply upstream patch to fix build w/boost 1.66

### DIFF
--- a/pkgs/development/tools/misc/uhd/default.nix
+++ b/pkgs/development/tools/misc/uhd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromGitHub, cmake, pkgconfig
+{ stdenv, fetchurl, fetchFromGitHub, fetchpatch, cmake, pkgconfig
 , python, pythonPackages, orc, libusb1, boost }:
 
 # You need these udev rules to not have to run as root (copied from
@@ -27,6 +27,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ python pythonPackages.pyramid_mako orc libusb1 boost ];
+
+  patches = [
+    # Boost 1.66 compat
+    (fetchpatch {
+      url = "https://github.com/EttusResearch/uhd/commit/d9d9d0a8a2e61b1b82e9799585cb7376f581f276.patch";
+      sha256 = "0bb7xyq85q591wsjipf1f3rm06zz4pl87xrcmm08xl21hw9avnb5";
+    })
+  ];
 
   # Build only the host software
   preConfigure = "cd host";


### PR DESCRIPTION
Fixes #33549.

###### Motivation for this change

Grab upstream patch for fixing compat with boost 1.66.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
