### PR TITLE
Minor cross fixes, 1

### DIFF
--- a/pkgs/development/interpreters/lua-5/5.2.nix
+++ b/pkgs/development/interpreters/lua-5/5.2.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   '';
 
   crossAttrs = let
-    inherit (hostPlatform) isDarwin isMingw;
+    inherit (hostPlatform) isDarwin isMinGW;
   in {
     configurePhase = ''
       makeFlagsArray=(
@@ -65,10 +65,10 @@ stdenv.mkDerivation rec {
         INSTALL_MAN=$out/share/man/man1
         V=${luaversion}
         R=${version}
-        ${if isMingw then "mingw" else stdenv.lib.optionalString isDarwin ''
+        ${if isMinGW then "mingw" else stdenv.lib.optionalString isDarwin ''
         ''}
       )
-    '' + stdenv.lib.optionalString isMingw ''
+    '' + stdenv.lib.optionalString isMinGW ''
       installFlagsArray=(
         TO_BIN="lua.exe luac.exe"
         TO_LIB="liblua.a lua52.dll"

--- a/pkgs/development/interpreters/lua-5/5.3.nix
+++ b/pkgs/development/interpreters/lua-5/5.3.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
   '';
 
   crossAttrs = let
-    inherit (hostPlatform) isDarwin isMingw;
+    inherit (hostPlatform) isDarwin isMinGW;
   in {
     configurePhase = ''
       makeFlagsArray=(
@@ -64,10 +64,10 @@ stdenv.mkDerivation rec {
         INSTALL_MAN=$out/share/man/man1
         V=${luaversion}
         R=${version}
-        ${if isMingw then "mingw" else stdenv.lib.optionalString isDarwin ''
+        ${if isMinGW then "mingw" else stdenv.lib.optionalString isDarwin ''
         ''}
       )
-    '' + stdenv.lib.optionalString isMingw ''
+    '' + stdenv.lib.optionalString isMinGW ''
       installFlagsArray=(
         TO_BIN="lua.exe luac.exe"
         TO_LIB="liblua.a lua52.dll"

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -22,7 +22,12 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   configureFlags = [ "--with-tcl=no" "--localstatedir=/var/lib"]
-    ++ optional stdenv.isFreeBSD ''WARN_CFLAGS=""'';
+    ++ optional stdenv.isFreeBSD ''WARN_CFLAGS=""''
+    ++ optionals (stdenv.buildPlatform != stdenv.hostPlatform)
+       [ "krb5_cv_attr_constructor_destructor=yes,yes"
+         "ac_cv_func_regcomp=yes"
+         "ac_cv_printf_positional=yes"
+       ];
 
   nativeBuildInputs = [ pkgconfig perl ]
     ++ optional (!libOnly) yacc

--- a/pkgs/development/tools/misc/pkgconfig/default.nix
+++ b/pkgs/development/tools/misc/pkgconfig/default.nix
@@ -24,7 +24,15 @@ stdenv.mkDerivation rec {
   buildInputs = optional (stdenv.isCygwin || stdenv.isDarwin || stdenv.isSunOS) libiconv;
 
   configureFlags = [ "--with-internal-glib" ]
-    ++ optional (stdenv.isSunOS) [ "--with-libiconv=gnu" "--with-system-library-path" "--with-system-include-path" "CFLAGS=-DENABLE_NLS" ];
+    ++ optional (stdenv.isSunOS) [ "--with-libiconv=gnu" "--with-system-library-path" "--with-system-include-path" "CFLAGS=-DENABLE_NLS" ]
+       # Can't run these tests while cross-compiling
+    ++ optional (stdenv.hostPlatform != stdenv.buildPlatform)
+       [ "glib_cv_stack_grows=no"
+         "glib_cv_uscore=no"
+         "ac_cv_func_posix_getpwuid_r=yes"
+         "ac_cv_func_posix_getgrgid_r=yes"
+       ];
+
 
   postInstall = ''rm -f "$out"/bin/*-pkg-config''; # clean the duplicate file
 

--- a/pkgs/tools/compression/bsdiff/default.nix
+++ b/pkgs/tools/compression/bsdiff/default.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
   patches = [ ./include-systypes.patch ];
 
   buildPhase = ''
-    cc -O3 -lbz2 bspatch.c -o bspatch
-    cc -O3 -lbz2 bsdiff.c  -o bsdiff
+    $CC -O3 -lbz2 bspatch.c -o bspatch
+    $CC -O3 -lbz2 bsdiff.c  -o bsdiff
   '';
 
   installPhase = ''

--- a/pkgs/tools/system/at/default.nix
+++ b/pkgs/tools/system/at/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, bison, flex, pam
+{ stdenv, fetchurl, fetchpatch, bison, flex, pam
 , sendmailPath ? "/run/wrappers/bin/sendmail"
 , atWrapperPath ? "/run/wrappers/bin/at"
 }:
@@ -13,10 +13,17 @@ stdenv.mkDerivation rec {
     sha256 = "1fgsrqpx0r6qcjxmlsqnwilydhfxn976c870mjc0n1bkmcy94w88";
   };
 
-  patches = [ ./install.patch ];
+  patches = [
+    ./install.patch
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/riscv/riscv-poky/master/meta/recipes-extended/at/at/0001-remove-glibc-assumption.patch";
+      sha256 = "1rk4hskp0c1jqkanzdxf873i6jgki3xhrm609fsam8an8sl1njnm";
+    })
+  ];
 
-  buildInputs =
-    [ bison flex pam ];
+  nativeBuildInputs = [ bison flex ];
+
+  buildInputs = [ pam ];
 
   preConfigure =
     ''

--- a/pkgs/tools/system/at/install.patch
+++ b/pkgs/tools/system/at/install.patch
@@ -20,7 +20,7 @@
 +	$(INSTALL) -m 755 -d $(IROOT)$(sbindir)
 +	$(INSTALL) -m 755 -d $(IROOT)$(docdir)
 +	$(INSTALL) -m 755 -d $(IROOT)$(atdocdir)
-+	$(INSTALL) -m 0755 -s at $(IROOT)$(bindir)
++	$(INSTALL) -m 0755 at $(IROOT)$(bindir)
  	$(LN_S) -f at $(IROOT)$(bindir)/atq
  	$(LN_S) -f at $(IROOT)$(bindir)/atrm
 -	$(INSTALL) -g root -o root -m 755 batch $(IROOT)$(bindir)
@@ -34,7 +34,7 @@
 +	$(INSTALL) -d -m 755 $(IROOT)$(man1dir)
 +	$(INSTALL) -d -m 755 $(IROOT)$(man5dir)
 +	$(INSTALL) -d -m 755 $(IROOT)$(man8dir)
-+	$(INSTALL) -m 755 -s atd $(IROOT)$(sbindir)
++	$(INSTALL) -m 755 atd $(IROOT)$(sbindir)
 +	$(INSTALL) -m 755 atrun $(IROOT)$(sbindir)
 +	$(INSTALL) -m 644 at.1 $(IROOT)$(man1dir)/
  	cd $(IROOT)$(man1dir) && $(LN_S) -f at.1 atq.1 && $(LN_S) -f at.1 batch.1 && $(LN_S) -f at.1 atrm.1


### PR DESCRIPTION
###### Motivation for this change

Number of straightforward-ish fixes for cross-compilation.

configure test overrides for `pkgconfig` and `libkrb5` are needed for at least `raspberryPi`
as can be seen if one reverts them (or looks at Hydra, probably).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

