### PR TITLE
busybox: 1.27.2 -> 1.28.0

### DIFF
--- a/pkgs/os-specific/linux/busybox/busybox-in-store.patch
+++ b/pkgs/os-specific/linux/busybox/busybox-in-store.patch
@@ -1,19 +1,19 @@
 Allow BusyBox to be invoked as "<something>-busybox". This is
 necessary when it's run from the Nix store as <hash>-busybox during
 stdenv bootstrap.
---- busybox-1.26.1-orig/libbb/appletlib.orig	2016-10-26 19:54:20.510957575 -0400
-+++ busybox-1.26.1/libbb/appletlib.c	2016-10-26 19:48:31.590862853 -0400
-@@ -887,7 +887,7 @@
+--- a/libbb/appletlib.c
++++ b/libbb/appletlib.c
+@@ -947,7 +947,7 @@ void FAST_FUNC run_applet_no_and_exit(int applet_no, const char *name, char **ar
  static NORETURN void run_applet_and_exit(const char *name, char **argv)
  {
  #  if ENABLE_BUSYBOX
 -	if (is_prefixed_with(name, "busybox"))
 +	if (strstr(name, "busybox") != 0)
- 		exit(busybox_main(argv));
+ 		exit(busybox_main(/*unused:*/ 0, argv));
  #  endif
  #  if NUM_APPLETS > 0
-@@ -981,7 +981,7 @@ int main(int argc UNUSED_PARAM, char **argv)
- 
+@@ -1045,7 +1045,7 @@ int main(int argc UNUSED_PARAM, char **argv)
+
  	lbb_prepare("busybox" IF_FEATURE_INDIVIDUAL(, argv));
  # if !ENABLE_BUSYBOX
 -	if (argv[1] && is_prefixed_with(bb_basename(argv[0]), "busybox"))

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -27,35 +27,20 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "busybox-1.27.2";
+  name = "busybox-1.28.0";
 
   # Note to whoever is updating busybox: please verify that:
   # nix-build pkgs/stdenv/linux/make-bootstrap-tools.nix -A test
   # still builds after the update.
   src = fetchurl {
     url = "http://busybox.net/downloads/${name}.tar.bz2";
-    sha256 = "1pv3vs2w4l2wnw5qb0rkbpvjjdd1fwjv87miavqq0r0ynqbfajwx";
+    sha256 = "1701carjf02y7r3djm1yvyd5kzrcxm4szinp7agfv7fmvfvm6ib0";
   };
 
   hardeningDisable = [ "format" ] ++ lib.optionals enableStatic [ "fortify" ];
 
   patches = [
-    ./busybox-in-store.patch 
-    (fetchpatch {
-      name = "CVE-2017-15873.patch";
-      url = "https://git.busybox.net/busybox/patch/?id=0402cb32df015d9372578e3db27db47b33d5c7b0";
-      sha256 = "1s3xqifd0dww19mbnzrks0i1az0qwd884sxjzrx33d6a9jxv4dzn";
-    })
-    (fetchpatch {
-      name = "CVE-2017-15874.patch";
-      url = "https://git.busybox.net/busybox/patch/?id=9ac42c500586fa5f10a1f6d22c3f797df11b1f6b";
-      sha256 = "0169p4ylz9zd14ghhb39yfjvbdca2kb21pphylfh9ny7i484ahql";
-    })
-    (fetchpatch {
-      name = "CVE-2017-16544.patch";
-      url = "https://git.busybox.net/busybox/patch/?id=c3797d40a1c57352192c6106cc0f435e7d9c11e8";
-      sha256 = "1q3lkc4xczxrzhz73x2r0w7kmd6y33zhcnz3478nk5xi0qr66mcy";
-    })
+    ./busybox-in-store.patch
   ];
 
   configurePhase = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc maintainer @viric 