### PR TITLE
make-derivation: Don't add host-suffix to fixed-output derivations names

### DIFF
--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -31,13 +31,8 @@ let
     then defaultBuildHostScope
     else assert pkgs.hostPlatform == pkgs.buildPlatform; defaultHostTargetScope;
   defaultHostHostScope = {}; # unimplemented
-  # TODO(@Ericson2314): we shouldn't preclude run-time fetching by removing
-  # these attributes. We should have a more general solution for selecting
-  # whether `nativeDrv` or `crossDrv` is the default in `defaultScope`.
-  pkgsWithoutFetchers = lib.filterAttrs (n: _: !lib.hasPrefix "fetch" n) pkgs;
-  targetPkgsWithoutFetchers = lib.filterAttrs (n: _: !lib.hasPrefix "fetch" n) pkgs.targetPackages;
-  defaultHostTargetScope = pkgsWithoutFetchers // pkgs.xorg;
-  defaultTargetTargetScope = targetPkgsWithoutFetchers // targetPkgsWithoutFetchers.xorg or {};
+  defaultHostTargetScope = pkgs // pkgs.xorg;
+  defaultTargetTargetScope = pkgs.targetPackages // pkgs.targetPackages.xorg or {};
 
   splicer = pkgsBuildBuild: pkgsBuildHost: pkgsBuildTarget:
             pkgsHostHost: pkgsHostTarget:


### PR DESCRIPTION
Not only does the suffix unnecessarily reduce sharing, but it also breaks
unpacker setup hooks (e.g. that of `unzip`) which identify interesting tarballs
using the file extension.

###### Motivation for this change

Fixes #32986.

(another from #30882!)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

