### PR TITLE
 nix-zsh-completions: 0.3.6 -> 0.3.7,  nix-bash-completions: 0.6.1 -> 0.6.2 

### DIFF
--- a/pkgs/shells/nix-bash-completions/default.nix
+++ b/pkgs/shells/nix-bash-completions/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "0.6.1";
+  version = "0.6.2";
   name = "nix-bash-completions-${version}";
 
   src = fetchFromGitHub {
     owner = "hedning";
     repo = "nix-bash-completions";
     rev = "v${version}";
-    sha256 = "10nzdn249f0cw6adgpbpg4x90ysvxm7vs9jjbbwynfh9kngijp64";
+    sha256 = "0w6mimi70drjkdpx5pcw66xy2a4kysjfzmank0kc5vbhrjgkjwyp";
   };
 
   # To enable lazy loading via. bash-completion we need a symlink to the script

--- a/pkgs/shells/nix-zsh-completions/default.nix
+++ b/pkgs/shells/nix-zsh-completions/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub }:
 
 let
-  version = "0.3.6";
+  version = "0.3.7";
 in
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "spwhitt";
     repo = "nix-zsh-completions";
     rev = "${version}";
-    sha256 = "193yd0c3j62lhy7n7y9l0viwdiymvrfbqcgki69dm2414n3mlh05";
+    sha256 = "164x8awia56z481r898pbywjgrx8fv8gfw8pxp4qgbxzp3gwq9iy";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Fixes a regression where .nix files containing a set, not a function, failed to produce completions. ref: https://github.com/spwhitt/nix-zsh-completions/issues/8

###### Things done

Tested installation and basic functionality via `nix-env`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


  