### PR TITLE
raiblocks: init at 9.0 [WIP]

### DIFF
--- a/pkgs/applications/altcoins/raiblocks/default.nix
+++ b/pkgs/applications/altcoins/raiblocks/default.nix
@@ -1,0 +1,28 @@
+{lib, pkgs, stdenv, fetchFromGitHub, cmake, pkgconfig, boost, python, ...}:
+
+stdenv.mkDerivation rec {
+
+  name = "${pname}-${version}";
+  pname = "raiblocks";
+  version = "9.0";
+
+  src = fetchFromGitHub {
+    owner = "clemahieu";
+    repo = pname;
+    rev = "V${version}";
+    sha256 = "1b41hn9hb60m4lwpqrqlk3idc29cdhgx6i8ww3lki1mh78cfpypa";
+    fetchSubmodules = true;
+  };
+
+  RAIBLOCKS_GUI = "ON";
+
+  BOOST_ROOT = "${boost}";
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ boost python ];
+
+  buildPhase = ''
+    make rai_wallet
+  '';
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4526,6 +4526,8 @@ with pkgs;
 
   radvd = callPackage ../tools/networking/radvd { };
 
+  raiblocks = callPackage ../applications/altcoins/raiblocks { };
+
   rainbowstream = pythonPackages.rainbowstream;
 
   rambox = callPackage ../applications/networking/instant-messengers/rambox { };


### PR DESCRIPTION
**NOTE: This is work in progress, not working yet. Hoping to get some help here..**

###### Motivation for this change

Add raiblocks wallet:
- https://raiblocks.net/
- https://github.com/clemahieu/raiblocks

Build instructions: https://github.com/clemahieu/raiblocks/wiki/Build-Instructions#build-raiblocks

I get the following error in cofiguration phase:

```
-- The following REQUIRED packages have not been found:
 * Boost (required version >= 1.57.0)
-- Configuring incomplete, errors occurred!
```

Any ideas how to make CMake find Boost? Or maybe I'm doing this totally wrong altogether.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

