### PR TITLE
electron-cash: 3.0.0 -> 3.1.1

### DIFF
--- a/pkgs/applications/misc/electron-cash/default.nix
+++ b/pkgs/applications/misc/electron-cash/default.nix
@@ -7,14 +7,14 @@ let
 in
 
 python3Packages.buildPythonApplication rec {
-  version = "3.0";
+  version = "3.1.1";
   name = "electron-cash-${version}";
 
   src = fetchurl {
     url = "https://electroncash.org/downloads/${version}/win-linux/ElectronCash-${version}.tar.gz";
     # Verified using official SHA-1 and signature from
     # https://github.com/fyookball/keys-n-hashes
-    sha256 = "f0e2bf5c6d29da714eddd50b45761fea9fc905a0172c7b92df8fca7427439f1a";
+    sha256 = "cd42a0a0075787125f195508834d8c34d651896c0986d0b2066763add59bad2b";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -35,6 +35,11 @@ python3Packages.buildPythonApplication rec {
     keepkey
     trezor
   ];
+
+  postPatch = ''
+    # Remove pyqt5 check
+    sed -i '/pyqt5/d' setup.py
+  '';
 
   preBuild = ''
     sed -i 's,usr_share = .*,usr_share = "'$out'/share",g' setup.py


### PR DESCRIPTION
###### Motivation for this change
This update addresses the same vulnerability in #33548

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change (none)
- [x] Tested execution of all binary files (works fine)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Lassulus 

  