### PR TITLE
SunVox: init at 1.9.3b

### DIFF
--- a/pkgs/applications/audio/sunvox/default.nix
+++ b/pkgs/applications/audio/sunvox/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, unzip, alsaLib, libX11, libXi, SDL2 }:
+
+let
+  libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc alsaLib libX11 libXi SDL2 ];
+  arch =
+    if stdenv.isAarch64
+    then "arm64"
+    else if stdenv.isArm
+    then "arm_armhf_raspberry_pi"
+    else if stdenv.is64bit
+    then "x86_64"
+    else "x86";
+in
+stdenv.mkDerivation rec {
+  name = "SunVox-${version}";
+  version = "1.9.3b";
+
+  src = fetchurl {
+    url = "http://www.warmplace.ru/soft/sunvox/sunvox-${version}.zip";
+    sha256 = "0k74rcq7niw4p17vj3zp9lpgi932896dmzqv4ln43g0pz7l18c8b";
+  };
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = "unzip $src";
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/share $out/bin
+    mv sunvox $out/share/
+
+    bin="$out/share/sunvox/sunvox/linux_${arch}/sunvox"
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+             --set-rpath "${libPath}" \
+             "$bin"
+
+    ln -s "$bin" $out/bin/sunvox
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Small, fast and powerful modular synthesizer with pattern-based sequencer";
+    license = licenses.unfreeRedistributable;
+    homepage = "http://www.warmplace.ru/soft/sunvox/";
+    maintainers = with maintainers; [ puffnfresh ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17054,6 +17054,8 @@ with pkgs;
 
   surf = callPackage ../applications/networking/browsers/surf { gtk = gtk2; };
 
+  sunvox = callPackage ../applications/audio/sunvox { };
+
   swh_lv2 = callPackage ../applications/audio/swh-lv2 { };
 
   sylpheed = callPackage ../applications/networking/mailreaders/sylpheed { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

