### PR TITLE
Debian ucode update for CVE-2017-5715 (Spectre)

### DIFF
--- a/nixos/modules/hardware/cpu/intel-microcode.nix
+++ b/nixos/modules/hardware/cpu/intel-microcode.nix
@@ -7,15 +7,22 @@ with lib;
   ###### interface
 
   options = {
-
-    hardware.cpu.intel.updateMicrocode = mkOption {
-      default = false;
-      type = types.bool;
-      description = ''
-        Update the CPU microcode for Intel processors.
-      '';
+    hardware.cpu.intel = {
+      updateMicrocode = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Update the CPU microcode for Intel processors.
+        '';
+      };
+      microcodePackage = mkOption {
+        default = pkgs.microcodeIntel;
+        defaultText = "pkgs.microcodeIntel";
+        type = types.package;
+        example = "pkgs.microcodeIntelDebian";
+        description = "Microcode update package.";
+      };
     };
-
   };
 
 
@@ -23,7 +30,7 @@ with lib;
 
   config = mkIf config.hardware.cpu.intel.updateMicrocode {
     # Microcode updates must be the first item prepended in the initrd
-    boot.initrd.prepend = mkOrder 1 [ "${pkgs.microcodeIntel}/intel-ucode.img" ];
+    boot.initrd.prepend = mkOrder 1 [ "${config.hardware.cpu.intel.microcodePackage}/intel-ucode.img" ];
   };
 
 }

--- a/pkgs/os-specific/linux/iucode_tool/default.nix
+++ b/pkgs/os-specific/linux/iucode_tool/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitLab, autoreconfHook }:
+let
+  version = "v2.2";
+in
+stdenv.mkDerivation{
+  name = "iucode_tool-${version}";
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  src = fetchFromGitLab {
+    owner = "iucode-tool";
+    repo = "iucode-tool";
+    rev = version;
+    sha256 = "0ndh33rj3l9gp7xkx7m167p2svp4m3fzmzblc6xpz4ldmwsjnrnc";
+  };
+
+  meta = with stdenv.lib; {
+    description = ''
+      iucode_tool is a program to manipulate microcode update
+      collections for Intel:registered: i686 and X86-64 system processors, and
+      prepare them for use by the Linux kernel. Please refer to the project wiki
+      for documentation and more details.
+    '';
+    homepage = https://gitlab.com/iucode-tool/iucode-tool;
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/os-specific/linux/microcode/intel_debian.nix
+++ b/pkgs/os-specific/linux/microcode/intel_debian.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, iucode_tool }:
+let
+  version = "3.20171215.1";
+in
+stdenv.mkDerivation {
+  name = "micorcode-intel-debian-${version}";
+
+  nativeBuildInputs = [ iucode_tool ];
+
+  src = fetchurl {
+    url = "http://http.debian.net/debian/pool/non-free/i/intel-microcode/intel-microcode_${version}.tar.xz";
+    sha256 = "0kgs3wk1xlcmpav106jwz9wi0z2p57i7fi104f3nlifwlv0fza7c";
+  };
+
+  installPhase = ''
+    mkdir -p $out
+    ${iucode_tool}/bin/iucode_tool -l --write-earlyfw="$out/intel-ucode.img" intel-microcode.bin intel-microcode.bin intel-microcode-64.bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.intel.com/;
+    description = "Microcode for Intel processors (with debian supplementary files)";
+    license = licenses.unfreeRedistributableFirmware;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12611,6 +12611,8 @@ with pkgs;
 
   intel-ocl = callPackage ../os-specific/linux/intel-ocl { };
 
+  iucode_tool = callPackage ../os-specific/linux/iucode_tool { };
+
   iomelt = callPackage ../os-specific/linux/iomelt { };
 
   iotop = callPackage ../os-specific/linux/iotop { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12402,6 +12402,7 @@ with pkgs;
   microcodeAmd = callPackage ../os-specific/linux/microcode/amd.nix { };
 
   microcodeIntel = callPackage ../os-specific/linux/microcode/intel.nix { };
+  microcodeIntelDebian = callPackage ../os-specific/linux/microcode/intel_debian.nix { };
 
   inherit (callPackages ../os-specific/linux/apparmor { pythonPackages = python27Packages; swig = swig2; })
     libapparmor apparmor-pam apparmor-parser apparmor-profiles apparmor-utils;


### PR DESCRIPTION
###### Motivation for this change

Debian, Redhat, Suse etc. seem to already got a pre-release (or acquire the files early) of the intel ucode patches relate to Spectre (CVE-2017-5715).

This PR adds a package `intelMicrocodeDebian` which uses the Debian source tarball, builds the firmware images and provides them in the same way as `intelMicrocode`. The new package can be used as a drop-in replacement of `intelMicrocode`.

Additionally a new configuration switch (`hardware.cpu.intel.microcodePackage`) has been added to provide users a simple way to select the desired firmware package.

I did rebuild my system using this package and so far it seems to be fine.


Changes that are contained within the Debian firmware package are:

```
  * Add supplementary-ucode-CVE-2017-5715.d/: (closes: #886367)
    New upstream microcodes to partially address CVE-2017-5715
    + Updated Microcodes:
      sig 0x000306c3, pf_mask 0x32, 2017-11-20, rev 0x0023, size 23552
      sig 0x000306d4, pf_mask 0xc0, 2017-11-17, rev 0x0028, size 18432
      sig 0x000306f2, pf_mask 0x6f, 2017-11-17, rev 0x003b, size 33792
      sig 0x00040651, pf_mask 0x72, 2017-11-20, rev 0x0021, size 22528
      sig 0x000406e3, pf_mask 0xc0, 2017-11-16, rev 0x00c2, size 99328
      sig 0x000406f1, pf_mask 0xef, 2017-11-18, rev 0xb000025, size 27648
      sig 0x00050654, pf_mask 0xb7, 2017-11-21, rev 0x200003a, size 27648
      sig 0x000506c9, pf_mask 0x03, 2017-11-22, rev 0x002e, size 16384
      sig 0x000806e9, pf_mask 0xc0, 2017-12-03, rev 0x007c, size 98304
      sig 0x000906e9, pf_mask 0x2a, 2017-12-03, rev 0x007c, size 98304
  * Implements IBRS and IBPB support via new MSR (Spectre variant 2
    mitigation, indirect branches).  Support is exposed through cpuid(7).EDX.
  * LFENCE terminates all previous instructions (Spectre variant 2
    mitigation, conditional branches).
```
(The full log can be seen at http://metadata.ftp-master.debian.org/changelogs/non-free/i/intel-microcode/intel-microcode_3.20171215.1_changelog)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---



