### PR TITLE
xfce: cleanup, hyphenate attributes

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -3,9 +3,7 @@
 with lib;
 
 let
-  xcfg = config.services.xserver;
-  pcfg = config.hardware.pulseaudio;
-  cfg = xcfg.desktopManager.xfce;
+  cfg = config.services.xserver.desktopManager.xfce;
 in
 
 {
@@ -52,82 +50,93 @@ in
         description = "Application used by XFCE to lock the screen.";
       };
     };
-
   };
 
+  config = mkIf cfg.enable {
+    environment.systemPackages = with pkgs.xfce // pkgs; [
+      # Get GTK+ themes and gtk-update-icon-cache
+      gtk2.out
 
-  config = mkIf (xcfg.enable && cfg.enable) {
+      # Supplies some abstract icons such as:
+      # utilities-terminal, accessories-text-editor
+      gnome3.defaultIconTheme
 
-    services.xserver.desktopManager.session = singleton
-      { name = "xfce";
-        bgSupport = true;
-        start =
-          ''
-            ${cfg.extraSessionCommands}
+      hicolor_icon_theme
+      tango-icon-theme
+      xfce4-icon-theme
 
-            # Set GTK_PATH so that GTK+ can find the theme engines.
-            export GTK_PATH="${config.system.path}/lib/gtk-2.0:${config.system.path}/lib/gtk-3.0"
+      desktop_file_utils
+      shared_mime_info
 
-            # Set GTK_DATA_PREFIX so that GTK+ can find the Xfce themes.
-            export GTK_DATA_PREFIX=${config.system.path}
+      # Needed by Xfce's xinitrc script
+      # TODO: replace with command -v
+      which
 
-            ${pkgs.stdenv.shell} ${pkgs.xfce.xinitrc} &
-            waitPID=$!
-          '';
-      };
+      exo
+      garcon
+      gtk-xfce-engine
+      gvfs
+      libxfce4ui
+      tumbler
+      xfconf
+
+      mousepad
+      ristretto
+      xfce4-appfinder
+      xfce4-screenshooter
+      xfce4-session
+      xfce4-settings
+      xfce4-terminal
+
+      (thunar.override { thunarPlugins = cfg.thunarPlugins; })
+      thunar-volman # TODO: drop
+    ] ++ (if config.hardware.pulseaudio.enable
+          then [ xfce4-mixer-pulse xfce4-volumed-pulse ]
+	  else [ xfce4-mixer xfce4-volumed ])
+      # TODO: NetworkManager doesn't belong here
+      ++ optionals config.networking.networkmanager.enable [ networkmanagerapplet ]
+      ++ optionals config.powerManagement.enable [ xfce4-power-manager ]
+      ++ optionals cfg.enableXfwm [ xfwm4 ]
+      ++ optionals (!cfg.noDesktop) [
+        xfce4-panel
+        xfce4-notifyd
+        xfdesktop
+      ];
+
+    environment.pathsToLink = [
+      "/share/xfce4"
+      "/share/themes"
+      "/share/mime"
+      "/share/desktop-directories"
+      "/share/gtksourceview-2.0"
+    ];
+
+    environment.variables = {
+      GDK_PIXBUF_MODULE_FILE = "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache";
+      GIO_EXTRA_MODULES = [ "${pkgs.xfce.gvfs}/lib/gio/modules" ];
+    };
+
+    services.xserver.desktopManager.session = [{
+      name = "xfce";
+      bgSupport = true;
+      start = ''
+        ${cfg.extraSessionCommands}
+
+        # Set GTK_PATH so that GTK+ can find the theme engines.
+        export GTK_PATH="${config.system.path}/lib/gtk-2.0:${config.system.path}/lib/gtk-3.0"
+
+        # Set GTK_DATA_PREFIX so that GTK+ can find the Xfce themes.
+        export GTK_DATA_PREFIX=${config.system.path}
+
+        ${pkgs.stdenv.shell} ${pkgs.xfce.xinitrc} &
+        waitPID=$!
+      '';
+    }];
 
     services.xserver.updateDbusEnvironment = true;
-
-    environment.systemPackages =
-      [ pkgs.gtk2.out # To get GTK+'s themes and gtk-update-icon-cache
-        pkgs.hicolor_icon_theme
-        pkgs.tango-icon-theme
-        pkgs.shared_mime_info
-        pkgs.which # Needed by the xfce's xinitrc script.
-        pkgs."${cfg.screenLock}"
-        pkgs.xfce.exo
-        pkgs.xfce.gtk_xfce_engine
-        pkgs.xfce.mousepad
-        pkgs.xfce.ristretto
-        pkgs.xfce.terminal
-       (pkgs.xfce.thunar.override { thunarPlugins = cfg.thunarPlugins; })
-        pkgs.xfce.xfce4icontheme
-        pkgs.xfce.xfce4session
-        pkgs.xfce.xfce4settings
-       (if pcfg.enable then pkgs.xfce.xfce4mixer_pulse else pkgs.xfce.xfce4mixer)
-       (if pcfg.enable then pkgs.xfce.xfce4volumed_pulse else pkgs.xfce.xfce4volumed)
-        pkgs.xfce.xfce4-screenshooter
-        pkgs.xfce.xfconf
-        # This supplies some "abstract" icons such as
-        # "utilities-terminal" and "accessories-text-editor".
-        pkgs.gnome3.defaultIconTheme
-        pkgs.desktop_file_utils
-        pkgs.xfce.libxfce4ui
-        pkgs.xfce.garcon
-        pkgs.xfce.thunar_volman
-        pkgs.xfce.gvfs
-        pkgs.xfce.xfce4_appfinder
-        pkgs.xfce.tumbler       # found via dbus
-      ]
-      ++ optional cfg.enableXfwm pkgs.xfce.xfwm4
-      ++ optional config.powerManagement.enable pkgs.xfce.xfce4_power_manager
-      ++ optional config.networking.networkmanager.enable pkgs.networkmanagerapplet
-      ++ optionals (!cfg.noDesktop)
-         [ pkgs.xfce.xfce4panel
-           pkgs.xfce.xfdesktop
-	   pkgs.xfce.xfce4notifyd  # found via dbus
-         ];
-
-    environment.pathsToLink =
-      [ "/share/xfce4" "/share/themes" "/share/mime" "/share/desktop-directories" "/share/gtksourceview-2.0" ];
-
-    environment.variables.GIO_EXTRA_MODULES = [ "${pkgs.xfce.gvfs}/lib/gio/modules" ];
-    environment.variables.GDK_PIXBUF_MODULE_FILE = "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache";
 
     # Enable helpful DBus services.
     services.udisks2.enable = true;
     services.upower.enable = config.powerManagement.enable;
-
   };
