### PR TITLE
gnumeric: 1.12.36 -> 1.12.38; goffice: 0.10.36 -> 0.10.38

### DIFF
--- a/pkgs/applications/office/gnumeric/default.nix
+++ b/pkgs/applications/office/gnumeric/default.nix
@@ -9,11 +9,11 @@ let
   isonum = fetchurl { url = http://www.oasis-open.org/docbook/xml/4.5/ent/isonum.ent; sha256 = "04b62dw2g3cj9i4vn9xyrsrlz8fpmmijq98dm0nrkky31bwbbrs3"; };
   isogrk1 = fetchurl { url = http://www.oasis-open.org/docbook/xml/4.5/ent/isogrk1.ent; sha256 = "04b23anhs5wr62n4rgsjirzvw7rpjcsf8smz4ffzaqh3b0vw90vm"; };
 in stdenv.mkDerivation rec {
-  name = "gnumeric-1.12.36";
+  name = "gnumeric-1.12.38";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnumeric/1.12/${name}.tar.xz";
-    sha256 = "3cbfe25f26bd31b832efed2827ac35c3c1600bed9ccd233a4037a9f4d7c54848";
+    sha256 = "3435d7d93a47a32764b1ec2d03f7fbb348a97af52530815e49370803a1a69c65";
   };
 
   configureFlags = "--disable-component";

--- a/pkgs/development/libraries/goffice/default.nix
+++ b/pkgs/development/libraries/goffice/default.nix
@@ -2,11 +2,11 @@
 , libgsf, libxml2, libxslt, cairo, pango, librsvg, libspectre }:
 
 stdenv.mkDerivation rec {
-  name = "goffice-0.10.36";
+  name = "goffice-0.10.38";
 
   src = fetchurl {
     url = "mirror://gnome/sources/goffice/0.10/${name}.tar.xz";
-    sha256 = "cfe65fc0a665538704c7bab8541784291cf0781df8b4cff73cb0a513ee0baad6";
+    sha256 = "443199d7a9833fddaadfc4f9065c289e639eed480de316f37da816e396bb9764";
   };
 
   nativeBuildInputs = [ pkgconfig intltool ];


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of gnumeric on macOS.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

