### PR TITLE
readline: Don't attempt to check for broken wcwidth

### DIFF
--- a/pkgs/development/libraries/readline/6.3.nix
+++ b/pkgs/development/libraries/readline/6.3.nix
@@ -16,6 +16,12 @@ stdenv.mkDerivation rec {
 
   patchFlags = "-p0";
 
+  configureFlags =
+    stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
+    [ # This test requires running host code
+      "bash_cv_wcwidth_broken=no"
+    ];
+
   patches =
     [ ./link-against-ncurses.patch
       ./no-arch_only-6.3.patch


### PR DESCRIPTION
The test requires running code on the target.

###### Motivation for this change

Before this change, readline does not currently build when cross-compiling.

Reviewers can confirm by trying this with and without this fix:

```
$ nix-build --arg crossSystem '(import ./lib).systems.examples.raspberryPi' -A readline
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

