### PR TITLE
ttwatch: 2017-10-31 -> 2017-12-31

### DIFF
--- a/pkgs/tools/misc/ttwatch/default.nix
+++ b/pkgs/tools/misc/ttwatch/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "ttwatch-${version}";
-  version = "2017-10-31";
+  version = "2017-12-31";
 
   src = fetchFromGitHub {
     owner = "ryanbinns";
     repo = "ttwatch";
-    rev = "f4103bdeb612a216ac21747941b3df943d67c48c";
-    sha256 = "0fylycdi0g119d21l11yz23cjjhr3qdxjv02vz86zkc15kyvgsas";
+    rev = "a261851d91e3304a47a04995758f6940747bc54a";
+    sha256 = "0llcai1yxikh8nvzry71rr1zz365rg0k0lwp24np5w74kzza3kwx";
   };
 
   nativeBuildInputs = [ cmake perl ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

