### PR TITLE
ocamlPackages.asn1-combinators: 0.1.3 -> 0.2.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "05z9kvd7gwr59ic7hnmbayhwyyqd41xxz01cvdlcgplk3z7zlwg5";
   };
 
+  patches = [ ./tls-0.9.0.patch ];
+
   buildInputs = with ocamlPackages; [
                   ocaml ocamlbuild findlib topkg ppx_sexp_conv
                   erm_xmpp_0_3 tls nocrypto x509 ocaml_lwt otr astring

--- a/pkgs/applications/networking/instant-messengers/jackline/tls-0.9.0.patch
+++ b/pkgs/applications/networking/instant-messengers/jackline/tls-0.9.0.patch
@@ -1,0 +1,29 @@
+diff --git a/cli/cli_config.ml b/cli/cli_config.ml
+index 991ee77..59a0edb 100644
+--- a/cli/cli_config.ml
++++ b/cli/cli_config.ml
+@@ -207,7 +207,9 @@ let configure term () =
+     ask above "CA file: " (fun x -> x) (fun x -> if Sys.file_exists x then `Ok x else `Invalid) term >>= fun trust_anchor ->
+     Lwt_unix.access trust_anchor [ Unix.F_OK ; Unix.R_OK ] >>= fun () ->
+     X509_lwt.certs_of_pem trust_anchor >>= fun tas ->
+-    (match X509.Validation.valid_cas ~time:(Unix.time ()) tas with
++    let time = match Ptime.of_float_s (Unix.time ())
++      with Some time -> time | None -> assert false in
++    (match X509.Validation.valid_cas ~time tas with
+      | [] -> Lwt.fail (Invalid_argument "trust anchor file is empty!")
+      | _ -> Lwt.return (`Trust_anchor trust_anchor))
+   | Some fp -> Lwt.return (`Fingerprint fp) ) >>= fun authenticator ->
+diff --git a/cli/cli_state.ml b/cli/cli_state.ml
+index d5db502..91540c9 100644
+--- a/cli/cli_state.ml
++++ b/cli/cli_state.ml
+@@ -262,7 +262,8 @@ module Connect = struct
+           (match config.Xconfig.authenticator with
+            | `Trust_anchor x -> X509_lwt.authenticator (`Ca_file x)
+            | `Fingerprint fp ->
+-             let time = Unix.gettimeofday () in
++             let time = match Ptime.of_float_s (Unix.gettimeofday ())
++               with Some time -> time | None -> assert false in
+              let fp =
+                Nocrypto.Uncommon.Cs.of_hex
+                  (String.map (function ':' -> ' ' | x -> x) fp)

--- a/pkgs/development/ocaml-modules/asn1-combinators/default.nix
+++ b/pkgs/development/ocaml-modules/asn1-combinators/default.nix
@@ -1,8 +1,22 @@
-{ stdenv, buildOcaml, fetchFromGitHub, ocaml, findlib, cstruct, zarith, ounit, result, topkg }:
+{ stdenv, buildOcaml, fetchFromGitHub, ocaml, findlib
+, cstruct, zarith, ounit, result, topkg, ptime
+}:
+
+let param =
+  if stdenv.lib.versionAtLeast ocaml.version "4.02" then {
+    version = "0.2.0";
+    sha256 = "0yfq4hnyzx6hy05m60007cfpq88wxwa8wqzib19lnk2qrgy772mx";
+    propagatedBuildInputs = [ ptime ];
+  } else {
+    version = "0.1.3";
+    sha256 = "0hpn049i46sdnv2i6m7r6m6ch0jz8argybh71wykbvcqdby08zxj";
+  propagatedBuildInputs = [ ];
+  };
+in
 
 buildOcaml rec {
   name = "asn1-combinators";
-  version = "0.1.3";
+  inherit (param) version;
 
   minimumSupportedOcamlVersion = "4.01";
 
@@ -10,13 +24,11 @@ buildOcaml rec {
     owner  = "mirleft";
     repo   = "ocaml-asn1-combinators";
     rev    = "v${version}";
-    sha256 = "0hpn049i46sdnv2i6m7r6m6ch0jz8argybh71wykbvcqdby08zxj";
+    inherit (param) sha256;
   };
 
   buildInputs = [ ocaml findlib ounit topkg ];
-  propagatedBuildInputs = [ result cstruct zarith ];
-
-  createFindlibDestdir = true;
+  propagatedBuildInputs = [ result cstruct zarith ] ++ param.propagatedBuildInputs;
 
   buildPhase = "${topkg.run} build --tests true";
 

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildOcaml, fetchFromGitHub, findlib, ocamlbuild, ocaml_oasis
+{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, topkg
 , ppx_tools, ppx_sexp_conv, result, x509, nocrypto, cstruct, ppx_cstruct, cstruct-unix, ounit
 , lwt     ? null}:
 
@@ -6,31 +6,27 @@ with stdenv.lib;
 
 let withLwt = lwt != null; in
 
-buildOcaml rec {
-  version = "0.7.1";
-  name = "tls";
-
-  minimunSupportedOcamlVersion = "4.02";
+stdenv.mkDerivation rec {
+  version = "0.9.0";
+  name = "ocaml${ocaml.version}-tls-${version}";
 
   src = fetchFromGitHub {
     owner  = "mirleft";
     repo   = "ocaml-tls";
     rev    = "${version}";
-    sha256 = "19q2hzxiasz9pzczgb63kikg0mc9mw98dfvch5falf2rincycj24";
+    sha256 = "0qgw8lq8pk9hss7b5i6fr08pi711i0zqx7yyjgcil47ipjig6c31";
   };
 
-  buildInputs = [ ocamlbuild findlib ocaml_oasis ppx_sexp_conv ounit ppx_cstruct cstruct-unix ];
+  buildInputs = [ ocaml ocamlbuild findlib topkg ppx_sexp_conv ounit ppx_cstruct cstruct-unix ];
   propagatedBuildInputs = [ cstruct nocrypto result x509 ] ++
                           optional withLwt lwt;
 
-  configureFlags = [ "--disable-mirage" "--enable-tests" ] ++
-                   optional withLwt ["--enable-lwt"];
-
-  configurePhase = "./configure --prefix $out $configureFlags";
+  buildPhase = "${topkg.run} build --tests true --with-mirage false --with-lwt ${if withLwt then "true" else "false"}";
 
   doCheck = true;
-  checkTarget = "test";
-  createFindlibDestdir = true;
+  checkPhase = "${topkg.run} test";
+
+  inherit (topkg) installPhase;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/mirleft/ocaml-tls;

--- a/pkgs/development/ocaml-modules/x509/default.nix
+++ b/pkgs/development/ocaml-modules/x509/default.nix
@@ -1,29 +1,28 @@
-{ stdenv, buildOcaml, fetchFromGitHub, ocaml, findlib, asn1-combinators, nocrypto
-, ounit, ocaml_oasis, ppx_sexp_conv, cstruct-unix
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg
+, asn1-combinators, astring, nocrypto, ppx_sexp_conv
+, ounit, cstruct-unix
 }:
 
-buildOcaml rec {
-  name = "x509";
-  version = "0.5.3";
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-x509-${version}";
+  version = "0.6.0";
 
-  mininimumSupportedOcamlVersion = "4.02";
-
-  src = fetchFromGitHub {
-    owner  = "mirleft";
-    repo   = "ocaml-x509";
-    rev    = "${version}";
-    sha256 = "07cc3z6h87460z3f4vz8nlczw5jkc4vjhix413z9x6nral876rn7";
+  src = fetchurl {
+    url = "https://github.com/mirleft/ocaml-x509/releases/download/${version}/x509-${version}.tbz";
+    sha256 = "0pmi3s4179bpy4076fmrhwv500wp9x1nrglsj9kk0xc8s8vadc7x";
   };
 
-  buildInputs = [ ocaml ocaml_oasis findlib ounit ppx_sexp_conv cstruct-unix ];
-  propagatedBuildInputs = [ asn1-combinators nocrypto ];
+  unpackCmd = "tar -xjf $curSrc";
 
-  configureFlags = "--enable-tests";
-  configurePhase = "./configure --prefix $out $configureFlags";
+  buildInputs = [ ocaml findlib ocamlbuild topkg ppx_sexp_conv ounit cstruct-unix ];
+  propagatedBuildInputs = [ asn1-combinators astring nocrypto ];
+
+  buildPhase = "${topkg.run} build --tests true";
 
   doCheck = true;
-  checkTarget = "test";
-  createFindlibDestdir = true;
+  checkPhase = "${topkg.run} test";
+
+  inherit (topkg) installPhase;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/mirleft/ocaml-x509;

--- a/pkgs/development/ocaml-modules/x509/default.nix
+++ b/pkgs/development/ocaml-modules/x509/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-x509-${version}";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-x509/releases/download/${version}/x509-${version}.tbz";
-    sha256 = "0pmi3s4179bpy4076fmrhwv500wp9x1nrglsj9kk0xc8s8vadc7x";
+    sha256 = "1c62mw9rnzq0rs3ihbhfs18nv4mdzwag7893hlqgji3wmaai70pk";
   };
 
   unpackCmd = "tar -xjf $curSrc";


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.06

Also update some related packages and adds a minor fix to `jackline` to accommodate for updated `ocaml-tls`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