-
 }

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -1,106 +1,208 @@
-{ config, pkgs, newScope }:
+{ lib, pkgs }:
 
-let
+lib.makeScope pkgs.newScope (self: with self; {
+  #### NixOS support
 
-callPackage = newScope (deps // xfce_self);
-
-deps = { # xfce-global dependency overrides should be here
   inherit (pkgs.gnome2) libglade libwnck vte gtksourceview;
   inherit (pkgs.gnome3) dconf;
   inherit (pkgs.perlPackages) URI;
+
   gtk = pkgs.gtk2;
-};
 
-xfce_self = rec { # the lines are very long but it seems better than the even-odd line approach
+  # Samba is a rather heavy dependency
+  gvfs = pkgs.gvfs.override { samba = null; };
 
-  #### NixOS support
+  xinitrc = "${xfce4-session}/etc/xdg/xfce4/xinitrc";
 
-  gvfs = pkgs.gvfs.override { samba = null; }; # samba is a rather heavy dependency
-  xinitrc = "${xfce4session}/etc/xdg/xfce4/xinitrc";
+  #### CORE
 
-  #### CORE                 from "mirror://xfce/src/xfce/${p_name}/${ver_maj}/${name}.tar.bz2"
+  exo = callPackage ./core/exo.nix { };
 
-  exo             = callPackage ./core/exo.nix { };
-  garcon          = callPackage ./core/garcon.nix { };
-  gtk_xfce_engine = callPackage ./core/gtk-xfce-engine.nix
-    { withGtk3 = false; }; # = true; was completely breaking GTK3 app layout
-  libxfce4ui      = callPackage ./core/libxfce4ui.nix { };
-  libxfce4ui_gtk3 = libxfce4ui.override { withGtk3 = true; };
-  libxfce4util    = callPackage ./core/libxfce4util.nix { };
-  libxfcegui4     = callPackage ./core/libxfcegui4.nix { };
-  thunar-build    = callPackage ./core/thunar-build.nix { };
-  thunar          = callPackage ./core/thunar.nix { };
-  thunarx-2-dev   = thunar-build; # Plugins need only the `thunarx-2` part of the package. Awaiting multiple outputs.
-  thunar_volman   = callPackage ./core/thunar-volman.nix { }; # ToDo: probably inside Thunar now
-  thunar-archive-plugin
-                  = callPackage ./thunar-plugins/archive { };
-  thunar-dropbox-plugin
-                  = callPackage ./thunar-plugins/dropbox { };
-  tumbler         = callPackage ./core/tumbler.nix { };
-  xfce4panel      = callPackage ./core/xfce4-panel.nix { }; # ToDo: impure plugins from /run/current-system/sw/lib/xfce4
-  xfce4panel_gtk3 = xfce4panel.override { withGtk3 = true; };
-  xfce4session    = callPackage ./core/xfce4-session.nix { };
-  xfce4settings   = callPackage ./core/xfce4-settings.nix { };
-  xfce4_power_manager = callPackage ./core/xfce4-power-manager.nix { };
-  xfce4_power_manager_gtk3 = callPackage ./core/xfce4-power-manager.nix { withGtk3 = true; };
-  xfconf          = callPackage ./core/xfconf.nix { };
-  xfdesktop       = callPackage ./core/xfdesktop.nix { };
-  xfwm4           = callPackage ./core/xfwm4.nix { };
+  garcon = callPackage ./core/garcon.nix { };
 
-  xfce4_appfinder = callPackage ./core/xfce4-appfinder.nix { };
-  xfce4_dev_tools = callPackage ./core/xfce4-dev-tools.nix { }; # only if autotools are needed
+  # When built with GTK+3, it was breaking GTK+3 app layout
+  gtk-xfce-engine = callPackage ./core/gtk-xfce-engine.nix { withGtk3 = false; };
 
-  #### APPLICATIONS         from "mirror://xfce/src/apps/${p_name}/${ver_maj}/${name}.tar.bz2"
+  libxfce4ui = callPackage ./core/libxfce4ui.nix { };
 
-  gigolo          = callPackage ./applications/gigolo.nix { };
-  mousepad        = callPackage ./applications/mousepad.nix { };
-  orage           = callPackage ./applications/orage.nix { };
-  parole          = callPackage ./applications/parole.nix { };
-  ristretto       = callPackage ./applications/ristretto.nix { };
-  terminal        = xfce4terminal; # it has changed its name
-  xfce4mixer      = callPackage ./applications/xfce4-mixer.nix { };
-  xfce4mixer_pulse = callPackage ./applications/xfce4-mixer.nix { pulseaudioSupport = true; };
-  xfce4notifyd    = callPackage ./applications/xfce4-notifyd.nix { };
-  xfce4taskmanager= callPackage ./applications/xfce4-taskmanager.nix { };
-  xfce4terminal   = callPackage ./applications/terminal.nix { };
+  libxfce4util = callPackage ./core/libxfce4util.nix { };
+
+  libxfcegui4 = callPackage ./core/libxfcegui4.nix { };
+
+  thunar-bare = callPackage ./core/thunar-build.nix { };
+
+  thunar = callPackage ./core/thunar.nix { };
+
+  # NB: thunar already has it
+  thunar-volman = callPackage ./core/thunar-volman.nix { };
+
+  thunar-archive-plugin = callPackage ./thunar-plugins/archive { };
+
+  thunar-dropbox-plugin = callPackage ./thunar-plugins/dropbox { };
+
+  tumbler = callPackage ./core/tumbler.nix { };
+
+  # TODO: impure plugins from /run/current-system/sw/lib/xfce4
+  xfce4-panel = callPackage ./core/xfce4-panel.nix { };
+
+  xfce4-session = callPackage ./core/xfce4-session.nix { };
+
+  xfce4-settings = callPackage ./core/xfce4-settings.nix { };
+
+  xfce4-power-manager = callPackage ./core/xfce4-power-manager.nix { };
+
+  xfconf = callPackage ./core/xfconf.nix { };
+
+  xfdesktop = callPackage ./core/xfdesktop.nix { };
+
+  xfwm4 = callPackage ./core/xfwm4.nix { };
+
+  xfce4-appfinder = callPackage ./core/xfce4-appfinder.nix { };
+
+  xfce4-dev-tools = callPackage ./core/xfce4-dev-tools.nix { };
+
+  #### APPLICATIONS
+
+  gigolo = callPackage ./applications/gigolo.nix { };
+
+  mousepad = callPackage ./applications/mousepad.nix { };
+
+  orage = callPackage ./applications/orage.nix { };
+
+  parole = callPackage ./applications/parole.nix { };
+
+  ristretto = callPackage ./applications/ristretto.nix { };
+
+  xfce4-mixer = callPackage ./applications/xfce4-mixer.nix { };
+
+  xfce4-mixer-pulse = callPackage ./applications/xfce4-mixer.nix { pulseaudioSupport = true; };
+
+  xfce4-notifyd = callPackage ./applications/xfce4-notifyd.nix { };
+
+  xfce4-taskmanager = callPackage ./applications/xfce4-taskmanager.nix { };
+
+  xfce4-terminal = callPackage ./applications/terminal.nix { };
+
   xfce4-screenshooter = callPackage ./applications/xfce4-screenshooter.nix { };
-  xfce4volumed    = callPackage ./applications/xfce4-volumed.nix { };
-  xfce4volumed_pulse = callPackage ./applications/xfce4-volumed-pulse.nix { };
 
-  #### ART                  from "mirror://xfce/src/art/${p_name}/${ver_maj}/${name}.tar.bz2"
+  xfce4-volumed = callPackage ./applications/xfce4-volumed.nix { };
 
-  xfce4icontheme  = callPackage ./art/xfce4-icon-theme.nix { };
-  xfwm4themes     = callPackage ./art/xfwm4-themes.nix { };
+  xfce4-volumed-pulse = callPackage ./applications/xfce4-volumed-pulse.nix { };
 
-  #### PANEL PLUGINS        from "mirror://xfce/src/panel-plugins/${p_name}/${ver_maj}/${name}.tar.{bz2,gz}"
+  #### ART
 
-  xfce4_battery_plugin          = callPackage ./panel-plugins/xfce4-battery-plugin.nix          { };
-  xfce4_clipman_plugin          = callPackage ./panel-plugins/xfce4-clipman-plugin.nix          { };
-  xfce4_cpufreq_plugin          = callPackage ./panel-plugins/xfce4-cpufreq-plugin.nix          { };
-  xfce4_cpugraph_plugin         = callPackage ./panel-plugins/xfce4-cpugraph-plugin.nix         { };
-  xfce4_datetime_plugin         = callPackage ./panel-plugins/xfce4-datetime-plugin.nix         { };
-  xfce4_dict_plugin             = callPackage ./panel-plugins/xfce4-dict-plugin.nix             { };
-  xfce4_dockbarx_plugin         = callPackage ./panel-plugins/xfce4-dockbarx-plugin.nix         { };
-  xfce4_embed_plugin            = callPackage ./panel-plugins/xfce4-embed-plugin.nix            { };
-  xfce4_eyes_plugin             = callPackage ./panel-plugins/xfce4-eyes-plugin.nix             { };
-  xfce4_fsguard_plugin          = callPackage ./panel-plugins/xfce4-fsguard-plugin.nix          { };
-  xfce4_genmon_plugin           = callPackage ./panel-plugins/xfce4-genmon-plugin.nix           { };
+  xfce4-icon-theme = callPackage ./art/xfce4-icon-theme.nix { };
+
+  xfwm4-themes = callPackage ./art/xfwm4-themes.nix { };
+
+  #### PANEL PLUGINS
+
+  xfce4-battery-plugin = callPackage ./panel-plugins/xfce4-battery-plugin.nix { };
+
+  xfce4-clipman-plugin = callPackage ./panel-plugins/xfce4-clipman-plugin.nix { };
+
+  xfce4-cpufreq-plugin = callPackage ./panel-plugins/xfce4-cpufreq-plugin.nix { };
+
+  xfce4-cpugraph-plugin = callPackage ./panel-plugins/xfce4-cpugraph-plugin.nix { };
+
+  xfce4-datetime-plugin = callPackage ./panel-plugins/xfce4-datetime-plugin.nix { };
+
+  xfce4-dict-plugin = callPackage ./panel-plugins/xfce4-dict-plugin.nix { };
+
+  xfce4-dockbarx-plugin = callPackage ./panel-plugins/xfce4-dockbarx-plugin.nix { };
+
+  xfce4-embed-plugin = callPackage ./panel-plugins/xfce4-embed-plugin.nix { };
+
+  xfce4-eyes-plugin = callPackage ./panel-plugins/xfce4-eyes-plugin.nix { };
+
+  xfce4-fsguard-plugin = callPackage ./panel-plugins/xfce4-fsguard-plugin.nix { };
+
+  xfce4-genmon-plugin = callPackage ./panel-plugins/xfce4-genmon-plugin.nix { };
+
   xfce4-hardware-monitor-plugin = callPackage ./panel-plugins/xfce4-hardware-monitor-plugin.nix { };
-  xfce4_namebar_plugin          = callPackage ./panel-plugins/xfce4-namebar-plugin.nix          { };
-  xfce4_netload_plugin          = callPackage ./panel-plugins/xfce4-netload-plugin.nix          { };
-  xfce4_notes_plugin            = callPackage ./panel-plugins/xfce4-notes-plugin.nix            { };
-  xfce4_mailwatch_plugin        = callPackage ./panel-plugins/xfce4-mailwatch-plugin.nix        { };
-  xfce4_mpc_plugin              = callPackage ./panel-plugins/xfce4-mpc-plugin.nix              { };
-  xfce4-sensors-plugin          = callPackage ./panel-plugins/xfce4-sensors-plugin.nix          { };
-  xfce4_systemload_plugin       = callPackage ./panel-plugins/xfce4-systemload-plugin.nix       { };
-  xfce4_timer_plugin            = callPackage ./panel-plugins/xfce4-timer-plugin.nix            { };
-  xfce4_verve_plugin            = callPackage ./panel-plugins/xfce4-verve-plugin.nix            { };
-  xfce4_xkb_plugin              = callPackage ./panel-plugins/xfce4-xkb-plugin.nix              { };
-  xfce4_weather_plugin          = callPackage ./panel-plugins/xfce4-weather-plugin.nix          { };
-  xfce4_whiskermenu_plugin      = callPackage ./panel-plugins/xfce4-whiskermenu-plugin.nix      { };
-  xfce4_windowck_plugin         = callPackage ./panel-plugins/xfce4-windowck-plugin.nix         { };
-  xfce4_pulseaudio_plugin       = callPackage ./panel-plugins/xfce4-pulseaudio-plugin.nix       { };
 
-}; # xfce_self
+  xfce4-namebar-plugin = callPackage ./panel-plugins/xfce4-namebar-plugin.nix { };
 
-in xfce_self
+  xfce4-netload-plugin = callPackage ./panel-plugins/xfce4-netload-plugin.nix { };
+
+  xfce4-notes-plugin = callPackage ./panel-plugins/xfce4-notes-plugin.nix { };
+
+  xfce4-mailwatch-plugin = callPackage ./panel-plugins/xfce4-mailwatch-plugin.nix { };
+
+  xfce4-mpc-plugin = callPackage ./panel-plugins/xfce4-mpc-plugin.nix { };
+
+  xfce4-sensors-plugin = callPackage ./panel-plugins/xfce4-sensors-plugin.nix { };
+
+  xfce4-systemload-plugin = callPackage ./panel-plugins/xfce4-systemload-plugin.nix { };
+
+  xfce4-timer-plugin = callPackage ./panel-plugins/xfce4-timer-plugin.nix { };
+
+  xfce4-verve-plugin = callPackage ./panel-plugins/xfce4-verve-plugin.nix { };
+
+  xfce4-xkb-plugin = callPackage ./panel-plugins/xfce4-xkb-plugin.nix { };
+
+  xfce4-weather-plugin = callPackage ./panel-plugins/xfce4-weather-plugin.nix { };
+
+  xfce4-whiskermenu-plugin = callPackage ./panel-plugins/xfce4-whiskermenu-plugin.nix { };
+
+  xfce4-windowck-plugin = callPackage ./panel-plugins/xfce4-windowck-plugin.nix { };
+
+  xfce4-pulseaudio-plugin = callPackage ./panel-plugins/xfce4-pulseaudio-plugin.nix { };
+
+  #### GTK+3 (deprecated, see NixOS/nixpkgs#32763)
+
+  libxfce4ui_gtk3 = libxfce4ui.override { withGtk3 = true; };
+
+  xfce4panel_gtk3 = xfce4-panel.override { withGtk3 = true; };
+
+  xfce4_power_manager_gtk3 = xfce4-power-manager.override { withGtk3 = true; };
+
+  #### ALIASES
+
+  terminal = xfce4-terminal;
+  thunar-build = thunar-bare;
+  thunarx-2-dev = thunar-build;
+  thunar_volman = thunar-volman;
+  xfce4panel = xfce4-panel;
+  xfce4session = xfce4-session;
+  xfce4settings = xfce4-settings;
+  xfce4_power_manager = xfce4-power-manager;
+  xfce4_appfinder = xfce4-appfinder;
+  xfce4_dev_tools = xfce4-dev-tools;
+  xfce4mixer = xfce4-mixer;
+  xfce4mixer_pulse = xfce4-mixer-pulse;
+  xfce4notifyd = xfce4-notifyd;
+  xfce4taskmanager = xfce4-taskmanager;
+  xfce4terminal = xfce4-terminal;
+  xfce4volumed = xfce4-volumed;
+  xfce4volumed_pulse = xfce4-volumed-pulse;
+  xfce4icontheme = xfce4-icon-theme;
+  xfwm4themes = xfwm4-themes;
+
+  xfce4_battery_plugin = xfce4-battery-plugin;
+  xfce4_clipman_plugin = xfce4-clipman-plugin;
+  xfce4_cpufreq_plugin = xfce4-cpufreq-plugin;
+  xfce4_cpugraph_plugin = xfce4-cpugraph-plugin;
+  xfce4_datetime_plugin = xfce4-datetime-plugin;
+  xfce4_dict_plugin = xfce4-dict-plugin;
+  xfce4_dockbarx_plugin = xfce4-dockbarx-plugin;
+  xfce4_embed_plugin = xfce4-embed-plugin;
+  xfce4_eyes_plugin = xfce4-eyes-plugin;
+  xfce4_fsguard_plugin = xfce4-fsguard-plugin;
+  xfce4_genmon_plugin = xfce4-genmon-plugin;
+  xfce4_hardware_monitor_plugin = xfce4-hardware-monitor-plugin;
+  xfce4_namebar_plugin = xfce4-namebar-plugin;
+  xfce4_netload_plugin = xfce4-netload-plugin;
+  xfce4_notes_plugin = xfce4-notes-plugin;
+  xfce4_mailwatch_plugin = xfce4-mailwatch-plugin;
+  xfce4_mpc_plugin = xfce4-mpc-plugin;
+  xfce4_sensors_plugin = xfce4-sensors-plugin;
+  xfce4_systemload_plugin = xfce4-systemload-plugin;
+  xfce4_timer_plugin = xfce4-timer-plugin;
+  xfce4_verve_plugin = xfce4-verve-plugin;
+  xfce4_xkb_plugin = xfce4-xkb-plugin;
+  xfce4_weather_plugin = xfce4-weather-plugin;
+  xfce4_whiskermenu_plugin = xfce4-whiskermenu-plugin;
+  xfce4_windowck_plugin = xfce4-windowck-plugin;
+  xfce4_pulseaudio_plugin = xfce4-pulseaudio-plugin;
+})


### PR DESCRIPTION
###### Motivation for this change

This is groundwork for adding Xfce 4.13.

I want to provide Xfce attrset as a NixOS option in https://github.com/NixOS/nixpkgs/pull/32763, and to do that, I will need to have consistent attribute names between Xfce versions.

I've rebuilt system with this change.

/cc @vcunat @volth

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

