### PR TITLE
Revert "gnome3.nautilus-sendto: fix build"

### DIFF
--- a/pkgs/desktops/gnome-3/apps/nautilus-sendto/default.nix
+++ b/pkgs/desktops/gnome-3/apps/nautilus-sendto/default.nix
@@ -1,6 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, glib, pkgconfig, gnome3, appstream-glib
-, gettext, gobjectIntrospection
-}:
+{ stdenv, fetchurl, meson, ninja, glib, pkgconfig, gnome3, appstream-glib, gettext }:
 
 stdenv.mkDerivation rec {
   name = "nautilus-sendto-${version}";
@@ -12,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "164d7c6e8bae29c4579bcc67a7bf50d783662b1545b62f3008e7ea3c0410e04d";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig appstream-glib gettext gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja pkgconfig appstream-glib gettext ];
   buildInputs = [ glib ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
This reverts commit d3ad52a58eb3e4513f962eb059918579d6813a39.

###### Motivation for this change

In order to see if https://github.com/NixOS/nixpkgs/pull/33524 is
sufficient