### PR TITLE
[RDY] Add skim and its vim plugin

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -1,7 +1,7 @@
 # TODO check that no license information gets lost
 { fetchurl, stdenv, python, go, cmake, vim, vimUtils, perl, ruby, unzip
 , which, fetchgit, llvmPackages
-, xkb_switch, rustracerd, fzf
+, xkb_switch, rustracerd, fzf, skim
 , python3, boost, icu
 , ycmd, makeWrapper, rake
 , pythonPackages, python3Packages
@@ -11,6 +11,8 @@
 }:
 
 let
+
+  _skim = skim;
 
 inherit (vimUtils.override {inherit vim;}) rtpPath addRtp buildVimPlugin
   buildVimPluginFrom2Nix vimHelpTags;
@@ -137,6 +139,12 @@ rec {
   fzfWrapper = buildVimPluginFrom2Nix {
     name = fzf.name;
     src = fzf.src;
+    dependencies = [];
+  };
+
+  skim = buildVimPluginFrom2Nix {
+    name = _skim.name;
+    src = _skim.vim;
     dependencies = [];
   };
 

--- a/pkgs/tools/misc/skim/default.nix
+++ b/pkgs/tools/misc/skim/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "skim-${version}";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "lotabout";
+    repo = "skim";
+    rev = "v${version}";
+    sha256 = "0spkkgjjrch1grb0115rn0wxzsh8pzmm96a7j69zy5pc1il2m5lp";
+  };
+
+  cargoSha256 = "0zbjnii8r41ih2m2vqhm3wdiwgi13kipvxx75sg4vm4maf4wpmhv";
+
+  postInstall = ''
+    install -D -m 555 bin/sk-tmux -t $out/bin
+    install -D -m 444 shell/* -t $out/share/skim
+
+    cat <<SCRIPT > $out/bin/sk-share
+    #!/bin/sh
+    # Run this script to find the skim shared folder where all the shell
+    # integration scripts are living.
+    echo $out/share/skim
+    SCRIPT
+    chmod +x $out/bin/sk-share
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Fuzzy Finder in rust!";
+    homepage = https://github.com/lotabout/skim;
+    license = licenses.mit;
+    maintainers = [];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/misc/skim/default.nix
+++ b/pkgs/tools/misc/skim/default.nix
@@ -11,11 +11,18 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0spkkgjjrch1grb0115rn0wxzsh8pzmm96a7j69zy5pc1il2m5lp";
   };
 
+  outputs = [ "out" "vim" ];
+
   cargoSha256 = "0zbjnii8r41ih2m2vqhm3wdiwgi13kipvxx75sg4vm4maf4wpmhv";
+
+  patchPhase = ''
+    sed -i -e "s|expand('<sfile>:h:h')|'$out'|" plugin/skim.vim
+  '';
 
   postInstall = ''
     install -D -m 555 bin/sk-tmux -t $out/bin
     install -D -m 444 shell/* -t $out/share/skim
+    install -D -m 444 plugin/skim.vim -t $vim/plugin
 
     cat <<SCRIPT > $out/bin/sk-share
     #!/bin/sh

--- a/pkgs/tools/misc/skim/default.nix
+++ b/pkgs/tools/misc/skim/default.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
     install -D -m 444 plugin/skim.vim -t $vim/plugin
 
     cat <<SCRIPT > $out/bin/sk-share
-    #!/bin/sh
+    #! ${stdenv.shell}
     # Run this script to find the skim shared folder where all the shell
     # integration scripts are living.
     echo $out/share/skim

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4650,6 +4650,8 @@ with pkgs;
 
   sdl-jstest = callPackage ../tools/misc/sdl-jstest { };
 
+  skim = callPackage ../tools/misc/skim { };
+
   sec = callPackage ../tools/admin/sec { };
 
   seccure = callPackage ../tools/security/seccure { };


### PR DESCRIPTION
###### Motivation for this change

[skim](https://github.com/lotabout/skim) is a command-line fuzzy finder written in Rust. It is a good alternative to fzf.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


  