### PR TITLE
binutils: support custom ld

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -2,7 +2,12 @@
 , fetchurl, zlib
 , buildPlatform, hostPlatform, targetPlatform
 , noSysDirs, gold ? true, bison ? null
+  # Which ld implementation to use by default?
+, defaultLd ? null
 }:
+
+assert (builtins.elem defaultLd ["bfd" "gold" null]);
+assert defaultLd == "gold" -> gold;
 
 let
   # Note to whoever is upgrading this: 2.29 is broken.
@@ -102,7 +107,8 @@ stdenv.mkDerivation rec {
     "--enable-deterministic-archives"
     "--disable-werror"
     "--enable-fix-loongson2f-nop"
-  ] ++ optionals gold [ "--enable-gold" "--enable-plugins" ];
+  ] ++ optionals gold [ "--enable-gold" "--enable-plugins" ]
+  ++ optional (defaultLd == "gold") "--enable-gold=default";
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7158,6 +7158,7 @@ with pkgs;
   binutils-unwrapped = callPackage ../development/tools/misc/binutils {
     # FHS sys dirs presumably only have stuff for the build platform
     noSysDirs = (targetPlatform != buildPlatform) || noSysDirs;
+    defaultLd = config.defaultLd or null;
   };
   binutils-raw = wrapBintoolsWith {
     libc = if targetPlatform != hostPlatform then libcCross else stdenv.cc.libc;
@@ -7167,6 +7168,7 @@ with pkgs;
   binutils_nogold = lowPrio (binutils-raw.override {
     bintools = binutils-raw.bintools.override {
       gold = false;
+      defaultLd = "bfd";
     };
   });
 


### PR DESCRIPTION
###### Motivation for this change

Currently the default linker is always "bfd", this introduces a config option for specifying a different default linker.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

**default**:
```
$ nix run -f . stdenv.cc  -c ld --version
GNU ld (GNU Binutils) 2.28.1
Copyright (C) 2017 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or (at your option) a later version.
This program has absolutely no warranty.
```

**gold**:
```
$ nix run -f . stdenv.cc --arg config '{ defaultLd = "gold"; }' -c ld --version
GNU gold (GNU Binutils 2.28.1) 1.14
Copyright (C) 2017 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or (at your option) a later version.
This program has absolutely no warranty.
```


Additionally, modifying the `cc-wrapper` test to include `-Wl,-v` shows this successfully controls the linker used during compilation.